### PR TITLE
[receiver/mysql] strip leading sql comments before explain check

### DIFF
--- a/.chloggen/fix_mysqlreceiver-strip-leading-comments.yaml
+++ b/.chloggen/fix_mysqlreceiver-strip-leading-comments.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Strip leading SQL comments before EXPLAIN check so queries prefixed with block or line comments are correctly identified as explainable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46587]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -848,24 +848,24 @@ func isQueryExplainable(query string) bool {
 // and line comments (-- ...) from a query.
 func stripLeadingSQLComments(query string) string {
 	for {
-		if strings.HasPrefix(query, "/*") {
+		switch {
+		case strings.HasPrefix(query, "/*"):
 			end := strings.Index(query, "*/")
 			if end == -1 {
-				break
+				return query
 			}
 			query = strings.TrimSpace(query[end+2:])
-		} else if strings.HasPrefix(query, "--") {
+		case strings.HasPrefix(query, "--"):
 			end := strings.Index(query, "\n")
 			if end == -1 {
 				// remaining text is a comment
 				return ""
 			}
 			query = strings.TrimSpace(query[end+1:])
-		} else {
-			break
+		default:
+			return query
 		}
 	}
-	return query
 }
 
 func query(c mySQLClient, query string) (map[string]string, error) {

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -845,7 +845,7 @@ func isQueryExplainable(query string) bool {
 }
 
 // stripLeadingSQLComments removes leading block (/* ... */)
-// and line comments (-- ...) from a query.
+// and line comments (-- ... and # ...) from a query.
 func stripLeadingSQLComments(query string) string {
 	for {
 		switch {
@@ -855,7 +855,7 @@ func stripLeadingSQLComments(query string) string {
 				return query
 			}
 			query = strings.TrimSpace(query[end+2:])
-		case strings.HasPrefix(query, "--"):
+		case strings.HasPrefix(query, "--"), strings.HasPrefix(query, "#"):
 			end := strings.Index(query, "\n")
 			if end == -1 {
 				// remaining text is a comment

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -834,7 +834,7 @@ func isQueryExplainable(query string) bool {
 	}
 
 	trimmedQuery := strings.TrimSpace(query)
-	lowerQuery := strings.ToLower(trimmedQuery)
+	lowerQuery := strings.ToLower(stripLeadingSQLComments(trimmedQuery))
 
 	for _, keyword := range sqlStartingKeywords {
 		if strings.HasPrefix(lowerQuery, keyword) {
@@ -842,6 +842,30 @@ func isQueryExplainable(query string) bool {
 		}
 	}
 	return false
+}
+
+// stripLeadingSQLComments removes leading block (/* ... */)
+// and line comments (-- ...) from a query.
+func stripLeadingSQLComments(query string) string {
+	for {
+		if strings.HasPrefix(query, "/*") {
+			end := strings.Index(query, "*/")
+			if end == -1 {
+				break
+			}
+			query = strings.TrimSpace(query[end+2:])
+		} else if strings.HasPrefix(query, "--") {
+			end := strings.Index(query, "\n")
+			if end == -1 {
+				// remaining text is a comment
+				return ""
+			}
+			query = strings.TrimSpace(query[end+1:])
+		} else {
+			break
+		}
+	}
+	return query
 }
 
 func query(c mySQLClient, query string) (map[string]string, error) {

--- a/receiver/mysqlreceiver/client_test.go
+++ b/receiver/mysqlreceiver/client_test.go
@@ -82,15 +82,8 @@ func TestIsQueryExplainable(t *testing.T) {
 			input:    "SELECT * FROM very_long_table_na...",
 			expected: true, // still starts with SELECT
 		},
-		// Any leading block comment makes the query not explainable; digest_text
-		// from performance_schema does not include them, so this won't arise in practice.
-		{
-			name:     "leading block comment before SELECT is not explainable",
-			input:    "/* a comment */ SELECT * FROM t",
-			expected: false,
-		},
-
-		// Additional test cases for comment handling
+		// Leading comments (/* */, --, #) are stripped before checking the keyword,
+		// so queries with any leading comment are correctly identified as explainable.
 		// Block comments
 		{
 			name:     "block comment",
@@ -103,7 +96,7 @@ func TestIsQueryExplainable(t *testing.T) {
 			expected: true,
 		},
 
-		// Line comments
+		// Line comments with --
 		{
 			name:     "line comment",
 			input:    "-- comment\nSELECT * FROM t",
@@ -112,6 +105,18 @@ func TestIsQueryExplainable(t *testing.T) {
 		{
 			name:     "multiple line comments",
 			input:    "-- comment line1\n-- comment line2\nSELECT * FROM t",
+			expected: true,
+		},
+
+		// Line comments with #
+		{
+			name:     "hash comment",
+			input:    "# comment\nSELECT * FROM t",
+			expected: true,
+		},
+		{
+			name:     "multiple hash comments",
+			input:    "# comment line1\n# comment line2\nSELECT * FROM t",
 			expected: true,
 		},
 

--- a/receiver/mysqlreceiver/client_test.go
+++ b/receiver/mysqlreceiver/client_test.go
@@ -89,6 +89,50 @@ func TestIsQueryExplainable(t *testing.T) {
 			input:    "/* a comment */ SELECT * FROM t",
 			expected: false,
 		},
+
+		// Additional test cases for comment handling
+		// Block comments
+		{
+			name:     "block comment",
+			input:    "/* ApplicationName=DBeaver */ SELECT * FROM t",
+			expected: true,
+		},
+		{
+			name:     "multiple block comments",
+			input:    "/* comment1 */ /* comment2 */ SELECT * FROM t",
+			expected: true,
+		},
+
+		// Line comments
+		{
+			name:     "line comment",
+			input:    "-- comment\nSELECT * FROM t",
+			expected: true,
+		},
+		{
+			name:     "multiple line comments",
+			input:    "-- comment line1\n-- comment line2\nSELECT * FROM t",
+			expected: true,
+		},
+
+		// Mixed comments
+		{
+			name:     "mixed comments",
+			input:    "/* block */ -- line\nSELECT * FROM t",
+			expected: true,
+		},
+
+		// Others
+		{
+			name:     "comment only",
+			input:    "-- just a comment",
+			expected: false,
+		},
+		{
+			name:     "unclosed block comment",
+			input:    "/* unclosed comment SELECT * FROM t",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Description

Fixes an issue where EXPLAIN was skipped for queries starting with SQL comments. Some tools (e.g., DBeaver) prepend queries with comments like /* ApplicationName=... */, which caused isQueryExplainable to miss the actual SQL keyword.

This change strips leading block (/* ... */) and line (-- ...) comments before checking the query keyword, allowing EXPLAIN to run correctly.

Fixes #46587.

Testing

Added table-driven tests for isQueryExplainable, covering:
explainable queries (SELECT, DELETE, INSERT, REPLACE, UPDATE) and non explainable queries
Queries with block comments
Queries with line comments
Mixed comment cases
All tests pass locally.