### PR TITLE
Add testbed for Prometheus receiver

### DIFF
--- a/testbed/datasenders/prometheus_static.go
+++ b/testbed/datasenders/prometheus_static.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -50,8 +51,9 @@ func (s *prometheusStaticSender) Start() error {
 	})
 
 	s.server = &http.Server{
-		Addr:    s.GetEndpoint().String(),
-		Handler: handler,
+		Addr:              s.GetEndpoint().String(),
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	ln, err := net.Listen("tcp", s.server.Addr)
 	if err != nil {

--- a/testbed/datasenders/prometheus_static.go
+++ b/testbed/datasenders/prometheus_static.go
@@ -20,7 +20,6 @@ type PrometheusStaticPayloadConfig struct {
 	SeriesCount          int
 	LabelsPerSeries      int
 	WithTargetInfo       bool
-	WithScopeInfo        bool
 	WithNativeHistograms bool
 }
 
@@ -103,25 +102,6 @@ func buildRegistry(cfg PrometheusStaticPayloadConfig) *prometheus.Registry {
 		reg.MustRegister(targetInfo)
 	}
 
-	constLabels := prometheus.Labels{}
-	if cfg.WithScopeInfo {
-		scopeInfo := prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "otel_scope_info",
-			Help: "Scope metadata",
-			ConstLabels: prometheus.Labels{
-				"otel_scope_name":    "bench.scope",
-				"otel_scope_version": "1.0",
-				"scope_attribute":    "bench_value",
-			},
-		})
-		scopeInfo.Set(1)
-		reg.MustRegister(scopeInfo)
-
-		// All regular metrics must carry matching scope labels for correlation to trigger.
-		constLabels["otel_scope_name"] = "bench.scope"
-		constLabels["otel_scope_version"] = "1.0"
-	}
-
 	labelsPerSeries := cfg.LabelsPerSeries
 	if labelsPerSeries <= 0 {
 		labelsPerSeries = 5
@@ -139,11 +119,10 @@ func buildRegistry(cfg PrometheusStaticPayloadConfig) *prometheus.Registry {
 			h := prometheus.NewHistogram(prometheus.HistogramOpts{
 				Name:                            name,
 				Help:                            fmt.Sprintf("Benchmark histogram %d", i),
-				ConstLabels:                     constLabels,
-				NativeHistogramBucketFactor:      1.1,
-				NativeHistogramMaxBucketNumber:   100,
-				NativeHistogramMinResetDuration:  0,
-				NativeHistogramMaxZeroThreshold:  0.001,
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  100,
+				NativeHistogramMinResetDuration: 0,
+				NativeHistogramMaxZeroThreshold: 0.001,
 			})
 			h.Observe(float64(i) + 0.5)
 			reg.MustRegister(h)
@@ -153,9 +132,8 @@ func buildRegistry(cfg PrometheusStaticPayloadConfig) *prometheus.Registry {
 				labelValues[j] = fmt.Sprintf("value_%d_%d", i, j)
 			}
 			cv := prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name:        name,
-				Help:        fmt.Sprintf("Benchmark counter %d", i),
-				ConstLabels: constLabels,
+				Name: name,
+				Help: fmt.Sprintf("Benchmark counter %d", i),
 			}, labelNames)
 			cv.WithLabelValues(labelValues...).Add(float64(i) + 1)
 			reg.MustRegister(cv)

--- a/testbed/datasenders/prometheus_static.go
+++ b/testbed/datasenders/prometheus_static.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package datasenders // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
+)
+
+// PrometheusStaticPayloadConfig defines how to populate a prometheus.Registry for benchmarking.
+type PrometheusStaticPayloadConfig struct {
+	SeriesCount          int
+	LabelsPerSeries      int
+	WithTargetInfo       bool
+	WithScopeInfo        bool
+	WithNativeHistograms bool
+}
+
+// prometheusStaticSender serves a pre-populated Prometheus registry via promhttp.
+// The collector's prometheusreceiver scrapes this endpoint.
+type prometheusStaticSender struct {
+	testbed.DataSenderBase
+	server   *http.Server
+	registry *prometheus.Registry
+}
+
+// NewPrometheusStaticSender builds a registry from the given config and returns
+// a DataSender that serves it on the given host:port.
+func NewPrometheusStaticSender(host string, port int, cfg PrometheusStaticPayloadConfig) testbed.DataSender {
+	reg := buildRegistry(cfg)
+	return &prometheusStaticSender{
+		DataSenderBase: testbed.DataSenderBase{
+			Port: port,
+			Host: host,
+		},
+		registry: reg,
+	}
+}
+
+func (s *prometheusStaticSender) Start() error {
+	handler := promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{
+		EnableOpenMetrics: true,
+	})
+
+	s.server = &http.Server{
+		Addr:    s.GetEndpoint().String(),
+		Handler: handler,
+	}
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	go func() { _ = s.server.Serve(ln) }()
+	return nil
+}
+
+func (s *prometheusStaticSender) Stop() error {
+	if s.server != nil {
+		return s.server.Shutdown(context.Background())
+	}
+	return nil
+}
+
+func (s *prometheusStaticSender) GenConfigYAMLStr() string {
+	format := `
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'testbed'
+          scrape_interval: 100ms
+          static_configs:
+            - targets: ['%s']
+`
+	return fmt.Sprintf(format, s.GetEndpoint())
+}
+
+func (*prometheusStaticSender) ProtocolName() string {
+	return "prometheus"
+}
+
+func buildRegistry(cfg PrometheusStaticPayloadConfig) *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+
+	if cfg.WithTargetInfo {
+		targetInfo := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "target_info",
+			Help: "Target metadata",
+			ConstLabels: prometheus.Labels{
+				"environment": "test",
+				"region":      "us-west-2",
+				"cluster":     "benchmark-cluster",
+			},
+		})
+		targetInfo.Set(1)
+		reg.MustRegister(targetInfo)
+	}
+
+	constLabels := prometheus.Labels{}
+	if cfg.WithScopeInfo {
+		scopeInfo := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "otel_scope_info",
+			Help: "Scope metadata",
+			ConstLabels: prometheus.Labels{
+				"otel_scope_name":    "bench.scope",
+				"otel_scope_version": "1.0",
+				"scope_attribute":    "bench_value",
+			},
+		})
+		scopeInfo.Set(1)
+		reg.MustRegister(scopeInfo)
+
+		// All regular metrics must carry matching scope labels for correlation to trigger.
+		constLabels["otel_scope_name"] = "bench.scope"
+		constLabels["otel_scope_version"] = "1.0"
+	}
+
+	labelsPerSeries := cfg.LabelsPerSeries
+	if labelsPerSeries <= 0 {
+		labelsPerSeries = 5
+	}
+
+	labelNames := make([]string, labelsPerSeries)
+	for i := range labelNames {
+		labelNames[i] = fmt.Sprintf("label_%d", i)
+	}
+
+	for i := range cfg.SeriesCount {
+		name := fmt.Sprintf("metric_%d", i)
+
+		if cfg.WithNativeHistograms {
+			h := prometheus.NewHistogram(prometheus.HistogramOpts{
+				Name:                            name,
+				Help:                            fmt.Sprintf("Benchmark histogram %d", i),
+				ConstLabels:                     constLabels,
+				NativeHistogramBucketFactor:      1.1,
+				NativeHistogramMaxBucketNumber:   100,
+				NativeHistogramMinResetDuration:  0,
+				NativeHistogramMaxZeroThreshold:  0.001,
+			})
+			h.Observe(float64(i) + 0.5)
+			reg.MustRegister(h)
+		} else {
+			labelValues := make([]string, labelsPerSeries)
+			for j := range labelValues {
+				labelValues[j] = fmt.Sprintf("value_%d_%d", i, j)
+			}
+			cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name:        name,
+				Help:        fmt.Sprintf("Benchmark counter %d", i),
+				ConstLabels: constLabels,
+			}, labelNames)
+			cv.WithLabelValues(labelValues...).Add(float64(i) + 1)
+			reg.MustRegister(cv)
+		}
+	}
+
+	return reg
+}

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.147.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatasenders/mockdatadogagentexporter v0.147.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/prometheus v0.309.2-0.20260113170727-c7bc56cf6c8f
 	github.com/shirou/gopsutil/v4 v4.26.1
@@ -307,7 +308,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/alertmanager v0.30.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_golang/exp v0.0.0-20260101091701-2cd067eb23c9 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common/assets v0.2.0 // indirect

--- a/testbed/tests/prometheus_test.go
+++ b/testbed/tests/prometheus_test.go
@@ -59,18 +59,6 @@ func TestPrometheusReceiver(t *testing.T) {
 			},
 		},
 		{
-			name: "WithScopeInfo/10k",
-			payload: datasenders.PrometheusStaticPayloadConfig{
-				SeriesCount:     10000,
-				LabelsPerSeries: 5,
-				WithScopeInfo:   true,
-			},
-			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 200,
-				ExpectedMaxRAM: 400,
-			},
-		},
-		{
 			name: "NativeHistogram/10k",
 			payload: datasenders.PrometheusStaticPayloadConfig{
 				SeriesCount:          10000,

--- a/testbed/tests/prometheus_test.go
+++ b/testbed/tests/prometheus_test.go
@@ -1,0 +1,232 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
+)
+
+func TestPrometheusReceiver(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      datasenders.PrometheusStaticPayloadConfig
+		resourceSpec testbed.ResourceSpec
+	}{
+		{
+			name: "Baseline/1k",
+			payload: datasenders.PrometheusStaticPayloadConfig{
+				SeriesCount:     1000,
+				LabelsPerSeries: 5,
+			},
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 200,
+				ExpectedMaxRAM: 300,
+			},
+		},
+		{
+			name: "Baseline/10k",
+			payload: datasenders.PrometheusStaticPayloadConfig{
+				SeriesCount:     10000,
+				LabelsPerSeries: 5,
+			},
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 200,
+				ExpectedMaxRAM: 400,
+			},
+		},
+		{
+			name: "WithTargetInfo/10k",
+			payload: datasenders.PrometheusStaticPayloadConfig{
+				SeriesCount:     10000,
+				LabelsPerSeries: 5,
+				WithTargetInfo:  true,
+			},
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 200,
+				ExpectedMaxRAM: 400,
+			},
+		},
+		{
+			name: "WithScopeInfo/10k",
+			payload: datasenders.PrometheusStaticPayloadConfig{
+				SeriesCount:     10000,
+				LabelsPerSeries: 5,
+				WithScopeInfo:   true,
+			},
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 200,
+				ExpectedMaxRAM: 400,
+			},
+		},
+		{
+			name: "NativeHistogram/10k",
+			payload: datasenders.PrometheusStaticPayloadConfig{
+				SeriesCount:          10000,
+				WithNativeHistograms: true,
+			},
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 200,
+				ExpectedMaxRAM: 500,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scenarioPrometheusScrape(t, tt.payload, tt.resourceSpec)
+		})
+	}
+}
+
+// scenarioPrometheusScrape runs a benchmark for the Prometheus receiver.
+// It starts a static HTTP endpoint serving Prometheus metrics, configures
+// a child-process collector to scrape it, and sinks data into an OTLP backend.
+func scenarioPrometheusScrape(
+	t *testing.T,
+	payloadCfg datasenders.PrometheusStaticPayloadConfig,
+	resourceSpec testbed.ResourceSpec,
+) {
+	sender := datasenders.NewPrometheusStaticSender(
+		testbed.DefaultHost,
+		testutil.GetAvailablePort(t),
+		payloadCfg,
+	)
+
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	agentProc := testbed.NewChildProcessCollector(testbed.WithEnvVar("GOMAXPROCS", "2"))
+	resultDir, err := filepath.Abs(filepath.Join("results", t.Name()))
+	require.NoError(t, err)
+	configStr := createPromConfigYaml(sender, receiver, resultDir)
+	configCleanup, err := agentProc.PrepareConfig(t, configStr)
+	require.NoError(t, err)
+	t.Cleanup(configCleanup)
+
+	loadGen := &staticScrapeLoadGenerator{sender: sender}
+	tc := testbed.NewLoadGeneratorTestCase(
+		t,
+		loadGen,
+		receiver,
+		agentProc,
+		&testbed.PerfTestValidator{IncludeLimitsInReport: true},
+		performanceResultsSummary,
+		testbed.WithResourceLimits(resourceSpec),
+	)
+	t.Cleanup(tc.Stop)
+
+	var senderStop func()
+	require.NoError(t, sender.Start())
+	senderStop = func() {
+		if stopper, ok := sender.(interface{ Stop() error }); ok {
+			_ = stopper.Stop()
+		}
+	}
+	t.Cleanup(senderStop)
+
+	tc.StartBackend()
+	tc.StartAgent()
+
+	require.Eventually(t, func() bool { return tc.MockBackend.DataItemsReceived() > 0 },
+		10*time.Second, 100*time.Millisecond, "collector never produced data from scrapes")
+
+	benchDuration := tc.Duration
+	time.Sleep(benchDuration)
+
+	// Stop the scrape target before taking final counters to avoid races with in-flight pull cycles.
+	senderStop()
+	received := waitForBackendDrain(t, tc.MockBackend, time.Second)
+	throughput := float64(received) / benchDuration.Seconds()
+	rc := agentProc.GetTotalConsumption()
+	loadGen.SetDataItemsSent(received)
+
+	t.Logf("Received %d data items in %s (%.0f items/sec). CPU avg/max=%.1f%%/%.1f%%, RAM avg/max=%d/%d MiB",
+		received, benchDuration, throughput, rc.CPUPercentAvg, rc.CPUPercentMax, rc.RAMMiBAvg, rc.RAMMiBMax)
+}
+
+// createPromConfigYaml generates collector config YAML for the Prometheus
+// scrape benchmark. We can't reuse createConfigYaml from scenarios.go because
+// the sender is not a MetricDataSender (it's pull-based, not push-based).
+func createPromConfigYaml(sender testbed.DataSender, receiver testbed.DataReceiver, resultDir string) string {
+	return fmt.Sprintf(`
+receivers:%s
+exporters:%s
+extensions:
+  pprof:
+    save_to_file: %s/cpu.prof
+
+service:
+  extensions: [pprof]
+  pipelines:
+    metrics:
+      receivers: [%s]
+      exporters: [%s]
+`,
+		sender.GenConfigYAMLStr(),
+		receiver.GenConfigYAMLStr(),
+		resultDir,
+		sender.ProtocolName(),
+		receiver.ProtocolName(),
+	)
+}
+
+type staticScrapeLoadGenerator struct {
+	sender testbed.DataSender
+	sent   atomic.Uint64
+}
+
+func (*staticScrapeLoadGenerator) Start(testbed.LoadOptions) {}
+func (*staticScrapeLoadGenerator) Stop()                     {}
+func (lg *staticScrapeLoadGenerator) DataItemsSent() uint64  { return lg.sent.Load() }
+func (lg *staticScrapeLoadGenerator) IncDataItemsSent()      { lg.sent.Add(1) }
+func (*staticScrapeLoadGenerator) PermanentErrors() uint64   { return 0 }
+func (*staticScrapeLoadGenerator) GetStats() string          { return "" }
+
+func (lg *staticScrapeLoadGenerator) SetDataItemsSent(n uint64) {
+	lg.sent.Store(n)
+}
+
+func waitForBackendDrain(t *testing.T, backend *testbed.MockBackend, timeout time.Duration) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := backend.DataItemsReceived()
+	stableReads := 0
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		cur := backend.DataItemsReceived()
+		if cur == last {
+			stableReads++
+			if stableReads >= 2 {
+				return cur
+			}
+			continue
+		}
+		last = cur
+		stableReads = 0
+	}
+	return backend.DataItemsReceived()
+}
+
+func (lg *staticScrapeLoadGenerator) IsReady() bool {
+	endpoint := lg.sender.GetEndpoint()
+	if endpoint == nil {
+		return true
+	}
+	conn, err := net.Dial(endpoint.Network(), endpoint.String())
+	if err == nil && conn != nil {
+		_ = conn.Close()
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
#### Description

Add end-to-end benchmarks for the Prometheus receiver using the testbed framework.

The CI pipeline ([load-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/load-tests.yml)) automatically publishes CPU, RAM, and throughput results to the repository's GitHub Pages benchmark dashboard. This means performance data for the Prometheus receiver will be continuously tracked and publicly accessible on [OTel's website](https://opentelemetry.io/docs/collector/benchmarks/).


What's included:
* A pull-based DataSender that serves a prometheus/client_golang registry as a scrape target.
* Benchmark scenarios for feature variants: Baseline (1k/10k series), WithTargetInfo, WithScopeInfo, and NativeHistogram.
* CPU/RAM monitoring via ChildProcessCollector, with results published to benchmarks.json.

Here is the architecture of the benchmark: 

```mermaid
graph LR
    A["prometheusStaticSender<br/>(promhttp server)"] -->|"scrape (pull)"| B["prometheusreceiver<br/>(ChildProcessCollector)"]
    B -->|"OTLP (push)"| C["MockBackend<br/>(OTLPDataReceiver)"]
    D["gopsutil"] -.->|"CPU / RAM monitoring"| B
    E["PerfTestValidator"] -.->|"records results"| F["benchmarks.json"]
```

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44195

#### Testing
All five scenarios pass locally with RUN_TESTBED=1 go test -run TestPrometheusReceiver -v after building the testbed binary with `make oteltestbedcol`. Verified that testbed/tests/results/benchmarks.json is produced with correct entries for all variants (cpu_percentage_avg/max, ram_mib_avg/max, dropped_span_count = 0).