### PR TITLE
[exporter/kafka]Add merge ctx to preserve metadata keys post batching

### DIFF
--- a/.chloggen/kafka_exporter_preserve_metadata.yaml
+++ b/.chloggen/kafka_exporter_preserve_metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `MergeCtx` to preserve `include_metadata_keys` when batching is enabled.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46718]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -165,7 +165,9 @@ func exporterhelperOptions(
 	shutdownFunc component.ShutdownFunc,
 ) []exporterhelper.Option {
 	if len(cfg.IncludeMetadataKeys) > 0 {
-		qbs.Partitioner = metadataKeysPartitioner{keys: cfg.IncludeMetadataKeys}
+		partitioner := metadataKeysPartitioner{keys: cfg.IncludeMetadataKeys}
+		qbs.Partitioner = partitioner
+		qbs.MergeCtx = partitioner.MergeCtx
 	}
 	return []exporterhelper.Option{
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -38,3 +38,21 @@ func (p metadataKeysPartitioner) GetKey(
 	}
 	return kb.String()
 }
+
+func (p metadataKeysPartitioner) MergeCtx(
+	ctx1, ctx2 context.Context,
+) context.Context {
+	m1 := client.FromContext(ctx1).Metadata
+
+	m := make(map[string][]string, len(p.keys))
+	for _, key := range p.keys {
+		// We assume that both context's metadata will have the same
+		// value since we have defined the custom partitioner using
+		// the same keys.
+		m[key] = m1.Get(key)
+	}
+	return client.NewContext(
+		context.Background(),
+		client.Info{Metadata: client.NewMetadata(m)},
+	)
+}

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -45,11 +45,16 @@ func (p metadataKeysPartitioner) MergeCtx(
 	m1 := client.FromContext(ctx1).Metadata
 
 	m := make(map[string][]string, len(p.keys))
+
 	for _, key := range p.keys {
+		v := m1.Get(key)
+		if len(v) == 0 {
+			continue
+		}
 		// We assume that both context's metadata will have the same
 		// value since we have defined the custom partitioner using
 		// the same keys.
-		m[key] = m1.Get(key)
+		m[key] = v
 	}
 	return client.NewContext(
 		context.Background(),

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -40,7 +40,7 @@ func (p metadataKeysPartitioner) GetKey(
 }
 
 func (p metadataKeysPartitioner) MergeCtx(
-	ctx1, ctx2 context.Context,
+	ctx1, _ context.Context,
 ) context.Context {
 	m1 := client.FromContext(ctx1).Metadata
 

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -73,13 +73,13 @@ func TestMergeCtx(t *testing.T) {
 			name:         "preserves included metadata keys from first context",
 			metadataKeys: []string{"key1", "key2"},
 			ctx1Metadata: map[string][]string{
-				"key1":       {"val1"},
-				"key2":       {"val2.1", "val2.2"},
+				"key1":        {"val1"},
+				"key2":        {"val2.1", "val2.2"},
 				"ignored-key": {"ctx1"},
 			},
 			ctx2Metadata: map[string][]string{
-				"key1":       {"val1"},
-				"key2":       {"val2.1", "val2.2"},
+				"key1":        {"val1"},
+				"key2":        {"val2.1", "val2.2"},
 				"ignored-key": {"ctx2"},
 			},
 			expected: map[string][]string{

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -118,11 +118,11 @@ func TestMergeCtx(t *testing.T) {
 			metadataKeys: []string{"key1", "key2"},
 			ctx1Metadata: map[string][]string{
 				"key1": nil,
-				"key2": []string{},
+				"key2": {},
 			},
 			ctx2Metadata: map[string][]string{
 				"key1": nil,
-				"key2": []string{},
+				"key2": {},
 			},
 			expectedAbsent: []string{"key1", "key2"},
 		},

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -113,6 +113,19 @@ func TestMergeCtx(t *testing.T) {
 			},
 			expectedAbsent: []string{"key1"},
 		},
+		{
+			name:         "keys with empty values are ignored",
+			metadataKeys: []string{"key1", "key2"},
+			ctx1Metadata: map[string][]string{
+				"key1": nil,
+				"key2": []string{},
+			},
+			ctx2Metadata: map[string][]string{
+				"key1": nil,
+				"key2": []string{},
+			},
+			expectedAbsent: []string{"key1", "key2"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := metadataKeysPartitioner{keys: tc.metadataKeys}
@@ -131,7 +144,16 @@ func TestMergeCtx(t *testing.T) {
 				assert.Equal(t, expected, mergedMetadata.Get(key))
 			}
 			for _, key := range tc.expectedAbsent {
-				assert.Empty(t, mergedMetadata.Get(key))
+				for k := range mergedMetadata.Keys() {
+					if k == key {
+						assert.Failf(
+							t,
+							"failed to validate absent keys",
+							"key %s is expected to be absent from merged metadata",
+							key,
+						)
+					}
+				}
 			}
 		})
 	}

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -60,6 +60,83 @@ func TestGetKey(t *testing.T) {
 	}
 }
 
+func TestMergeCtx(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		metadataKeys   []string
+		ctx1Metadata   map[string][]string
+		ctx2Metadata   map[string][]string
+		expected       map[string][]string
+		expectedAbsent []string
+	}{
+		{
+			name:         "preserves included metadata keys from first context",
+			metadataKeys: []string{"key1", "key2"},
+			ctx1Metadata: map[string][]string{
+				"key1":       {"val1"},
+				"key2":       {"val2.1", "val2.2"},
+				"ignored-key": {"ctx1"},
+			},
+			ctx2Metadata: map[string][]string{
+				"key1":       {"val1"},
+				"key2":       {"val2.1", "val2.2"},
+				"ignored-key": {"ctx2"},
+			},
+			expected: map[string][]string{
+				"key1": {"val1"},
+				"key2": {"val2.1", "val2.2"},
+			},
+			expectedAbsent: []string{"ignored-key"},
+		},
+		{
+			name:         "keeps configured keys when some are missing",
+			metadataKeys: []string{"key1", "key404"},
+			ctx1Metadata: map[string][]string{
+				"key1": {"val1"},
+			},
+			ctx2Metadata: map[string][]string{
+				"key1": {"val1"},
+			},
+			expected: map[string][]string{
+				"key1":   {"val1"},
+				"key404": nil,
+			},
+		},
+		{
+			name:         "empty configured keys produce empty merged metadata",
+			metadataKeys: nil,
+			ctx1Metadata: map[string][]string{
+				"key1": {"val1"},
+			},
+			ctx2Metadata: map[string][]string{
+				"key1": {"val1"},
+			},
+			expectedAbsent: []string{"key1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := metadataKeysPartitioner{keys: tc.metadataKeys}
+
+			ctx1 := client.NewContext(t.Context(), client.Info{
+				Metadata: client.NewMetadata(tc.ctx1Metadata),
+			})
+			ctx2 := client.NewContext(t.Context(), client.Info{
+				Metadata: client.NewMetadata(tc.ctx2Metadata),
+			})
+
+			merged := p.MergeCtx(ctx1, ctx2)
+			mergedMetadata := client.FromContext(merged).Metadata
+
+			for key, expected := range tc.expected {
+				assert.Equal(t, expected, mergedMetadata.Get(key))
+			}
+			for _, key := range tc.expectedAbsent {
+				assert.Empty(t, mergedMetadata.Get(key))
+			}
+		})
+	}
+}
+
 func BenchmarkGetKey(b *testing.B) {
 	p := metadataKeysPartitioner{keys: []string{"key1", "key2"}}
 	ctx := client.NewContext(b.Context(), client.Info{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes client metadata keys defined by `include_metadata_keys` to persist if batching is enabled. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46718 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added test cases

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
