### PR TITLE
[pkg/datadog][exporter/datadog] Move feature gate to pkg/datadog

### DIFF
--- a/.chloggen/mx-psi_expose-infer-delta-fg.yaml
+++ b/.chloggen/mx-psi_expose-infer-delta-fg.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose feature gate to infer intervals for delta metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/mx-psi_expose-infer-delta-fg.yaml
+++ b/.chloggen/mx-psi_expose-infer-delta-fg.yaml
@@ -10,7 +10,7 @@ component: pkg/datadog
 note: Expose feature gate to infer intervals for delta metrics.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [46851]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -72,12 +72,6 @@ var metricExportSerializerClientFeatureGate = featuregate.GlobalRegistry().MustR
 	featuregate.WithRegisterDescription("When enabled, metric export in datadogexporter uses the serializer exporter from the Datadog Agent."),
 )
 
-var inferIntervalDeltaFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"exporter.datadogexporter.InferIntervalForDeltaMetrics",
-	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("When enabled, the exporter will infer the metrics interval for OTLP delta sums using a heuristic."),
-)
-
 func init() {
 	log.SetupLogger(log.Disabled(), "off")
 }

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -78,7 +78,7 @@ func newMetricsExporter(
 		options = append(options, otlpmetrics.WithRemapping())
 	}
 
-	if inferIntervalDeltaFeatureGate.IsEnabled() {
+	if featuregates.InferIntervalDeltaFeatureGate.IsEnabled() {
 		params.Logger.Info("Metrics interval will be inferred for OTLP delta metrics with a set StartTimestamp.")
 		options = append(options, otlpmetrics.WithInferDeltaInterval())
 	}

--- a/pkg/datadog/featuregates/featuregates.go
+++ b/pkg/datadog/featuregates/featuregates.go
@@ -44,3 +44,10 @@ var AttributeSliceMultiTagExportingFeatureGate = featuregate.GlobalRegistry().Mu
 	featuregate.WithRegisterFromVersion("v0.142.0"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44859"),
 )
+
+// InferIntervalDeltaFeatureGate is a feature gate that enables inferring the metrics interval for OTLP delta sums
+var InferIntervalDeltaFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.datadogexporter.InferIntervalForDeltaMetrics",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, the exporter will infer the metrics interval for OTLP delta sums using a heuristic."),
+)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Expose `exporter.datadogexporter.InferIntervalForDeltaMetric` feature gate on `pkg/datadog` for external use.