### PR TITLE
[chore] Make test tittles linkable for easier access from docs

### DIFF
--- a/docs/benchmarks/loadtests/index.html
+++ b/docs/benchmarks/loadtests/index.html
@@ -79,6 +79,7 @@
       width: 100%;
       display: flex;
       flex-direction: column;
+      scroll-margin-top: 1rem;
     }
 
     .benchmark-title {
@@ -99,6 +100,21 @@
 
     .benchmark-chart {
       max-width: 1000px;
+    }
+
+    .chart-title {
+      scroll-margin-top: 1rem;
+    }
+
+    .anchor-link {
+      color: #3273dc;
+      font-weight: normal;
+      text-decoration: none;
+      margin-left: 0.25rem;
+    }
+
+    .anchor-link:hover {
+      text-decoration: underline;
     }
 
     header nav {
@@ -179,6 +195,10 @@
   <script id="main-script">
     'use strict';
     (function () {
+      function toAnchorId(name) {
+        return String(name).trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'section';
+      }
+
       const COLORS = [
         "#48aaf9",
         "#8a3ef2",
@@ -252,7 +272,15 @@
 
         function renderGraph(parent, name, commitIds, byName) {
           const chartTitle = document.createElement('h3');
+          chartTitle.className = 'chart-title';
+          chartTitle.id = toAnchorId(name);
           chartTitle.textContent = name;
+          const anchorLink = document.createElement('a');
+          anchorLink.href = '#' + toAnchorId(name);
+          anchorLink.className = 'anchor-link';
+          anchorLink.textContent = ' #';
+          anchorLink.title = 'Link to this section';
+          chartTitle.appendChild(anchorLink);
           parent.append(chartTitle);
 
           const canvas = document.createElement('canvas');
@@ -340,6 +368,7 @@
         function renderBenchSet(name, benchSet, main) {
           const setElem = document.createElement('div');
           setElem.className = 'benchmark-set';
+          setElem.id = toAnchorId(name);
           main.appendChild(setElem);
 
           const graphsElem = document.createElement('div');


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR makes the test results' titles to be linkable so we can reference specific tests results directly from external pages, docs etc.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
This will be useful for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46422

<!--Describe what testing was performed and which tests were added.-->
#### Testing

The produced page now looks like this:
<img width="1293" height="819" alt="Screenshot 2026-03-09 at 3 29 07 PM" src="https://github.com/user-attachments/assets/3e658336-111b-4c26-86a2-d188b0fff336" />


AI Usage Disclaimer:
Cursor was used to update the html code, and the result was validated locally by loading the html page in the broswer.

