### PR TITLE
[oidcauthextension] Log failed authentication attempts with client IP

### DIFF
--- a/.chloggen/oidc-auth-logs.yaml
+++ b/.chloggen/oidc-auth-logs.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: oidcauthextension
+note: Add logging for failed authentication attempts with client IP and username.
+issues: [46482]

--- a/.chloggen/oidc-auth-logs.yaml
+++ b/.chloggen/oidc-auth-logs.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
-component: oidcauthextension
+component: extension/oidc
 note: Add logging for failed authentication attempts with client IP and username.
 issues: [46482]

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -156,6 +156,12 @@ func (e *oidcExtension) Shutdown(context.Context) error {
 
 // authenticate checks whether the given context contains valid auth data. Successfully authenticated calls will always return a nil error and a context with the auth data.
 func (e *oidcExtension) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
+	clInfo := client.FromContext(ctx)
+	clientIP := "unknown"
+	if clInfo.Addr != nil {
+		clientIP = clInfo.Addr.String()
+	}
+
 	var authHeaders []string
 	for k, v := range headers {
 		if strings.EqualFold(k, e.cfg.Attribute) {
@@ -164,27 +170,49 @@ func (e *oidcExtension) Authenticate(ctx context.Context, headers map[string][]s
 		}
 	}
 	if len(authHeaders) == 0 {
+		e.logger.Warn("Authentication failed: missing or empty header",
+			zap.String("client_ip", clientIP),
+			zap.Error(errNotAuthenticated),
+		)
 		return ctx, errNotAuthenticated
 	}
 
 	// we only use the first header, if multiple values exist
 	parts := strings.Split(authHeaders[0], " ")
 	if len(parts) != 2 {
+		e.logger.Warn("Authentication failed: invalid header format",
+			zap.String("client_ip", clientIP),
+			zap.Error(errInvalidAuthenticationHeaderFormat),
+		)
 		return ctx, errInvalidAuthenticationHeaderFormat
 	}
 
 	raw := parts[1]
 	unverifiedIssuer, err := getIssuerFromUnverifiedJWT(raw)
 	if err != nil {
+		e.logger.Warn("Authentication failed: could not parse issuer from token",
+			zap.String("client_ip", clientIP),
+			zap.Error(err),
+		)
 		return ctx, fmt.Errorf("failed to parse the token: %w", err)
 	}
 	pc, err := e.resolveProvider(unverifiedIssuer)
 	if err != nil {
+		e.logger.Warn("Authentication failed: could not resolve provider",
+			zap.String("client_ip", clientIP),
+			zap.String("issuer", unverifiedIssuer),
+			zap.Error(err),
+		)
 		return ctx, fmt.Errorf("failed to resolve OIDC provider for the issuer %q: %w", unverifiedIssuer, err)
 	}
 
 	idToken, err := pc.Verify(ctx, raw)
 	if err != nil {
+		e.logger.Warn("Authentication failed: token verification failed",
+			zap.String("client_ip", clientIP),
+			zap.String("issuer", unverifiedIssuer),
+			zap.Error(err),
+		)
 		return ctx, fmt.Errorf("failed to verify token: %w", err)
 	}
 
@@ -196,15 +224,28 @@ func (e *oidcExtension) Authenticate(ctx context.Context, headers map[string][]s
 		// to read the claims. It could fail if we were using a custom struct. Instead of
 		// swallowing the error, it's better to make this future-proof, in case the underlying
 		// code changes
+		e.logger.Warn("Authentication failed: could not obtain claims",
+			zap.String("client_ip", clientIP),
+			zap.Error(err),
+		)
 		return ctx, errFailedToObtainClaimsFromToken
 	}
 
 	subject, err := getSubjectFromClaims(claims, pc.providerCfg.UsernameClaim, idToken.Subject)
 	if err != nil {
+		e.logger.Warn("Authentication failed: could not get subject from claims",
+			zap.String("client_ip", clientIP),
+			zap.Error(err),
+		)
 		return ctx, fmt.Errorf("failed to get subject from claims in the token: %w", err)
 	}
 	membership, err := getGroupsFromClaims(claims, pc.providerCfg.GroupsClaim)
 	if err != nil {
+		e.logger.Warn("Authentication failed: could not get groups from claims",
+			zap.String("client_ip", clientIP),
+			zap.String("subject", subject),
+			zap.Error(err),
+		)
 		return ctx, fmt.Errorf("failed to get groups from claims in the token: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #46482 . Adds structured WARN logging to the Authenticate function. It now captures the client_ip from the context and logs it with every authentication failure to aid in security auditing. It also logs the subject (username) when token validation succeeds but authorization (group check) fails.