### PR TITLE
[chore] Move chloggen config staleness check out of changelog job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -187,6 +187,10 @@ jobs:
         run: |
           make generate-schemas
           git diff --exit-code '*.schema.yaml' || (echo 'Config schemas are out of date, please run "make generate-schemas" and commit the changes in this PR.' && exit 1)
+      - name: generate-chloggen-components
+        run: |
+          make generate-chloggen-components
+          git diff --exit-code || (echo '.chloggen/config.yaml is out of date, please run "make generate-chloggen-components" and commit the changes.' && exit 1)
   unittest-matrix:
     strategy:
       fail-fast: false

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -54,17 +54,6 @@ jobs:
             echo "CHANGELOG.md and CHANGELOG-API.md were not modified."
           fi
 
-      - name: Ensure changelog config.yaml is up to date
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
-        run: |
-          make generate-chloggen-components
-          if [[ $(git diff --name-only) ]]; then
-            echo ".chloggen/config.yaml is out of date. Please run 'make generate-chloggen-components' and commit the changes."
-            false
-          else
-            echo ".chloggen/config.yaml is up to date."
-          fi
-
       - name: Ensure ./.chloggen/*.yaml addition(s)
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |


### PR DESCRIPTION
The `generate-chloggen-components` check was living in the `changelog` job, which is skipped for PRs with the `Skip Changelog` label. This meant auto-generated PRs could merge with a stale `.chloggen/config.yaml`, causing the next unrelated PR to fail the check.

Move the check to the `checks` job in `build-and-test.yml`, which runs unconditionally on all PRs and merge queue entries.

Mirrors https://github.com/open-telemetry/opentelemetry-collector/pull/14726