### PR TITLE
pkg/ottl: introduce ValueType enum for OTTL expression typing

### DIFF
--- a/.chloggen/unreleased/add-value-type.yaml
+++ b/.chloggen/unreleased/add-value-type.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: pkg/ottl
+note: "Introduce ValueType enum to support future OTTL type system improvements."
+issues: [45365]

--- a/pkg/ottl/config.schema.yaml
+++ b/pkg/ottl/config.schema.yaml
@@ -18,3 +18,6 @@ $defs:
   type_error:
     description: TypeError represents that a value was not an expected type.
     type: string
+  value_type:
+    description: ValueType represents the compile-time type of an OTTL expression. This enum provides foundational infrastructure for future improvements to the OTTL type system and expression validation.
+    type: integer

--- a/pkg/ottl/types.go
+++ b/pkg/ottl/types.go
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // SPDX-License-Identifier: Apache-2.0
 
-package ottl
+package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 
 // ValueType represents the compile-time type of an OTTL expression.
 // This enum provides foundational infrastructure for future improvements

--- a/pkg/ottl/types.go
+++ b/pkg/ottl/types.go
@@ -1,0 +1,14 @@
+package ottl
+
+// ValueType represents the compile-time type of an OTTL expression.
+type ValueType int
+
+const (
+	TypeUnknown ValueType = iota
+	TypeString
+	TypeInt
+	TypeFloat
+	TypeBool
+	TypeMap
+	TypeSlice
+)

--- a/pkg/ottl/types.go
+++ b/pkg/ottl/types.go
@@ -1,14 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: Apache-2.0
+
 package ottl
 
 // ValueType represents the compile-time type of an OTTL expression.
+// This enum provides foundational infrastructure for future improvements
+// to the OTTL type system and expression validation.
 type ValueType int
 
 const (
+	// TypeUnknown indicates that the type of the expression is not known.
 	TypeUnknown ValueType = iota
+
+	// TypeString represents string values.
 	TypeString
+
+	// TypeInt represents integer values.
 	TypeInt
+
+	// TypeFloat represents floating point values.
 	TypeFloat
+
+	// TypeBool represents boolean values.
 	TypeBool
+
+	// TypeMap represents map-like values.
 	TypeMap
+
+	// TypeSlice represents slice or list values.
 	TypeSlice
 )


### PR DESCRIPTION
# PR Description

## Description

Introduce a `ValueType` enum in `pkg/ottl` to represent compile-time
types for OTTL expressions.\
This change provides groundwork for future improvements to the OTTL type
system and expression validation.

## Link to tracking issue

Fixes #45365

## Testing

-   Ran `go test ./...` in `pkg/ottl`
-   Verified that all existing tests pass with no failures
-   Confirmed the change introduces no runtime behavior changes

## Documentation

No user-facing documentation changes are required.\
This change only introduces internal infrastructure for future OTTL
typing improvements.
