### PR TITLE
[chore][processor/k8s_attributes] Add benchmarks section in the docs

### DIFF
--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -1118,7 +1118,7 @@ are currently in `beta` stability and are actively moving towards `stable` stabi
 
 ## Available Benchmarks
 
-The component is tested as part of the project's load tests with the results being publicly
+The component is tested as part of the project's load tests, with the results being publicly
 available at benchmarks' 
 [page](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests).
 In that page, users can find details such as 

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -1115,3 +1115,16 @@ The breaking changes between the 2 schemas are the following:
 
 All attributes emitted through the `processor.k8sattributes.EmitV1K8sConventions` feature gate
 are currently in `beta` stability and are actively moving towards `stable` stability.
+
+## Available Benchmarks
+
+The component is tested as part of the project's load tests with the results being publicly
+available at benchmarks' 
+[page](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests).
+In that page, users can find details such as 
+[memory](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-ram-mib)
+and [cpu](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-cpu-percentage)
+performance when the component is used in K8s Clusters (tests use [KOWK](https://kwok.sigs.k8s.io/))
+with a range number of workloads'.
+Refer to the [test](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/be97561f515e7ecad2db9ed2acc7818f66e864c9/testbed/tests/k8sattributes_processor_test.go#L394-L398)
+for more information about the setup.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -1125,6 +1125,6 @@ In that page, users can find details such as
 [memory](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-ram-mib)
 and [cpu](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-cpu-percentage)
 performance when the component is used in K8s Clusters (tests use [KOWK](https://kwok.sigs.k8s.io/))
-with a range number of workloads'.
+with a range number of workloads.
 Refer to the [test](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/be97561f515e7ecad2db9ed2acc7818f66e864c9/testbed/tests/k8sattributes_processor_test.go#L394-L398)
 for more information about the setup.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -1119,7 +1119,7 @@ are currently in `beta` stability and are actively moving towards `stable` stabi
 ## Available Benchmarks
 
 The component is tested as part of the project's load tests, with the results being publicly
-available at benchmarks' 
+available at the benchmarks 
 [page](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests).
 In that page, users can find details such as 
 [memory](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-ram-mib)

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -1123,7 +1123,7 @@ available at benchmarks'
 [page](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests).
 In that page, users can find details such as 
 [memory](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-ram-mib)
-and [cpu](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-cpu-percentage)
+and [CPU](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/#metrick8sattributesprocessor-5k-workload-cluster-cpu-percentage)
 performance when the component is used in K8s Clusters (tests use [KOWK](https://kwok.sigs.k8s.io/))
 with a range number of workloads.
 Refer to the [test](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/be97561f515e7ecad2db9ed2acc7818f66e864c9/testbed/tests/k8sattributes_processor_test.go#L394-L398)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds a section to the docs of the component to cover the benchmarks requirement as described at https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44585. The section also links to the benchmark results published at https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44585
