### PR TITLE
[receiver/k8s_cluster] Start adding entity references to the resources

### DIFF
--- a/.chloggen/k8scluster-entities-builder.yaml
+++ b/.chloggen/k8scluster-entities-builder.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/k8s_cluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Emit entity references as part of metrics resources.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41080]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/k8sclusterreceiver/documentation.md
+++ b/receiver/k8sclusterreceiver/documentation.md
@@ -690,7 +690,6 @@ A Kubernetes service
 - `k8s.service.name`
 - `k8s.service.type`
 - `k8s.service.publish_not_ready_addresses`
-- `k8s.service.traffic_distribution`
 
 ### k8s.hpa
 

--- a/receiver/k8sclusterreceiver/internal/clusterresourcequota/clusterresourcequotas.go
+++ b/receiver/k8sclusterreceiver/internal/clusterresourcequota/clusterresourcequotas.go
@@ -15,32 +15,33 @@ import (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, crq *quotav1.ClusterResourceQuota, ts pcommon.Timestamp) {
+	e := metadata.NewOpenshiftClusterquotaEntity(string(crq.UID))
+	e.SetOpenshiftClusterquotaName(crq.Name)
+	eb := mb.ForOpenshiftClusterquota(e)
+
 	for k, v := range crq.Status.Total.Hard {
 		val := extractValue(k, v)
-		mb.RecordOpenshiftClusterquotaLimitDataPoint(ts, val, string(k)) //nolint:staticcheck
+		eb.RecordOpenshiftClusterquotaLimitDataPoint(ts, val, string(k))
 	}
 
 	for k, v := range crq.Status.Total.Used {
 		val := extractValue(k, v)
-		mb.RecordOpenshiftClusterquotaUsedDataPoint(ts, val, string(k)) //nolint:staticcheck
+		eb.RecordOpenshiftClusterquotaUsedDataPoint(ts, val, string(k))
 	}
 
 	for _, ns := range crq.Status.Namespaces {
 		for k, v := range ns.Status.Hard {
 			val := extractValue(k, v)
-			mb.RecordOpenshiftAppliedclusterquotaLimitDataPoint(ts, val, ns.Namespace, string(k)) //nolint:staticcheck
+			eb.RecordOpenshiftAppliedclusterquotaLimitDataPoint(ts, val, ns.Namespace, string(k))
 		}
 
 		for k, v := range ns.Status.Used {
 			val := extractValue(k, v)
-			mb.RecordOpenshiftAppliedclusterquotaUsedDataPoint(ts, val, ns.Namespace, string(k)) //nolint:staticcheck
+			eb.RecordOpenshiftAppliedclusterquotaUsedDataPoint(ts, val, ns.Namespace, string(k))
 		}
 	}
 
-	rb := mb.NewResourceBuilder()
-	rb.SetOpenshiftClusterquotaName(crq.Name)
-	rb.SetOpenshiftClusterquotaUID(string(crq.UID))
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 func extractValue(k v1.ResourceName, v resource.Quantity) int64 {

--- a/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
@@ -7,6 +7,12 @@ resourceMetrics:
         - key: openshift.clusterquota.uid
           value:
             stringValue: test-clusterquota-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - openshift.clusterquota.name
+          idKeys:
+            - openshift.clusterquota.uid
+          type: openshift.clusterquota
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/container/containers.go
+++ b/receiver/k8sclusterreceiver/internal/container/containers.go
@@ -47,17 +47,49 @@ var allContainerStatusReasons = []metadata.AttributeK8sContainerStatusReason{
 // RecordSpecMetrics metricizes values from the container spec.
 // This includes values like resource requests and limits.
 func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1.Container, pod *corev1.Pod, ts pcommon.Timestamp) {
+	var cs *corev1.ContainerStatus
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == c.Name {
+			cs = &pod.Status.ContainerStatuses[i]
+			break
+		}
+	}
+
+	var containerID string
+	if cs != nil {
+		containerID = cs.ContainerID
+	}
+	e := metadata.NewK8sContainerEntity(stripContainerID(containerID))
+	e.SetK8sContainerName(c.Name)
+	if cs != nil && cs.LastTerminationState.Terminated != nil {
+		e.SetK8sContainerStatusLastTerminatedReason(cs.LastTerminationState.Terminated.Reason)
+	}
+	image, err := docker.ParseImageName(cs.Image)
+	if err != nil {
+		docker.LogParseError(err, cs.Image, logger)
+	} else {
+		e.SetContainerImageName(image.Repository)
+		e.SetContainerImageTag(image.Tag)
+	}
+
+	e.SetK8sPodName(pod.Name)
+	e.SetK8sPodUID(string(pod.UID))
+	e.SetK8sNamespaceName(pod.Namespace)
+	e.SetK8sNodeName(pod.Spec.NodeName)
+
+	eb := mb.ForK8sContainer(e)
+
 	for k, r := range c.Resources.Requests {
 		//exhaustive:ignore
 		switch k {
 		case corev1.ResourceCPU:
-			mb.RecordK8sContainerCPURequestDataPoint(ts, float64(r.MilliValue())/1000.0) //nolint:staticcheck
+			eb.RecordK8sContainerCPURequestDataPoint(ts, float64(r.MilliValue())/1000.0)
 		case corev1.ResourceMemory:
-			mb.RecordK8sContainerMemoryRequestDataPoint(ts, r.Value()) //nolint:staticcheck
+			eb.RecordK8sContainerMemoryRequestDataPoint(ts, r.Value())
 		case corev1.ResourceStorage:
-			mb.RecordK8sContainerStorageRequestDataPoint(ts, r.Value()) //nolint:staticcheck
+			eb.RecordK8sContainerStorageRequestDataPoint(ts, r.Value())
 		case corev1.ResourceEphemeralStorage:
-			mb.RecordK8sContainerEphemeralstorageRequestDataPoint(ts, r.Value()) //nolint:staticcheck
+			eb.RecordK8sContainerEphemeralstorageRequestDataPoint(ts, r.Value())
 		default:
 			logger.Debug("unsupported request type", zap.Any("type", k))
 		}
@@ -66,46 +98,34 @@ func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1
 		//exhaustive:ignore
 		switch k {
 		case corev1.ResourceCPU:
-			mb.RecordK8sContainerCPULimitDataPoint(ts, float64(l.MilliValue())/1000.0) //nolint:staticcheck
+			eb.RecordK8sContainerCPULimitDataPoint(ts, float64(l.MilliValue())/1000.0)
 		case corev1.ResourceMemory:
-			mb.RecordK8sContainerMemoryLimitDataPoint(ts, l.Value()) //nolint:staticcheck
+			eb.RecordK8sContainerMemoryLimitDataPoint(ts, l.Value())
 		case corev1.ResourceStorage:
-			mb.RecordK8sContainerStorageLimitDataPoint(ts, l.Value()) //nolint:staticcheck
+			eb.RecordK8sContainerStorageLimitDataPoint(ts, l.Value())
 		case corev1.ResourceEphemeralStorage:
-			mb.RecordK8sContainerEphemeralstorageLimitDataPoint(ts, l.Value()) //nolint:staticcheck
+			eb.RecordK8sContainerEphemeralstorageLimitDataPoint(ts, l.Value())
 		default:
 			logger.Debug("unsupported request type", zap.Any("type", k))
 		}
 	}
 
-	rb := mb.NewResourceBuilder()
-	var containerID string
-	var imageStr string
-	for i := range pod.Status.ContainerStatuses {
-		cs := pod.Status.ContainerStatuses[i]
-		if cs.Name != c.Name {
-			continue
-		}
-		containerID = cs.ContainerID
-		imageStr = cs.Image
-		mb.RecordK8sContainerRestartsDataPoint(ts, int64(cs.RestartCount)) //nolint:staticcheck
-		mb.RecordK8sContainerReadyDataPoint(ts, boolToInt64(cs.Ready))     //nolint:staticcheck
-		if cs.LastTerminationState.Terminated != nil {
-			rb.SetK8sContainerStatusLastTerminatedReason(cs.LastTerminationState.Terminated.Reason)
-		}
+	if cs != nil {
+		eb.RecordK8sContainerRestartsDataPoint(ts, int64(cs.RestartCount))
+		eb.RecordK8sContainerReadyDataPoint(ts, boolToInt64(cs.Ready))
 		switch {
 		case cs.State.Running != nil:
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateRunning)    //nolint:staticcheck
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)    //nolint:staticcheck
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated) //nolint:staticcheck
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateRunning)
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated)
 		case cs.State.Terminated != nil:
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)    //nolint:staticcheck
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)    //nolint:staticcheck
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateTerminated) //nolint:staticcheck
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateTerminated)
 		case cs.State.Waiting != nil:
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)    //nolint:staticcheck
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateWaiting)    //nolint:staticcheck
-			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated) //nolint:staticcheck
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateWaiting)
+			eb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated)
 		}
 
 		// Record k8s.container.status.reason metric: for each known reason emit 1 for the current one, 0 otherwise.
@@ -124,25 +144,11 @@ func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1
 			if reason != "" && reason == attrVal.String() {
 				val = 1
 			}
-			mb.RecordK8sContainerStatusReasonDataPoint(ts, val, attrVal) //nolint:staticcheck
+			eb.RecordK8sContainerStatusReasonDataPoint(ts, val, attrVal)
 		}
-		break
 	}
 
-	rb.SetK8sPodUID(string(pod.UID))
-	rb.SetK8sPodName(pod.Name)
-	rb.SetK8sNodeName(pod.Spec.NodeName)
-	rb.SetK8sNamespaceName(pod.Namespace)
-	rb.SetContainerID(stripContainerID(containerID))
-	rb.SetK8sContainerName(c.Name)
-	image, err := docker.ParseImageName(imageStr)
-	if err != nil {
-		docker.LogParseError(err, imageStr, logger)
-	} else {
-		rb.SetContainerImageName(image.Repository)
-		rb.SetContainerImageTag(image.Tag)
-	}
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 func GetMetadata(pod *corev1.Pod, cs corev1.ContainerStatus, logger *zap.Logger) *metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/cronjob/cronjobs.go
+++ b/receiver/k8sclusterreceiver/internal/cronjob/cronjobs.go
@@ -19,13 +19,12 @@ const (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, cj *batchv1.CronJob, ts pcommon.Timestamp) {
-	mb.RecordK8sCronjobActiveJobsDataPoint(ts, int64(len(cj.Status.Active))) //nolint:staticcheck
-
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceName(cj.Namespace)
-	rb.SetK8sCronjobUID(string(cj.UID))
-	rb.SetK8sCronjobName(cj.Name)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sCronjobEntity(string(cj.UID))
+	e.SetK8sCronjobName(cj.Name)
+	e.SetK8sNamespaceName(cj.Namespace)
+	eb := mb.ForK8sCronjob(e)
+	eb.RecordK8sCronjobActiveJobsDataPoint(ts, int64(len(cj.Status.Active)))
+	eb.Emit()
 }
 
 func GetMetadata(cj *batchv1.CronJob) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.cronjob.uid
           value:
             stringValue: test-cronjob-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.cronjob.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.cronjob.uid
+          type: k8s.cronjob
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.cronjob.name
-            - k8s.namespace.name
           idKeys:
             - k8s.cronjob.uid
           type: k8s.cronjob

--- a/receiver/k8sclusterreceiver/internal/daemonset/daemonsets.go
+++ b/receiver/k8sclusterreceiver/internal/daemonset/daemonsets.go
@@ -27,16 +27,15 @@ func Transform(ds *appsv1.DaemonSet) *appsv1.DaemonSet {
 }
 
 func RecordMetrics(mb *metadata.MetricsBuilder, ds *appsv1.DaemonSet, ts pcommon.Timestamp) {
-	mb.RecordK8sDaemonsetCurrentScheduledNodesDataPoint(ts, int64(ds.Status.CurrentNumberScheduled)) //nolint:staticcheck
-	mb.RecordK8sDaemonsetDesiredScheduledNodesDataPoint(ts, int64(ds.Status.DesiredNumberScheduled)) //nolint:staticcheck
-	mb.RecordK8sDaemonsetMisscheduledNodesDataPoint(ts, int64(ds.Status.NumberMisscheduled))         //nolint:staticcheck
-	mb.RecordK8sDaemonsetReadyNodesDataPoint(ts, int64(ds.Status.NumberReady))                       //nolint:staticcheck
-
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceName(ds.Namespace)
-	rb.SetK8sDaemonsetName(ds.Name)
-	rb.SetK8sDaemonsetUID(string(ds.UID))
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sDaemonsetEntity(string(ds.UID))
+	e.SetK8sDaemonsetName(ds.Name)
+	e.SetK8sNamespaceName(ds.Namespace)
+	eb := mb.ForK8sDaemonset(e)
+	eb.RecordK8sDaemonsetCurrentScheduledNodesDataPoint(ts, int64(ds.Status.CurrentNumberScheduled))
+	eb.RecordK8sDaemonsetDesiredScheduledNodesDataPoint(ts, int64(ds.Status.DesiredNumberScheduled))
+	eb.RecordK8sDaemonsetMisscheduledNodesDataPoint(ts, int64(ds.Status.NumberMisscheduled))
+	eb.RecordK8sDaemonsetReadyNodesDataPoint(ts, int64(ds.Status.NumberReady))
+	eb.Emit()
 }
 
 func GetMetadata(ds *appsv1.DaemonSet) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/daemonset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/daemonset/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.daemonset.uid
           value:
             stringValue: test-daemonset-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.daemonset.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.daemonset.uid
+          type: k8s.daemonset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/daemonset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/daemonset/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.daemonset.name
-            - k8s.namespace.name
           idKeys:
             - k8s.daemonset.uid
           type: k8s.daemonset

--- a/receiver/k8sclusterreceiver/internal/deployment/deployments.go
+++ b/receiver/k8sclusterreceiver/internal/deployment/deployments.go
@@ -28,13 +28,13 @@ func Transform(deployment *appsv1.Deployment) *appsv1.Deployment {
 }
 
 func RecordMetrics(mb *metadata.MetricsBuilder, dep *appsv1.Deployment, ts pcommon.Timestamp) {
-	mb.RecordK8sDeploymentDesiredDataPoint(ts, int64(*dep.Spec.Replicas))             //nolint:staticcheck
-	mb.RecordK8sDeploymentAvailableDataPoint(ts, int64(dep.Status.AvailableReplicas)) //nolint:staticcheck
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sDeploymentName(dep.Name)
-	rb.SetK8sDeploymentUID(string(dep.UID))
-	rb.SetK8sNamespaceName(dep.Namespace)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sDeploymentEntity(string(dep.UID))
+	e.SetK8sDeploymentName(dep.Name)
+	e.SetK8sNamespaceName(dep.Namespace)
+	eb := mb.ForK8sDeployment(e)
+	eb.RecordK8sDeploymentDesiredDataPoint(ts, int64(*dep.Spec.Replicas))
+	eb.RecordK8sDeploymentAvailableDataPoint(ts, int64(dep.Status.AvailableReplicas))
+	eb.Emit()
 }
 
 func GetMetadata(dep *appsv1.Deployment) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: test-namespace
+      entityRefs:
+        - descriptionKeys:
+            - k8s.deployment.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.deployment.uid
+          type: k8s.deployment
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.deployment.name
-            - k8s.namespace.name
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment

--- a/receiver/k8sclusterreceiver/internal/hpa/hpa.go
+++ b/receiver/k8sclusterreceiver/internal/hpa/hpa.go
@@ -12,18 +12,18 @@ import (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, hpa *autoscalingv2.HorizontalPodAutoscaler, ts pcommon.Timestamp) {
-	mb.RecordK8sHpaMaxReplicasDataPoint(ts, int64(hpa.Spec.MaxReplicas))           //nolint:staticcheck
-	mb.RecordK8sHpaMinReplicasDataPoint(ts, int64(*hpa.Spec.MinReplicas))          //nolint:staticcheck
-	mb.RecordK8sHpaCurrentReplicasDataPoint(ts, int64(hpa.Status.CurrentReplicas)) //nolint:staticcheck
-	mb.RecordK8sHpaDesiredReplicasDataPoint(ts, int64(hpa.Status.DesiredReplicas)) //nolint:staticcheck
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sHpaUID(string(hpa.UID))
-	rb.SetK8sHpaName(hpa.Name)
-	rb.SetK8sNamespaceName(hpa.Namespace)
-	rb.SetK8sHpaScaletargetrefApiversion(hpa.Spec.ScaleTargetRef.APIVersion)
-	rb.SetK8sHpaScaletargetrefKind(hpa.Spec.ScaleTargetRef.Kind)
-	rb.SetK8sHpaScaletargetrefName(hpa.Spec.ScaleTargetRef.Name)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sHpaEntity(string(hpa.UID))
+	e.SetK8sHpaName(hpa.Name)
+	e.SetK8sNamespaceName(hpa.Namespace)
+	e.SetK8sHpaScaletargetrefApiversion(hpa.Spec.ScaleTargetRef.APIVersion)
+	e.SetK8sHpaScaletargetrefKind(hpa.Spec.ScaleTargetRef.Kind)
+	e.SetK8sHpaScaletargetrefName(hpa.Spec.ScaleTargetRef.Name)
+	eb := mb.ForK8sHpa(e)
+	eb.RecordK8sHpaMaxReplicasDataPoint(ts, int64(hpa.Spec.MaxReplicas))
+	eb.RecordK8sHpaMinReplicasDataPoint(ts, int64(*hpa.Spec.MinReplicas))
+	eb.RecordK8sHpaCurrentReplicasDataPoint(ts, int64(hpa.Status.CurrentReplicas))
+	eb.RecordK8sHpaDesiredReplicasDataPoint(ts, int64(hpa.Status.DesiredReplicas))
+	eb.Emit()
 }
 
 func GetMetadata(hpa *autoscalingv2.HorizontalPodAutoscaler) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/jobs/jobs.go
+++ b/receiver/k8sclusterreceiver/internal/jobs/jobs.go
@@ -13,22 +13,21 @@ import (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, j *batchv1.Job, ts pcommon.Timestamp) {
-	mb.RecordK8sJobActivePodsDataPoint(ts, int64(j.Status.Active))        //nolint:staticcheck
-	mb.RecordK8sJobFailedPodsDataPoint(ts, int64(j.Status.Failed))        //nolint:staticcheck
-	mb.RecordK8sJobSuccessfulPodsDataPoint(ts, int64(j.Status.Succeeded)) //nolint:staticcheck
+	e := metadata.NewK8sJobEntity(string(j.UID))
+	e.SetK8sJobName(j.Name)
+	e.SetK8sNamespaceName(j.Namespace)
+	eb := mb.ForK8sJob(e)
+	eb.RecordK8sJobActivePodsDataPoint(ts, int64(j.Status.Active))
+	eb.RecordK8sJobFailedPodsDataPoint(ts, int64(j.Status.Failed))
+	eb.RecordK8sJobSuccessfulPodsDataPoint(ts, int64(j.Status.Succeeded))
 
 	if j.Spec.Completions != nil {
-		mb.RecordK8sJobDesiredSuccessfulPodsDataPoint(ts, int64(*j.Spec.Completions)) //nolint:staticcheck
+		eb.RecordK8sJobDesiredSuccessfulPodsDataPoint(ts, int64(*j.Spec.Completions))
 	}
 	if j.Spec.Parallelism != nil {
-		mb.RecordK8sJobMaxParallelPodsDataPoint(ts, int64(*j.Spec.Parallelism)) //nolint:staticcheck
+		eb.RecordK8sJobMaxParallelPodsDataPoint(ts, int64(*j.Spec.Parallelism))
 	}
-
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceName(j.Namespace)
-	rb.SetK8sJobName(j.Name)
-	rb.SetK8sJobUID(string(j.UID))
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 // Transform transforms the job to remove the fields that we don't use to reduce RAM utilization.

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.job.uid
           value:
             stringValue: test-job-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -46,4 +53,3 @@ resourceMetrics:
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
-

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.job.name
-            - k8s.namespace.name
           idKeys:
             - k8s.job.uid
           type: k8s.job

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.job.uid
           value:
             stringValue: test-job-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -34,4 +41,3 @@ resourceMetrics:
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
-

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.job.name
-            - k8s.namespace.name
           idKeys:
             - k8s.job.uid
           type: k8s.job

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics.go
@@ -154,9 +154,9 @@ func (e *K8sNodeEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon
 // K8sDeploymentEntity represents a k8s.deployment entity.
 // Create one with NewK8sDeploymentEntity and pass it to EmitForEntity.
 type K8sDeploymentEntity struct {
-	k8sDeploymentUID   string
-	k8sDeploymentName  string
-	partOfK8sNamespace *K8sNamespaceEntity
+	k8sDeploymentUID  string
+	k8sDeploymentName string
+	k8sNamespaceName  string
 }
 
 // NewK8sDeploymentEntity creates a new K8sDeploymentEntity.
@@ -174,12 +174,12 @@ func (e *K8sDeploymentEntity) SetK8sDeploymentName(val string) {
 	e.k8sDeploymentName = val
 }
 
-// Relationship setters for k8s.deployment.
+// Extra attribute setters for k8s.deployment.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sDeploymentEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sDeploymentEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -192,6 +192,9 @@ func (e *K8sDeploymentEntity) copyToResource(cfg ResourceAttributesConfig, res p
 		if cfg.K8sDeploymentName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.deployment.name", e.k8sDeploymentName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sDeploymentUID.Enabled {
 			res.Attributes().PutStr("k8s.deployment.uid", e.k8sDeploymentUID)
@@ -199,15 +202,18 @@ func (e *K8sDeploymentEntity) copyToResource(cfg ResourceAttributesConfig, res p
 		if cfg.K8sDeploymentName.Enabled {
 			res.Attributes().PutStr("k8s.deployment.name", e.k8sDeploymentName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	}
 }
 
 // K8sReplicasetEntity represents a k8s.replicaset entity.
 // Create one with NewK8sReplicasetEntity and pass it to EmitForEntity.
 type K8sReplicasetEntity struct {
-	k8sReplicasetUID       string
-	k8sReplicasetName      string
-	managedByK8sDeployment *K8sDeploymentEntity
+	k8sReplicasetUID  string
+	k8sReplicasetName string
+	k8sNamespaceName  string
 }
 
 // NewK8sReplicasetEntity creates a new K8sReplicasetEntity.
@@ -225,12 +231,12 @@ func (e *K8sReplicasetEntity) SetK8sReplicasetName(val string) {
 	e.k8sReplicasetName = val
 }
 
-// Relationship setters for k8s.replicaset.
+// Extra attribute setters for k8s.replicaset.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetManagedByK8sDeployment sets the managed_by relationship to a k8s.deployment entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sReplicasetEntity) SetManagedByK8sDeployment(target *K8sDeploymentEntity) {
-	e.managedByK8sDeployment = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sReplicasetEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -243,12 +249,18 @@ func (e *K8sReplicasetEntity) copyToResource(cfg ResourceAttributesConfig, res p
 		if cfg.K8sReplicasetName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.replicaset.name", e.k8sReplicasetName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sReplicasetUID.Enabled {
 			res.Attributes().PutStr("k8s.replicaset.uid", e.k8sReplicasetUID)
 		}
 		if cfg.K8sReplicasetName.Enabled {
 			res.Attributes().PutStr("k8s.replicaset.name", e.k8sReplicasetName)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
 		}
 	}
 }
@@ -258,7 +270,7 @@ func (e *K8sReplicasetEntity) copyToResource(cfg ResourceAttributesConfig, res p
 type K8sStatefulsetEntity struct {
 	k8sStatefulsetUID  string
 	k8sStatefulsetName string
-	partOfK8sNamespace *K8sNamespaceEntity
+	k8sNamespaceName   string
 }
 
 // NewK8sStatefulsetEntity creates a new K8sStatefulsetEntity.
@@ -276,12 +288,12 @@ func (e *K8sStatefulsetEntity) SetK8sStatefulsetName(val string) {
 	e.k8sStatefulsetName = val
 }
 
-// Relationship setters for k8s.statefulset.
+// Extra attribute setters for k8s.statefulset.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sStatefulsetEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sStatefulsetEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -294,6 +306,9 @@ func (e *K8sStatefulsetEntity) copyToResource(cfg ResourceAttributesConfig, res 
 		if cfg.K8sStatefulsetName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.statefulset.name", e.k8sStatefulsetName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sStatefulsetUID.Enabled {
 			res.Attributes().PutStr("k8s.statefulset.uid", e.k8sStatefulsetUID)
@@ -301,15 +316,18 @@ func (e *K8sStatefulsetEntity) copyToResource(cfg ResourceAttributesConfig, res 
 		if cfg.K8sStatefulsetName.Enabled {
 			res.Attributes().PutStr("k8s.statefulset.name", e.k8sStatefulsetName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	}
 }
 
 // K8sDaemonsetEntity represents a k8s.daemonset entity.
 // Create one with NewK8sDaemonsetEntity and pass it to EmitForEntity.
 type K8sDaemonsetEntity struct {
-	k8sDaemonsetUID    string
-	k8sDaemonsetName   string
-	partOfK8sNamespace *K8sNamespaceEntity
+	k8sDaemonsetUID  string
+	k8sDaemonsetName string
+	k8sNamespaceName string
 }
 
 // NewK8sDaemonsetEntity creates a new K8sDaemonsetEntity.
@@ -327,12 +345,12 @@ func (e *K8sDaemonsetEntity) SetK8sDaemonsetName(val string) {
 	e.k8sDaemonsetName = val
 }
 
-// Relationship setters for k8s.daemonset.
+// Extra attribute setters for k8s.daemonset.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sDaemonsetEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sDaemonsetEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -345,6 +363,9 @@ func (e *K8sDaemonsetEntity) copyToResource(cfg ResourceAttributesConfig, res pc
 		if cfg.K8sDaemonsetName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.daemonset.name", e.k8sDaemonsetName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sDaemonsetUID.Enabled {
 			res.Attributes().PutStr("k8s.daemonset.uid", e.k8sDaemonsetUID)
@@ -352,15 +373,18 @@ func (e *K8sDaemonsetEntity) copyToResource(cfg ResourceAttributesConfig, res pc
 		if cfg.K8sDaemonsetName.Enabled {
 			res.Attributes().PutStr("k8s.daemonset.name", e.k8sDaemonsetName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	}
 }
 
 // K8sCronjobEntity represents a k8s.cronjob entity.
 // Create one with NewK8sCronjobEntity and pass it to EmitForEntity.
 type K8sCronjobEntity struct {
-	k8sCronjobUID      string
-	k8sCronjobName     string
-	partOfK8sNamespace *K8sNamespaceEntity
+	k8sCronjobUID    string
+	k8sCronjobName   string
+	k8sNamespaceName string
 }
 
 // NewK8sCronjobEntity creates a new K8sCronjobEntity.
@@ -378,12 +402,12 @@ func (e *K8sCronjobEntity) SetK8sCronjobName(val string) {
 	e.k8sCronjobName = val
 }
 
-// Relationship setters for k8s.cronjob.
+// Extra attribute setters for k8s.cronjob.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sCronjobEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sCronjobEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -396,6 +420,9 @@ func (e *K8sCronjobEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sCronjobName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.cronjob.name", e.k8sCronjobName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sCronjobUID.Enabled {
 			res.Attributes().PutStr("k8s.cronjob.uid", e.k8sCronjobUID)
@@ -403,16 +430,18 @@ func (e *K8sCronjobEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sCronjobName.Enabled {
 			res.Attributes().PutStr("k8s.cronjob.name", e.k8sCronjobName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	}
 }
 
 // K8sJobEntity represents a k8s.job entity.
 // Create one with NewK8sJobEntity and pass it to EmitForEntity.
 type K8sJobEntity struct {
-	k8sJobUID           string
-	k8sJobName          string
-	partOfK8sNamespace  *K8sNamespaceEntity
-	managedByK8sCronjob *K8sCronjobEntity
+	k8sJobUID        string
+	k8sJobName       string
+	k8sNamespaceName string
 }
 
 // NewK8sJobEntity creates a new K8sJobEntity.
@@ -430,18 +459,12 @@ func (e *K8sJobEntity) SetK8sJobName(val string) {
 	e.k8sJobName = val
 }
 
-// Relationship setters for k8s.job.
+// Extra attribute setters for k8s.job.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sJobEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
-}
-
-// SetManagedByK8sCronjob sets the managed_by relationship to a k8s.cronjob entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sJobEntity) SetManagedByK8sCronjob(target *K8sCronjobEntity) {
-	e.managedByK8sCronjob = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sJobEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -454,6 +477,9 @@ func (e *K8sJobEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon.
 		if cfg.K8sJobName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.job.name", e.k8sJobName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sJobUID.Enabled {
 			res.Attributes().PutStr("k8s.job.uid", e.k8sJobUID)
@@ -461,22 +487,20 @@ func (e *K8sJobEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon.
 		if cfg.K8sJobName.Enabled {
 			res.Attributes().PutStr("k8s.job.name", e.k8sJobName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	}
 }
 
 // K8sPodEntity represents a k8s.pod entity.
 // Create one with NewK8sPodEntity and pass it to EmitForEntity.
 type K8sPodEntity struct {
-	k8sPodUID                         string
-	k8sPodName                        string
-	k8sPodQosClass                    string
-	scheduledOnK8sNode                *K8sNodeEntity
-	partOfK8sNamespace                *K8sNamespaceEntity
-	managedByK8sReplicaset            *K8sReplicasetEntity
-	managedByK8sStatefulset           *K8sStatefulsetEntity
-	managedByK8sDaemonset             *K8sDaemonsetEntity
-	managedByK8sJob                   *K8sJobEntity
-	managedByK8sReplicationcontroller *K8sReplicationcontrollerEntity
+	k8sPodUID        string
+	k8sPodName       string
+	k8sPodQosClass   string
+	k8sNamespaceName string
+	k8sNodeName      string
 }
 
 // NewK8sPodEntity creates a new K8sPodEntity.
@@ -499,48 +523,17 @@ func (e *K8sPodEntity) SetK8sPodQosClass(val string) {
 	e.k8sPodQosClass = val
 }
 
-// Relationship setters for k8s.pod.
+// Extra attribute setters for k8s.pod.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetScheduledOnK8sNode sets the scheduled_on relationship to a k8s.node entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetScheduledOnK8sNode(target *K8sNodeEntity) {
-	e.scheduledOnK8sNode = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sPodEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
-}
-
-// SetManagedByK8sReplicaset sets the managed_by relationship to a k8s.replicaset entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetManagedByK8sReplicaset(target *K8sReplicasetEntity) {
-	e.managedByK8sReplicaset = target
-}
-
-// SetManagedByK8sStatefulset sets the managed_by relationship to a k8s.statefulset entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetManagedByK8sStatefulset(target *K8sStatefulsetEntity) {
-	e.managedByK8sStatefulset = target
-}
-
-// SetManagedByK8sDaemonset sets the managed_by relationship to a k8s.daemonset entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetManagedByK8sDaemonset(target *K8sDaemonsetEntity) {
-	e.managedByK8sDaemonset = target
-}
-
-// SetManagedByK8sJob sets the managed_by relationship to a k8s.job entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetManagedByK8sJob(target *K8sJobEntity) {
-	e.managedByK8sJob = target
-}
-
-// SetManagedByK8sReplicationcontroller sets the managed_by relationship to a k8s.replicationcontroller entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sPodEntity) SetManagedByK8sReplicationcontroller(target *K8sReplicationcontrollerEntity) {
-	e.managedByK8sReplicationcontroller = target
+// SetK8sNodeName sets the k8s.node.name extra attribute on the resource.
+func (e *K8sPodEntity) SetK8sNodeName(val string) {
+	e.k8sNodeName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -556,6 +549,12 @@ func (e *K8sPodEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon.
 		if cfg.K8sPodQosClass.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.pod.qos_class", e.k8sPodQosClass)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
+		if cfg.K8sNodeName.Enabled {
+			res.Attributes().PutStr("k8s.node.name", e.k8sNodeName)
+		}
 	} else {
 		if cfg.K8sPodUID.Enabled {
 			res.Attributes().PutStr("k8s.pod.uid", e.k8sPodUID)
@@ -565,6 +564,12 @@ func (e *K8sPodEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon.
 		}
 		if cfg.K8sPodQosClass.Enabled {
 			res.Attributes().PutStr("k8s.pod.qos_class", e.k8sPodQosClass)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
+		if cfg.K8sNodeName.Enabled {
+			res.Attributes().PutStr("k8s.node.name", e.k8sNodeName)
 		}
 	}
 }
@@ -577,7 +582,10 @@ type K8sContainerEntity struct {
 	containerImageName                     string
 	containerImageTag                      string
 	k8sContainerStatusLastTerminatedReason string
-	childOfK8sPod                          *K8sPodEntity
+	k8sPodUID                              string
+	k8sPodName                             string
+	k8sNamespaceName                       string
+	k8sNodeName                            string
 }
 
 // NewK8sContainerEntity creates a new K8sContainerEntity.
@@ -610,12 +618,27 @@ func (e *K8sContainerEntity) SetK8sContainerStatusLastTerminatedReason(val strin
 	e.k8sContainerStatusLastTerminatedReason = val
 }
 
-// Relationship setters for k8s.container.
+// Extra attribute setters for k8s.container.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetChildOfK8sPod sets the child_of relationship to a k8s.pod entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sContainerEntity) SetChildOfK8sPod(target *K8sPodEntity) {
-	e.childOfK8sPod = target
+// SetK8sPodUID sets the k8s.pod.uid extra attribute on the resource.
+func (e *K8sContainerEntity) SetK8sPodUID(val string) {
+	e.k8sPodUID = val
+}
+
+// SetK8sPodName sets the k8s.pod.name extra attribute on the resource.
+func (e *K8sContainerEntity) SetK8sPodName(val string) {
+	e.k8sPodName = val
+}
+
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sContainerEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
+}
+
+// SetK8sNodeName sets the k8s.node.name extra attribute on the resource.
+func (e *K8sContainerEntity) SetK8sNodeName(val string) {
+	e.k8sNodeName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -637,6 +660,18 @@ func (e *K8sContainerEntity) copyToResource(cfg ResourceAttributesConfig, res pc
 		if cfg.K8sContainerStatusLastTerminatedReason.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.container.status.last_terminated_reason", e.k8sContainerStatusLastTerminatedReason)
 		}
+		if cfg.K8sPodUID.Enabled {
+			res.Attributes().PutStr("k8s.pod.uid", e.k8sPodUID)
+		}
+		if cfg.K8sPodName.Enabled {
+			res.Attributes().PutStr("k8s.pod.name", e.k8sPodName)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
+		if cfg.K8sNodeName.Enabled {
+			res.Attributes().PutStr("k8s.node.name", e.k8sNodeName)
+		}
 	} else {
 		if cfg.ContainerID.Enabled {
 			res.Attributes().PutStr("container.id", e.containerID)
@@ -653,6 +688,18 @@ func (e *K8sContainerEntity) copyToResource(cfg ResourceAttributesConfig, res pc
 		if cfg.K8sContainerStatusLastTerminatedReason.Enabled {
 			res.Attributes().PutStr("k8s.container.status.last_terminated_reason", e.k8sContainerStatusLastTerminatedReason)
 		}
+		if cfg.K8sPodUID.Enabled {
+			res.Attributes().PutStr("k8s.pod.uid", e.k8sPodUID)
+		}
+		if cfg.K8sPodName.Enabled {
+			res.Attributes().PutStr("k8s.pod.name", e.k8sPodName)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
+		if cfg.K8sNodeName.Enabled {
+			res.Attributes().PutStr("k8s.node.name", e.k8sNodeName)
+		}
 	}
 }
 
@@ -661,7 +708,7 @@ func (e *K8sContainerEntity) copyToResource(cfg ResourceAttributesConfig, res pc
 type K8sReplicationcontrollerEntity struct {
 	k8sReplicationcontrollerUID  string
 	k8sReplicationcontrollerName string
-	partOfK8sNamespace           *K8sNamespaceEntity
+	k8sNamespaceName             string
 }
 
 // NewK8sReplicationcontrollerEntity creates a new K8sReplicationcontrollerEntity.
@@ -679,12 +726,12 @@ func (e *K8sReplicationcontrollerEntity) SetK8sReplicationcontrollerName(val str
 	e.k8sReplicationcontrollerName = val
 }
 
-// Relationship setters for k8s.replicationcontroller.
+// Extra attribute setters for k8s.replicationcontroller.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sReplicationcontrollerEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sReplicationcontrollerEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -697,12 +744,18 @@ func (e *K8sReplicationcontrollerEntity) copyToResource(cfg ResourceAttributesCo
 		if cfg.K8sReplicationcontrollerName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.replicationcontroller.name", e.k8sReplicationcontrollerName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sReplicationcontrollerUID.Enabled {
 			res.Attributes().PutStr("k8s.replicationcontroller.uid", e.k8sReplicationcontrollerUID)
 		}
 		if cfg.K8sReplicationcontrollerName.Enabled {
 			res.Attributes().PutStr("k8s.replicationcontroller.name", e.k8sReplicationcontrollerName)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
 		}
 	}
 }
@@ -712,7 +765,7 @@ func (e *K8sReplicationcontrollerEntity) copyToResource(cfg ResourceAttributesCo
 type K8sResourcequotaEntity struct {
 	k8sResourcequotaUID  string
 	k8sResourcequotaName string
-	partOfK8sNamespace   *K8sNamespaceEntity
+	k8sNamespaceName     string
 }
 
 // NewK8sResourcequotaEntity creates a new K8sResourcequotaEntity.
@@ -730,12 +783,12 @@ func (e *K8sResourcequotaEntity) SetK8sResourcequotaName(val string) {
 	e.k8sResourcequotaName = val
 }
 
-// Relationship setters for k8s.resourcequota.
+// Extra attribute setters for k8s.resourcequota.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sResourcequotaEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sResourcequotaEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -748,12 +801,18 @@ func (e *K8sResourcequotaEntity) copyToResource(cfg ResourceAttributesConfig, re
 		if cfg.K8sResourcequotaName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.resourcequota.name", e.k8sResourcequotaName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sResourcequotaUID.Enabled {
 			res.Attributes().PutStr("k8s.resourcequota.uid", e.k8sResourcequotaUID)
 		}
 		if cfg.K8sResourcequotaName.Enabled {
 			res.Attributes().PutStr("k8s.resourcequota.name", e.k8sResourcequotaName)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
 		}
 	}
 }
@@ -766,7 +825,7 @@ type K8sServiceEntity struct {
 	k8sServiceType                     string
 	k8sServicePublishNotReadyAddresses bool
 	k8sServiceTrafficDistribution      string
-	partOfK8sNamespace                 *K8sNamespaceEntity
+	k8sNamespaceName                   string
 }
 
 // NewK8sServiceEntity creates a new K8sServiceEntity.
@@ -799,12 +858,12 @@ func (e *K8sServiceEntity) SetK8sServiceTrafficDistribution(val string) {
 	e.k8sServiceTrafficDistribution = val
 }
 
-// Relationship setters for k8s.service.
+// Extra attribute setters for k8s.service.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sServiceEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sServiceEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -826,6 +885,9 @@ func (e *K8sServiceEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sServiceTrafficDistribution.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sServiceUID.Enabled {
 			res.Attributes().PutStr("k8s.service.uid", e.k8sServiceUID)
@@ -842,6 +904,9 @@ func (e *K8sServiceEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sServiceTrafficDistribution.Enabled {
 			res.Attributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	}
 }
 
@@ -853,7 +918,7 @@ type K8sHpaEntity struct {
 	k8sHpaScaletargetrefApiversion string
 	k8sHpaScaletargetrefKind       string
 	k8sHpaScaletargetrefName       string
-	partOfK8sNamespace             *K8sNamespaceEntity
+	k8sNamespaceName               string
 }
 
 // NewK8sHpaEntity creates a new K8sHpaEntity.
@@ -886,12 +951,12 @@ func (e *K8sHpaEntity) SetK8sHpaScaletargetrefName(val string) {
 	e.k8sHpaScaletargetrefName = val
 }
 
-// Relationship setters for k8s.hpa.
+// Extra attribute setters for k8s.hpa.
+// These attributes are contextually relevant but are not part of the entity's identity or description.
 
-// SetPartOfK8sNamespace sets the part_of relationship to a k8s.namespace entity.
-// The related entity will be emitted alongside this entity's metrics.
-func (e *K8sHpaEntity) SetPartOfK8sNamespace(target *K8sNamespaceEntity) {
-	e.partOfK8sNamespace = target
+// SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
+func (e *K8sHpaEntity) SetK8sNamespaceName(val string) {
+	e.k8sNamespaceName = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -913,6 +978,9 @@ func (e *K8sHpaEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon.
 		if cfg.K8sHpaScaletargetrefName.Enabled {
 			ent.DescriptiveAttributes().PutStr("k8s.hpa.scaletargetref.name", e.k8sHpaScaletargetrefName)
 		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
 	} else {
 		if cfg.K8sHpaUID.Enabled {
 			res.Attributes().PutStr("k8s.hpa.uid", e.k8sHpaUID)
@@ -928,6 +996,9 @@ func (e *K8sHpaEntity) copyToResource(cfg ResourceAttributesConfig, res pcommon.
 		}
 		if cfg.K8sHpaScaletargetrefName.Enabled {
 			res.Attributes().PutStr("k8s.hpa.scaletargetref.name", e.k8sHpaScaletargetrefName)
+		}
+		if cfg.K8sNamespaceName.Enabled {
+			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
 		}
 	}
 }
@@ -1042,9 +1113,6 @@ func (eb *K8sDeploymentMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1072,9 +1140,6 @@ func (eb *K8sReplicasetMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.managedByK8sDeployment != nil {
-		eb.entity.managedByK8sDeployment.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1112,9 +1177,6 @@ func (eb *K8sStatefulsetMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1152,9 +1214,6 @@ func (eb *K8sDaemonsetMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1177,9 +1236,6 @@ func (eb *K8sCronjobMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1222,12 +1278,6 @@ func (eb *K8sJobMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
-	if eb.entity.managedByK8sCronjob != nil {
-		eb.entity.managedByK8sCronjob.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1255,27 +1305,6 @@ func (eb *K8sPodMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.scheduledOnK8sNode != nil {
-		eb.entity.scheduledOnK8sNode.copyToResource(cfg, res)
-	}
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
-	if eb.entity.managedByK8sReplicaset != nil {
-		eb.entity.managedByK8sReplicaset.copyToResource(cfg, res)
-	}
-	if eb.entity.managedByK8sStatefulset != nil {
-		eb.entity.managedByK8sStatefulset.copyToResource(cfg, res)
-	}
-	if eb.entity.managedByK8sDaemonset != nil {
-		eb.entity.managedByK8sDaemonset.copyToResource(cfg, res)
-	}
-	if eb.entity.managedByK8sJob != nil {
-		eb.entity.managedByK8sJob.copyToResource(cfg, res)
-	}
-	if eb.entity.managedByK8sReplicationcontroller != nil {
-		eb.entity.managedByK8sReplicationcontroller.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1353,9 +1382,6 @@ func (eb *K8sContainerMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.childOfK8sPod != nil {
-		eb.entity.childOfK8sPod.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1383,9 +1409,6 @@ func (eb *K8sReplicationcontrollerMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1413,9 +1436,6 @@ func (eb *K8sResourcequotaMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1443,9 +1463,6 @@ func (eb *K8sServiceMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 
@@ -1483,9 +1500,6 @@ func (eb *K8sHpaMetricsBuilder) Emit() {
 	res := pcommon.NewResource()
 	cfg := eb.mb.config.ResourceAttributes
 	eb.entity.copyToResource(cfg, res)
-	if eb.entity.partOfK8sNamespace != nil {
-		eb.entity.partOfK8sNamespace.copyToResource(cfg, res)
-	}
 	eb.mb.EmitForResource(withResourceMoved(res))
 }
 

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics.go
@@ -885,7 +885,7 @@ func (e *K8sServiceEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sNamespaceName.Enabled {
 			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
 		}
-		if cfg.K8sServiceTrafficDistribution.Enabled && e.k8sServiceTrafficDistribution != "" {
+		if cfg.K8sServiceTrafficDistribution.Enabled {
 			res.Attributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
 		}
 	} else {
@@ -904,7 +904,7 @@ func (e *K8sServiceEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sNamespaceName.Enabled {
 			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
 		}
-		if cfg.K8sServiceTrafficDistribution.Enabled && e.k8sServiceTrafficDistribution != "" {
+		if cfg.K8sServiceTrafficDistribution.Enabled {
 			res.Attributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
 		}
 	}

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics.go
@@ -824,8 +824,8 @@ type K8sServiceEntity struct {
 	k8sServiceName                     string
 	k8sServiceType                     string
 	k8sServicePublishNotReadyAddresses bool
-	k8sServiceTrafficDistribution      string
 	k8sNamespaceName                   string
+	k8sServiceTrafficDistribution      string
 }
 
 // NewK8sServiceEntity creates a new K8sServiceEntity.
@@ -853,17 +853,17 @@ func (e *K8sServiceEntity) SetK8sServicePublishNotReadyAddresses(val bool) {
 	e.k8sServicePublishNotReadyAddresses = val
 }
 
-// SetK8sServiceTrafficDistribution sets the k8s.service.traffic_distribution description attribute.
-func (e *K8sServiceEntity) SetK8sServiceTrafficDistribution(val string) {
-	e.k8sServiceTrafficDistribution = val
-}
-
 // Extra attribute setters for k8s.service.
 // These attributes are contextually relevant but are not part of the entity's identity or description.
 
 // SetK8sNamespaceName sets the k8s.namespace.name extra attribute on the resource.
 func (e *K8sServiceEntity) SetK8sNamespaceName(val string) {
 	e.k8sNamespaceName = val
+}
+
+// SetK8sServiceTrafficDistribution sets the k8s.service.traffic_distribution extra attribute on the resource.
+func (e *K8sServiceEntity) SetK8sServiceTrafficDistribution(val string) {
+	e.k8sServiceTrafficDistribution = val
 }
 
 // copyToResource populates res with the entity's attributes according to cfg.
@@ -882,11 +882,11 @@ func (e *K8sServiceEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sServicePublishNotReadyAddresses.Enabled {
 			ent.DescriptiveAttributes().PutEmpty("k8s.service.publish_not_ready_addresses").SetBool(e.k8sServicePublishNotReadyAddresses)
 		}
-		if cfg.K8sServiceTrafficDistribution.Enabled {
-			ent.DescriptiveAttributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
-		}
 		if cfg.K8sNamespaceName.Enabled {
 			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
+		if cfg.K8sServiceTrafficDistribution.Enabled && e.k8sServiceTrafficDistribution != "" {
+			res.Attributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
 		}
 	} else {
 		if cfg.K8sServiceUID.Enabled {
@@ -901,11 +901,11 @@ func (e *K8sServiceEntity) copyToResource(cfg ResourceAttributesConfig, res pcom
 		if cfg.K8sServicePublishNotReadyAddresses.Enabled {
 			res.Attributes().PutBool("k8s.service.publish_not_ready_addresses", e.k8sServicePublishNotReadyAddresses)
 		}
-		if cfg.K8sServiceTrafficDistribution.Enabled {
-			res.Attributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
-		}
 		if cfg.K8sNamespaceName.Enabled {
 			res.Attributes().PutStr("k8s.namespace.name", e.k8sNamespaceName)
+		}
+		if cfg.K8sServiceTrafficDistribution.Enabled && e.k8sServiceTrafficDistribution != "" {
+			res.Attributes().PutStr("k8s.service.traffic_distribution", e.k8sServiceTrafficDistribution)
 		}
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics_test.go
@@ -1145,8 +1145,8 @@ func TestEntityBuilders(t *testing.T) {
 		e.SetK8sServiceName("k8s.service.name-val")
 		e.SetK8sServiceType("k8s.service.type-val")
 		e.SetK8sServicePublishNotReadyAddresses(false)
-		e.SetK8sServiceTrafficDistribution("k8s.service.traffic_distribution-val")
 		e.SetK8sNamespaceName("k8s.namespace.name-val")
+		e.SetK8sServiceTrafficDistribution("k8s.service.traffic_distribution-val")
 
 		eb := mb.ForK8sService(e)
 		eb.RecordK8sServiceEndpointCountDataPoint(ts, 1, AttributeK8sServiceEndpointAddressTypeIPv4, AttributeK8sServiceEndpointConditionReady, "k8s.service.endpoint.zone-val")

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_entity_metrics_test.go
@@ -117,8 +117,7 @@ func TestEntityBuilders(t *testing.T) {
 		e := NewK8sDeploymentEntity("k8s.deployment.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sDeploymentName("k8s.deployment.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sDeployment(e)
 		eb.RecordK8sDeploymentAvailableDataPoint(ts, 1)
@@ -136,6 +135,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sDeploymentNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.deployment.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.deployment.name-val", k8sDeploymentNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -171,10 +175,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sDeploymentName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sDeploymentEntity("k8s.deployment.uid-val")
 		e.SetK8sDeploymentName("k8s.deployment.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sDeployment(e)
 		eb.RecordK8sDeploymentAvailableDataPoint(ts, 1)
@@ -193,14 +199,15 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.deployment.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.replicaset", func(t *testing.T) {
 		e := NewK8sReplicasetEntity("k8s.replicaset.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sReplicasetName("k8s.replicaset.name-val")
-		relatedK8sDeployment := NewK8sDeploymentEntity("k8s.deployment.uid-val")
-		e.SetManagedByK8sDeployment(relatedK8sDeployment)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sReplicaset(e)
 		eb.RecordK8sReplicasetAvailableDataPoint(ts, 1)
@@ -218,6 +225,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sReplicasetNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.replicaset.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.replicaset.name-val", k8sReplicasetNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -253,10 +265,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sReplicasetName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sReplicasetEntity("k8s.replicaset.uid-val")
 		e.SetK8sReplicasetName("k8s.replicaset.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sReplicaset(e)
 		eb.RecordK8sReplicasetAvailableDataPoint(ts, 1)
@@ -275,14 +289,15 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.replicaset.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.statefulset", func(t *testing.T) {
 		e := NewK8sStatefulsetEntity("k8s.statefulset.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sStatefulsetName("k8s.statefulset.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sStatefulset(e)
 		eb.RecordK8sStatefulsetCurrentPodsDataPoint(ts, 1)
@@ -302,6 +317,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sStatefulsetNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.statefulset.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.statefulset.name-val", k8sStatefulsetNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -339,10 +359,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sStatefulsetName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sStatefulsetEntity("k8s.statefulset.uid-val")
 		e.SetK8sStatefulsetName("k8s.statefulset.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sStatefulset(e)
 		eb.RecordK8sStatefulsetCurrentPodsDataPoint(ts, 1)
@@ -363,14 +385,15 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.statefulset.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.daemonset", func(t *testing.T) {
 		e := NewK8sDaemonsetEntity("k8s.daemonset.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sDaemonsetName("k8s.daemonset.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sDaemonset(e)
 		eb.RecordK8sDaemonsetCurrentScheduledNodesDataPoint(ts, 1)
@@ -390,6 +413,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sDaemonsetNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.daemonset.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.daemonset.name-val", k8sDaemonsetNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -427,10 +455,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sDaemonsetName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sDaemonsetEntity("k8s.daemonset.uid-val")
 		e.SetK8sDaemonsetName("k8s.daemonset.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sDaemonset(e)
 		eb.RecordK8sDaemonsetCurrentScheduledNodesDataPoint(ts, 1)
@@ -451,14 +481,15 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.daemonset.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.cronjob", func(t *testing.T) {
 		e := NewK8sCronjobEntity("k8s.cronjob.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sCronjobName("k8s.cronjob.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sCronjob(e)
 		eb.RecordK8sCronjobActiveJobsDataPoint(ts, 1)
@@ -475,6 +506,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sCronjobNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.cronjob.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.cronjob.name-val", k8sCronjobNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -509,10 +545,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sCronjobName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sCronjobEntity("k8s.cronjob.uid-val")
 		e.SetK8sCronjobName("k8s.cronjob.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sCronjob(e)
 		eb.RecordK8sCronjobActiveJobsDataPoint(ts, 1)
@@ -530,16 +568,15 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.cronjob.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.job", func(t *testing.T) {
 		e := NewK8sJobEntity("k8s.job.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sJobName("k8s.job.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
-		relatedK8sCronjob := NewK8sCronjobEntity("k8s.cronjob.uid-val")
-		e.SetManagedByK8sCronjob(relatedK8sCronjob)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sJob(e)
 		eb.RecordK8sJobActivePodsDataPoint(ts, 1)
@@ -560,6 +597,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sJobNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.job.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.job.name-val", k8sJobNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -598,10 +640,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sJobName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sJobEntity("k8s.job.uid-val")
 		e.SetK8sJobName("k8s.job.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sJob(e)
 		eb.RecordK8sJobActivePodsDataPoint(ts, 1)
@@ -623,6 +667,8 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.job.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.pod", func(t *testing.T) {
@@ -630,20 +676,8 @@ func TestEntityBuilders(t *testing.T) {
 		require.NotNil(t, e)
 		e.SetK8sPodName("k8s.pod.name-val")
 		e.SetK8sPodQosClass("k8s.pod.qos_class-val")
-		relatedK8sNode := NewK8sNodeEntity("k8s.node.uid-val")
-		e.SetScheduledOnK8sNode(relatedK8sNode)
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
-		relatedK8sReplicaset := NewK8sReplicasetEntity("k8s.replicaset.uid-val")
-		e.SetManagedByK8sReplicaset(relatedK8sReplicaset)
-		relatedK8sStatefulset := NewK8sStatefulsetEntity("k8s.statefulset.uid-val")
-		e.SetManagedByK8sStatefulset(relatedK8sStatefulset)
-		relatedK8sDaemonset := NewK8sDaemonsetEntity("k8s.daemonset.uid-val")
-		e.SetManagedByK8sDaemonset(relatedK8sDaemonset)
-		relatedK8sJob := NewK8sJobEntity("k8s.job.uid-val")
-		e.SetManagedByK8sJob(relatedK8sJob)
-		relatedK8sReplicationcontroller := NewK8sReplicationcontrollerEntity("k8s.replicationcontroller.uid-val")
-		e.SetManagedByK8sReplicationcontroller(relatedK8sReplicationcontroller)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
+		e.SetK8sNodeName("k8s.node.name-val")
 
 		eb := mb.ForK8sPod(e)
 		eb.RecordK8sPodPhaseDataPoint(ts, 1)
@@ -663,6 +697,16 @@ func TestEntityBuilders(t *testing.T) {
 		assert.Equal(t, "k8s.pod.name-val", k8sPodNameAttrVal.Str())
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.pod.qos_class")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.node.name")
+		assert.False(t, ok)
+		k8sNodeNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.node.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.node.name-val", k8sNodeNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -700,11 +744,15 @@ func TestEntityBuilders(t *testing.T) {
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sPodName.Enabled = false
 		cfg.ResourceAttributes.K8sPodQosClass.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
+		cfg.ResourceAttributes.K8sNodeName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sPodEntity("k8s.pod.uid-val")
 		e.SetK8sPodName("k8s.pod.name-val")
 		e.SetK8sPodQosClass("k8s.pod.qos_class-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
+		e.SetK8sNodeName("k8s.node.name-val")
 
 		eb := mb.ForK8sPod(e)
 		eb.RecordK8sPodPhaseDataPoint(ts, 1)
@@ -725,6 +773,10 @@ func TestEntityBuilders(t *testing.T) {
 		assert.False(t, ok)
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.pod.qos_class")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.node.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.container", func(t *testing.T) {
@@ -734,8 +786,10 @@ func TestEntityBuilders(t *testing.T) {
 		e.SetContainerImageName("container.image.name-val")
 		e.SetContainerImageTag("container.image.tag-val")
 		e.SetK8sContainerStatusLastTerminatedReason("k8s.container.status.last_terminated_reason-val")
-		relatedK8sPod := NewK8sPodEntity("k8s.pod.uid-val")
-		e.SetChildOfK8sPod(relatedK8sPod)
+		e.SetK8sPodUID("k8s.pod.uid-val")
+		e.SetK8sPodName("k8s.pod.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
+		e.SetK8sNodeName("k8s.node.name-val")
 
 		eb := mb.ForK8sContainer(e)
 		eb.RecordK8sContainerCPULimitDataPoint(ts, 1)
@@ -771,6 +825,26 @@ func TestEntityBuilders(t *testing.T) {
 		assert.Equal(t, "container.image.tag-val", containerImageTagAttrVal.Str())
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.container.status.last_terminated_reason")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.pod.uid")
+		assert.False(t, ok)
+		k8sPodUIDAttrVal, ok := rm.Resource().Attributes().Get("k8s.pod.uid")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.pod.uid-val", k8sPodUIDAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.pod.name")
+		assert.False(t, ok)
+		k8sPodNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.pod.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.pod.name-val", k8sPodNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.node.name")
+		assert.False(t, ok)
+		k8sNodeNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.node.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.node.name-val", k8sNodeNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -826,6 +900,10 @@ func TestEntityBuilders(t *testing.T) {
 		cfg.ResourceAttributes.ContainerImageName.Enabled = false
 		cfg.ResourceAttributes.ContainerImageTag.Enabled = false
 		cfg.ResourceAttributes.K8sContainerStatusLastTerminatedReason.Enabled = false
+		cfg.ResourceAttributes.K8sPodUID.Enabled = false
+		cfg.ResourceAttributes.K8sPodName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
+		cfg.ResourceAttributes.K8sNodeName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sContainerEntity("container.id-val")
@@ -833,6 +911,10 @@ func TestEntityBuilders(t *testing.T) {
 		e.SetContainerImageName("container.image.name-val")
 		e.SetContainerImageTag("container.image.tag-val")
 		e.SetK8sContainerStatusLastTerminatedReason("k8s.container.status.last_terminated_reason-val")
+		e.SetK8sPodUID("k8s.pod.uid-val")
+		e.SetK8sPodName("k8s.pod.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
+		e.SetK8sNodeName("k8s.node.name-val")
 
 		eb := mb.ForK8sContainer(e)
 		eb.RecordK8sContainerCPULimitDataPoint(ts, 1)
@@ -867,14 +949,21 @@ func TestEntityBuilders(t *testing.T) {
 		assert.False(t, ok)
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.container.status.last_terminated_reason")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.pod.uid")
+		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.pod.name")
+		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.node.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.replicationcontroller", func(t *testing.T) {
 		e := NewK8sReplicationcontrollerEntity("k8s.replicationcontroller.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sReplicationcontrollerName("k8s.replicationcontroller.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sReplicationcontroller(e)
 		eb.RecordK8sReplicationControllerAvailableDataPoint(ts, 1)
@@ -892,6 +981,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sReplicationcontrollerNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.replicationcontroller.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.replicationcontroller.name-val", k8sReplicationcontrollerNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -927,10 +1021,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sReplicationcontrollerName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sReplicationcontrollerEntity("k8s.replicationcontroller.uid-val")
 		e.SetK8sReplicationcontrollerName("k8s.replicationcontroller.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sReplicationcontroller(e)
 		eb.RecordK8sReplicationControllerAvailableDataPoint(ts, 1)
@@ -949,14 +1045,15 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.replicationcontroller.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.resourcequota", func(t *testing.T) {
 		e := NewK8sResourcequotaEntity("k8s.resourcequota.uid-val")
 		require.NotNil(t, e)
 		e.SetK8sResourcequotaName("k8s.resourcequota.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sResourcequota(e)
 		eb.RecordK8sResourceQuotaHardLimitDataPoint(ts, 1, "resource-val")
@@ -974,6 +1071,11 @@ func TestEntityBuilders(t *testing.T) {
 		k8sResourcequotaNameAttrVal, ok := entityVal.DescriptiveAttributes().Get("k8s.resourcequota.name")
 		require.True(t, ok)
 		assert.Equal(t, "k8s.resourcequota.name-val", k8sResourcequotaNameAttrVal.Str())
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -1009,10 +1111,12 @@ func TestEntityBuilders(t *testing.T) {
 		// with its identity but the disabled attribute is not added.
 		cfg := DefaultMetricsBuilderConfig()
 		cfg.ResourceAttributes.K8sResourcequotaName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sResourcequotaEntity("k8s.resourcequota.uid-val")
 		e.SetK8sResourcequotaName("k8s.resourcequota.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sResourcequota(e)
 		eb.RecordK8sResourceQuotaHardLimitDataPoint(ts, 1, "resource-val")
@@ -1031,6 +1135,8 @@ func TestEntityBuilders(t *testing.T) {
 		// Disabled descriptive/extra attributes must not be present.
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.resourcequota.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
 	})
 
 	t.Run("k8s.service", func(t *testing.T) {
@@ -1040,8 +1146,7 @@ func TestEntityBuilders(t *testing.T) {
 		e.SetK8sServiceType("k8s.service.type-val")
 		e.SetK8sServicePublishNotReadyAddresses(false)
 		e.SetK8sServiceTrafficDistribution("k8s.service.traffic_distribution-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sService(e)
 		eb.RecordK8sServiceEndpointCountDataPoint(ts, 1, AttributeK8sServiceEndpointAddressTypeIPv4, AttributeK8sServiceEndpointConditionReady, "k8s.service.endpoint.zone-val")
@@ -1059,8 +1164,7 @@ func TestEntityBuilders(t *testing.T) {
 		e.SetK8sHpaScaletargetrefApiversion("k8s.hpa.scaletargetref.apiversion-val")
 		e.SetK8sHpaScaletargetrefKind("k8s.hpa.scaletargetref.kind-val")
 		e.SetK8sHpaScaletargetrefName("k8s.hpa.scaletargetref.name-val")
-		relatedK8sNamespace := NewK8sNamespaceEntity("k8s.namespace.uid-val")
-		e.SetPartOfK8sNamespace(relatedK8sNamespace)
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sHpa(e)
 		eb.RecordK8sHpaCurrentReplicasDataPoint(ts, 1)
@@ -1086,6 +1190,11 @@ func TestEntityBuilders(t *testing.T) {
 		assert.False(t, ok)
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.hpa.scaletargetref.name")
 		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
+		assert.False(t, ok)
+		k8sNamespaceNameAttrVal, ok := rm.Resource().Attributes().Get("k8s.namespace.name")
+		require.True(t, ok)
+		assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
 
 		require.Equal(t, 1, rm.ScopeMetrics().Len())
 		ms := rm.ScopeMetrics().At(0).Metrics()
@@ -1129,6 +1238,7 @@ func TestEntityBuilders(t *testing.T) {
 		cfg.ResourceAttributes.K8sHpaScaletargetrefApiversion.Enabled = false
 		cfg.ResourceAttributes.K8sHpaScaletargetrefKind.Enabled = false
 		cfg.ResourceAttributes.K8sHpaScaletargetrefName.Enabled = false
+		cfg.ResourceAttributes.K8sNamespaceName.Enabled = false
 		mb := NewMetricsBuilder(cfg, settings, WithStartTime(start))
 
 		e := NewK8sHpaEntity("k8s.hpa.uid-val")
@@ -1136,6 +1246,7 @@ func TestEntityBuilders(t *testing.T) {
 		e.SetK8sHpaScaletargetrefApiversion("k8s.hpa.scaletargetref.apiversion-val")
 		e.SetK8sHpaScaletargetrefKind("k8s.hpa.scaletargetref.kind-val")
 		e.SetK8sHpaScaletargetrefName("k8s.hpa.scaletargetref.name-val")
+		e.SetK8sNamespaceName("k8s.namespace.name-val")
 
 		eb := mb.ForK8sHpa(e)
 		eb.RecordK8sHpaCurrentReplicasDataPoint(ts, 1)
@@ -1161,6 +1272,8 @@ func TestEntityBuilders(t *testing.T) {
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.hpa.scaletargetref.kind")
 		assert.False(t, ok)
 		_, ok = entityVal.DescriptiveAttributes().Get("k8s.hpa.scaletargetref.name")
+		assert.False(t, ok)
+		_, ok = entityVal.DescriptiveAttributes().Get("k8s.namespace.name")
 		assert.False(t, ok)
 	})
 

--- a/receiver/k8sclusterreceiver/internal/namespace/namespaces.go
+++ b/receiver/k8sclusterreceiver/internal/namespace/namespaces.go
@@ -21,11 +21,11 @@ const (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, ns *corev1.Namespace, ts pcommon.Timestamp) {
-	mb.RecordK8sNamespacePhaseDataPoint(ts, int64(namespacePhaseValues[ns.Status.Phase])) //nolint:staticcheck
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceUID(string(ns.UID))
-	rb.SetK8sNamespaceName(ns.Name)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sNamespaceEntity(string(ns.UID))
+	e.SetK8sNamespaceName(ns.Name)
+	eb := mb.ForK8sNamespace(e)
+	eb.RecordK8sNamespacePhaseDataPoint(ts, int64(namespacePhaseValues[ns.Status.Phase]))
+	eb.Emit()
 }
 
 var namespacePhaseValues = map[corev1.NamespacePhase]int32{

--- a/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
@@ -7,6 +7,12 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: test-namespace-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.namespace.name
+          idKeys:
+            - k8s.namespace.uid
+          type: k8s.namespace
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/node/nodes.go
+++ b/receiver/k8sclusterreceiver/internal/node/nodes.go
@@ -52,14 +52,14 @@ func Transform(node *corev1.Node) *corev1.Node {
 }
 
 func RecordMetrics(mb *metadata.MetricsBuilder, node *corev1.Node, ts pcommon.Timestamp) {
+	e := metadata.NewK8sNodeEntity(string(node.UID))
+	e.SetK8sNodeName(node.Name)
+	e.SetK8sKubeletVersion(node.Status.NodeInfo.KubeletVersion)
+	eb := mb.ForK8sNode(e)
 	for _, c := range node.Status.Conditions {
-		mb.RecordK8sNodeConditionDataPoint(ts, nodeConditionValues[c.Status], string(c.Type)) //nolint:staticcheck
+		eb.RecordK8sNodeConditionDataPoint(ts, nodeConditionValues[c.Status], string(c.Type))
 	}
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNodeUID(string(node.UID))
-	rb.SetK8sNodeName(node.Name)
-	rb.SetK8sKubeletVersion(node.Status.NodeInfo.KubeletVersion)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 func CustomMetrics(set receiver.Settings, rb *metadata.ResourceBuilder, node *corev1.Node, nodeConditionTypesToReport,

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
@@ -1,9 +1,6 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: k8s.kubelet.version
-          value:
-            stringValue: v1.25.3
         - key: k8s.node.name
           value:
             stringValue: test-node-1
@@ -13,7 +10,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.node.name
-            - k8s.kubelet.version
           idKeys:
             - k8s.node.uid
           type: k8s.node

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
@@ -1,12 +1,22 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: k8s.kubelet.version
+          value:
+            stringValue: v1.25.3
         - key: k8s.node.name
           value:
             stringValue: test-node-1
         - key: k8s.node.uid
           value:
             stringValue: test-node-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.node.name
+            - k8s.kubelet.version
+          idKeys:
+            - k8s.node.uid
+          type: k8s.node
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -74,15 +74,15 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 }
 
 func RecordMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, pod *corev1.Pod, ts pcommon.Timestamp) {
-	mb.RecordK8sPodPhaseDataPoint(ts, int64(phaseToInt(pod.Status.Phase)))          //nolint:staticcheck
-	mb.RecordK8sPodStatusReasonDataPoint(ts, int64(reasonToInt(pod.Status.Reason))) //nolint:staticcheck
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceName(pod.Namespace)
-	rb.SetK8sNodeName(pod.Spec.NodeName)
-	rb.SetK8sPodName(pod.Name)
-	rb.SetK8sPodUID(string(pod.UID))
-	rb.SetK8sPodQosClass(string(pod.Status.QOSClass))
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sPodEntity(string(pod.UID))
+	e.SetK8sPodName(pod.Name)
+	e.SetK8sPodQosClass(string(pod.Status.QOSClass))
+	e.SetK8sNamespaceName(pod.Namespace)
+	e.SetK8sNodeName(pod.Spec.NodeName)
+	eb := mb.ForK8sPod(e)
+	eb.RecordK8sPodPhaseDataPoint(ts, int64(phaseToInt(pod.Status.Phase)))
+	eb.RecordK8sPodStatusReasonDataPoint(ts, int64(reasonToInt(pod.Status.Reason)))
+	eb.Emit()
 
 	for i := range pod.Spec.Containers {
 		c := pod.Spec.Containers[i]

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
@@ -13,6 +13,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -51,6 +57,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_reason.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_reason.yaml
@@ -16,9 +16,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.pod.name
-            - k8s.pod.qos_class
-            - k8s.namespace.name
-            - k8s.node.name
           idKeys:
             - k8s.pod.uid
           type: k8s.pod

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_reason.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_reason.yaml
@@ -13,6 +13,15 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+            - k8s.pod.qos_class
+            - k8s.namespace.name
+            - k8s.node.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -51,6 +60,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -132,4 +149,4 @@ resourceMetrics:
             unit: "{cpu}"
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
-          version: latest 
+          version: latest

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_state.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_state.yaml
@@ -13,6 +13,15 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+            - k8s.pod.qos_class
+            - k8s.namespace.name
+            - k8s.node.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -51,6 +60,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -102,4 +119,4 @@ resourceMetrics:
             unit: "{cpu}"
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
-          version: latest 
+          version: latest

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_state.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_state.yaml
@@ -16,9 +16,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.pod.name
-            - k8s.pod.qos_class
-            - k8s.namespace.name
-            - k8s.node.name
           idKeys:
             - k8s.pod.uid
           type: k8s.pod

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
@@ -16,6 +16,13 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+            - k8s.pod.qos_class
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -63,6 +70,15 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+            - k8s.container.status.last_terminated_reason
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/replicaset/replicasets.go
+++ b/receiver/k8sclusterreceiver/internal/replicaset/replicasets.go
@@ -27,16 +27,15 @@ func Transform(rs *appsv1.ReplicaSet) *appsv1.ReplicaSet {
 }
 
 func RecordMetrics(mb *metadata.MetricsBuilder, rs *appsv1.ReplicaSet, ts pcommon.Timestamp) {
+	e := metadata.NewK8sReplicasetEntity(string(rs.UID))
+	e.SetK8sReplicasetName(rs.Name)
+	e.SetK8sNamespaceName(rs.Namespace)
+	eb := mb.ForK8sReplicaset(e)
 	if rs.Spec.Replicas != nil {
-		mb.RecordK8sReplicasetDesiredDataPoint(ts, int64(*rs.Spec.Replicas))             //nolint:staticcheck
-		mb.RecordK8sReplicasetAvailableDataPoint(ts, int64(rs.Status.AvailableReplicas)) //nolint:staticcheck
+		eb.RecordK8sReplicasetDesiredDataPoint(ts, int64(*rs.Spec.Replicas))
+		eb.RecordK8sReplicasetAvailableDataPoint(ts, int64(rs.Status.AvailableReplicas))
 	}
-
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceName(rs.Namespace)
-	rb.SetK8sReplicasetName(rs.Name)
-	rb.SetK8sReplicasetUID(string(rs.UID))
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 func GetMetadata(rs *appsv1.ReplicaSet) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.replicaset.name
-            - k8s.namespace.name
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset

--- a/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: test-replicaset-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicaset.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.replicaset.uid
+          type: k8s.replicaset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -25,8 +32,6 @@ resourceMetrics:
                 - asInt: "2"
             name: k8s.replicaset.available
             unit: "{pod}"
-
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
-

--- a/receiver/k8sclusterreceiver/internal/replicationcontroller/replicationcontrollers.go
+++ b/receiver/k8sclusterreceiver/internal/replicationcontroller/replicationcontrollers.go
@@ -13,16 +13,17 @@ import (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, rc *corev1.ReplicationController, ts pcommon.Timestamp) {
+	e := metadata.NewK8sReplicationcontrollerEntity(string(rc.UID))
+	e.SetK8sReplicationcontrollerName(rc.Name)
+	e.SetK8sNamespaceName(rc.Namespace)
+	eb := mb.ForK8sReplicationcontroller(e)
+
 	if rc.Spec.Replicas != nil {
-		mb.RecordK8sReplicationControllerDesiredDataPoint(ts, int64(*rc.Spec.Replicas))             //nolint:staticcheck
-		mb.RecordK8sReplicationControllerAvailableDataPoint(ts, int64(rc.Status.AvailableReplicas)) //nolint:staticcheck
+		eb.RecordK8sReplicationControllerDesiredDataPoint(ts, int64(*rc.Spec.Replicas))
+		eb.RecordK8sReplicationControllerAvailableDataPoint(ts, int64(rc.Status.AvailableReplicas))
 	}
 
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sNamespaceName(rc.Namespace)
-	rb.SetK8sReplicationcontrollerName(rc.Name)
-	rb.SetK8sReplicationcontrollerUID(string(rc.UID))
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 func GetMetadata(rc *corev1.ReplicationController) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.replicationcontroller.name
-            - k8s.namespace.name
           idKeys:
             - k8s.replicationcontroller.uid
           type: k8s.replicationcontroller

--- a/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.replicationcontroller.uid
           value:
             stringValue: test-replicationcontroller-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicationcontroller.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.replicationcontroller.uid
+          type: k8s.replicationcontroller
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/resourcequota/resourcequotas.go
+++ b/receiver/k8sclusterreceiver/internal/resourcequota/resourcequotas.go
@@ -13,12 +13,17 @@ import (
 )
 
 func RecordMetrics(mb *metadata.MetricsBuilder, rq *corev1.ResourceQuota, ts pcommon.Timestamp) {
+	e := metadata.NewK8sResourcequotaEntity(string(rq.UID))
+	e.SetK8sResourcequotaName(rq.Name)
+	e.SetK8sNamespaceName(rq.Namespace)
+	eb := mb.ForK8sResourcequota(e)
+
 	for k, v := range rq.Status.Hard {
 		val := v.Value()
 		if strings.HasSuffix(string(k), ".cpu") {
 			val = v.MilliValue()
 		}
-		mb.RecordK8sResourceQuotaHardLimitDataPoint(ts, val, string(k)) //nolint:staticcheck
+		eb.RecordK8sResourceQuotaHardLimitDataPoint(ts, val, string(k))
 	}
 
 	for k, v := range rq.Status.Used {
@@ -26,12 +31,8 @@ func RecordMetrics(mb *metadata.MetricsBuilder, rq *corev1.ResourceQuota, ts pco
 		if strings.HasSuffix(string(k), ".cpu") {
 			val = v.MilliValue()
 		}
-		mb.RecordK8sResourceQuotaUsedDataPoint(ts, val, string(k)) //nolint:staticcheck
+		eb.RecordK8sResourceQuotaUsedDataPoint(ts, val, string(k))
 	}
 
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sResourcequotaUID(string(rq.UID))
-	rb.SetK8sResourcequotaName(rq.Name)
-	rb.SetK8sNamespaceName(rq.Namespace)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }

--- a/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
@@ -10,6 +10,13 @@ resourceMetrics:
         - key: k8s.resourcequota.uid
           value:
             stringValue: test-resourcequota-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.resourcequota.name
+            - k8s.namespace.name
+          idKeys:
+            - k8s.resourcequota.uid
+          type: k8s.resourcequota
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
@@ -13,7 +13,6 @@ resourceMetrics:
       entityRefs:
         - descriptionKeys:
             - k8s.resourcequota.name
-            - k8s.namespace.name
           idKeys:
             - k8s.resourcequota.uid
           type: k8s.resourcequota

--- a/receiver/k8sclusterreceiver/internal/service/service.go
+++ b/receiver/k8sclusterreceiver/internal/service/service.go
@@ -52,23 +52,13 @@ func Transform(service *corev1.Service) *corev1.Service {
 }
 
 func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Service, endpointCounts EndpointCountsByKey, ts pcommon.Timestamp) {
-	e := metadata.NewK8sServiceEntity(string(svc.UID))
-	e.SetK8sServiceName(svc.Name)
-	e.SetK8sNamespaceName(svc.Namespace)
-	e.SetK8sServiceType(string(svc.Spec.Type))
-	if svc.Spec.TrafficDistribution != nil {
-		e.SetK8sServiceTrafficDistribution(*svc.Spec.TrafficDistribution)
-	}
-	e.SetK8sServicePublishNotReadyAddresses(svc.Spec.PublishNotReadyAddresses)
-	eb := mb.ForK8sService(e)
-
 	for key, counts := range endpointCounts {
 		addressTypeEnum, ok := metadata.MapAttributeK8sServiceEndpointAddressType[key.AddressType]
 		if !ok {
 			continue
 		}
 
-		eb.RecordK8sServiceEndpointCountDataPoint(
+		mb.RecordK8sServiceEndpointCountDataPoint( //nolint:staticcheck
 			ts,
 			int64(counts.Ready),
 			addressTypeEnum,
@@ -76,7 +66,7 @@ func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Servi
 			key.Zone,
 		)
 
-		eb.RecordK8sServiceEndpointCountDataPoint(
+		mb.RecordK8sServiceEndpointCountDataPoint( //nolint:staticcheck
 			ts,
 			int64(counts.Serving),
 			addressTypeEnum,
@@ -84,7 +74,7 @@ func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Servi
 			key.Zone,
 		)
 
-		eb.RecordK8sServiceEndpointCountDataPoint(
+		mb.RecordK8sServiceEndpointCountDataPoint( //nolint:staticcheck
 			ts,
 			int64(counts.Terminating),
 			addressTypeEnum,
@@ -95,10 +85,19 @@ func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Servi
 
 	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		ingressCount := len(svc.Status.LoadBalancer.Ingress)
-		eb.RecordK8sServiceLoadBalancerIngressCountDataPoint(ts, int64(ingressCount))
+		mb.RecordK8sServiceLoadBalancerIngressCountDataPoint(ts, int64(ingressCount)) //nolint:staticcheck
 	}
 
-	eb.Emit()
+	rb := mb.NewResourceBuilder()
+	rb.SetK8sServiceName(svc.Name)
+	rb.SetK8sServiceUID(string(svc.UID))
+	rb.SetK8sNamespaceName(svc.Namespace)
+	rb.SetK8sServiceType(string(svc.Spec.Type))
+	if svc.Spec.TrafficDistribution != nil {
+		rb.SetK8sServiceTrafficDistribution(*svc.Spec.TrafficDistribution)
+	}
+	rb.SetK8sServicePublishNotReadyAddresses(svc.Spec.PublishNotReadyAddresses)
+	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
 }
 
 // EndpointCounts tracks the counts of endpoints in different conditions

--- a/receiver/k8sclusterreceiver/internal/service/service.go
+++ b/receiver/k8sclusterreceiver/internal/service/service.go
@@ -52,13 +52,23 @@ func Transform(service *corev1.Service) *corev1.Service {
 }
 
 func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Service, endpointCounts EndpointCountsByKey, ts pcommon.Timestamp) {
+	e := metadata.NewK8sServiceEntity(string(svc.UID))
+	e.SetK8sServiceName(svc.Name)
+	e.SetK8sNamespaceName(svc.Namespace)
+	e.SetK8sServiceType(string(svc.Spec.Type))
+	if svc.Spec.TrafficDistribution != nil {
+		e.SetK8sServiceTrafficDistribution(*svc.Spec.TrafficDistribution)
+	}
+	e.SetK8sServicePublishNotReadyAddresses(svc.Spec.PublishNotReadyAddresses)
+	eb := mb.ForK8sService(e)
+
 	for key, counts := range endpointCounts {
 		addressTypeEnum, ok := metadata.MapAttributeK8sServiceEndpointAddressType[key.AddressType]
 		if !ok {
 			continue
 		}
 
-		mb.RecordK8sServiceEndpointCountDataPoint( //nolint:staticcheck
+		eb.RecordK8sServiceEndpointCountDataPoint(
 			ts,
 			int64(counts.Ready),
 			addressTypeEnum,
@@ -66,7 +76,7 @@ func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Servi
 			key.Zone,
 		)
 
-		mb.RecordK8sServiceEndpointCountDataPoint( //nolint:staticcheck
+		eb.RecordK8sServiceEndpointCountDataPoint(
 			ts,
 			int64(counts.Serving),
 			addressTypeEnum,
@@ -74,7 +84,7 @@ func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Servi
 			key.Zone,
 		)
 
-		mb.RecordK8sServiceEndpointCountDataPoint( //nolint:staticcheck
+		eb.RecordK8sServiceEndpointCountDataPoint(
 			ts,
 			int64(counts.Terminating),
 			addressTypeEnum,
@@ -85,19 +95,10 @@ func RecordMetrics(_ *zap.Logger, mb *metadata.MetricsBuilder, svc *corev1.Servi
 
 	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		ingressCount := len(svc.Status.LoadBalancer.Ingress)
-		mb.RecordK8sServiceLoadBalancerIngressCountDataPoint(ts, int64(ingressCount)) //nolint:staticcheck
+		eb.RecordK8sServiceLoadBalancerIngressCountDataPoint(ts, int64(ingressCount))
 	}
 
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sServiceName(svc.Name)
-	rb.SetK8sServiceUID(string(svc.UID))
-	rb.SetK8sNamespaceName(svc.Namespace)
-	rb.SetK8sServiceType(string(svc.Spec.Type))
-	if svc.Spec.TrafficDistribution != nil {
-		rb.SetK8sServiceTrafficDistribution(*svc.Spec.TrafficDistribution)
-	}
-	rb.SetK8sServicePublishNotReadyAddresses(svc.Spec.PublishNotReadyAddresses)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	eb.Emit()
 }
 
 // EndpointCounts tracks the counts of endpoints in different conditions

--- a/receiver/k8sclusterreceiver/internal/statefulset/statefulsets.go
+++ b/receiver/k8sclusterreceiver/internal/statefulset/statefulsets.go
@@ -38,15 +38,15 @@ func RecordMetrics(mb *metadata.MetricsBuilder, ss *appsv1.StatefulSet, ts pcomm
 	if ss.Spec.Replicas == nil {
 		return
 	}
-	mb.RecordK8sStatefulsetDesiredPodsDataPoint(ts, int64(*ss.Spec.Replicas))         //nolint:staticcheck
-	mb.RecordK8sStatefulsetReadyPodsDataPoint(ts, int64(ss.Status.ReadyReplicas))     //nolint:staticcheck
-	mb.RecordK8sStatefulsetCurrentPodsDataPoint(ts, int64(ss.Status.CurrentReplicas)) //nolint:staticcheck
-	mb.RecordK8sStatefulsetUpdatedPodsDataPoint(ts, int64(ss.Status.UpdatedReplicas)) //nolint:staticcheck
-	rb := mb.NewResourceBuilder()
-	rb.SetK8sStatefulsetUID(string(ss.UID))
-	rb.SetK8sStatefulsetName(ss.Name)
-	rb.SetK8sNamespaceName(ss.Namespace)
-	mb.EmitForResource(metadata.WithResource(rb.Emit())) //nolint:staticcheck
+	e := metadata.NewK8sStatefulsetEntity(string(ss.UID))
+	e.SetK8sStatefulsetName(ss.Name)
+	e.SetK8sNamespaceName(ss.Namespace)
+	eb := mb.ForK8sStatefulset(e)
+	eb.RecordK8sStatefulsetDesiredPodsDataPoint(ts, int64(*ss.Spec.Replicas))
+	eb.RecordK8sStatefulsetReadyPodsDataPoint(ts, int64(ss.Status.ReadyReplicas))
+	eb.RecordK8sStatefulsetCurrentPodsDataPoint(ts, int64(ss.Status.CurrentReplicas))
+	eb.RecordK8sStatefulsetUpdatedPodsDataPoint(ts, int64(ss.Status.UpdatedReplicas))
+	eb.Emit()
 }
 
 func GetMetadata(ss *appsv1.StatefulSet) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -156,6 +156,10 @@ entities:
     extra_attributes:
       - ref: k8s.namespace.name
 
+  # TODO: k8s.service uses the old ResourceBuilder API (not ForK8sService) because
+  # k8s.service.traffic_distribution is an optional field (nil pointer in the K8s API) and
+  # mdatagen-generated copyToResource unconditionally emits enabled string attributes even when
+  # never set. Switch to the entity API once mdatagen supports optional/omitempty string attributes.
   - type: k8s.service
     brief: A Kubernetes service
     stability: development
@@ -167,10 +171,6 @@ entities:
       - ref: k8s.service.publish_not_ready_addresses
     extra_attributes:
       - ref: k8s.namespace.name
-      # TODO: k8s.service.traffic_distribution is an optional field (nil pointer in the K8s API).
-      # mdatagen-generated copyToResource always emits enabled string attributes even when they
-      # were never set (zero value ""). Until mdatagen supports optional/omitempty string descriptors,
-      # keep traffic_distribution as an extra_attribute and guard the nil check in service.go.
       - ref: k8s.service.traffic_distribution
 
   - type: k8s.hpa

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -165,9 +165,13 @@ entities:
       - ref: k8s.service.name
       - ref: k8s.service.type
       - ref: k8s.service.publish_not_ready_addresses
-      - ref: k8s.service.traffic_distribution
     extra_attributes:
       - ref: k8s.namespace.name
+      # TODO: k8s.service.traffic_distribution is an optional field (nil pointer in the K8s API).
+      # mdatagen-generated copyToResource always emits enabled string attributes even when they
+      # were never set (zero value ""). Until mdatagen supports optional/omitempty string descriptors,
+      # keep traffic_distribution as an extra_attribute and guard the nil check in service.go.
+      - ref: k8s.service.traffic_distribution
 
   - type: k8s.hpa
     brief: A Kubernetes horizontal pod autoscaler

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -46,9 +46,8 @@ entities:
       - ref: k8s.deployment.uid
     description:
       - ref: k8s.deployment.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.replicaset
     brief: A Kubernetes replicaset
@@ -57,9 +56,8 @@ entities:
       - ref: k8s.replicaset.uid
     description:
       - ref: k8s.replicaset.name
-    relationships:
-      - type: managed_by
-        target: k8s.deployment
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.statefulset
     brief: A Kubernetes statefulset
@@ -68,9 +66,8 @@ entities:
       - ref: k8s.statefulset.uid
     description:
       - ref: k8s.statefulset.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.daemonset
     brief: A Kubernetes daemonset
@@ -79,9 +76,8 @@ entities:
       - ref: k8s.daemonset.uid
     description:
       - ref: k8s.daemonset.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.cronjob
     brief: A Kubernetes cronjob
@@ -90,9 +86,8 @@ entities:
       - ref: k8s.cronjob.uid
     description:
       - ref: k8s.cronjob.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.job
     brief: A Kubernetes job
@@ -101,11 +96,8 @@ entities:
       - ref: k8s.job.uid
     description:
       - ref: k8s.job.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
-      - type: managed_by
-        target: k8s.cronjob
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.pod
     brief: A Kubernetes pod
@@ -115,21 +107,9 @@ entities:
     description:
       - ref: k8s.pod.name
       - ref: k8s.pod.qos_class
-    relationships:
-      - type: scheduled_on
-        target: k8s.node
-      - type: part_of
-        target: k8s.namespace
-      - type: managed_by
-        target: k8s.replicaset
-      - type: managed_by
-        target: k8s.statefulset
-      - type: managed_by
-        target: k8s.daemonset
-      - type: managed_by
-        target: k8s.job
-      - type: managed_by
-        target: k8s.replicationcontroller
+    extra_attributes:
+      - ref: k8s.namespace.name
+      - ref: k8s.node.name
 
   - type: k8s.container
     brief: A Kubernetes container
@@ -141,9 +121,20 @@ entities:
       - ref: container.image.name
       - ref: container.image.tag
       - ref: k8s.container.status.last_terminated_reason
-    relationships:
-      - type: child_of
-        target: k8s.pod
+    # TODO: Use "relationships" instead of "extra_attribu˝˝tes" here.
+    # Currently, k8s.container does not inherit all descriptive attributes from
+    # the k8s.pod entity (for example, k8s.pod.qos_class is not emitted). To define
+    # a related entity here instead of using extra_attributes, we would need to either:
+    # - start explicitly emitting k8s.container metrics with the k8s.pod.qos_class attribute, or
+    # - make the related-entity description configurable.
+      # relationships:
+      #   target: k8s.pod
+      # - type: child_of
+    extra_attributes:
+      - ref: k8s.pod.uid
+      - ref: k8s.pod.name
+      - ref: k8s.namespace.name
+      - ref: k8s.node.name
 
   - type: k8s.replicationcontroller
     brief: A Kubernetes replication controller
@@ -152,9 +143,8 @@ entities:
       - ref: k8s.replicationcontroller.uid
     description:
       - ref: k8s.replicationcontroller.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.resourcequota
     brief: A Kubernetes resource quota
@@ -163,9 +153,8 @@ entities:
       - ref: k8s.resourcequota.uid
     description:
       - ref: k8s.resourcequota.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.service
     brief: A Kubernetes service
@@ -177,9 +166,8 @@ entities:
       - ref: k8s.service.type
       - ref: k8s.service.publish_not_ready_addresses
       - ref: k8s.service.traffic_distribution
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: k8s.hpa
     brief: A Kubernetes horizontal pod autoscaler
@@ -191,9 +179,8 @@ entities:
       - ref: k8s.hpa.scaletargetref.apiversion
       - ref: k8s.hpa.scaletargetref.kind
       - ref: k8s.hpa.scaletargetref.name
-    relationships:
-      - type: part_of
-        target: k8s.namespace
+    extra_attributes:
+      - ref: k8s.namespace.name
 
   - type: openshift.clusterquota
     brief: An OpenShift cluster resource quota

--- a/receiver/k8sclusterreceiver/testdata/e2e/cluster-scoped/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/cluster-scoped/expected.yaml
@@ -142,12 +142,6 @@ resourceMetrics:
         - key: k8s.node.uid
           value:
             stringValue: 5a4b4eed-f9d2-4055-b9f2-96cfcd69ced1
-      entityRefs:
-        - descriptionKeys:
-            - k8s.node.name
-          idKeys:
-            - k8s.node.uid
-          type: k8s.node
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/testdata/e2e/cluster-scoped/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/cluster-scoped/expected.yaml
@@ -7,6 +7,12 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 79f9ec63-8403-4dac-8459-a87d71e0dc5f
+      entityRefs:
+        - descriptionKeys:
+            - k8s.namespace.name
+          idKeys:
+            - k8s.namespace.uid
+          type: k8s.namespace
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -28,6 +34,12 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 94a3157d-591a-4fc4-b91f-a3a7af7668a2
+      entityRefs:
+        - descriptionKeys:
+            - k8s.namespace.name
+          idKeys:
+            - k8s.namespace.uid
+          type: k8s.namespace
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -49,6 +61,12 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 789a9453-8d96-41f6-8eb7-f296a6cec8f9
+      entityRefs:
+        - descriptionKeys:
+            - k8s.namespace.name
+          idKeys:
+            - k8s.namespace.uid
+          type: k8s.namespace
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -70,6 +88,12 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 5a2fd18d-35e2-44bb-a5a6-182114f19e30
+      entityRefs:
+        - descriptionKeys:
+            - k8s.namespace.name
+          idKeys:
+            - k8s.namespace.uid
+          type: k8s.namespace
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -91,6 +115,12 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: ba93ff9c-3566-4aa5-bb1f-0aa703331949
+      entityRefs:
+        - descriptionKeys:
+            - k8s.namespace.name
+          idKeys:
+            - k8s.namespace.uid
+          type: k8s.namespace
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -112,6 +142,12 @@ resourceMetrics:
         - key: k8s.node.uid
           value:
             stringValue: 5a4b4eed-f9d2-4055-b9f2-96cfcd69ced1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.node.name
+          idKeys:
+            - k8s.node.uid
+          type: k8s.node
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -135,6 +171,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: default
+      entityRefs:
+        - descriptionKeys:
+            - k8s.cronjob.name
+          idKeys:
+            - k8s.cronjob.uid
+          type: k8s.cronjob
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -160,6 +202,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kube-system
+      entityRefs:
+        - descriptionKeys:
+            - k8s.daemonset.name
+          idKeys:
+            - k8s.daemonset.uid
+          type: k8s.daemonset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -209,6 +257,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kube-system
+      entityRefs:
+        - descriptionKeys:
+            - k8s.daemonset.name
+          idKeys:
+            - k8s.daemonset.uid
+          type: k8s.daemonset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -258,6 +312,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kube-system
+      entityRefs:
+        - descriptionKeys:
+            - k8s.deployment.name
+          idKeys:
+            - k8s.deployment.uid
+          type: k8s.deployment
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -291,6 +351,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: local-path-storage
+      entityRefs:
+        - descriptionKeys:
+            - k8s.deployment.name
+          idKeys:
+            - k8s.deployment.uid
+          type: k8s.deployment
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -324,6 +390,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: default
+      entityRefs:
+        - descriptionKeys:
+            - k8s.deployment.name
+          idKeys:
+            - k8s.deployment.uid
+          type: k8s.deployment
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -357,6 +429,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: default
+      entityRefs:
+        - descriptionKeys:
+            - k8s.hpa.name
+          idKeys:
+            - k8s.hpa.uid
+          type: k8s.hpa
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -406,6 +484,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: default
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -463,6 +547,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: default
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -520,6 +610,12 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: 52aaefd2-d4b6-4600-90b7-d1b84eefd671
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicaset.name
+          idKeys:
+            - k8s.replicaset.uid
+          type: k8s.replicaset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -553,6 +649,12 @@ resourceMetrics:
         - key: k8s.statefulset.uid
           value:
             stringValue: 65b8c0ad-1a19-4690-b708-c4acfcdf6466
+      entityRefs:
+        - descriptionKeys:
+            - k8s.statefulset.name
+          idKeys:
+            - k8s.statefulset.uid
+          type: k8s.statefulset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -602,6 +704,12 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: 16414230-48ea-4446-a9df-d770b212eb68
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicaset.name
+          idKeys:
+            - k8s.replicaset.uid
+          type: k8s.replicaset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -635,6 +743,12 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: f0772f91-ca62-499b-90c4-2c94251fe1c7
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicaset.name
+          idKeys:
+            - k8s.replicaset.uid
+          type: k8s.replicaset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -671,6 +785,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 6787bb58-1d90-472c-b2a1-c6618e19177d
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -698,6 +818,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 16c02129-b9f6-40df-a64a-094126edc3ea
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -725,6 +851,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 8df02f1d-f7bf-467c-b371-f87b7f603d22
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -752,6 +884,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 7f495e91-d116-4524-bde9-8ed320e01b45
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -779,6 +917,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 5699a609-3dc1-442d-aa93-e2b54ab049f1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -806,6 +950,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 0607eacd-aac1-48ab-8aad-a5926fc2f699
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -833,6 +983,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: cbafd89e-b3db-481f-8f68-25240b380516
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -860,6 +1016,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 7a3e3d02-7d66-44c6-835c-2ffa8b8759e5
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -887,6 +1049,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 8855c932-7948-4f97-86bb-bf0c7d9cd068
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -914,6 +1082,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 426f48fb-3d34-4793-a827-1650cbd9303a
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -941,6 +1115,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: edba691f-ff22-497d-9a8f-a1f284ad3da8
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -968,6 +1148,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 6ce0c4ec-fd65-4a93-9bbf-803283ff7635
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -995,6 +1181,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 0191a447-a9a4-414c-96c2-fc906640e0b9
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1336,6 +1528,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 8df02f1d-f7bf-467c-b371-f87b7f603d22
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1383,6 +1583,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 6787bb58-1d90-472c-b2a1-c6618e19177d
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1462,6 +1670,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 7f495e91-d116-4524-bde9-8ed320e01b45
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1509,6 +1725,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 8855c932-7948-4f97-86bb-bf0c7d9cd068
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1564,6 +1788,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 6ce0c4ec-fd65-4a93-9bbf-803283ff7635
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1619,6 +1851,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 5699a609-3dc1-442d-aa93-e2b54ab049f1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1690,6 +1930,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: edba691f-ff22-497d-9a8f-a1f284ad3da8
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1737,6 +1985,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 426f48fb-3d34-4793-a827-1650cbd9303a
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1792,6 +2048,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 7a3e3d02-7d66-44c6-835c-2ffa8b8759e5
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1871,6 +2135,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 0191a447-a9a4-414c-96c2-fc906640e0b9
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1918,6 +2190,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 0607eacd-aac1-48ab-8aad-a5926fc2f699
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1989,6 +2269,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 16c02129-b9f6-40df-a64a-094126edc3ea
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -2036,6 +2324,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: cbafd89e-b3db-481f-8f68-25240b380516
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped-multiple-namespaces/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped-multiple-namespaces/expected.yaml
@@ -10,6 +10,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.cronjob.name
+          idKeys:
+            - k8s.cronjob.uid
+          type: k8s.cronjob
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -35,6 +41,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-2
+      entityRefs:
+        - descriptionKeys:
+            - k8s.cronjob.name
+          idKeys:
+            - k8s.cronjob.uid
+          type: k8s.cronjob
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -60,6 +72,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.deployment.name
+          idKeys:
+            - k8s.deployment.uid
+          type: k8s.deployment
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -93,6 +111,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.hpa.name
+          idKeys:
+            - k8s.hpa.uid
+          type: k8s.hpa
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -142,6 +166,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-2
+      entityRefs:
+        - descriptionKeys:
+            - k8s.hpa.name
+          idKeys:
+            - k8s.hpa.uid
+          type: k8s.hpa
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -191,6 +221,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-2
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -248,6 +284,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -305,6 +347,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-1
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -362,6 +410,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace-2
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -419,6 +473,12 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: f83257ca-c1dc-4f9b-9ed8-4652a9eedf3d
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicaset.name
+          idKeys:
+            - k8s.replicaset.uid
+          type: k8s.replicaset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -452,6 +512,12 @@ resourceMetrics:
         - key: k8s.statefulset.uid
           value:
             stringValue: 07f042a5-4be8-4be5-96a2-329d54cd6a66
+      entityRefs:
+        - descriptionKeys:
+            - k8s.statefulset.name
+          idKeys:
+            - k8s.statefulset.uid
+          type: k8s.statefulset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -501,6 +567,12 @@ resourceMetrics:
         - key: k8s.statefulset.uid
           value:
             stringValue: 21b5debc-58b2-4884-b1f2-db4ecb3d1deb
+      entityRefs:
+        - descriptionKeys:
+            - k8s.statefulset.name
+          idKeys:
+            - k8s.statefulset.uid
+          type: k8s.statefulset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -553,6 +625,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: a0c21a67-69e6-428c-96d8-464f30d3f1ca
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -580,6 +658,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 4cb2af42-2a1d-46f0-ae87-962783d1f99e
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -607,6 +691,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 59da87d9-f320-497e-a088-c2e8c1e03d68
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -634,6 +724,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: d3c0c3c9-8d6c-4df1-b37d-c34f58c8c3e0
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -661,6 +757,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 618936b7-6803-4909-8671-143c9e7aa5c9
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -688,6 +790,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 25797a0a-6011-4c01-a9ed-b4fb8cb11080
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -715,6 +823,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 86b99b1b-08b9-4fb4-a100-c426110b81e7
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -754,6 +868,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: a0c21a67-69e6-428c-96d8-464f30d3f1ca
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -833,6 +955,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: d3c0c3c9-8d6c-4df1-b37d-c34f58c8c3e0
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -880,6 +1010,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 4cb2af42-2a1d-46f0-ae87-962783d1f99e
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -927,6 +1065,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 25797a0a-6011-4c01-a9ed-b4fb8cb11080
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -974,6 +1120,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 618936b7-6803-4909-8671-143c9e7aa5c9
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1021,6 +1175,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 59da87d9-f320-497e-a088-c2e8c1e03d68
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -1068,6 +1230,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 86b99b1b-08b9-4fb4-a100-c426110b81e7
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped/expected.yaml
@@ -10,6 +10,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace
+      entityRefs:
+        - descriptionKeys:
+            - k8s.cronjob.name
+          idKeys:
+            - k8s.cronjob.uid
+          type: k8s.cronjob
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -35,6 +41,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace
+      entityRefs:
+        - descriptionKeys:
+            - k8s.deployment.name
+          idKeys:
+            - k8s.deployment.uid
+          type: k8s.deployment
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -68,6 +80,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace
+      entityRefs:
+        - descriptionKeys:
+            - k8s.hpa.name
+          idKeys:
+            - k8s.hpa.uid
+          type: k8s.hpa
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -117,6 +135,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -174,6 +198,12 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: my-namespace
+      entityRefs:
+        - descriptionKeys:
+            - k8s.job.name
+          idKeys:
+            - k8s.job.uid
+          type: k8s.job
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -231,6 +261,12 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: 27e40405-9394-4ed8-96d3-d4ae2cc315f6
+      entityRefs:
+        - descriptionKeys:
+            - k8s.replicaset.name
+          idKeys:
+            - k8s.replicaset.uid
+          type: k8s.replicaset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -264,6 +300,12 @@ resourceMetrics:
         - key: k8s.statefulset.uid
           value:
             stringValue: c6944d62-dfe9-436a-be8e-8105b5232599
+      entityRefs:
+        - descriptionKeys:
+            - k8s.statefulset.name
+          idKeys:
+            - k8s.statefulset.uid
+          type: k8s.statefulset
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -316,6 +358,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 3c623bc0-2acc-46be-818e-581fb0fddcb4
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -343,6 +391,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: b7cec813-0873-4c72-9e25-94f5a275c726
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -370,6 +424,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: a786bfad-1bc0-474e-b466-93bbbe685d6a
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -397,6 +457,12 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 1ad7584b-a845-4a30-ace3-79c7b5e69372
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -648,6 +714,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 1ad7584b-a845-4a30-ace3-79c7b5e69372
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -695,6 +769,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: b7cec813-0873-4c72-9e25-94f5a275c726
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -742,6 +824,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: a786bfad-1bc0-474e-b466-93bbbe685d6a
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -789,6 +879,14 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 3c623bc0-2acc-46be-818e-581fb0fddcb4
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:


### PR DESCRIPTION
Apply the new entity-scoped Metrics builder API (https://github.com/open-telemetry/opentelemetry-collector/pull/14660), which:

- Adds entity references to the resource associated with emitted telemetry (user-facing change)
- Enforces associating metrics with entity resource attributes in metadata.yaml (internal change)

The added entity references are reflected in metadata.yaml.

**For reviewers:** The goal of this PR is to adopt the new Metrics builder API without introducing changes to emitted telemetry, except for the additional entity references on resources. You can verify this by confirming that the expected output files remain unchanged apart from these added references.