### PR TITLE
skip other tests to speed up runs while debugging

### DIFF
--- a/testbed/tests/batcher_test.go
+++ b/testbed/tests/batcher_test.go
@@ -31,7 +31,8 @@ type batcherTestSpec struct {
 	extensions          map[string]string
 }
 
-func TestLog10kDPSNoProcessors(t *testing.T) {
+// skipTestLog10kDPSNoProcessors temporarily disabled for CI debugging - rename to TestLog10kDPSNoProcessors to re-enable.
+func skipTestLog10kDPSNoProcessors(t *testing.T) {
 	tests := []batcherTestSpec{
 		{
 			name: "No batching, no queue",
@@ -130,7 +131,8 @@ func TestLog10kDPSNoProcessors(t *testing.T) {
 	}
 }
 
-func TestLog10kDPSWithProcessors(t *testing.T) {
+// skipTestLog10kDPSWithProcessors temporarily disabled for CI debugging - rename to TestLog10kDPSWithProcessors to re-enable.
+func skipTestLog10kDPSWithProcessors(t *testing.T) {
 	processors := []ProcessorNameAndConfigBody{
 		{
 			Name: "filter",

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
-func TestIdleMode(t *testing.T) {
+// skipTestIdleMode temporarily disabled for CI debugging - rename to TestIdleMode to re-enable.
+func skipTestIdleMode(t *testing.T) {
 	options := testbed.LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 	dataProvider := testbed.NewPerfTestDataProvider(options)
 

--- a/testbed/tests/k8sattributes_processor_test.go
+++ b/testbed/tests/k8sattributes_processor_test.go
@@ -393,8 +393,8 @@ func setupKWOKCluster(t *testing.T, numPods int) (kubeconfigPath, podUID string,
 // TestMetricK8sAttributesProcessor tests the k8sattributes processor's
 // performance and resource utilization when the component
 // is used to collect k8s metadata from a test k8s cluster
-// with 100 number of nodes, N number of Pods controlled by
-// each own Deployment/Replicaset, while there are also N number of Namespaces
+// with 100 number of nodes, N number of Pods each controlled by
+// its own Deployment/Replicaset, while there are also N number of Namespaces
 func TestMetricK8sAttributesProcessor(t *testing.T) {
 	tests := getK8sAttributesProcessorTestCases()
 

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -21,7 +21,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
-func TestLog10kDPS(t *testing.T) {
+// skipTestLog10kDPS temporarily disabled for CI debugging - rename to TestLog10kDPS to re-enable.
+func skipTestLog10kDPS(t *testing.T) {
 	tests := []struct {
 		name         string
 		sender       testbed.DataSender
@@ -185,7 +186,8 @@ func TestLog10kDPS(t *testing.T) {
 	}
 }
 
-func TestLogOtlpSendingQueue(t *testing.T) {
+// skipTestLogOtlpSendingQueue temporarily disabled for CI debugging - rename to TestLogOtlpSendingQueue to re-enable.
+func skipTestLogOtlpSendingQueue(t *testing.T) {
 	otlpreceiver10 := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
 	otlpreceiver10.WithRetry(`
     retry_on_failure:
@@ -245,7 +247,8 @@ func TestLogOtlpSendingQueue(t *testing.T) {
 	})
 }
 
-func TestLogLargeFiles(t *testing.T) {
+// skipTestLogLargeFiles temporarily disabled for CI debugging - rename to TestLogLargeFiles to re-enable.
+func skipTestLogLargeFiles(t *testing.T) {
 	tests := []struct {
 		name         string
 		sender       testbed.DataSender
@@ -318,7 +321,8 @@ func TestLogLargeFiles(t *testing.T) {
 	}
 }
 
-func TestLargeFileOnce(t *testing.T) {
+// skipTestLargeFileOnce temporarily disabled for CI debugging - rename to TestLargeFileOnce to re-enable.
+func skipTestLargeFileOnce(t *testing.T) {
 	processors := []ProcessorNameAndConfigBody{
 		{
 			Name: "batch",
@@ -371,7 +375,8 @@ func TestLargeFileOnce(t *testing.T) {
 	tc.ValidateData()
 }
 
-func TestMemoryLimiterHit(t *testing.T) {
+// skipTestMemoryLimiterHit temporarily disabled for CI debugging - rename to TestMemoryLimiterHit to re-enable.
+func skipTestMemoryLimiterHit(t *testing.T) {
 	tests := []struct {
 		name   string
 		sender testbed.DataSender

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
-func TestMetric10kDPS(t *testing.T) {
+// skipTestMetric10kDPS temporarily disabled for CI debugging - rename to TestMetric10kDPS to re-enable.
+func skipTestMetric10kDPS(t *testing.T) {
 	tests := []struct {
 		name         string
 		sender       testbed.DataSender
@@ -96,7 +97,8 @@ func TestMetric10kDPS(t *testing.T) {
 	}
 }
 
-func TestMetricsFromFile(t *testing.T) {
+// skipTestMetricsFromFile temporarily disabled for CI debugging - rename to TestMetricsFromFile to re-enable.
+func skipTestMetricsFromFile(t *testing.T) {
 	// This test demonstrates usage of NewFileDataProvider to generate load using
 	// previously recorded data.
 

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -95,7 +95,8 @@ func getResourceProcessorTestCases() []resourceProcessorTestCase {
 	return tests
 }
 
-func TestMetricResourceProcessor(t *testing.T) {
+// skipTestMetricResourceProcessor temporarily disabled for CI debugging - rename to TestMetricResourceProcessor to re-enable.
+func skipTestMetricResourceProcessor(t *testing.T) {
 	sender := testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
 	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
 

--- a/testbed/tests/syslog_integration_test.go
+++ b/testbed/tests/syslog_integration_test.go
@@ -29,7 +29,8 @@ type expectedDataType struct {
 	attributes     map[string]any
 }
 
-func TestSyslogComplementaryRFC5424(t *testing.T) {
+// skipTestSyslogComplementaryRFC5424 temporarily disabled for CI debugging - rename to TestSyslogComplementaryRFC5424 to re-enable.
+func skipTestSyslogComplementaryRFC5424(t *testing.T) {
 	expectedData := []expectedDataType{
 		{
 			message:        "<165>1 2003-10-11T22:14:15.003Z mymachine.example.com eventslog - ID47 [exampleSDID@32473 iut=\"3\"] Some message",
@@ -69,8 +70,8 @@ func TestSyslogComplementaryRFC5424(t *testing.T) {
 	complementaryTest(t, "rfc5424", expectedData)
 }
 
-func TestSyslogComplementaryRFC3164(t *testing.T) {
-	t.Skip("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38238")
+// skipTestSyslogComplementaryRFC3164 temporarily disabled for CI debugging - rename to TestSyslogComplementaryRFC3164 to re-enable.
+func skipTestSyslogComplementaryRFC3164(t *testing.T) {
 	expectedData := []expectedDataType{
 		{
 			message:        "<34>Oct 11 2023 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8",

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -29,7 +29,8 @@ func TestMain(m *testing.M) {
 	testbed.DoTestMain(m, performanceResultsSummary)
 }
 
-func TestTrace10kSPS(t *testing.T) {
+// skipTestTrace10kSPS temporarily disabled for CI debugging - rename to TestTrace10kSPS to re-enable.
+func skipTestTrace10kSPS(t *testing.T) {
 	tests := []struct {
 		name         string
 		sender       testbed.DataSender
@@ -117,7 +118,8 @@ func TestTrace10kSPS(t *testing.T) {
 	}
 }
 
-func TestTrace10kSPSJaegerGRPC(t *testing.T) {
+// skipTestTrace10kSPSJaegerGRPC temporarily disabled for CI debugging - rename to TestTrace10kSPSJaegerGRPC to re-enable.
+func skipTestTrace10kSPSJaegerGRPC(t *testing.T) {
 	port := testutil.GetAvailablePort(t)
 	receiver := datareceivers.NewJaegerDataReceiver(port)
 	Scenario10kItemsPerSecondAlternateBackend(
@@ -142,7 +144,8 @@ func TestTrace10kSPSJaegerGRPC(t *testing.T) {
 	)
 }
 
-func TestTraceNoBackend10kSPS(t *testing.T) {
+// skipTestTraceNoBackend10kSPS temporarily disabled for CI debugging - rename to TestTraceNoBackend10kSPS to re-enable.
+func skipTestTraceNoBackend10kSPS(t *testing.T) {
 	limitProcessors := []ProcessorNameAndConfigBody{
 		{
 			Name: "memory_limiter",
@@ -185,7 +188,8 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 	}
 }
 
-func TestTrace1kSPSWithAttrs(t *testing.T) {
+// skipTestTrace1kSPSWithAttrs temporarily disabled for CI debugging - rename to TestTrace1kSPSWithAttrs to re-enable.
+func skipTestTrace1kSPSWithAttrs(t *testing.T) {
 	Scenario1kSPSWithAttrs(t, []string{}, []TestCase{
 		// No attributes.
 		{
@@ -281,7 +285,8 @@ func verifySingleSpan(
 	assert.Equal(t, 1, count, "must receive one span")
 }
 
-func TestTraceAttributesProcessor(t *testing.T) {
+// skipTestTraceAttributesProcessor temporarily disabled for CI debugging - rename to TestTraceAttributesProcessor to re-enable.
+func skipTestTraceAttributesProcessor(t *testing.T) {
 	tests := []struct {
 		name     string
 		sender   testbed.DataSender
@@ -384,7 +389,8 @@ func TestTraceAttributesProcessor(t *testing.T) {
 	}
 }
 
-func TestTraceAttributesProcessorJaegerGRPC(t *testing.T) {
+// skipTestTraceAttributesProcessorJaegerGRPC temporarily disabled for CI debugging - rename to TestTraceAttributesProcessorJaegerGRPC to re-enable.
+func skipTestTraceAttributesProcessorJaegerGRPC(t *testing.T) {
 	port := testutil.GetAvailablePort(t)
 	sender := datasenders.NewJaegerGRPCDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
 	receiver := datareceivers.NewJaegerDataReceiver(port)


### PR DESCRIPTION
To update the upstream branch while testing the updated workflow of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46665.