### PR TITLE
[exporter/elasticsearch] Detect APM intake histograms by heuristic

### DIFF
--- a/.chloggen/es-exporter-poc-apm-histogram.yaml
+++ b/.chloggen/es-exporter-poc-apm-histogram.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Detect APM intake histograms for the ECS mapping mode using heuristic using processor.event attribute and equal-length bucket counts/bounds
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46831]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -172,6 +172,10 @@ behaviours, which may be configured through the following settings:
   - `mode` (DEPRECATED): The mapping mode if supplied via config file is ignored. Use the `X-Elastic-Mapping-Mode` client metadata key or the `elastic.mapping.mode` scope attribute instead. If not specified via these methods, the default mapping mode is `otel`.
   - `allowed_modes` (defaults to all mapping modes): A list of allowed mapping modes.
 
+In ECS mapping mode, histogram data points that originated from APM intake are detected by heuristic and their original bucket boundaries are preserved. Detection requires the `processor.event` attribute to equal `"metric"` and `len(bucket_counts) == len(explicit_bounds)` (no underflow/overflow buckets). When these conditions are met, explicit bounds map 1:1 to bucket counts with no midpoint interpolation. Otherwise, the standard OTel conversion applies:
+- If `len(bucket_counts) == len(explicit_bounds) + 1`, the exporter applies midpoint interpolation for bucket values.
+- Any other non-empty shape is treated as invalid and the data point is dropped with a validation error.
+
 The mapping mode can be controlled via the client metadata key `X-Elastic-Mapping-Mode`,
 e.g. via HTTP headers, gRPC metadata.
 

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -289,7 +289,7 @@ func (e *elasticsearchExporter) pushMetricsData(ctx context.Context, metrics pme
 						continue
 					}
 					for _, dp := range metric.Histogram().DataPoints().All() {
-						if err := upsertDataPoint(datapoints.NewHistogram(metric, dp)); err != nil {
+						if err := upsertDataPoint(datapoints.NewHistogram(metric, dp, mappingMode.String())); err != nil {
 							validationErrs = append(validationErrs, err)
 							continue
 						}

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram.go
@@ -15,14 +15,16 @@ import (
 type Histogram struct {
 	pmetric.HistogramDataPoint
 	elasticsearch.MappingHintGetter
-	metric pmetric.Metric
+	metric      pmetric.Metric
+	mappingMode string
 }
 
-func NewHistogram(metric pmetric.Metric, dp pmetric.HistogramDataPoint) Histogram {
+func NewHistogram(metric pmetric.Metric, dp pmetric.HistogramDataPoint, mappingMode string) Histogram {
 	return Histogram{
 		HistogramDataPoint: dp,
 		MappingHintGetter:  elasticsearch.NewMappingHintGetter(dp.Attributes()),
 		metric:             metric,
+		mappingMode:        mappingMode,
 	}
 }
 
@@ -34,7 +36,32 @@ func (dp Histogram) Value() (pcommon.Value, error) {
 		m.PutInt("value_count", safeUint64ToInt64(dp.Count()))
 		return vm, nil
 	}
+	if dp.shouldPreserveAPMIntakeBounds() {
+		return apmIntakeHistogramToValue(dp.HistogramDataPoint, dp.metric)
+	}
 	return histogramToValue(dp.HistogramDataPoint, dp.metric)
+}
+
+// shouldPreserveAPMIntakeBounds reports whether the histogram data point
+// originated from APM intake and should preserve its original bounds.
+// APM intake histograms have a 1:1 mapping between bucket counts and explicit
+// bounds (no underflow/overflow buckets), unlike standard OTel histograms
+// which have n+1 bucket counts for n explicit bounds.
+// Detection requires all of: "ecs" mapping mode, a "processor.event"
+// attribute equal to "metric", and equal-length bucket counts and bounds.
+func (dp Histogram) shouldPreserveAPMIntakeBounds() bool {
+	if dp.mappingMode != "ecs" {
+		return false
+	}
+
+	processorEvent, exists := dp.Attributes().Get("processor.event")
+	if !exists || processorEvent.Str() != "metric" {
+		return false
+	}
+
+	bucketCounts := dp.BucketCounts()
+	explicitBounds := dp.ExplicitBounds()
+	return bucketCounts.Len() > 0 && bucketCounts.Len() == explicitBounds.Len()
 }
 
 func (dp Histogram) DynamicTemplate(_ pmetric.Metric, mode DynamicTemplateMode) string {
@@ -44,7 +71,6 @@ func (dp Histogram) DynamicTemplate(_ pmetric.Metric, mode DynamicTemplateMode) 
 		}
 		return "histogram_metrics"
 	}
-
 	if dp.HasMappingHint(elasticsearch.HintAggregateMetricDouble) {
 		return "summary"
 	}
@@ -113,5 +139,42 @@ func histogramToValue(dp pmetric.HistogramDataPoint, metric pmetric.Metric) (pco
 		values.AppendEmpty().SetDouble(value)
 	}
 
+	return vm, nil
+}
+
+// apmIntakeHistogramToValue converts an APM intake histogram data point into
+// an Elasticsearch histogram value. Unlike histogramToValue, explicit bounds
+// map 1:1 to bucket counts with no midpoint interpolation, preserving the
+// original bucket boundaries produced by APM intake.
+func apmIntakeHistogramToValue(dp pmetric.HistogramDataPoint, metric pmetric.Metric) (pcommon.Value, error) {
+	bucketCounts := dp.BucketCounts()
+	explicitBounds := dp.ExplicitBounds()
+	if bucketCounts.Len() > 0 && bucketCounts.Len() != explicitBounds.Len() {
+		return pcommon.Value{}, fmt.Errorf("invalid apm intake histogram data point %q", metric.Name())
+	}
+
+	vm := pcommon.NewValueMap()
+	m := vm.Map()
+	counts := m.PutEmptySlice("counts")
+	values := m.PutEmptySlice("values")
+
+	if explicitBounds.Len() == 0 {
+		// It is possible for explicit bounds to be nil. In this case create
+		// a bucket using the count and sum which are required to be present.
+		// See https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
+		if dp.Count() > 0 {
+			counts.AppendEmpty().SetInt(safeUint64ToInt64(dp.Count()))
+			values.AppendEmpty().SetDouble(dp.Sum() / float64(dp.Count()))
+		}
+
+		return vm, nil
+	}
+
+	counts.EnsureCapacity(bucketCounts.Len())
+	values.EnsureCapacity(explicitBounds.Len())
+	for i, count := range bucketCounts.All() {
+		counts.AppendEmpty().SetInt(safeUint64ToInt64(count))
+		values.AppendEmpty().SetDouble(explicitBounds.At(i))
+	}
 	return vm, nil
 }

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
@@ -17,6 +17,8 @@ func TestHistogramValue(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		histogramDP pmetric.HistogramDataPoint
+		mappingMode string
+		wantErr     bool
 		expected    func(t *testing.T) pcommon.Value
 	}{
 		{
@@ -59,14 +61,79 @@ func TestHistogramValue(t *testing.T) {
 				return v
 			},
 		},
+		{
+			name: "default_midpoint_with_explicit_bounds",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				now := time.Now()
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.ExplicitBounds().FromRaw([]float64{10, 20, 30})
+				dp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				return dp
+			}(),
+			expected: func(t *testing.T) pcommon.Value {
+				t.Helper()
+				v := pcommon.NewValueMap()
+				require.NoError(t, v.FromRaw(map[string]any{
+					"counts": []any{1, 2, 3, 4},
+					"values": []any{5.0, 15.0, 25.0, 30.0},
+				}))
+				return v
+			},
+		},
+		{
+			name: "preserve_intake_histogram_values",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				now := time.Now()
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.SetCount(50)
+				dp.SetSum(3350)
+				dp.ExplicitBounds().FromRaw([]float64{10, 50, 100, 200})
+				dp.BucketCounts().FromRaw([]uint64{10, 25, 10, 5})
+				dp.Attributes().PutStr("processor.event", "metric")
+				return dp
+			}(),
+			mappingMode: "ecs",
+			expected: func(t *testing.T) pcommon.Value {
+				t.Helper()
+				v := pcommon.NewValueMap()
+				require.NoError(t, v.FromRaw(map[string]any{
+					"counts": []any{10, 25, 10, 5},
+					"values": []any{10.0, 50.0, 100.0, 200.0},
+				}))
+				return v
+			},
+		},
+		{
+			name: "preserve_intake_histogram_values_invalid_shape",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				now := time.Now()
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.ExplicitBounds().FromRaw([]float64{10, 50})
+				dp.BucketCounts().FromRaw([]uint64{10, 25, 10, 5})
+				dp.Attributes().PutStr("processor.event", "metric")
+				return dp
+			}(),
+			mappingMode: "ecs",
+			wantErr:     true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := pmetric.NewMetric()
 			m.SetName("test")
 			tc.histogramDP.MoveTo(m.SetEmptyHistogram().DataPoints().AppendEmpty())
 
-			esHist := NewHistogram(m, m.Histogram().DataPoints().At(0))
+			esHist := NewHistogram(m, m.Histogram().DataPoints().At(0), tc.mappingMode)
 			actual, err := esHist.Value()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			assert.True(t, tc.expected(t).Equal(actual))
 		})

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
@@ -4,6 +4,7 @@
 package datapoints // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/datapoints"
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -14,17 +15,17 @@ import (
 )
 
 func TestHistogramValue(t *testing.T) {
+	now := time.Now()
 	for _, tc := range []struct {
 		name        string
 		histogramDP pmetric.HistogramDataPoint
 		mappingMode string
-		wantErr     bool
+		expectedErr error
 		expected    func(t *testing.T) pcommon.Value
 	}{
 		{
 			name: "empty",
 			histogramDP: func() pmetric.HistogramDataPoint {
-				now := time.Now()
 				dp := pmetric.NewHistogramDataPoint()
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
@@ -43,7 +44,6 @@ func TestHistogramValue(t *testing.T) {
 		{
 			name: "required_fields_only",
 			histogramDP: func() pmetric.HistogramDataPoint {
-				now := time.Now()
 				dp := pmetric.NewHistogramDataPoint()
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
@@ -64,7 +64,6 @@ func TestHistogramValue(t *testing.T) {
 		{
 			name: "default_midpoint_with_explicit_bounds",
 			histogramDP: func() pmetric.HistogramDataPoint {
-				now := time.Now()
 				dp := pmetric.NewHistogramDataPoint()
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
@@ -85,7 +84,6 @@ func TestHistogramValue(t *testing.T) {
 		{
 			name: "preserve_intake_histogram_values",
 			histogramDP: func() pmetric.HistogramDataPoint {
-				now := time.Now()
 				dp := pmetric.NewHistogramDataPoint()
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
@@ -108,9 +106,49 @@ func TestHistogramValue(t *testing.T) {
 			},
 		},
 		{
-			name: "preserve_intake_histogram_values_invalid_shape",
+			name: "non_ecs_mode_falls_through_to_standard_validation",
 			histogramDP: func() pmetric.HistogramDataPoint {
-				now := time.Now()
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.ExplicitBounds().FromRaw([]float64{10, 50, 100, 200})
+				dp.BucketCounts().FromRaw([]uint64{10, 25, 10, 5})
+				dp.Attributes().PutStr("processor.event", "metric")
+				return dp
+			}(),
+			mappingMode: "otel",
+			expectedErr: fmt.Errorf("invalid histogram data point %q", "test"),
+		},
+		{
+			name: "ecs_mode_missing_processor_event_falls_through",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.ExplicitBounds().FromRaw([]float64{10, 50, 100, 200})
+				dp.BucketCounts().FromRaw([]uint64{10, 25, 10, 5})
+				return dp
+			}(),
+			mappingMode: "ecs",
+			expectedErr: fmt.Errorf("invalid histogram data point %q", "test"),
+		},
+		{
+			name: "ecs_mode_wrong_processor_event_falls_through",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.ExplicitBounds().FromRaw([]float64{10, 50, 100, 200})
+				dp.BucketCounts().FromRaw([]uint64{10, 25, 10, 5})
+				dp.Attributes().PutStr("processor.event", "transaction")
+				return dp
+			}(),
+			mappingMode: "ecs",
+			expectedErr: fmt.Errorf("invalid histogram data point %q", "test"),
+		},
+		{
+			name: "intake_histogram_values_invalid_shape",
+			histogramDP: func() pmetric.HistogramDataPoint {
 				dp := pmetric.NewHistogramDataPoint()
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
@@ -120,7 +158,7 @@ func TestHistogramValue(t *testing.T) {
 				return dp
 			}(),
 			mappingMode: "ecs",
-			wantErr:     true,
+			expectedErr: fmt.Errorf("invalid histogram data point %q", "test"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -130,8 +168,8 @@ func TestHistogramValue(t *testing.T) {
 
 			esHist := NewHistogram(m, m.Histogram().DataPoints().At(0), tc.mappingMode)
 			actual, err := esHist.Value()
-			if tc.wantErr {
-				require.Error(t, err)
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
 				return
 			}
 			require.NoError(t, err)

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -96,7 +96,7 @@ func TestDynamicTemplateMode(t *testing.T) {
 	}{
 		{m, datapoints.NewNumber(m, dp)},
 		{m2, datapoints.NewNumber(m2, dp2)},
-		{m3, datapoints.NewHistogram(m3, histDp)},
+		{m3, datapoints.NewHistogram(m3, histDp, "")},
 		{m4, datapoints.NewSummary(m4, summaryDp)},
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The goal of this PR it to update histogram encoding for the ECS mapping mode to preserve histogram bounds for events ingested by the r[eceiver/elasticapmintakereceiver](https://github.com/elastic/opentelemetry-collector-components/tree/main/receiver/elasticapmintakereceiver) to better match apm-data behavior.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
