### PR TITLE
[processor/deltatorate] Correctly transform unit of rates

### DIFF
--- a/.chloggen/mx-psi_unit-rates.yaml
+++ b/.chloggen/mx-psi_unit-rates.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/deltatorate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Append "/s" to the unit of output datapoints to reflect the per-second rate.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46841]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/deltatorateprocessor/processor.go
+++ b/processor/deltatorateprocessor/processor.go
@@ -75,6 +75,26 @@ func (dtrp *deltaToRateProcessor) processMetrics(_ context.Context, md pmetric.M
 
 				// Setting the data type removed all the data points, so we must move them back to the metric.
 				dataPointSlice.MoveAndAppendTo(metric.SetEmptyGauge().DataPoints())
+
+				if metric.Unit() != "" {
+					// Append "/s" to nonempty units to reflect the per-second rate.
+					// There are a couple of edge cases that could be considered here:
+					// 1. The unit could already end with "/s" or a different denominator unit.
+					// 2. The unit could be a time unit which would result in a scalar.
+					//
+					// There are two relevant rules in the UCUM specification that apply here:
+					//  a. UCUM 2.2. §7.2, https://ucum.org/ucum#section-Syntax-Rules
+					//    > Terms are evaluated from left to right with the period and the solidus
+					//    > having the same operator precedence. Multiple division operators are
+					//    > allowed within one term."
+					//  b. UCUM 2 §2.2 https://ucum.org/ucum#section-Grammar-of-Units-and-Unit-Terms
+					//    > Programs that declare full conformance [...] must detect equivalence
+					//    > for different expressions with the same meaning
+					//
+					//  This means that resulting expressions such as "m/s/s" or "ms/s" are valid UCUM
+					//  units and there is no need to simplify them to be compliant.
+					metric.SetUnit(metric.Unit() + "/s")
+				}
 			}
 		}
 	}

--- a/processor/deltatorateprocessor/processor_test.go
+++ b/processor/deltatorateprocessor/processor_test.go
@@ -24,6 +24,7 @@ type testMetric struct {
 	metricIntValues [][]int64
 	isDelta         []bool
 	deltaSecond     int
+	metricUnit      string
 }
 
 type deltaToRateTest struct {
@@ -108,6 +109,22 @@ var testCases = []deltaToRateTest{
 			metricValues: [][]float64{{1, 2, 3}, {3}},
 		}),
 	},
+	{
+		name:    "delta_to_rate_with_unit",
+		metrics: []string{"metric_1"},
+		inMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1"},
+			metricValues: [][]float64{{120}},
+			isDelta:      []bool{true},
+			deltaSecond:  120,
+			metricUnit:   "By",
+		}),
+		outMetrics: generateGaugeMetrics(testMetric{
+			metricNames:  []string{"metric_1"},
+			metricValues: [][]float64{{1}},
+			metricUnit:   "By/s",
+		}),
+	},
 }
 
 func TestCumulativeToDeltaProcessor(t *testing.T) {
@@ -150,6 +167,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				aM := actualMetrics.At(i)
 
 				require.Equal(t, eM.Name(), aM.Name())
+				require.Equal(t, eM.Unit(), aM.Unit())
 
 				if eM.Type() == pmetric.MetricTypeGauge {
 					eDataPoints := eM.Gauge().DataPoints()
@@ -189,6 +207,7 @@ func generateSumMetrics(tm testMetric) pmetric.Metrics {
 	for i, name := range tm.metricNames {
 		m := ms.AppendEmpty()
 		m.SetName(name)
+		m.SetUnit(tm.metricUnit)
 		sum := m.SetEmptySum()
 		sum.SetIsMonotonic(true)
 
@@ -228,6 +247,7 @@ func generateGaugeMetrics(tm testMetric) pmetric.Metrics {
 	for i, name := range tm.metricNames {
 		m := ms.AppendEmpty()
 		m.SetName(name)
+		m.SetUnit(tm.metricUnit)
 		dps := m.SetEmptyGauge().DataPoints()
 		if i < len(tm.metricValues) {
 			for _, value := range tm.metricValues[i] {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Since we are calculating a rate per second, we want the unit to be transformed to "original units" per second.
This PR appends `/s` to the unit of generated rates if the unit is set.

I argue this is compliant with [UCUM](https://ucum.org/ucum) (the unit spec [used by OpenTelemetry](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/metrics/v1/metrics.proto#L197-L199)) no matter what the original unit is, because (quoting the UCUM spec):

> The semantics of The Unified Code for Units of Measure implies equivalence classes such that different expressions may have the same meaning.

and

> Terms are evaluated from left to right with the period and the solidus having the same operator precedence. Multiple division operators are allowed within one term.

Therefore units like `m/s/s` or `ms/s` are valid UCUM units.

Since the unit may be missing, to avoid assuming the unit is "1" we don't add `/s` in that case.
