### PR TITLE
[receiver/flinkmetrics]: enable re-aggregation feature

### DIFF
--- a/.chloggen/46356-flinkmetrics-enable-reagg.yaml
+++ b/.chloggen/46356-flinkmetrics-enable-reagg.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: receiver/flinkmetrics
+
+note: Enable re-aggregation feature by classifying attributes with requirement_level and setting reaggregation_enabled to true
+
+issues: [46356]
+
+subtext: |
+  Attributes are classified as required when aggregating across them produces meaningless results
+  (checkpoint, garbage_collector_name, record), and recommended when totals remain operationally
+  meaningful (operator_name).
+
+change_logs: [user]

--- a/receiver/flinkmetricsreceiver/documentation.md
+++ b/receiver/flinkmetricsreceiver/documentation.md
@@ -24,7 +24,7 @@ The number of checkpoints completed or failed.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| checkpoint | The number of checkpoints completed or that failed. | Str: ``completed``, ``failed`` | Recommended |
+| checkpoint | The number of checkpoints completed or that failed. | Str: ``completed``, ``failed`` | Required |
 
 ### flink.job.checkpoint.in_progress
 
@@ -94,7 +94,7 @@ The total number of collections that have occurred.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| name | The names for the parallel scavenge and garbage first garbage collectors. | Str: ``PS_MarkSweep``, ``PS_Scavenge``, ``G1_Young_Generation``, ``G1_Old_Generation`` | Recommended |
+| name | The names for the parallel scavenge and garbage first garbage collectors. | Str: ``PS_MarkSweep``, ``PS_Scavenge``, ``G1_Young_Generation``, ``G1_Old_Generation`` | Required |
 
 ### flink.jvm.gc.collections.time
 
@@ -108,7 +108,7 @@ The total time spent performing garbage collection.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| name | The names for the parallel scavenge and garbage first garbage collectors. | Str: ``PS_MarkSweep``, ``PS_Scavenge``, ``G1_Young_Generation``, ``G1_Old_Generation`` | Recommended |
+| name | The names for the parallel scavenge and garbage first garbage collectors. | Str: ``PS_MarkSweep``, ``PS_Scavenge``, ``G1_Young_Generation``, ``G1_Old_Generation`` | Required |
 
 ### flink.jvm.memory.direct.total_capacity
 
@@ -251,7 +251,7 @@ The number of records an operator has.
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
 | name | The operator name. | Any Str | Recommended |
-| record | The number of records received in, sent out or dropped due to arriving late. | Str: ``in``, ``out``, ``dropped`` | Recommended |
+| record | The number of records received in, sent out or dropped due to arriving late. | Str: ``in``, ``out``, ``dropped`` | Required |
 
 ### flink.operator.watermark.output
 
@@ -279,7 +279,7 @@ The number of records a task has.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| record | The number of records received in, sent out or dropped due to arriving late. | Str: ``in``, ``out``, ``dropped`` | Recommended |
+| record | The number of records received in, sent out or dropped due to arriving late. | Str: ``in``, ``out``, ``dropped`` | Required |
 
 ## Resource Attributes
 

--- a/receiver/flinkmetricsreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/flinkmetricsreceiver/internal/metadata/config.schema.yaml
@@ -193,6 +193,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "name"
+                - "record"
+            default:
+              - "name"
+              - "record"
       flink.operator.watermark.output:
         description: "FlinkOperatorWatermarkOutputConfig provides config for the flink.operator.watermark.output metric."
         type: object
@@ -200,6 +218,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "name"
+            default:
+              - "name"
       flink.task.record.count:
         description: "FlinkTaskRecordCountConfig provides config for the flink.task.record.count metric."
         type: object

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_config.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,640 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// FlinkJobCheckpointCountConfig provides config for the flink.job.checkpoint.count metric.
+type FlinkJobCheckpointCountConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *FlinkJobCheckpointCountConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJobCheckpointInProgressConfig provides config for the flink.job.checkpoint.in_progress metric.
+type FlinkJobCheckpointInProgressConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJobCheckpointInProgressConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJobLastCheckpointSizeConfig provides config for the flink.job.last_checkpoint.size metric.
+type FlinkJobLastCheckpointSizeConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJobLastCheckpointSizeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJobLastCheckpointTimeConfig provides config for the flink.job.last_checkpoint.time metric.
+type FlinkJobLastCheckpointTimeConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJobLastCheckpointTimeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJobRestartCountConfig provides config for the flink.job.restart.count metric.
+type FlinkJobRestartCountConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJobRestartCountConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmClassLoaderClassesLoadedConfig provides config for the flink.jvm.class_loader.classes_loaded metric.
+type FlinkJvmClassLoaderClassesLoadedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmClassLoaderClassesLoadedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmCPULoadConfig provides config for the flink.jvm.cpu.load metric.
+type FlinkJvmCPULoadConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmCPULoadConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmCPUTimeConfig provides config for the flink.jvm.cpu.time metric.
+type FlinkJvmCPUTimeConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmCPUTimeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmGcCollectionsCountConfig provides config for the flink.jvm.gc.collections.count metric.
+type FlinkJvmGcCollectionsCountConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmGcCollectionsCountConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmGcCollectionsTimeConfig provides config for the flink.jvm.gc.collections.time metric.
+type FlinkJvmGcCollectionsTimeConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmGcCollectionsTimeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryDirectTotalCapacityConfig provides config for the flink.jvm.memory.direct.total_capacity metric.
+type FlinkJvmMemoryDirectTotalCapacityConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryDirectTotalCapacityConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryDirectUsedConfig provides config for the flink.jvm.memory.direct.used metric.
+type FlinkJvmMemoryDirectUsedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryDirectUsedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryHeapCommittedConfig provides config for the flink.jvm.memory.heap.committed metric.
+type FlinkJvmMemoryHeapCommittedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryHeapCommittedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryHeapMaxConfig provides config for the flink.jvm.memory.heap.max metric.
+type FlinkJvmMemoryHeapMaxConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryHeapMaxConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryHeapUsedConfig provides config for the flink.jvm.memory.heap.used metric.
+type FlinkJvmMemoryHeapUsedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryHeapUsedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryMappedTotalCapacityConfig provides config for the flink.jvm.memory.mapped.total_capacity metric.
+type FlinkJvmMemoryMappedTotalCapacityConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryMappedTotalCapacityConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryMappedUsedConfig provides config for the flink.jvm.memory.mapped.used metric.
+type FlinkJvmMemoryMappedUsedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryMappedUsedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryMetaspaceCommittedConfig provides config for the flink.jvm.memory.metaspace.committed metric.
+type FlinkJvmMemoryMetaspaceCommittedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryMetaspaceCommittedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryMetaspaceMaxConfig provides config for the flink.jvm.memory.metaspace.max metric.
+type FlinkJvmMemoryMetaspaceMaxConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryMetaspaceMaxConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryMetaspaceUsedConfig provides config for the flink.jvm.memory.metaspace.used metric.
+type FlinkJvmMemoryMetaspaceUsedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryMetaspaceUsedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryNonheapCommittedConfig provides config for the flink.jvm.memory.nonheap.committed metric.
+type FlinkJvmMemoryNonheapCommittedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryNonheapCommittedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryNonheapMaxConfig provides config for the flink.jvm.memory.nonheap.max metric.
+type FlinkJvmMemoryNonheapMaxConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryNonheapMaxConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmMemoryNonheapUsedConfig provides config for the flink.jvm.memory.nonheap.used metric.
+type FlinkJvmMemoryNonheapUsedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmMemoryNonheapUsedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkJvmThreadsCountConfig provides config for the flink.jvm.threads.count metric.
+type FlinkJvmThreadsCountConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkJvmThreadsCountConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkMemoryManagedTotalConfig provides config for the flink.memory.managed.total metric.
+type FlinkMemoryManagedTotalConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkMemoryManagedTotalConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkMemoryManagedUsedConfig provides config for the flink.memory.managed.used metric.
+type FlinkMemoryManagedUsedConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkMemoryManagedUsedConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FlinkOperatorRecordCountAttributeKey specifies the key of an attribute for the flink.operator.record.count metric.
+type FlinkOperatorRecordCountAttributeKey string
+
+const (
+	FlinkOperatorRecordCountAttributeKeyOperatorName FlinkOperatorRecordCountAttributeKey = "name"
+	FlinkOperatorRecordCountAttributeKeyRecord       FlinkOperatorRecordCountAttributeKey = "record"
+)
+
+// FlinkOperatorRecordCountConfig provides config for the flink.operator.record.count metric.
+type FlinkOperatorRecordCountConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []FlinkOperatorRecordCountAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *FlinkOperatorRecordCountConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *FlinkOperatorRecordCountConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case FlinkOperatorRecordCountAttributeKeyOperatorName, FlinkOperatorRecordCountAttributeKeyRecord:
+		default:
+			return fmt.Errorf("metric flink.operator.record.count doesn't have an attribute %v, valid attributes: [name, record]", val)
+		}
+	}
+	if !slices.Contains(ms.EnabledAttributes, FlinkOperatorRecordCountAttributeKeyRecord) {
+		return fmt.Errorf("record is a required attribute for flink.operator.record.count metric and must be included")
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// FlinkOperatorWatermarkOutputAttributeKey specifies the key of an attribute for the flink.operator.watermark.output metric.
+type FlinkOperatorWatermarkOutputAttributeKey string
+
+const (
+	FlinkOperatorWatermarkOutputAttributeKeyOperatorName FlinkOperatorWatermarkOutputAttributeKey = "name"
+)
+
+// FlinkOperatorWatermarkOutputConfig provides config for the flink.operator.watermark.output metric.
+type FlinkOperatorWatermarkOutputConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []FlinkOperatorWatermarkOutputAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *FlinkOperatorWatermarkOutputConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *FlinkOperatorWatermarkOutputConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case FlinkOperatorWatermarkOutputAttributeKeyOperatorName:
+		default:
+			return fmt.Errorf("metric flink.operator.watermark.output doesn't have an attribute %v, valid attributes: [name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// FlinkTaskRecordCountConfig provides config for the flink.task.record.count metric.
+type FlinkTaskRecordCountConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FlinkTaskRecordCountConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,124 +652,128 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for flinkmetrics metrics.
 type MetricsConfig struct {
-	FlinkJobCheckpointCount           MetricConfig `mapstructure:"flink.job.checkpoint.count"`
-	FlinkJobCheckpointInProgress      MetricConfig `mapstructure:"flink.job.checkpoint.in_progress"`
-	FlinkJobLastCheckpointSize        MetricConfig `mapstructure:"flink.job.last_checkpoint.size"`
-	FlinkJobLastCheckpointTime        MetricConfig `mapstructure:"flink.job.last_checkpoint.time"`
-	FlinkJobRestartCount              MetricConfig `mapstructure:"flink.job.restart.count"`
-	FlinkJvmClassLoaderClassesLoaded  MetricConfig `mapstructure:"flink.jvm.class_loader.classes_loaded"`
-	FlinkJvmCPULoad                   MetricConfig `mapstructure:"flink.jvm.cpu.load"`
-	FlinkJvmCPUTime                   MetricConfig `mapstructure:"flink.jvm.cpu.time"`
-	FlinkJvmGcCollectionsCount        MetricConfig `mapstructure:"flink.jvm.gc.collections.count"`
-	FlinkJvmGcCollectionsTime         MetricConfig `mapstructure:"flink.jvm.gc.collections.time"`
-	FlinkJvmMemoryDirectTotalCapacity MetricConfig `mapstructure:"flink.jvm.memory.direct.total_capacity"`
-	FlinkJvmMemoryDirectUsed          MetricConfig `mapstructure:"flink.jvm.memory.direct.used"`
-	FlinkJvmMemoryHeapCommitted       MetricConfig `mapstructure:"flink.jvm.memory.heap.committed"`
-	FlinkJvmMemoryHeapMax             MetricConfig `mapstructure:"flink.jvm.memory.heap.max"`
-	FlinkJvmMemoryHeapUsed            MetricConfig `mapstructure:"flink.jvm.memory.heap.used"`
-	FlinkJvmMemoryMappedTotalCapacity MetricConfig `mapstructure:"flink.jvm.memory.mapped.total_capacity"`
-	FlinkJvmMemoryMappedUsed          MetricConfig `mapstructure:"flink.jvm.memory.mapped.used"`
-	FlinkJvmMemoryMetaspaceCommitted  MetricConfig `mapstructure:"flink.jvm.memory.metaspace.committed"`
-	FlinkJvmMemoryMetaspaceMax        MetricConfig `mapstructure:"flink.jvm.memory.metaspace.max"`
-	FlinkJvmMemoryMetaspaceUsed       MetricConfig `mapstructure:"flink.jvm.memory.metaspace.used"`
-	FlinkJvmMemoryNonheapCommitted    MetricConfig `mapstructure:"flink.jvm.memory.nonheap.committed"`
-	FlinkJvmMemoryNonheapMax          MetricConfig `mapstructure:"flink.jvm.memory.nonheap.max"`
-	FlinkJvmMemoryNonheapUsed         MetricConfig `mapstructure:"flink.jvm.memory.nonheap.used"`
-	FlinkJvmThreadsCount              MetricConfig `mapstructure:"flink.jvm.threads.count"`
-	FlinkMemoryManagedTotal           MetricConfig `mapstructure:"flink.memory.managed.total"`
-	FlinkMemoryManagedUsed            MetricConfig `mapstructure:"flink.memory.managed.used"`
-	FlinkOperatorRecordCount          MetricConfig `mapstructure:"flink.operator.record.count"`
-	FlinkOperatorWatermarkOutput      MetricConfig `mapstructure:"flink.operator.watermark.output"`
-	FlinkTaskRecordCount              MetricConfig `mapstructure:"flink.task.record.count"`
+	FlinkJobCheckpointCount           FlinkJobCheckpointCountConfig           `mapstructure:"flink.job.checkpoint.count"`
+	FlinkJobCheckpointInProgress      FlinkJobCheckpointInProgressConfig      `mapstructure:"flink.job.checkpoint.in_progress"`
+	FlinkJobLastCheckpointSize        FlinkJobLastCheckpointSizeConfig        `mapstructure:"flink.job.last_checkpoint.size"`
+	FlinkJobLastCheckpointTime        FlinkJobLastCheckpointTimeConfig        `mapstructure:"flink.job.last_checkpoint.time"`
+	FlinkJobRestartCount              FlinkJobRestartCountConfig              `mapstructure:"flink.job.restart.count"`
+	FlinkJvmClassLoaderClassesLoaded  FlinkJvmClassLoaderClassesLoadedConfig  `mapstructure:"flink.jvm.class_loader.classes_loaded"`
+	FlinkJvmCPULoad                   FlinkJvmCPULoadConfig                   `mapstructure:"flink.jvm.cpu.load"`
+	FlinkJvmCPUTime                   FlinkJvmCPUTimeConfig                   `mapstructure:"flink.jvm.cpu.time"`
+	FlinkJvmGcCollectionsCount        FlinkJvmGcCollectionsCountConfig        `mapstructure:"flink.jvm.gc.collections.count"`
+	FlinkJvmGcCollectionsTime         FlinkJvmGcCollectionsTimeConfig         `mapstructure:"flink.jvm.gc.collections.time"`
+	FlinkJvmMemoryDirectTotalCapacity FlinkJvmMemoryDirectTotalCapacityConfig `mapstructure:"flink.jvm.memory.direct.total_capacity"`
+	FlinkJvmMemoryDirectUsed          FlinkJvmMemoryDirectUsedConfig          `mapstructure:"flink.jvm.memory.direct.used"`
+	FlinkJvmMemoryHeapCommitted       FlinkJvmMemoryHeapCommittedConfig       `mapstructure:"flink.jvm.memory.heap.committed"`
+	FlinkJvmMemoryHeapMax             FlinkJvmMemoryHeapMaxConfig             `mapstructure:"flink.jvm.memory.heap.max"`
+	FlinkJvmMemoryHeapUsed            FlinkJvmMemoryHeapUsedConfig            `mapstructure:"flink.jvm.memory.heap.used"`
+	FlinkJvmMemoryMappedTotalCapacity FlinkJvmMemoryMappedTotalCapacityConfig `mapstructure:"flink.jvm.memory.mapped.total_capacity"`
+	FlinkJvmMemoryMappedUsed          FlinkJvmMemoryMappedUsedConfig          `mapstructure:"flink.jvm.memory.mapped.used"`
+	FlinkJvmMemoryMetaspaceCommitted  FlinkJvmMemoryMetaspaceCommittedConfig  `mapstructure:"flink.jvm.memory.metaspace.committed"`
+	FlinkJvmMemoryMetaspaceMax        FlinkJvmMemoryMetaspaceMaxConfig        `mapstructure:"flink.jvm.memory.metaspace.max"`
+	FlinkJvmMemoryMetaspaceUsed       FlinkJvmMemoryMetaspaceUsedConfig       `mapstructure:"flink.jvm.memory.metaspace.used"`
+	FlinkJvmMemoryNonheapCommitted    FlinkJvmMemoryNonheapCommittedConfig    `mapstructure:"flink.jvm.memory.nonheap.committed"`
+	FlinkJvmMemoryNonheapMax          FlinkJvmMemoryNonheapMaxConfig          `mapstructure:"flink.jvm.memory.nonheap.max"`
+	FlinkJvmMemoryNonheapUsed         FlinkJvmMemoryNonheapUsedConfig         `mapstructure:"flink.jvm.memory.nonheap.used"`
+	FlinkJvmThreadsCount              FlinkJvmThreadsCountConfig              `mapstructure:"flink.jvm.threads.count"`
+	FlinkMemoryManagedTotal           FlinkMemoryManagedTotalConfig           `mapstructure:"flink.memory.managed.total"`
+	FlinkMemoryManagedUsed            FlinkMemoryManagedUsedConfig            `mapstructure:"flink.memory.managed.used"`
+	FlinkOperatorRecordCount          FlinkOperatorRecordCountConfig          `mapstructure:"flink.operator.record.count"`
+	FlinkOperatorWatermarkOutput      FlinkOperatorWatermarkOutputConfig      `mapstructure:"flink.operator.watermark.output"`
+	FlinkTaskRecordCount              FlinkTaskRecordCountConfig              `mapstructure:"flink.task.record.count"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		FlinkJobCheckpointCount: MetricConfig{
+		FlinkJobCheckpointCount: FlinkJobCheckpointCountConfig{
 			Enabled: true,
 		},
-		FlinkJobCheckpointInProgress: MetricConfig{
+		FlinkJobCheckpointInProgress: FlinkJobCheckpointInProgressConfig{
 			Enabled: true,
 		},
-		FlinkJobLastCheckpointSize: MetricConfig{
+		FlinkJobLastCheckpointSize: FlinkJobLastCheckpointSizeConfig{
 			Enabled: true,
 		},
-		FlinkJobLastCheckpointTime: MetricConfig{
+		FlinkJobLastCheckpointTime: FlinkJobLastCheckpointTimeConfig{
 			Enabled: true,
 		},
-		FlinkJobRestartCount: MetricConfig{
+		FlinkJobRestartCount: FlinkJobRestartCountConfig{
 			Enabled: true,
 		},
-		FlinkJvmClassLoaderClassesLoaded: MetricConfig{
+		FlinkJvmClassLoaderClassesLoaded: FlinkJvmClassLoaderClassesLoadedConfig{
 			Enabled: true,
 		},
-		FlinkJvmCPULoad: MetricConfig{
+		FlinkJvmCPULoad: FlinkJvmCPULoadConfig{
 			Enabled: true,
 		},
-		FlinkJvmCPUTime: MetricConfig{
+		FlinkJvmCPUTime: FlinkJvmCPUTimeConfig{
 			Enabled: true,
 		},
-		FlinkJvmGcCollectionsCount: MetricConfig{
+		FlinkJvmGcCollectionsCount: FlinkJvmGcCollectionsCountConfig{
 			Enabled: true,
 		},
-		FlinkJvmGcCollectionsTime: MetricConfig{
+		FlinkJvmGcCollectionsTime: FlinkJvmGcCollectionsTimeConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryDirectTotalCapacity: MetricConfig{
+		FlinkJvmMemoryDirectTotalCapacity: FlinkJvmMemoryDirectTotalCapacityConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryDirectUsed: MetricConfig{
+		FlinkJvmMemoryDirectUsed: FlinkJvmMemoryDirectUsedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryHeapCommitted: MetricConfig{
+		FlinkJvmMemoryHeapCommitted: FlinkJvmMemoryHeapCommittedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryHeapMax: MetricConfig{
+		FlinkJvmMemoryHeapMax: FlinkJvmMemoryHeapMaxConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryHeapUsed: MetricConfig{
+		FlinkJvmMemoryHeapUsed: FlinkJvmMemoryHeapUsedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMappedTotalCapacity: MetricConfig{
+		FlinkJvmMemoryMappedTotalCapacity: FlinkJvmMemoryMappedTotalCapacityConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMappedUsed: MetricConfig{
+		FlinkJvmMemoryMappedUsed: FlinkJvmMemoryMappedUsedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMetaspaceCommitted: MetricConfig{
+		FlinkJvmMemoryMetaspaceCommitted: FlinkJvmMemoryMetaspaceCommittedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMetaspaceMax: MetricConfig{
+		FlinkJvmMemoryMetaspaceMax: FlinkJvmMemoryMetaspaceMaxConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMetaspaceUsed: MetricConfig{
+		FlinkJvmMemoryMetaspaceUsed: FlinkJvmMemoryMetaspaceUsedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryNonheapCommitted: MetricConfig{
+		FlinkJvmMemoryNonheapCommitted: FlinkJvmMemoryNonheapCommittedConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryNonheapMax: MetricConfig{
+		FlinkJvmMemoryNonheapMax: FlinkJvmMemoryNonheapMaxConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryNonheapUsed: MetricConfig{
+		FlinkJvmMemoryNonheapUsed: FlinkJvmMemoryNonheapUsedConfig{
 			Enabled: true,
 		},
-		FlinkJvmThreadsCount: MetricConfig{
+		FlinkJvmThreadsCount: FlinkJvmThreadsCountConfig{
 			Enabled: true,
 		},
-		FlinkMemoryManagedTotal: MetricConfig{
+		FlinkMemoryManagedTotal: FlinkMemoryManagedTotalConfig{
 			Enabled: true,
 		},
-		FlinkMemoryManagedUsed: MetricConfig{
+		FlinkMemoryManagedUsed: FlinkMemoryManagedUsedConfig{
 			Enabled: true,
 		},
-		FlinkOperatorRecordCount: MetricConfig{
-			Enabled: true,
+		FlinkOperatorRecordCount: FlinkOperatorRecordCountConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []FlinkOperatorRecordCountAttributeKey{FlinkOperatorRecordCountAttributeKeyOperatorName, FlinkOperatorRecordCountAttributeKeyRecord},
 		},
-		FlinkOperatorWatermarkOutput: MetricConfig{
-			Enabled: true,
+		FlinkOperatorWatermarkOutput: FlinkOperatorWatermarkOutputConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []FlinkOperatorWatermarkOutputAttributeKey{FlinkOperatorWatermarkOutputAttributeKeyOperatorName},
 		},
-		FlinkTaskRecordCount: MetricConfig{
+		FlinkTaskRecordCount: FlinkTaskRecordCountConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_config_test.go
@@ -26,91 +26,95 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					FlinkJobCheckpointCount: MetricConfig{
+					FlinkJobCheckpointCount: FlinkJobCheckpointCountConfig{
 						Enabled: true,
 					},
-					FlinkJobCheckpointInProgress: MetricConfig{
+					FlinkJobCheckpointInProgress: FlinkJobCheckpointInProgressConfig{
 						Enabled: true,
 					},
-					FlinkJobLastCheckpointSize: MetricConfig{
+					FlinkJobLastCheckpointSize: FlinkJobLastCheckpointSizeConfig{
 						Enabled: true,
 					},
-					FlinkJobLastCheckpointTime: MetricConfig{
+					FlinkJobLastCheckpointTime: FlinkJobLastCheckpointTimeConfig{
 						Enabled: true,
 					},
-					FlinkJobRestartCount: MetricConfig{
+					FlinkJobRestartCount: FlinkJobRestartCountConfig{
 						Enabled: true,
 					},
-					FlinkJvmClassLoaderClassesLoaded: MetricConfig{
+					FlinkJvmClassLoaderClassesLoaded: FlinkJvmClassLoaderClassesLoadedConfig{
 						Enabled: true,
 					},
-					FlinkJvmCPULoad: MetricConfig{
+					FlinkJvmCPULoad: FlinkJvmCPULoadConfig{
 						Enabled: true,
 					},
-					FlinkJvmCPUTime: MetricConfig{
+					FlinkJvmCPUTime: FlinkJvmCPUTimeConfig{
 						Enabled: true,
 					},
-					FlinkJvmGcCollectionsCount: MetricConfig{
+					FlinkJvmGcCollectionsCount: FlinkJvmGcCollectionsCountConfig{
 						Enabled: true,
 					},
-					FlinkJvmGcCollectionsTime: MetricConfig{
+					FlinkJvmGcCollectionsTime: FlinkJvmGcCollectionsTimeConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryDirectTotalCapacity: MetricConfig{
+					FlinkJvmMemoryDirectTotalCapacity: FlinkJvmMemoryDirectTotalCapacityConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryDirectUsed: MetricConfig{
+					FlinkJvmMemoryDirectUsed: FlinkJvmMemoryDirectUsedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryHeapCommitted: MetricConfig{
+					FlinkJvmMemoryHeapCommitted: FlinkJvmMemoryHeapCommittedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryHeapMax: MetricConfig{
+					FlinkJvmMemoryHeapMax: FlinkJvmMemoryHeapMaxConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryHeapUsed: MetricConfig{
+					FlinkJvmMemoryHeapUsed: FlinkJvmMemoryHeapUsedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryMappedTotalCapacity: MetricConfig{
+					FlinkJvmMemoryMappedTotalCapacity: FlinkJvmMemoryMappedTotalCapacityConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryMappedUsed: MetricConfig{
+					FlinkJvmMemoryMappedUsed: FlinkJvmMemoryMappedUsedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryMetaspaceCommitted: MetricConfig{
+					FlinkJvmMemoryMetaspaceCommitted: FlinkJvmMemoryMetaspaceCommittedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryMetaspaceMax: MetricConfig{
+					FlinkJvmMemoryMetaspaceMax: FlinkJvmMemoryMetaspaceMaxConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryMetaspaceUsed: MetricConfig{
+					FlinkJvmMemoryMetaspaceUsed: FlinkJvmMemoryMetaspaceUsedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryNonheapCommitted: MetricConfig{
+					FlinkJvmMemoryNonheapCommitted: FlinkJvmMemoryNonheapCommittedConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryNonheapMax: MetricConfig{
+					FlinkJvmMemoryNonheapMax: FlinkJvmMemoryNonheapMaxConfig{
 						Enabled: true,
 					},
-					FlinkJvmMemoryNonheapUsed: MetricConfig{
+					FlinkJvmMemoryNonheapUsed: FlinkJvmMemoryNonheapUsedConfig{
 						Enabled: true,
 					},
-					FlinkJvmThreadsCount: MetricConfig{
+					FlinkJvmThreadsCount: FlinkJvmThreadsCountConfig{
 						Enabled: true,
 					},
-					FlinkMemoryManagedTotal: MetricConfig{
+					FlinkMemoryManagedTotal: FlinkMemoryManagedTotalConfig{
 						Enabled: true,
 					},
-					FlinkMemoryManagedUsed: MetricConfig{
+					FlinkMemoryManagedUsed: FlinkMemoryManagedUsedConfig{
 						Enabled: true,
 					},
-					FlinkOperatorRecordCount: MetricConfig{
-						Enabled: true,
+					FlinkOperatorRecordCount: FlinkOperatorRecordCountConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []FlinkOperatorRecordCountAttributeKey{FlinkOperatorRecordCountAttributeKeyOperatorName, FlinkOperatorRecordCountAttributeKeyRecord},
 					},
-					FlinkOperatorWatermarkOutput: MetricConfig{
-						Enabled: true,
+					FlinkOperatorWatermarkOutput: FlinkOperatorWatermarkOutputConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []FlinkOperatorWatermarkOutputAttributeKey{FlinkOperatorWatermarkOutputAttributeKeyOperatorName},
 					},
-					FlinkTaskRecordCount: MetricConfig{
+					FlinkTaskRecordCount: FlinkTaskRecordCountConfig{
 						Enabled: true,
 					},
 				},
@@ -128,91 +132,95 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					FlinkJobCheckpointCount: MetricConfig{
+					FlinkJobCheckpointCount: FlinkJobCheckpointCountConfig{
 						Enabled: false,
 					},
-					FlinkJobCheckpointInProgress: MetricConfig{
+					FlinkJobCheckpointInProgress: FlinkJobCheckpointInProgressConfig{
 						Enabled: false,
 					},
-					FlinkJobLastCheckpointSize: MetricConfig{
+					FlinkJobLastCheckpointSize: FlinkJobLastCheckpointSizeConfig{
 						Enabled: false,
 					},
-					FlinkJobLastCheckpointTime: MetricConfig{
+					FlinkJobLastCheckpointTime: FlinkJobLastCheckpointTimeConfig{
 						Enabled: false,
 					},
-					FlinkJobRestartCount: MetricConfig{
+					FlinkJobRestartCount: FlinkJobRestartCountConfig{
 						Enabled: false,
 					},
-					FlinkJvmClassLoaderClassesLoaded: MetricConfig{
+					FlinkJvmClassLoaderClassesLoaded: FlinkJvmClassLoaderClassesLoadedConfig{
 						Enabled: false,
 					},
-					FlinkJvmCPULoad: MetricConfig{
+					FlinkJvmCPULoad: FlinkJvmCPULoadConfig{
 						Enabled: false,
 					},
-					FlinkJvmCPUTime: MetricConfig{
+					FlinkJvmCPUTime: FlinkJvmCPUTimeConfig{
 						Enabled: false,
 					},
-					FlinkJvmGcCollectionsCount: MetricConfig{
+					FlinkJvmGcCollectionsCount: FlinkJvmGcCollectionsCountConfig{
 						Enabled: false,
 					},
-					FlinkJvmGcCollectionsTime: MetricConfig{
+					FlinkJvmGcCollectionsTime: FlinkJvmGcCollectionsTimeConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryDirectTotalCapacity: MetricConfig{
+					FlinkJvmMemoryDirectTotalCapacity: FlinkJvmMemoryDirectTotalCapacityConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryDirectUsed: MetricConfig{
+					FlinkJvmMemoryDirectUsed: FlinkJvmMemoryDirectUsedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryHeapCommitted: MetricConfig{
+					FlinkJvmMemoryHeapCommitted: FlinkJvmMemoryHeapCommittedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryHeapMax: MetricConfig{
+					FlinkJvmMemoryHeapMax: FlinkJvmMemoryHeapMaxConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryHeapUsed: MetricConfig{
+					FlinkJvmMemoryHeapUsed: FlinkJvmMemoryHeapUsedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryMappedTotalCapacity: MetricConfig{
+					FlinkJvmMemoryMappedTotalCapacity: FlinkJvmMemoryMappedTotalCapacityConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryMappedUsed: MetricConfig{
+					FlinkJvmMemoryMappedUsed: FlinkJvmMemoryMappedUsedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryMetaspaceCommitted: MetricConfig{
+					FlinkJvmMemoryMetaspaceCommitted: FlinkJvmMemoryMetaspaceCommittedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryMetaspaceMax: MetricConfig{
+					FlinkJvmMemoryMetaspaceMax: FlinkJvmMemoryMetaspaceMaxConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryMetaspaceUsed: MetricConfig{
+					FlinkJvmMemoryMetaspaceUsed: FlinkJvmMemoryMetaspaceUsedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryNonheapCommitted: MetricConfig{
+					FlinkJvmMemoryNonheapCommitted: FlinkJvmMemoryNonheapCommittedConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryNonheapMax: MetricConfig{
+					FlinkJvmMemoryNonheapMax: FlinkJvmMemoryNonheapMaxConfig{
 						Enabled: false,
 					},
-					FlinkJvmMemoryNonheapUsed: MetricConfig{
+					FlinkJvmMemoryNonheapUsed: FlinkJvmMemoryNonheapUsedConfig{
 						Enabled: false,
 					},
-					FlinkJvmThreadsCount: MetricConfig{
+					FlinkJvmThreadsCount: FlinkJvmThreadsCountConfig{
 						Enabled: false,
 					},
-					FlinkMemoryManagedTotal: MetricConfig{
+					FlinkMemoryManagedTotal: FlinkMemoryManagedTotalConfig{
 						Enabled: false,
 					},
-					FlinkMemoryManagedUsed: MetricConfig{
+					FlinkMemoryManagedUsed: FlinkMemoryManagedUsedConfig{
 						Enabled: false,
 					},
-					FlinkOperatorRecordCount: MetricConfig{
-						Enabled: false,
+					FlinkOperatorRecordCount: FlinkOperatorRecordCountConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []FlinkOperatorRecordCountAttributeKey{FlinkOperatorRecordCountAttributeKeyOperatorName, FlinkOperatorRecordCountAttributeKeyRecord},
 					},
-					FlinkOperatorWatermarkOutput: MetricConfig{
-						Enabled: false,
+					FlinkOperatorWatermarkOutput: FlinkOperatorWatermarkOutputConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []FlinkOperatorWatermarkOutputAttributeKey{FlinkOperatorWatermarkOutputAttributeKeyOperatorName},
 					},
-					FlinkTaskRecordCount: MetricConfig{
+					FlinkTaskRecordCount: FlinkTaskRecordCountConfig{
 						Enabled: false,
 					},
 				},
@@ -230,7 +238,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(FlinkJobCheckpointCountConfig{}, FlinkJobCheckpointInProgressConfig{}, FlinkJobLastCheckpointSizeConfig{}, FlinkJobLastCheckpointTimeConfig{}, FlinkJobRestartCountConfig{}, FlinkJvmClassLoaderClassesLoadedConfig{}, FlinkJvmCPULoadConfig{}, FlinkJvmCPUTimeConfig{}, FlinkJvmGcCollectionsCountConfig{}, FlinkJvmGcCollectionsTimeConfig{}, FlinkJvmMemoryDirectTotalCapacityConfig{}, FlinkJvmMemoryDirectUsedConfig{}, FlinkJvmMemoryHeapCommittedConfig{}, FlinkJvmMemoryHeapMaxConfig{}, FlinkJvmMemoryHeapUsedConfig{}, FlinkJvmMemoryMappedTotalCapacityConfig{}, FlinkJvmMemoryMappedUsedConfig{}, FlinkJvmMemoryMetaspaceCommittedConfig{}, FlinkJvmMemoryMetaspaceMaxConfig{}, FlinkJvmMemoryMetaspaceUsedConfig{}, FlinkJvmMemoryNonheapCommittedConfig{}, FlinkJvmMemoryNonheapMaxConfig{}, FlinkJvmMemoryNonheapUsedConfig{}, FlinkJvmThreadsCountConfig{}, FlinkMemoryManagedTotalConfig{}, FlinkMemoryManagedUsedConfig{}, FlinkOperatorRecordCountConfig{}, FlinkOperatorWatermarkOutputConfig{}, FlinkTaskRecordCountConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -12,6 +13,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeCheckpoint specifies the value checkpoint attribute.
@@ -231,9 +239,9 @@ type metricInfo struct {
 }
 
 type metricFlinkJobCheckpointCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   FlinkJobCheckpointCountConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills flink.job.checkpoint.count metric with initial data.
@@ -274,7 +282,7 @@ func (m *metricFlinkJobCheckpointCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJobCheckpointCount(cfg MetricConfig) metricFlinkJobCheckpointCount {
+func newMetricFlinkJobCheckpointCount(cfg FlinkJobCheckpointCountConfig) metricFlinkJobCheckpointCount {
 	m := metricFlinkJobCheckpointCount{config: cfg}
 
 	if cfg.Enabled {
@@ -285,9 +293,9 @@ func newMetricFlinkJobCheckpointCount(cfg MetricConfig) metricFlinkJobCheckpoint
 }
 
 type metricFlinkJobCheckpointInProgress struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   FlinkJobCheckpointInProgressConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills flink.job.checkpoint.in_progress metric with initial data.
@@ -326,7 +334,7 @@ func (m *metricFlinkJobCheckpointInProgress) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJobCheckpointInProgress(cfg MetricConfig) metricFlinkJobCheckpointInProgress {
+func newMetricFlinkJobCheckpointInProgress(cfg FlinkJobCheckpointInProgressConfig) metricFlinkJobCheckpointInProgress {
 	m := metricFlinkJobCheckpointInProgress{config: cfg}
 
 	if cfg.Enabled {
@@ -337,9 +345,9 @@ func newMetricFlinkJobCheckpointInProgress(cfg MetricConfig) metricFlinkJobCheck
 }
 
 type metricFlinkJobLastCheckpointSize struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   FlinkJobLastCheckpointSizeConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills flink.job.last_checkpoint.size metric with initial data.
@@ -378,7 +386,7 @@ func (m *metricFlinkJobLastCheckpointSize) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJobLastCheckpointSize(cfg MetricConfig) metricFlinkJobLastCheckpointSize {
+func newMetricFlinkJobLastCheckpointSize(cfg FlinkJobLastCheckpointSizeConfig) metricFlinkJobLastCheckpointSize {
 	m := metricFlinkJobLastCheckpointSize{config: cfg}
 
 	if cfg.Enabled {
@@ -389,9 +397,9 @@ func newMetricFlinkJobLastCheckpointSize(cfg MetricConfig) metricFlinkJobLastChe
 }
 
 type metricFlinkJobLastCheckpointTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   FlinkJobLastCheckpointTimeConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills flink.job.last_checkpoint.time metric with initial data.
@@ -428,7 +436,7 @@ func (m *metricFlinkJobLastCheckpointTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJobLastCheckpointTime(cfg MetricConfig) metricFlinkJobLastCheckpointTime {
+func newMetricFlinkJobLastCheckpointTime(cfg FlinkJobLastCheckpointTimeConfig) metricFlinkJobLastCheckpointTime {
 	m := metricFlinkJobLastCheckpointTime{config: cfg}
 
 	if cfg.Enabled {
@@ -439,9 +447,9 @@ func newMetricFlinkJobLastCheckpointTime(cfg MetricConfig) metricFlinkJobLastChe
 }
 
 type metricFlinkJobRestartCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   FlinkJobRestartCountConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills flink.job.restart.count metric with initial data.
@@ -480,7 +488,7 @@ func (m *metricFlinkJobRestartCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJobRestartCount(cfg MetricConfig) metricFlinkJobRestartCount {
+func newMetricFlinkJobRestartCount(cfg FlinkJobRestartCountConfig) metricFlinkJobRestartCount {
 	m := metricFlinkJobRestartCount{config: cfg}
 
 	if cfg.Enabled {
@@ -491,9 +499,9 @@ func newMetricFlinkJobRestartCount(cfg MetricConfig) metricFlinkJobRestartCount 
 }
 
 type metricFlinkJvmClassLoaderClassesLoaded struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   FlinkJvmClassLoaderClassesLoadedConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.class_loader.classes_loaded metric with initial data.
@@ -532,7 +540,7 @@ func (m *metricFlinkJvmClassLoaderClassesLoaded) emit(metrics pmetric.MetricSlic
 	}
 }
 
-func newMetricFlinkJvmClassLoaderClassesLoaded(cfg MetricConfig) metricFlinkJvmClassLoaderClassesLoaded {
+func newMetricFlinkJvmClassLoaderClassesLoaded(cfg FlinkJvmClassLoaderClassesLoadedConfig) metricFlinkJvmClassLoaderClassesLoaded {
 	m := metricFlinkJvmClassLoaderClassesLoaded{config: cfg}
 
 	if cfg.Enabled {
@@ -543,9 +551,9 @@ func newMetricFlinkJvmClassLoaderClassesLoaded(cfg MetricConfig) metricFlinkJvmC
 }
 
 type metricFlinkJvmCPULoad struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric        // data buffer for generated metric.
+	config   FlinkJvmCPULoadConfig // metric config provided by user.
+	capacity int                   // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.cpu.load metric with initial data.
@@ -582,7 +590,7 @@ func (m *metricFlinkJvmCPULoad) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmCPULoad(cfg MetricConfig) metricFlinkJvmCPULoad {
+func newMetricFlinkJvmCPULoad(cfg FlinkJvmCPULoadConfig) metricFlinkJvmCPULoad {
 	m := metricFlinkJvmCPULoad{config: cfg}
 
 	if cfg.Enabled {
@@ -593,9 +601,9 @@ func newMetricFlinkJvmCPULoad(cfg MetricConfig) metricFlinkJvmCPULoad {
 }
 
 type metricFlinkJvmCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric        // data buffer for generated metric.
+	config   FlinkJvmCPUTimeConfig // metric config provided by user.
+	capacity int                   // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.cpu.time metric with initial data.
@@ -634,7 +642,7 @@ func (m *metricFlinkJvmCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmCPUTime(cfg MetricConfig) metricFlinkJvmCPUTime {
+func newMetricFlinkJvmCPUTime(cfg FlinkJvmCPUTimeConfig) metricFlinkJvmCPUTime {
 	m := metricFlinkJvmCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -645,9 +653,9 @@ func newMetricFlinkJvmCPUTime(cfg MetricConfig) metricFlinkJvmCPUTime {
 }
 
 type metricFlinkJvmGcCollectionsCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   FlinkJvmGcCollectionsCountConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.gc.collections.count metric with initial data.
@@ -688,7 +696,7 @@ func (m *metricFlinkJvmGcCollectionsCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmGcCollectionsCount(cfg MetricConfig) metricFlinkJvmGcCollectionsCount {
+func newMetricFlinkJvmGcCollectionsCount(cfg FlinkJvmGcCollectionsCountConfig) metricFlinkJvmGcCollectionsCount {
 	m := metricFlinkJvmGcCollectionsCount{config: cfg}
 
 	if cfg.Enabled {
@@ -699,9 +707,9 @@ func newMetricFlinkJvmGcCollectionsCount(cfg MetricConfig) metricFlinkJvmGcColle
 }
 
 type metricFlinkJvmGcCollectionsTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   FlinkJvmGcCollectionsTimeConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.gc.collections.time metric with initial data.
@@ -742,7 +750,7 @@ func (m *metricFlinkJvmGcCollectionsTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmGcCollectionsTime(cfg MetricConfig) metricFlinkJvmGcCollectionsTime {
+func newMetricFlinkJvmGcCollectionsTime(cfg FlinkJvmGcCollectionsTimeConfig) metricFlinkJvmGcCollectionsTime {
 	m := metricFlinkJvmGcCollectionsTime{config: cfg}
 
 	if cfg.Enabled {
@@ -753,9 +761,9 @@ func newMetricFlinkJvmGcCollectionsTime(cfg MetricConfig) metricFlinkJvmGcCollec
 }
 
 type metricFlinkJvmMemoryDirectTotalCapacity struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   FlinkJvmMemoryDirectTotalCapacityConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.direct.total_capacity metric with initial data.
@@ -794,7 +802,7 @@ func (m *metricFlinkJvmMemoryDirectTotalCapacity) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricFlinkJvmMemoryDirectTotalCapacity(cfg MetricConfig) metricFlinkJvmMemoryDirectTotalCapacity {
+func newMetricFlinkJvmMemoryDirectTotalCapacity(cfg FlinkJvmMemoryDirectTotalCapacityConfig) metricFlinkJvmMemoryDirectTotalCapacity {
 	m := metricFlinkJvmMemoryDirectTotalCapacity{config: cfg}
 
 	if cfg.Enabled {
@@ -805,9 +813,9 @@ func newMetricFlinkJvmMemoryDirectTotalCapacity(cfg MetricConfig) metricFlinkJvm
 }
 
 type metricFlinkJvmMemoryDirectUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   FlinkJvmMemoryDirectUsedConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.direct.used metric with initial data.
@@ -846,7 +854,7 @@ func (m *metricFlinkJvmMemoryDirectUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryDirectUsed(cfg MetricConfig) metricFlinkJvmMemoryDirectUsed {
+func newMetricFlinkJvmMemoryDirectUsed(cfg FlinkJvmMemoryDirectUsedConfig) metricFlinkJvmMemoryDirectUsed {
 	m := metricFlinkJvmMemoryDirectUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -857,9 +865,9 @@ func newMetricFlinkJvmMemoryDirectUsed(cfg MetricConfig) metricFlinkJvmMemoryDir
 }
 
 type metricFlinkJvmMemoryHeapCommitted struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   FlinkJvmMemoryHeapCommittedConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.heap.committed metric with initial data.
@@ -898,7 +906,7 @@ func (m *metricFlinkJvmMemoryHeapCommitted) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryHeapCommitted(cfg MetricConfig) metricFlinkJvmMemoryHeapCommitted {
+func newMetricFlinkJvmMemoryHeapCommitted(cfg FlinkJvmMemoryHeapCommittedConfig) metricFlinkJvmMemoryHeapCommitted {
 	m := metricFlinkJvmMemoryHeapCommitted{config: cfg}
 
 	if cfg.Enabled {
@@ -909,9 +917,9 @@ func newMetricFlinkJvmMemoryHeapCommitted(cfg MetricConfig) metricFlinkJvmMemory
 }
 
 type metricFlinkJvmMemoryHeapMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric              // data buffer for generated metric.
+	config   FlinkJvmMemoryHeapMaxConfig // metric config provided by user.
+	capacity int                         // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.heap.max metric with initial data.
@@ -950,7 +958,7 @@ func (m *metricFlinkJvmMemoryHeapMax) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryHeapMax(cfg MetricConfig) metricFlinkJvmMemoryHeapMax {
+func newMetricFlinkJvmMemoryHeapMax(cfg FlinkJvmMemoryHeapMaxConfig) metricFlinkJvmMemoryHeapMax {
 	m := metricFlinkJvmMemoryHeapMax{config: cfg}
 
 	if cfg.Enabled {
@@ -961,9 +969,9 @@ func newMetricFlinkJvmMemoryHeapMax(cfg MetricConfig) metricFlinkJvmMemoryHeapMa
 }
 
 type metricFlinkJvmMemoryHeapUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   FlinkJvmMemoryHeapUsedConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.heap.used metric with initial data.
@@ -1002,7 +1010,7 @@ func (m *metricFlinkJvmMemoryHeapUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryHeapUsed(cfg MetricConfig) metricFlinkJvmMemoryHeapUsed {
+func newMetricFlinkJvmMemoryHeapUsed(cfg FlinkJvmMemoryHeapUsedConfig) metricFlinkJvmMemoryHeapUsed {
 	m := metricFlinkJvmMemoryHeapUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -1013,9 +1021,9 @@ func newMetricFlinkJvmMemoryHeapUsed(cfg MetricConfig) metricFlinkJvmMemoryHeapU
 }
 
 type metricFlinkJvmMemoryMappedTotalCapacity struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   FlinkJvmMemoryMappedTotalCapacityConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.mapped.total_capacity metric with initial data.
@@ -1054,7 +1062,7 @@ func (m *metricFlinkJvmMemoryMappedTotalCapacity) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricFlinkJvmMemoryMappedTotalCapacity(cfg MetricConfig) metricFlinkJvmMemoryMappedTotalCapacity {
+func newMetricFlinkJvmMemoryMappedTotalCapacity(cfg FlinkJvmMemoryMappedTotalCapacityConfig) metricFlinkJvmMemoryMappedTotalCapacity {
 	m := metricFlinkJvmMemoryMappedTotalCapacity{config: cfg}
 
 	if cfg.Enabled {
@@ -1065,9 +1073,9 @@ func newMetricFlinkJvmMemoryMappedTotalCapacity(cfg MetricConfig) metricFlinkJvm
 }
 
 type metricFlinkJvmMemoryMappedUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   FlinkJvmMemoryMappedUsedConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.mapped.used metric with initial data.
@@ -1106,7 +1114,7 @@ func (m *metricFlinkJvmMemoryMappedUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryMappedUsed(cfg MetricConfig) metricFlinkJvmMemoryMappedUsed {
+func newMetricFlinkJvmMemoryMappedUsed(cfg FlinkJvmMemoryMappedUsedConfig) metricFlinkJvmMemoryMappedUsed {
 	m := metricFlinkJvmMemoryMappedUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -1117,9 +1125,9 @@ func newMetricFlinkJvmMemoryMappedUsed(cfg MetricConfig) metricFlinkJvmMemoryMap
 }
 
 type metricFlinkJvmMemoryMetaspaceCommitted struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   FlinkJvmMemoryMetaspaceCommittedConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.metaspace.committed metric with initial data.
@@ -1158,7 +1166,7 @@ func (m *metricFlinkJvmMemoryMetaspaceCommitted) emit(metrics pmetric.MetricSlic
 	}
 }
 
-func newMetricFlinkJvmMemoryMetaspaceCommitted(cfg MetricConfig) metricFlinkJvmMemoryMetaspaceCommitted {
+func newMetricFlinkJvmMemoryMetaspaceCommitted(cfg FlinkJvmMemoryMetaspaceCommittedConfig) metricFlinkJvmMemoryMetaspaceCommitted {
 	m := metricFlinkJvmMemoryMetaspaceCommitted{config: cfg}
 
 	if cfg.Enabled {
@@ -1169,9 +1177,9 @@ func newMetricFlinkJvmMemoryMetaspaceCommitted(cfg MetricConfig) metricFlinkJvmM
 }
 
 type metricFlinkJvmMemoryMetaspaceMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   FlinkJvmMemoryMetaspaceMaxConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.metaspace.max metric with initial data.
@@ -1210,7 +1218,7 @@ func (m *metricFlinkJvmMemoryMetaspaceMax) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryMetaspaceMax(cfg MetricConfig) metricFlinkJvmMemoryMetaspaceMax {
+func newMetricFlinkJvmMemoryMetaspaceMax(cfg FlinkJvmMemoryMetaspaceMaxConfig) metricFlinkJvmMemoryMetaspaceMax {
 	m := metricFlinkJvmMemoryMetaspaceMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1221,9 +1229,9 @@ func newMetricFlinkJvmMemoryMetaspaceMax(cfg MetricConfig) metricFlinkJvmMemoryM
 }
 
 type metricFlinkJvmMemoryMetaspaceUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   FlinkJvmMemoryMetaspaceUsedConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.metaspace.used metric with initial data.
@@ -1262,7 +1270,7 @@ func (m *metricFlinkJvmMemoryMetaspaceUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryMetaspaceUsed(cfg MetricConfig) metricFlinkJvmMemoryMetaspaceUsed {
+func newMetricFlinkJvmMemoryMetaspaceUsed(cfg FlinkJvmMemoryMetaspaceUsedConfig) metricFlinkJvmMemoryMetaspaceUsed {
 	m := metricFlinkJvmMemoryMetaspaceUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -1273,9 +1281,9 @@ func newMetricFlinkJvmMemoryMetaspaceUsed(cfg MetricConfig) metricFlinkJvmMemory
 }
 
 type metricFlinkJvmMemoryNonheapCommitted struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   FlinkJvmMemoryNonheapCommittedConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.nonheap.committed metric with initial data.
@@ -1314,7 +1322,7 @@ func (m *metricFlinkJvmMemoryNonheapCommitted) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricFlinkJvmMemoryNonheapCommitted(cfg MetricConfig) metricFlinkJvmMemoryNonheapCommitted {
+func newMetricFlinkJvmMemoryNonheapCommitted(cfg FlinkJvmMemoryNonheapCommittedConfig) metricFlinkJvmMemoryNonheapCommitted {
 	m := metricFlinkJvmMemoryNonheapCommitted{config: cfg}
 
 	if cfg.Enabled {
@@ -1325,9 +1333,9 @@ func newMetricFlinkJvmMemoryNonheapCommitted(cfg MetricConfig) metricFlinkJvmMem
 }
 
 type metricFlinkJvmMemoryNonheapMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   FlinkJvmMemoryNonheapMaxConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.nonheap.max metric with initial data.
@@ -1366,7 +1374,7 @@ func (m *metricFlinkJvmMemoryNonheapMax) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryNonheapMax(cfg MetricConfig) metricFlinkJvmMemoryNonheapMax {
+func newMetricFlinkJvmMemoryNonheapMax(cfg FlinkJvmMemoryNonheapMaxConfig) metricFlinkJvmMemoryNonheapMax {
 	m := metricFlinkJvmMemoryNonheapMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1377,9 +1385,9 @@ func newMetricFlinkJvmMemoryNonheapMax(cfg MetricConfig) metricFlinkJvmMemoryNon
 }
 
 type metricFlinkJvmMemoryNonheapUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   FlinkJvmMemoryNonheapUsedConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.memory.nonheap.used metric with initial data.
@@ -1418,7 +1426,7 @@ func (m *metricFlinkJvmMemoryNonheapUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmMemoryNonheapUsed(cfg MetricConfig) metricFlinkJvmMemoryNonheapUsed {
+func newMetricFlinkJvmMemoryNonheapUsed(cfg FlinkJvmMemoryNonheapUsedConfig) metricFlinkJvmMemoryNonheapUsed {
 	m := metricFlinkJvmMemoryNonheapUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -1429,9 +1437,9 @@ func newMetricFlinkJvmMemoryNonheapUsed(cfg MetricConfig) metricFlinkJvmMemoryNo
 }
 
 type metricFlinkJvmThreadsCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   FlinkJvmThreadsCountConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills flink.jvm.threads.count metric with initial data.
@@ -1470,7 +1478,7 @@ func (m *metricFlinkJvmThreadsCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkJvmThreadsCount(cfg MetricConfig) metricFlinkJvmThreadsCount {
+func newMetricFlinkJvmThreadsCount(cfg FlinkJvmThreadsCountConfig) metricFlinkJvmThreadsCount {
 	m := metricFlinkJvmThreadsCount{config: cfg}
 
 	if cfg.Enabled {
@@ -1481,9 +1489,9 @@ func newMetricFlinkJvmThreadsCount(cfg MetricConfig) metricFlinkJvmThreadsCount 
 }
 
 type metricFlinkMemoryManagedTotal struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   FlinkMemoryManagedTotalConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills flink.memory.managed.total metric with initial data.
@@ -1522,7 +1530,7 @@ func (m *metricFlinkMemoryManagedTotal) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkMemoryManagedTotal(cfg MetricConfig) metricFlinkMemoryManagedTotal {
+func newMetricFlinkMemoryManagedTotal(cfg FlinkMemoryManagedTotalConfig) metricFlinkMemoryManagedTotal {
 	m := metricFlinkMemoryManagedTotal{config: cfg}
 
 	if cfg.Enabled {
@@ -1533,9 +1541,9 @@ func newMetricFlinkMemoryManagedTotal(cfg MetricConfig) metricFlinkMemoryManaged
 }
 
 type metricFlinkMemoryManagedUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   FlinkMemoryManagedUsedConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills flink.memory.managed.used metric with initial data.
@@ -1574,7 +1582,7 @@ func (m *metricFlinkMemoryManagedUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkMemoryManagedUsed(cfg MetricConfig) metricFlinkMemoryManagedUsed {
+func newMetricFlinkMemoryManagedUsed(cfg FlinkMemoryManagedUsedConfig) metricFlinkMemoryManagedUsed {
 	m := metricFlinkMemoryManagedUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -1585,9 +1593,10 @@ func newMetricFlinkMemoryManagedUsed(cfg MetricConfig) metricFlinkMemoryManagedU
 }
 
 type metricFlinkOperatorRecordCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        FlinkOperatorRecordCountConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills flink.operator.record.count metric with initial data.
@@ -1599,18 +1608,51 @@ func (m *metricFlinkOperatorRecordCount) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFlinkOperatorRecordCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operatorNameAttributeValue string, recordAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, FlinkOperatorRecordCountAttributeKeyOperatorName) {
+		dp.Attributes().PutStr("name", operatorNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, FlinkOperatorRecordCountAttributeKeyRecord) {
+		dp.Attributes().PutStr("record", recordAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("name", operatorNameAttributeValue)
-	dp.Attributes().PutStr("record", recordAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1623,13 +1665,18 @@ func (m *metricFlinkOperatorRecordCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkOperatorRecordCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkOperatorRecordCount(cfg MetricConfig) metricFlinkOperatorRecordCount {
+func newMetricFlinkOperatorRecordCount(cfg FlinkOperatorRecordCountConfig) metricFlinkOperatorRecordCount {
 	m := metricFlinkOperatorRecordCount{config: cfg}
 
 	if cfg.Enabled {
@@ -1640,9 +1687,10 @@ func newMetricFlinkOperatorRecordCount(cfg MetricConfig) metricFlinkOperatorReco
 }
 
 type metricFlinkOperatorWatermarkOutput struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        FlinkOperatorWatermarkOutputConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []int64                            // slice containing number of aggregated datapoints at each index
 }
 
 // init fills flink.operator.watermark.output metric with initial data.
@@ -1654,17 +1702,48 @@ func (m *metricFlinkOperatorWatermarkOutput) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFlinkOperatorWatermarkOutput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operatorNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, FlinkOperatorWatermarkOutputAttributeKeyOperatorName) {
+		dp.Attributes().PutStr("name", operatorNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("name", operatorNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1677,13 +1756,18 @@ func (m *metricFlinkOperatorWatermarkOutput) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkOperatorWatermarkOutput) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkOperatorWatermarkOutput(cfg MetricConfig) metricFlinkOperatorWatermarkOutput {
+func newMetricFlinkOperatorWatermarkOutput(cfg FlinkOperatorWatermarkOutputConfig) metricFlinkOperatorWatermarkOutput {
 	m := metricFlinkOperatorWatermarkOutput{config: cfg}
 
 	if cfg.Enabled {
@@ -1694,9 +1778,9 @@ func newMetricFlinkOperatorWatermarkOutput(cfg MetricConfig) metricFlinkOperator
 }
 
 type metricFlinkTaskRecordCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   FlinkTaskRecordCountConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills flink.task.record.count metric with initial data.
@@ -1737,7 +1821,7 @@ func (m *metricFlinkTaskRecordCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFlinkTaskRecordCount(cfg MetricConfig) metricFlinkTaskRecordCount {
+func newMetricFlinkTaskRecordCount(cfg FlinkTaskRecordCountConfig) metricFlinkTaskRecordCount {
 	m := metricFlinkTaskRecordCount{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,14 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["FlinkOperatorRecordCount"] = mb.metricFlinkOperatorRecordCount.config.AggregationStrategy
+			aggMap["FlinkOperatorWatermarkOutput"] = mb.metricFlinkOperatorWatermarkOutput.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -174,10 +185,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFlinkOperatorRecordCountDataPoint(ts, "1", "operator_name-val", AttributeRecordIn)
+			if tt.name == "reaggregate_set" {
+				mb.RecordFlinkOperatorRecordCountDataPoint(ts, "3", "operator_name-val-2", AttributeRecordIn)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFlinkOperatorWatermarkOutputDataPoint(ts, "1", "operator_name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFlinkOperatorWatermarkOutputDataPoint(ts, "3", "operator_name-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -192,6 +209,10 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetHostName("host.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricFlinkOperatorRecordCount.aggDataPoints)
+				assert.Empty(t, mb.metricFlinkOperatorWatermarkOutput.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -588,42 +609,98 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "flink.operator.record.count":
-					assert.False(t, validatedMetrics["flink.operator.record.count"], "Found a duplicate in the metrics slice: flink.operator.record.count")
-					validatedMetrics["flink.operator.record.count"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of records an operator has.", mi.Description())
-					assert.Equal(t, "{records}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("name")
-					assert.True(t, ok)
-					assert.Equal(t, "operator_name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("record")
-					assert.True(t, ok)
-					assert.Equal(t, "in", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["flink.operator.record.count"], "Found a duplicate in the metrics slice: flink.operator.record.count")
+						validatedMetrics["flink.operator.record.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of records an operator has.", mi.Description())
+						assert.Equal(t, "{records}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("name")
+						assert.True(t, ok)
+						assert.Equal(t, "operator_name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("record")
+						assert.True(t, ok)
+						assert.Equal(t, "in", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["flink.operator.record.count"], "Found a duplicate in the metrics slice: flink.operator.record.count")
+						validatedMetrics["flink.operator.record.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of records an operator has.", mi.Description())
+						assert.Equal(t, "{records}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["flink.operator.record.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("record")
+						assert.True(t, ok)
+					}
 				case "flink.operator.watermark.output":
-					assert.False(t, validatedMetrics["flink.operator.watermark.output"], "Found a duplicate in the metrics slice: flink.operator.watermark.output")
-					validatedMetrics["flink.operator.watermark.output"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The last watermark this operator has emitted.", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("name")
-					assert.True(t, ok)
-					assert.Equal(t, "operator_name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["flink.operator.watermark.output"], "Found a duplicate in the metrics slice: flink.operator.watermark.output")
+						validatedMetrics["flink.operator.watermark.output"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The last watermark this operator has emitted.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("name")
+						assert.True(t, ok)
+						assert.Equal(t, "operator_name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["flink.operator.watermark.output"], "Found a duplicate in the metrics slice: flink.operator.watermark.output")
+						validatedMetrics["flink.operator.watermark.output"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The last watermark this operator has emitted.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["flink.operator.watermark.output"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("name")
+						assert.False(t, ok)
+					}
 				case "flink.task.record.count":
 					assert.False(t, validatedMetrics["flink.task.record.count"], "Found a duplicate in the metrics slice: flink.task.record.count")
 					validatedMetrics["flink.task.record.count"] = true

--- a/receiver/flinkmetricsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/flinkmetricsreceiver/internal/metadata/testdata/config.yaml
@@ -55,8 +55,85 @@ all_set:
       enabled: true
     flink.operator.record.count:
       enabled: true
+      attributes: ["name","record"]
     flink.operator.watermark.output:
       enabled: true
+      attributes: ["name"]
+    flink.task.record.count:
+      enabled: true
+  resource_attributes:
+    flink.job.name:
+      enabled: true
+    flink.resource.type:
+      enabled: true
+    flink.subtask.index:
+      enabled: true
+    flink.task.name:
+      enabled: true
+    flink.taskmanager.id:
+      enabled: true
+    host.name:
+      enabled: true
+reaggregate_set:
+  metrics:
+    flink.job.checkpoint.count:
+      enabled: true
+    flink.job.checkpoint.in_progress:
+      enabled: true
+    flink.job.last_checkpoint.size:
+      enabled: true
+    flink.job.last_checkpoint.time:
+      enabled: true
+    flink.job.restart.count:
+      enabled: true
+    flink.jvm.class_loader.classes_loaded:
+      enabled: true
+    flink.jvm.cpu.load:
+      enabled: true
+    flink.jvm.cpu.time:
+      enabled: true
+    flink.jvm.gc.collections.count:
+      enabled: true
+    flink.jvm.gc.collections.time:
+      enabled: true
+    flink.jvm.memory.direct.total_capacity:
+      enabled: true
+    flink.jvm.memory.direct.used:
+      enabled: true
+    flink.jvm.memory.heap.committed:
+      enabled: true
+    flink.jvm.memory.heap.max:
+      enabled: true
+    flink.jvm.memory.heap.used:
+      enabled: true
+    flink.jvm.memory.mapped.total_capacity:
+      enabled: true
+    flink.jvm.memory.mapped.used:
+      enabled: true
+    flink.jvm.memory.metaspace.committed:
+      enabled: true
+    flink.jvm.memory.metaspace.max:
+      enabled: true
+    flink.jvm.memory.metaspace.used:
+      enabled: true
+    flink.jvm.memory.nonheap.committed:
+      enabled: true
+    flink.jvm.memory.nonheap.max:
+      enabled: true
+    flink.jvm.memory.nonheap.used:
+      enabled: true
+    flink.jvm.threads.count:
+      enabled: true
+    flink.memory.managed.total:
+      enabled: true
+    flink.memory.managed.used:
+      enabled: true
+    flink.operator.record.count:
+      enabled: true
+      attributes: ["record"]
+    flink.operator.watermark.output:
+      enabled: true
+      attributes: []
     flink.task.record.count:
       enabled: true
   resource_attributes:
@@ -128,8 +205,10 @@ none_set:
       enabled: false
     flink.operator.record.count:
       enabled: false
+      attributes: ["name","record"]
     flink.operator.watermark.output:
       enabled: false
+      attributes: ["name"]
     flink.task.record.count:
       enabled: false
   resource_attributes:

--- a/receiver/flinkmetricsreceiver/metadata.yaml
+++ b/receiver/flinkmetricsreceiver/metadata.yaml
@@ -14,6 +14,8 @@ status:
     active: [JonathanWamsley]
     seeking_new: true
 
+reaggregation_enabled: true
+
 resource_attributes:
   # These resource attributes are Flinks system scope variables, which contains context information about metrics. These are required to uniquely identify incoming metrics as the same job can run multiple times concurrently. See https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/ops/metrics/#system-scope for more information.
   flink.job.name:
@@ -47,19 +49,23 @@ attributes:
     description: The number of checkpoints completed or that failed.
     type: string
     enum: [completed, failed]
+    requirement_level: required
   garbage_collector_name:
     name_override: name
     description: The names for the parallel scavenge and garbage first garbage collectors.
     type: string
     enum: [PS_MarkSweep, PS_Scavenge, G1_Young_Generation, G1_Old_Generation]
+    requirement_level: required
   operator_name:
     name_override: name
     description: The operator name.
     type: string
+    requirement_level: recommended
   record:
     description: The number of records received in, sent out or dropped due to arriving late.
     type: string
     enum: [in, out, dropped]
+    requirement_level: required
 
 metrics:
   flink.job.checkpoint.count:


### PR DESCRIPTION
## Description
This PR enables re-aggregation for the `flinkmetrics` receiver by setting `reaggregation_enabled: true` and classifying all attributes with appropriate `requirement_level` values.

Attributes are classified as `required` where aggregation would produce meaningless results — `checkpoint` (completed vs failed are distinct states), `garbage_collector_name` (distinct GC implementations), and `record` (in/out/dropped are fundamentally different). `operator_name` is classified as `recommended` as aggregating across operators can still produce operationally meaningful totals.

## Link to tracking issue
Fixes #46356
Part of #45396

## Testing
Unit tests are passing