### PR TITLE
[receiver/macos_unified_logging] add deprecated_type and introduce new name

### DIFF
--- a/.chloggen/codeboten_dep-macos.yaml
+++ b/.chloggen/codeboten_dep-macos.yaml
@@ -1,0 +1,4 @@
+change_type: 'deprecation'
+component: receiver/macos_unified_logging
+note: Introduce new snake case compliant name `macos_unified_logging`
+issues: []

--- a/.chloggen/codeboten_dep-macos.yaml
+++ b/.chloggen/codeboten_dep-macos.yaml
@@ -1,4 +1,4 @@
 change_type: 'deprecation'
 component: receiver/macos_unified_logging
 note: Introduce new snake case compliant name `macos_unified_logging`
-issues: []
+issues: [46729]

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -281,7 +281,7 @@ components:
     - receiver/kubeletstats
     - receiver/libhoney
     - receiver/loki
-    - receiver/macosunifiedlogging
+    - receiver/macos_unified_logging
     - receiver/memcached
     - receiver/mongodb
     - receiver/mongodb_atlas

--- a/receiver/macosunifiedloggingreceiver/README.md
+++ b/receiver/macosunifiedloggingreceiver/README.md
@@ -11,7 +11,7 @@ supports both live system logs and archived log files (`.logarchive`).
 | Unsupported Platforms | linux, windows |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fmacosunifiedlogging%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fmacosunifiedlogging) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fmacosunifiedlogging%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fmacosunifiedlogging) |
-| Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=receiver_macosunifiedlogging)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=receiver_macosunifiedlogging&displayType=list) |
+| Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=receiver_macos_unified_logging)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=receiver_macos_unified_logging&displayType=list) |
 | [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Caleb-Hurshman](https://www.github.com/Caleb-Hurshman), [@atoulme](https://www.github.com/atoulme) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
@@ -53,7 +53,7 @@ This approach minimizes both latency during active logging and resource usage du
 
 ```yaml
 receivers:
-  macosunifiedlogging:
+  macos_unified_logging:
     max_poll_interval: 30s  # Maximum interval between polls (uses exponential backoff)
     max_log_age: 24h        # How far back to read on startup
 ```
@@ -62,7 +62,7 @@ receivers:
 
 ```yaml
 receivers:
-  macosunifiedlogging:
+  macos_unified_logging:
     archive_path: "/path/to/system_logs.logarchive"
     start_time: "2024-01-01 00:00:00"
     end_time: "2024-01-02 00:00:00"
@@ -72,7 +72,7 @@ receivers:
 
 ```yaml
 receivers:
-  macosunifiedlogging:
+  macos_unified_logging:
     archive_path: "/logs/**/*.logarchive"  # Matches all .logarchive directories recursively
     format: "ndjson"
 ```
@@ -82,7 +82,7 @@ receivers:
 
 ```yaml
 receivers:
-  macosunifiedlogging:
+  macos_unified_logging:
     archive_path: "./logs.logarchive"
     predicate: "subsystem == 'com.apple.systempreferences'"
 ```
@@ -91,7 +91,7 @@ receivers:
 
 ```yaml
 receivers:
-  macosunifiedlogging:
+  macos_unified_logging:
     format: ndjson             # Use structured JSON output
     max_poll_interval: 30s
     max_log_age: 24h
@@ -163,7 +163,7 @@ Complete example configuration:
 
 ```yaml
 receivers:
-  macosunifiedlogging:
+  macos_unified_logging:
     archive_path: "./system_logs.logarchive"
     predicate: "subsystem BEGINSWITH 'com.apple'"
     start_time: "2024-01-01 00:00:00"

--- a/receiver/macosunifiedloggingreceiver/factory_darwin.go
+++ b/receiver/macosunifiedloggingreceiver/factory_darwin.go
@@ -11,15 +11,17 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver/internal/metadata"
 )
 
 func newFactoryAdapter() receiver.Factory {
-	return receiver.NewFactory(
+	return xreceiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		receiver.WithLogs(createLogsReceiverDarwin, metadata.LogsStability),
+		xreceiver.WithLogs(createLogsReceiverDarwin, metadata.LogsStability),
+		xreceiver.WithDeprecatedTypeAlias(metadata.DeprecatedType),
 	)
 }
 

--- a/receiver/macosunifiedloggingreceiver/generated_component_test.go
+++ b/receiver/macosunifiedloggingreceiver/generated_component_test.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
-var typ = component.MustNewType("macosunifiedlogging")
+var typ = component.MustNewType("macos_unified_logging")
 
 func TestComponentFactoryType(t *testing.T) {
 	require.Equal(t, typ, NewFactory().Type())

--- a/receiver/macosunifiedloggingreceiver/go.mod
+++ b/receiver/macosunifiedloggingreceiver/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.53.1-0.20260306010043-a44ab254898b
 	go.opentelemetry.io/collector/receiver v1.53.1-0.20260306010043-a44ab254898b
 	go.opentelemetry.io/collector/receiver/receivertest v0.147.1-0.20260306010043-a44ab254898b
+	go.opentelemetry.io/collector/receiver/xreceiver v0.147.1-0.20260306010043-a44ab254898b
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )
@@ -43,7 +44,6 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.147.1-0.20260306010043-a44ab254898b // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.147.1-0.20260306010043-a44ab254898b // indirect
 	go.opentelemetry.io/collector/pipeline v1.53.1-0.20260306010043-a44ab254898b // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.147.1-0.20260306010043-a44ab254898b // indirect
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.41.0 // indirect

--- a/receiver/macosunifiedloggingreceiver/internal/metadata/generated_status.go
+++ b/receiver/macosunifiedloggingreceiver/internal/metadata/generated_status.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("macosunifiedlogging")
-	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver"
+	Type           = component.MustNewType("macos_unified_logging")
+	DeprecatedType = component.MustNewType("macosunifiedlogging")
+	ScopeName      = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver"
 )
 
 const (

--- a/receiver/macosunifiedloggingreceiver/metadata.yaml
+++ b/receiver/macosunifiedloggingreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: macOS Unified Logging Receiver
-type: macosunifiedlogging
+type: macos_unified_logging
+deprecated_type: macosunifiedlogging
 
 description: |
   The macOS Unified Logging Receiver collects logs from macOS systems using the native `log` command. This receiver

--- a/reports/distributions/contrib.yaml
+++ b/reports/distributions/contrib.yaml
@@ -180,7 +180,7 @@ components:
         - kubeletstats
         - libhoney
         - loki
-        - macosunifiedlogging
+        - macos_unified_logging
         - memcached
         - mongodb
         - mongodb_atlas


### PR DESCRIPTION
Following the lower snake case convention, part of #45339
