### PR TITLE
fix(datadogreceiver): preserve original per-span attribute

### DIFF
--- a/.chloggen/fix-datadogreceiver-preserve-span-service-name.yaml
+++ b/.chloggen/fix-datadogreceiver-preserve-span-service-name.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: receiver/datadog
+note: Preserve original per-span service name when `_dd.base_service` overrides the resource-level service name, so the DD exporter can recover it on the DD-to-OTEL-to-DD roundtrip path.
+issues: [1909]
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -267,6 +267,9 @@ func ToTraces(logger *zap.Logger, payload *pb.TracerPayload, req *http.Request, 
 			// Restore base service name as the service name.
 			// Without this, internal spans such as postgresql queries have a service.name set to postgresql
 			if val, ok := span.Meta["_dd.base_service"]; ok {
+				// Preserve original per-span service name so the DD exporter
+				// can recover it via span-level service.name precedence
+				span.Meta["service.name"] = span.Service
 				span.Service = val
 			}
 			slice, exist := groupByService[span.Service]

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -344,6 +344,198 @@ func TestToTracesServiceName(t *testing.T) {
 	}
 }
 
+// TestToTracesBaseServicePreservesPerSpanServiceName verifies the DD→OTEL→DD
+// roundtrip path for spans that have a dedicated per-span service name (e.g.,
+// database child spans like "defaultdb" or "postgresql") together with a
+// _dd.base_service override. Without the fix, the original per-span service
+// name is lost because span.Service is overwritten by _dd.base_service and
+// nothing preserves the original value as a span attribute.
+func TestToTracesBaseServicePreservesPerSpanServiceName(t *testing.T) {
+	cases := []struct {
+		name                        string
+		spans                       []pb.Span
+		expectedResourceServiceName string
+		// expectedSpanServiceNames maps span name → expected span-level service.name attribute.
+		// This is the value the DD exporter uses to recover the original per-span service.
+		expectedSpanServiceNames map[string]string
+	}{
+		{
+			name: "postgresql-child-with-dedicated-service",
+			spans: []pb.Span{
+				{
+					Name:     "web.request",
+					Service:  "my-app",
+					TraceID:  1,
+					SpanID:   1,
+					ParentID: 0,
+					Meta: map[string]string{
+						"http.method": "GET",
+						"http.route":  "/api/users",
+					},
+				},
+				{
+					Name:     "postgresql.query",
+					Service:  "defaultdb",
+					TraceID:  1,
+					SpanID:   2,
+					ParentID: 1,
+					Meta: map[string]string{
+						"_dd.base_service": "my-app",
+						"db.type":          "postgresql",
+						"db.operation":     "select",
+						"db.instance":      "pg_users",
+						"span.kind":        "client",
+					},
+				},
+			},
+			expectedResourceServiceName: "my-app",
+			expectedSpanServiceNames: map[string]string{
+				"select pg_users": "defaultdb",
+			},
+		},
+		{
+			name: "postgresql-child-with-insert-operation",
+			spans: []pb.Span{
+				{
+					Name:     "web.request",
+					Service:  "my-app",
+					TraceID:  2,
+					SpanID:   10,
+					ParentID: 0,
+					Meta: map[string]string{
+						"http.method": "POST",
+						"http.route":  "/api/orders",
+					},
+				},
+				{
+					Name:     "postgresql.query",
+					Service:  "orders-db",
+					TraceID:  2,
+					SpanID:   11,
+					ParentID: 10,
+					Meta: map[string]string{
+						"_dd.base_service": "my-app",
+						"db.type":          "postgresql",
+						"db.operation":     "insert",
+						"db.instance":      "orders",
+						"span.kind":        "client",
+					},
+				},
+			},
+			expectedResourceServiceName: "my-app",
+			expectedSpanServiceNames: map[string]string{
+				"insert orders": "orders-db",
+			},
+		},
+		{
+			name: "multiple-db-children-different-services",
+			spans: []pb.Span{
+				{
+					Name:     "web.request",
+					Service:  "my-app",
+					TraceID:  3,
+					SpanID:   100,
+					ParentID: 0,
+					Meta: map[string]string{
+						"http.method": "GET",
+						"http.route":  "/dashboard",
+					},
+				},
+				{
+					Name:     "postgresql.query",
+					Service:  "defaultdb",
+					TraceID:  3,
+					SpanID:   101,
+					ParentID: 100,
+					Meta: map[string]string{
+						"_dd.base_service": "my-app",
+						"db.type":          "postgresql",
+						"db.operation":     "select",
+						"db.instance":      "analytics",
+						"span.kind":        "client",
+					},
+				},
+				{
+					Name:     "redis.query",
+					Service:  "redis-cache",
+					TraceID:  3,
+					SpanID:   102,
+					ParentID: 100,
+					Meta: map[string]string{
+						"_dd.base_service": "my-app",
+						"db.type":          "redis",
+						"span.kind":        "client",
+					},
+				},
+			},
+			expectedResourceServiceName: "my-app",
+			expectedSpanServiceNames: map[string]string{
+				"select analytics": "defaultdb",
+				"redis":            "redis-cache",
+			},
+		},
+		{
+			name: "span-without-base-service-has-no-span-level-service-name",
+			spans: []pb.Span{
+				{
+					Name:     "web.request",
+					Service:  "my-app",
+					TraceID:  4,
+					SpanID:   200,
+					ParentID: 0,
+					Meta: map[string]string{
+						"http.method": "GET",
+						"http.route":  "/health",
+					},
+				},
+			},
+			expectedResourceServiceName: "my-app",
+			// No span should have a span-level service.name injected
+			expectedSpanServiceNames: map[string]string{},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := &pb.TracerPayload{
+				LanguageName:    "go",
+				LanguageVersion: "1.20",
+				TracerVersion:   "v1",
+				Chunks:          traceChunksFromSpans(tt.spans),
+			}
+
+			req := &http.Request{
+				Header: http.Header{},
+			}
+			req.Header.Set(header.Lang, "go")
+
+			traces, err := ToTraces(zap.NewNop(), payload, req, nil)
+			require.NoError(t, err)
+
+			for _, rs := range traces.ResourceSpans().All() {
+				actualServiceName, ok := rs.Resource().Attributes().Get("service.name")
+				assert.True(t, ok, "resource should have service.name")
+				assert.Equal(t, tt.expectedResourceServiceName, actualServiceName.AsString())
+
+				for _, ss := range rs.ScopeSpans().All() {
+					for _, span := range ss.Spans().All() {
+						expectedPerSpanSvc, shouldHaveAttr := tt.expectedSpanServiceNames[span.Name()]
+						val, exists := span.Attributes().Get("service.name")
+						if shouldHaveAttr {
+							if assert.True(t, exists, "span %q should have span-level service.name attribute", span.Name()) {
+								assert.Equal(t, expectedPerSpanSvc, val.AsString(),
+									"span %q: per-span service.name should preserve the original dedicated service name", span.Name())
+							}
+						} else {
+							assert.False(t, exists, "span %q should not have a span-level service.name attribute", span.Name())
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestToTraces(t *testing.T) {
 	cases := []struct {
 		name                   string


### PR DESCRIPTION
#### Description

This is to fix an issue with spans like db / sql ones not showing the override name (i.e. testdb) that would display when doing through the DD agent directly prior to routing through a shared OTEL collector like Alloy

Why this works end-to-end:

1. `span.Meta` entries become span attributes in the OTEL conversion (`newSpan.Attributes().PutStr(k, v)`)
2. `span.Service` (after override) becomes the resource-level `service.name` via `groupByService` which satisfies OTEL's resource model
3. The DD exporter's OTelSpanAccessor checks span attributes before resource attributes, so `span.Meta["service.name"]` (the original per-span service) takes precedence over the resource-level base service

No config flags needed, no language-specific heuristics, no groupbyattrs. The original service name roundtrips cleanly through DD→OTEL→DD. Works for all tracers and all languages.

Currently, we get around this with something like this in the Alloy config. The Alloy datadog exporter just natively uses primitives here and that's what led me to this change.
```
	trace_statements {
		context    = "span"
		statements = [
			`set(attributes["server.address"], attributes["http.server_name"]) where attributes["http.server_name"] != nil and attributes["server.address"] == nil`,
			`set(attributes["peer.service"], Concat([attributes["django.db.alias"], "db"], "")) where attributes["django.db.alias"] != nil`,
			`set(attributes["base_service"], attributes["service.name"]) where attributes["django.db.alias"] != nil`,
			`set(attributes["_dd.base_service"], attributes["service.name"]) where attributes["django.db.alias"] != nil`,
			`set(attributes["service.name"], attributes["peer.service"]) where attributes["django.db.alias"] != nil`,
		]
	}

	trace_statements {
		context    = "span"
		statements = [
			// Outbound calls (DB, cache, HTTP client) have server.address set by DD trace libs
			`set(span.kind, SPAN_KIND_CLIENT) where instrumentation_scope.name == "datadog" and span.kind == SPAN_KIND_UNSPECIFIED and attributes["server.address"] != nil`,
			// Inbound request handlers have http.route set by DD trace libs
			`set(span.kind, SPAN_KIND_SERVER) where instrumentation_scope.name == "datadog" and span.kind == SPAN_KIND_UNSPECIFIED and attributes["http.route"] != nil`,
		]
	}
```

#### Link to tracking issue

Related to - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1909
