### PR TITLE
exporter/signalfxexporter: include inactive memory in `memory total`

### DIFF
--- a/.chloggen/46474-signalfx-memory-total-inactive.yaml
+++ b/.chloggen/46474-signalfx-memory-total-inactive.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "exporter/signalfxexporter: include inactive in memory total"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46474]

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -198,6 +198,53 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.Equal(t, int64(10e9), *dps[0].Value.IntValue)
 }
 
+func TestDefaultTranslationRules_MemoryTotalIncludesInactive(t *testing.T) {
+	rules := defaultTranslationRules
+	require.NotNil(t, rules, "rules are nil")
+	tr, err := translation.NewMetricTranslator(rules, 1, make(chan struct{}))
+	require.NoError(t, err)
+
+	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil, "", false, true)
+	require.NoError(t, err)
+
+	md := pmetric.NewMetrics()
+	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("system.memory.usage")
+	m.SetDescription("Bytes of memory in use")
+	m.SetUnit("bytes")
+	g := m.SetEmptyGauge().DataPoints()
+
+	add := func(state string, value int64) {
+		dp := g.AppendEmpty()
+		dp.Attributes().PutStr("state", state)
+		dp.Attributes().PutStr("host", "host0")
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1596000000, 0)))
+		dp.SetIntValue(value)
+	}
+
+	add("used", 6)
+	add("free", 2)
+	add("inactive", 2)
+
+	translated := c.MetricsToSignalFxV2(md)
+	require.NotNil(t, translated)
+
+	metrics := make(map[string][]*sfxpb.DataPoint)
+	for _, pt := range translated {
+		metrics[pt.Metric] = append(metrics[pt.Metric], pt)
+	}
+
+	total, ok := metrics["memory.total"]
+	require.True(t, ok, "memory.total metric not found")
+	require.Len(t, total, 1)
+	require.EqualValues(t, 10, *total[0].Value.IntValue)
+
+	util, ok := metrics["memory.utilization"]
+	require.True(t, ok, "memory.utilization metric not found")
+	require.Len(t, util, 1)
+	require.Equal(t, 60.0, *util[0].Value.DoubleValue)
+}
+
 func requireDimension(t *testing.T, dims []*sfxpb.Dimension, key, val string) {
 	var found bool
 	for _, dim := range dims {

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -169,6 +169,7 @@ translation_rules:
     buffered: true
     cached: true
     free: true
+    inactive: true
     used: true
 - action: aggregate_metric
   metric_name: sf_temp.memory.total


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
in `signalfxexporter`, `memory.total` did not include `state=inactive` which led to a mismatch between the reported memory and the actual one.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46474

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a regression test.
