### PR TITLE
[exporter/awss3] Fix outdated StorageClass and ACL validation by using AWS SDK types

### DIFF
--- a/.chloggen/fix-awss3exporter-storage-class-acl-validation.yaml
+++ b/.chloggen/fix-awss3exporter-storage-class-acl-validation.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+component: exporter/awss3
+note: Use AWS SDK S3 types for StorageClass and ACL validation instead of hardcoded lists
+issues: [46825]
+subtext: |
+  The hardcoded list of valid S3 storage classes was missing GLACIER_IR, REDUCED_REDUNDANCY, and EXPRESS_ONEZONE.
+  Replaced both StorageClass and ACL hardcoded validation maps with values from the AWS SDK s3types package
+  to prevent this from going out of date again in the future.
+change_logs: [user]

--- a/exporter/awss3exporter/config.go
+++ b/exporter/awss3exporter/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"time"
 
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -104,23 +105,15 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	var errs error
-	validStorageClasses := map[string]bool{
-		"STANDARD":            true,
-		"STANDARD_IA":         true,
-		"ONEZONE_IA":          true,
-		"INTELLIGENT_TIERING": true,
-		"GLACIER":             true,
-		"DEEP_ARCHIVE":        true,
+
+	validStorageClasses := make(map[s3types.StorageClass]bool)
+	for _, sc := range s3types.StorageClassStandard.Values() {
+		validStorageClasses[sc] = true
 	}
 
-	validACLs := map[string]bool{
-		"private":                   true,
-		"public-read":               true,
-		"public-read-write":         true,
-		"authenticated-read":        true,
-		"aws-exec-read":             true,
-		"bucket-owner-read":         true,
-		"bucket-owner-full-control": true,
+	validACLs := make(map[s3types.ObjectCannedACL]bool)
+	for _, acl := range s3types.ObjectCannedACLPrivate.Values() {
+		validACLs[acl] = true
 	}
 
 	validUniqueKeyFuncs := map[string]bool{
@@ -134,11 +127,11 @@ func (c *Config) Validate() error {
 		errs = multierr.Append(errs, errors.New("bucket or endpoint is required"))
 	}
 
-	if !validStorageClasses[c.S3Uploader.StorageClass] {
+	if !validStorageClasses[s3types.StorageClass(c.S3Uploader.StorageClass)] {
 		errs = multierr.Append(errs, errors.New("invalid StorageClass"))
 	}
 
-	if c.S3Uploader.ACL != "" && !validACLs[c.S3Uploader.ACL] {
+	if c.S3Uploader.ACL != "" && !validACLs[s3types.ObjectCannedACL(c.S3Uploader.ACL)] {
 		errs = multierr.Append(errs, errors.New("invalid ACL"))
 	}
 

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -320,6 +320,50 @@ func TestConfig_Validate(t *testing.T) {
 			}(),
 			errExpected: errors.New("region is required"),
 		},
+		{
+			name: "valid storage class GLACIER_IR",
+			config: func() *Config {
+				c := createDefaultConfig().(*Config)
+				c.S3Uploader.Region = "us-east-1"
+				c.S3Uploader.S3Bucket = "mybucket"
+				c.S3Uploader.StorageClass = "GLACIER_IR"
+				return c
+			}(),
+			errExpected: nil,
+		},
+		{
+			name: "valid storage class REDUCED_REDUNDANCY",
+			config: func() *Config {
+				c := createDefaultConfig().(*Config)
+				c.S3Uploader.Region = "us-east-1"
+				c.S3Uploader.S3Bucket = "mybucket"
+				c.S3Uploader.StorageClass = "REDUCED_REDUNDANCY"
+				return c
+			}(),
+			errExpected: nil,
+		},
+		{
+			name: "valid storage class EXPRESS_ONEZONE",
+			config: func() *Config {
+				c := createDefaultConfig().(*Config)
+				c.S3Uploader.Region = "us-east-1"
+				c.S3Uploader.S3Bucket = "mybucket"
+				c.S3Uploader.StorageClass = "EXPRESS_ONEZONE"
+				return c
+			}(),
+			errExpected: nil,
+		},
+		{
+			name: "invalid storage class FAKE_CLASS",
+			config: func() *Config {
+				c := createDefaultConfig().(*Config)
+				c.S3Uploader.Region = "us-east-1"
+				c.S3Uploader.S3Bucket = "mybucket"
+				c.S3Uploader.StorageClass = "FAKE_CLASS"
+				return c
+			}(),
+			errExpected: errors.New("invalid StorageClass"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fixes #46825

### Problem

The `awss3exporter` config validation in `config.go` uses hardcoded maps to validate `StorageClass` and `ACL` values. The `StorageClass` allowlist was missing several valid AWS S3 storage classes:

| Storage Class | Status |
|---|---|
| `GLACIER_IR` |  Missing -- rejected as invalid |
| `REDUCED_REDUNDANCY` |  Missing -- rejected as invalid |
| `EXPRESS_ONEZONE` |  Missing -- rejected as invalid |

This caused users configuring any of these storage classes to receive the error:
```
Error: invalid configuration: exporters::awss3: invalid StorageClass
```

The same maintenance concern applies to the `ACL` validation map - while it happens to be complete today, it is equally susceptible to going stale if AWS introduces new canned ACL values in the future.

### Root Cause

The exporter treats `StorageClass` and `ACL` as **pass-through** values - the config string is cast directly to the corresponding AWS SDK type (`s3types.StorageClass` / `s3types.ObjectCannedACL`) and forwarded to the S3 API with no class-specific or ACL-specific logic. The hardcoded validation maps were therefore both redundant and incomplete.

### Fix

Replaced both hardcoded validation maps with dynamic lookups using the AWS SDK's own type values:

- `StorageClass`: now validated against `s3types.StorageClassStandard.Values()`
- `ACL`: now validated against `s3types.ObjectCannedACLPrivate.Values()`

This ensures validation stays in sync with the AWS SDK automatically, eliminating the need for manual updates when AWS introduces new storage classes or ACL types.

### Testing

- Added test cases to `TestConfig_Validate` for `GLACIER_IR`, `REDUCED_REDUNDANCY`, and `EXPRESS_ONEZONE` storage classes -- these **fail** against the old code and **pass** with the fix.
- Added a negative test case for a truly invalid storage class (`FAKE_CLASS`) to verify rejection still works correctly.

### Changes

| File | Change |
|---|---|
| `exporter/awss3exporter/config.go` | Replaced hardcoded `validStorageClasses` and `validACLs` maps with AWS SDK `.Values()` lookups |
| `exporter/awss3exporter/config_test.go` | Added test cases for missing storage classes and invalid class rejection |
| `.chloggen/fix-awss3exporter-storage-class-acl-validation.yaml` | Changelog entry |