### PR TITLE
[processor/redaction] document audit trail attributes in README

### DIFF
--- a/.chloggen/46648-redaction-audit-trail-docs.yaml
+++ b/.chloggen/46648-redaction-audit-trail-docs.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/redaction
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Document audit trail attributes emitted when `summary` is set to `debug` or `info`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46648]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds an Audit Trail section to the README describing the diagnostic attributes
+  the processor appends to spans, log records, and metric datapoints, including
+  a worked example. Also fixes the example output to omit zero-count attributes
+  that are never emitted, and restores URL Sanitization and Span Name Sanitization
+  as top-level README sections.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/redactionprocessor/README.md
+++ b/processor/redactionprocessor/README.md
@@ -185,9 +185,91 @@ processors:
     summary: silent
 ```
 
+## Audit Trail
+
+When `summary` is set to `debug` or `info`, the processor appends diagnostic
+attributes to each span, log record, or metric datapoint describing the actions
+it took. Setting `summary: silent` suppresses all audit attributes.
+
+### Attribute-level audit (spans, logs, metric datapoints)
+
+These attributes are added to the record's attribute map:
+
+| Attribute | `info` | `debug` | Description |
+|---|:---:|:---:|---|
+| `redaction.redacted.keys` | | ✓ | Comma-separated list of attribute keys removed because they were not in `allowed_keys` |
+| `redaction.redacted.count` | ✓ | ✓ | Number of attributes removed |
+| `redaction.masked.keys` | | ✓ | Comma-separated list of attribute keys whose values matched a `blocked_values` pattern and were masked |
+| `redaction.masked.count` | ✓ | ✓ | Number of attribute values masked |
+| `redaction.allowed.keys` | | ✓ | Comma-separated list of attribute keys that passed through |
+| `redaction.allowed.count` | ✓ | ✓ | Number of attributes allowed through |
+| `redaction.ignored.count` | ✓ | ✓ | Number of attributes skipped due to `ignored_keys` or `ignored_key_patterns` |
+
+### Log body audit
+
+For log records whose body is a map, the processor additionally appends audit
+attributes into the body map itself:
+
+| Attribute | `info` | `debug` | Description |
+|---|:---:|:---:|---|
+| `redaction.body.redacted.keys` | | ✓ | Comma-separated list of body map keys removed |
+| `redaction.body.redacted.count` | ✓ | ✓ | Number of body map keys removed |
+| `redaction.body.masked.keys` | | ✓ | Comma-separated list of body map keys whose values were masked |
+| `redaction.body.masked.count` | ✓ | ✓ | Number of body map values masked |
+| `redaction.body.allowed.keys` | | ✓ | Comma-separated list of body map keys permitted |
+| `redaction.body.allowed.count` | ✓ | ✓ | Number of body map keys allowed through |
+| `redaction.body.ignored.count` | ✓ | ✓ | Number of body map keys ignored |
+
+### Example
+
+Given this configuration:
+
+```yaml
+processors:
+  redaction:
+    allowed_keys:
+      - description
+      - email
+    blocked_values:
+      - "4[0-9]{12}(?:[0-9]{3})?"  ## Visa credit card number
+    summary: debug
+```
+
+A span arriving with these attributes:
+
+| Key | Value |
+|---|---|
+| `description` | `"payment processed"` |
+| `email` | `"user@example.com"` |
+| `credit_card` | `"4111111111111111"` |
+| `internal_id` | `"abc-123"` |
+
+Would be emitted with:
+
+| Key | Value |
+|---|---|
+| `description` | `"payment processed"` |
+| `email` | `"user@example.com"` |
+| `redaction.redacted.keys` | `"credit_card,internal_id"` |
+| `redaction.redacted.count` | `2` |
+| `redaction.allowed.keys` | `"description,email"` |
+| `redaction.allowed.count` | `2` |
+
+Note that `credit_card` was **removed** (not masked) because it was not in
+`allowed_keys` — its value never reached the `blocked_values` check. If
+`credit_card` had been in `allowed_keys`, its value `4111111111111111` would
+have matched the Visa pattern and `redaction.masked.keys` would show
+`"credit_card"` instead.
+
+Attributes with a zero count (e.g. `redaction.masked.count`, `redaction.ignored.count`) are
+**not emitted** — the processor only writes audit attributes when at least one relevant
+action occurred.
+
+## URL Sanitization
+
 The `url_sanitizer` configuration enables sanitization of URLs in specified attributes by removing potentially sensitive information like UUIDs, timestamps, and other non-essential path segments. This is particularly useful for reducing cardinality in telemetry data while preserving the essential parts of URLs for troubleshooting.
 
-### Span Name Sanitization
+## Span Name Sanitization
 
 By default, when URL sanitization is enabled, span names for client and server span types that contain "/" characters are automatically sanitized. This helps reduce cardinality issues caused by high-variability URL paths in span names while preserving essential routing information.
 


### PR DESCRIPTION
#### Description
The redaction processor emits diagnostic attributes on spans, log records,
and metric datapoints when `summary` is set to `debug` or `info`, but this
behaviour was not documented anywhere. This PR adds an **Audit Trail** section
to the README covering:
- The full set of attribute-level audit attributes (`redaction.redacted.*`,
  `redaction.masked.*`, `redaction.allowed.*`, `redaction.ignored.count`) with
  a table showing which are emitted under `info` vs `debug`.
- The log-body audit attributes (`redaction.body.*`) for log records whose
  body is a map.
- A worked example showing a before/after attribute table for a realistic
  span, with a config snippet using `summary: debug`.
Two follow-up fixes are also included:
- The example output no longer shows zero-count attributes (e.g.
  `redaction.masked.count: 0`) that the processor never actually emits —
  `addMetaAttrs` returns early when the count is zero.
- `## URL Sanitization` and `## Span Name Sanitization` are restored as
  top-level sections; the original insertion had accidentally nested them
  inside `## Audit Trail`.
#### Link to tracking issue
Fixes #46648
#### Testing
No code changes — documentation only. The attribute names and
`info`/`debug` visibility were verified directly against the constants
and logic in `processor/redactionprocessor/processor.go:583-438`.
#### Documentation
This PR **is** the documentation change. The new Audit Trail section in
`processor/redactionprocessor/README.md` describes the audit attributes
and provides a concrete example of their use.