### PR TITLE
[receiver/riakreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46377-riak-enable-reaggregation.yaml
+++ b/.chloggen/46377-riak-enable-reaggregation.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/riakreceiver
+note: Enable re-aggregation feature for riak receiver.
+issues: [46377]
+subtext: ""

--- a/receiver/riakreceiver/generated_package_test.go
+++ b/receiver/riakreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package riakreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/riakreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/riakreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/riakreceiver/metadata.yaml
+++ b/receiver/riakreceiver/metadata.yaml
@@ -20,6 +20,7 @@ attributes:
   operation:
     description: The operation type for index operations.
     type: string
+    requirement_level: recommended
     enum:
       - read
       - write
@@ -27,6 +28,7 @@ attributes:
   request:
     description: The request operation type.
     type: string
+    requirement_level: recommended
     enum:
       - put
       - get


### PR DESCRIPTION
Resolves #46377

This PR enables the re-aggregation feature for the riak receiver by:
- Adding `requirement_level: recommended` to all metric attributes
- Regenerating code with `go generate`

## Testing
- `go generate ./...` completed successfully
- `go test ./...` passed

Assisted-by: Claude Opus 4.6