### PR TITLE
[processor/k8sattributes]: fix otel annotations attribute priority

### DIFF
--- a/.chloggen/fix_k8s-attributes-otel-annotation.yaml
+++ b/.chloggen/fix_k8s-attributes-otel-annotation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/k8s_attributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: correctly handle OpenTelemetry annotations attribute priority in k8s_attributes processor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46849]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -1040,6 +1040,16 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 		copyLabel(pod, tags, "app.kubernetes.io/version", conventions.ServiceVersionKey)
 	}
 
+	if c.Rules.OtelAnnotations {
+		r := OtelAnnotations()
+		if !disableLegacy {
+			r.extractFromPodMetadata(pod.Annotations, tags, K8SPodAnnotations)
+		}
+		if enableStable {
+			r.extractFromPodMetadata(pod.Annotations, tags, conventions.K8SPodAnnotation)
+		}
+	}
+
 	return tags
 }
 
@@ -1137,7 +1147,7 @@ func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Po
 		transformedPod.Labels = maps.Clone(pod.Labels)
 	}
 
-	if len(rules.Annotations) > 0 {
+	if len(rules.Annotations) > 0 || rules.OtelAnnotations {
 		transformedPod.Annotations = maps.Clone(pod.Annotations)
 	}
 
@@ -1234,7 +1244,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 			container.Name = containerName
 		}
 		if c.Rules.ServiceInstanceID {
-			container.ServiceInstanceID = automaticServiceInstanceID(pod, containerName)
+			container.ServiceInstanceID = automaticServiceInstanceID(c.Rules.OtelAnnotations, pod, containerName)
 		}
 		containerID := apiStatus.ContainerID
 		// Remove container runtime prefix
@@ -1970,7 +1980,12 @@ func ignoreDeletedFinalStateUnknown(obj any) any {
 	return obj
 }
 
-func automaticServiceInstanceID(pod *api_v1.Pod, containerName string) string {
+func automaticServiceInstanceID(enableOtelAnnotations bool, pod *api_v1.Pod, containerName string) string {
+	if enableOtelAnnotations {
+		if val, ok := pod.Annotations["resource.opentelemetry.io/service.instance.id"]; ok {
+			return val
+		}
+	}
 	resNames := []string{pod.Namespace, pod.Name, containerName}
 	return strings.Join(resNames, ".")
 }

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -711,7 +711,8 @@ func TestExtractionRules(t *testing.T) {
 		ServiceName:       true,
 		ServiceVersion:    true,
 		ServiceInstanceID: true,
-		Annotations:       []FieldExtractionRule{OtelAnnotations()},
+		OtelAnnotations:   true,
+		Annotations:       []FieldExtractionRule{},
 	}
 
 	testCases := []struct {
@@ -1093,8 +1094,29 @@ func TestExtractionRules(t *testing.T) {
 			},
 		},
 		{
+			name:  "service-attributes-annotation",
+			rules: serviceRules,
+			additionalAnnotations: map[string]string{
+				"resource.opentelemetry.io/service.instance.id": "annotation-id",
+				"resource.opentelemetry.io/service.version":     "annotation-version",
+				"resource.opentelemetry.io/service.name":        "annotation-service",
+				"resource.opentelemetry.io/service.namespace":   "annotation-namespace",
+			},
+			attributes: map[string]string{
+				"service.instance.id": "annotation-id",
+				"service.name":        "annotation-service",
+				"service.version":     "annotation-version",
+				"service.namespace":   "annotation-namespace",
+			},
+		},
+		{
 			name:  "service-attributes-annotation-override",
 			rules: serviceRules,
+			additionalLabels: map[string]string{
+				"app.kubernetes.io/instance": "instance-service",
+				"app.kubernetes.io/name":     "label-service",
+				"app.kubernetes.io/version":  "label-version",
+			},
 			additionalAnnotations: map[string]string{
 				"resource.opentelemetry.io/service.instance.id": "annotation-id",
 				"resource.opentelemetry.io/service.version":     "annotation-version",
@@ -2436,6 +2458,9 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				"resource.opentelemetry.io/service.instance.id": "annotation-id",
+			},
 		},
 		Spec: api_v1.PodSpec{
 			Containers: []api_v1.Container{
@@ -2533,6 +2558,31 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 					"container2":     {ServiceInstanceID: "test-namespace.test-pod.container2", ServiceVersion: "sha256:430ac608abaa332de4ce45d68534447c7a206edc5e98aaff9923ecc12f8a80d9"},
 					"container3":     {ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0@sha256:4b0b1b6f6cdd3e5b9e55f74a1e8d19ed93a3f5a04c6b6c3c57c4e6d19f6b7c4d"},
 					"init_container": {ServiceInstanceID: "test-namespace.test-pod.init_container"},
+				},
+			},
+		},
+		{
+			name: "automatic-container-level-attributes-otel-annotation-override",
+			rules: ExtractionRules{
+				ServiceNamespace:  true,
+				ServiceName:       true,
+				ServiceVersion:    true,
+				ServiceInstanceID: true,
+				OtelAnnotations:   true,
+			},
+			pod: &pod,
+			want: PodContainers{
+				ByID: map[string]*Container{
+					"container1-id-123":     {ServiceInstanceID: "annotation-id", ServiceVersion: "0.1.0"},
+					"container2-id-456":     {ServiceInstanceID: "annotation-id", ServiceVersion: "sha256:430ac608abaa332de4ce45d68534447c7a206edc5e98aaff9923ecc12f8a80d9"},
+					"container3-id-abc":     {ServiceInstanceID: "annotation-id", ServiceVersion: "1.0@sha256:4b0b1b6f6cdd3e5b9e55f74a1e8d19ed93a3f5a04c6b6c3c57c4e6d19f6b7c4d"},
+					"init-container-id-789": {ServiceInstanceID: "annotation-id"},
+				},
+				ByName: map[string]*Container{
+					"container1":     {ServiceInstanceID: "annotation-id", ServiceVersion: "0.1.0"},
+					"container2":     {ServiceInstanceID: "annotation-id", ServiceVersion: "sha256:430ac608abaa332de4ce45d68534447c7a206edc5e98aaff9923ecc12f8a80d9"},
+					"container3":     {ServiceInstanceID: "annotation-id", ServiceVersion: "1.0@sha256:4b0b1b6f6cdd3e5b9e55f74a1e8d19ed93a3f5a04c6b6c3c57c4e6d19f6b7c4d"},
+					"init_container": {ServiceInstanceID: "annotation-id"},
 				},
 			},
 		},

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -259,6 +259,7 @@ type ExtractionRules struct {
 
 	Annotations                  []FieldExtractionRule
 	Labels                       []FieldExtractionRule
+	OtelAnnotations              bool
 	DeploymentNameFromReplicaSet bool
 }
 

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -224,7 +224,7 @@ func withExtractMetadata(fields ...string) option {
 func withOtelAnnotations(enabled bool) option {
 	return func(p *kubernetesprocessor) error {
 		if enabled {
-			p.rules.Annotations = append(p.rules.Annotations, kube.OtelAnnotations())
+			p.rules.OtelAnnotations = true
 		}
 		return nil
 	}

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -787,14 +787,6 @@ func TestOtelAnnotations(t *testing.T) {
 		{
 			name:    "with otel annotations",
 			enabled: true,
-			wantAnnotations: []kube.FieldExtractionRule{
-				{
-					Name:                 "$1",
-					KeyRegex:             regexp.MustCompile(`^resource\.opentelemetry\.io/(.+)$`),
-					HasKeyRegexReference: true,
-					From:                 kube.MetadataFromPod,
-				},
-			},
 		},
 	}
 	for _, tt := range tests {
@@ -803,7 +795,7 @@ func TestOtelAnnotations(t *testing.T) {
 			rules := withOtelAnnotations(tt.enabled)
 			err := rules(&p)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantAnnotations, p.rules.Annotations)
+			assert.Equal(t, tt.enabled, p.rules.OtelAnnotations)
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

According to the [semconv](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/), the `resource.opentelemetry.io/*` pod annotations should have the highest priority for configuring the `service.namespace`, `service.name`, `service.version` and `service.instance.id` attributes. However, in the current logic the values from the [well-known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) will override the ones coming from the `resource.opentelemetry.io/*` pod annotations. This PR fixes this and includes unit tests to ensure the pod annotations will have the highest priority.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests to ensure the otel attributes have higher priority than the well-known labels.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
