### PR TITLE
fix: otelarrowreceiver assumes that the root payload type is always at position 0

### DIFF
--- a/.chloggen/arrow-payload-positions.yaml
+++ b/.chloggen/arrow-payload-positions.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/otelarrowreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove assumed positions of otel arrow root payload types
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46878]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+otelarrowreceiver assumed that the root payload type (logs, metrics, spans) was
+always at position 0. This assumption no longer holds caused interoperability
+issues with the rust implementation.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/arrow-payload-positions.yaml
+++ b/.chloggen/arrow-payload-positions.yaml
@@ -4,7 +4,7 @@
 change_type: 'bug_fix'
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/otelarrowreceiver
+component: receiver/otelarrow
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove assumed positions of otel arrow root payload types
@@ -15,10 +15,7 @@ issues: [46878]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: |
-otelarrowreceiver assumed that the root payload type (logs, metrics, spans) was
-always at position 0. This assumption no longer holds caused interoperability
-issues with the rust implementation.
+subtext: 
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -305,29 +305,30 @@ const (
 	signalLogs
 )
 
-func signalTypeFromMethod(method string) signalType {
-	switch method {
-	case arrowTracesMethod:
-		return signalTraces
-	case arrowMetricsMethod:
-		return signalMetrics
-	case arrowLogsMethod:
-		return signalLogs
+// method returns the gRPC method name for netstats reporting.
+func (s signalType) method() string {
+	switch s {
+	case signalTraces:
+		return arrowTracesMethod
+	case signalMetrics:
+		return arrowMetricsMethod
+	case signalLogs:
+		return arrowLogsMethod
 	default:
-		return 0
+		return ""
 	}
 }
 
 func (r *Receiver) ArrowTraces(serverStream arrowpb.ArrowTracesService_ArrowTracesServer) error {
-	return r.anyStream(serverStream, arrowTracesMethod)
+	return r.anyStream(serverStream, signalTraces)
 }
 
 func (r *Receiver) ArrowLogs(serverStream arrowpb.ArrowLogsService_ArrowLogsServer) error {
-	return r.anyStream(serverStream, arrowLogsMethod)
+	return r.anyStream(serverStream, signalLogs)
 }
 
 func (r *Receiver) ArrowMetrics(serverStream arrowpb.ArrowMetricsService_ArrowMetricsServer) error {
-	return r.anyStream(serverStream, arrowMetricsMethod)
+	return r.anyStream(serverStream, signalMetrics)
 }
 
 type anyStreamServer interface {
@@ -354,7 +355,7 @@ func (r *Receiver) recoverErr(retErr *error) {
 	}
 }
 
-func (r *Receiver) anyStream(serverStream anyStreamServer, method string) (retErr error) {
+func (r *Receiver) anyStream(serverStream anyStreamServer, sig signalType) (retErr error) {
 	streamCtx := serverStream.Context()
 	ac := r.newConsumer()
 
@@ -394,7 +395,7 @@ func (r *Receiver) anyStream(serverStream anyStreamServer, method string) (retEr
 		var err error
 		defer recvWG.Done()
 		defer r.recoverErr(&err)
-		err = rstream.srvReceiveLoop(doneCtx, serverStream, pendingCh, method, ac)
+		err = rstream.srvReceiveLoop(doneCtx, serverStream, pendingCh, sig, ac)
 		recvErrCh <- err
 	}()
 
@@ -433,13 +434,13 @@ func (r *Receiver) anyStream(serverStream anyStreamServer, method string) (retEr
 	}
 }
 
-func (r *receiverStream) newInFlightData(ctx context.Context, method string, batchID int64, pendingCh chan<- batchResp) *inFlightData {
+func (r *receiverStream) newInFlightData(ctx context.Context, sig signalType, batchID int64, pendingCh chan<- batchResp) *inFlightData {
 	_, span := r.tracer.Start(ctx, "otel_arrow_stream_inflight")
 
 	r.inFlightWG.Add(1)
 	id := &inFlightData{
 		receiverStream: r,
-		method:         method,
+		sig:            sig,
 		batchID:        batchID,
 		pendingCh:      pendingCh,
 		span:           span,
@@ -453,7 +454,7 @@ type inFlightData struct {
 	// Receiver is the owner of the resources held by this object.
 	*receiverStream
 
-	method    string
+	sig       signalType
 	batchID   int64
 	pendingCh chan<- batchResp
 	span      trace.Span
@@ -523,7 +524,7 @@ func (id *inFlightData) anyDone(ctx context.Context) {
 	// directly here.  Only the primary direction of transport
 	// is instrumented this way.
 	var sized netstats.SizesStruct
-	sized.Method = id.method
+	sized.Method = id.sig.method()
 	sized.Length = id.uncompSize
 	id.netReporter.CountReceive(ctx, sized)
 
@@ -547,7 +548,7 @@ func (id *inFlightData) anyDone(ctx context.Context) {
 // This handles constructing an inFlightData object, which itself
 // tracks everything that needs to be used by instrumentation when the
 // batch finishes.
-func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStreamServer, hrcv *headerReceiver, pendingCh chan<- batchResp, method string, ac arrowRecord.ConsumerAPI) (retErr error) {
+func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStreamServer, hrcv *headerReceiver, pendingCh chan<- batchResp, sig signalType, ac arrowRecord.ConsumerAPI) (retErr error) {
 	// Receive a batch corresponding with one ptrace.Traces, pmetric.Metrics,
 	// or plog.Logs item.
 	req, recvErr := serverStream.Recv()
@@ -556,7 +557,7 @@ func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStre
 	// carries a span covering sequential stream-processing work.  the context
 	// is severed at this point, with flight.span a contextless child that will be
 	// finished in recvDone().
-	flight := r.newInFlightData(streamCtx, method, req.GetBatchId(), pendingCh)
+	flight := r.newInFlightData(streamCtx, sig, req.GetBatchId(), pendingCh)
 
 	// inflightCtx is carried through into consumeAndProcess on the success path.
 	// this inherits the stream context so that its auth headers are present
@@ -621,7 +622,7 @@ func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStre
 		}
 	}
 
-	data, numItems, uncompSize, consumeErr := r.consumeBatch(ac, req, signalTypeFromMethod(method))
+	data, numItems, uncompSize, consumeErr := r.consumeBatch(ac, req, sig)
 
 	if consumeErr != nil {
 		if errors.Is(consumeErr, arrowRecord.ErrConsumerMemoryLimit) {
@@ -675,14 +676,14 @@ func (r *Receiver) consumeAndRespond(ctx, streamCtx context.Context, data any, f
 }
 
 // srvReceiveLoop repeatedly receives one batch of data.
-func (r *receiverStream) srvReceiveLoop(ctx context.Context, serverStream anyStreamServer, pendingCh chan<- batchResp, method string, ac arrowRecord.ConsumerAPI) (retErr error) {
+func (r *receiverStream) srvReceiveLoop(ctx context.Context, serverStream anyStreamServer, pendingCh chan<- batchResp, sig signalType, ac arrowRecord.ConsumerAPI) (retErr error) {
 	hrcv := newHeaderReceiver(ctx, r.authServer, r.gsettings.IncludeMetadata)
 	for {
 		select {
 		case <-ctx.Done():
 			return status.Error(codes.Canceled, "server stream shutdown")
 		default:
-			if err := r.recvOne(ctx, serverStream, hrcv, pendingCh, method, ac); err != nil {
+			if err := r.recvOne(ctx, serverStream, hrcv, pendingCh, sig, ac); err != nil {
 				return err
 			}
 		}

--- a/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -297,6 +297,27 @@ var (
 	arrowLogsMethod    = gRPCName(arrowpb.ArrowLogsService_ServiceDesc)
 )
 
+type signalType int
+
+const (
+	signalTraces signalType = iota + 1
+	signalMetrics
+	signalLogs
+)
+
+func signalTypeFromMethod(method string) signalType {
+	switch method {
+	case arrowTracesMethod:
+		return signalTraces
+	case arrowMetricsMethod:
+		return signalMetrics
+	case arrowLogsMethod:
+		return signalLogs
+	default:
+		return 0
+	}
+}
+
 func (r *Receiver) ArrowTraces(serverStream arrowpb.ArrowTracesService_ArrowTracesServer) error {
 	return r.anyStream(serverStream, arrowTracesMethod)
 }
@@ -600,7 +621,7 @@ func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStre
 		}
 	}
 
-	data, numItems, uncompSize, consumeErr := r.consumeBatch(ac, req)
+	data, numItems, uncompSize, consumeErr := r.consumeBatch(ac, req, signalTypeFromMethod(method))
 
 	if consumeErr != nil {
 		if errors.Is(consumeErr, arrowRecord.ErrConsumerMemoryLimit) {
@@ -749,14 +770,14 @@ func (r *receiverStream) srvSendLoop(ctx context.Context, serverStream anyStream
 // consumeBatch applies the batch to the Arrow Consumer, returns a
 // slice of pdata objects of the corresponding data type as `any`.
 // along with the number of items and true uncompressed size.
-func (r *Receiver) consumeBatch(arrowConsumer arrowRecord.ConsumerAPI, records *arrowpb.BatchArrowRecords) (retData any, numItems int, uncompSize int64, retErr error) {
-	payloads := records.GetArrowPayloads()
-	if len(payloads) == 0 {
-		return nil, 0, 0, nil
-	}
-
-	switch payloads[0].Type {
-	case arrowpb.ArrowPayloadType_UNIVARIATE_METRICS:
+//
+// The signal type is determined by the gRPC service method (e.g.,
+// ArrowTraces, ArrowLogs, ArrowMetrics) rather than by inspecting
+// payload positions. This ensures correct behavior regardless of
+// payload ordering within the batch.
+func (r *Receiver) consumeBatch(arrowConsumer arrowRecord.ConsumerAPI, records *arrowpb.BatchArrowRecords, sig signalType) (retData any, numItems int, uncompSize int64, retErr error) {
+	switch sig {
+	case signalMetrics:
 		if r.Metrics() == nil {
 			return nil, 0, 0, status.Error(codes.Unimplemented, "metrics service not available")
 		}
@@ -772,7 +793,7 @@ func (r *Receiver) consumeBatch(arrowConsumer arrowRecord.ConsumerAPI, records *
 		retData = data
 		retErr = err
 
-	case arrowpb.ArrowPayloadType_LOGS:
+	case signalLogs:
 		if r.Logs() == nil {
 			return nil, 0, 0, status.Error(codes.Unimplemented, "logs service not available")
 		}
@@ -788,7 +809,7 @@ func (r *Receiver) consumeBatch(arrowConsumer arrowRecord.ConsumerAPI, records *
 		retData = data
 		retErr = err
 
-	case arrowpb.ArrowPayloadType_SPANS:
+	case signalTraces:
 		if r.Traces() == nil {
 			return nil, 0, 0, status.Error(codes.Unimplemented, "traces service not available")
 		}

--- a/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -773,9 +773,7 @@ func (r *receiverStream) srvSendLoop(ctx context.Context, serverStream anyStream
 // along with the number of items and true uncompressed size.
 //
 // The signal type is determined by the gRPC service method (e.g.,
-// ArrowTraces, ArrowLogs, ArrowMetrics) rather than by inspecting
-// payload positions. This ensures correct behavior regardless of
-// payload ordering within the batch.
+// ArrowTraces, ArrowLogs, ArrowMetrics)
 func (r *Receiver) consumeBatch(arrowConsumer arrowRecord.ConsumerAPI, records *arrowpb.BatchArrowRecords, sig signalType) (retData any, numItems int, uncompSize int64, retErr error) {
 	switch sig {
 	case signalMetrics:

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -368,39 +368,10 @@ func (ctc *commonTestCase) newOOMConsumer() arrowRecord.ConsumerAPI {
 }
 
 func (ctc *commonTestCase) start(newConsumer func() arrowRecord.ConsumerAPI, bq admission2.Queue, opts ...func(*configgrpc.ServerConfig, *extensionauth.Server)) {
-	var authServer extensionauth.Server
-	var gsettings configgrpc.ServerConfig
-	for _, gf := range opts {
-		gf(&gsettings, &authServer)
-	}
-	rc := receiver.Settings{
-		TelemetrySettings: ctc.telset,
-		BuildInfo:         component.NewDefaultBuildInfo(),
-	}
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             component.NewID(component.MustNewType("arrowtest")),
-		Transport:              "grpc",
-		ReceiverCreateSettings: rc,
-	})
-	require.NoError(ctc.T, err)
-
-	rcvr, err := New(
-		ctc.consumers,
-		rc,
-		obsrecv,
-		gsettings,
-		authServer,
-		newConsumer,
-		bq,
-		netstats.Noop{},
-	)
-	require.NoError(ctc.T, err)
-	go func() {
-		ctc.streamErr <- rcvr.ArrowTraces(ctc.stream)
-	}()
+	ctc.startWithSignal(signalTraces, newConsumer, bq, opts...)
 }
 
-func (ctc *commonTestCase) startWithMethod(method string, newConsumer func() arrowRecord.ConsumerAPI, bq admission2.Queue, opts ...func(*configgrpc.ServerConfig, *extensionauth.Server)) {
+func (ctc *commonTestCase) startWithSignal(sig signalType, newConsumer func() arrowRecord.ConsumerAPI, bq admission2.Queue, opts ...func(*configgrpc.ServerConfig, *extensionauth.Server)) {
 	var authServer extensionauth.Server
 	var gsettings configgrpc.ServerConfig
 	for _, gf := range opts {
@@ -429,7 +400,7 @@ func (ctc *commonTestCase) startWithMethod(method string, newConsumer func() arr
 	)
 	require.NoError(ctc.T, err)
 	go func() {
-		ctc.streamErr <- rcvr.anyStream(ctc.stream, method)
+		ctc.streamErr <- rcvr.anyStream(ctc.stream, sig)
 	}()
 }
 
@@ -569,7 +540,7 @@ func TestReceiverLogs(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(nil)
 
-	ctc.startWithMethod(arrowLogsMethod, ctc.newRealConsumer, defaultBQ())
+	ctc.startWithSignal(signalLogs, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	assert.Equal(t, []json.Marshaler{compareJSONLogs{ld}}, []json.Marshaler{compareJSONLogs{(<-ctc.consume).Data.(plog.Logs)}})
@@ -589,7 +560,7 @@ func TestReceiverMetrics(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(nil)
 
-	ctc.startWithMethod(arrowMetricsMethod, ctc.newRealConsumer, defaultBQ())
+	ctc.startWithSignal(signalMetrics, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	otelAssert.Equiv(stdTesting, []json.Marshaler{
@@ -624,7 +595,7 @@ func TestReceiverSendError(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(status.Errorf(codes.Unavailable, "test send error"))
 
-	ctc.startWithMethod(arrowLogsMethod, ctc.newRealConsumer, defaultBQ())
+	ctc.startWithSignal(signalLogs, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	assert.EqualValues(t, ld, (<-ctc.consume).Data)
@@ -671,7 +642,7 @@ func TestReceiverTimeoutError(t *testing.T) {
 	batch.Headers = make([]byte, hpb.Len())
 	copy(batch.Headers, hpb.Bytes())
 
-	ctc.startWithMethod(arrowLogsMethod, ctc.newRealConsumer, defaultBQ())
+	ctc.startWithSignal(signalLogs, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	assert.EqualValues(t, ld, (<-ctc.consume).Data)
@@ -693,13 +664,13 @@ func TestReceiverConsumeError(t *testing.T) {
 	stdTesting := otelAssert.NewStdUnitTest(t)
 
 	type testItem struct {
-		data   any
-		method string
+		data any
+		sig  signalType
 	}
 	items := []testItem{
-		{data: testdata.GenerateTraces(2), method: arrowTracesMethod},
-		{data: testdata.GenerateMetrics(2), method: arrowMetricsMethod},
-		{data: testdata.GenerateLogs(2), method: arrowLogsMethod},
+		{data: testdata.GenerateTraces(2), sig: signalTraces},
+		{data: testdata.GenerateMetrics(2), sig: signalMetrics},
+		{data: testdata.GenerateLogs(2), sig: signalLogs},
 	}
 
 	for _, item := range items {
@@ -724,7 +695,7 @@ func TestReceiverConsumeError(t *testing.T) {
 
 		ctc.stream.EXPECT().Send(statusUnavailableFor(batch.BatchId, "consumer unhealthy")).Times(1).Return(nil)
 
-		ctc.startWithMethod(item.method, ctc.newRealConsumer, defaultBQ())
+		ctc.startWithSignal(item.sig, ctc.newRealConsumer, defaultBQ())
 
 		ctc.putBatch(batch, nil)
 
@@ -756,13 +727,13 @@ func TestReceiverConsumeError(t *testing.T) {
 
 func TestReceiverInvalidData(t *testing.T) {
 	type testItem struct {
-		data   any
-		method string
+		data any
+		sig  signalType
 	}
 	items := []testItem{
-		{data: testdata.GenerateTraces(2), method: arrowTracesMethod},
-		{data: testdata.GenerateMetrics(2), method: arrowMetricsMethod},
-		{data: testdata.GenerateLogs(2), method: arrowLogsMethod},
+		{data: testdata.GenerateTraces(2), sig: signalTraces},
+		{data: testdata.GenerateMetrics(2), sig: signalMetrics},
+		{data: testdata.GenerateLogs(2), sig: signalLogs},
 	}
 
 	for _, item := range items {
@@ -786,7 +757,7 @@ func TestReceiverInvalidData(t *testing.T) {
 		batch = copyBatch(batch)
 
 		// newErrorConsumer determines the internal error in decoding above
-		ctc.startWithMethod(item.method, ctc.newErrorConsumer, defaultBQ())
+		ctc.startWithSignal(item.sig, ctc.newErrorConsumer, defaultBQ())
 		ctc.putBatch(batch, nil)
 
 		err = ctc.wait()
@@ -796,13 +767,13 @@ func TestReceiverInvalidData(t *testing.T) {
 
 func TestReceiverMemoryLimit(t *testing.T) {
 	type testItem struct {
-		data   any
-		method string
+		data any
+		sig  signalType
 	}
 	items := []testItem{
-		{data: testdata.GenerateTraces(2), method: arrowTracesMethod},
-		{data: testdata.GenerateMetrics(2), method: arrowMetricsMethod},
-		{data: testdata.GenerateLogs(2), method: arrowLogsMethod},
+		{data: testdata.GenerateTraces(2), sig: signalTraces},
+		{data: testdata.GenerateMetrics(2), sig: signalMetrics},
+		{data: testdata.GenerateLogs(2), sig: signalLogs},
 	}
 
 	for _, item := range items {
@@ -827,7 +798,7 @@ func TestReceiverMemoryLimit(t *testing.T) {
 
 		// The Recv() returns an error, there are no Send() calls.
 
-		ctc.startWithMethod(item.method, ctc.newOOMConsumer, defaultBQ())
+		ctc.startWithSignal(item.sig, ctc.newOOMConsumer, defaultBQ())
 		ctc.putBatch(batch, nil)
 
 		err = ctc.wait()
@@ -867,7 +838,7 @@ func TestReceiverPayloadPositionIndependent(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(nil)
 
-	ctc.startWithMethod(arrowTracesMethod, ctc.newRealConsumer, defaultBQ())
+	ctc.startWithSignal(signalTraces, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	otelAssert.Equiv(stdTesting, []json.Marshaler{

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -400,6 +400,39 @@ func (ctc *commonTestCase) start(newConsumer func() arrowRecord.ConsumerAPI, bq 
 	}()
 }
 
+func (ctc *commonTestCase) startWithMethod(method string, newConsumer func() arrowRecord.ConsumerAPI, bq admission2.Queue, opts ...func(*configgrpc.ServerConfig, *extensionauth.Server)) {
+	var authServer extensionauth.Server
+	var gsettings configgrpc.ServerConfig
+	for _, gf := range opts {
+		gf(&gsettings, &authServer)
+	}
+	rc := receiver.Settings{
+		TelemetrySettings: ctc.telset,
+		BuildInfo:         component.NewDefaultBuildInfo(),
+	}
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             component.NewID(component.MustNewType("arrowtest")),
+		Transport:              "grpc",
+		ReceiverCreateSettings: rc,
+	})
+	require.NoError(ctc.T, err)
+
+	rcvr, err := New(
+		ctc.consumers,
+		rc,
+		obsrecv,
+		gsettings,
+		authServer,
+		newConsumer,
+		bq,
+		netstats.Noop{},
+	)
+	require.NoError(ctc.T, err)
+	go func() {
+		ctc.streamErr <- rcvr.anyStream(ctc.stream, method)
+	}()
+}
+
 func requireCanceledStatus(t *testing.T, err error) {
 	requireStatus(t, codes.Canceled, err)
 }
@@ -536,7 +569,7 @@ func TestReceiverLogs(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(nil)
 
-	ctc.start(ctc.newRealConsumer, defaultBQ())
+	ctc.startWithMethod(arrowLogsMethod, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	assert.Equal(t, []json.Marshaler{compareJSONLogs{ld}}, []json.Marshaler{compareJSONLogs{(<-ctc.consume).Data.(plog.Logs)}})
@@ -556,7 +589,7 @@ func TestReceiverMetrics(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(nil)
 
-	ctc.start(ctc.newRealConsumer, defaultBQ())
+	ctc.startWithMethod(arrowMetricsMethod, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	otelAssert.Equiv(stdTesting, []json.Marshaler{
@@ -591,7 +624,7 @@ func TestReceiverSendError(t *testing.T) {
 
 	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(status.Errorf(codes.Unavailable, "test send error"))
 
-	ctc.start(ctc.newRealConsumer, defaultBQ())
+	ctc.startWithMethod(arrowLogsMethod, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	assert.EqualValues(t, ld, (<-ctc.consume).Data)
@@ -638,7 +671,7 @@ func TestReceiverTimeoutError(t *testing.T) {
 	batch.Headers = make([]byte, hpb.Len())
 	copy(batch.Headers, hpb.Bytes())
 
-	ctc.start(ctc.newRealConsumer, defaultBQ())
+	ctc.startWithMethod(arrowLogsMethod, ctc.newRealConsumer, defaultBQ())
 	ctc.putBatch(batch, nil)
 
 	assert.EqualValues(t, ld, (<-ctc.consume).Data)
@@ -659,19 +692,23 @@ func TestReceiverTimeoutError(t *testing.T) {
 func TestReceiverConsumeError(t *testing.T) {
 	stdTesting := otelAssert.NewStdUnitTest(t)
 
-	data := []any{
-		testdata.GenerateTraces(2),
-		testdata.GenerateMetrics(2),
-		testdata.GenerateLogs(2),
+	type testItem struct {
+		data   any
+		method string
+	}
+	items := []testItem{
+		{data: testdata.GenerateTraces(2), method: arrowTracesMethod},
+		{data: testdata.GenerateMetrics(2), method: arrowMetricsMethod},
+		{data: testdata.GenerateLogs(2), method: arrowLogsMethod},
 	}
 
-	for _, item := range data {
+	for _, item := range items {
 		tc := newUnhealthyTestChannel(t)
 		ctc := newCommonTestCase(t, tc)
 
 		var batch *arrowpb.BatchArrowRecords
 		var err error
-		switch input := item.(type) {
+		switch input := item.data.(type) {
 		case ptrace.Traces:
 			batch, err = ctc.testProducer.BatchArrowRecordsFromTraces(input)
 		case plog.Logs:
@@ -687,11 +724,11 @@ func TestReceiverConsumeError(t *testing.T) {
 
 		ctc.stream.EXPECT().Send(statusUnavailableFor(batch.BatchId, "consumer unhealthy")).Times(1).Return(nil)
 
-		ctc.start(ctc.newRealConsumer, defaultBQ())
+		ctc.startWithMethod(item.method, ctc.newRealConsumer, defaultBQ())
 
 		ctc.putBatch(batch, nil)
 
-		switch input := item.(type) {
+		switch input := item.data.(type) {
 		case ptrace.Traces:
 			otelAssert.Equiv(stdTesting, []json.Marshaler{
 				compareJSONTraces{input},
@@ -718,19 +755,23 @@ func TestReceiverConsumeError(t *testing.T) {
 }
 
 func TestReceiverInvalidData(t *testing.T) {
-	data := []any{
-		testdata.GenerateTraces(2),
-		testdata.GenerateMetrics(2),
-		testdata.GenerateLogs(2),
+	type testItem struct {
+		data   any
+		method string
+	}
+	items := []testItem{
+		{data: testdata.GenerateTraces(2), method: arrowTracesMethod},
+		{data: testdata.GenerateMetrics(2), method: arrowMetricsMethod},
+		{data: testdata.GenerateLogs(2), method: arrowLogsMethod},
 	}
 
-	for _, item := range data {
+	for _, item := range items {
 		tc := newHealthyTestChannel(t)
 		ctc := newCommonTestCase(t, tc)
 
 		var batch *arrowpb.BatchArrowRecords
 		var err error
-		switch input := item.(type) {
+		switch input := item.data.(type) {
 		case ptrace.Traces:
 			batch, err = ctc.testProducer.BatchArrowRecordsFromTraces(input)
 		case plog.Logs:
@@ -745,7 +786,7 @@ func TestReceiverInvalidData(t *testing.T) {
 		batch = copyBatch(batch)
 
 		// newErrorConsumer determines the internal error in decoding above
-		ctc.start(ctc.newErrorConsumer, defaultBQ())
+		ctc.startWithMethod(item.method, ctc.newErrorConsumer, defaultBQ())
 		ctc.putBatch(batch, nil)
 
 		err = ctc.wait()
@@ -754,19 +795,23 @@ func TestReceiverInvalidData(t *testing.T) {
 }
 
 func TestReceiverMemoryLimit(t *testing.T) {
-	data := []any{
-		testdata.GenerateTraces(2),
-		testdata.GenerateMetrics(2),
-		testdata.GenerateLogs(2),
+	type testItem struct {
+		data   any
+		method string
+	}
+	items := []testItem{
+		{data: testdata.GenerateTraces(2), method: arrowTracesMethod},
+		{data: testdata.GenerateMetrics(2), method: arrowMetricsMethod},
+		{data: testdata.GenerateLogs(2), method: arrowLogsMethod},
 	}
 
-	for _, item := range data {
+	for _, item := range items {
 		tc := newHealthyTestChannel(t)
 		ctc := newCommonTestCase(t, tc)
 
 		var batch *arrowpb.BatchArrowRecords
 		var err error
-		switch input := item.(type) {
+		switch input := item.data.(type) {
 		case ptrace.Traces:
 			batch, err = ctc.testProducer.BatchArrowRecordsFromTraces(input)
 		case plog.Logs:
@@ -782,12 +827,57 @@ func TestReceiverMemoryLimit(t *testing.T) {
 
 		// The Recv() returns an error, there are no Send() calls.
 
-		ctc.start(ctc.newOOMConsumer, defaultBQ())
+		ctc.startWithMethod(item.method, ctc.newOOMConsumer, defaultBQ())
 		ctc.putBatch(batch, nil)
 
 		err = ctc.wait()
 		requireExhaustedStatus(t, err)
 	}
+}
+
+// TestReceiverPayloadPositionIndependent verifies that the receiver
+// correctly processes data based on the gRPC service method rather than
+// the ArrowPayload.Type field at position 0. This reproduces the bug
+// where a Rust OTAP producer sends payloads with the root payload type
+// not at index 0, causing ErrUnrecognizedPayload with the old logic.
+//
+// The batch payloads are reversed so the root type (e.g. SPANS) is no
+// longer at position 0. The Arrow consumer still decodes correctly
+// because it routes each payload by its own Type field internally.
+func TestReceiverPayloadPositionIndependent(t *testing.T) {
+	stdTesting := otelAssert.NewStdUnitTest(t)
+	tc := newHealthyTestChannel(t)
+	ctc := newCommonTestCase(t, tc)
+
+	td := testdata.GenerateTraces(2)
+	batch, err := ctc.testProducer.BatchArrowRecordsFromTraces(td)
+	require.NoError(t, err)
+
+	batch = copyBatch(batch)
+
+	// Reverse the payload order so that the root payload type (SPANS)
+	// is no longer at position 0. With the old payloads[0].Type logic,
+	// the receiver would see a non-root type (e.g. RESOURCE_ATTRS) at
+	// position 0 and return ErrUnrecognizedPayload.
+	payloads := batch.ArrowPayloads
+	require.Greater(t, len(payloads), 1, "need multiple payloads to test reordering")
+	for i, j := 0, len(payloads)-1; i < j; i, j = i+1, j-1 {
+		payloads[i], payloads[j] = payloads[j], payloads[i]
+	}
+
+	ctc.stream.EXPECT().Send(statusOKFor(batch.BatchId)).Times(1).Return(nil)
+
+	ctc.startWithMethod(arrowTracesMethod, ctc.newRealConsumer, defaultBQ())
+	ctc.putBatch(batch, nil)
+
+	otelAssert.Equiv(stdTesting, []json.Marshaler{
+		compareJSONTraces{td},
+	}, []json.Marshaler{
+		compareJSONTraces{(<-ctc.consume).Data.(ptrace.Traces)},
+	})
+
+	err = ctc.cancelAndWait()
+	requireCanceledStatus(t, err)
 }
 
 func copyBatch(in *arrowpb.BatchArrowRecords) *arrowpb.BatchArrowRecords {

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -808,13 +808,9 @@ func TestReceiverMemoryLimit(t *testing.T) {
 
 // TestReceiverPayloadPositionIndependent verifies that the receiver
 // correctly processes data based on the gRPC service method rather than
-// the ArrowPayload.Type field at position 0. This reproduces the bug
-// where a Rust OTAP producer sends payloads with the root payload type
-// not at index 0, causing ErrUnrecognizedPayload with the old logic.
+// the ArrowPayload.Type field at position 0.
 //
-// The batch payloads are reversed so the root type (e.g. SPANS) is no
-// longer at position 0. The Arrow consumer still decodes correctly
-// because it routes each payload by its own Type field internally.
+// See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46878
 func TestReceiverPayloadPositionIndependent(t *testing.T) {
 	stdTesting := otelAssert.NewStdUnitTest(t)
 	tc := newHealthyTestChannel(t)
@@ -827,9 +823,7 @@ func TestReceiverPayloadPositionIndependent(t *testing.T) {
 	batch = copyBatch(batch)
 
 	// Reverse the payload order so that the root payload type (SPANS)
-	// is no longer at position 0. With the old payloads[0].Type logic,
-	// the receiver would see a non-root type (e.g. RESOURCE_ATTRS) at
-	// position 0 and return ErrUnrecognizedPayload.
+	// is no longer at position 0.
 	payloads := batch.ArrowPayloads
 	require.Greater(t, len(payloads), 1, "need multiple payloads to test reordering")
 	for i, j := 0, len(payloads)-1; i < j; i, j = i+1, j-1 {


### PR DESCRIPTION
#### Description

The otelarrowreceiver always assumes that the root payload type is at position 0, however this is an old assumption and we don't want to make this a part of the otap spec. This PR removes the assumption which causes interoperability problems with the rust libraries.

#### Link to tracking issue

Fixes #46878

#### Testing

Added a unit test for the scenario
