### PR TITLE
[receiver/chronyreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46350-chrony-enable-reaggregation.yaml
+++ b/.chloggen/46350-chrony-enable-reaggregation.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/chronyreceiver
+note: Enable re-aggregation feature for chrony receiver.
+issues: [46350]
+subtext: ""

--- a/receiver/chronyreceiver/generated_package_test.go
+++ b/receiver/chronyreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package chronyreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/chronyreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/chronyreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/chronyreceiver/metadata.yaml
+++ b/receiver/chronyreceiver/metadata.yaml
@@ -13,6 +13,7 @@ attributes:
   leap.status:
     description: how the chrony is handling leap seconds
     type: string
+    requirement_level: recommended
     enum:
     - normal
     - insert_second


### PR DESCRIPTION
Resolves #46350

This PR enables the re-aggregation feature for the chrony receiver by:
- Adding `requirement_level: recommended` to all metric attributes
- Regenerating code with `go generate`

## Testing
- `go generate ./...` completed successfully
- `go test ./...` passed

Assisted-by: Claude Opus 4.6