### PR TITLE
[CHORE] Increase go test timeout for testbed

### DIFF
--- a/testbed/Makefile
+++ b/testbed/Makefile
@@ -8,7 +8,7 @@ list-tests:
 
 .PHONY: run-tests
 run-tests: $(GOJUNIT)
-	GOJUNIT="$(GOJUNIT)" ./runtests.sh
+	TEST_ARGS="$${TEST_ARGS} -timeout 30m" GOJUNIT="$(GOJUNIT)" ./runtests.sh
 
 .PHONY: list-loadtest-tests
 list-loadtest-tests:


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46675, the [latest workflow](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22732630603/job/65926906631) shows we're still seeing timeouts.

`runtests.sh` uses the TEST_ARGS env to add additional arguments to the Go CLI.