### PR TITLE
[chore][ci] use single source of truth for check-collector-module-version

### DIFF
--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -8,9 +8,9 @@
 # as a dependency.
 #
 
-source ./internal/buildscripts/modules
-
 set -eu -o pipefail
+
+CORE_REPO_RAW_BASE_URL="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector"
 
 mod_files=$(find . -type f -name "go.mod")
 
@@ -34,6 +34,62 @@ get_collector_version() {
    fi
 }
 
+get_collector_release_tag_candidates() {
+   collector_mod_version="$1"
+   # Strip pseudo-version suffix, if present.
+   release_tag="${collector_mod_version%%-*}"
+   echo "$release_tag"
+
+   # For -0 pseudo versions, also try the previous patch tag.
+   # Example: v0.146.2-0.20260219223409-abcdef012345 -> v0.146.1
+   if [[ "$collector_mod_version" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-0\.[0-9]{14}-[0-9a-f]+$ ]]; then
+      patch="${BASH_REMATCH[3]}"
+      if (( patch > 0 )); then
+         echo "v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((patch - 1))"
+      fi
+   fi
+}
+
+fetch_collector_versions_yaml() {
+   collector_mod_version="$1"
+   versions_file_path="$2"
+
+   while IFS= read -r release_tag; do
+      versions_url="${CORE_REPO_RAW_BASE_URL}/${release_tag}/versions.yaml"
+      if curl --fail --silent --show-error --location --retry 3 --retry-delay 1 "$versions_url" --output "$versions_file_path"; then
+         echo "$release_tag"
+         return 0
+      fi
+   done < <(get_collector_release_tag_candidates "$collector_mod_version")
+
+   echo "Error: failed to fetch opentelemetry-collector/versions.yaml for $collector_mod_version" >&2
+   return 1
+}
+
+get_module_set_modules() {
+   module_set="$1"
+   versions_file_path="$2"
+
+   awk -v module_set="$module_set" '
+      /^  [^[:space:]][^:]*:/ {
+         in_target_set = ($1 == module_set ":")
+         in_modules = 0
+      }
+      in_target_set && $1 == "modules:" {
+         in_modules = 1
+         next
+      }
+      in_target_set && in_modules && /^      - / {
+         sub(/^      - /, "")
+         print
+         next
+      }
+      in_target_set && in_modules && !/^      - / {
+         in_modules = 0
+      }
+   ' "$versions_file_path"
+}
+
 # Compare the collector main core version against all the collector component
 # modules to verify that they are using this version as its dependency
 check_collector_versions_correct() {
@@ -43,30 +99,35 @@ check_collector_versions_correct() {
 
    # Loop through all the module files, checking the collector version
    if [ "${GNU_SED_INSTALLED}" = false ]; then
-      sed -i '' "s|$collector_module [^ ]*|$collector_module $collector_mod_version|g" $mod_files
+      sed -i '' "s|$collector_module v[^ ]*|$collector_module $collector_mod_version|g" $mod_files
    else
-      sed -i'' "s|$collector_module [^ ]*|$collector_module $collector_mod_version|g" $mod_files
+      sed -i'' "s|$collector_module v[^ ]*|$collector_module $collector_mod_version|g" $mod_files
    fi
 }
 
 MAIN_MOD_FILE="./cmd/otelcontribcol/go.mod"
 
-
 BETA_MODULE="go.opentelemetry.io/collector"
 # Note space at end of string. This is so it filters for the exact string
 # only and does not return string which contains this string as a substring.
 BETA_MOD_VERSION=$(get_collector_version "$BETA_MODULE " "$MAIN_MOD_FILE")
-check_collector_versions_correct "$BETA_MODULE" "$BETA_MOD_VERSION"
-for mod in "${beta_modules[@]}"; do
-   check_collector_versions_correct "$mod" "$BETA_MOD_VERSION"
-done
 
-# Check stable modules, none currently exist, uncomment when pdata is 1.0.0
+collector_versions_yaml=$(mktemp)
+trap 'rm -f "$collector_versions_yaml"' EXIT
+selected_release_tag=$(fetch_collector_versions_yaml "$BETA_MOD_VERSION" "$collector_versions_yaml")
+echo "Using module list from opentelemetry-collector $selected_release_tag"
+
+check_collector_versions_correct "$BETA_MODULE" "$BETA_MOD_VERSION"
+while IFS= read -r mod; do
+   check_collector_versions_correct "$mod" "$BETA_MOD_VERSION"
+done < <(get_module_set_modules "beta" "$collector_versions_yaml")
+
+# Check stable modules using the stable module-set from collector versions.yaml.
 STABLE_MODULE="go.opentelemetry.io/collector/pdata"
 STABLE_MOD_VERSION=$(get_collector_version "$STABLE_MODULE" "$MAIN_MOD_FILE")
 check_collector_versions_correct "$STABLE_MODULE" "$STABLE_MOD_VERSION"
-for mod in "${stable_modules[@]}"; do
+while IFS= read -r mod; do
    check_collector_versions_correct "$mod" "$STABLE_MOD_VERSION"
-done
+done < <(get_module_set_modules "stable" "$collector_versions_yaml")
 
 git diff --exit-code


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This pr updates check-collector-module-version to use the `versions.yaml` from the opentelemetry-collector release tag corresponding to the core version currently used in contrib (handling pseudo-versions), instead of [`internal/buildscripts/modules`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/buildscripts/modules) as the source of truth.
This reduces the need of having to manually maintain this file.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38396

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Validated with bash -n and shellcheck.
