### PR TITLE
[chore] Add make help to list available targets

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -96,6 +96,10 @@ ADDLICENSE_CMD := $(ADDLICENSE) -s=only -y "" -c "The OpenTelemetry Authors"
 # All source code and .sh files (evaluated when used)
 ALL_SRC_AND_SHELL_CMD := find . -type f \( \( -name "*.go" -o -name "*.sh" \) -and \( -not -path '*/third_party/*' \) \) | sort
 
+no_targets__:
+help:
+	sh -c "$(MAKE) -p no_targets__ | awk -F':' '/^[a-zA-Z0-9][^\$$#\/\\t=]*:([^=]|$$)/ {split(\$$1,A,/ /);for(i in A)print A[i]}' | grep -v '__\$$' | sort"
+
 pwd:
 	@pwd
 


### PR DESCRIPTION
#### Description

Adds a `make help` target that prints all the available targets. This works for the top level Makefile as well as any of the inner make configurations that inherit from Makefile.common.

#### Testing

```txt
$ cd receiver/hostmetricsreceiver
$ make help
sh -c "make -p no_targets__ | awk -F':' '/^[a-zA-Z0-9][^\$#\/\\t=]*:([^=]|$)/ {split(\$1,A,/ /);for(i in A)print A[i]}' | grep -v '__\$' | sort"
addlicense
benchmark
buildtest
checklicense
checklinks
common
do-integration-tests-with-cover
do-unit-tests-with-cover
fmt
for-affected-components
gci
generate
govulncheck
help
lint
make[1]
Makefile
mdatagen
misspell
misspell-correction
moddownload
modernize
mod-integration-sudo-test
mod-integration-test
pwd
runbuilttest
run-changed-tests
schemagen
test
test-twice
test-with-cover
test-with-junit
test-with-junit-and-cover
tidy
toolchain
```
