### PR TITLE
[chore] [cmd/schemagen] Exclude metadata schema check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,7 @@ clean:
 generate-gh-issue-templates:
 	$(GITHUBGEN) issue-templates
 
-SCHEMA_DIRS := $(shell find $(CURDIR) -path "*testdata*" -prune -o -name "config.schema.yaml" -exec dirname {} \; | sort -u)
+SCHEMA_DIRS := $(shell find $(CURDIR) -path "*testdata*" -prune -o -path "*internal/metadata/*" -prune -o -name "config.schema.yaml" -exec dirname {} \; | sort -u)
 
 .PHONY: generate-schemas
 generate-schemas:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Excluded `internal/metadata` directories from schema generation since it's now handled by mdatagen (change introduced in #14710)
