### PR TITLE
receiver/prometheusreceiver: return stable refs for histograms

### DIFF
--- a/.chloggen/44528-prometheusreceiver-stable-hist-seriesref.yaml
+++ b/.chloggen/44528-prometheusreceiver-stable-hist-seriesref.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "receiver/prometheusreceiver: return stable SeriesRef from AppendHistogram for correct per-series staleness tracking"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44528]

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -330,15 +330,17 @@ func (t *transaction) AppendHistogram(_ storage.SeriesRef, ls labels.Labels, atM
 	// thus we don't check for them here as opposed to the Append function.
 
 	curMF := t.getOrCreateMetricFamily(*rKey, getScopeID(ls), metricName)
+	seriesRef := t.getSeriesRef(ls, curMF.mtype)
+	cacheRef := ls.Hash()
 
 	if h != nil && h.CounterResetHint == histogram.GaugeType || fh != nil && fh.CounterResetHint == histogram.GaugeType {
 		t.logger.Warn("dropping unsupported gauge histogram datapoint", zap.String("metric_name", metricName), zap.Any("labels", ls))
 	}
 
 	if schema == -53 {
-		err = curMF.addNHCBSeries(t.getSeriesRef(ls, curMF.mtype), metricName, ls, atMs, h, fh)
+		err = curMF.addNHCBSeries(seriesRef, metricName, ls, atMs, h, fh)
 	} else {
-		err = curMF.addExponentialHistogramSeries(t.getSeriesRef(ls, curMF.mtype), metricName, ls, atMs, h, fh)
+		err = curMF.addExponentialHistogramSeries(seriesRef, metricName, ls, atMs, h, fh)
 	}
 	if err != nil {
 		t.logger.Warn("failed to add histogram datapoint", zap.Error(err), zap.String("metric_name", metricName), zap.Any("labels", ls))
@@ -348,8 +350,8 @@ func (t *transaction) AppendHistogram(_ storage.SeriesRef, ls labels.Labels, atM
 	}
 
 	// never return errors, as that fails the whole scrape
-	// return ref==1 indicating that the series was added and needs staleness tracking
-	return 1, nil
+	// return a stable ref so Prometheus can track series staleness
+	return storage.SeriesRef(cacheRef), nil
 }
 
 func (t *transaction) AppendSTZeroSample(_ storage.SeriesRef, ls labels.Labels, atMs, stMs int64) (storage.SeriesRef, error) {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/scrape"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -622,6 +623,71 @@ func TestAppendHistogramCTZeroSample(t *testing.T) {
 		pcommon.NewTimestampFromTime(time.UnixMilli(ctMs)),
 		mds[0].ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).ExponentialHistogram().DataPoints().At(0).StartTimestamp(),
 	)
+}
+
+func TestAppendHistogramReturnsStableSeriesRef(t *testing.T) {
+	tr := newTxn(t, false)
+	lsA := labels.FromStrings(
+		model.InstanceLabel, "localhost:1234",
+		model.JobLabel, "job-a",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "bar",
+	)
+	lsB := labels.FromStrings(
+		model.InstanceLabel, "localhost:1234",
+		model.JobLabel, "job-a",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "baz",
+	)
+
+	refA, err := tr.AppendHistogram(0, lsA, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(lsA.Hash()), refA)
+
+	refB, err := tr.AppendHistogram(0, lsB, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+	require.Equal(t, storage.SeriesRef(lsB.Hash()), refB)
+	require.NotEqual(t, refA, refB)
+}
+
+func TestAppendHistogramStableSeriesRefEnablesSeriesDisappearanceTracking(t *testing.T) {
+	lsA := labels.FromStrings(
+		model.InstanceLabel, "localhost:1234",
+		model.JobLabel, "job-a",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "bar",
+	)
+	lsB := labels.FromStrings(
+		model.InstanceLabel, "localhost:1234",
+		model.JobLabel, "job-a",
+		model.MetricNameLabel, "native_hist_test",
+		"foo", "baz",
+	)
+
+	// Scrape #1: both series are present.
+	tr1 := newTxn(t, false)
+	refA1, err := tr1.AppendHistogram(0, lsA, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+	refB1, err := tr1.AppendHistogram(0, lsB, ts, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+
+	// Scrape #2: only series A is present.
+	tr2 := newTxn(t, false)
+	refA2, err := tr2.AppendHistogram(0, lsA, ts+interval, tsdbutil.GenerateTestHistogram(1), nil)
+	require.NoError(t, err)
+
+	prev := map[storage.SeriesRef]struct{}{refA1: {}, refB1: {}}
+	cur := map[storage.SeriesRef]struct{}{refA2: {}}
+
+	var missing []storage.SeriesRef
+	for ref := range prev {
+		if _, ok := cur[ref]; !ok {
+			missing = append(missing, ref)
+		}
+	}
+
+	require.Len(t, missing, 1)
+	require.Equal(t, refB1, missing[0])
 }
 
 func nopObsRecv(t *testing.T) *receiverhelper.ObsReport {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The Prometheus scrape cache uses returned `SeriesRef` values to detect which series disappeared between scrapes. In `prometheusreceiver`, the histogram append path returned a constant ref (1), which could make a disappeared histogram series look present if another histogram series remained. 
The fix is to give each histogram line its own ID based on its labels.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44528

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests to check:
  - different histogram lines get different IDs
  - missing histogram series between scrapes is detectable via SeriesRef comparison