### PR TITLE
[extension/aws_logs_encoding] add deprecated_type and introduce new name

### DIFF
--- a/.chloggen/codeboten_dep-awslogsencoding.yaml
+++ b/.chloggen/codeboten_dep-awslogsencoding.yaml
@@ -1,4 +1,4 @@
 change_type: 'deprecation'
 component: extension/aws_logs_encoding
 note: Introduce new snake case compliant name `aws_logs_encoding`
-issues: []
+issues: [46776]

--- a/.chloggen/codeboten_dep-awslogsencoding.yaml
+++ b/.chloggen/codeboten_dep-awslogsencoding.yaml
@@ -1,0 +1,4 @@
+change_type: 'deprecation'
+component: extension/aws_logs_encoding
+note: Introduce new snake case compliant name `aws_logs_encoding`
+issues: []

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -79,8 +79,8 @@ components:
     - extension/ack
     - extension/asapclient
     - extension/avro_log_encoding
+    - extension/aws_logs_encoding
     - extension/awscloudwatchmetricstreams_encoding
-    - extension/awslogs_encoding
     - extension/awsproxy
     - extension/azure_auth
     - extension/azure_encoding

--- a/.chloggen/feat_aws-logs-cloudtrail-streaming.yaml
+++ b/.chloggen/feat_aws-logs-cloudtrail-streaming.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt streaming for CloudTrail signal

--- a/.chloggen/feat_aws-logs-cw-subscription-streaming.yaml
+++ b/.chloggen/feat_aws-logs-cw-subscription-streaming.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt encoding extension streaming contract for CloudWatch Logs subscription

--- a/.chloggen/feat_aws-logs-elb-streaming.yaml
+++ b/.chloggen/feat_aws-logs-elb-streaming.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt streaming for ELB signal

--- a/.chloggen/feat_aws-logs-network-fw-streaming.yaml
+++ b/.chloggen/feat_aws-logs-network-fw-streaming.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt streaming for Network Firewall logs

--- a/.chloggen/feat_aws-logs-s3-access-streaming.yaml
+++ b/.chloggen/feat_aws-logs-s3-access-streaming.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt streaming for S3 access logs

--- a/.chloggen/feat_aws-logs-vpc-flow-logs.yaml
+++ b/.chloggen/feat_aws-logs-vpc-flow-logs.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt encoding extension streaming contract for VPC flow logs

--- a/.chloggen/feat_aws-logs-waf-logs.yaml
+++ b/.chloggen/feat_aws-logs-waf-logs.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogs_encoding
+component: extension/aws_logs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Adopt encoding extension streaming contract for WAF logs

--- a/extension/encoding/awslogsencodingextension/factory.go
+++ b/extension/encoding/awslogsencodingextension/factory.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/xextension"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/constants"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/metadata"
@@ -15,11 +16,12 @@ import (
 )
 
 func NewFactory() extension.Factory {
-	return extension.NewFactory(
+	return xextension.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
 		createExtension,
 		metadata.ExtensionStability,
+		xextension.WithDeprecatedTypeAlias(metadata.DeprecatedType),
 	)
 }
 

--- a/extension/encoding/awslogsencodingextension/generated_component_test.go
+++ b/extension/encoding/awslogsencodingextension/generated_component_test.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/collector/extension/extensiontest"
 )
 
-var typ = component.MustNewType("awslogs_encoding")
+var typ = component.MustNewType("aws_logs_encoding")
 
 func TestComponentFactoryType(t *testing.T) {
 	require.Equal(t, typ, NewFactory().Type())

--- a/extension/encoding/awslogsencodingextension/go.mod
+++ b/extension/encoding/awslogsencodingextension/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/confmap/xconfmap v0.147.1-0.20260309153054-85fc1918516c
 	go.opentelemetry.io/collector/extension v1.53.1-0.20260309153054-85fc1918516c
 	go.opentelemetry.io/collector/extension/extensiontest v0.147.1-0.20260309153054-85fc1918516c
+	go.opentelemetry.io/collector/extension/xextension v0.147.1-0.20260309153054-85fc1918516c
 	go.opentelemetry.io/collector/featuregate v1.53.1-0.20260309153054-85fc1918516c
 	go.opentelemetry.io/collector/pdata v1.53.1-0.20260309153054-85fc1918516c
 	go.opentelemetry.io/otel v1.42.0

--- a/extension/encoding/awslogsencodingextension/go.sum
+++ b/extension/encoding/awslogsencodingextension/go.sum
@@ -71,6 +71,8 @@ go.opentelemetry.io/collector/extension v1.53.1-0.20260309153054-85fc1918516c h1
 go.opentelemetry.io/collector/extension v1.53.1-0.20260309153054-85fc1918516c/go.mod h1:lilKOXazlrnxCad5h1OWnt0ARTfcBaJUz9oL5cCN00A=
 go.opentelemetry.io/collector/extension/extensiontest v0.147.1-0.20260309153054-85fc1918516c h1:ZQvQHd8bEdhUQstDLnB552vWLIAwHf9WiFJMcuLLzxM=
 go.opentelemetry.io/collector/extension/extensiontest v0.147.1-0.20260309153054-85fc1918516c/go.mod h1:RPY6Odd01nJr3bERxqDZq/7uxdpn/g7G0R8iKk7yTOk=
+go.opentelemetry.io/collector/extension/xextension v0.147.1-0.20260309153054-85fc1918516c h1:iGk0A4cmIE0wlFKnOzzqzpOFsMXfdleD4WBmD7yTDLY=
+go.opentelemetry.io/collector/extension/xextension v0.147.1-0.20260309153054-85fc1918516c/go.mod h1:+D9ZkloMIsa8s5GTNogAUXE8K1kfHvwYImaLveAnxpE=
 go.opentelemetry.io/collector/featuregate v1.53.1-0.20260309153054-85fc1918516c h1:uZFpf4HTIi5a7Q4Vtk8OCUPAcJQO9EC5eQcCLgEQ5f0=
 go.opentelemetry.io/collector/featuregate v1.53.1-0.20260309153054-85fc1918516c/go.mod h1:PS7zY/zaCb28EqciePVwRHVhc3oKortTFXsi3I6ee4g=
 go.opentelemetry.io/collector/internal/componentalias v0.147.1-0.20260309153054-85fc1918516c h1:Lncm2NQHFlJqlgFz2NdV934xcIxJ/pkuYQNYlWIqhNQ=

--- a/extension/encoding/awslogsencodingextension/internal/metadata/generated_status.go
+++ b/extension/encoding/awslogsencodingextension/internal/metadata/generated_status.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("awslogs_encoding")
-	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension"
+	Type           = component.MustNewType("aws_logs_encoding")
+	DeprecatedType = component.MustNewType("awslogs_encoding")
+	ScopeName      = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension"
 )
 
 const (

--- a/extension/encoding/awslogsencodingextension/metadata.yaml
+++ b/extension/encoding/awslogsencodingextension/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: AWS Logs Encoding Extension
-type: awslogs_encoding
+type: aws_logs_encoding
+deprecated_type: awslogs_encoding
 
 description: This extension unmarshalls logs encoded in formats produced by AWS services.
 

--- a/extension/encoding/awslogsencodingextension/testdata/config.yaml
+++ b/extension/encoding/awslogsencodingextension/testdata/config.yaml
@@ -1,44 +1,44 @@
-awslogs_encoding:
+aws_logs_encoding:
 
-awslogs_encoding/cloudwatch:
+aws_logs_encoding/cloudwatch:
   format: cloudwatch
 
-awslogs_encoding/text_vpcflow:
+aws_logs_encoding/text_vpcflow:
   format: vpcflow
   vpcflow:
     file_format: plain-text
 
-awslogs_encoding/text_vpc_flow_log:
+aws_logs_encoding/text_vpc_flow_log:
   format: vpc_flow_log
   vpc_flow_log:
     file_format: plain-text
 
-awslogs_encoding/parquet_vpcflow:
+aws_logs_encoding/parquet_vpcflow:
   format: vpcflow
   vpcflow:
     file_format: parquet
 
-awslogs_encoding/invalid_vpcflow:
+aws_logs_encoding/invalid_vpcflow:
   format: vpcflow
   vpcflow:
     file_format: invalid
 
-awslogs_encoding/invalid_vpc_flow_log:
+aws_logs_encoding/invalid_vpc_flow_log:
   format: vpc_flow_log
   vpc_flow_log:
     file_format: invalid
 
-awslogs_encoding/s3access:
+aws_logs_encoding/s3access:
   format: s3access
 
-awslogs_encoding/waf:
+aws_logs_encoding/waf:
   format: waf
 
-awslogs_encoding/cloudtrail:
+aws_logs_encoding/cloudtrail:
   format: cloudtrail
 
-awslogs_encoding/elbaccess:
+aws_logs_encoding/elbaccess:
   format: elbaccess
 
-awslogs_encoding/networkfirewall:
+aws_logs_encoding/networkfirewall:
   format: networkfirewall

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -55,7 +55,7 @@ S3 events are handled in the following manner:
 - Download S3 object payload
 - Decode payload using the configured encoding extension
   - Default encoding: Preserve S3 object content as-is
-  - Custom encoding: Use specified encoding extension (for example, `awslogs_encoding` for AWS log formats)
+  - Custom encoding: Use specified encoding extension (for example, `aws_logs_encoding` for AWS log formats)
   - Metrics use `awscloudwatchmetricstreams_encoding` extension by default
 
 ### CloudWatch Logs subscription
@@ -66,7 +66,7 @@ CloudWatch Logs events are handled in the following manner:
 - Parse the CloudWatch Logs message (note - unlike S3 events, the payload is included in the event)
 - Decode payload using the configured encoding extension
   - Default encoding: Parse CloudWatch Logs messages to OpenTelemetry log records
-  - Custom encoding: Use specified encoding extension (for example, `awslogs_encoding` for AWS log formats)
+  - Custom encoding: Use specified encoding extension (for example, `aws_logs_encoding` for AWS log formats)
 
 ### Configurations
 
@@ -92,10 +92,10 @@ Given below are example configurations for various use cases.
 receivers:
   awslambda:
     s3:
-      encoding: awslogs_encoding
+      encoding: aws_logs_encoding
 
 extensions:
-  awslogs_encoding:
+  aws_logs_encoding:
     format: vpcflow
     vpcflow:
       file_format: plain-text
@@ -106,7 +106,7 @@ exporters:
 
 service:
   extensions:
-    - awslogs_encoding
+    - aws_logs_encoding
   pipelines:
     logs:
       receivers: [awslambda]
@@ -114,7 +114,7 @@ service:
 ```
 
 In this example, the `awslambdareceiver` is expected to be triggered when a VPC flow log is created at S3 bucket.
-The receiver retrieves the log file from S3 and decodes it using the `awslogs_encoding` extension with the `vpcflow` format.
+The receiver retrieves the log file from S3 and decodes it using the `aws_logs_encoding` extension with the `vpcflow` format.
 Parsed logs are forwarded to an OTLP listener via the `otlp_http` exporter.
 
 ### Example 2: ELB Access Logs from S3
@@ -123,10 +123,10 @@ Parsed logs are forwarded to an OTLP listener via the `otlp_http` exporter.
 receivers:
   awslambda:
     s3:
-      encoding: awslogs_encoding
+      encoding: aws_logs_encoding
 
 extensions:
-  awslogs_encoding:
+  aws_logs_encoding:
     format: elbaccess
     elbaccess:
       file_format: plain-text
@@ -137,7 +137,7 @@ exporters:
 
 service:
   extensions:
-    - awslogs_encoding
+    - aws_logs_encoding
   pipelines:
     logs:
       receivers: [awslambda]
@@ -233,7 +233,7 @@ To enable this feature, set the `failure_bucket_arn` configuration to the ARN of
 receivers:
   awslambda:
     s3:
-      encoding: awslogs_encoding
+      encoding: aws_logs_encoding
     failure_bucket_arn: "arn:aws:s3:::example"
 ```
 

--- a/receiver/awslambdareceiver/config_test.go
+++ b/receiver/awslambdareceiver/config_test.go
@@ -29,13 +29,13 @@ func TestLoadConfig(t *testing.T) {
 	}{
 		{
 			name:              "Config with both S3 and CloudWatch encoding",
-			componentIDToLoad: component.NewIDWithName(metadata.Type, "awslogs_encoding"),
+			componentIDToLoad: component.NewIDWithName(metadata.Type, "aws_logs_encoding"),
 			expected: &Config{
 				S3: sharedConfig{
-					Encoding: "awslogs_encoding",
+					Encoding: "aws_logs_encoding",
 				},
 				CloudWatch: sharedConfig{
-					Encoding: "awslogs_encoding",
+					Encoding: "aws_logs_encoding",
 				},
 			},
 		},

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -29,7 +29,7 @@ func TestCreateLogs(t *testing.T) {
 	// Create receiver using factory with S3 encoding config.
 	// Note: The S3Encoding value must match the component ID used when registering the extension.
 
-	s3Encoding := "awslogs_encoding"
+	s3Encoding := "aws_logs_encoding"
 
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)

--- a/receiver/awslambdareceiver/testdata/config.yaml
+++ b/receiver/awslambdareceiver/testdata/config.yaml
@@ -1,8 +1,8 @@
-awslambda/awslogs_encoding:
+awslambda/aws_logs_encoding:
   s3:
-    encoding: awslogs_encoding
+    encoding: aws_logs_encoding
   cloudwatch:
-    encoding: awslogs_encoding
+    encoding: aws_logs_encoding
 
 awslambda/json_log_encoding:
   s3:

--- a/reports/distributions/contrib.yaml
+++ b/reports/distributions/contrib.yaml
@@ -64,8 +64,8 @@ components:
     extension:
         - ack
         - asapclient
+        - aws_logs_encoding
         - awscloudwatchmetricstreams_encoding
-        - awslogs_encoding
         - awsproxy
         - azure_auth
         - basicauth


### PR DESCRIPTION
Following the lower snake case convention, part of #45339
