### PR TITLE
[receiver/tcpcheckreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46382-tcpcheck-enable-reaggregation.yaml
+++ b/.chloggen/46382-tcpcheck-enable-reaggregation.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/tcpcheckreceiver
+note: Enable re-aggregation feature for tcpcheck receiver.
+issues: [46382]
+subtext: ""

--- a/receiver/tcpcheckreceiver/generated_package_test.go
+++ b/receiver/tcpcheckreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package tcpcheckreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/tcpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/tcpcheckreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/tcpcheckreceiver/metadata.yaml
+++ b/receiver/tcpcheckreceiver/metadata.yaml
@@ -14,10 +14,12 @@ attributes:
   error.code:
     description: Error code recorded during check
     type: string
+    requirement_level: recommended
     enum: [connection_refused, connection_timeout, invalid_endpoint, network_unreachable, unknown_error]
   tcpcheck.endpoint:
     description: TCP endpoint
     type: string
+    requirement_level: recommended
 
 metrics:
   tcpcheck.duration:


### PR DESCRIPTION
Resolves #46382

This PR enables the re-aggregation feature for the tcpcheck receiver by:
- Adding `requirement_level: recommended` to all metric attributes
- Regenerating code with `go generate`

## Testing
- `go generate ./...` completed successfully
- `go test ./...` passed

Assisted-by: Claude Opus 4.6