### PR TITLE
[receiver/sshcheckreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46380-sshcheck-enable-reaggregation.yaml
+++ b/.chloggen/46380-sshcheck-enable-reaggregation.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/sshcheckreceiver
+note: Enable re-aggregation feature for sshcheck receiver.
+issues: [46380]
+subtext: ""

--- a/receiver/sshcheckreceiver/generated_package_test.go
+++ b/receiver/sshcheckreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package sshcheckreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/sshcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -19,6 +19,7 @@ attributes:
   error.message:
     description: Error message recorded during check
     type: string
+    requirement_level: recommended
 
 metrics:
   sshcheck.duration:


### PR DESCRIPTION
Resolves #46380

This PR enables the re-aggregation feature for the sshcheck receiver by:
- Adding `requirement_level: recommended` to all metric attributes
- Regenerating code with `go generate`

## Testing
- `go generate ./...` completed successfully
- `go test ./...` passed

Assisted-by: Claude Opus 4.6