### PR TITLE
[receiver/mongodbreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46366-mongodb-enable-reaggregation.yaml
+++ b/.chloggen/46366-mongodb-enable-reaggregation.yaml
@@ -2,4 +2,4 @@ change_type: enhancement
 component: receiver/mongodbreceiver
 note: Enable re-aggregation feature for mongodb receiver.
 issues: [46366]
-subtext: \"\"
+subtext: ""

--- a/.chloggen/46366-mongodb-enable-reaggregation.yaml
+++ b/.chloggen/46366-mongodb-enable-reaggregation.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/mongodbreceiver
+note: Enable re-aggregation feature for mongodb receiver.
+issues: [46366]
+subtext: \"\"

--- a/receiver/mongodbreceiver/generated_package_test.go
+++ b/receiver/mongodbreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package mongodbreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -33,10 +33,12 @@ attributes:
   collection:
     description: The name of a collection.
     type: string
+    requirement_level: recommended
   connection_type:
     name_override: type
     description: The status of the connection.
     type: string
+    requirement_level: recommended
     enum:
       - active
       - available
@@ -44,9 +46,11 @@ attributes:
   db.namespace:
     description: The name of a database.
     type: string
+    requirement_level: recommended
   lock_mode:
     description: The mode of Lock which denotes the degree of access
     type: string
+    requirement_level: recommended
     enum:
       - shared
       - exclusive
@@ -56,6 +60,7 @@ attributes:
   lock_type:
     description: The Resource over which the Lock controls access
     type: string
+    requirement_level: recommended
     enum:
       - parallel_batch_write_mode
       - replication_state_transition
@@ -69,12 +74,14 @@ attributes:
     name_override: type
     description: The type of memory used.
     type: string
+    requirement_level: recommended
     enum:
       - resident
       - virtual
   operation:
     description: The MongoDB operation being counted.
     type: string
+    requirement_level: recommended
     enum:
       - insert
       - query
@@ -86,6 +93,7 @@ attributes:
     name_override: operation
     description: The MongoDB operation with regards to latency
     type: string
+    requirement_level: recommended
     enum:
       - read
       - write
@@ -93,6 +101,7 @@ attributes:
   type:
     description: The result of a cache request.
     type: string
+    requirement_level: recommended
     enum:
       - hit
       - miss


### PR DESCRIPTION
Resolves #46366

This PR enables the re-aggregation feature for the mongodb receiver by:
- Adding `requirement_level: recommended` to all metric attributes
- Regenerating code with `go generate`

## Testing
- `go generate ./...` completed successfully
- `go test ./...` passed

Assisted-by: Claude Opus 4.6