### PR TITLE
[chore][exporter/rabbitmq] Pin RabbtiMQ container tag for integration tests

### DIFF
--- a/exporter/rabbitmqexporter/integration_test.go
+++ b/exporter/rabbitmqexporter/integration_test.go
@@ -31,14 +31,13 @@ const (
 )
 
 func TestExportWithNetworkIssueRecovery(t *testing.T) {
-	t.Skip("failed to create container: content digest sha256:14eb391011e8fcbceb99d309a07cc95171d2a338b57e912a18b3467454626020: not found")
 	testCase := []struct {
 		name  string
 		image string
 	}{
 		{
-			name:  "test rabbitmq latest",
-			image: "rabbitmq:latest",
+			name:  "test rabbitmq 4.2.4",
+			image: "rabbitmq:4.2",
 		},
 	}
 

--- a/exporter/rabbitmqexporter/integration_test.go
+++ b/exporter/rabbitmqexporter/integration_test.go
@@ -36,7 +36,7 @@ func TestExportWithNetworkIssueRecovery(t *testing.T) {
 		image string
 	}{
 		{
-			name:  "test rabbitmq 4.2.4",
+			name:  "test rabbitmq 4.2",
 			image: "rabbitmq:4.2",
 		},
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The error found can happen when the layer cache holds a manifest for an old latest image whose layers have since been garbage-collected by the upstream repo. Pinning to `rabbitmq:4.2.4` makes the image reference more stable and reduces the possibility of cache/registry drift.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46083