### PR TITLE
[connector/servicegraph] Add `virtual_node_server_peer_attributes` to resolve virtual client node names

### DIFF
--- a/.chloggen/servicegraph-virtual-node-server-peer-attributes.yaml
+++ b/.chloggen/servicegraph-virtual-node-server-peer-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/servicegraph
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `virtual_node_server_peer_attributes` config to resolve virtual client node names from server span attributes instead of defaulting to "user".
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45397]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// VirtualNodePeerAttributes the list of attributes need to match, the higher the front, the higher the priority.
 	VirtualNodePeerAttributes []string `mapstructure:"virtual_node_peer_attributes"`
 
+	// VirtualNodeServerPeerAttributes the list of server span attributes need to match for virtual client node, the higher the front, the higher the priority.
+	VirtualNodeServerPeerAttributes []string `mapstructure:"virtual_node_server_peer_attributes"`
+
 	// VirtualNodeExtraLabel enables the `virtual_node` label to be added to the spans.
 	VirtualNodeExtraLabel bool `mapstructure:"virtual_node_extra_label"`
 

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -299,6 +299,10 @@ func (p *serviceGraphConnector) aggregateMetrics(ctx context.Context, td ptrace.
 						e.ServerLatencySec = spanDuration(span)
 						e.Failed = e.Failed || span.Status().Code() == ptrace.StatusCodeError
 						p.upsertDimensions(serverKind, e.Dimensions, rAttributes, span.Attributes())
+
+						if virtualNodeFeatureGate.IsEnabled() {
+							p.upsertPeerAttributes(p.config.VirtualNodeServerPeerAttributes, e.ServerPeer, span.Attributes())
+						}
 					})
 				default:
 					// this span is not part of an edge
@@ -364,10 +368,14 @@ func (p *serviceGraphConnector) onExpire(e *store.Edge) {
 
 	p.telemetryBuilder.ConnectorServicegraphExpiredEdges.Add(context.Background(), 1)
 
-	if virtualNodeFeatureGate.IsEnabled() && len(p.config.VirtualNodePeerAttributes) > 0 {
+	if virtualNodeFeatureGate.IsEnabled() && (len(p.config.VirtualNodePeerAttributes) > 0 || len(p.config.VirtualNodeServerPeerAttributes) > 0) {
 		e.ConnectionType = store.VirtualNode
 		if e.ClientService == "" && e.Key.SpanIDIsEmpty() {
-			e.ClientService = "user"
+			if len(p.config.VirtualNodeServerPeerAttributes) > 0 {
+				e.ClientService = p.getPeerHost(p.config.VirtualNodeServerPeerAttributes, e.ServerPeer)
+			} else {
+				e.ClientService = "user"
+			}
 			if p.config.VirtualNodeExtraLabel {
 				e.VirtualNodeLabel = store.ClientVirtualNode
 			}

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -792,6 +792,10 @@ func TestVirtualNodeClientFromServerPeerAttributes(t *testing.T) {
 	defer func() { require.NoError(t, conn.Shutdown(t.Context())) }()
 
 	require.NoError(t, conn.ConsumeTraces(t.Context(), traces))
+	if runtime.GOOS == "windows" {
+		// On Windows timing doesn't tick forward quickly for the store data to expire, force a wait before expiring.
+		time.Sleep(time.Second)
+	}
 	conn.store.Expire()
 	md, err := conn.buildMetrics()
 	require.NoError(t, err)

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -765,6 +765,44 @@ func TestVirtualNodeClientLabels(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVirtualNodeClientFromServerPeerAttributes(t *testing.T) {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "instrumented-server")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetTraceID([16]byte{0xa0})
+	span.SetSpanID([8]byte{0xb0})
+	span.SetKind(ptrace.SpanKindServer)
+	span.SetStartTimestamp(1_800_000_000_000_000_000)
+	span.SetEndTimestamp(1_800_000_000_000_001_000)
+	span.Attributes().PutStr("peer.service", "uninstrumented-client")
+
+	cfg := &Config{
+		Store:                           StoreConfig{MaxItems: 10, TTL: time.Nanosecond},
+		VirtualNodePeerAttributes:       []string{"peer.service"},
+		VirtualNodeServerPeerAttributes: []string{"peer.service"},
+		VirtualNodeExtraLabel:           true,
+	}
+
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	conn, err := newConnector(set, cfg, newMockMetricsExporter())
+	require.NoError(t, err)
+	require.NoError(t, conn.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, conn.Shutdown(t.Context())) }()
+
+	require.NoError(t, conn.ConsumeTraces(t.Context(), traces))
+	conn.store.Expire()
+	md, err := conn.buildMetrics()
+	require.NoError(t, err)
+	require.Equal(t, 3, md.MetricCount())
+
+	dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0)
+	clientAttr, ok := dp.Attributes().Get("client")
+	require.True(t, ok)
+	assert.Equal(t, "uninstrumented-client", clientAttr.Str())
+}
+
 func TestExponentialHistogram(t *testing.T) {
 	// Prepare
 	set := componenttest.NewNopTelemetrySettings()

--- a/connector/servicegraphconnector/internal/store/edge.go
+++ b/connector/servicegraphconnector/internal/store/edge.go
@@ -48,6 +48,9 @@ type Edge struct {
 	// Peer is a map of peer attributes to be used for virtual node matching
 	Peer map[string]string
 
+	// ServerPeer is a map of peer attributes from server spans to be used for virtual client node matching
+	ServerPeer map[string]string
+
 	// VirtualNodeLabel is an optional label to be added to the spans
 	VirtualNodeLabel VirtualNodeLabel
 }
@@ -58,6 +61,7 @@ func newEdge(key Key, ttl time.Duration) *Edge {
 		Dimensions: make(map[string]string),
 		expiration: time.Now().Add(ttl),
 		Peer:       make(map[string]string),
+		ServerPeer: make(map[string]string),
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
when only a server span exists (without a matching client span), the service graph connector was hardcoding the virtual client node name to `"user"` with no way to configure it.

this change adds a new `virtual_node_server_peer_attributes` config field that works similarly to the existing `virtual_node_peer_attributes`. it captures attributes from server spans and uses them to resolve the virtual client node name when an edge expires without a matching client span.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45397 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added `TestVirtualNodeClientFromServerPeerAttributes` regression test that sends a lone server span with `peer.service=uninstrumented-client`, configures `virtual_node_server_peer_attributes: [peer.service]` and asserts the virtual client label resolves to `uninstrumented-client` instead of `user`.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
