### PR TITLE
[receiver/httpcheck] Enable dynamic metric reaggregation

### DIFF
--- a/.chloggen/46358-httpcheck-enable-reaggregation.yaml
+++ b/.chloggen/46358-httpcheck-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/httpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable dynamic metric reaggregation in the HTTP Check receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46358]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/httpcheckreceiver/generated_package_test.go
+++ b/receiver/httpcheckreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package httpcheckreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config.go
@@ -3,6 +3,9 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -10,6 +13,11 @@ import (
 type MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []string `mapstructure:"attributes"`
+	definedAttributes   []string
+	requiredAttributes  []string
 }
 
 func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -21,9 +29,32 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
+	for _, val := range ms.EnabledAttributes {
+		if !slices.Contains(ms.definedAttributes, val) {
+			return fmt.Errorf("%v is not defined in metadata.yaml", val)
+		}
+	}
+
+	for _, val := range ms.requiredAttributes {
+		if !slices.Contains(ms.EnabledAttributes, val) {
+			return fmt.Errorf("`attributes` field must contain required attribute: %v", val)
+		}
+	}
+
+	if ms.AggregationStrategy != AggregationStrategySum &&
+		ms.AggregationStrategy != AggregationStrategyAvg &&
+		ms.AggregationStrategy != AggregationStrategyMin &&
+		ms.AggregationStrategy != AggregationStrategyMax {
+		return fmt.Errorf("invalid aggregation strategy set: '%v'", ms.AggregationStrategy)
+	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
+}
+
+// AttributeConfig holds configuration information for a particular metric.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // MetricsConfig provides config for httpcheck metrics.
@@ -46,39 +77,99 @@ func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		HttpcheckClientConnectionDuration: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url", "network.transport"},
+			EnabledAttributes:   []string{"http.url", "network.transport"},
 		},
 		HttpcheckClientRequestDuration: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url"},
+			EnabledAttributes:   []string{"http.url"},
 		},
 		HttpcheckDNSLookupDuration: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url"},
+			EnabledAttributes:   []string{"http.url"},
 		},
 		HttpcheckDuration: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url"},
+			EnabledAttributes:   []string{"http.url"},
 		},
 		HttpcheckError: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategySum,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url", "error.message"},
+			EnabledAttributes:   []string{"http.url", "error.message"},
 		},
 		HttpcheckResponseDuration: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url"},
+			EnabledAttributes:   []string{"http.url"},
 		},
 		HttpcheckResponseSize: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url"},
+			EnabledAttributes:   []string{"http.url"},
 		},
 		HttpcheckStatus: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategySum,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url", "http.status_code", "http.method", "http.status_class"},
+			EnabledAttributes:   []string{"http.url", "http.status_code", "http.method", "http.status_class"},
 		},
 		HttpcheckTLSCertRemaining: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url", "http.tls.issuer", "http.tls.cn", "http.tls.san"},
+			EnabledAttributes:   []string{"http.url", "http.tls.issuer", "http.tls.cn", "http.tls.san"},
 		},
 		HttpcheckTLSHandshakeDuration: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url"},
+			EnabledAttributes:   []string{"http.url"},
 		},
 		HttpcheckValidationFailed: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategySum,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url", "validation.type"},
+			EnabledAttributes:   []string{"http.url", "validation.type"},
 		},
 		HttpcheckValidationPassed: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategySum,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{"http.url", "validation.type"},
+			EnabledAttributes:   []string{"http.url", "validation.type"},
 		},
 	}
 }

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,18 +27,66 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					HttpcheckClientConnectionDuration: MetricConfig{Enabled: true},
-					HttpcheckClientRequestDuration:    MetricConfig{Enabled: true},
-					HttpcheckDNSLookupDuration:        MetricConfig{Enabled: true},
-					HttpcheckDuration:                 MetricConfig{Enabled: true},
-					HttpcheckError:                    MetricConfig{Enabled: true},
-					HttpcheckResponseDuration:         MetricConfig{Enabled: true},
-					HttpcheckResponseSize:             MetricConfig{Enabled: true},
-					HttpcheckStatus:                   MetricConfig{Enabled: true},
-					HttpcheckTLSCertRemaining:         MetricConfig{Enabled: true},
-					HttpcheckTLSHandshakeDuration:     MetricConfig{Enabled: true},
-					HttpcheckValidationFailed:         MetricConfig{Enabled: true},
-					HttpcheckValidationPassed:         MetricConfig{Enabled: true},
+					HttpcheckClientConnectionDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url", "network.transport"},
+					},
+					HttpcheckClientRequestDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckDNSLookupDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckError: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "error.message"},
+					},
+					HttpcheckResponseDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckResponseSize: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckStatus: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "http.status_code", "http.method", "http.status_class"},
+					},
+					HttpcheckTLSCertRemaining: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url", "http.tls.issuer", "http.tls.cn", "http.tls.san"},
+					},
+					HttpcheckTLSHandshakeDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckValidationFailed: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "validation.type"},
+					},
+					HttpcheckValidationPassed: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "validation.type"},
+					},
 				},
 			},
 		},
@@ -45,18 +94,66 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					HttpcheckClientConnectionDuration: MetricConfig{Enabled: false},
-					HttpcheckClientRequestDuration:    MetricConfig{Enabled: false},
-					HttpcheckDNSLookupDuration:        MetricConfig{Enabled: false},
-					HttpcheckDuration:                 MetricConfig{Enabled: false},
-					HttpcheckError:                    MetricConfig{Enabled: false},
-					HttpcheckResponseDuration:         MetricConfig{Enabled: false},
-					HttpcheckResponseSize:             MetricConfig{Enabled: false},
-					HttpcheckStatus:                   MetricConfig{Enabled: false},
-					HttpcheckTLSCertRemaining:         MetricConfig{Enabled: false},
-					HttpcheckTLSHandshakeDuration:     MetricConfig{Enabled: false},
-					HttpcheckValidationFailed:         MetricConfig{Enabled: false},
-					HttpcheckValidationPassed:         MetricConfig{Enabled: false},
+					HttpcheckClientConnectionDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url", "network.transport"},
+					},
+					HttpcheckClientRequestDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckDNSLookupDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckError: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "error.message"},
+					},
+					HttpcheckResponseDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckResponseSize: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckStatus: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "http.status_code", "http.method", "http.status_class"},
+					},
+					HttpcheckTLSCertRemaining: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url", "http.tls.issuer", "http.tls.cn", "http.tls.san"},
+					},
+					HttpcheckTLSHandshakeDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"http.url"},
+					},
+					HttpcheckValidationFailed: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "validation.type"},
+					},
+					HttpcheckValidationPassed: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []string{"http.url", "validation.type"},
+					},
 				},
 			},
 		},

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -37,6 +38,11 @@ func TestMetricsBuilder(t *testing.T) {
 			resAttrsSet: testDataSetAll,
 		},
 		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
+		},
+		{
 			name:        "none_set",
 			metricsSet:  testDataSetNone,
 			resAttrsSet: testDataSetNone,
@@ -51,54 +57,119 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["HttpcheckClientConnectionDuration"] = mb.metricHttpcheckClientConnectionDuration.config.AggregationStrategy
+			aggMap["HttpcheckClientRequestDuration"] = mb.metricHttpcheckClientRequestDuration.config.AggregationStrategy
+			aggMap["HttpcheckDNSLookupDuration"] = mb.metricHttpcheckDNSLookupDuration.config.AggregationStrategy
+			aggMap["HttpcheckDuration"] = mb.metricHttpcheckDuration.config.AggregationStrategy
+			aggMap["HttpcheckError"] = mb.metricHttpcheckError.config.AggregationStrategy
+			aggMap["HttpcheckResponseDuration"] = mb.metricHttpcheckResponseDuration.config.AggregationStrategy
+			aggMap["HttpcheckResponseSize"] = mb.metricHttpcheckResponseSize.config.AggregationStrategy
+			aggMap["HttpcheckStatus"] = mb.metricHttpcheckStatus.config.AggregationStrategy
+			aggMap["HttpcheckTLSCertRemaining"] = mb.metricHttpcheckTLSCertRemaining.config.AggregationStrategy
+			aggMap["HttpcheckTLSHandshakeDuration"] = mb.metricHttpcheckTLSHandshakeDuration.config.AggregationStrategy
+			aggMap["HttpcheckValidationFailed"] = mb.metricHttpcheckValidationFailed.config.AggregationStrategy
+			aggMap["HttpcheckValidationPassed"] = mb.metricHttpcheckValidationPassed.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
 			allMetricsCount++
 			mb.RecordHttpcheckClientConnectionDurationDataPoint(ts, 1, "http.url-val", "network.transport-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckClientConnectionDurationDataPoint(ts, 3, "http.url-val-2", "network.transport-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckClientRequestDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckClientRequestDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckDNSLookupDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckDNSLookupDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordHttpcheckDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordHttpcheckErrorDataPoint(ts, 1, "http.url-val", "error.message-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckErrorDataPoint(ts, 3, "http.url-val-2", "error.message-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckResponseDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckResponseDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckResponseSizeDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckResponseSizeDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordHttpcheckStatusDataPoint(ts, 1, "http.url-val", 16, "http.method-val", "http.status_class-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckStatusDataPoint(ts, 3, "http.url-val-2", 17, "http.method-val-2", "http.status_class-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckTLSCertRemainingDataPoint(ts, 1, "http.url-val", "http.tls.issuer-val", "http.tls.cn-val", []any{"http.tls.san-item1", "http.tls.san-item2"})
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckTLSCertRemainingDataPoint(ts, 3, "http.url-val-2", "http.tls.issuer-val-2", "http.tls.cn-val-2", []any{"http.tls.san-item3", "http.tls.san-item4"})
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckTLSHandshakeDurationDataPoint(ts, 1, "http.url-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckTLSHandshakeDurationDataPoint(ts, 3, "http.url-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckValidationFailedDataPoint(ts, 1, "http.url-val", "validation.type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckValidationFailedDataPoint(ts, 3, "http.url-val-2", "validation.type-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordHttpcheckValidationPassedDataPoint(ts, 1, "http.url-val", "validation.type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordHttpcheckValidationPassedDataPoint(ts, 3, "http.url-val-2", "validation.type-val-2")
+			}
 
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricHttpcheckClientConnectionDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckClientRequestDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckDNSLookupDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckError.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckResponseDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckResponseSize.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckStatus.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckTLSCertRemaining.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckTLSHandshakeDuration.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckValidationFailed.aggDataPoints)
+				assert.Empty(t, mb.metricHttpcheckValidationPassed.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -120,223 +191,551 @@ func TestMetricsBuilder(t *testing.T) {
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
 				case "httpcheck.client.connection.duration":
-					assert.False(t, validatedMetrics["httpcheck.client.connection.duration"], "Found a duplicate in the metrics slice: httpcheck.client.connection.duration")
-					validatedMetrics["httpcheck.client.connection.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent establishing TCP connection to the endpoint.", ms.At(i).Description())
-					assert.Equal(t, "ms", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("network.transport")
-					assert.True(t, ok)
-					assert.Equal(t, "network.transport-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.client.connection.duration"], "Found a duplicate in the metrics slice: httpcheck.client.connection.duration")
+						validatedMetrics["httpcheck.client.connection.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent establishing TCP connection to the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("network.transport")
+						assert.True(t, ok)
+						assert.Equal(t, "network.transport-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.client.connection.duration"], "Found a duplicate in the metrics slice: httpcheck.client.connection.duration")
+						validatedMetrics["httpcheck.client.connection.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent establishing TCP connection to the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.client.connection.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("network.transport")
+						assert.False(t, ok)
+					}
 				case "httpcheck.client.request.duration":
-					assert.False(t, validatedMetrics["httpcheck.client.request.duration"], "Found a duplicate in the metrics slice: httpcheck.client.request.duration")
-					validatedMetrics["httpcheck.client.request.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent sending the HTTP request to the endpoint.", ms.At(i).Description())
-					assert.Equal(t, "ms", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.client.request.duration"], "Found a duplicate in the metrics slice: httpcheck.client.request.duration")
+						validatedMetrics["httpcheck.client.request.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent sending the HTTP request to the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.client.request.duration"], "Found a duplicate in the metrics slice: httpcheck.client.request.duration")
+						validatedMetrics["httpcheck.client.request.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent sending the HTTP request to the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.client.request.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.dns.lookup.duration":
-					assert.False(t, validatedMetrics["httpcheck.dns.lookup.duration"], "Found a duplicate in the metrics slice: httpcheck.dns.lookup.duration")
-					validatedMetrics["httpcheck.dns.lookup.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent performing DNS lookup for the endpoint.", ms.At(i).Description())
-					assert.Equal(t, "ms", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.dns.lookup.duration"], "Found a duplicate in the metrics slice: httpcheck.dns.lookup.duration")
+						validatedMetrics["httpcheck.dns.lookup.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing DNS lookup for the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.dns.lookup.duration"], "Found a duplicate in the metrics slice: httpcheck.dns.lookup.duration")
+						validatedMetrics["httpcheck.dns.lookup.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing DNS lookup for the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.dns.lookup.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.duration":
-					assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
-					validatedMetrics["httpcheck.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the duration of the HTTP check.", ms.At(i).Description())
-					assert.Equal(t, "ms", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
+						validatedMetrics["httpcheck.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the duration of the HTTP check.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
+						validatedMetrics["httpcheck.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the duration of the HTTP check.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.error":
-					assert.False(t, validatedMetrics["httpcheck.error"], "Found a duplicate in the metrics slice: httpcheck.error")
-					validatedMetrics["httpcheck.error"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Records errors occurring during HTTP check.", ms.At(i).Description())
-					assert.Equal(t, "{error}", ms.At(i).Unit())
-					assert.False(t, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-					dp := ms.At(i).Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("error.message")
-					assert.True(t, ok)
-					assert.Equal(t, "error.message-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.error"], "Found a duplicate in the metrics slice: httpcheck.error")
+						validatedMetrics["httpcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during HTTP check.", ms.At(i).Description())
+						assert.Equal(t, "{error}", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("error.message")
+						assert.True(t, ok)
+						assert.Equal(t, "error.message-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.error"], "Found a duplicate in the metrics slice: httpcheck.error")
+						validatedMetrics["httpcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during HTTP check.", ms.At(i).Description())
+						assert.Equal(t, "{error}", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.error"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("error.message")
+						assert.False(t, ok)
+					}
 				case "httpcheck.response.duration":
-					assert.False(t, validatedMetrics["httpcheck.response.duration"], "Found a duplicate in the metrics slice: httpcheck.response.duration")
-					validatedMetrics["httpcheck.response.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent receiving the HTTP response from the endpoint.", ms.At(i).Description())
-					assert.Equal(t, "ms", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.response.duration"], "Found a duplicate in the metrics slice: httpcheck.response.duration")
+						validatedMetrics["httpcheck.response.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent receiving the HTTP response from the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.response.duration"], "Found a duplicate in the metrics slice: httpcheck.response.duration")
+						validatedMetrics["httpcheck.response.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent receiving the HTTP response from the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.response.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.response.size":
-					assert.False(t, validatedMetrics["httpcheck.response.size"], "Found a duplicate in the metrics slice: httpcheck.response.size")
-					validatedMetrics["httpcheck.response.size"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Size of response body in bytes.", ms.At(i).Description())
-					assert.Equal(t, "By", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.response.size"], "Found a duplicate in the metrics slice: httpcheck.response.size")
+						validatedMetrics["httpcheck.response.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of response body in bytes.", ms.At(i).Description())
+						assert.Equal(t, "By", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.response.size"], "Found a duplicate in the metrics slice: httpcheck.response.size")
+						validatedMetrics["httpcheck.response.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of response body in bytes.", ms.At(i).Description())
+						assert.Equal(t, "By", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.response.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.status":
-					assert.False(t, validatedMetrics["httpcheck.status"], "Found a duplicate in the metrics slice: httpcheck.status")
-					validatedMetrics["httpcheck.status"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "1 if the check resulted in status_code matching the status_class, otherwise 0.", ms.At(i).Description())
-					assert.Equal(t, "1", ms.At(i).Unit())
-					assert.False(t, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-					dp := ms.At(i).Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.status_code")
-					assert.True(t, ok)
-					assert.EqualValues(t, 16, attrVal.Int())
-					attrVal, ok = dp.Attributes().Get("http.method")
-					assert.True(t, ok)
-					assert.Equal(t, "http.method-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.status_class")
-					assert.True(t, ok)
-					assert.Equal(t, "http.status_class-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.status"], "Found a duplicate in the metrics slice: httpcheck.status")
+						validatedMetrics["httpcheck.status"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "1 if the check resulted in status_code matching the status_class, otherwise 0.", ms.At(i).Description())
+						assert.Equal(t, "1", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.status_code")
+						assert.True(t, ok)
+						assert.EqualValues(t, 16, attrVal.Int())
+						attrVal, ok = dp.Attributes().Get("http.method")
+						assert.True(t, ok)
+						assert.Equal(t, "http.method-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.status_class")
+						assert.True(t, ok)
+						assert.Equal(t, "http.status_class-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.status"], "Found a duplicate in the metrics slice: httpcheck.status")
+						validatedMetrics["httpcheck.status"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "1 if the check resulted in status_code matching the status_class, otherwise 0.", ms.At(i).Description())
+						assert.Equal(t, "1", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.status"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.status_code")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.method")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.status_class")
+						assert.False(t, ok)
+					}
 				case "httpcheck.tls.cert_remaining":
-					assert.False(t, validatedMetrics["httpcheck.tls.cert_remaining"], "Found a duplicate in the metrics slice: httpcheck.tls.cert_remaining")
-					validatedMetrics["httpcheck.tls.cert_remaining"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", ms.At(i).Description())
-					assert.Equal(t, "s", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.tls.issuer")
-					assert.True(t, ok)
-					assert.Equal(t, "http.tls.issuer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.tls.cn")
-					assert.True(t, ok)
-					assert.Equal(t, "http.tls.cn-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("http.tls.san")
-					assert.True(t, ok)
-					assert.Equal(t, []any{"http.tls.san-item1", "http.tls.san-item2"}, attrVal.Slice().AsRaw())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.tls.cert_remaining"], "Found a duplicate in the metrics slice: httpcheck.tls.cert_remaining")
+						validatedMetrics["httpcheck.tls.cert_remaining"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.tls.issuer")
+						assert.True(t, ok)
+						assert.Equal(t, "http.tls.issuer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.tls.cn")
+						assert.True(t, ok)
+						assert.Equal(t, "http.tls.cn-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("http.tls.san")
+						assert.True(t, ok)
+						assert.Equal(t, []any{"http.tls.san-item1", "http.tls.san-item2"}, attrVal.Slice().AsRaw())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.tls.cert_remaining"], "Found a duplicate in the metrics slice: httpcheck.tls.cert_remaining")
+						validatedMetrics["httpcheck.tls.cert_remaining"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.tls.cert_remaining"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.tls.issuer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.tls.cn")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("http.tls.san")
+						assert.False(t, ok)
+					}
 				case "httpcheck.tls.handshake.duration":
-					assert.False(t, validatedMetrics["httpcheck.tls.handshake.duration"], "Found a duplicate in the metrics slice: httpcheck.tls.handshake.duration")
-					validatedMetrics["httpcheck.tls.handshake.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time spent performing TLS handshake with the endpoint.", ms.At(i).Description())
-					assert.Equal(t, "ms", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.tls.handshake.duration"], "Found a duplicate in the metrics slice: httpcheck.tls.handshake.duration")
+						validatedMetrics["httpcheck.tls.handshake.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing TLS handshake with the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.tls.handshake.duration"], "Found a duplicate in the metrics slice: httpcheck.tls.handshake.duration")
+						validatedMetrics["httpcheck.tls.handshake.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time spent performing TLS handshake with the endpoint.", ms.At(i).Description())
+						assert.Equal(t, "ms", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.tls.handshake.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+					}
 				case "httpcheck.validation.failed":
-					assert.False(t, validatedMetrics["httpcheck.validation.failed"], "Found a duplicate in the metrics slice: httpcheck.validation.failed")
-					validatedMetrics["httpcheck.validation.failed"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Number of response validations that failed.", ms.At(i).Description())
-					assert.Equal(t, "{validation}", ms.At(i).Unit())
-					assert.False(t, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-					dp := ms.At(i).Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("validation.type")
-					assert.True(t, ok)
-					assert.Equal(t, "validation.type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.validation.failed"], "Found a duplicate in the metrics slice: httpcheck.validation.failed")
+						validatedMetrics["httpcheck.validation.failed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that failed.", ms.At(i).Description())
+						assert.Equal(t, "{validation}", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("validation.type")
+						assert.True(t, ok)
+						assert.Equal(t, "validation.type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.validation.failed"], "Found a duplicate in the metrics slice: httpcheck.validation.failed")
+						validatedMetrics["httpcheck.validation.failed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that failed.", ms.At(i).Description())
+						assert.Equal(t, "{validation}", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.validation.failed"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("validation.type")
+						assert.False(t, ok)
+					}
 				case "httpcheck.validation.passed":
-					assert.False(t, validatedMetrics["httpcheck.validation.passed"], "Found a duplicate in the metrics slice: httpcheck.validation.passed")
-					validatedMetrics["httpcheck.validation.passed"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Number of response validations that passed.", ms.At(i).Description())
-					assert.Equal(t, "{validation}", ms.At(i).Unit())
-					assert.False(t, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-					dp := ms.At(i).Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("http.url")
-					assert.True(t, ok)
-					assert.Equal(t, "http.url-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("validation.type")
-					assert.True(t, ok)
-					assert.Equal(t, "validation.type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["httpcheck.validation.passed"], "Found a duplicate in the metrics slice: httpcheck.validation.passed")
+						validatedMetrics["httpcheck.validation.passed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that passed.", ms.At(i).Description())
+						assert.Equal(t, "{validation}", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("http.url")
+						assert.True(t, ok)
+						assert.Equal(t, "http.url-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("validation.type")
+						assert.True(t, ok)
+						assert.Equal(t, "validation.type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["httpcheck.validation.passed"], "Found a duplicate in the metrics slice: httpcheck.validation.passed")
+						validatedMetrics["httpcheck.validation.passed"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+						assert.Equal(t, "Number of response validations that passed.", ms.At(i).Description())
+						assert.Equal(t, "{validation}", ms.At(i).Unit())
+						assert.False(t, ms.At(i).Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+						dp := ms.At(i).Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["httpcheck.validation.passed"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.url")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("validation.type")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -3,51 +3,113 @@ all_set:
   metrics:
     httpcheck.client.connection.duration:
       enabled: true
+      attributes: ["http.url","network.transport"]
     httpcheck.client.request.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.dns.lookup.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.error:
       enabled: true
+      attributes: ["http.url","error.message"]
     httpcheck.response.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.response.size:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.status:
       enabled: true
+      attributes: ["http.url","http.status_code","http.method","http.status_class"]
     httpcheck.tls.cert_remaining:
       enabled: true
+      attributes: ["http.url","http.tls.issuer","http.tls.cn","http.tls.san"]
     httpcheck.tls.handshake.duration:
       enabled: true
+      attributes: ["http.url"]
     httpcheck.validation.failed:
       enabled: true
+      attributes: ["http.url","validation.type"]
     httpcheck.validation.passed:
       enabled: true
+      attributes: ["http.url","validation.type"]
+reaggregate_set:
+  metrics:
+    httpcheck.client.connection.duration:
+      enabled: true
+      attributes: []
+    httpcheck.client.request.duration:
+      enabled: true
+      attributes: []
+    httpcheck.dns.lookup.duration:
+      enabled: true
+      attributes: []
+    httpcheck.duration:
+      enabled: true
+      attributes: []
+    httpcheck.error:
+      enabled: true
+      attributes: []
+    httpcheck.response.duration:
+      enabled: true
+      attributes: []
+    httpcheck.response.size:
+      enabled: true
+      attributes: []
+    httpcheck.status:
+      enabled: true
+      attributes: []
+    httpcheck.tls.cert_remaining:
+      enabled: true
+      attributes: []
+    httpcheck.tls.handshake.duration:
+      enabled: true
+      attributes: []
+    httpcheck.validation.failed:
+      enabled: true
+      attributes: []
+    httpcheck.validation.passed:
+      enabled: true
+      attributes: []
 none_set:
   metrics:
     httpcheck.client.connection.duration:
       enabled: false
+      attributes: ["http.url","network.transport"]
     httpcheck.client.request.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.dns.lookup.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.error:
       enabled: false
+      attributes: ["http.url","error.message"]
     httpcheck.response.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.response.size:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.status:
       enabled: false
+      attributes: ["http.url","http.status_code","http.method","http.status_class"]
     httpcheck.tls.cert_remaining:
       enabled: false
+      attributes: ["http.url","http.tls.issuer","http.tls.cn","http.tls.san"]
     httpcheck.tls.handshake.duration:
       enabled: false
+      attributes: ["http.url"]
     httpcheck.validation.failed:
       enabled: false
+      attributes: ["http.url","validation.type"]
     httpcheck.validation.passed:
       enabled: false
+      attributes: ["http.url","validation.type"]

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -1,6 +1,8 @@
 display_name: HTTP Check Receiver
 type: httpcheck
 
+reaggregation_enabled: true
+
 description: |
   The HTTP Check Receiver can be used for synthetic checks against HTTP endpoints. 
 
@@ -21,33 +23,43 @@ attributes:
   error.message:
     description: Error message recorded during check
     type: string
+    requirement_level: recommended
   http.method:
     description: HTTP request method
     type: string
+    requirement_level: recommended
   http.status_class:
     description: HTTP response status class
     type: string
+    requirement_level: recommended
   http.status_code:
     description: HTTP response status code
     type: int
+    requirement_level: recommended
   http.tls.cn:
     description: The commonName in the subject of the certificate.
     type: string
+    requirement_level: recommended
   http.tls.issuer:
     description: The entity that issued the certificate.
     type: string
+    requirement_level: recommended
   http.tls.san:
     description: The Subject Alternative Name of the certificate.
     type: slice
+    requirement_level: recommended
   http.url:
     description: Full HTTP request URL.
     type: string
+    requirement_level: recommended
   network.transport:
     description: OSI transport layer or inter-process communication method.
     type: string
+    requirement_level: recommended
   validation.type:
     description: Type of validation performed (contains, json_path, size, regex)
     type: string
+    requirement_level: recommended
 
 metrics:
   httpcheck.client.connection.duration:


### PR DESCRIPTION
### Description

Enable the reaggregation feature for the HTTP Check receiver, allowing users to dynamically reduce metric dimensionality by enabling/disabling attributes from their collector configuration.

All 10 metric attributes are set to `recommended` requirement level.

### Link to tracking issue

Closes #46358

### Testing

- `go generate ./...` ran successfully
- `go test ./...` passes (all existing tests)
- No manual changes to generated code

### Documentation

No additional documentation needed — the feature is auto-configured via `metadata.yaml` and the generated code handles validation.