### PR TITLE
[receiver/awslambda] Allow metadata placement customization

### DIFF
--- a/.chloggen/feat_aws-lambda-override-metadata-target.yaml
+++ b/.chloggen/feat_aws-lambda-override-metadata-target.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awslambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow metadata placement overrides between attributes (default) vs body
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46858]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -72,10 +72,18 @@ CloudWatch Logs events are handled in the following manner:
 
 The following receiver configuration parameters are supported.
 
-| Name                   | Description                                             |
-|:-----------------------|:--------------------------------------------------------|
-| `s3::encoding`         | Optional encoder to use for S3 event processing         | 
-| `cloudwatch::encoding` | Optional encoder to use for CloudWatch event processing | 
+| Name                   | Description                                                                      |
+|:-----------------------|:---------------------------------------------------------------------------------|
+| `s3::encoding`         | Optional encoder to use for S3 event processing                                  | 
+| `s3::metadata_target`  | Where to place S3 event metadata (`attributes` or `body`). Default: `attributes` |
+| `cloudwatch::encoding` | Optional encoder to use for CloudWatch event processing                          |
+| `failure_bucket_arn`   | ARN of the S3 bucket used as Lambda failure destination for error replaying      |
+
+When processing S3 events, the receiver enriches log records with S3 event metadata (e.g., bucket name, object key).
+The `s3::metadata_target` option controls where this metadata is placed:
+
+- `attributes` (default): Metadata is added as log record attributes.
+- `body`: Metadata is added to the log record body. This only works when the body is already a map. Otherwise, metadata addition will be skipped.
 
 Consider following notes on default behaviors:
 

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -84,6 +84,7 @@ The `s3::metadata_target` option controls where this metadata is placed:
 
 - `attributes` (default): Metadata is added as log record attributes.
 - `body`: Metadata is added to the log record body. This only works when the body is already a map. Otherwise, metadata addition will be skipped.
+- `none`: Metadata will not be added to the log record. Use this mode to reduce log record size when S3 metadata is not needed.
 
 Consider following notes on default behaviors:
 

--- a/receiver/awslambdareceiver/benchmark_test.go
+++ b/receiver/awslambdareceiver/benchmark_test.go
@@ -41,7 +41,7 @@ func BenchmarkHandleS3Notification(b *testing.B) {
 	consumer := noOpLogsConsumer{}
 	// Wrap the consumer to match the new s3EventConsumerFunc signature
 	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-		enrichS3Logs(logs, event)
+		enrichS3Logs(attributes, logs, event)
 		return consumer.ConsumeLogs(ctx, logs)
 	}
 	handler := newS3LogsHandler(service, zap.NewNop(), &customLogUnmarshaler{}, logsConsumer)

--- a/receiver/awslambdareceiver/config.go
+++ b/receiver/awslambdareceiver/config.go
@@ -10,11 +10,18 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-const s3ARNPrefix = "arn:aws:s3:::"
+type metadataTarget string
+
+const (
+	attributes metadataTarget = "attributes"
+	body       metadataTarget = "body"
+
+	s3ARNPrefix = "arn:aws:s3:::"
+)
 
 type Config struct {
 	// S3 defines configuration options for S3 Lambda trigger.
-	S3 sharedConfig `mapstructure:"s3"`
+	S3 s3Config `mapstructure:"s3"`
 
 	// CloudWatch defines configuration options for CloudWatch Lambda trigger.
 	CloudWatch sharedConfig `mapstructure:"cloudwatch"`
@@ -23,6 +30,15 @@ type Config struct {
 	FailureBucketARN string `mapstructure:"failure_bucket_arn"`
 
 	_ struct{} // Prevent unkeyed literal initialization
+}
+
+type s3Config struct {
+	// MetadataTarget defines where to place S3 event metadata. Supported values: "attributes" (default), "body".
+	// When set to "body", metadata is added to the log record body only if the body is already a map.
+	// If the body is not a map, body enrichment is skipped for that log record.
+	MetadataTarget metadataTarget `mapstructure:"metadata_target"`
+
+	sharedConfig `mapstructure:",squash"`
 }
 
 // sharedConfig defines configuration options shared between different AWS Lambda trigger types.
@@ -39,7 +55,11 @@ type sharedConfig struct {
 var _ component.Config = (*Config)(nil)
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		S3: s3Config{
+			MetadataTarget: attributes,
+		},
+	}
 }
 
 func (c *Config) Validate() error {
@@ -48,6 +68,10 @@ func (c *Config) Validate() error {
 		if err != nil {
 			return fmt.Errorf("invalid failure_bucket_arn: %w", err)
 		}
+	}
+
+	if c.S3.MetadataTarget != attributes && c.S3.MetadataTarget != body {
+		return fmt.Errorf("invalid s3.metadata_target: %s, supported values are 'attributes' (default) and 'body'", c.S3.MetadataTarget)
 	}
 
 	return nil

--- a/receiver/awslambdareceiver/config.go
+++ b/receiver/awslambdareceiver/config.go
@@ -15,6 +15,7 @@ type metadataTarget string
 const (
 	attributes metadataTarget = "attributes"
 	body       metadataTarget = "body"
+	none       metadataTarget = "none"
 
 	s3ARNPrefix = "arn:aws:s3:::"
 )
@@ -70,7 +71,7 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	if c.S3.MetadataTarget != attributes && c.S3.MetadataTarget != body {
+	if c.S3.MetadataTarget != attributes && c.S3.MetadataTarget != body && c.S3.MetadataTarget != none {
 		return fmt.Errorf("invalid s3.metadata_target: %s, supported values are 'attributes' (default) and 'body'", c.S3.MetadataTarget)
 	}
 

--- a/receiver/awslambdareceiver/config.schema.yaml
+++ b/receiver/awslambdareceiver/config.schema.yaml
@@ -17,3 +17,6 @@ properties:
       encoding:
         description: Encoding defines the encoding to decode incoming Lambda invocation data. This extension is expected to further process content of the events that are extracted from Lambda trigger. If receiving data is in different formats(ex:- a mix of VPC flow logs, CloudTrail logs), receiver is recommended to have separate Lambda functions with specific extension configurations.
         type: string
+      metadata_target:
+        description: 'MetadataTarget defines where to place S3 event metadata. Supported values: "attributes" (default), "body". When set to "body", metadata is added to the log record body only if the body is already a map. If the body is not a map, body enrichment is skipped for that log record.'
+        type: string

--- a/receiver/awslambdareceiver/config_test.go
+++ b/receiver/awslambdareceiver/config_test.go
@@ -56,6 +56,19 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			name:              "Config with metadata target",
+			componentIDToLoad: component.NewIDWithName(metadata.Type, "with_attribute_target"),
+			expected: &Config{
+				S3: s3Config{
+					MetadataTarget: body,
+					sharedConfig: sharedConfig{
+						Encoding: "encoding",
+					},
+				},
+				CloudWatch: sharedConfig{},
+			},
+		},
+		{
 			name:              "Config with empty encoding",
 			componentIDToLoad: component.NewIDWithName(metadata.Type, "empty_encoding"),
 			expected: &Config{

--- a/receiver/awslambdareceiver/config_test.go
+++ b/receiver/awslambdareceiver/config_test.go
@@ -31,8 +31,11 @@ func TestLoadConfig(t *testing.T) {
 			name:              "Config with both S3 and CloudWatch encoding",
 			componentIDToLoad: component.NewIDWithName(metadata.Type, "aws_logs_encoding"),
 			expected: &Config{
-				S3: sharedConfig{
-					Encoding: "aws_logs_encoding",
+				S3: s3Config{
+					MetadataTarget: attributes,
+					sharedConfig: sharedConfig{
+						Encoding: "aws_logs_encoding",
+					},
 				},
 				CloudWatch: sharedConfig{
 					Encoding: "aws_logs_encoding",
@@ -43,8 +46,11 @@ func TestLoadConfig(t *testing.T) {
 			name:              "Config with both S3 config only",
 			componentIDToLoad: component.NewIDWithName(metadata.Type, "json_log_encoding"),
 			expected: &Config{
-				S3: sharedConfig{
-					Encoding: "json_log_encoding",
+				S3: s3Config{
+					MetadataTarget: attributes,
+					sharedConfig: sharedConfig{
+						Encoding: "json_log_encoding",
+					},
 				},
 				CloudWatch: sharedConfig{},
 			},
@@ -53,7 +59,9 @@ func TestLoadConfig(t *testing.T) {
 			name:              "Config with empty encoding",
 			componentIDToLoad: component.NewIDWithName(metadata.Type, "empty_encoding"),
 			expected: &Config{
-				S3:         sharedConfig{},
+				S3: s3Config{
+					MetadataTarget: attributes,
+				},
 				CloudWatch: sharedConfig{},
 			},
 		},
@@ -61,7 +69,9 @@ func TestLoadConfig(t *testing.T) {
 			name:              "Config with failure bucket ARN",
 			componentIDToLoad: component.NewIDWithName(metadata.Type, "with_failure_arn"),
 			expected: &Config{
-				S3:               sharedConfig{},
+				S3: s3Config{
+					MetadataTarget: attributes,
+				},
 				CloudWatch:       sharedConfig{},
 				FailureBucketARN: "arn:aws:s3:::example",
 			},

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -114,7 +114,6 @@ func newS3LogsHandler(
 				return fmt.Errorf("failed to decode S3 logs: %w", err)
 			}
 
-			enrichS3Logs(logs, event)
 			if err = consumer(ctx, event, logs); err != nil {
 				return checkConsumerErrorAndWrap(err)
 			}
@@ -310,17 +309,30 @@ func gunzipIfNeeded(r io.Reader) (io.Reader, error) {
 	return buf, nil
 }
 
-func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {
+func enrichS3Logs(target metadataTarget, logs plog.Logs, event events.S3EventRecord) {
 	for _, resourceLogs := range logs.ResourceLogs().All() {
-		resourceAttrs := resourceLogs.Resource().Attributes()
-		resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
-		resourceAttrs.PutStr(string(conventions.CloudRegionKey), event.AWSRegion)
-		resourceAttrs.PutStr(string(conventions.AWSS3BucketKey), event.S3.Bucket.Name)
-		resourceAttrs.PutStr(string(conventions.AWSS3KeyKey), event.S3.Object.Key)
+		if target == attributes {
+			attrs := resourceLogs.Resource().Attributes()
+			attrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
+			attrs.PutStr(string(conventions.CloudRegionKey), event.AWSRegion)
+			attrs.PutStr(string(conventions.AWSS3KeyKey), event.S3.Object.Key)
+			attrs.PutStr("aws.s3.bucket.name", event.S3.Bucket.Name)
+			attrs.PutStr("aws.s3.bucket.arn", event.S3.Bucket.Arn)
+		}
 
 		for _, scopeLogs := range resourceLogs.ScopeLogs().All() {
 			for _, logRecord := range scopeLogs.LogRecords().All() {
 				logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(event.EventTime))
+
+				// Write metadata to body if requested through configuration & body is a map
+				if target == body && logRecord.Body().Type() == pcommon.ValueTypeMap {
+					bodyMap := logRecord.Body().Map()
+					bodyMap.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
+					bodyMap.PutStr(string(conventions.CloudRegionKey), event.AWSRegion)
+					bodyMap.PutStr(string(conventions.AWSS3KeyKey), event.S3.Object.Key)
+					bodyMap.PutStr("aws.s3.bucket.name", event.S3.Bucket.Name)
+					bodyMap.PutStr("aws.s3.bucket.arn", event.S3.Bucket.Arn)
+				}
 			}
 		}
 	}

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -405,136 +405,118 @@ func TestHandleCloudwatchLogEvent(t *testing.T) {
 func TestEnrichS3Logs(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Enrich S3 logs with event metadata in attributes", func(t *testing.T) {
-		// given
-		logs := plog.NewLogs()
+	observedTimestamp := time.UnixMilli(1765574662915)
+	expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
 
-		rl := logs.ResourceLogs().AppendEmpty()
-		sl := rl.ScopeLogs()
-		lr := sl.AppendEmpty().LogRecords()
-		lr.AppendEmpty()
-
-		observedTimestamp := time.UnixMilli(1765574662915)
-		expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
-
-		s3Record := events.S3EventRecord{
-			AWSRegion: "us-east-1",
-			EventTime: observedTimestamp,
-			S3: events.S3Entity{
-				SchemaVersion: "",
-				Bucket: events.S3Bucket{
-					Name: "bucket-name",
-					Arn:  "arn:aws:s3:::bucket-name",
-				},
-				Object: events.S3Object{
-					Key: "object-key",
-				},
+	s3Record := events.S3EventRecord{
+		AWSRegion: "us-east-1",
+		EventTime: observedTimestamp,
+		S3: events.S3Entity{
+			Bucket: events.S3Bucket{
+				Name: "bucket-name",
+				Arn:  "arn:aws:s3:::bucket-name",
 			},
-		}
+			Object: events.S3Object{
+				Key: "object-key",
+			},
+		},
+	}
 
-		// when
-		enrichS3Logs(attributes, logs, s3Record)
+	expectedMetadata := map[string]string{
+		"cloud.provider":     "aws",
+		"cloud.region":       "us-east-1",
+		"aws.s3.bucket.name": "bucket-name",
+		"aws.s3.bucket.arn":  "arn:aws:s3:::bucket-name",
+		"aws.s3.key":         "object-key",
+	}
 
-		// then
-		for _, resource := range logs.ResourceLogs().All() {
-			resourceAttrs := resource.Resource().Attributes()
+	tests := []struct {
+		name                string
+		target              metadataTarget
+		bodyIsMap           bool
+		expectResourceAttrs bool
+		expectBodyAttrs     bool
+	}{
+		{
+			name:                "Enrich S3 logs with event metadata in attributes",
+			target:              attributes,
+			bodyIsMap:           false,
+			expectResourceAttrs: true,
+			expectBodyAttrs:     false,
+		},
+		{
+			name:                "Enrich S3 logs with event metadata in body when body is a map",
+			target:              body,
+			bodyIsMap:           true,
+			expectResourceAttrs: false,
+			expectBodyAttrs:     true,
+		},
+		{
+			name:                "Enrich S3 logs with no event metadata",
+			target:              none,
+			bodyIsMap:           true,
+			expectResourceAttrs: false,
+			expectBodyAttrs:     false,
+		},
+	}
 
-			v, b := resourceAttrs.Get("cloud.provider")
-			require.True(t, b)
-			require.Equal(t, "aws", v.AsString())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// given
+			logs := plog.NewLogs()
+			rl := logs.ResourceLogs().AppendEmpty()
+			sl := rl.ScopeLogs().AppendEmpty()
+			lr := sl.LogRecords().AppendEmpty()
 
-			v, b = resourceAttrs.Get("cloud.region")
-			require.True(t, b)
-			require.Equal(t, "us-east-1", v.AsString())
+			if test.bodyIsMap {
+				bodyMap := lr.Body().SetEmptyMap()
+				bodyMap.PutStr("message", "Body message")
+			}
 
-			v, b = resourceAttrs.Get("aws.s3.bucket.name")
-			require.True(t, b)
-			require.Equal(t, "bucket-name", v.AsString())
+			// when
+			enrichS3Logs(test.target, logs, s3Record)
 
-			v, b = resourceAttrs.Get("aws.s3.bucket.arn")
-			require.True(t, b)
-			require.Equal(t, "arn:aws:s3:::bucket-name", v.AsString())
+			// then
+			for _, resource := range logs.ResourceLogs().All() {
+				resourceAttrs := resource.Resource().Attributes()
 
-			v, b = resourceAttrs.Get("aws.s3.key")
-			require.True(t, b)
-			require.Equal(t, "object-key", v.AsString())
+				for key, expected := range expectedMetadata {
+					v, ok := resourceAttrs.Get(key)
+					if test.expectResourceAttrs {
+						require.True(t, ok, "expected resource attribute %s", key)
+						require.Equal(t, expected, v.AsString())
+					} else {
+						require.False(t, ok, "unexpected resource attribute %s", key)
+					}
+				}
 
-			for _, scope := range resource.ScopeLogs().All() {
-				for _, logRecord := range scope.LogRecords().All() {
-					require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+				for _, scope := range resource.ScopeLogs().All() {
+					for _, logRecord := range scope.LogRecords().All() {
+						require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+
+						if test.bodyIsMap {
+							require.Equal(t, pcommon.ValueTypeMap, logRecord.Body().Type())
+							bMap := logRecord.Body().Map()
+
+							v, ok := bMap.Get("message")
+							require.True(t, ok)
+							require.Equal(t, "Body message", v.AsString())
+
+							for key, expected := range expectedMetadata {
+								v, ok := bMap.Get(key)
+								if test.expectBodyAttrs {
+									require.True(t, ok, "expected body attribute %s", key)
+									require.Equal(t, expected, v.AsString())
+								} else {
+									require.False(t, ok, "unexpected body attribute %s", key)
+								}
+							}
+						}
+					}
 				}
 			}
-		}
-	})
-
-	t.Run("Enrich S3 logs with event metadata in body when body is a map", func(t *testing.T) {
-		// given
-		logs := plog.NewLogs()
-
-		rl := logs.ResourceLogs().AppendEmpty()
-		sl := rl.ScopeLogs().AppendEmpty()
-		lr := sl.LogRecords().AppendEmpty()
-
-		// Set the body to a map so the body enrichment path applies
-		bodyMap := lr.Body().SetEmptyMap()
-		bodyMap.PutStr("message", "Body message")
-
-		observedTimestamp := time.UnixMilli(1765574662915)
-		expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
-
-		s3Record := events.S3EventRecord{
-			AWSRegion: "us-east-1",
-			EventTime: observedTimestamp,
-			S3: events.S3Entity{
-				Bucket: events.S3Bucket{
-					Name: "bucket-name",
-					Arn:  "arn:aws:s3:::bucket-name",
-				},
-				Object: events.S3Object{
-					Key: "object-key",
-				},
-			},
-		}
-
-		// when
-		enrichS3Logs(body, logs, s3Record)
-
-		// then
-		for _, resource := range logs.ResourceLogs().All() {
-			for _, scope := range resource.ScopeLogs().All() {
-				for _, logRecord := range scope.LogRecords().All() {
-					require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
-					require.Equal(t, pcommon.ValueTypeMap, logRecord.Body().Type())
-
-					bMap := logRecord.Body().Map()
-
-					v, ok := bMap.Get("message")
-					require.True(t, ok)
-					require.Equal(t, "Body message", v.AsString())
-
-					v, ok = bMap.Get("cloud.provider")
-					require.True(t, ok)
-					require.Equal(t, "aws", v.AsString())
-
-					v, ok = bMap.Get("cloud.region")
-					require.True(t, ok)
-					require.Equal(t, "us-east-1", v.AsString())
-
-					v, ok = bMap.Get("aws.s3.bucket.name")
-					require.True(t, ok)
-					require.Equal(t, "bucket-name", v.AsString())
-
-					v, ok = bMap.Get("aws.s3.bucket.arn")
-					require.True(t, ok)
-					require.Equal(t, "arn:aws:s3:::bucket-name", v.AsString())
-
-					v, ok = bMap.Get("aws.s3.key")
-					require.True(t, ok)
-					require.Equal(t, "object-key", v.AsString())
-				}
-			}
-		}
-	})
+		})
+	}
 }
 
 func TestConsumerErrorHandling(t *testing.T) {

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -226,7 +226,7 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 
 			// Wrap the consumer to match the new s3EventConsumerFunc signature
 			logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-				enrichS3Logs(logs, event)
+				enrichS3Logs(attributes, logs, event)
 				return test.eventConsumer.ConsumeLogs(ctx, logs)
 			}
 
@@ -319,7 +319,7 @@ func TestS3HandlerParseEvent(t *testing.T) {
 	var consumer noOpLogsConsumer
 	// Wrap the consumer to match the new s3EventConsumerFunc signature
 	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-		enrichS3Logs(logs, event)
+		enrichS3Logs(attributes, logs, event)
 		return consumer.ConsumeLogs(ctx, logs)
 	}
 	handler := newS3LogsHandler(s3Service, zap.NewNop(), &customLogUnmarshaler{}, logsConsumer)
@@ -405,60 +405,136 @@ func TestHandleCloudwatchLogEvent(t *testing.T) {
 func TestEnrichS3Logs(t *testing.T) {
 	t.Parallel()
 
-	// given
-	logs := plog.NewLogs()
+	t.Run("Enrich S3 logs with event metadata in attributes", func(t *testing.T) {
+		// given
+		logs := plog.NewLogs()
 
-	rl := logs.ResourceLogs().AppendEmpty()
-	sl := rl.ScopeLogs()
-	lr := sl.AppendEmpty().LogRecords()
-	lr.AppendEmpty()
+		rl := logs.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs()
+		lr := sl.AppendEmpty().LogRecords()
+		lr.AppendEmpty()
 
-	observedTimestamp := time.UnixMilli(1765574662915)
-	expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
+		observedTimestamp := time.UnixMilli(1765574662915)
+		expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
 
-	s3Record := events.S3EventRecord{
-		AWSRegion: "us-east-1",
-		EventTime: observedTimestamp,
-		S3: events.S3Entity{
-			SchemaVersion: "",
-			Bucket: events.S3Bucket{
-				Name: "bucket-name",
+		s3Record := events.S3EventRecord{
+			AWSRegion: "us-east-1",
+			EventTime: observedTimestamp,
+			S3: events.S3Entity{
+				SchemaVersion: "",
+				Bucket: events.S3Bucket{
+					Name: "bucket-name",
+					Arn:  "arn:aws:s3:::bucket-name",
+				},
+				Object: events.S3Object{
+					Key: "object-key",
+				},
 			},
-			Object: events.S3Object{
-				Key: "object-key",
-			},
-		},
-	}
+		}
 
-	// when
-	enrichS3Logs(logs, s3Record)
+		// when
+		enrichS3Logs(attributes, logs, s3Record)
 
-	// then
-	for _, resource := range logs.ResourceLogs().All() {
-		resourceAttrs := resource.Resource().Attributes()
+		// then
+		for _, resource := range logs.ResourceLogs().All() {
+			resourceAttrs := resource.Resource().Attributes()
 
-		v, b := resourceAttrs.Get("cloud.provider")
-		require.True(t, b)
-		require.Equal(t, "aws", v.AsString())
+			v, b := resourceAttrs.Get("cloud.provider")
+			require.True(t, b)
+			require.Equal(t, "aws", v.AsString())
 
-		v, b = resourceAttrs.Get("cloud.region")
-		require.True(t, b)
-		require.Equal(t, "us-east-1", v.AsString())
+			v, b = resourceAttrs.Get("cloud.region")
+			require.True(t, b)
+			require.Equal(t, "us-east-1", v.AsString())
 
-		v, b = resourceAttrs.Get("aws.s3.bucket")
-		require.True(t, b)
-		require.Equal(t, "bucket-name", v.AsString())
+			v, b = resourceAttrs.Get("aws.s3.bucket.name")
+			require.True(t, b)
+			require.Equal(t, "bucket-name", v.AsString())
 
-		v, b = resourceAttrs.Get("aws.s3.key")
-		require.True(t, b)
-		require.Equal(t, "object-key", v.AsString())
+			v, b = resourceAttrs.Get("aws.s3.bucket.arn")
+			require.True(t, b)
+			require.Equal(t, "arn:aws:s3:::bucket-name", v.AsString())
 
-		for _, scope := range resource.ScopeLogs().All() {
-			for _, logRecord := range scope.LogRecords().All() {
-				require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+			v, b = resourceAttrs.Get("aws.s3.key")
+			require.True(t, b)
+			require.Equal(t, "object-key", v.AsString())
+
+			for _, scope := range resource.ScopeLogs().All() {
+				for _, logRecord := range scope.LogRecords().All() {
+					require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+				}
 			}
 		}
-	}
+	})
+
+	t.Run("Enrich S3 logs with event metadata in body when body is a map", func(t *testing.T) {
+		// given
+		logs := plog.NewLogs()
+
+		rl := logs.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		lr := sl.LogRecords().AppendEmpty()
+
+		// Set the body to a map so the body enrichment path applies
+		bodyMap := lr.Body().SetEmptyMap()
+		bodyMap.PutStr("message", "Body message")
+
+		observedTimestamp := time.UnixMilli(1765574662915)
+		expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
+
+		s3Record := events.S3EventRecord{
+			AWSRegion: "us-east-1",
+			EventTime: observedTimestamp,
+			S3: events.S3Entity{
+				Bucket: events.S3Bucket{
+					Name: "bucket-name",
+					Arn:  "arn:aws:s3:::bucket-name",
+				},
+				Object: events.S3Object{
+					Key: "object-key",
+				},
+			},
+		}
+
+		// when
+		enrichS3Logs(body, logs, s3Record)
+
+		// then
+		for _, resource := range logs.ResourceLogs().All() {
+			for _, scope := range resource.ScopeLogs().All() {
+				for _, logRecord := range scope.LogRecords().All() {
+					require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+					require.Equal(t, pcommon.ValueTypeMap, logRecord.Body().Type())
+
+					bMap := logRecord.Body().Map()
+
+					v, ok := bMap.Get("message")
+					require.True(t, ok)
+					require.Equal(t, "Body message", v.AsString())
+
+					v, ok = bMap.Get("cloud.provider")
+					require.True(t, ok)
+					require.Equal(t, "aws", v.AsString())
+
+					v, ok = bMap.Get("cloud.region")
+					require.True(t, ok)
+					require.Equal(t, "us-east-1", v.AsString())
+
+					v, ok = bMap.Get("aws.s3.bucket.name")
+					require.True(t, ok)
+					require.Equal(t, "bucket-name", v.AsString())
+
+					v, ok = bMap.Get("aws.s3.bucket.arn")
+					require.True(t, ok)
+					require.Equal(t, "arn:aws:s3:::bucket-name", v.AsString())
+
+					v, ok = bMap.Get("aws.s3.key")
+					require.True(t, ok)
+					require.Equal(t, "object-key", v.AsString())
+				}
+			}
+		}
+	})
 }
 
 func TestConsumerErrorHandling(t *testing.T) {

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -250,7 +250,7 @@ func newLogsHandler(
 
 	// Wrapper function that sets observed timestamp for S3 logs
 	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-		enrichS3Logs(logs, event)
+		enrichS3Logs(cfg.S3.MetadataTarget, logs, event)
 		return next.ConsumeLogs(ctx, logs)
 	}
 

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -181,8 +181,10 @@ func TestStartRequiresLambdaEnvironment(t *testing.T) {
 
 func TestProcessLambdaEvent(t *testing.T) {
 	commonCfg := Config{
-		S3: sharedConfig{
-			Encoding: "awslogs",
+		S3: s3Config{
+			sharedConfig: sharedConfig{
+				Encoding: "awslogs",
+			},
 		},
 	}
 

--- a/receiver/awslambdareceiver/testdata/config.yaml
+++ b/receiver/awslambdareceiver/testdata/config.yaml
@@ -8,6 +8,11 @@ awslambda/json_log_encoding:
   s3:
     encoding: json_log_encoding
 
+awslambda/with_attribute_target:
+  s3:
+    encoding: encoding
+    metadata_target: body
+
 awslambda/empty_encoding:
 
 awslambda/with_failure_arn:

--- a/receiver/awslambdareceiver/testdata/s3_log_expected_gzip.yaml
+++ b/receiver/awslambdareceiver/testdata/s3_log_expected_gzip.yaml
@@ -7,12 +7,15 @@ resourceLogs:
         - key: cloud.region
           value:
             stringValue: us-east-1
-        - key: aws.s3.bucket
-          value:
-            stringValue: test-bucket
         - key: aws.s3.key
           value:
             stringValue: test-file.txt
+        - key: aws.s3.bucket.name
+          value:
+            stringValue: test-bucket
+        - key: aws.s3.bucket.arn
+          value:
+            stringValue: arn:aws:s3:::test-bucket
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/awslambdareceiver/testdata/s3_log_expected_string.yaml
+++ b/receiver/awslambdareceiver/testdata/s3_log_expected_string.yaml
@@ -7,16 +7,18 @@ resourceLogs:
         - key: cloud.region
           value:
             stringValue: us-east-1
-        - key: aws.s3.bucket
-          value:
-            stringValue: test-bucket
         - key: aws.s3.key
           value:
             stringValue: test-file.txt
+        - key: aws.s3.bucket.name
+          value:
+            stringValue: test-bucket
+        - key: aws.s3.bucket.arn
+          value:
+            stringValue: arn:aws:s3:::test-bucket
     scopeLogs:
       - logRecords:
-          - attributes:
-            body:
+          - body:
               stringValue: Some log in S3 object
             observedTimeUnixNano: "1764625361000000000"
         scope:


### PR DESCRIPTION
#### Description

This enhancement focuses on AWS S3 event metadata. Currently, these metadata get added to resource log attributes.

With this PR I am proposing an option for users to put the S3 metadata to log record body. This is based on new configuration option `s3::metadata_target`

`s3::metadata_target:attributes`: (Default)  Metadata get added to attributes
`s3::metadata_target:body`: Metadata is added to the log record body. However, the body already should be a map
`s3::metadata_target:none`: Skips metadata. Useful to reduce payload size

**Why**: Provides flexibility for encoding extensions (e.g., jsonlogencodingextension) that use the log record body as a map-typed payload, allowing S3 event metadata to be enriched into the same body map instead of attributes.

___

Additionally, I have enhance `aws.s3.bucket` attribute with two sub sections,

- `aws.s3.bucket.name` : S3 bucket name
- `aws.s3.bucket.arn`: S3 bucket ARN

#### Link to tracking issue
N/A

#### Testing

Updated tests

#### Documentation

Updated documentation on config usage