### PR TITLE
[receiver/k8scluster] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46361-k8scluster-enable-reaggregation.yaml
+++ b/.chloggen/46361-k8scluster-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/k8s_cluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable dynamic metric reaggregation in the Kubernetes Cluster receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46361]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/documentation.md
+++ b/receiver/k8sclusterreceiver/documentation.md
@@ -280,7 +280,7 @@ The upper limit for a particular resource in a specific namespace. Will only be 
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| resource | the name of the resource on which the quota is applied | Any Str | Recommended | - |
+| resource | the name of the resource on which the quota is applied | Any Str | Required | - |
 
 ### k8s.resource_quota.used
 
@@ -294,7 +294,7 @@ The usage for a particular resource in a specific namespace. Will only be sent i
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| resource | the name of the resource on which the quota is applied | Any Str | Recommended | - |
+| resource | the name of the resource on which the quota is applied | Any Str | Required | - |
 
 ### k8s.statefulset.current_pods
 
@@ -341,7 +341,7 @@ The upper limit for a particular resource in a specific namespace.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | k8s.namespace.name | The k8s namespace name. | Any Str | Recommended | - |
-| resource | the name of the resource on which the quota is applied | Any Str | Recommended | - |
+| resource | the name of the resource on which the quota is applied | Any Str | Required | - |
 
 ### openshift.appliedclusterquota.used
 
@@ -356,7 +356,7 @@ The usage for a particular resource in a specific namespace.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | k8s.namespace.name | The k8s namespace name. | Any Str | Recommended | - |
-| resource | the name of the resource on which the quota is applied | Any Str | Recommended | - |
+| resource | the name of the resource on which the quota is applied | Any Str | Required | - |
 
 ### openshift.clusterquota.limit
 
@@ -370,7 +370,7 @@ The configured upper limit for a particular resource.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| resource | the name of the resource on which the quota is applied | Any Str | Recommended | - |
+| resource | the name of the resource on which the quota is applied | Any Str | Required | - |
 
 ### openshift.clusterquota.used
 
@@ -384,7 +384,7 @@ The usage for a particular resource with a configured limit.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| resource | the name of the resource on which the quota is applied | Any Str | Recommended | - |
+| resource | the name of the resource on which the quota is applied | Any Str | Required | - |
 
 ## Optional Metrics
 
@@ -408,7 +408,7 @@ Experimental metric, may experience breaking changes. Describes the number of K8
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| k8s.container.status.reason | The reason of the current container status. | Str: ``ContainerCreating``, ``CrashLoopBackOff``, ``CreateContainerConfigError``, ``ErrImagePull``, ``ImagePullBackOff``, ``OOMKilled``, ``Completed``, ``Error``, ``ContainerCannotRun`` | Recommended | - |
+| k8s.container.status.reason | The reason of the current container status. | Str: ``ContainerCreating``, ``CrashLoopBackOff``, ``CreateContainerConfigError``, ``ErrImagePull``, ``ImagePullBackOff``, ``OOMKilled``, ``Completed``, ``Error``, ``ContainerCannotRun`` | Required | - |
 
 ### k8s.container.status.state
 
@@ -422,7 +422,7 @@ Experimental metric, may experience breaking changes. Describes the number of K8
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| k8s.container.status.state | The state of the container (terminated, running, waiting). See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstate-v1-core for details. | Str: ``terminated``, ``running``, ``waiting`` | Recommended | - |
+| k8s.container.status.state | The state of the container (terminated, running, waiting). See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstate-v1-core for details. | Str: ``terminated``, ``running``, ``waiting`` | Required | - |
 
 ### k8s.node.condition
 
@@ -436,7 +436,7 @@ The condition of a particular Node.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| condition | the name of Kubernetes Node condition. Example: Ready, Memory, PID, DiskPressure | Any Str | Recommended | - |
+| condition | the name of Kubernetes Node condition. Example: Ready, Memory, PID, DiskPressure | Any Str | Required | - |
 
 ### k8s.pod.status_reason
 

--- a/receiver/k8sclusterreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/k8sclusterreceiver/internal/metadata/config.schema.yaml
@@ -277,6 +277,26 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "k8s.service.endpoint.address_type"
+                - "k8s.service.endpoint.condition"
+                - "k8s.service.endpoint.zone"
+            default:
+              - "k8s.service.endpoint.address_type"
+              - "k8s.service.endpoint.condition"
+              - "k8s.service.endpoint.zone"
       k8s.service.load_balancer.ingress.count:
         description: "K8sServiceLoadBalancerIngressCountMetricConfig provides config for the k8s.service.load_balancer.ingress.count metric."
         type: object
@@ -319,6 +339,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "k8s.namespace.name"
+                - "resource"
+            default:
+              - "k8s.namespace.name"
+              - "resource"
       openshift.appliedclusterquota.used:
         description: "OpenshiftAppliedclusterquotaUsedMetricConfig provides config for the openshift.appliedclusterquota.used metric."
         type: object
@@ -326,6 +364,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "k8s.namespace.name"
+                - "resource"
+            default:
+              - "k8s.namespace.name"
+              - "resource"
       openshift.clusterquota.limit:
         description: "OpenshiftClusterquotaLimitMetricConfig provides config for the openshift.clusterquota.limit metric."
         type: object

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_config.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,1054 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// K8sContainerCPULimitMetricConfig provides config for the k8s.container.cpu_limit metric.
+type K8sContainerCPULimitMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *K8sContainerCPULimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerCPURequestMetricConfig provides config for the k8s.container.cpu_request metric.
+type K8sContainerCPURequestMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerCPURequestMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerEphemeralstorageLimitMetricConfig provides config for the k8s.container.ephemeralstorage_limit metric.
+type K8sContainerEphemeralstorageLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerEphemeralstorageLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerEphemeralstorageRequestMetricConfig provides config for the k8s.container.ephemeralstorage_request metric.
+type K8sContainerEphemeralstorageRequestMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerEphemeralstorageRequestMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerMemoryLimitMetricConfig provides config for the k8s.container.memory_limit metric.
+type K8sContainerMemoryLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerMemoryLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerMemoryRequestMetricConfig provides config for the k8s.container.memory_request metric.
+type K8sContainerMemoryRequestMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerMemoryRequestMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerReadyMetricConfig provides config for the k8s.container.ready metric.
+type K8sContainerReadyMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerReadyMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerRestartsMetricConfig provides config for the k8s.container.restarts metric.
+type K8sContainerRestartsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerRestartsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerStatusReasonMetricConfig provides config for the k8s.container.status.reason metric.
+type K8sContainerStatusReasonMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerStatusReasonMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerStatusStateMetricConfig provides config for the k8s.container.status.state metric.
+type K8sContainerStatusStateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerStatusStateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerStorageLimitMetricConfig provides config for the k8s.container.storage_limit metric.
+type K8sContainerStorageLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerStorageLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerStorageRequestMetricConfig provides config for the k8s.container.storage_request metric.
+type K8sContainerStorageRequestMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerStorageRequestMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sCronjobActiveJobsMetricConfig provides config for the k8s.cronjob.active_jobs metric.
+type K8sCronjobActiveJobsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sCronjobActiveJobsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sDaemonsetCurrentScheduledNodesMetricConfig provides config for the k8s.daemonset.current_scheduled_nodes metric.
+type K8sDaemonsetCurrentScheduledNodesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sDaemonsetCurrentScheduledNodesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sDaemonsetDesiredScheduledNodesMetricConfig provides config for the k8s.daemonset.desired_scheduled_nodes metric.
+type K8sDaemonsetDesiredScheduledNodesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sDaemonsetDesiredScheduledNodesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sDaemonsetMisscheduledNodesMetricConfig provides config for the k8s.daemonset.misscheduled_nodes metric.
+type K8sDaemonsetMisscheduledNodesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sDaemonsetMisscheduledNodesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sDaemonsetReadyNodesMetricConfig provides config for the k8s.daemonset.ready_nodes metric.
+type K8sDaemonsetReadyNodesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sDaemonsetReadyNodesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sDeploymentAvailableMetricConfig provides config for the k8s.deployment.available metric.
+type K8sDeploymentAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sDeploymentAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sDeploymentDesiredMetricConfig provides config for the k8s.deployment.desired metric.
+type K8sDeploymentDesiredMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sDeploymentDesiredMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sHpaCurrentReplicasMetricConfig provides config for the k8s.hpa.current_replicas metric.
+type K8sHpaCurrentReplicasMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sHpaCurrentReplicasMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sHpaDesiredReplicasMetricConfig provides config for the k8s.hpa.desired_replicas metric.
+type K8sHpaDesiredReplicasMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sHpaDesiredReplicasMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sHpaMaxReplicasMetricConfig provides config for the k8s.hpa.max_replicas metric.
+type K8sHpaMaxReplicasMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sHpaMaxReplicasMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sHpaMinReplicasMetricConfig provides config for the k8s.hpa.min_replicas metric.
+type K8sHpaMinReplicasMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sHpaMinReplicasMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sJobActivePodsMetricConfig provides config for the k8s.job.active_pods metric.
+type K8sJobActivePodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sJobActivePodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sJobDesiredSuccessfulPodsMetricConfig provides config for the k8s.job.desired_successful_pods metric.
+type K8sJobDesiredSuccessfulPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sJobDesiredSuccessfulPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sJobFailedPodsMetricConfig provides config for the k8s.job.failed_pods metric.
+type K8sJobFailedPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sJobFailedPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sJobMaxParallelPodsMetricConfig provides config for the k8s.job.max_parallel_pods metric.
+type K8sJobMaxParallelPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sJobMaxParallelPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sJobSuccessfulPodsMetricConfig provides config for the k8s.job.successful_pods metric.
+type K8sJobSuccessfulPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sJobSuccessfulPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNamespacePhaseMetricConfig provides config for the k8s.namespace.phase metric.
+type K8sNamespacePhaseMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNamespacePhaseMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeConditionMetricConfig provides config for the k8s.node.condition metric.
+type K8sNodeConditionMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeConditionMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodPhaseMetricConfig provides config for the k8s.pod.phase metric.
+type K8sPodPhaseMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodPhaseMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodStatusReasonMetricConfig provides config for the k8s.pod.status_reason metric.
+type K8sPodStatusReasonMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodStatusReasonMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sReplicasetAvailableMetricConfig provides config for the k8s.replicaset.available metric.
+type K8sReplicasetAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sReplicasetAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sReplicasetDesiredMetricConfig provides config for the k8s.replicaset.desired metric.
+type K8sReplicasetDesiredMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sReplicasetDesiredMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sReplicationControllerAvailableMetricConfig provides config for the k8s.replication_controller.available metric.
+type K8sReplicationControllerAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sReplicationControllerAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sReplicationControllerDesiredMetricConfig provides config for the k8s.replication_controller.desired metric.
+type K8sReplicationControllerDesiredMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sReplicationControllerDesiredMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sResourceQuotaHardLimitMetricConfig provides config for the k8s.resource_quota.hard_limit metric.
+type K8sResourceQuotaHardLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sResourceQuotaHardLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sResourceQuotaUsedMetricConfig provides config for the k8s.resource_quota.used metric.
+type K8sResourceQuotaUsedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sResourceQuotaUsedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sServiceEndpointCountMetricAttributeKey specifies the key of an attribute for the k8s.service.endpoint.count metric.
+type K8sServiceEndpointCountMetricAttributeKey string
+
+const (
+	K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointAddressType K8sServiceEndpointCountMetricAttributeKey = "k8s.service.endpoint.address_type"
+	K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointCondition   K8sServiceEndpointCountMetricAttributeKey = "k8s.service.endpoint.condition"
+	K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointZone        K8sServiceEndpointCountMetricAttributeKey = "k8s.service.endpoint.zone"
+)
+
+// K8sServiceEndpointCountMetricConfig provides config for the k8s.service.endpoint.count metric.
+type K8sServiceEndpointCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sServiceEndpointCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sServiceEndpointCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sServiceEndpointCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointAddressType, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointCondition, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointZone:
+		default:
+			return fmt.Errorf("metric k8s.service.endpoint.count doesn't have an attribute %v, valid attributes: [k8s.service.endpoint.address_type, k8s.service.endpoint.condition, k8s.service.endpoint.zone]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sServiceLoadBalancerIngressCountMetricConfig provides config for the k8s.service.load_balancer.ingress.count metric.
+type K8sServiceLoadBalancerIngressCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sServiceLoadBalancerIngressCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sStatefulsetCurrentPodsMetricConfig provides config for the k8s.statefulset.current_pods metric.
+type K8sStatefulsetCurrentPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sStatefulsetCurrentPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sStatefulsetDesiredPodsMetricConfig provides config for the k8s.statefulset.desired_pods metric.
+type K8sStatefulsetDesiredPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sStatefulsetDesiredPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sStatefulsetReadyPodsMetricConfig provides config for the k8s.statefulset.ready_pods metric.
+type K8sStatefulsetReadyPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sStatefulsetReadyPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sStatefulsetUpdatedPodsMetricConfig provides config for the k8s.statefulset.updated_pods metric.
+type K8sStatefulsetUpdatedPodsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sStatefulsetUpdatedPodsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OpenshiftAppliedclusterquotaLimitMetricAttributeKey specifies the key of an attribute for the openshift.appliedclusterquota.limit metric.
+type OpenshiftAppliedclusterquotaLimitMetricAttributeKey string
+
+const (
+	OpenshiftAppliedclusterquotaLimitMetricAttributeKeyK8sNamespaceName OpenshiftAppliedclusterquotaLimitMetricAttributeKey = "k8s.namespace.name"
+	OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource         OpenshiftAppliedclusterquotaLimitMetricAttributeKey = "resource"
+)
+
+// OpenshiftAppliedclusterquotaLimitMetricConfig provides config for the openshift.appliedclusterquota.limit metric.
+type OpenshiftAppliedclusterquotaLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OpenshiftAppliedclusterquotaLimitMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OpenshiftAppliedclusterquotaLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OpenshiftAppliedclusterquotaLimitMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OpenshiftAppliedclusterquotaLimitMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource:
+		default:
+			return fmt.Errorf("metric openshift.appliedclusterquota.limit doesn't have an attribute %v, valid attributes: [k8s.namespace.name, resource]", val)
+		}
+	}
+	if !slices.Contains(ms.EnabledAttributes, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource) {
+		return fmt.Errorf("resource is a required attribute for openshift.appliedclusterquota.limit metric and must be included")
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OpenshiftAppliedclusterquotaUsedMetricAttributeKey specifies the key of an attribute for the openshift.appliedclusterquota.used metric.
+type OpenshiftAppliedclusterquotaUsedMetricAttributeKey string
+
+const (
+	OpenshiftAppliedclusterquotaUsedMetricAttributeKeyK8sNamespaceName OpenshiftAppliedclusterquotaUsedMetricAttributeKey = "k8s.namespace.name"
+	OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource         OpenshiftAppliedclusterquotaUsedMetricAttributeKey = "resource"
+)
+
+// OpenshiftAppliedclusterquotaUsedMetricConfig provides config for the openshift.appliedclusterquota.used metric.
+type OpenshiftAppliedclusterquotaUsedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OpenshiftAppliedclusterquotaUsedMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OpenshiftAppliedclusterquotaUsedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OpenshiftAppliedclusterquotaUsedMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OpenshiftAppliedclusterquotaUsedMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource:
+		default:
+			return fmt.Errorf("metric openshift.appliedclusterquota.used doesn't have an attribute %v, valid attributes: [k8s.namespace.name, resource]", val)
+		}
+	}
+	if !slices.Contains(ms.EnabledAttributes, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource) {
+		return fmt.Errorf("resource is a required attribute for openshift.appliedclusterquota.used metric and must be included")
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OpenshiftClusterquotaLimitMetricConfig provides config for the openshift.clusterquota.limit metric.
+type OpenshiftClusterquotaLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OpenshiftClusterquotaLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OpenshiftClusterquotaUsedMetricConfig provides config for the openshift.clusterquota.used metric.
+type OpenshiftClusterquotaUsedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OpenshiftClusterquotaUsedMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,200 +1066,206 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for k8s_cluster metrics.
 type MetricsConfig struct {
-	K8sContainerCPULimit                MetricConfig `mapstructure:"k8s.container.cpu_limit"`
-	K8sContainerCPURequest              MetricConfig `mapstructure:"k8s.container.cpu_request"`
-	K8sContainerEphemeralstorageLimit   MetricConfig `mapstructure:"k8s.container.ephemeralstorage_limit"`
-	K8sContainerEphemeralstorageRequest MetricConfig `mapstructure:"k8s.container.ephemeralstorage_request"`
-	K8sContainerMemoryLimit             MetricConfig `mapstructure:"k8s.container.memory_limit"`
-	K8sContainerMemoryRequest           MetricConfig `mapstructure:"k8s.container.memory_request"`
-	K8sContainerReady                   MetricConfig `mapstructure:"k8s.container.ready"`
-	K8sContainerRestarts                MetricConfig `mapstructure:"k8s.container.restarts"`
-	K8sContainerStatusReason            MetricConfig `mapstructure:"k8s.container.status.reason"`
-	K8sContainerStatusState             MetricConfig `mapstructure:"k8s.container.status.state"`
-	K8sContainerStorageLimit            MetricConfig `mapstructure:"k8s.container.storage_limit"`
-	K8sContainerStorageRequest          MetricConfig `mapstructure:"k8s.container.storage_request"`
-	K8sCronjobActiveJobs                MetricConfig `mapstructure:"k8s.cronjob.active_jobs"`
-	K8sDaemonsetCurrentScheduledNodes   MetricConfig `mapstructure:"k8s.daemonset.current_scheduled_nodes"`
-	K8sDaemonsetDesiredScheduledNodes   MetricConfig `mapstructure:"k8s.daemonset.desired_scheduled_nodes"`
-	K8sDaemonsetMisscheduledNodes       MetricConfig `mapstructure:"k8s.daemonset.misscheduled_nodes"`
-	K8sDaemonsetReadyNodes              MetricConfig `mapstructure:"k8s.daemonset.ready_nodes"`
-	K8sDeploymentAvailable              MetricConfig `mapstructure:"k8s.deployment.available"`
-	K8sDeploymentDesired                MetricConfig `mapstructure:"k8s.deployment.desired"`
-	K8sHpaCurrentReplicas               MetricConfig `mapstructure:"k8s.hpa.current_replicas"`
-	K8sHpaDesiredReplicas               MetricConfig `mapstructure:"k8s.hpa.desired_replicas"`
-	K8sHpaMaxReplicas                   MetricConfig `mapstructure:"k8s.hpa.max_replicas"`
-	K8sHpaMinReplicas                   MetricConfig `mapstructure:"k8s.hpa.min_replicas"`
-	K8sJobActivePods                    MetricConfig `mapstructure:"k8s.job.active_pods"`
-	K8sJobDesiredSuccessfulPods         MetricConfig `mapstructure:"k8s.job.desired_successful_pods"`
-	K8sJobFailedPods                    MetricConfig `mapstructure:"k8s.job.failed_pods"`
-	K8sJobMaxParallelPods               MetricConfig `mapstructure:"k8s.job.max_parallel_pods"`
-	K8sJobSuccessfulPods                MetricConfig `mapstructure:"k8s.job.successful_pods"`
-	K8sNamespacePhase                   MetricConfig `mapstructure:"k8s.namespace.phase"`
-	K8sNodeCondition                    MetricConfig `mapstructure:"k8s.node.condition"`
-	K8sPodPhase                         MetricConfig `mapstructure:"k8s.pod.phase"`
-	K8sPodStatusReason                  MetricConfig `mapstructure:"k8s.pod.status_reason"`
-	K8sReplicasetAvailable              MetricConfig `mapstructure:"k8s.replicaset.available"`
-	K8sReplicasetDesired                MetricConfig `mapstructure:"k8s.replicaset.desired"`
-	K8sReplicationControllerAvailable   MetricConfig `mapstructure:"k8s.replication_controller.available"`
-	K8sReplicationControllerDesired     MetricConfig `mapstructure:"k8s.replication_controller.desired"`
-	K8sResourceQuotaHardLimit           MetricConfig `mapstructure:"k8s.resource_quota.hard_limit"`
-	K8sResourceQuotaUsed                MetricConfig `mapstructure:"k8s.resource_quota.used"`
-	K8sServiceEndpointCount             MetricConfig `mapstructure:"k8s.service.endpoint.count"`
-	K8sServiceLoadBalancerIngressCount  MetricConfig `mapstructure:"k8s.service.load_balancer.ingress.count"`
-	K8sStatefulsetCurrentPods           MetricConfig `mapstructure:"k8s.statefulset.current_pods"`
-	K8sStatefulsetDesiredPods           MetricConfig `mapstructure:"k8s.statefulset.desired_pods"`
-	K8sStatefulsetReadyPods             MetricConfig `mapstructure:"k8s.statefulset.ready_pods"`
-	K8sStatefulsetUpdatedPods           MetricConfig `mapstructure:"k8s.statefulset.updated_pods"`
-	OpenshiftAppliedclusterquotaLimit   MetricConfig `mapstructure:"openshift.appliedclusterquota.limit"`
-	OpenshiftAppliedclusterquotaUsed    MetricConfig `mapstructure:"openshift.appliedclusterquota.used"`
-	OpenshiftClusterquotaLimit          MetricConfig `mapstructure:"openshift.clusterquota.limit"`
-	OpenshiftClusterquotaUsed           MetricConfig `mapstructure:"openshift.clusterquota.used"`
+	K8sContainerCPULimit                K8sContainerCPULimitMetricConfig                `mapstructure:"k8s.container.cpu_limit"`
+	K8sContainerCPURequest              K8sContainerCPURequestMetricConfig              `mapstructure:"k8s.container.cpu_request"`
+	K8sContainerEphemeralstorageLimit   K8sContainerEphemeralstorageLimitMetricConfig   `mapstructure:"k8s.container.ephemeralstorage_limit"`
+	K8sContainerEphemeralstorageRequest K8sContainerEphemeralstorageRequestMetricConfig `mapstructure:"k8s.container.ephemeralstorage_request"`
+	K8sContainerMemoryLimit             K8sContainerMemoryLimitMetricConfig             `mapstructure:"k8s.container.memory_limit"`
+	K8sContainerMemoryRequest           K8sContainerMemoryRequestMetricConfig           `mapstructure:"k8s.container.memory_request"`
+	K8sContainerReady                   K8sContainerReadyMetricConfig                   `mapstructure:"k8s.container.ready"`
+	K8sContainerRestarts                K8sContainerRestartsMetricConfig                `mapstructure:"k8s.container.restarts"`
+	K8sContainerStatusReason            K8sContainerStatusReasonMetricConfig            `mapstructure:"k8s.container.status.reason"`
+	K8sContainerStatusState             K8sContainerStatusStateMetricConfig             `mapstructure:"k8s.container.status.state"`
+	K8sContainerStorageLimit            K8sContainerStorageLimitMetricConfig            `mapstructure:"k8s.container.storage_limit"`
+	K8sContainerStorageRequest          K8sContainerStorageRequestMetricConfig          `mapstructure:"k8s.container.storage_request"`
+	K8sCronjobActiveJobs                K8sCronjobActiveJobsMetricConfig                `mapstructure:"k8s.cronjob.active_jobs"`
+	K8sDaemonsetCurrentScheduledNodes   K8sDaemonsetCurrentScheduledNodesMetricConfig   `mapstructure:"k8s.daemonset.current_scheduled_nodes"`
+	K8sDaemonsetDesiredScheduledNodes   K8sDaemonsetDesiredScheduledNodesMetricConfig   `mapstructure:"k8s.daemonset.desired_scheduled_nodes"`
+	K8sDaemonsetMisscheduledNodes       K8sDaemonsetMisscheduledNodesMetricConfig       `mapstructure:"k8s.daemonset.misscheduled_nodes"`
+	K8sDaemonsetReadyNodes              K8sDaemonsetReadyNodesMetricConfig              `mapstructure:"k8s.daemonset.ready_nodes"`
+	K8sDeploymentAvailable              K8sDeploymentAvailableMetricConfig              `mapstructure:"k8s.deployment.available"`
+	K8sDeploymentDesired                K8sDeploymentDesiredMetricConfig                `mapstructure:"k8s.deployment.desired"`
+	K8sHpaCurrentReplicas               K8sHpaCurrentReplicasMetricConfig               `mapstructure:"k8s.hpa.current_replicas"`
+	K8sHpaDesiredReplicas               K8sHpaDesiredReplicasMetricConfig               `mapstructure:"k8s.hpa.desired_replicas"`
+	K8sHpaMaxReplicas                   K8sHpaMaxReplicasMetricConfig                   `mapstructure:"k8s.hpa.max_replicas"`
+	K8sHpaMinReplicas                   K8sHpaMinReplicasMetricConfig                   `mapstructure:"k8s.hpa.min_replicas"`
+	K8sJobActivePods                    K8sJobActivePodsMetricConfig                    `mapstructure:"k8s.job.active_pods"`
+	K8sJobDesiredSuccessfulPods         K8sJobDesiredSuccessfulPodsMetricConfig         `mapstructure:"k8s.job.desired_successful_pods"`
+	K8sJobFailedPods                    K8sJobFailedPodsMetricConfig                    `mapstructure:"k8s.job.failed_pods"`
+	K8sJobMaxParallelPods               K8sJobMaxParallelPodsMetricConfig               `mapstructure:"k8s.job.max_parallel_pods"`
+	K8sJobSuccessfulPods                K8sJobSuccessfulPodsMetricConfig                `mapstructure:"k8s.job.successful_pods"`
+	K8sNamespacePhase                   K8sNamespacePhaseMetricConfig                   `mapstructure:"k8s.namespace.phase"`
+	K8sNodeCondition                    K8sNodeConditionMetricConfig                    `mapstructure:"k8s.node.condition"`
+	K8sPodPhase                         K8sPodPhaseMetricConfig                         `mapstructure:"k8s.pod.phase"`
+	K8sPodStatusReason                  K8sPodStatusReasonMetricConfig                  `mapstructure:"k8s.pod.status_reason"`
+	K8sReplicasetAvailable              K8sReplicasetAvailableMetricConfig              `mapstructure:"k8s.replicaset.available"`
+	K8sReplicasetDesired                K8sReplicasetDesiredMetricConfig                `mapstructure:"k8s.replicaset.desired"`
+	K8sReplicationControllerAvailable   K8sReplicationControllerAvailableMetricConfig   `mapstructure:"k8s.replication_controller.available"`
+	K8sReplicationControllerDesired     K8sReplicationControllerDesiredMetricConfig     `mapstructure:"k8s.replication_controller.desired"`
+	K8sResourceQuotaHardLimit           K8sResourceQuotaHardLimitMetricConfig           `mapstructure:"k8s.resource_quota.hard_limit"`
+	K8sResourceQuotaUsed                K8sResourceQuotaUsedMetricConfig                `mapstructure:"k8s.resource_quota.used"`
+	K8sServiceEndpointCount             K8sServiceEndpointCountMetricConfig             `mapstructure:"k8s.service.endpoint.count"`
+	K8sServiceLoadBalancerIngressCount  K8sServiceLoadBalancerIngressCountMetricConfig  `mapstructure:"k8s.service.load_balancer.ingress.count"`
+	K8sStatefulsetCurrentPods           K8sStatefulsetCurrentPodsMetricConfig           `mapstructure:"k8s.statefulset.current_pods"`
+	K8sStatefulsetDesiredPods           K8sStatefulsetDesiredPodsMetricConfig           `mapstructure:"k8s.statefulset.desired_pods"`
+	K8sStatefulsetReadyPods             K8sStatefulsetReadyPodsMetricConfig             `mapstructure:"k8s.statefulset.ready_pods"`
+	K8sStatefulsetUpdatedPods           K8sStatefulsetUpdatedPodsMetricConfig           `mapstructure:"k8s.statefulset.updated_pods"`
+	OpenshiftAppliedclusterquotaLimit   OpenshiftAppliedclusterquotaLimitMetricConfig   `mapstructure:"openshift.appliedclusterquota.limit"`
+	OpenshiftAppliedclusterquotaUsed    OpenshiftAppliedclusterquotaUsedMetricConfig    `mapstructure:"openshift.appliedclusterquota.used"`
+	OpenshiftClusterquotaLimit          OpenshiftClusterquotaLimitMetricConfig          `mapstructure:"openshift.clusterquota.limit"`
+	OpenshiftClusterquotaUsed           OpenshiftClusterquotaUsedMetricConfig           `mapstructure:"openshift.clusterquota.used"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		K8sContainerCPULimit: MetricConfig{
+		K8sContainerCPULimit: K8sContainerCPULimitMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerCPURequest: MetricConfig{
+		K8sContainerCPURequest: K8sContainerCPURequestMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerEphemeralstorageLimit: MetricConfig{
+		K8sContainerEphemeralstorageLimit: K8sContainerEphemeralstorageLimitMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerEphemeralstorageRequest: MetricConfig{
+		K8sContainerEphemeralstorageRequest: K8sContainerEphemeralstorageRequestMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerMemoryLimit: MetricConfig{
+		K8sContainerMemoryLimit: K8sContainerMemoryLimitMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerMemoryRequest: MetricConfig{
+		K8sContainerMemoryRequest: K8sContainerMemoryRequestMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerReady: MetricConfig{
+		K8sContainerReady: K8sContainerReadyMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerRestarts: MetricConfig{
+		K8sContainerRestarts: K8sContainerRestartsMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerStatusReason: MetricConfig{
+		K8sContainerStatusReason: K8sContainerStatusReasonMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerStatusState: MetricConfig{
+		K8sContainerStatusState: K8sContainerStatusStateMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerStorageLimit: MetricConfig{
+		K8sContainerStorageLimit: K8sContainerStorageLimitMetricConfig{
 			Enabled: true,
 		},
-		K8sContainerStorageRequest: MetricConfig{
+		K8sContainerStorageRequest: K8sContainerStorageRequestMetricConfig{
 			Enabled: true,
 		},
-		K8sCronjobActiveJobs: MetricConfig{
+		K8sCronjobActiveJobs: K8sCronjobActiveJobsMetricConfig{
 			Enabled: true,
 		},
-		K8sDaemonsetCurrentScheduledNodes: MetricConfig{
+		K8sDaemonsetCurrentScheduledNodes: K8sDaemonsetCurrentScheduledNodesMetricConfig{
 			Enabled: true,
 		},
-		K8sDaemonsetDesiredScheduledNodes: MetricConfig{
+		K8sDaemonsetDesiredScheduledNodes: K8sDaemonsetDesiredScheduledNodesMetricConfig{
 			Enabled: true,
 		},
-		K8sDaemonsetMisscheduledNodes: MetricConfig{
+		K8sDaemonsetMisscheduledNodes: K8sDaemonsetMisscheduledNodesMetricConfig{
 			Enabled: true,
 		},
-		K8sDaemonsetReadyNodes: MetricConfig{
+		K8sDaemonsetReadyNodes: K8sDaemonsetReadyNodesMetricConfig{
 			Enabled: true,
 		},
-		K8sDeploymentAvailable: MetricConfig{
+		K8sDeploymentAvailable: K8sDeploymentAvailableMetricConfig{
 			Enabled: true,
 		},
-		K8sDeploymentDesired: MetricConfig{
+		K8sDeploymentDesired: K8sDeploymentDesiredMetricConfig{
 			Enabled: true,
 		},
-		K8sHpaCurrentReplicas: MetricConfig{
+		K8sHpaCurrentReplicas: K8sHpaCurrentReplicasMetricConfig{
 			Enabled: true,
 		},
-		K8sHpaDesiredReplicas: MetricConfig{
+		K8sHpaDesiredReplicas: K8sHpaDesiredReplicasMetricConfig{
 			Enabled: true,
 		},
-		K8sHpaMaxReplicas: MetricConfig{
+		K8sHpaMaxReplicas: K8sHpaMaxReplicasMetricConfig{
 			Enabled: true,
 		},
-		K8sHpaMinReplicas: MetricConfig{
+		K8sHpaMinReplicas: K8sHpaMinReplicasMetricConfig{
 			Enabled: true,
 		},
-		K8sJobActivePods: MetricConfig{
+		K8sJobActivePods: K8sJobActivePodsMetricConfig{
 			Enabled: true,
 		},
-		K8sJobDesiredSuccessfulPods: MetricConfig{
+		K8sJobDesiredSuccessfulPods: K8sJobDesiredSuccessfulPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sJobFailedPods: MetricConfig{
+		K8sJobFailedPods: K8sJobFailedPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sJobMaxParallelPods: MetricConfig{
+		K8sJobMaxParallelPods: K8sJobMaxParallelPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sJobSuccessfulPods: MetricConfig{
+		K8sJobSuccessfulPods: K8sJobSuccessfulPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sNamespacePhase: MetricConfig{
+		K8sNamespacePhase: K8sNamespacePhaseMetricConfig{
 			Enabled: true,
 		},
-		K8sNodeCondition: MetricConfig{
+		K8sNodeCondition: K8sNodeConditionMetricConfig{
 			Enabled: false,
 		},
-		K8sPodPhase: MetricConfig{
+		K8sPodPhase: K8sPodPhaseMetricConfig{
 			Enabled: true,
 		},
-		K8sPodStatusReason: MetricConfig{
+		K8sPodStatusReason: K8sPodStatusReasonMetricConfig{
 			Enabled: false,
 		},
-		K8sReplicasetAvailable: MetricConfig{
+		K8sReplicasetAvailable: K8sReplicasetAvailableMetricConfig{
 			Enabled: true,
 		},
-		K8sReplicasetDesired: MetricConfig{
+		K8sReplicasetDesired: K8sReplicasetDesiredMetricConfig{
 			Enabled: true,
 		},
-		K8sReplicationControllerAvailable: MetricConfig{
+		K8sReplicationControllerAvailable: K8sReplicationControllerAvailableMetricConfig{
 			Enabled: true,
 		},
-		K8sReplicationControllerDesired: MetricConfig{
+		K8sReplicationControllerDesired: K8sReplicationControllerDesiredMetricConfig{
 			Enabled: true,
 		},
-		K8sResourceQuotaHardLimit: MetricConfig{
+		K8sResourceQuotaHardLimit: K8sResourceQuotaHardLimitMetricConfig{
 			Enabled: true,
 		},
-		K8sResourceQuotaUsed: MetricConfig{
+		K8sResourceQuotaUsed: K8sResourceQuotaUsedMetricConfig{
 			Enabled: true,
 		},
-		K8sServiceEndpointCount: MetricConfig{
+		K8sServiceEndpointCount: K8sServiceEndpointCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []K8sServiceEndpointCountMetricAttributeKey{K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointAddressType, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointCondition, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointZone},
+		},
+		K8sServiceLoadBalancerIngressCount: K8sServiceLoadBalancerIngressCountMetricConfig{
 			Enabled: false,
 		},
-		K8sServiceLoadBalancerIngressCount: MetricConfig{
-			Enabled: false,
-		},
-		K8sStatefulsetCurrentPods: MetricConfig{
+		K8sStatefulsetCurrentPods: K8sStatefulsetCurrentPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sStatefulsetDesiredPods: MetricConfig{
+		K8sStatefulsetDesiredPods: K8sStatefulsetDesiredPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sStatefulsetReadyPods: MetricConfig{
+		K8sStatefulsetReadyPods: K8sStatefulsetReadyPodsMetricConfig{
 			Enabled: true,
 		},
-		K8sStatefulsetUpdatedPods: MetricConfig{
+		K8sStatefulsetUpdatedPods: K8sStatefulsetUpdatedPodsMetricConfig{
 			Enabled: true,
 		},
-		OpenshiftAppliedclusterquotaLimit: MetricConfig{
+		OpenshiftAppliedclusterquotaLimit: OpenshiftAppliedclusterquotaLimitMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OpenshiftAppliedclusterquotaLimitMetricAttributeKey{OpenshiftAppliedclusterquotaLimitMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource},
+		},
+		OpenshiftAppliedclusterquotaUsed: OpenshiftAppliedclusterquotaUsedMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OpenshiftAppliedclusterquotaUsedMetricAttributeKey{OpenshiftAppliedclusterquotaUsedMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource},
+		},
+		OpenshiftClusterquotaLimit: OpenshiftClusterquotaLimitMetricConfig{
 			Enabled: true,
 		},
-		OpenshiftAppliedclusterquotaUsed: MetricConfig{
-			Enabled: true,
-		},
-		OpenshiftClusterquotaLimit: MetricConfig{
-			Enabled: true,
-		},
-		OpenshiftClusterquotaUsed: MetricConfig{
+		OpenshiftClusterquotaUsed: OpenshiftClusterquotaUsedMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_config_test.go
@@ -26,148 +26,154 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					K8sContainerCPULimit: MetricConfig{
+					K8sContainerCPULimit: K8sContainerCPULimitMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerCPURequest: MetricConfig{
+					K8sContainerCPURequest: K8sContainerCPURequestMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerEphemeralstorageLimit: MetricConfig{
+					K8sContainerEphemeralstorageLimit: K8sContainerEphemeralstorageLimitMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerEphemeralstorageRequest: MetricConfig{
+					K8sContainerEphemeralstorageRequest: K8sContainerEphemeralstorageRequestMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerMemoryLimit: MetricConfig{
+					K8sContainerMemoryLimit: K8sContainerMemoryLimitMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerMemoryRequest: MetricConfig{
+					K8sContainerMemoryRequest: K8sContainerMemoryRequestMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerReady: MetricConfig{
+					K8sContainerReady: K8sContainerReadyMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerRestarts: MetricConfig{
+					K8sContainerRestarts: K8sContainerRestartsMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerStatusReason: MetricConfig{
+					K8sContainerStatusReason: K8sContainerStatusReasonMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerStatusState: MetricConfig{
+					K8sContainerStatusState: K8sContainerStatusStateMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerStorageLimit: MetricConfig{
+					K8sContainerStorageLimit: K8sContainerStorageLimitMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerStorageRequest: MetricConfig{
+					K8sContainerStorageRequest: K8sContainerStorageRequestMetricConfig{
 						Enabled: true,
 					},
-					K8sCronjobActiveJobs: MetricConfig{
+					K8sCronjobActiveJobs: K8sCronjobActiveJobsMetricConfig{
 						Enabled: true,
 					},
-					K8sDaemonsetCurrentScheduledNodes: MetricConfig{
+					K8sDaemonsetCurrentScheduledNodes: K8sDaemonsetCurrentScheduledNodesMetricConfig{
 						Enabled: true,
 					},
-					K8sDaemonsetDesiredScheduledNodes: MetricConfig{
+					K8sDaemonsetDesiredScheduledNodes: K8sDaemonsetDesiredScheduledNodesMetricConfig{
 						Enabled: true,
 					},
-					K8sDaemonsetMisscheduledNodes: MetricConfig{
+					K8sDaemonsetMisscheduledNodes: K8sDaemonsetMisscheduledNodesMetricConfig{
 						Enabled: true,
 					},
-					K8sDaemonsetReadyNodes: MetricConfig{
+					K8sDaemonsetReadyNodes: K8sDaemonsetReadyNodesMetricConfig{
 						Enabled: true,
 					},
-					K8sDeploymentAvailable: MetricConfig{
+					K8sDeploymentAvailable: K8sDeploymentAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sDeploymentDesired: MetricConfig{
+					K8sDeploymentDesired: K8sDeploymentDesiredMetricConfig{
 						Enabled: true,
 					},
-					K8sHpaCurrentReplicas: MetricConfig{
+					K8sHpaCurrentReplicas: K8sHpaCurrentReplicasMetricConfig{
 						Enabled: true,
 					},
-					K8sHpaDesiredReplicas: MetricConfig{
+					K8sHpaDesiredReplicas: K8sHpaDesiredReplicasMetricConfig{
 						Enabled: true,
 					},
-					K8sHpaMaxReplicas: MetricConfig{
+					K8sHpaMaxReplicas: K8sHpaMaxReplicasMetricConfig{
 						Enabled: true,
 					},
-					K8sHpaMinReplicas: MetricConfig{
+					K8sHpaMinReplicas: K8sHpaMinReplicasMetricConfig{
 						Enabled: true,
 					},
-					K8sJobActivePods: MetricConfig{
+					K8sJobActivePods: K8sJobActivePodsMetricConfig{
 						Enabled: true,
 					},
-					K8sJobDesiredSuccessfulPods: MetricConfig{
+					K8sJobDesiredSuccessfulPods: K8sJobDesiredSuccessfulPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sJobFailedPods: MetricConfig{
+					K8sJobFailedPods: K8sJobFailedPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sJobMaxParallelPods: MetricConfig{
+					K8sJobMaxParallelPods: K8sJobMaxParallelPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sJobSuccessfulPods: MetricConfig{
+					K8sJobSuccessfulPods: K8sJobSuccessfulPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sNamespacePhase: MetricConfig{
+					K8sNamespacePhase: K8sNamespacePhaseMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeCondition: MetricConfig{
+					K8sNodeCondition: K8sNodeConditionMetricConfig{
 						Enabled: true,
 					},
-					K8sPodPhase: MetricConfig{
+					K8sPodPhase: K8sPodPhaseMetricConfig{
 						Enabled: true,
 					},
-					K8sPodStatusReason: MetricConfig{
+					K8sPodStatusReason: K8sPodStatusReasonMetricConfig{
 						Enabled: true,
 					},
-					K8sReplicasetAvailable: MetricConfig{
+					K8sReplicasetAvailable: K8sReplicasetAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sReplicasetDesired: MetricConfig{
+					K8sReplicasetDesired: K8sReplicasetDesiredMetricConfig{
 						Enabled: true,
 					},
-					K8sReplicationControllerAvailable: MetricConfig{
+					K8sReplicationControllerAvailable: K8sReplicationControllerAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sReplicationControllerDesired: MetricConfig{
+					K8sReplicationControllerDesired: K8sReplicationControllerDesiredMetricConfig{
 						Enabled: true,
 					},
-					K8sResourceQuotaHardLimit: MetricConfig{
+					K8sResourceQuotaHardLimit: K8sResourceQuotaHardLimitMetricConfig{
 						Enabled: true,
 					},
-					K8sResourceQuotaUsed: MetricConfig{
+					K8sResourceQuotaUsed: K8sResourceQuotaUsedMetricConfig{
 						Enabled: true,
 					},
-					K8sServiceEndpointCount: MetricConfig{
+					K8sServiceEndpointCount: K8sServiceEndpointCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []K8sServiceEndpointCountMetricAttributeKey{K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointAddressType, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointCondition, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointZone},
+					},
+					K8sServiceLoadBalancerIngressCount: K8sServiceLoadBalancerIngressCountMetricConfig{
 						Enabled: true,
 					},
-					K8sServiceLoadBalancerIngressCount: MetricConfig{
+					K8sStatefulsetCurrentPods: K8sStatefulsetCurrentPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sStatefulsetCurrentPods: MetricConfig{
+					K8sStatefulsetDesiredPods: K8sStatefulsetDesiredPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sStatefulsetDesiredPods: MetricConfig{
+					K8sStatefulsetReadyPods: K8sStatefulsetReadyPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sStatefulsetReadyPods: MetricConfig{
+					K8sStatefulsetUpdatedPods: K8sStatefulsetUpdatedPodsMetricConfig{
 						Enabled: true,
 					},
-					K8sStatefulsetUpdatedPods: MetricConfig{
+					OpenshiftAppliedclusterquotaLimit: OpenshiftAppliedclusterquotaLimitMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OpenshiftAppliedclusterquotaLimitMetricAttributeKey{OpenshiftAppliedclusterquotaLimitMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource},
+					},
+					OpenshiftAppliedclusterquotaUsed: OpenshiftAppliedclusterquotaUsedMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OpenshiftAppliedclusterquotaUsedMetricAttributeKey{OpenshiftAppliedclusterquotaUsedMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource},
+					},
+					OpenshiftClusterquotaLimit: OpenshiftClusterquotaLimitMetricConfig{
 						Enabled: true,
 					},
-					OpenshiftAppliedclusterquotaLimit: MetricConfig{
-						Enabled: true,
-					},
-					OpenshiftAppliedclusterquotaUsed: MetricConfig{
-						Enabled: true,
-					},
-					OpenshiftClusterquotaLimit: MetricConfig{
-						Enabled: true,
-					},
-					OpenshiftClusterquotaUsed: MetricConfig{
+					OpenshiftClusterquotaUsed: OpenshiftClusterquotaUsedMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -224,148 +230,154 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					K8sContainerCPULimit: MetricConfig{
+					K8sContainerCPULimit: K8sContainerCPULimitMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerCPURequest: MetricConfig{
+					K8sContainerCPURequest: K8sContainerCPURequestMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerEphemeralstorageLimit: MetricConfig{
+					K8sContainerEphemeralstorageLimit: K8sContainerEphemeralstorageLimitMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerEphemeralstorageRequest: MetricConfig{
+					K8sContainerEphemeralstorageRequest: K8sContainerEphemeralstorageRequestMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerMemoryLimit: MetricConfig{
+					K8sContainerMemoryLimit: K8sContainerMemoryLimitMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerMemoryRequest: MetricConfig{
+					K8sContainerMemoryRequest: K8sContainerMemoryRequestMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerReady: MetricConfig{
+					K8sContainerReady: K8sContainerReadyMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerRestarts: MetricConfig{
+					K8sContainerRestarts: K8sContainerRestartsMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerStatusReason: MetricConfig{
+					K8sContainerStatusReason: K8sContainerStatusReasonMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerStatusState: MetricConfig{
+					K8sContainerStatusState: K8sContainerStatusStateMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerStorageLimit: MetricConfig{
+					K8sContainerStorageLimit: K8sContainerStorageLimitMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerStorageRequest: MetricConfig{
+					K8sContainerStorageRequest: K8sContainerStorageRequestMetricConfig{
 						Enabled: false,
 					},
-					K8sCronjobActiveJobs: MetricConfig{
+					K8sCronjobActiveJobs: K8sCronjobActiveJobsMetricConfig{
 						Enabled: false,
 					},
-					K8sDaemonsetCurrentScheduledNodes: MetricConfig{
+					K8sDaemonsetCurrentScheduledNodes: K8sDaemonsetCurrentScheduledNodesMetricConfig{
 						Enabled: false,
 					},
-					K8sDaemonsetDesiredScheduledNodes: MetricConfig{
+					K8sDaemonsetDesiredScheduledNodes: K8sDaemonsetDesiredScheduledNodesMetricConfig{
 						Enabled: false,
 					},
-					K8sDaemonsetMisscheduledNodes: MetricConfig{
+					K8sDaemonsetMisscheduledNodes: K8sDaemonsetMisscheduledNodesMetricConfig{
 						Enabled: false,
 					},
-					K8sDaemonsetReadyNodes: MetricConfig{
+					K8sDaemonsetReadyNodes: K8sDaemonsetReadyNodesMetricConfig{
 						Enabled: false,
 					},
-					K8sDeploymentAvailable: MetricConfig{
+					K8sDeploymentAvailable: K8sDeploymentAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sDeploymentDesired: MetricConfig{
+					K8sDeploymentDesired: K8sDeploymentDesiredMetricConfig{
 						Enabled: false,
 					},
-					K8sHpaCurrentReplicas: MetricConfig{
+					K8sHpaCurrentReplicas: K8sHpaCurrentReplicasMetricConfig{
 						Enabled: false,
 					},
-					K8sHpaDesiredReplicas: MetricConfig{
+					K8sHpaDesiredReplicas: K8sHpaDesiredReplicasMetricConfig{
 						Enabled: false,
 					},
-					K8sHpaMaxReplicas: MetricConfig{
+					K8sHpaMaxReplicas: K8sHpaMaxReplicasMetricConfig{
 						Enabled: false,
 					},
-					K8sHpaMinReplicas: MetricConfig{
+					K8sHpaMinReplicas: K8sHpaMinReplicasMetricConfig{
 						Enabled: false,
 					},
-					K8sJobActivePods: MetricConfig{
+					K8sJobActivePods: K8sJobActivePodsMetricConfig{
 						Enabled: false,
 					},
-					K8sJobDesiredSuccessfulPods: MetricConfig{
+					K8sJobDesiredSuccessfulPods: K8sJobDesiredSuccessfulPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sJobFailedPods: MetricConfig{
+					K8sJobFailedPods: K8sJobFailedPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sJobMaxParallelPods: MetricConfig{
+					K8sJobMaxParallelPods: K8sJobMaxParallelPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sJobSuccessfulPods: MetricConfig{
+					K8sJobSuccessfulPods: K8sJobSuccessfulPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sNamespacePhase: MetricConfig{
+					K8sNamespacePhase: K8sNamespacePhaseMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeCondition: MetricConfig{
+					K8sNodeCondition: K8sNodeConditionMetricConfig{
 						Enabled: false,
 					},
-					K8sPodPhase: MetricConfig{
+					K8sPodPhase: K8sPodPhaseMetricConfig{
 						Enabled: false,
 					},
-					K8sPodStatusReason: MetricConfig{
+					K8sPodStatusReason: K8sPodStatusReasonMetricConfig{
 						Enabled: false,
 					},
-					K8sReplicasetAvailable: MetricConfig{
+					K8sReplicasetAvailable: K8sReplicasetAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sReplicasetDesired: MetricConfig{
+					K8sReplicasetDesired: K8sReplicasetDesiredMetricConfig{
 						Enabled: false,
 					},
-					K8sReplicationControllerAvailable: MetricConfig{
+					K8sReplicationControllerAvailable: K8sReplicationControllerAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sReplicationControllerDesired: MetricConfig{
+					K8sReplicationControllerDesired: K8sReplicationControllerDesiredMetricConfig{
 						Enabled: false,
 					},
-					K8sResourceQuotaHardLimit: MetricConfig{
+					K8sResourceQuotaHardLimit: K8sResourceQuotaHardLimitMetricConfig{
 						Enabled: false,
 					},
-					K8sResourceQuotaUsed: MetricConfig{
+					K8sResourceQuotaUsed: K8sResourceQuotaUsedMetricConfig{
 						Enabled: false,
 					},
-					K8sServiceEndpointCount: MetricConfig{
+					K8sServiceEndpointCount: K8sServiceEndpointCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []K8sServiceEndpointCountMetricAttributeKey{K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointAddressType, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointCondition, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointZone},
+					},
+					K8sServiceLoadBalancerIngressCount: K8sServiceLoadBalancerIngressCountMetricConfig{
 						Enabled: false,
 					},
-					K8sServiceLoadBalancerIngressCount: MetricConfig{
+					K8sStatefulsetCurrentPods: K8sStatefulsetCurrentPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sStatefulsetCurrentPods: MetricConfig{
+					K8sStatefulsetDesiredPods: K8sStatefulsetDesiredPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sStatefulsetDesiredPods: MetricConfig{
+					K8sStatefulsetReadyPods: K8sStatefulsetReadyPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sStatefulsetReadyPods: MetricConfig{
+					K8sStatefulsetUpdatedPods: K8sStatefulsetUpdatedPodsMetricConfig{
 						Enabled: false,
 					},
-					K8sStatefulsetUpdatedPods: MetricConfig{
+					OpenshiftAppliedclusterquotaLimit: OpenshiftAppliedclusterquotaLimitMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OpenshiftAppliedclusterquotaLimitMetricAttributeKey{OpenshiftAppliedclusterquotaLimitMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource},
+					},
+					OpenshiftAppliedclusterquotaUsed: OpenshiftAppliedclusterquotaUsedMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OpenshiftAppliedclusterquotaUsedMetricAttributeKey{OpenshiftAppliedclusterquotaUsedMetricAttributeKeyK8sNamespaceName, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource},
+					},
+					OpenshiftClusterquotaLimit: OpenshiftClusterquotaLimitMetricConfig{
 						Enabled: false,
 					},
-					OpenshiftAppliedclusterquotaLimit: MetricConfig{
-						Enabled: false,
-					},
-					OpenshiftAppliedclusterquotaUsed: MetricConfig{
-						Enabled: false,
-					},
-					OpenshiftClusterquotaLimit: MetricConfig{
-						Enabled: false,
-					},
-					OpenshiftClusterquotaUsed: MetricConfig{
+					OpenshiftClusterquotaUsed: OpenshiftClusterquotaUsedMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -422,7 +434,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(K8sContainerCPULimitMetricConfig{}, K8sContainerCPURequestMetricConfig{}, K8sContainerEphemeralstorageLimitMetricConfig{}, K8sContainerEphemeralstorageRequestMetricConfig{}, K8sContainerMemoryLimitMetricConfig{}, K8sContainerMemoryRequestMetricConfig{}, K8sContainerReadyMetricConfig{}, K8sContainerRestartsMetricConfig{}, K8sContainerStatusReasonMetricConfig{}, K8sContainerStatusStateMetricConfig{}, K8sContainerStorageLimitMetricConfig{}, K8sContainerStorageRequestMetricConfig{}, K8sCronjobActiveJobsMetricConfig{}, K8sDaemonsetCurrentScheduledNodesMetricConfig{}, K8sDaemonsetDesiredScheduledNodesMetricConfig{}, K8sDaemonsetMisscheduledNodesMetricConfig{}, K8sDaemonsetReadyNodesMetricConfig{}, K8sDeploymentAvailableMetricConfig{}, K8sDeploymentDesiredMetricConfig{}, K8sHpaCurrentReplicasMetricConfig{}, K8sHpaDesiredReplicasMetricConfig{}, K8sHpaMaxReplicasMetricConfig{}, K8sHpaMinReplicasMetricConfig{}, K8sJobActivePodsMetricConfig{}, K8sJobDesiredSuccessfulPodsMetricConfig{}, K8sJobFailedPodsMetricConfig{}, K8sJobMaxParallelPodsMetricConfig{}, K8sJobSuccessfulPodsMetricConfig{}, K8sNamespacePhaseMetricConfig{}, K8sNodeConditionMetricConfig{}, K8sPodPhaseMetricConfig{}, K8sPodStatusReasonMetricConfig{}, K8sReplicasetAvailableMetricConfig{}, K8sReplicasetDesiredMetricConfig{}, K8sReplicationControllerAvailableMetricConfig{}, K8sReplicationControllerDesiredMetricConfig{}, K8sResourceQuotaHardLimitMetricConfig{}, K8sResourceQuotaUsedMetricConfig{}, K8sServiceEndpointCountMetricConfig{}, K8sServiceLoadBalancerIngressCountMetricConfig{}, K8sStatefulsetCurrentPodsMetricConfig{}, K8sStatefulsetDesiredPodsMetricConfig{}, K8sStatefulsetReadyPodsMetricConfig{}, K8sStatefulsetUpdatedPodsMetricConfig{}, OpenshiftAppliedclusterquotaLimitMetricConfig{}, OpenshiftAppliedclusterquotaUsedMetricConfig{}, OpenshiftClusterquotaLimitMetricConfig{}, OpenshiftClusterquotaUsedMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -11,6 +12,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/otel/semconv/v1.18.0"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeK8sContainerStatusReason specifies the value k8s.container.status.reason attribute.
@@ -360,9 +368,9 @@ type metricInfo struct {
 }
 
 type metricK8sContainerCPULimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sContainerCPULimitMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.cpu_limit metric with initial data.
@@ -399,7 +407,7 @@ func (m *metricK8sContainerCPULimit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerCPULimit(cfg MetricConfig) metricK8sContainerCPULimit {
+func newMetricK8sContainerCPULimit(cfg K8sContainerCPULimitMetricConfig) metricK8sContainerCPULimit {
 	m := metricK8sContainerCPULimit{config: cfg}
 
 	if cfg.Enabled {
@@ -410,9 +418,9 @@ func newMetricK8sContainerCPULimit(cfg MetricConfig) metricK8sContainerCPULimit 
 }
 
 type metricK8sContainerCPURequest struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sContainerCPURequestMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.cpu_request metric with initial data.
@@ -449,7 +457,7 @@ func (m *metricK8sContainerCPURequest) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerCPURequest(cfg MetricConfig) metricK8sContainerCPURequest {
+func newMetricK8sContainerCPURequest(cfg K8sContainerCPURequestMetricConfig) metricK8sContainerCPURequest {
 	m := metricK8sContainerCPURequest{config: cfg}
 
 	if cfg.Enabled {
@@ -460,9 +468,9 @@ func newMetricK8sContainerCPURequest(cfg MetricConfig) metricK8sContainerCPURequ
 }
 
 type metricK8sContainerEphemeralstorageLimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sContainerEphemeralstorageLimitMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.ephemeralstorage_limit metric with initial data.
@@ -499,7 +507,7 @@ func (m *metricK8sContainerEphemeralstorageLimit) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sContainerEphemeralstorageLimit(cfg MetricConfig) metricK8sContainerEphemeralstorageLimit {
+func newMetricK8sContainerEphemeralstorageLimit(cfg K8sContainerEphemeralstorageLimitMetricConfig) metricK8sContainerEphemeralstorageLimit {
 	m := metricK8sContainerEphemeralstorageLimit{config: cfg}
 
 	if cfg.Enabled {
@@ -510,9 +518,9 @@ func newMetricK8sContainerEphemeralstorageLimit(cfg MetricConfig) metricK8sConta
 }
 
 type metricK8sContainerEphemeralstorageRequest struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                  // data buffer for generated metric.
+	config   K8sContainerEphemeralstorageRequestMetricConfig // metric config provided by user.
+	capacity int                                             // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.ephemeralstorage_request metric with initial data.
@@ -549,7 +557,7 @@ func (m *metricK8sContainerEphemeralstorageRequest) emit(metrics pmetric.MetricS
 	}
 }
 
-func newMetricK8sContainerEphemeralstorageRequest(cfg MetricConfig) metricK8sContainerEphemeralstorageRequest {
+func newMetricK8sContainerEphemeralstorageRequest(cfg K8sContainerEphemeralstorageRequestMetricConfig) metricK8sContainerEphemeralstorageRequest {
 	m := metricK8sContainerEphemeralstorageRequest{config: cfg}
 
 	if cfg.Enabled {
@@ -560,9 +568,9 @@ func newMetricK8sContainerEphemeralstorageRequest(cfg MetricConfig) metricK8sCon
 }
 
 type metricK8sContainerMemoryLimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   K8sContainerMemoryLimitMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.memory_limit metric with initial data.
@@ -599,7 +607,7 @@ func (m *metricK8sContainerMemoryLimit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerMemoryLimit(cfg MetricConfig) metricK8sContainerMemoryLimit {
+func newMetricK8sContainerMemoryLimit(cfg K8sContainerMemoryLimitMetricConfig) metricK8sContainerMemoryLimit {
 	m := metricK8sContainerMemoryLimit{config: cfg}
 
 	if cfg.Enabled {
@@ -610,9 +618,9 @@ func newMetricK8sContainerMemoryLimit(cfg MetricConfig) metricK8sContainerMemory
 }
 
 type metricK8sContainerMemoryRequest struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sContainerMemoryRequestMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.memory_request metric with initial data.
@@ -649,7 +657,7 @@ func (m *metricK8sContainerMemoryRequest) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerMemoryRequest(cfg MetricConfig) metricK8sContainerMemoryRequest {
+func newMetricK8sContainerMemoryRequest(cfg K8sContainerMemoryRequestMetricConfig) metricK8sContainerMemoryRequest {
 	m := metricK8sContainerMemoryRequest{config: cfg}
 
 	if cfg.Enabled {
@@ -660,9 +668,9 @@ func newMetricK8sContainerMemoryRequest(cfg MetricConfig) metricK8sContainerMemo
 }
 
 type metricK8sContainerReady struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sContainerReadyMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.ready metric with initial data.
@@ -699,7 +707,7 @@ func (m *metricK8sContainerReady) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerReady(cfg MetricConfig) metricK8sContainerReady {
+func newMetricK8sContainerReady(cfg K8sContainerReadyMetricConfig) metricK8sContainerReady {
 	m := metricK8sContainerReady{config: cfg}
 
 	if cfg.Enabled {
@@ -710,9 +718,9 @@ func newMetricK8sContainerReady(cfg MetricConfig) metricK8sContainerReady {
 }
 
 type metricK8sContainerRestarts struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sContainerRestartsMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.restarts metric with initial data.
@@ -749,7 +757,7 @@ func (m *metricK8sContainerRestarts) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerRestarts(cfg MetricConfig) metricK8sContainerRestarts {
+func newMetricK8sContainerRestarts(cfg K8sContainerRestartsMetricConfig) metricK8sContainerRestarts {
 	m := metricK8sContainerRestarts{config: cfg}
 
 	if cfg.Enabled {
@@ -760,9 +768,9 @@ func newMetricK8sContainerRestarts(cfg MetricConfig) metricK8sContainerRestarts 
 }
 
 type metricK8sContainerStatusReason struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   K8sContainerStatusReasonMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.status.reason metric with initial data.
@@ -803,7 +811,7 @@ func (m *metricK8sContainerStatusReason) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerStatusReason(cfg MetricConfig) metricK8sContainerStatusReason {
+func newMetricK8sContainerStatusReason(cfg K8sContainerStatusReasonMetricConfig) metricK8sContainerStatusReason {
 	m := metricK8sContainerStatusReason{config: cfg}
 
 	if cfg.Enabled {
@@ -814,9 +822,9 @@ func newMetricK8sContainerStatusReason(cfg MetricConfig) metricK8sContainerStatu
 }
 
 type metricK8sContainerStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   K8sContainerStatusStateMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.status.state metric with initial data.
@@ -857,7 +865,7 @@ func (m *metricK8sContainerStatusState) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerStatusState(cfg MetricConfig) metricK8sContainerStatusState {
+func newMetricK8sContainerStatusState(cfg K8sContainerStatusStateMetricConfig) metricK8sContainerStatusState {
 	m := metricK8sContainerStatusState{config: cfg}
 
 	if cfg.Enabled {
@@ -868,9 +876,9 @@ func newMetricK8sContainerStatusState(cfg MetricConfig) metricK8sContainerStatus
 }
 
 type metricK8sContainerStorageLimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   K8sContainerStorageLimitMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.storage_limit metric with initial data.
@@ -907,7 +915,7 @@ func (m *metricK8sContainerStorageLimit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerStorageLimit(cfg MetricConfig) metricK8sContainerStorageLimit {
+func newMetricK8sContainerStorageLimit(cfg K8sContainerStorageLimitMetricConfig) metricK8sContainerStorageLimit {
 	m := metricK8sContainerStorageLimit{config: cfg}
 
 	if cfg.Enabled {
@@ -918,9 +926,9 @@ func newMetricK8sContainerStorageLimit(cfg MetricConfig) metricK8sContainerStora
 }
 
 type metricK8sContainerStorageRequest struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   K8sContainerStorageRequestMetricConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.storage_request metric with initial data.
@@ -957,7 +965,7 @@ func (m *metricK8sContainerStorageRequest) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sContainerStorageRequest(cfg MetricConfig) metricK8sContainerStorageRequest {
+func newMetricK8sContainerStorageRequest(cfg K8sContainerStorageRequestMetricConfig) metricK8sContainerStorageRequest {
 	m := metricK8sContainerStorageRequest{config: cfg}
 
 	if cfg.Enabled {
@@ -968,9 +976,9 @@ func newMetricK8sContainerStorageRequest(cfg MetricConfig) metricK8sContainerSto
 }
 
 type metricK8sCronjobActiveJobs struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sCronjobActiveJobsMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.cronjob.active_jobs metric with initial data.
@@ -1007,7 +1015,7 @@ func (m *metricK8sCronjobActiveJobs) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sCronjobActiveJobs(cfg MetricConfig) metricK8sCronjobActiveJobs {
+func newMetricK8sCronjobActiveJobs(cfg K8sCronjobActiveJobsMetricConfig) metricK8sCronjobActiveJobs {
 	m := metricK8sCronjobActiveJobs{config: cfg}
 
 	if cfg.Enabled {
@@ -1018,9 +1026,9 @@ func newMetricK8sCronjobActiveJobs(cfg MetricConfig) metricK8sCronjobActiveJobs 
 }
 
 type metricK8sDaemonsetCurrentScheduledNodes struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sDaemonsetCurrentScheduledNodesMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.daemonset.current_scheduled_nodes metric with initial data.
@@ -1057,7 +1065,7 @@ func (m *metricK8sDaemonsetCurrentScheduledNodes) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sDaemonsetCurrentScheduledNodes(cfg MetricConfig) metricK8sDaemonsetCurrentScheduledNodes {
+func newMetricK8sDaemonsetCurrentScheduledNodes(cfg K8sDaemonsetCurrentScheduledNodesMetricConfig) metricK8sDaemonsetCurrentScheduledNodes {
 	m := metricK8sDaemonsetCurrentScheduledNodes{config: cfg}
 
 	if cfg.Enabled {
@@ -1068,9 +1076,9 @@ func newMetricK8sDaemonsetCurrentScheduledNodes(cfg MetricConfig) metricK8sDaemo
 }
 
 type metricK8sDaemonsetDesiredScheduledNodes struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sDaemonsetDesiredScheduledNodesMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.daemonset.desired_scheduled_nodes metric with initial data.
@@ -1107,7 +1115,7 @@ func (m *metricK8sDaemonsetDesiredScheduledNodes) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sDaemonsetDesiredScheduledNodes(cfg MetricConfig) metricK8sDaemonsetDesiredScheduledNodes {
+func newMetricK8sDaemonsetDesiredScheduledNodes(cfg K8sDaemonsetDesiredScheduledNodesMetricConfig) metricK8sDaemonsetDesiredScheduledNodes {
 	m := metricK8sDaemonsetDesiredScheduledNodes{config: cfg}
 
 	if cfg.Enabled {
@@ -1118,9 +1126,9 @@ func newMetricK8sDaemonsetDesiredScheduledNodes(cfg MetricConfig) metricK8sDaemo
 }
 
 type metricK8sDaemonsetMisscheduledNodes struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   K8sDaemonsetMisscheduledNodesMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
 }
 
 // init fills k8s.daemonset.misscheduled_nodes metric with initial data.
@@ -1157,7 +1165,7 @@ func (m *metricK8sDaemonsetMisscheduledNodes) emit(metrics pmetric.MetricSlice) 
 	}
 }
 
-func newMetricK8sDaemonsetMisscheduledNodes(cfg MetricConfig) metricK8sDaemonsetMisscheduledNodes {
+func newMetricK8sDaemonsetMisscheduledNodes(cfg K8sDaemonsetMisscheduledNodesMetricConfig) metricK8sDaemonsetMisscheduledNodes {
 	m := metricK8sDaemonsetMisscheduledNodes{config: cfg}
 
 	if cfg.Enabled {
@@ -1168,9 +1176,9 @@ func newMetricK8sDaemonsetMisscheduledNodes(cfg MetricConfig) metricK8sDaemonset
 }
 
 type metricK8sDaemonsetReadyNodes struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sDaemonsetReadyNodesMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.daemonset.ready_nodes metric with initial data.
@@ -1207,7 +1215,7 @@ func (m *metricK8sDaemonsetReadyNodes) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sDaemonsetReadyNodes(cfg MetricConfig) metricK8sDaemonsetReadyNodes {
+func newMetricK8sDaemonsetReadyNodes(cfg K8sDaemonsetReadyNodesMetricConfig) metricK8sDaemonsetReadyNodes {
 	m := metricK8sDaemonsetReadyNodes{config: cfg}
 
 	if cfg.Enabled {
@@ -1218,9 +1226,9 @@ func newMetricK8sDaemonsetReadyNodes(cfg MetricConfig) metricK8sDaemonsetReadyNo
 }
 
 type metricK8sDeploymentAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sDeploymentAvailableMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.deployment.available metric with initial data.
@@ -1257,7 +1265,7 @@ func (m *metricK8sDeploymentAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sDeploymentAvailable(cfg MetricConfig) metricK8sDeploymentAvailable {
+func newMetricK8sDeploymentAvailable(cfg K8sDeploymentAvailableMetricConfig) metricK8sDeploymentAvailable {
 	m := metricK8sDeploymentAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -1268,9 +1276,9 @@ func newMetricK8sDeploymentAvailable(cfg MetricConfig) metricK8sDeploymentAvaila
 }
 
 type metricK8sDeploymentDesired struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sDeploymentDesiredMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.deployment.desired metric with initial data.
@@ -1307,7 +1315,7 @@ func (m *metricK8sDeploymentDesired) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sDeploymentDesired(cfg MetricConfig) metricK8sDeploymentDesired {
+func newMetricK8sDeploymentDesired(cfg K8sDeploymentDesiredMetricConfig) metricK8sDeploymentDesired {
 	m := metricK8sDeploymentDesired{config: cfg}
 
 	if cfg.Enabled {
@@ -1318,9 +1326,9 @@ func newMetricK8sDeploymentDesired(cfg MetricConfig) metricK8sDeploymentDesired 
 }
 
 type metricK8sHpaCurrentReplicas struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   K8sHpaCurrentReplicasMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills k8s.hpa.current_replicas metric with initial data.
@@ -1357,7 +1365,7 @@ func (m *metricK8sHpaCurrentReplicas) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sHpaCurrentReplicas(cfg MetricConfig) metricK8sHpaCurrentReplicas {
+func newMetricK8sHpaCurrentReplicas(cfg K8sHpaCurrentReplicasMetricConfig) metricK8sHpaCurrentReplicas {
 	m := metricK8sHpaCurrentReplicas{config: cfg}
 
 	if cfg.Enabled {
@@ -1368,9 +1376,9 @@ func newMetricK8sHpaCurrentReplicas(cfg MetricConfig) metricK8sHpaCurrentReplica
 }
 
 type metricK8sHpaDesiredReplicas struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   K8sHpaDesiredReplicasMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills k8s.hpa.desired_replicas metric with initial data.
@@ -1407,7 +1415,7 @@ func (m *metricK8sHpaDesiredReplicas) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sHpaDesiredReplicas(cfg MetricConfig) metricK8sHpaDesiredReplicas {
+func newMetricK8sHpaDesiredReplicas(cfg K8sHpaDesiredReplicasMetricConfig) metricK8sHpaDesiredReplicas {
 	m := metricK8sHpaDesiredReplicas{config: cfg}
 
 	if cfg.Enabled {
@@ -1418,9 +1426,9 @@ func newMetricK8sHpaDesiredReplicas(cfg MetricConfig) metricK8sHpaDesiredReplica
 }
 
 type metricK8sHpaMaxReplicas struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sHpaMaxReplicasMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.hpa.max_replicas metric with initial data.
@@ -1457,7 +1465,7 @@ func (m *metricK8sHpaMaxReplicas) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sHpaMaxReplicas(cfg MetricConfig) metricK8sHpaMaxReplicas {
+func newMetricK8sHpaMaxReplicas(cfg K8sHpaMaxReplicasMetricConfig) metricK8sHpaMaxReplicas {
 	m := metricK8sHpaMaxReplicas{config: cfg}
 
 	if cfg.Enabled {
@@ -1468,9 +1476,9 @@ func newMetricK8sHpaMaxReplicas(cfg MetricConfig) metricK8sHpaMaxReplicas {
 }
 
 type metricK8sHpaMinReplicas struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sHpaMinReplicasMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.hpa.min_replicas metric with initial data.
@@ -1507,7 +1515,7 @@ func (m *metricK8sHpaMinReplicas) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sHpaMinReplicas(cfg MetricConfig) metricK8sHpaMinReplicas {
+func newMetricK8sHpaMinReplicas(cfg K8sHpaMinReplicasMetricConfig) metricK8sHpaMinReplicas {
 	m := metricK8sHpaMinReplicas{config: cfg}
 
 	if cfg.Enabled {
@@ -1518,9 +1526,9 @@ func newMetricK8sHpaMinReplicas(cfg MetricConfig) metricK8sHpaMinReplicas {
 }
 
 type metricK8sJobActivePods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   K8sJobActivePodsMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills k8s.job.active_pods metric with initial data.
@@ -1557,7 +1565,7 @@ func (m *metricK8sJobActivePods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sJobActivePods(cfg MetricConfig) metricK8sJobActivePods {
+func newMetricK8sJobActivePods(cfg K8sJobActivePodsMetricConfig) metricK8sJobActivePods {
 	m := metricK8sJobActivePods{config: cfg}
 
 	if cfg.Enabled {
@@ -1568,9 +1576,9 @@ func newMetricK8sJobActivePods(cfg MetricConfig) metricK8sJobActivePods {
 }
 
 type metricK8sJobDesiredSuccessfulPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   K8sJobDesiredSuccessfulPodsMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills k8s.job.desired_successful_pods metric with initial data.
@@ -1607,7 +1615,7 @@ func (m *metricK8sJobDesiredSuccessfulPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sJobDesiredSuccessfulPods(cfg MetricConfig) metricK8sJobDesiredSuccessfulPods {
+func newMetricK8sJobDesiredSuccessfulPods(cfg K8sJobDesiredSuccessfulPodsMetricConfig) metricK8sJobDesiredSuccessfulPods {
 	m := metricK8sJobDesiredSuccessfulPods{config: cfg}
 
 	if cfg.Enabled {
@@ -1618,9 +1626,9 @@ func newMetricK8sJobDesiredSuccessfulPods(cfg MetricConfig) metricK8sJobDesiredS
 }
 
 type metricK8sJobFailedPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   K8sJobFailedPodsMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills k8s.job.failed_pods metric with initial data.
@@ -1657,7 +1665,7 @@ func (m *metricK8sJobFailedPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sJobFailedPods(cfg MetricConfig) metricK8sJobFailedPods {
+func newMetricK8sJobFailedPods(cfg K8sJobFailedPodsMetricConfig) metricK8sJobFailedPods {
 	m := metricK8sJobFailedPods{config: cfg}
 
 	if cfg.Enabled {
@@ -1668,9 +1676,9 @@ func newMetricK8sJobFailedPods(cfg MetricConfig) metricK8sJobFailedPods {
 }
 
 type metricK8sJobMaxParallelPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   K8sJobMaxParallelPodsMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills k8s.job.max_parallel_pods metric with initial data.
@@ -1707,7 +1715,7 @@ func (m *metricK8sJobMaxParallelPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sJobMaxParallelPods(cfg MetricConfig) metricK8sJobMaxParallelPods {
+func newMetricK8sJobMaxParallelPods(cfg K8sJobMaxParallelPodsMetricConfig) metricK8sJobMaxParallelPods {
 	m := metricK8sJobMaxParallelPods{config: cfg}
 
 	if cfg.Enabled {
@@ -1718,9 +1726,9 @@ func newMetricK8sJobMaxParallelPods(cfg MetricConfig) metricK8sJobMaxParallelPod
 }
 
 type metricK8sJobSuccessfulPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sJobSuccessfulPodsMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.job.successful_pods metric with initial data.
@@ -1757,7 +1765,7 @@ func (m *metricK8sJobSuccessfulPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sJobSuccessfulPods(cfg MetricConfig) metricK8sJobSuccessfulPods {
+func newMetricK8sJobSuccessfulPods(cfg K8sJobSuccessfulPodsMetricConfig) metricK8sJobSuccessfulPods {
 	m := metricK8sJobSuccessfulPods{config: cfg}
 
 	if cfg.Enabled {
@@ -1768,9 +1776,9 @@ func newMetricK8sJobSuccessfulPods(cfg MetricConfig) metricK8sJobSuccessfulPods 
 }
 
 type metricK8sNamespacePhase struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sNamespacePhaseMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.namespace.phase metric with initial data.
@@ -1807,7 +1815,7 @@ func (m *metricK8sNamespacePhase) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNamespacePhase(cfg MetricConfig) metricK8sNamespacePhase {
+func newMetricK8sNamespacePhase(cfg K8sNamespacePhaseMetricConfig) metricK8sNamespacePhase {
 	m := metricK8sNamespacePhase{config: cfg}
 
 	if cfg.Enabled {
@@ -1818,9 +1826,9 @@ func newMetricK8sNamespacePhase(cfg MetricConfig) metricK8sNamespacePhase {
 }
 
 type metricK8sNodeCondition struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   K8sNodeConditionMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.condition metric with initial data.
@@ -1859,7 +1867,7 @@ func (m *metricK8sNodeCondition) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeCondition(cfg MetricConfig) metricK8sNodeCondition {
+func newMetricK8sNodeCondition(cfg K8sNodeConditionMetricConfig) metricK8sNodeCondition {
 	m := metricK8sNodeCondition{config: cfg}
 
 	if cfg.Enabled {
@@ -1870,9 +1878,9 @@ func newMetricK8sNodeCondition(cfg MetricConfig) metricK8sNodeCondition {
 }
 
 type metricK8sPodPhase struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric          // data buffer for generated metric.
+	config   K8sPodPhaseMetricConfig // metric config provided by user.
+	capacity int                     // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.phase metric with initial data.
@@ -1909,7 +1917,7 @@ func (m *metricK8sPodPhase) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodPhase(cfg MetricConfig) metricK8sPodPhase {
+func newMetricK8sPodPhase(cfg K8sPodPhaseMetricConfig) metricK8sPodPhase {
 	m := metricK8sPodPhase{config: cfg}
 
 	if cfg.Enabled {
@@ -1920,9 +1928,9 @@ func newMetricK8sPodPhase(cfg MetricConfig) metricK8sPodPhase {
 }
 
 type metricK8sPodStatusReason struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   K8sPodStatusReasonMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.status_reason metric with initial data.
@@ -1959,7 +1967,7 @@ func (m *metricK8sPodStatusReason) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodStatusReason(cfg MetricConfig) metricK8sPodStatusReason {
+func newMetricK8sPodStatusReason(cfg K8sPodStatusReasonMetricConfig) metricK8sPodStatusReason {
 	m := metricK8sPodStatusReason{config: cfg}
 
 	if cfg.Enabled {
@@ -1970,9 +1978,9 @@ func newMetricK8sPodStatusReason(cfg MetricConfig) metricK8sPodStatusReason {
 }
 
 type metricK8sReplicasetAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sReplicasetAvailableMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.replicaset.available metric with initial data.
@@ -2009,7 +2017,7 @@ func (m *metricK8sReplicasetAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sReplicasetAvailable(cfg MetricConfig) metricK8sReplicasetAvailable {
+func newMetricK8sReplicasetAvailable(cfg K8sReplicasetAvailableMetricConfig) metricK8sReplicasetAvailable {
 	m := metricK8sReplicasetAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -2020,9 +2028,9 @@ func newMetricK8sReplicasetAvailable(cfg MetricConfig) metricK8sReplicasetAvaila
 }
 
 type metricK8sReplicasetDesired struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sReplicasetDesiredMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.replicaset.desired metric with initial data.
@@ -2059,7 +2067,7 @@ func (m *metricK8sReplicasetDesired) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sReplicasetDesired(cfg MetricConfig) metricK8sReplicasetDesired {
+func newMetricK8sReplicasetDesired(cfg K8sReplicasetDesiredMetricConfig) metricK8sReplicasetDesired {
 	m := metricK8sReplicasetDesired{config: cfg}
 
 	if cfg.Enabled {
@@ -2070,9 +2078,9 @@ func newMetricK8sReplicasetDesired(cfg MetricConfig) metricK8sReplicasetDesired 
 }
 
 type metricK8sReplicationControllerAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sReplicationControllerAvailableMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.replication_controller.available metric with initial data.
@@ -2109,7 +2117,7 @@ func (m *metricK8sReplicationControllerAvailable) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sReplicationControllerAvailable(cfg MetricConfig) metricK8sReplicationControllerAvailable {
+func newMetricK8sReplicationControllerAvailable(cfg K8sReplicationControllerAvailableMetricConfig) metricK8sReplicationControllerAvailable {
 	m := metricK8sReplicationControllerAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -2120,9 +2128,9 @@ func newMetricK8sReplicationControllerAvailable(cfg MetricConfig) metricK8sRepli
 }
 
 type metricK8sReplicationControllerDesired struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                              // data buffer for generated metric.
+	config   K8sReplicationControllerDesiredMetricConfig // metric config provided by user.
+	capacity int                                         // max observed number of data points added to the metric.
 }
 
 // init fills k8s.replication_controller.desired metric with initial data.
@@ -2159,7 +2167,7 @@ func (m *metricK8sReplicationControllerDesired) emit(metrics pmetric.MetricSlice
 	}
 }
 
-func newMetricK8sReplicationControllerDesired(cfg MetricConfig) metricK8sReplicationControllerDesired {
+func newMetricK8sReplicationControllerDesired(cfg K8sReplicationControllerDesiredMetricConfig) metricK8sReplicationControllerDesired {
 	m := metricK8sReplicationControllerDesired{config: cfg}
 
 	if cfg.Enabled {
@@ -2170,9 +2178,9 @@ func newMetricK8sReplicationControllerDesired(cfg MetricConfig) metricK8sReplica
 }
 
 type metricK8sResourceQuotaHardLimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sResourceQuotaHardLimitMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.resource_quota.hard_limit metric with initial data.
@@ -2211,7 +2219,7 @@ func (m *metricK8sResourceQuotaHardLimit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sResourceQuotaHardLimit(cfg MetricConfig) metricK8sResourceQuotaHardLimit {
+func newMetricK8sResourceQuotaHardLimit(cfg K8sResourceQuotaHardLimitMetricConfig) metricK8sResourceQuotaHardLimit {
 	m := metricK8sResourceQuotaHardLimit{config: cfg}
 
 	if cfg.Enabled {
@@ -2222,9 +2230,9 @@ func newMetricK8sResourceQuotaHardLimit(cfg MetricConfig) metricK8sResourceQuota
 }
 
 type metricK8sResourceQuotaUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   K8sResourceQuotaUsedMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.resource_quota.used metric with initial data.
@@ -2263,7 +2271,7 @@ func (m *metricK8sResourceQuotaUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sResourceQuotaUsed(cfg MetricConfig) metricK8sResourceQuotaUsed {
+func newMetricK8sResourceQuotaUsed(cfg K8sResourceQuotaUsedMetricConfig) metricK8sResourceQuotaUsed {
 	m := metricK8sResourceQuotaUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -2274,9 +2282,10 @@ func newMetricK8sResourceQuotaUsed(cfg MetricConfig) metricK8sResourceQuotaUsed 
 }
 
 type metricK8sServiceEndpointCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        K8sServiceEndpointCountMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.service.endpoint.count metric with initial data.
@@ -2286,19 +2295,54 @@ func (m *metricK8sServiceEndpointCount) init() {
 	m.data.SetUnit("{endpoint}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sServiceEndpointCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, k8sServiceEndpointAddressTypeAttributeValue string, k8sServiceEndpointConditionAttributeValue string, k8sServiceEndpointZoneAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointAddressType) {
+		dp.Attributes().PutStr("k8s.service.endpoint.address_type", k8sServiceEndpointAddressTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointCondition) {
+		dp.Attributes().PutStr("k8s.service.endpoint.condition", k8sServiceEndpointConditionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, K8sServiceEndpointCountMetricAttributeKeyK8sServiceEndpointZone) {
+		dp.Attributes().PutStr("k8s.service.endpoint.zone", k8sServiceEndpointZoneAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("k8s.service.endpoint.address_type", k8sServiceEndpointAddressTypeAttributeValue)
-	dp.Attributes().PutStr("k8s.service.endpoint.condition", k8sServiceEndpointConditionAttributeValue)
-	dp.Attributes().PutStr("k8s.service.endpoint.zone", k8sServiceEndpointZoneAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2311,13 +2355,18 @@ func (m *metricK8sServiceEndpointCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sServiceEndpointCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sServiceEndpointCount(cfg MetricConfig) metricK8sServiceEndpointCount {
+func newMetricK8sServiceEndpointCount(cfg K8sServiceEndpointCountMetricConfig) metricK8sServiceEndpointCount {
 	m := metricK8sServiceEndpointCount{config: cfg}
 
 	if cfg.Enabled {
@@ -2328,9 +2377,9 @@ func newMetricK8sServiceEndpointCount(cfg MetricConfig) metricK8sServiceEndpoint
 }
 
 type metricK8sServiceLoadBalancerIngressCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                 // data buffer for generated metric.
+	config   K8sServiceLoadBalancerIngressCountMetricConfig // metric config provided by user.
+	capacity int                                            // max observed number of data points added to the metric.
 }
 
 // init fills k8s.service.load_balancer.ingress.count metric with initial data.
@@ -2367,7 +2416,7 @@ func (m *metricK8sServiceLoadBalancerIngressCount) emit(metrics pmetric.MetricSl
 	}
 }
 
-func newMetricK8sServiceLoadBalancerIngressCount(cfg MetricConfig) metricK8sServiceLoadBalancerIngressCount {
+func newMetricK8sServiceLoadBalancerIngressCount(cfg K8sServiceLoadBalancerIngressCountMetricConfig) metricK8sServiceLoadBalancerIngressCount {
 	m := metricK8sServiceLoadBalancerIngressCount{config: cfg}
 
 	if cfg.Enabled {
@@ -2378,9 +2427,9 @@ func newMetricK8sServiceLoadBalancerIngressCount(cfg MetricConfig) metricK8sServ
 }
 
 type metricK8sStatefulsetCurrentPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sStatefulsetCurrentPodsMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.statefulset.current_pods metric with initial data.
@@ -2417,7 +2466,7 @@ func (m *metricK8sStatefulsetCurrentPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sStatefulsetCurrentPods(cfg MetricConfig) metricK8sStatefulsetCurrentPods {
+func newMetricK8sStatefulsetCurrentPods(cfg K8sStatefulsetCurrentPodsMetricConfig) metricK8sStatefulsetCurrentPods {
 	m := metricK8sStatefulsetCurrentPods{config: cfg}
 
 	if cfg.Enabled {
@@ -2428,9 +2477,9 @@ func newMetricK8sStatefulsetCurrentPods(cfg MetricConfig) metricK8sStatefulsetCu
 }
 
 type metricK8sStatefulsetDesiredPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sStatefulsetDesiredPodsMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.statefulset.desired_pods metric with initial data.
@@ -2467,7 +2516,7 @@ func (m *metricK8sStatefulsetDesiredPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sStatefulsetDesiredPods(cfg MetricConfig) metricK8sStatefulsetDesiredPods {
+func newMetricK8sStatefulsetDesiredPods(cfg K8sStatefulsetDesiredPodsMetricConfig) metricK8sStatefulsetDesiredPods {
 	m := metricK8sStatefulsetDesiredPods{config: cfg}
 
 	if cfg.Enabled {
@@ -2478,9 +2527,9 @@ func newMetricK8sStatefulsetDesiredPods(cfg MetricConfig) metricK8sStatefulsetDe
 }
 
 type metricK8sStatefulsetReadyPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   K8sStatefulsetReadyPodsMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
 }
 
 // init fills k8s.statefulset.ready_pods metric with initial data.
@@ -2517,7 +2566,7 @@ func (m *metricK8sStatefulsetReadyPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sStatefulsetReadyPods(cfg MetricConfig) metricK8sStatefulsetReadyPods {
+func newMetricK8sStatefulsetReadyPods(cfg K8sStatefulsetReadyPodsMetricConfig) metricK8sStatefulsetReadyPods {
 	m := metricK8sStatefulsetReadyPods{config: cfg}
 
 	if cfg.Enabled {
@@ -2528,9 +2577,9 @@ func newMetricK8sStatefulsetReadyPods(cfg MetricConfig) metricK8sStatefulsetRead
 }
 
 type metricK8sStatefulsetUpdatedPods struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sStatefulsetUpdatedPodsMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.statefulset.updated_pods metric with initial data.
@@ -2567,7 +2616,7 @@ func (m *metricK8sStatefulsetUpdatedPods) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sStatefulsetUpdatedPods(cfg MetricConfig) metricK8sStatefulsetUpdatedPods {
+func newMetricK8sStatefulsetUpdatedPods(cfg K8sStatefulsetUpdatedPodsMetricConfig) metricK8sStatefulsetUpdatedPods {
 	m := metricK8sStatefulsetUpdatedPods{config: cfg}
 
 	if cfg.Enabled {
@@ -2578,9 +2627,10 @@ func newMetricK8sStatefulsetUpdatedPods(cfg MetricConfig) metricK8sStatefulsetUp
 }
 
 type metricOpenshiftAppliedclusterquotaLimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        OpenshiftAppliedclusterquotaLimitMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills openshift.appliedclusterquota.limit metric with initial data.
@@ -2590,18 +2640,51 @@ func (m *metricOpenshiftAppliedclusterquotaLimit) init() {
 	m.data.SetUnit("{resource}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricOpenshiftAppliedclusterquotaLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, k8sNamespaceNameAttributeValue string, resourceAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyK8sNamespaceName) {
+		dp.Attributes().PutStr("k8s.namespace.name", k8sNamespaceNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, OpenshiftAppliedclusterquotaLimitMetricAttributeKeyResource) {
+		dp.Attributes().PutStr("resource", resourceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("k8s.namespace.name", k8sNamespaceNameAttributeValue)
-	dp.Attributes().PutStr("resource", resourceAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2614,13 +2697,18 @@ func (m *metricOpenshiftAppliedclusterquotaLimit) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOpenshiftAppliedclusterquotaLimit) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOpenshiftAppliedclusterquotaLimit(cfg MetricConfig) metricOpenshiftAppliedclusterquotaLimit {
+func newMetricOpenshiftAppliedclusterquotaLimit(cfg OpenshiftAppliedclusterquotaLimitMetricConfig) metricOpenshiftAppliedclusterquotaLimit {
 	m := metricOpenshiftAppliedclusterquotaLimit{config: cfg}
 
 	if cfg.Enabled {
@@ -2631,9 +2719,10 @@ func newMetricOpenshiftAppliedclusterquotaLimit(cfg MetricConfig) metricOpenshif
 }
 
 type metricOpenshiftAppliedclusterquotaUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        OpenshiftAppliedclusterquotaUsedMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills openshift.appliedclusterquota.used metric with initial data.
@@ -2643,18 +2732,51 @@ func (m *metricOpenshiftAppliedclusterquotaUsed) init() {
 	m.data.SetUnit("{resource}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricOpenshiftAppliedclusterquotaUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, k8sNamespaceNameAttributeValue string, resourceAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyK8sNamespaceName) {
+		dp.Attributes().PutStr("k8s.namespace.name", k8sNamespaceNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, OpenshiftAppliedclusterquotaUsedMetricAttributeKeyResource) {
+		dp.Attributes().PutStr("resource", resourceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("k8s.namespace.name", k8sNamespaceNameAttributeValue)
-	dp.Attributes().PutStr("resource", resourceAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2667,13 +2789,18 @@ func (m *metricOpenshiftAppliedclusterquotaUsed) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOpenshiftAppliedclusterquotaUsed) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOpenshiftAppliedclusterquotaUsed(cfg MetricConfig) metricOpenshiftAppliedclusterquotaUsed {
+func newMetricOpenshiftAppliedclusterquotaUsed(cfg OpenshiftAppliedclusterquotaUsedMetricConfig) metricOpenshiftAppliedclusterquotaUsed {
 	m := metricOpenshiftAppliedclusterquotaUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -2684,9 +2811,9 @@ func newMetricOpenshiftAppliedclusterquotaUsed(cfg MetricConfig) metricOpenshift
 }
 
 type metricOpenshiftClusterquotaLimit struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   OpenshiftClusterquotaLimitMetricConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
 }
 
 // init fills openshift.clusterquota.limit metric with initial data.
@@ -2725,7 +2852,7 @@ func (m *metricOpenshiftClusterquotaLimit) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOpenshiftClusterquotaLimit(cfg MetricConfig) metricOpenshiftClusterquotaLimit {
+func newMetricOpenshiftClusterquotaLimit(cfg OpenshiftClusterquotaLimitMetricConfig) metricOpenshiftClusterquotaLimit {
 	m := metricOpenshiftClusterquotaLimit{config: cfg}
 
 	if cfg.Enabled {
@@ -2736,9 +2863,9 @@ func newMetricOpenshiftClusterquotaLimit(cfg MetricConfig) metricOpenshiftCluste
 }
 
 type metricOpenshiftClusterquotaUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   OpenshiftClusterquotaUsedMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills openshift.clusterquota.used metric with initial data.
@@ -2777,7 +2904,7 @@ func (m *metricOpenshiftClusterquotaUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOpenshiftClusterquotaUsed(cfg MetricConfig) metricOpenshiftClusterquotaUsed {
+func newMetricOpenshiftClusterquotaUsed(cfg OpenshiftClusterquotaUsedMetricConfig) metricOpenshiftClusterquotaUsed {
 	m := metricOpenshiftClusterquotaUsed{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,15 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["K8sServiceEndpointCount"] = mb.metricK8sServiceEndpointCount.config.AggregationStrategy
+			aggMap["OpenshiftAppliedclusterquotaLimit"] = mb.metricOpenshiftAppliedclusterquotaLimit.config.AggregationStrategy
+			aggMap["OpenshiftAppliedclusterquotaUsed"] = mb.metricOpenshiftAppliedclusterquotaUsed.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -232,6 +244,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			ebK8sService.RecordK8sServiceEndpointCountDataPoint(ts, 1, AttributeK8sServiceEndpointAddressTypeIPv4, AttributeK8sServiceEndpointConditionReady, "k8s.service.endpoint.zone-val")
+			if tt.name == "reaggregate_set" {
+				ebK8sService.RecordK8sServiceEndpointCountDataPoint(ts, 3, AttributeK8sServiceEndpointAddressTypeIPv6, AttributeK8sServiceEndpointConditionServing, "k8s.service.endpoint.zone-val-2")
+			}
 
 			allMetricsCount++
 			ebK8sService.RecordK8sServiceLoadBalancerIngressCountDataPoint(ts, 1)
@@ -255,10 +270,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			ebOpenshiftClusterquota.RecordOpenshiftAppliedclusterquotaLimitDataPoint(ts, 1, "k8s.namespace.name-val", "resource-val")
+			if tt.name == "reaggregate_set" {
+				ebOpenshiftClusterquota.RecordOpenshiftAppliedclusterquotaLimitDataPoint(ts, 3, "k8s.namespace.name-val-2", "resource-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			ebOpenshiftClusterquota.RecordOpenshiftAppliedclusterquotaUsedDataPoint(ts, 1, "k8s.namespace.name-val", "resource-val")
+			if tt.name == "reaggregate_set" {
+				ebOpenshiftClusterquota.RecordOpenshiftAppliedclusterquotaUsedDataPoint(ts, 3, "k8s.namespace.name-val-2", "resource-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -331,6 +352,11 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetOsType("os.type-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricK8sServiceEndpointCount.aggDataPoints)
+				assert.Empty(t, mb.metricOpenshiftAppliedclusterquotaLimit.aggDataPoints)
+				assert.Empty(t, mb.metricOpenshiftAppliedclusterquotaUsed.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -833,26 +859,55 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.True(t, ok)
 					assert.Equal(t, "resource-val", resourceAttrVal.Str())
 				case "k8s.service.endpoint.count":
-					assert.False(t, validatedMetrics["k8s.service.endpoint.count"], "Found a duplicate in the metrics slice: k8s.service.endpoint.count")
-					validatedMetrics["k8s.service.endpoint.count"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of endpoints for a service, broken down by condition, address type, and zone.", mi.Description())
-					assert.Equal(t, "{endpoint}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					k8sServiceEndpointAddressTypeAttrVal, ok := dp.Attributes().Get("k8s.service.endpoint.address_type")
-					assert.True(t, ok)
-					assert.Equal(t, "IPv4", k8sServiceEndpointAddressTypeAttrVal.Str())
-					k8sServiceEndpointConditionAttrVal, ok := dp.Attributes().Get("k8s.service.endpoint.condition")
-					assert.True(t, ok)
-					assert.Equal(t, "ready", k8sServiceEndpointConditionAttrVal.Str())
-					k8sServiceEndpointZoneAttrVal, ok := dp.Attributes().Get("k8s.service.endpoint.zone")
-					assert.True(t, ok)
-					assert.Equal(t, "k8s.service.endpoint.zone-val", k8sServiceEndpointZoneAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.service.endpoint.count"], "Found a duplicate in the metrics slice: k8s.service.endpoint.count")
+						validatedMetrics["k8s.service.endpoint.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of endpoints for a service, broken down by condition, address type, and zone.", mi.Description())
+						assert.Equal(t, "{endpoint}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						k8sServiceEndpointAddressTypeAttrVal, ok := dp.Attributes().Get("k8s.service.endpoint.address_type")
+						assert.True(t, ok)
+						assert.Equal(t, "IPv4", k8sServiceEndpointAddressTypeAttrVal.Str())
+						k8sServiceEndpointConditionAttrVal, ok := dp.Attributes().Get("k8s.service.endpoint.condition")
+						assert.True(t, ok)
+						assert.Equal(t, "ready", k8sServiceEndpointConditionAttrVal.Str())
+						k8sServiceEndpointZoneAttrVal, ok := dp.Attributes().Get("k8s.service.endpoint.zone")
+						assert.True(t, ok)
+						assert.Equal(t, "k8s.service.endpoint.zone-val", k8sServiceEndpointZoneAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.service.endpoint.count"], "Found a duplicate in the metrics slice: k8s.service.endpoint.count")
+						validatedMetrics["k8s.service.endpoint.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of endpoints for a service, broken down by condition, address type, and zone.", mi.Description())
+						assert.Equal(t, "{endpoint}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.service.endpoint.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("k8s.service.endpoint.address_type")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("k8s.service.endpoint.condition")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("k8s.service.endpoint.zone")
+						assert.False(t, ok)
+					}
 				case "k8s.service.load_balancer.ingress.count":
 					assert.False(t, validatedMetrics["k8s.service.load_balancer.ingress.count"], "Found a duplicate in the metrics slice: k8s.service.load_balancer.ingress.count")
 					validatedMetrics["k8s.service.load_balancer.ingress.count"] = true
@@ -914,41 +969,95 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "openshift.appliedclusterquota.limit":
-					assert.False(t, validatedMetrics["openshift.appliedclusterquota.limit"], "Found a duplicate in the metrics slice: openshift.appliedclusterquota.limit")
-					validatedMetrics["openshift.appliedclusterquota.limit"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "The upper limit for a particular resource in a specific namespace.", mi.Description())
-					assert.Equal(t, "{resource}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					k8sNamespaceNameAttrVal, ok := dp.Attributes().Get("k8s.namespace.name")
-					assert.True(t, ok)
-					assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
-					resourceAttrVal, ok := dp.Attributes().Get("resource")
-					assert.True(t, ok)
-					assert.Equal(t, "resource-val", resourceAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["openshift.appliedclusterquota.limit"], "Found a duplicate in the metrics slice: openshift.appliedclusterquota.limit")
+						validatedMetrics["openshift.appliedclusterquota.limit"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The upper limit for a particular resource in a specific namespace.", mi.Description())
+						assert.Equal(t, "{resource}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						k8sNamespaceNameAttrVal, ok := dp.Attributes().Get("k8s.namespace.name")
+						assert.True(t, ok)
+						assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
+						resourceAttrVal, ok := dp.Attributes().Get("resource")
+						assert.True(t, ok)
+						assert.Equal(t, "resource-val", resourceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["openshift.appliedclusterquota.limit"], "Found a duplicate in the metrics slice: openshift.appliedclusterquota.limit")
+						validatedMetrics["openshift.appliedclusterquota.limit"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The upper limit for a particular resource in a specific namespace.", mi.Description())
+						assert.Equal(t, "{resource}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["openshift.appliedclusterquota.limit"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("k8s.namespace.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("resource")
+						assert.True(t, ok)
+					}
 				case "openshift.appliedclusterquota.used":
-					assert.False(t, validatedMetrics["openshift.appliedclusterquota.used"], "Found a duplicate in the metrics slice: openshift.appliedclusterquota.used")
-					validatedMetrics["openshift.appliedclusterquota.used"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "The usage for a particular resource in a specific namespace.", mi.Description())
-					assert.Equal(t, "{resource}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					k8sNamespaceNameAttrVal, ok := dp.Attributes().Get("k8s.namespace.name")
-					assert.True(t, ok)
-					assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
-					resourceAttrVal, ok := dp.Attributes().Get("resource")
-					assert.True(t, ok)
-					assert.Equal(t, "resource-val", resourceAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["openshift.appliedclusterquota.used"], "Found a duplicate in the metrics slice: openshift.appliedclusterquota.used")
+						validatedMetrics["openshift.appliedclusterquota.used"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The usage for a particular resource in a specific namespace.", mi.Description())
+						assert.Equal(t, "{resource}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						k8sNamespaceNameAttrVal, ok := dp.Attributes().Get("k8s.namespace.name")
+						assert.True(t, ok)
+						assert.Equal(t, "k8s.namespace.name-val", k8sNamespaceNameAttrVal.Str())
+						resourceAttrVal, ok := dp.Attributes().Get("resource")
+						assert.True(t, ok)
+						assert.Equal(t, "resource-val", resourceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["openshift.appliedclusterquota.used"], "Found a duplicate in the metrics slice: openshift.appliedclusterquota.used")
+						validatedMetrics["openshift.appliedclusterquota.used"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The usage for a particular resource in a specific namespace.", mi.Description())
+						assert.Equal(t, "{resource}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["openshift.appliedclusterquota.used"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("k8s.namespace.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("resource")
+						assert.True(t, ok)
+					}
 				case "openshift.clusterquota.limit":
 					assert.False(t, validatedMetrics["openshift.clusterquota.limit"], "Found a duplicate in the metrics slice: openshift.clusterquota.limit")
 					validatedMetrics["openshift.clusterquota.limit"] = true

--- a/receiver/k8sclusterreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/k8sclusterreceiver/internal/metadata/testdata/config.yaml
@@ -79,6 +79,7 @@ all_set:
       enabled: true
     k8s.service.endpoint.count:
       enabled: true
+      attributes: ["k8s.service.endpoint.address_type","k8s.service.endpoint.condition","k8s.service.endpoint.zone"]
     k8s.service.load_balancer.ingress.count:
       enabled: true
     k8s.statefulset.current_pods:
@@ -91,8 +92,202 @@ all_set:
       enabled: true
     openshift.appliedclusterquota.limit:
       enabled: true
+      attributes: ["k8s.namespace.name","resource"]
     openshift.appliedclusterquota.used:
       enabled: true
+      attributes: ["k8s.namespace.name","resource"]
+    openshift.clusterquota.limit:
+      enabled: true
+    openshift.clusterquota.used:
+      enabled: true
+  resource_attributes:
+    container.id:
+      enabled: true
+    container.image.name:
+      enabled: true
+    container.image.tag:
+      enabled: true
+    container.runtime:
+      enabled: true
+    container.runtime.version:
+      enabled: true
+    k8s.container.name:
+      enabled: true
+    k8s.container.status.last_terminated_reason:
+      enabled: true
+    k8s.cronjob.name:
+      enabled: true
+    k8s.cronjob.uid:
+      enabled: true
+    k8s.daemonset.name:
+      enabled: true
+    k8s.daemonset.uid:
+      enabled: true
+    k8s.deployment.name:
+      enabled: true
+    k8s.deployment.uid:
+      enabled: true
+    k8s.hpa.name:
+      enabled: true
+    k8s.hpa.scaletargetref.apiversion:
+      enabled: true
+    k8s.hpa.scaletargetref.kind:
+      enabled: true
+    k8s.hpa.scaletargetref.name:
+      enabled: true
+    k8s.hpa.uid:
+      enabled: true
+    k8s.job.name:
+      enabled: true
+    k8s.job.uid:
+      enabled: true
+    k8s.kubelet.version:
+      enabled: true
+    k8s.namespace.name:
+      enabled: true
+    k8s.namespace.uid:
+      enabled: true
+    k8s.node.name:
+      enabled: true
+    k8s.node.uid:
+      enabled: true
+    k8s.pod.name:
+      enabled: true
+    k8s.pod.qos_class:
+      enabled: true
+    k8s.pod.uid:
+      enabled: true
+    k8s.replicaset.name:
+      enabled: true
+    k8s.replicaset.uid:
+      enabled: true
+    k8s.replicationcontroller.name:
+      enabled: true
+    k8s.replicationcontroller.uid:
+      enabled: true
+    k8s.resourcequota.name:
+      enabled: true
+    k8s.resourcequota.uid:
+      enabled: true
+    k8s.service.name:
+      enabled: true
+    k8s.service.publish_not_ready_addresses:
+      enabled: true
+    k8s.service.traffic_distribution:
+      enabled: true
+    k8s.service.type:
+      enabled: true
+    k8s.service.uid:
+      enabled: true
+    k8s.statefulset.name:
+      enabled: true
+    k8s.statefulset.uid:
+      enabled: true
+    openshift.clusterquota.name:
+      enabled: true
+    openshift.clusterquota.uid:
+      enabled: true
+    os.description:
+      enabled: true
+    os.type:
+      enabled: true
+reaggregate_set:
+  metrics:
+    k8s.container.cpu_limit:
+      enabled: true
+    k8s.container.cpu_request:
+      enabled: true
+    k8s.container.ephemeralstorage_limit:
+      enabled: true
+    k8s.container.ephemeralstorage_request:
+      enabled: true
+    k8s.container.memory_limit:
+      enabled: true
+    k8s.container.memory_request:
+      enabled: true
+    k8s.container.ready:
+      enabled: true
+    k8s.container.restarts:
+      enabled: true
+    k8s.container.status.reason:
+      enabled: true
+    k8s.container.status.state:
+      enabled: true
+    k8s.container.storage_limit:
+      enabled: true
+    k8s.container.storage_request:
+      enabled: true
+    k8s.cronjob.active_jobs:
+      enabled: true
+    k8s.daemonset.current_scheduled_nodes:
+      enabled: true
+    k8s.daemonset.desired_scheduled_nodes:
+      enabled: true
+    k8s.daemonset.misscheduled_nodes:
+      enabled: true
+    k8s.daemonset.ready_nodes:
+      enabled: true
+    k8s.deployment.available:
+      enabled: true
+    k8s.deployment.desired:
+      enabled: true
+    k8s.hpa.current_replicas:
+      enabled: true
+    k8s.hpa.desired_replicas:
+      enabled: true
+    k8s.hpa.max_replicas:
+      enabled: true
+    k8s.hpa.min_replicas:
+      enabled: true
+    k8s.job.active_pods:
+      enabled: true
+    k8s.job.desired_successful_pods:
+      enabled: true
+    k8s.job.failed_pods:
+      enabled: true
+    k8s.job.max_parallel_pods:
+      enabled: true
+    k8s.job.successful_pods:
+      enabled: true
+    k8s.namespace.phase:
+      enabled: true
+    k8s.node.condition:
+      enabled: true
+    k8s.pod.phase:
+      enabled: true
+    k8s.pod.status_reason:
+      enabled: true
+    k8s.replicaset.available:
+      enabled: true
+    k8s.replicaset.desired:
+      enabled: true
+    k8s.replication_controller.available:
+      enabled: true
+    k8s.replication_controller.desired:
+      enabled: true
+    k8s.resource_quota.hard_limit:
+      enabled: true
+    k8s.resource_quota.used:
+      enabled: true
+    k8s.service.endpoint.count:
+      enabled: true
+      attributes: []
+    k8s.service.load_balancer.ingress.count:
+      enabled: true
+    k8s.statefulset.current_pods:
+      enabled: true
+    k8s.statefulset.desired_pods:
+      enabled: true
+    k8s.statefulset.ready_pods:
+      enabled: true
+    k8s.statefulset.updated_pods:
+      enabled: true
+    openshift.appliedclusterquota.limit:
+      enabled: true
+      attributes: ["resource"]
+    openshift.appliedclusterquota.used:
+      enabled: true
+      attributes: ["resource"]
     openshift.clusterquota.limit:
       enabled: true
     openshift.clusterquota.used:
@@ -268,6 +463,7 @@ none_set:
       enabled: false
     k8s.service.endpoint.count:
       enabled: false
+      attributes: ["k8s.service.endpoint.address_type","k8s.service.endpoint.condition","k8s.service.endpoint.zone"]
     k8s.service.load_balancer.ingress.count:
       enabled: false
     k8s.statefulset.current_pods:
@@ -280,8 +476,10 @@ none_set:
       enabled: false
     openshift.appliedclusterquota.limit:
       enabled: false
+      attributes: ["k8s.namespace.name","resource"]
     openshift.appliedclusterquota.used:
       enabled: false
+      attributes: ["k8s.namespace.name","resource"]
     openshift.clusterquota.limit:
       enabled: false
     openshift.clusterquota.used:

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -6,6 +6,8 @@ description: |
   API server. It uses the K8s API to listen for updates. A single instance of this
   receiver should be used to monitor a cluster.
 
+reaggregation_enabled: true
+
 status:
   class: receiver
   stability:
@@ -433,9 +435,11 @@ attributes:
   condition:
     description: "the name of Kubernetes Node condition. Example: Ready, Memory, PID, DiskPressure"
     type: string
+    requirement_level: required
   k8s.container.status.reason:
     description: The reason of the current container status.
     type: string
+    requirement_level: required
     enum:
       - ContainerCreating
       - CrashLoopBackOff
@@ -449,6 +453,7 @@ attributes:
   k8s.container.status.state:
     description: The state of the container (terminated, running, waiting). See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstate-v1-core for details.
     type: string
+    requirement_level: required
     enum:
       - terminated
       - running
@@ -456,9 +461,11 @@ attributes:
   k8s.namespace.name:
     description: The k8s namespace name.
     type: string
+    requirement_level: recommended
   k8s.service.endpoint.address_type:
     description: The address type of the endpoint.
     type: string
+    requirement_level: recommended
     enum:
       - IPv4
       - IPv6
@@ -466,6 +473,7 @@ attributes:
   k8s.service.endpoint.condition:
     description: The condition of the service endpoint.
     type: string
+    requirement_level: recommended
     enum:
       - ready
       - serving
@@ -473,9 +481,11 @@ attributes:
   k8s.service.endpoint.zone:
     description: The zone of the service endpoint, typically corresponding to a failure domain.
     type: string
+    requirement_level: recommended
   resource:
     description: the name of the resource on which the quota is applied
     type: string
+    requirement_level: required
 
 metrics:
   k8s.container.cpu_limit:


### PR DESCRIPTION
- Enable re-aggregation feature for k8scluster receiver.
- Setting `reaggregation_enabled: true` in `metadata.yaml` 
- Adding `requirement_level` for each attributes

The motivation for `required` are when required attributes are absent, the metric becomes unimpactful

Fixes [#46361](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46361)
Part of [#45396](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45396)

### Test plan

- [x] `go generate ./...` ran successfully
- [x] `make gci` ran successfully
- [x] `make generate-schemas` ran successfully
- [x] `go test ./...` passes
- [x] `make chlog-validate` passes

### Manual Test Plan - Testing aggregation functionalities

Required cannot be excluded, while recommended can be excluded. Enabling the re-aggregation features

<img width="1484" height="823" alt="image" src="https://github.com/user-attachments/assets/cc6e3af8-8b81-4a14-b44b-1b04f0a4d068" />

For reproducing: 
- https://github.com/ToHe-MT/otel-collector-for-k8s