### PR TITLE
[chore] docs: donating-components.md metadata.yaml example lists incomplete class values

### DIFF
--- a/docs/new-components.md
+++ b/docs/new-components.md
@@ -158,7 +158,7 @@ Here is a minimal representation:
 type: <name of your component, such as apache, http, haproxy, postgresql>
 
 status:
-  class: <class of component, one of cmd, connector, exporter, extension, processor or receiver>
+  class: <class of component, one of cmd, connector, converter, exporter, extension, pkg, processor, provider, receiver, scraper> 
   stability:
     development: [<pick the signals supported: logs, metrics, traces. For extension, use "extension">]
   codeowners:


### PR DESCRIPTION
## Description

The `metadata.yaml` example in `docs/donating-components.md` lists incomplete 
valid values for the `class` field:

**Before:**
```yaml
class: <class of component, one of cmd, connector, exporter, extension, processor or receiver>
```

**After:**
```yaml
class: <class of component, one of cmd, connector, converter, exporter, extension, pkg, processor, provider, receiver, scraper>
```

## Motivation

The comment was missing `pkg`, `scraper`, `converter`, and `provider` as valid 
class values, which are all defined in the 
[metadata-schema.yaml](https://github.com/open-telemetry/opentelemetry-collector/blob/main/cmd/mdatagen/metadata-schema.yaml).

This is misleading for contributors donating a scraper (e.g. like those under 
`scraper/zookeeperscraper`) or a pkg component, who would not find their 
component class listed in the donation guide.

## Type of change

- [x] Chore (docs fix, no code change)