### PR TITLE
[receiver/kafka]: deprecate built-in azure_resource_logs unmarshaler, redirect users to azure encoding extension

### DIFF
--- a/.chloggen/46267-kafkareceiver-azure-us-timestamp.yaml
+++ b/.chloggen/46267-kafkareceiver-azure-us-timestamp.yaml
@@ -1,0 +1,10 @@
+change_type: deprecation
+component: receiver/kafka
+note: Deprecate the built-in `azure_resource_logs` encoding in favour of `azureencodingextension`.
+issues: [46267]
+subtext: |
+  The built-in `azure_resource_logs` encoding does not support all timestamp formats
+  emitted by Azure services (e.g. US-format timestamps from Azure Functions).
+  Users should migrate to the [`azureencodingextension`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/azureencodingextension),
+  which provides full control over time formats and is actively maintained.
+change_logs: [user]

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -170,7 +170,7 @@ Available only for logs:
 - `raw`: the payload's bytes are inserted as the body of a log record.
 - `text`: the payload are decoded as text and inserted as the body of a log record. By default, it uses UTF-8 to decode. You can use `text_<ENCODING>`, like `text_utf-8`, `text_shift_jis`, etc., to customize this behavior.
 - `json`: the payload is decoded as JSON and inserted as the body of a log record.
-- `azure_resource_logs`: the payload is converted from Azure Resource Logs format to OTel format.
+- `azure_resource_logs` (Deprecated [v0.149.0]: use [`azureencodingextension`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/azureencodingextension)): the payload is converted from Azure Resource Logs format to OTel format.
 
 ### Message header propagation
 

--- a/receiver/kafkareceiver/encoding.go
+++ b/receiver/kafkareceiver/encoding.go
@@ -73,6 +73,7 @@ func newLogsUnmarshaler(encoding string, set receiver.Settings, host component.H
 	case "json":
 		return unmarshaler.JSONLogsUnmarshaler{}, nil
 	case "azure_resource_logs":
+		set.Logger.Warn("The azure_resource_logs encoding is deprecated. Please migrate to azureencodingextension.")
 		return &azure.ResourceLogsUnmarshaler{
 			Version: set.BuildInfo.Version,
 			Logger:  set.Logger,

--- a/receiver/kafkareceiver/encoding_test.go
+++ b/receiver/kafkareceiver/encoding_test.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/testdata"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/text/encoding/unicode"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
@@ -188,6 +190,18 @@ func TestNewLogsUnmarshalerTextEncoding(t *testing.T) {
 	u, err := newLogsUnmarshaler("text_invalid", settings, componenttest.NewNopHost())
 	require.EqualError(t, err, `invalid text encoding: unsupported encoding 'invalid'`)
 	assert.Nil(t, u)
+}
+
+func TestAzureResourceLogsDeprecationWarning(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(core)
+
+	_, err := newLogsUnmarshaler("azure_resource_logs", settings, componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, logs.Len())
+	assert.Contains(t, logs.All()[0].Message, "azure_resource_logs")
 }
 
 func TestNewMetricsUnmarshaler(t *testing.T) {


### PR DESCRIPTION
Fixes #46267

## Description

Following discussion with @axw, the preferred path for this issue is to deprecate the built-in `azure_resource_logs` encoding in the Kafka receiver (tracked for removal in #39113) and direct users to the [`azureencodingextension`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/azureencodingextension), which provides full control over time formats and is actively maintained.

This PR makes two changes:

1. **Deprecation notice in README** — marks `azure_resource_logs` as deprecated since v0.147.0 with a link to `azureencodingextension`.
2. **Runtime warning** — logs a `Warn`-level message at startup when `azure_resource_logs` is configured, so users are notified even if they haven't read the docs.

## Tests

Added `TestAzureResourceLogsDeprecationWarning` which uses an observed logger to assert that exactly one warning is emitted containing `"azure_resource_logs"` when the encoding is constructed.