### PR TITLE
[receiver/httpcheck]: enable re-aggregation feature

### DIFF
--- a/.chloggen/46358-httpcheckreceiver-enable-reagg.yaml
+++ b/.chloggen/46358-httpcheckreceiver-enable-reagg.yaml
@@ -1,0 +1,16 @@
+change_type: enhancement
+
+component: receiver/httpcheck
+
+note: Enable re-aggregation feature by classifying attributes with requirement_level and setting reaggregation_enabled to true
+
+issues: [46358]
+
+
+subtext: |
+  Attributes are classified as opt_in when aggregating across them produces meaningless results
+  (error.message due to high cardinality), and recommended when totals remain operationally
+  meaningful (http.url, http.method, http.status_class, http.status_code, network.transport,
+  validation.type).
+
+change_logs: [user]

--- a/receiver/httpcheckreceiver/documentation.md
+++ b/receiver/httpcheckreceiver/documentation.md
@@ -39,7 +39,7 @@ Records errors occurring during HTTP check.
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
 | http.url | Full HTTP request URL. | Any Str | Recommended |
-| error.message | Error message recorded during check | Any Str | Recommended |
+| error.message | Error message recorded during check | Any Str | Opt-In |
 
 ### httpcheck.status
 
@@ -152,9 +152,9 @@ Time in seconds until certificate expiry, as specified by `NotAfter` field in th
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
 | http.url | Full HTTP request URL. | Any Str | Recommended |
-| http.tls.issuer | The entity that issued the certificate. | Any Str | Recommended |
-| http.tls.cn | The commonName in the subject of the certificate. | Any Str | Recommended |
-| http.tls.san | The Subject Alternative Name of the certificate. | Any Slice | Recommended |
+| http.tls.issuer | The entity that issued the certificate. | Any Str | Opt-In |
+| http.tls.cn | The commonName in the subject of the certificate. | Any Str | Opt-In |
+| http.tls.san | The Subject Alternative Name of the certificate. | Any Slice | Opt-In |
 
 ### httpcheck.tls.handshake.duration
 
@@ -183,7 +183,7 @@ Number of response validations that failed.
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
 | http.url | Full HTTP request URL. | Any Str | Recommended |
-| validation.type | Type of validation performed (contains, json_path, size, regex) | Any Str | Recommended |
+| validation.type | Type of validation performed (contains, json_path, size, regex) | Any Str | Opt-In |
 
 ### httpcheck.validation.passed
 
@@ -198,4 +198,4 @@ Number of response validations that passed.
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
 | http.url | Full HTTP request URL. | Any Str | Recommended |
-| validation.type | Type of validation performed (contains, json_path, size, regex) | Any Str | Recommended |
+| validation.type | Type of validation performed (contains, json_path, size, regex) | Any Str | Opt-In |

--- a/receiver/httpcheckreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/httpcheckreceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,24 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+                - "network.transport"
+            default:
+              - "http.url"
+              - "network.transport"
       httpcheck.client.request.duration:
         description: "HttpcheckClientRequestDurationConfig provides config for the httpcheck.client.request.duration metric."
         type: object
@@ -18,6 +36,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+            default:
+              - "http.url"
       httpcheck.dns.lookup.duration:
         description: "HttpcheckDNSLookupDurationConfig provides config for the httpcheck.dns.lookup.duration metric."
         type: object
@@ -25,6 +59,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+            default:
+              - "http.url"
       httpcheck.duration:
         description: "HttpcheckDurationConfig provides config for the httpcheck.duration metric."
         type: object
@@ -32,6 +82,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+            default:
+              - "http.url"
       httpcheck.error:
         description: "HttpcheckErrorConfig provides config for the httpcheck.error metric."
         type: object
@@ -39,6 +105,23 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+                - "error.message"
+            default:
+              - "http.url"
       httpcheck.response.duration:
         description: "HttpcheckResponseDurationConfig provides config for the httpcheck.response.duration metric."
         type: object
@@ -46,6 +129,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+            default:
+              - "http.url"
       httpcheck.response.size:
         description: "HttpcheckResponseSizeConfig provides config for the httpcheck.response.size metric."
         type: object
@@ -53,6 +152,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+            default:
+              - "http.url"
       httpcheck.status:
         description: "HttpcheckStatusConfig provides config for the httpcheck.status metric."
         type: object
@@ -60,6 +175,28 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+                - "http.status_code"
+                - "http.method"
+                - "http.status_class"
+            default:
+              - "http.url"
+              - "http.status_code"
+              - "http.method"
+              - "http.status_class"
       httpcheck.tls.cert_remaining:
         description: "HttpcheckTLSCertRemainingConfig provides config for the httpcheck.tls.cert_remaining metric."
         type: object
@@ -67,6 +204,25 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+                - "http.tls.issuer"
+                - "http.tls.cn"
+                - "http.tls.san"
+            default:
+              - "http.url"
       httpcheck.tls.handshake.duration:
         description: "HttpcheckTLSHandshakeDurationConfig provides config for the httpcheck.tls.handshake.duration metric."
         type: object
@@ -74,6 +230,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+            default:
+              - "http.url"
       httpcheck.validation.failed:
         description: "HttpcheckValidationFailedConfig provides config for the httpcheck.validation.failed metric."
         type: object
@@ -81,6 +253,23 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+                - "validation.type"
+            default:
+              - "http.url"
       httpcheck.validation.passed:
         description: "HttpcheckValidationPassedConfig provides config for the httpcheck.validation.passed metric."
         type: object
@@ -88,6 +277,23 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.url"
+                - "validation.type"
+            default:
+              - "http.url"
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for httpcheck metrics builder.
     type: object

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config.go
@@ -3,16 +3,29 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// HttpcheckClientConnectionDurationAttributeKey specifies the key of an attribute for the httpcheck.client.connection.duration metric.
+type HttpcheckClientConnectionDurationAttributeKey string
+
+const (
+	HttpcheckClientConnectionDurationAttributeKeyHTTPURL          HttpcheckClientConnectionDurationAttributeKey = "http.url"
+	HttpcheckClientConnectionDurationAttributeKeyNetworkTransport HttpcheckClientConnectionDurationAttributeKey = "network.transport"
+)
+
+// HttpcheckClientConnectionDurationConfig provides config for the httpcheck.client.connection.duration metric.
+type HttpcheckClientConnectionDurationConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                                          `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckClientConnectionDurationAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *HttpcheckClientConnectionDurationConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -26,59 +39,638 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+func (ms *HttpcheckClientConnectionDurationConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckClientConnectionDurationAttributeKeyHTTPURL, HttpcheckClientConnectionDurationAttributeKeyNetworkTransport:
+		default:
+			return fmt.Errorf("metric httpcheck.client.connection.duration doesn't have an attribute %v, valid attributes: [http.url, network.transport]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckClientRequestDurationAttributeKey specifies the key of an attribute for the httpcheck.client.request.duration metric.
+type HttpcheckClientRequestDurationAttributeKey string
+
+const (
+	HttpcheckClientRequestDurationAttributeKeyHTTPURL HttpcheckClientRequestDurationAttributeKey = "http.url"
+)
+
+// HttpcheckClientRequestDurationConfig provides config for the httpcheck.client.request.duration metric.
+type HttpcheckClientRequestDurationConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckClientRequestDurationAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckClientRequestDurationConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckClientRequestDurationConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckClientRequestDurationAttributeKeyHTTPURL:
+		default:
+			return fmt.Errorf("metric httpcheck.client.request.duration doesn't have an attribute %v, valid attributes: [http.url]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckDNSLookupDurationAttributeKey specifies the key of an attribute for the httpcheck.dns.lookup.duration metric.
+type HttpcheckDNSLookupDurationAttributeKey string
+
+const (
+	HttpcheckDNSLookupDurationAttributeKeyHTTPURL HttpcheckDNSLookupDurationAttributeKey = "http.url"
+)
+
+// HttpcheckDNSLookupDurationConfig provides config for the httpcheck.dns.lookup.duration metric.
+type HttpcheckDNSLookupDurationConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckDNSLookupDurationAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckDNSLookupDurationConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckDNSLookupDurationConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckDNSLookupDurationAttributeKeyHTTPURL:
+		default:
+			return fmt.Errorf("metric httpcheck.dns.lookup.duration doesn't have an attribute %v, valid attributes: [http.url]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckDurationAttributeKey specifies the key of an attribute for the httpcheck.duration metric.
+type HttpcheckDurationAttributeKey string
+
+const (
+	HttpcheckDurationAttributeKeyHTTPURL HttpcheckDurationAttributeKey = "http.url"
+)
+
+// HttpcheckDurationConfig provides config for the httpcheck.duration metric.
+type HttpcheckDurationConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                          `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckDurationAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckDurationConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckDurationConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckDurationAttributeKeyHTTPURL:
+		default:
+			return fmt.Errorf("metric httpcheck.duration doesn't have an attribute %v, valid attributes: [http.url]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckErrorAttributeKey specifies the key of an attribute for the httpcheck.error metric.
+type HttpcheckErrorAttributeKey string
+
+const (
+	HttpcheckErrorAttributeKeyHTTPURL      HttpcheckErrorAttributeKey = "http.url"
+	HttpcheckErrorAttributeKeyErrorMessage HttpcheckErrorAttributeKey = "error.message"
+)
+
+// HttpcheckErrorConfig provides config for the httpcheck.error metric.
+type HttpcheckErrorConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckErrorAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckErrorConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckErrorConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckErrorAttributeKeyHTTPURL, HttpcheckErrorAttributeKeyErrorMessage:
+		default:
+			return fmt.Errorf("metric httpcheck.error doesn't have an attribute %v, valid attributes: [http.url, error.message]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckResponseDurationAttributeKey specifies the key of an attribute for the httpcheck.response.duration metric.
+type HttpcheckResponseDurationAttributeKey string
+
+const (
+	HttpcheckResponseDurationAttributeKeyHTTPURL HttpcheckResponseDurationAttributeKey = "http.url"
+)
+
+// HttpcheckResponseDurationConfig provides config for the httpcheck.response.duration metric.
+type HttpcheckResponseDurationConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckResponseDurationAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckResponseDurationConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckResponseDurationConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckResponseDurationAttributeKeyHTTPURL:
+		default:
+			return fmt.Errorf("metric httpcheck.response.duration doesn't have an attribute %v, valid attributes: [http.url]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckResponseSizeAttributeKey specifies the key of an attribute for the httpcheck.response.size metric.
+type HttpcheckResponseSizeAttributeKey string
+
+const (
+	HttpcheckResponseSizeAttributeKeyHTTPURL HttpcheckResponseSizeAttributeKey = "http.url"
+)
+
+// HttpcheckResponseSizeConfig provides config for the httpcheck.response.size metric.
+type HttpcheckResponseSizeConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckResponseSizeAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckResponseSizeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckResponseSizeConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckResponseSizeAttributeKeyHTTPURL:
+		default:
+			return fmt.Errorf("metric httpcheck.response.size doesn't have an attribute %v, valid attributes: [http.url]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckStatusAttributeKey specifies the key of an attribute for the httpcheck.status metric.
+type HttpcheckStatusAttributeKey string
+
+const (
+	HttpcheckStatusAttributeKeyHTTPURL         HttpcheckStatusAttributeKey = "http.url"
+	HttpcheckStatusAttributeKeyHTTPStatusCode  HttpcheckStatusAttributeKey = "http.status_code"
+	HttpcheckStatusAttributeKeyHTTPMethod      HttpcheckStatusAttributeKey = "http.method"
+	HttpcheckStatusAttributeKeyHTTPStatusClass HttpcheckStatusAttributeKey = "http.status_class"
+)
+
+// HttpcheckStatusConfig provides config for the httpcheck.status metric.
+type HttpcheckStatusConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckStatusAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckStatusConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckStatusConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckStatusAttributeKeyHTTPURL, HttpcheckStatusAttributeKeyHTTPStatusCode, HttpcheckStatusAttributeKeyHTTPMethod, HttpcheckStatusAttributeKeyHTTPStatusClass:
+		default:
+			return fmt.Errorf("metric httpcheck.status doesn't have an attribute %v, valid attributes: [http.url, http.status_code, http.method, http.status_class]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckTLSCertRemainingAttributeKey specifies the key of an attribute for the httpcheck.tls.cert_remaining metric.
+type HttpcheckTLSCertRemainingAttributeKey string
+
+const (
+	HttpcheckTLSCertRemainingAttributeKeyHTTPURL       HttpcheckTLSCertRemainingAttributeKey = "http.url"
+	HttpcheckTLSCertRemainingAttributeKeyHTTPTLSIssuer HttpcheckTLSCertRemainingAttributeKey = "http.tls.issuer"
+	HttpcheckTLSCertRemainingAttributeKeyHTTPTLSCn     HttpcheckTLSCertRemainingAttributeKey = "http.tls.cn"
+	HttpcheckTLSCertRemainingAttributeKeyHTTPTLSSan    HttpcheckTLSCertRemainingAttributeKey = "http.tls.san"
+)
+
+// HttpcheckTLSCertRemainingConfig provides config for the httpcheck.tls.cert_remaining metric.
+type HttpcheckTLSCertRemainingConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckTLSCertRemainingAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckTLSCertRemainingConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckTLSCertRemainingConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckTLSCertRemainingAttributeKeyHTTPURL, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSIssuer, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSCn, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSSan:
+		default:
+			return fmt.Errorf("metric httpcheck.tls.cert_remaining doesn't have an attribute %v, valid attributes: [http.url, http.tls.issuer, http.tls.cn, http.tls.san]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckTLSHandshakeDurationAttributeKey specifies the key of an attribute for the httpcheck.tls.handshake.duration metric.
+type HttpcheckTLSHandshakeDurationAttributeKey string
+
+const (
+	HttpcheckTLSHandshakeDurationAttributeKeyHTTPURL HttpcheckTLSHandshakeDurationAttributeKey = "http.url"
+)
+
+// HttpcheckTLSHandshakeDurationConfig provides config for the httpcheck.tls.handshake.duration metric.
+type HttpcheckTLSHandshakeDurationConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckTLSHandshakeDurationAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckTLSHandshakeDurationConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckTLSHandshakeDurationConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckTLSHandshakeDurationAttributeKeyHTTPURL:
+		default:
+			return fmt.Errorf("metric httpcheck.tls.handshake.duration doesn't have an attribute %v, valid attributes: [http.url]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckValidationFailedAttributeKey specifies the key of an attribute for the httpcheck.validation.failed metric.
+type HttpcheckValidationFailedAttributeKey string
+
+const (
+	HttpcheckValidationFailedAttributeKeyHTTPURL        HttpcheckValidationFailedAttributeKey = "http.url"
+	HttpcheckValidationFailedAttributeKeyValidationType HttpcheckValidationFailedAttributeKey = "validation.type"
+)
+
+// HttpcheckValidationFailedConfig provides config for the httpcheck.validation.failed metric.
+type HttpcheckValidationFailedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckValidationFailedAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckValidationFailedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckValidationFailedConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckValidationFailedAttributeKeyHTTPURL, HttpcheckValidationFailedAttributeKeyValidationType:
+		default:
+			return fmt.Errorf("metric httpcheck.validation.failed doesn't have an attribute %v, valid attributes: [http.url, validation.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// HttpcheckValidationPassedAttributeKey specifies the key of an attribute for the httpcheck.validation.passed metric.
+type HttpcheckValidationPassedAttributeKey string
+
+const (
+	HttpcheckValidationPassedAttributeKeyHTTPURL        HttpcheckValidationPassedAttributeKey = "http.url"
+	HttpcheckValidationPassedAttributeKeyValidationType HttpcheckValidationPassedAttributeKey = "validation.type"
+)
+
+// HttpcheckValidationPassedConfig provides config for the httpcheck.validation.passed metric.
+type HttpcheckValidationPassedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []HttpcheckValidationPassedAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *HttpcheckValidationPassedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *HttpcheckValidationPassedConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case HttpcheckValidationPassedAttributeKeyHTTPURL, HttpcheckValidationPassedAttributeKeyValidationType:
+		default:
+			return fmt.Errorf("metric httpcheck.validation.passed doesn't have an attribute %v, valid attributes: [http.url, validation.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MetricsConfig provides config for httpcheck metrics.
 type MetricsConfig struct {
-	HttpcheckClientConnectionDuration MetricConfig `mapstructure:"httpcheck.client.connection.duration"`
-	HttpcheckClientRequestDuration    MetricConfig `mapstructure:"httpcheck.client.request.duration"`
-	HttpcheckDNSLookupDuration        MetricConfig `mapstructure:"httpcheck.dns.lookup.duration"`
-	HttpcheckDuration                 MetricConfig `mapstructure:"httpcheck.duration"`
-	HttpcheckError                    MetricConfig `mapstructure:"httpcheck.error"`
-	HttpcheckResponseDuration         MetricConfig `mapstructure:"httpcheck.response.duration"`
-	HttpcheckResponseSize             MetricConfig `mapstructure:"httpcheck.response.size"`
-	HttpcheckStatus                   MetricConfig `mapstructure:"httpcheck.status"`
-	HttpcheckTLSCertRemaining         MetricConfig `mapstructure:"httpcheck.tls.cert_remaining"`
-	HttpcheckTLSHandshakeDuration     MetricConfig `mapstructure:"httpcheck.tls.handshake.duration"`
-	HttpcheckValidationFailed         MetricConfig `mapstructure:"httpcheck.validation.failed"`
-	HttpcheckValidationPassed         MetricConfig `mapstructure:"httpcheck.validation.passed"`
+	HttpcheckClientConnectionDuration HttpcheckClientConnectionDurationConfig `mapstructure:"httpcheck.client.connection.duration"`
+	HttpcheckClientRequestDuration    HttpcheckClientRequestDurationConfig    `mapstructure:"httpcheck.client.request.duration"`
+	HttpcheckDNSLookupDuration        HttpcheckDNSLookupDurationConfig        `mapstructure:"httpcheck.dns.lookup.duration"`
+	HttpcheckDuration                 HttpcheckDurationConfig                 `mapstructure:"httpcheck.duration"`
+	HttpcheckError                    HttpcheckErrorConfig                    `mapstructure:"httpcheck.error"`
+	HttpcheckResponseDuration         HttpcheckResponseDurationConfig         `mapstructure:"httpcheck.response.duration"`
+	HttpcheckResponseSize             HttpcheckResponseSizeConfig             `mapstructure:"httpcheck.response.size"`
+	HttpcheckStatus                   HttpcheckStatusConfig                   `mapstructure:"httpcheck.status"`
+	HttpcheckTLSCertRemaining         HttpcheckTLSCertRemainingConfig         `mapstructure:"httpcheck.tls.cert_remaining"`
+	HttpcheckTLSHandshakeDuration     HttpcheckTLSHandshakeDurationConfig     `mapstructure:"httpcheck.tls.handshake.duration"`
+	HttpcheckValidationFailed         HttpcheckValidationFailedConfig         `mapstructure:"httpcheck.validation.failed"`
+	HttpcheckValidationPassed         HttpcheckValidationPassedConfig         `mapstructure:"httpcheck.validation.passed"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		HttpcheckClientConnectionDuration: MetricConfig{
-			Enabled: false,
+		HttpcheckClientConnectionDuration: HttpcheckClientConnectionDurationConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckClientConnectionDurationAttributeKey{HttpcheckClientConnectionDurationAttributeKeyHTTPURL, HttpcheckClientConnectionDurationAttributeKeyNetworkTransport},
 		},
-		HttpcheckClientRequestDuration: MetricConfig{
-			Enabled: false,
+		HttpcheckClientRequestDuration: HttpcheckClientRequestDurationConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckClientRequestDurationAttributeKey{HttpcheckClientRequestDurationAttributeKeyHTTPURL},
 		},
-		HttpcheckDNSLookupDuration: MetricConfig{
-			Enabled: false,
+		HttpcheckDNSLookupDuration: HttpcheckDNSLookupDurationConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckDNSLookupDurationAttributeKey{HttpcheckDNSLookupDurationAttributeKeyHTTPURL},
 		},
-		HttpcheckDuration: MetricConfig{
-			Enabled: true,
+		HttpcheckDuration: HttpcheckDurationConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckDurationAttributeKey{HttpcheckDurationAttributeKeyHTTPURL},
 		},
-		HttpcheckError: MetricConfig{
-			Enabled: true,
+		HttpcheckError: HttpcheckErrorConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []HttpcheckErrorAttributeKey{HttpcheckErrorAttributeKeyHTTPURL},
 		},
-		HttpcheckResponseDuration: MetricConfig{
-			Enabled: false,
+		HttpcheckResponseDuration: HttpcheckResponseDurationConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckResponseDurationAttributeKey{HttpcheckResponseDurationAttributeKeyHTTPURL},
 		},
-		HttpcheckResponseSize: MetricConfig{
-			Enabled: false,
+		HttpcheckResponseSize: HttpcheckResponseSizeConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckResponseSizeAttributeKey{HttpcheckResponseSizeAttributeKeyHTTPURL},
 		},
-		HttpcheckStatus: MetricConfig{
-			Enabled: true,
+		HttpcheckStatus: HttpcheckStatusConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []HttpcheckStatusAttributeKey{HttpcheckStatusAttributeKeyHTTPURL, HttpcheckStatusAttributeKeyHTTPStatusCode, HttpcheckStatusAttributeKeyHTTPMethod, HttpcheckStatusAttributeKeyHTTPStatusClass},
 		},
-		HttpcheckTLSCertRemaining: MetricConfig{
-			Enabled: false,
+		HttpcheckTLSCertRemaining: HttpcheckTLSCertRemainingConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckTLSCertRemainingAttributeKey{HttpcheckTLSCertRemainingAttributeKeyHTTPURL},
 		},
-		HttpcheckTLSHandshakeDuration: MetricConfig{
-			Enabled: false,
+		HttpcheckTLSHandshakeDuration: HttpcheckTLSHandshakeDurationConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []HttpcheckTLSHandshakeDurationAttributeKey{HttpcheckTLSHandshakeDurationAttributeKeyHTTPURL},
 		},
-		HttpcheckValidationFailed: MetricConfig{
-			Enabled: false,
+		HttpcheckValidationFailed: HttpcheckValidationFailedConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []HttpcheckValidationFailedAttributeKey{HttpcheckValidationFailedAttributeKeyHTTPURL},
 		},
-		HttpcheckValidationPassed: MetricConfig{
-			Enabled: false,
+		HttpcheckValidationPassed: HttpcheckValidationPassedConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []HttpcheckValidationPassedAttributeKey{HttpcheckValidationPassedAttributeKeyHTTPURL},
 		},
 	}
 }

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
@@ -26,41 +26,65 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					HttpcheckClientConnectionDuration: MetricConfig{
-						Enabled: true,
+					HttpcheckClientConnectionDuration: HttpcheckClientConnectionDurationConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckClientConnectionDurationAttributeKey{HttpcheckClientConnectionDurationAttributeKeyHTTPURL, HttpcheckClientConnectionDurationAttributeKeyNetworkTransport},
 					},
-					HttpcheckClientRequestDuration: MetricConfig{
-						Enabled: true,
+					HttpcheckClientRequestDuration: HttpcheckClientRequestDurationConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckClientRequestDurationAttributeKey{HttpcheckClientRequestDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckDNSLookupDuration: MetricConfig{
-						Enabled: true,
+					HttpcheckDNSLookupDuration: HttpcheckDNSLookupDurationConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckDNSLookupDurationAttributeKey{HttpcheckDNSLookupDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckDuration: MetricConfig{
-						Enabled: true,
+					HttpcheckDuration: HttpcheckDurationConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckDurationAttributeKey{HttpcheckDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckError: MetricConfig{
-						Enabled: true,
+					HttpcheckError: HttpcheckErrorConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckErrorAttributeKey{HttpcheckErrorAttributeKeyHTTPURL, HttpcheckErrorAttributeKeyErrorMessage},
 					},
-					HttpcheckResponseDuration: MetricConfig{
-						Enabled: true,
+					HttpcheckResponseDuration: HttpcheckResponseDurationConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckResponseDurationAttributeKey{HttpcheckResponseDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckResponseSize: MetricConfig{
-						Enabled: true,
+					HttpcheckResponseSize: HttpcheckResponseSizeConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckResponseSizeAttributeKey{HttpcheckResponseSizeAttributeKeyHTTPURL},
 					},
-					HttpcheckStatus: MetricConfig{
-						Enabled: true,
+					HttpcheckStatus: HttpcheckStatusConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckStatusAttributeKey{HttpcheckStatusAttributeKeyHTTPURL, HttpcheckStatusAttributeKeyHTTPStatusCode, HttpcheckStatusAttributeKeyHTTPMethod, HttpcheckStatusAttributeKeyHTTPStatusClass},
 					},
-					HttpcheckTLSCertRemaining: MetricConfig{
-						Enabled: true,
+					HttpcheckTLSCertRemaining: HttpcheckTLSCertRemainingConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckTLSCertRemainingAttributeKey{HttpcheckTLSCertRemainingAttributeKeyHTTPURL, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSIssuer, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSCn, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSSan},
 					},
-					HttpcheckTLSHandshakeDuration: MetricConfig{
-						Enabled: true,
+					HttpcheckTLSHandshakeDuration: HttpcheckTLSHandshakeDurationConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckTLSHandshakeDurationAttributeKey{HttpcheckTLSHandshakeDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckValidationFailed: MetricConfig{
-						Enabled: true,
+					HttpcheckValidationFailed: HttpcheckValidationFailedConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckValidationFailedAttributeKey{HttpcheckValidationFailedAttributeKeyHTTPURL, HttpcheckValidationFailedAttributeKeyValidationType},
 					},
-					HttpcheckValidationPassed: MetricConfig{
-						Enabled: true,
+					HttpcheckValidationPassed: HttpcheckValidationPassedConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckValidationPassedAttributeKey{HttpcheckValidationPassedAttributeKeyHTTPURL, HttpcheckValidationPassedAttributeKeyValidationType},
 					},
 				},
 			},
@@ -69,41 +93,65 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					HttpcheckClientConnectionDuration: MetricConfig{
-						Enabled: false,
+					HttpcheckClientConnectionDuration: HttpcheckClientConnectionDurationConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckClientConnectionDurationAttributeKey{HttpcheckClientConnectionDurationAttributeKeyHTTPURL, HttpcheckClientConnectionDurationAttributeKeyNetworkTransport},
 					},
-					HttpcheckClientRequestDuration: MetricConfig{
-						Enabled: false,
+					HttpcheckClientRequestDuration: HttpcheckClientRequestDurationConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckClientRequestDurationAttributeKey{HttpcheckClientRequestDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckDNSLookupDuration: MetricConfig{
-						Enabled: false,
+					HttpcheckDNSLookupDuration: HttpcheckDNSLookupDurationConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckDNSLookupDurationAttributeKey{HttpcheckDNSLookupDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckDuration: MetricConfig{
-						Enabled: false,
+					HttpcheckDuration: HttpcheckDurationConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckDurationAttributeKey{HttpcheckDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckError: MetricConfig{
-						Enabled: false,
+					HttpcheckError: HttpcheckErrorConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckErrorAttributeKey{HttpcheckErrorAttributeKeyHTTPURL, HttpcheckErrorAttributeKeyErrorMessage},
 					},
-					HttpcheckResponseDuration: MetricConfig{
-						Enabled: false,
+					HttpcheckResponseDuration: HttpcheckResponseDurationConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckResponseDurationAttributeKey{HttpcheckResponseDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckResponseSize: MetricConfig{
-						Enabled: false,
+					HttpcheckResponseSize: HttpcheckResponseSizeConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckResponseSizeAttributeKey{HttpcheckResponseSizeAttributeKeyHTTPURL},
 					},
-					HttpcheckStatus: MetricConfig{
-						Enabled: false,
+					HttpcheckStatus: HttpcheckStatusConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckStatusAttributeKey{HttpcheckStatusAttributeKeyHTTPURL, HttpcheckStatusAttributeKeyHTTPStatusCode, HttpcheckStatusAttributeKeyHTTPMethod, HttpcheckStatusAttributeKeyHTTPStatusClass},
 					},
-					HttpcheckTLSCertRemaining: MetricConfig{
-						Enabled: false,
+					HttpcheckTLSCertRemaining: HttpcheckTLSCertRemainingConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckTLSCertRemainingAttributeKey{HttpcheckTLSCertRemainingAttributeKeyHTTPURL, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSIssuer, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSCn, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSSan},
 					},
-					HttpcheckTLSHandshakeDuration: MetricConfig{
-						Enabled: false,
+					HttpcheckTLSHandshakeDuration: HttpcheckTLSHandshakeDurationConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []HttpcheckTLSHandshakeDurationAttributeKey{HttpcheckTLSHandshakeDurationAttributeKeyHTTPURL},
 					},
-					HttpcheckValidationFailed: MetricConfig{
-						Enabled: false,
+					HttpcheckValidationFailed: HttpcheckValidationFailedConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckValidationFailedAttributeKey{HttpcheckValidationFailedAttributeKeyHTTPURL, HttpcheckValidationFailedAttributeKeyValidationType},
 					},
-					HttpcheckValidationPassed: MetricConfig{
-						Enabled: false,
+					HttpcheckValidationPassed: HttpcheckValidationPassedConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []HttpcheckValidationPassedAttributeKey{HttpcheckValidationPassedAttributeKeyHTTPURL, HttpcheckValidationPassedAttributeKeyValidationType},
 					},
 				},
 			},
@@ -112,7 +160,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(HttpcheckClientConnectionDurationConfig{}, HttpcheckClientRequestDurationConfig{}, HttpcheckDNSLookupDurationConfig{}, HttpcheckDurationConfig{}, HttpcheckErrorConfig{}, HttpcheckResponseDurationConfig{}, HttpcheckResponseSizeConfig{}, HttpcheckStatusConfig{}, HttpcheckTLSCertRemainingConfig{}, HttpcheckTLSHandshakeDurationConfig{}, HttpcheckValidationFailedConfig{}, HttpcheckValidationPassedConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
@@ -3,12 +3,20 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -70,9 +78,10 @@ type metricInfo struct {
 }
 
 type metricHttpcheckClientConnectionDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                          // data buffer for generated metric.
+	config        HttpcheckClientConnectionDurationConfig // metric config provided by user.
+	capacity      int                                     // max observed number of data points added to the metric.
+	aggDataPoints []int64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.client.connection.duration metric with initial data.
@@ -82,18 +91,51 @@ func (m *metricHttpcheckClientConnectionDuration) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckClientConnectionDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, networkTransportAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckClientConnectionDurationAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckClientConnectionDurationAttributeKeyNetworkTransport) {
+		dp.Attributes().PutStr("network.transport", networkTransportAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
-	dp.Attributes().PutStr("network.transport", networkTransportAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -106,13 +148,18 @@ func (m *metricHttpcheckClientConnectionDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckClientConnectionDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckClientConnectionDuration(cfg MetricConfig) metricHttpcheckClientConnectionDuration {
+func newMetricHttpcheckClientConnectionDuration(cfg HttpcheckClientConnectionDurationConfig) metricHttpcheckClientConnectionDuration {
 	m := metricHttpcheckClientConnectionDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -123,9 +170,10 @@ func newMetricHttpcheckClientConnectionDuration(cfg MetricConfig) metricHttpchec
 }
 
 type metricHttpcheckClientRequestDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                       // data buffer for generated metric.
+	config        HttpcheckClientRequestDurationConfig // metric config provided by user.
+	capacity      int                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.client.request.duration metric with initial data.
@@ -135,17 +183,48 @@ func (m *metricHttpcheckClientRequestDuration) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckClientRequestDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckClientRequestDurationAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -158,13 +237,18 @@ func (m *metricHttpcheckClientRequestDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckClientRequestDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckClientRequestDuration(cfg MetricConfig) metricHttpcheckClientRequestDuration {
+func newMetricHttpcheckClientRequestDuration(cfg HttpcheckClientRequestDurationConfig) metricHttpcheckClientRequestDuration {
 	m := metricHttpcheckClientRequestDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -175,9 +259,10 @@ func newMetricHttpcheckClientRequestDuration(cfg MetricConfig) metricHttpcheckCl
 }
 
 type metricHttpcheckDNSLookupDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        HttpcheckDNSLookupDurationConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                          // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.dns.lookup.duration metric with initial data.
@@ -187,17 +272,48 @@ func (m *metricHttpcheckDNSLookupDuration) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckDNSLookupDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckDNSLookupDurationAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -210,13 +326,18 @@ func (m *metricHttpcheckDNSLookupDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckDNSLookupDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckDNSLookupDuration(cfg MetricConfig) metricHttpcheckDNSLookupDuration {
+func newMetricHttpcheckDNSLookupDuration(cfg HttpcheckDNSLookupDurationConfig) metricHttpcheckDNSLookupDuration {
 	m := metricHttpcheckDNSLookupDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -227,9 +348,10 @@ func newMetricHttpcheckDNSLookupDuration(cfg MetricConfig) metricHttpcheckDNSLoo
 }
 
 type metricHttpcheckDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric          // data buffer for generated metric.
+	config        HttpcheckDurationConfig // metric config provided by user.
+	capacity      int                     // max observed number of data points added to the metric.
+	aggDataPoints []int64                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.duration metric with initial data.
@@ -239,17 +361,48 @@ func (m *metricHttpcheckDuration) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckDurationAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -262,13 +415,18 @@ func (m *metricHttpcheckDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckDuration(cfg MetricConfig) metricHttpcheckDuration {
+func newMetricHttpcheckDuration(cfg HttpcheckDurationConfig) metricHttpcheckDuration {
 	m := metricHttpcheckDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -279,9 +437,10 @@ func newMetricHttpcheckDuration(cfg MetricConfig) metricHttpcheckDuration {
 }
 
 type metricHttpcheckError struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric       // data buffer for generated metric.
+	config        HttpcheckErrorConfig // metric config provided by user.
+	capacity      int                  // max observed number of data points added to the metric.
+	aggDataPoints []int64              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.error metric with initial data.
@@ -293,18 +452,51 @@ func (m *metricHttpcheckError) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, errorMessageAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckErrorAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckErrorAttributeKeyErrorMessage) {
+		dp.Attributes().PutStr("error.message", errorMessageAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
-	dp.Attributes().PutStr("error.message", errorMessageAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -317,13 +509,18 @@ func (m *metricHttpcheckError) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckError) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckError(cfg MetricConfig) metricHttpcheckError {
+func newMetricHttpcheckError(cfg HttpcheckErrorConfig) metricHttpcheckError {
 	m := metricHttpcheckError{config: cfg}
 
 	if cfg.Enabled {
@@ -334,9 +531,10 @@ func newMetricHttpcheckError(cfg MetricConfig) metricHttpcheckError {
 }
 
 type metricHttpcheckResponseDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        HttpcheckResponseDurationConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.response.duration metric with initial data.
@@ -346,17 +544,48 @@ func (m *metricHttpcheckResponseDuration) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckResponseDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckResponseDurationAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -369,13 +598,18 @@ func (m *metricHttpcheckResponseDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckResponseDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckResponseDuration(cfg MetricConfig) metricHttpcheckResponseDuration {
+func newMetricHttpcheckResponseDuration(cfg HttpcheckResponseDurationConfig) metricHttpcheckResponseDuration {
 	m := metricHttpcheckResponseDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -386,9 +620,10 @@ func newMetricHttpcheckResponseDuration(cfg MetricConfig) metricHttpcheckRespons
 }
 
 type metricHttpcheckResponseSize struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric              // data buffer for generated metric.
+	config        HttpcheckResponseSizeConfig // metric config provided by user.
+	capacity      int                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.response.size metric with initial data.
@@ -398,17 +633,48 @@ func (m *metricHttpcheckResponseSize) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckResponseSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckResponseSizeAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -421,13 +687,18 @@ func (m *metricHttpcheckResponseSize) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckResponseSize) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckResponseSize(cfg MetricConfig) metricHttpcheckResponseSize {
+func newMetricHttpcheckResponseSize(cfg HttpcheckResponseSizeConfig) metricHttpcheckResponseSize {
 	m := metricHttpcheckResponseSize{config: cfg}
 
 	if cfg.Enabled {
@@ -438,9 +709,10 @@ func newMetricHttpcheckResponseSize(cfg MetricConfig) metricHttpcheckResponseSiz
 }
 
 type metricHttpcheckStatus struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric        // data buffer for generated metric.
+	config        HttpcheckStatusConfig // metric config provided by user.
+	capacity      int                   // max observed number of data points added to the metric.
+	aggDataPoints []int64               // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.status metric with initial data.
@@ -452,20 +724,57 @@ func (m *metricHttpcheckStatus) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckStatus) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, httpStatusCodeAttributeValue int64, httpMethodAttributeValue string, httpStatusClassAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckStatusAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckStatusAttributeKeyHTTPStatusCode) {
+		dp.Attributes().PutInt("http.status_code", httpStatusCodeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckStatusAttributeKeyHTTPMethod) {
+		dp.Attributes().PutStr("http.method", httpMethodAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckStatusAttributeKeyHTTPStatusClass) {
+		dp.Attributes().PutStr("http.status_class", httpStatusClassAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
-	dp.Attributes().PutInt("http.status_code", httpStatusCodeAttributeValue)
-	dp.Attributes().PutStr("http.method", httpMethodAttributeValue)
-	dp.Attributes().PutStr("http.status_class", httpStatusClassAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -478,13 +787,18 @@ func (m *metricHttpcheckStatus) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckStatus) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckStatus(cfg MetricConfig) metricHttpcheckStatus {
+func newMetricHttpcheckStatus(cfg HttpcheckStatusConfig) metricHttpcheckStatus {
 	m := metricHttpcheckStatus{config: cfg}
 
 	if cfg.Enabled {
@@ -495,9 +809,10 @@ func newMetricHttpcheckStatus(cfg MetricConfig) metricHttpcheckStatus {
 }
 
 type metricHttpcheckTLSCertRemaining struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        HttpcheckTLSCertRemainingConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.tls.cert_remaining metric with initial data.
@@ -507,20 +822,57 @@ func (m *metricHttpcheckTLSCertRemaining) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckTLSCertRemaining) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, httpTLSIssuerAttributeValue string, httpTLSCnAttributeValue string, httpTLSSanAttributeValue []any) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckTLSCertRemainingAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSIssuer) {
+		dp.Attributes().PutStr("http.tls.issuer", httpTLSIssuerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSCn) {
+		dp.Attributes().PutStr("http.tls.cn", httpTLSCnAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckTLSCertRemainingAttributeKeyHTTPTLSSan) {
+		dp.Attributes().PutEmptySlice("http.tls.san").FromRaw(httpTLSSanAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
-	dp.Attributes().PutStr("http.tls.issuer", httpTLSIssuerAttributeValue)
-	dp.Attributes().PutStr("http.tls.cn", httpTLSCnAttributeValue)
-	dp.Attributes().PutEmptySlice("http.tls.san").FromRaw(httpTLSSanAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -533,13 +885,18 @@ func (m *metricHttpcheckTLSCertRemaining) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckTLSCertRemaining) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckTLSCertRemaining(cfg MetricConfig) metricHttpcheckTLSCertRemaining {
+func newMetricHttpcheckTLSCertRemaining(cfg HttpcheckTLSCertRemainingConfig) metricHttpcheckTLSCertRemaining {
 	m := metricHttpcheckTLSCertRemaining{config: cfg}
 
 	if cfg.Enabled {
@@ -550,9 +907,10 @@ func newMetricHttpcheckTLSCertRemaining(cfg MetricConfig) metricHttpcheckTLSCert
 }
 
 type metricHttpcheckTLSHandshakeDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        HttpcheckTLSHandshakeDurationConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.tls.handshake.duration metric with initial data.
@@ -562,17 +920,48 @@ func (m *metricHttpcheckTLSHandshakeDuration) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckTLSHandshakeDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckTLSHandshakeDurationAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -585,13 +974,18 @@ func (m *metricHttpcheckTLSHandshakeDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckTLSHandshakeDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckTLSHandshakeDuration(cfg MetricConfig) metricHttpcheckTLSHandshakeDuration {
+func newMetricHttpcheckTLSHandshakeDuration(cfg HttpcheckTLSHandshakeDurationConfig) metricHttpcheckTLSHandshakeDuration {
 	m := metricHttpcheckTLSHandshakeDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -602,9 +996,10 @@ func newMetricHttpcheckTLSHandshakeDuration(cfg MetricConfig) metricHttpcheckTLS
 }
 
 type metricHttpcheckValidationFailed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        HttpcheckValidationFailedConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.validation.failed metric with initial data.
@@ -616,18 +1011,51 @@ func (m *metricHttpcheckValidationFailed) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckValidationFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, validationTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckValidationFailedAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckValidationFailedAttributeKeyValidationType) {
+		dp.Attributes().PutStr("validation.type", validationTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
-	dp.Attributes().PutStr("validation.type", validationTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -640,13 +1068,18 @@ func (m *metricHttpcheckValidationFailed) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckValidationFailed) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckValidationFailed(cfg MetricConfig) metricHttpcheckValidationFailed {
+func newMetricHttpcheckValidationFailed(cfg HttpcheckValidationFailedConfig) metricHttpcheckValidationFailed {
 	m := metricHttpcheckValidationFailed{config: cfg}
 
 	if cfg.Enabled {
@@ -657,9 +1090,10 @@ func newMetricHttpcheckValidationFailed(cfg MetricConfig) metricHttpcheckValidat
 }
 
 type metricHttpcheckValidationPassed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        HttpcheckValidationPassedConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills httpcheck.validation.passed metric with initial data.
@@ -671,18 +1105,51 @@ func (m *metricHttpcheckValidationPassed) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricHttpcheckValidationPassed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, validationTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckValidationPassedAttributeKeyHTTPURL) {
+		dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, HttpcheckValidationPassedAttributeKeyValidationType) {
+		dp.Attributes().PutStr("validation.type", validationTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
-	dp.Attributes().PutStr("validation.type", validationTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -695,13 +1162,18 @@ func (m *metricHttpcheckValidationPassed) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckValidationPassed) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckValidationPassed(cfg MetricConfig) metricHttpcheckValidationPassed {
+func newMetricHttpcheckValidationPassed(cfg HttpcheckValidationPassedConfig) metricHttpcheckValidationPassed {
 	m := metricHttpcheckValidationPassed{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -37,6 +38,11 @@ func TestMetricsBuilder(t *testing.T) {
 			resAttrsSet: testDataSetAll,
 		},
 		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
+		},
+		{
 			name:        "none_set",
 			metricsSet:  testDataSetNone,
 			resAttrsSet: testDataSetNone,
@@ -51,54 +57,119 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["HttpcheckClientConnectionDuration"] = mb.metricHttpcheckClientConnectionDuration.config.AggregationStrategy
+			aggMap["HttpcheckClientRequestDuration"] = mb.metricHttpcheckClientRequestDuration.config.AggregationStrategy
+			aggMap["HttpcheckDNSLookupDuration"] = mb.metricHttpcheckDNSLookupDuration.config.AggregationStrategy
+			aggMap["HttpcheckDuration"] = mb.metricHttpcheckDuration.config.AggregationStrategy
+			aggMap["HttpcheckError"] = mb.metricHttpcheckError.config.AggregationStrategy
+			aggMap["HttpcheckResponseDuration"] = mb.metricHttpcheckResponseDuration.config.AggregationStrategy
+			aggMap["HttpcheckResponseSize"] = mb.metricHttpcheckResponseSize.config.AggregationStrategy
+			aggMap["HttpcheckStatus"] = mb.metricHttpcheckStatus.config.AggregationStrategy
+			aggMap["HttpcheckTLSCertRemaining"] = mb.metricHttpcheckTLSCertRemaining.config.AggregationStrategy
+			aggMap["HttpcheckTLSHandshakeDuration"] = mb.metricHttpcheckTLSHandshakeDuration.config.AggregationStrategy
+			aggMap["HttpcheckValidationFailed"] = mb.metricHttpcheckValidationFailed.config.AggregationStrategy
+			aggMap["HttpcheckValidationPassed"] = mb.metricHttpcheckValidationPassed.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
 			allMetricsCount++
 			mb.RecordHttpcheckClientConnectionDurationDataPoint(ts, 1, "http.url-val", "network.transport-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckClientConnectionDurationDataPoint(ts, 3, "http.url-val-2", "network.transport-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckClientRequestDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckClientRequestDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckDNSLookupDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckDNSLookupDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordHttpcheckDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordHttpcheckErrorDataPoint(ts, 1, "http.url-val", "error.message-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckErrorDataPoint(ts, 3, "http.url-val-2", "error.message-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckResponseDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckResponseDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckResponseSizeDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckResponseSizeDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordHttpcheckStatusDataPoint(ts, 1, "http.url-val", 16, "http.method-val", "http.status_class-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckStatusDataPoint(ts, 3, "http.url-val-2", 17, "http.method-val-2", "http.status_class-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckTLSCertRemainingDataPoint(ts, 1, "http.url-val", "http.tls.issuer-val", "http.tls.cn-val", []any{"http.tls.san-item1", "http.tls.san-item2"})
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckTLSCertRemainingDataPoint(ts, 3, "http.url-val-2", "http.tls.issuer-val-2", "http.tls.cn-val-2", []any{"http.tls.san-item3", "http.tls.san-item4"})
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckTLSHandshakeDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckTLSHandshakeDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckValidationFailedDataPoint(ts, 1, "http.url-val", "validation.type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckValidationFailedDataPoint(ts, 3, "http.url-val-2", "validation.type-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckValidationPassedDataPoint(ts, 1, "http.url-val", "validation.type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckValidationPassedDataPoint(ts, 3, "http.url-val-2", "validation.type-val-2")
+			}
 
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricHttpcheckClientConnectionDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckClientRequestDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckDNSLookupDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckError.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckResponseDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckResponseSize.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckStatus.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckTLSCertRemaining.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckTLSHandshakeDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckValidationFailed.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckValidationPassed.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -126,223 +197,533 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "httpcheck.client.connection.duration":
-					assert.False(t, validatedMetrics["httpcheck.client.connection.duration"], "Found a duplicate in the metrics slice: httpcheck.client.connection.duration")
-					validatedMetrics["httpcheck.client.connection.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent establishing TCP connection to the endpoint.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("network.transport")
-					assert.True(t, ok)
-					assert.Equal(t, "network.transport-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.client.connection.duration"], "Found a duplicate in the metrics slice: httpcheck.client.connection.duration")
+						validatedMetrics["httpcheck.client.connection.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent establishing TCP connection to the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("network.transport")
+						assert.True(t, ok)
+						assert.Equal(t, "network.transport-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.client.connection.duration"], "Found a duplicate in the metrics slice: httpcheck.client.connection.duration")
+						validatedMetrics["httpcheck.client.connection.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent establishing TCP connection to the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.client.connection.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("network.transport")
+						assert.False(t, ok)
+					}
 				case "httpcheck.client.request.duration":
-					assert.False(t, validatedMetrics["httpcheck.client.request.duration"], "Found a duplicate in the metrics slice: httpcheck.client.request.duration")
-					validatedMetrics["httpcheck.client.request.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent sending the HTTP request to the endpoint.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.client.request.duration"], "Found a duplicate in the metrics slice: httpcheck.client.request.duration")
+						validatedMetrics["httpcheck.client.request.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent sending the HTTP request to the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.client.request.duration"], "Found a duplicate in the metrics slice: httpcheck.client.request.duration")
+						validatedMetrics["httpcheck.client.request.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent sending the HTTP request to the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.client.request.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.dns.lookup.duration":
-					assert.False(t, validatedMetrics["httpcheck.dns.lookup.duration"], "Found a duplicate in the metrics slice: httpcheck.dns.lookup.duration")
-					validatedMetrics["httpcheck.dns.lookup.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent performing DNS lookup for the endpoint.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.dns.lookup.duration"], "Found a duplicate in the metrics slice: httpcheck.dns.lookup.duration")
+						validatedMetrics["httpcheck.dns.lookup.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing DNS lookup for the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.dns.lookup.duration"], "Found a duplicate in the metrics slice: httpcheck.dns.lookup.duration")
+						validatedMetrics["httpcheck.dns.lookup.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing DNS lookup for the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.dns.lookup.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.duration":
-					assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
-					validatedMetrics["httpcheck.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the duration of the HTTP check.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
+						validatedMetrics["httpcheck.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the duration of the HTTP check.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
+						validatedMetrics["httpcheck.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the duration of the HTTP check.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.error":
-					assert.False(t, validatedMetrics["httpcheck.error"], "Found a duplicate in the metrics slice: httpcheck.error")
-					validatedMetrics["httpcheck.error"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Records errors occurring during HTTP check.", mi.Description())
-					assert.Equal(t, "{error}", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("error.message")
-					assert.True(t, ok)
-					assert.Equal(t, "error.message-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.error"], "Found a duplicate in the metrics slice: httpcheck.error")
+						validatedMetrics["httpcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during HTTP check.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.error"], "Found a duplicate in the metrics slice: httpcheck.error")
+						validatedMetrics["httpcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during HTTP check.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.error"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("error.message")
+						assert.False(t, ok)
+					}
 				case "httpcheck.response.duration":
-					assert.False(t, validatedMetrics["httpcheck.response.duration"], "Found a duplicate in the metrics slice: httpcheck.response.duration")
-					validatedMetrics["httpcheck.response.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent receiving the HTTP response from the endpoint.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.response.duration"], "Found a duplicate in the metrics slice: httpcheck.response.duration")
+						validatedMetrics["httpcheck.response.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent receiving the HTTP response from the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.response.duration"], "Found a duplicate in the metrics slice: httpcheck.response.duration")
+						validatedMetrics["httpcheck.response.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent receiving the HTTP response from the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.response.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.response.size":
-					assert.False(t, validatedMetrics["httpcheck.response.size"], "Found a duplicate in the metrics slice: httpcheck.response.size")
-					validatedMetrics["httpcheck.response.size"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Size of response body in bytes.", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.response.size"], "Found a duplicate in the metrics slice: httpcheck.response.size")
+						validatedMetrics["httpcheck.response.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of response body in bytes.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.response.size"], "Found a duplicate in the metrics slice: httpcheck.response.size")
+						validatedMetrics["httpcheck.response.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of response body in bytes.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.response.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.status":
-					assert.False(t, validatedMetrics["httpcheck.status"], "Found a duplicate in the metrics slice: httpcheck.status")
-					validatedMetrics["httpcheck.status"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "1 if the check resulted in status_code matching the status_class, otherwise 0.", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.status_code")
-					assert.True(t, ok)
-					assert.EqualValues(t, 16, attrVal.Int())
-					attrVal, ok = dp.Attributes().Get("http.method")
-					assert.True(t, ok)
-					assert.Equal(t, "http.method-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.status_class")
-					assert.True(t, ok)
-					assert.Equal(t, "http.status_class-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.status"], "Found a duplicate in the metrics slice: httpcheck.status")
+						validatedMetrics["httpcheck.status"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "1 if the check resulted in status_code matching the status_class, otherwise 0.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.status_code")
+						assert.True(t, ok)
+						assert.EqualValues(t, 16, attrVal.Int())
+						attrVal, ok = dp.Attributes().Get("http.method")
+						assert.True(t, ok)
+						assert.Equal(t, "http.method-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.status_class")
+						assert.True(t, ok)
+						assert.Equal(t, "http.status_class-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.status"], "Found a duplicate in the metrics slice: httpcheck.status")
+						validatedMetrics["httpcheck.status"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "1 if the check resulted in status_code matching the status_class, otherwise 0.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.status"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.status_code")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.method")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.status_class")
+						assert.False(t, ok)
+					}
 				case "httpcheck.tls.cert_remaining":
-					assert.False(t, validatedMetrics["httpcheck.tls.cert_remaining"], "Found a duplicate in the metrics slice: httpcheck.tls.cert_remaining")
-					validatedMetrics["httpcheck.tls.cert_remaining"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.tls.issuer")
-					assert.True(t, ok)
-					assert.Equal(t, "http.tls.issuer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.tls.cn")
-					assert.True(t, ok)
-					assert.Equal(t, "http.tls.cn-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.tls.san")
-					assert.True(t, ok)
-					assert.Equal(t, []any{"http.tls.san-item1", "http.tls.san-item2"}, attrVal.Slice().AsRaw())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.tls.cert_remaining"], "Found a duplicate in the metrics slice: httpcheck.tls.cert_remaining")
+						validatedMetrics["httpcheck.tls.cert_remaining"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.tls.cert_remaining"], "Found a duplicate in the metrics slice: httpcheck.tls.cert_remaining")
+						validatedMetrics["httpcheck.tls.cert_remaining"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.tls.cert_remaining"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.tls.issuer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.tls.cn")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.tls.san")
+						assert.False(t, ok)
+					}
 				case "httpcheck.tls.handshake.duration":
-					assert.False(t, validatedMetrics["httpcheck.tls.handshake.duration"], "Found a duplicate in the metrics slice: httpcheck.tls.handshake.duration")
-					validatedMetrics["httpcheck.tls.handshake.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent performing TLS handshake with the endpoint.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.tls.handshake.duration"], "Found a duplicate in the metrics slice: httpcheck.tls.handshake.duration")
+						validatedMetrics["httpcheck.tls.handshake.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing TLS handshake with the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.tls.handshake.duration"], "Found a duplicate in the metrics slice: httpcheck.tls.handshake.duration")
+						validatedMetrics["httpcheck.tls.handshake.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing TLS handshake with the endpoint.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.tls.handshake.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.validation.failed":
-					assert.False(t, validatedMetrics["httpcheck.validation.failed"], "Found a duplicate in the metrics slice: httpcheck.validation.failed")
-					validatedMetrics["httpcheck.validation.failed"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of response validations that failed.", mi.Description())
-					assert.Equal(t, "{validation}", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("validation.type")
-					assert.True(t, ok)
-					assert.Equal(t, "validation.type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.validation.failed"], "Found a duplicate in the metrics slice: httpcheck.validation.failed")
+						validatedMetrics["httpcheck.validation.failed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that failed.", mi.Description())
+						assert.Equal(t, "{validation}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.validation.failed"], "Found a duplicate in the metrics slice: httpcheck.validation.failed")
+						validatedMetrics["httpcheck.validation.failed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that failed.", mi.Description())
+						assert.Equal(t, "{validation}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.validation.failed"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("validation.type")
+						assert.False(t, ok)
+					}
 				case "httpcheck.validation.passed":
-					assert.False(t, validatedMetrics["httpcheck.validation.passed"], "Found a duplicate in the metrics slice: httpcheck.validation.passed")
-					validatedMetrics["httpcheck.validation.passed"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of response validations that passed.", mi.Description())
-					assert.Equal(t, "{validation}", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("validation.type")
-					assert.True(t, ok)
-					assert.Equal(t, "validation.type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.validation.passed"], "Found a duplicate in the metrics slice: httpcheck.validation.passed")
+						validatedMetrics["httpcheck.validation.passed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that passed.", mi.Description())
+						assert.Equal(t, "{validation}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.validation.passed"], "Found a duplicate in the metrics slice: httpcheck.validation.passed")
+						validatedMetrics["httpcheck.validation.passed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that passed.", mi.Description())
+						assert.Equal(t, "{validation}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.validation.passed"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("validation.type")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -3,51 +3,113 @@ all_set:
   metrics:
     httpcheck.client.connection.duration:
       enabled: true
+      attributes: ["http.url","network.transport"]
     httpcheck.client.request.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.dns.lookup.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.error:
       enabled: true
+      attributes: ["http.url","error.message"]
     httpcheck.response.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.response.size:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.status:
       enabled: true
+      attributes: ["http.url","http.status_code","http.method","http.status_class"]
     httpcheck.tls.cert_remaining:
       enabled: true
+      attributes: ["http.url","http.tls.issuer","http.tls.cn","http.tls.san"]
     httpcheck.tls.handshake.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.validation.failed:
       enabled: true
+      attributes: ["http.url","validation.type"]
     httpcheck.validation.passed:
       enabled: true
+      attributes: ["http.url","validation.type"]
+reaggregate_set:
+  metrics:
+    httpcheck.client.connection.duration:
+      enabled: true
+      attributes: []
+    httpcheck.client.request.duration:
+      enabled: true
+      attributes: []
+    httpcheck.dns.lookup.duration:
+      enabled: true
+      attributes: []
+    httpcheck.duration:
+      enabled: true
+      attributes: []
+    httpcheck.error:
+      enabled: true
+      attributes: []
+    httpcheck.response.duration:
+      enabled: true
+      attributes: []
+    httpcheck.response.size:
+      enabled: true
+      attributes: []
+    httpcheck.status:
+      enabled: true
+      attributes: []
+    httpcheck.tls.cert_remaining:
+      enabled: true
+      attributes: []
+    httpcheck.tls.handshake.duration:
+      enabled: true
+      attributes: []
+    httpcheck.validation.failed:
+      enabled: true
+      attributes: []
+    httpcheck.validation.passed:
+      enabled: true
+      attributes: []
 none_set:
   metrics:
     httpcheck.client.connection.duration:
       enabled: false
+      attributes: ["http.url","network.transport"]
     httpcheck.client.request.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.dns.lookup.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.error:
       enabled: false
+      attributes: ["http.url","error.message"]
     httpcheck.response.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.response.size:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.status:
       enabled: false
+      attributes: ["http.url","http.status_code","http.method","http.status_class"]
     httpcheck.tls.cert_remaining:
       enabled: false
+      attributes: ["http.url","http.tls.issuer","http.tls.cn","http.tls.san"]
     httpcheck.tls.handshake.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.validation.failed:
       enabled: false
+      attributes: ["http.url","validation.type"]
     httpcheck.validation.passed:
       enabled: false
+      attributes: ["http.url","validation.type"]

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -15,39 +15,50 @@ status:
     emeritus: [codeboten]
     seeking_new: true
 
+reaggregation_enabled: true
 resource_attributes:
 
 attributes:
   error.message:
     description: Error message recorded during check
     type: string
+    requirement_level: opt_in
   http.method:
     description: HTTP request method
     type: string
+    requirement_level: recommended
   http.status_class:
     description: HTTP response status class
     type: string
+    requirement_level: recommended
   http.status_code:
     description: HTTP response status code
     type: int
+    requirement_level: recommended
   http.tls.cn:
     description: The commonName in the subject of the certificate.
     type: string
+    requirement_level: opt_in
   http.tls.issuer:
     description: The entity that issued the certificate.
     type: string
+    requirement_level: opt_in
   http.tls.san:
     description: The Subject Alternative Name of the certificate.
     type: slice
+    requirement_level: opt_in
   http.url:
     description: Full HTTP request URL.
     type: string
+    requirement_level: recommended
   network.transport:
     description: OSI transport layer or inter-process communication method.
     type: string
+    requirement_level: recommended
   validation.type:
     description: Type of validation performed (contains, json_path, size, regex)
     type: string
+    requirement_level: opt_in
 
 metrics:
   httpcheck.client.connection.duration:

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
@@ -19,9 +19,6 @@ resourceMetrics:
               dataPoints:
                 - asInt: "1"
                   attributes:
-                    - key: error.message
-                      value:
-                        stringValue: 'Get "http://invalid-endpoint": dial tcp: lookup invalid-endpoint: no such host'
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint


### PR DESCRIPTION
#### Description
Enables re-aggregation for the HTTP Check Receiver by classifying attributes with `requirement_level` and setting `reaggregation_enabled: true`. Part of the broader initiative to enable re-aggregation across receivers.

Attribute classifications:
opt_in — aggregating across these attributes produces meaningless results:

- `error.message` — high cardinality; each unique error string represents a distinct failure mode, summing across them loses diagnostic signal
- `http.tls.cn`, `http.tls.issuer`, `http.tls.san` — certificate-specific identifiers; aggregating across different certificates is not operationally meaningful
- `validation.type` — different validation types (contains, json_path, size, regex) represent fundamentally different checks and should not be aggregated together

recommended — totals remain operationally meaningful:

- `http.url`, `http.method`, `http.status_class`, `http.status_code`, `network.transport`

Note: `http.status_code` uses custom conditional inclusion in the scraper — present only when the status matches (value=1), absent otherwise. This behavior is preserved.

#### Link to tracking issue
Fixes #46358

Part of #45396

#### Testing
Ran make generate and make test in receiver/httpcheckreceiver. All 71 tests pass. Updated testdata/expected_metrics/`invalid_endpoint.yaml` to reflect that error.message is no longer emitted by default.