### PR TITLE
[exporter/elasticsearch] Encode require_data_stream in bulk action metadata

### DIFF
--- a/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
+++ b/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
@@ -1,8 +1,30 @@
-# Use this file to generate a changelog entry.
-# For more information see: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-changelog
+# Use this changelog template to create an entry for release notes.
 
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Encode `require_data_stream` in Elasticsearch bulk action metadata instead of the bulk request query string."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46022]
-subtext: "This preserves existing endpoint query parameters while moving `require_data_stream` to the per-document action line expected by newer bulk workflows. Benchmarks show a stable ~27 bytes/item NDJSON payload overhead."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This preserves existing endpoint query parameters while moving `require_data_stream`
+  to the per-document action line expected by newer bulk workflows. Benchmarks show
+  a stable ~27 bytes/item NDJSON payload overhead before compression.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
+++ b/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
@@ -10,7 +10,7 @@ component: exporter/elasticsearch
 note: "Encode `require_data_stream` in Elasticsearch bulk action metadata instead of the bulk request query string."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [46022]
+issues: [46970]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
+++ b/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
@@ -5,4 +5,4 @@ change_type: enhancement
 component: exporter/elasticsearch
 note: "Encode `require_data_stream` in Elasticsearch bulk action metadata instead of the bulk request query string."
 issues: [46022]
-subtext: "This preserves existing endpoint query parameters while moving `require_data_stream` to the per-document action line expected by newer bulk workflows."
+subtext: "This preserves existing endpoint query parameters while moving `require_data_stream` to the per-document action line expected by newer bulk workflows. Benchmarks show a stable ~27 bytes/item NDJSON payload overhead."

--- a/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
+++ b/.chloggen/elasticsearchexporter-require-data-stream-doc-level.yaml
@@ -1,0 +1,8 @@
+# Use this file to generate a changelog entry.
+# For more information see: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-changelog
+
+change_type: enhancement
+component: exporter/elasticsearch
+note: "Encode `require_data_stream` in Elasticsearch bulk action metadata instead of the bulk request query string."
+issues: [46022]
+subtext: "This preserves existing endpoint query parameters while moving `require_data_stream` to the per-document action line expected by newer bulk workflows."

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -236,7 +236,7 @@ service:
 > `otel` and `ecs` mapping modes require Elasticsearch 8.12 or above[^1].
 > `otel` mode works best with Elasticsearch 8.16 or above[^2].
 
-[^1]: as OTel and ECS mapping modes rely on the `require_data_stream` bulk API parameter, available since Elasticsearch 8.12
+[^1]: as OTel and ECS mapping modes rely on the `require_data_stream` bulk action metadata, available since Elasticsearch 8.12
 [^2]: Elasticsearch 8.16 contains a built-in `otel-data` plugin
 
 #### OTel mapping mode
@@ -702,7 +702,7 @@ error   elasticsearchexporter@v0.120.1/bulkindexer.go:343       bulk indexer flu
 }
 ```
 
-In this scenario, Elasticsearch may reject the bulk request because the `require_data_stream` query parameter is not supported.
+In this scenario, Elasticsearch may reject the bulk request because the `require_data_stream` bulk action metadata is not supported.
 This may happen when you use [OTel mapping mode](#otel-mapping-mode) (the default mapping mode from v0.122.0, or explicitly by configuring `mapping::mode: otel`) or [ECS mapping mode](#ecs-mapping-mode), and send data to Elasticsearch version < 8.12.
 
 To resolve this, upgrade Elasticsearch to 8.12+; for OTel mapping mode, 8.16+ is recommended.

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -122,10 +122,6 @@ func getQueryParamsFromEndpoint(config *Config, logger *zap.Logger) (queryParams
 		if err != nil {
 			logger.Warn("Failed to parse query parameters from endpoint", zap.Error(err))
 		}
-		delete(queryParams, "require_data_stream")
-		if len(queryParams) == 0 {
-			return nil
-		}
 		return queryParams
 	}
 	return nil

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -122,6 +122,10 @@ func getQueryParamsFromEndpoint(config *Config, logger *zap.Logger) (queryParams
 		if err != nil {
 			logger.Warn("Failed to parse query parameters from endpoint", zap.Error(err))
 		}
+		delete(queryParams, "require_data_stream")
+		if len(queryParams) == 0 {
+			return nil
+		}
 		return queryParams
 	}
 	return nil
@@ -153,7 +157,7 @@ func newSyncBulkIndexer(
 		}
 	}
 	return &syncBulkIndexer{
-		config:                bulkIndexerConfig(client, config, requireDataStream, logger),
+		config:                bulkIndexerConfig(client, config, false, logger),
 		maxFlushBytes:         maxFlushBytes,
 		flushTimeout:          config.Timeout,
 		retryConfig:           config.Retry,
@@ -162,6 +166,7 @@ func newSyncBulkIndexer(
 		logger:                logger,
 		failedDocsInputLogger: newFailedDocsInputLogger(logger, config),
 		getErrorHintFunc:      getErrorHintFunc,
+		requireDataStream:     requireDataStream,
 	}
 }
 
@@ -175,6 +180,7 @@ type syncBulkIndexer struct {
 	logger                *zap.Logger
 	failedDocsInputLogger *zap.Logger
 	getErrorHintFunc      func(index, errorType string) string
+	requireDataStream     bool
 }
 
 // StartSession creates a new docappender.BulkIndexer, and wraps
@@ -204,12 +210,13 @@ type syncBulkIndexerSession struct {
 // Add adds an item to the sync bulk indexer session.
 func (s *syncBulkIndexerSession) Add(ctx context.Context, index, docID, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error {
 	doc := docappender.BulkIndexerItem{
-		Index:            index,
-		Body:             document,
-		DocumentID:       docID,
-		DynamicTemplates: dynamicTemplates,
-		Action:           action,
-		Pipeline:         pipeline,
+		Index:             index,
+		Body:              document,
+		DocumentID:        docID,
+		DynamicTemplates:  dynamicTemplates,
+		Action:            action,
+		Pipeline:          pipeline,
+		RequireDataStream: s.s.requireDataStream,
 	}
 	err := s.bi.Add(doc)
 	if err != nil {

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -261,7 +261,7 @@ func TestBulkIndexerLogsStatusCode(t *testing.T) {
 
 func TestQueryParamsParsedFromEndpoints(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoints = []string{"http://localhost:9200?pipeline=test-pipeline"}
+	cfg.Endpoints = []string{"http://localhost:9200?pipeline=test-pipeline&pretty=false&require_data_stream=true"}
 
 	client, err := newElasticsearchClient(t.Context(), cfg, componenttest.NewNopHost(), componenttest.NewTelemetry().NewTelemetrySettings(), "")
 	require.NoError(t, err)
@@ -269,6 +269,7 @@ func TestQueryParamsParsedFromEndpoints(t *testing.T) {
 	bi := bulkIndexerConfig(client, cfg, true, zaptest.NewLogger(t))
 	require.Equal(t, map[string][]string{
 		"pipeline": {"test-pipeline"},
+		"pretty":   {"false"},
 	}, bi.QueryParams)
 }
 
@@ -355,4 +356,95 @@ func TestGetErrorHint(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// BenchmarkRequireDataStreamPayloadOverhead benchmarks the payload size
+// overhead of encoding require_data_stream at the document level vs
+// omitting it.
+func BenchmarkRequireDataStreamPayloadOverhead(b *testing.B) {
+	for _, tc := range []struct {
+		name              string
+		requireDataStream bool
+		numItems          int
+	}{
+		{name: "without_rds/10_items", requireDataStream: false, numItems: 10},
+		{name: "with_rds/10_items", requireDataStream: true, numItems: 10},
+		{name: "without_rds/100_items", requireDataStream: false, numItems: 100},
+		{name: "with_rds/100_items", requireDataStream: true, numItems: 100},
+		{name: "without_rds/1000_items", requireDataStream: false, numItems: 1000},
+		{name: "with_rds/1000_items", requireDataStream: true, numItems: 1000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				biCfg := newBenchBulkIndexerConfig(b)
+				bi, err := docappender.NewBulkIndexer(biCfg)
+				require.NoError(b, err)
+				for i := 0; i < tc.numItems; i++ {
+					doc := strings.NewReader(`{"@timestamp":"2024-01-01T00:00:00Z","message":"test log message with some realistic content"}`)
+					err := bi.Add(docappender.BulkIndexerItem{
+						Index:             "logs-generic-default",
+						Body:              doc,
+						Action:            "create",
+						RequireDataStream: tc.requireDataStream,
+					})
+					require.NoError(b, err)
+				}
+				b.ReportMetric(float64(bi.Len()), "payload_bytes")
+			}
+		})
+	}
+}
+
+// TestRequireDataStreamPayloadSizeImpact measures the byte overhead of
+// require_data_stream encoded on the action line.
+func TestRequireDataStreamPayloadSizeImpact(t *testing.T) {
+	buildPayload := func(requireDataStream bool, numItems int) int {
+		biCfg := newBenchBulkIndexerConfig(t)
+		bi, err := docappender.NewBulkIndexer(biCfg)
+		require.NoError(t, err)
+		for i := 0; i < numItems; i++ {
+			doc := strings.NewReader(`{"@timestamp":"2024-01-01T00:00:00Z","message":"test log message"}`)
+			err := bi.Add(docappender.BulkIndexerItem{
+				Index:             "logs-generic-default",
+				Body:              doc,
+				Action:            "create",
+				RequireDataStream: requireDataStream,
+			})
+			require.NoError(t, err)
+		}
+		return bi.Len()
+	}
+
+	for _, numItems := range []int{1, 10, 100, 1000} {
+		withoutRDS := buildPayload(false, numItems)
+		withRDS := buildPayload(true, numItems)
+
+		overhead := withRDS - withoutRDS
+		overheadPercent := float64(overhead) / float64(withoutRDS) * 100
+
+		t.Logf("Items: %4d | Without RDS: %6d bytes | With RDS: %6d bytes | Overhead: %4d bytes (%.2f%%)",
+			numItems, withoutRDS, withRDS, overhead, overheadPercent)
+
+		assert.Less(t, overheadPercent, 30.0,
+			"require_data_stream overhead should be less than 30%% for %d items", numItems)
+	}
+}
+
+func newBenchBulkIndexerConfig(tb testing.TB) docappender.BulkIndexerConfig {
+	tb.Helper()
+	client, err := elastictransport.New(elastictransport.Config{
+		URLs: []*url.URL{{Scheme: "http", Host: "localhost:9200"}},
+		Transport: &mockTransport{
+			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+					Body:       io.NopCloser(strings.NewReader(`{"items":[]}`)),
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	})
+	require.NoError(tb, err)
+	return docappender.BulkIndexerConfig{Client: client}
 }

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -4,6 +4,7 @@
 package elasticsearchexporter
 
 import (
+	"compress/gzip"
 	"io"
 	"net/http"
 	"net/url"
@@ -268,8 +269,9 @@ func TestQueryParamsParsedFromEndpoints(t *testing.T) {
 
 	bi := bulkIndexerConfig(client, cfg, true, zaptest.NewLogger(t))
 	require.Equal(t, map[string][]string{
-		"pipeline": {"test-pipeline"},
-		"pretty":   {"false"},
+		"pipeline":            {"test-pipeline"},
+		"pretty":              {"false"},
+		"require_data_stream": {"true"},
 	}, bi.QueryParams)
 }
 
@@ -360,24 +362,29 @@ func TestGetErrorHint(t *testing.T) {
 
 // BenchmarkRequireDataStreamPayloadOverhead benchmarks the payload size
 // overhead of encoding require_data_stream at the document level vs
-// omitting it.
+// omitting it, and reports compression impact on payload size.
 func BenchmarkRequireDataStreamPayloadOverhead(b *testing.B) {
 	for _, tc := range []struct {
 		name              string
 		requireDataStream bool
 		numItems          int
+		compressionLevel  int
 	}{
-		{name: "without_rds/10_items", requireDataStream: false, numItems: 10},
-		{name: "with_rds/10_items", requireDataStream: true, numItems: 10},
-		{name: "without_rds/100_items", requireDataStream: false, numItems: 100},
-		{name: "with_rds/100_items", requireDataStream: true, numItems: 100},
-		{name: "without_rds/1000_items", requireDataStream: false, numItems: 1000},
-		{name: "with_rds/1000_items", requireDataStream: true, numItems: 1000},
+		{name: "no_compression/without_rds/10_items", requireDataStream: false, numItems: 10},
+		{name: "no_compression/with_rds/10_items", requireDataStream: true, numItems: 10},
+		{name: "no_compression/without_rds/100_items", requireDataStream: false, numItems: 100},
+		{name: "no_compression/with_rds/100_items", requireDataStream: true, numItems: 100},
+		{name: "no_compression/without_rds/1000_items", requireDataStream: false, numItems: 1000},
+		{name: "no_compression/with_rds/1000_items", requireDataStream: true, numItems: 1000},
+		{name: "gzip_best_speed/without_rds/1000_items", requireDataStream: false, numItems: 1000, compressionLevel: gzip.BestSpeed},
+		{name: "gzip_best_speed/with_rds/1000_items", requireDataStream: true, numItems: 1000, compressionLevel: gzip.BestSpeed},
+		{name: "gzip_best_compression/without_rds/1000_items", requireDataStream: false, numItems: 1000, compressionLevel: gzip.BestCompression},
+		{name: "gzip_best_compression/with_rds/1000_items", requireDataStream: true, numItems: 1000, compressionLevel: gzip.BestCompression},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				biCfg := newBenchBulkIndexerConfig(b)
+				biCfg := newBenchBulkIndexerConfig(b, tc.compressionLevel)
 				bi, err := docappender.NewBulkIndexer(biCfg)
 				require.NoError(b, err)
 				for range tc.numItems {
@@ -390,48 +397,14 @@ func BenchmarkRequireDataStreamPayloadOverhead(b *testing.B) {
 					})
 					require.NoError(b, err)
 				}
+				b.ReportMetric(float64(bi.UncompressedLen()), "uncompressed_payload_bytes")
 				b.ReportMetric(float64(bi.Len()), "payload_bytes")
 			}
 		})
 	}
 }
 
-// TestRequireDataStreamPayloadSizeImpact measures the byte overhead of
-// require_data_stream encoded on the action line.
-func TestRequireDataStreamPayloadSizeImpact(t *testing.T) {
-	buildPayload := func(requireDataStream bool, numItems int) int {
-		biCfg := newBenchBulkIndexerConfig(t)
-		bi, err := docappender.NewBulkIndexer(biCfg)
-		require.NoError(t, err)
-		for range numItems {
-			doc := strings.NewReader(`{"@timestamp":"2024-01-01T00:00:00Z","message":"test log message"}`)
-			err := bi.Add(docappender.BulkIndexerItem{
-				Index:             "logs-generic-default",
-				Body:              doc,
-				Action:            "create",
-				RequireDataStream: requireDataStream,
-			})
-			require.NoError(t, err)
-		}
-		return bi.Len()
-	}
-
-	for _, numItems := range []int{1, 10, 100, 1000} {
-		withoutRDS := buildPayload(false, numItems)
-		withRDS := buildPayload(true, numItems)
-
-		overhead := withRDS - withoutRDS
-		overheadPercent := float64(overhead) / float64(withoutRDS) * 100
-
-		t.Logf("Items: %4d | Without RDS: %6d bytes | With RDS: %6d bytes | Overhead: %4d bytes (%.2f%%)",
-			numItems, withoutRDS, withRDS, overhead, overheadPercent)
-
-		assert.Less(t, overheadPercent, 30.0,
-			"require_data_stream overhead should be less than 30%% for %d items", numItems)
-	}
-}
-
-func newBenchBulkIndexerConfig(tb testing.TB) docappender.BulkIndexerConfig {
+func newBenchBulkIndexerConfig(tb testing.TB, compressionLevel int) docappender.BulkIndexerConfig {
 	tb.Helper()
 	client, err := elastictransport.New(elastictransport.Config{
 		URLs: []*url.URL{{Scheme: "http", Host: "localhost:9200"}},
@@ -446,5 +419,8 @@ func newBenchBulkIndexerConfig(tb testing.TB) docappender.BulkIndexerConfig {
 		},
 	})
 	require.NoError(tb, err)
-	return docappender.BulkIndexerConfig{Client: client}
+	return docappender.BulkIndexerConfig{
+		Client:           client,
+		CompressionLevel: compressionLevel,
+	}
 }

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -380,7 +380,7 @@ func BenchmarkRequireDataStreamPayloadOverhead(b *testing.B) {
 				biCfg := newBenchBulkIndexerConfig(b)
 				bi, err := docappender.NewBulkIndexer(biCfg)
 				require.NoError(b, err)
-				for i := 0; i < tc.numItems; i++ {
+				for range tc.numItems {
 					doc := strings.NewReader(`{"@timestamp":"2024-01-01T00:00:00Z","message":"test log message with some realistic content"}`)
 					err := bi.Add(docappender.BulkIndexerItem{
 						Index:             "logs-generic-default",
@@ -403,7 +403,7 @@ func TestRequireDataStreamPayloadSizeImpact(t *testing.T) {
 		biCfg := newBenchBulkIndexerConfig(t)
 		bi, err := docappender.NewBulkIndexer(biCfg)
 		require.NoError(t, err)
-		for i := 0; i < numItems; i++ {
+		for range numItems {
 			doc := strings.NewReader(`{"@timestamp":"2024-01-01T00:00:00Z","message":"test log message"}`)
 			err := bi.Add(docappender.BulkIndexerItem{
 				Index:             "logs-generic-default",

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -316,15 +316,10 @@ func TestExporterLogs(t *testing.T) {
 	})
 
 	t.Run("publish with ecs mapping mode sets require_data_stream", func(t *testing.T) {
-		done := make(chan struct{}, 1)
-		server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "true", r.URL.Query().Get("require_data_stream"))
-
-			w.WriteHeader(http.StatusOK)
-			select {
-			case done <- struct{}{}:
-			default:
-			}
+		rec := newBulkRecorder()
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			rec.Record(docs)
+			return itemsAllOK(docs)
 		})
 
 		exporter := newTestLogsExporter(t, server.URL)
@@ -336,7 +331,9 @@ func TestExporterLogs(t *testing.T) {
 			client.Info{Metadata: client.NewMetadata(map[string][]string{"X-Elastic-Mapping-Mode": {"ecs"}})},
 		)
 		mustSendLogsWithCtx(ctx, t, exporter, logs)
-		<-done
+
+		docs := rec.WaitItems(1)
+		assert.JSONEq(t, `{"create":{"_index":"logs-generic-default","require_data_stream":true}}`, string(docs[0].Action))
 	})
 
 	t.Run("publish with elasticsearch.index", func(t *testing.T) {
@@ -518,7 +515,7 @@ func TestExporterLogs(t *testing.T) {
 
 				expected := []itemRequest{
 					{
-						Action:   []byte(`{"create":{"_index":"logs-attr.dataset.otel-resource.attribute.namespace"}}`),
+						Action:   []byte(`{"create":{"_index":"logs-attr.dataset.otel-resource.attribute.namespace","require_data_stream":true}}`),
 						Document: tc.wantDocument,
 					},
 				}
@@ -1083,15 +1080,10 @@ func TestExporterMetrics(t *testing.T) {
 	})
 
 	t.Run("publish with ecs mapping mode sets require_data_stream", func(t *testing.T) {
-		done := make(chan struct{}, 1)
-		server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "true", r.URL.Query().Get("require_data_stream"))
-
-			w.WriteHeader(http.StatusOK)
-			select {
-			case done <- struct{}{}:
-			default:
-			}
+		rec := newBulkRecorder()
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			rec.Record(docs)
+			return itemsAllOK(docs)
 		})
 
 		exporter := newTestMetricsExporter(t, server.URL)
@@ -1101,7 +1093,10 @@ func TestExporterMetrics(t *testing.T) {
 			client.Info{Metadata: client.NewMetadata(map[string][]string{"X-Elastic-Mapping-Mode": {"ecs"}})},
 		)
 		mustSendMetricsWithCtx(ctx, t, exporter, metrics)
-		<-done
+
+		docs := rec.WaitItems(1)
+		assert.Equal(t, "metrics-generic-default", actionJSONToIndex(t, docs[0].Action))
+		assert.True(t, gjson.GetBytes(docs[0].Action, "create.require_data_stream").Bool())
 	})
 
 	t.Run("publish with elasticsearch.index", func(t *testing.T) {
@@ -1195,11 +1190,11 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"foo":{"counts":[1,2,3,4],"values":[0.5,1.5,2.5,3.0]}}}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T01:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"foo":{"counts":[4,5,6,7],"values":[2.0,4.5,5.5,6.0]}}}`),
 			},
 		}
@@ -1238,7 +1233,7 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"foo":{"counts":[1,1,2,1,1],"values":[-24.0,-3.0,0.0,6.0,12.0]}}}`),
 			},
 		}
@@ -1341,11 +1336,11 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.bar":"double_metrics","metric.foo":"histogram_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.bar":"double_metrics","metric.foo":"histogram_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"bar":1.0}}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"histogram_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T01:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"foo":{"counts":[4,5,6,7],"values":[2.0,4.5,5.5,6.0]}}}`),
 			},
 		}
@@ -1433,19 +1428,19 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.foo":"histogram"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.foo":"histogram"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":0,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"metrics":{"metric.foo":{"counts":[1,2,3,4],"values":[0.5,1.5,2.5,3.0]}},"resource":{},"scope":{},"_metric_names_hash":"b23939f78dc5f649"}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.foo":"histogram"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.foo":"histogram"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":3600000,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"metrics":{"metric.foo":{"counts":[4,5,6,7],"values":[2.0,4.5,5.5,6.0]}},"resource":{},"scope":{},"_metric_names_hash":"b23939f78dc5f649"}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.sum.monotonic.delta":"gauge_double","metrics.metric.sum.nonmonotonic.cumulative":"gauge_double","metrics.metric.sum.nonmonotonic.delta":"gauge_double","metrics.metric.sum.monotonic.cumulative":"counter_double"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.sum.monotonic.delta":"gauge_double","metrics.metric.sum.nonmonotonic.cumulative":"gauge_double","metrics.metric.sum.nonmonotonic.delta":"gauge_double","metrics.metric.sum.monotonic.cumulative":"counter_double"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":3600000,"start_timestamp":7200000,"data_stream":{"type":"metrics","dataset":"generic.otel","namespace":"default"},"resource":{},"scope":{},"metrics":{"metric.sum.monotonic.cumulative":1.5,"metric.sum.monotonic.delta":2.5,"metric.sum.nonmonotonic.cumulative":3.5,"metric.sum.nonmonotonic.delta":4.5},"_metric_names_hash":"4c23ec9ba381ab20"}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.summary":"summary"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.metric.summary":"summary"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":10800000,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"metrics":{"metric.summary":{"sum":1.5,"value_count":1}},"resource":{},"scope":{},"start_timestamp":10800000,"_metric_names_hash":"2f30c89222c9d308"}`),
 			},
 		}
@@ -1551,7 +1546,7 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.sum":"gauge_long","metrics.summary":"summary"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.sum":"gauge_long","metrics.summary":"summary"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":0,"_doc_count":10,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"metrics":{"sum":0,"summary":{"sum":1.0,"value_count":10}},"resource":{},"scope":{},"_metric_names_hash":"e446964dc8337bbb"}`),
 			},
 		}
@@ -1600,11 +1595,11 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.histogram.summary":"summary"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.histogram.summary":"summary"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":0,"_doc_count":10,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"attributes":{},"metrics":{"histogram.summary":{"sum":1.0,"value_count":10}},"resource":{},"scope":{},"_metric_names_hash":"fcd1d6737d725996"}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.exphistogram.summary":"summary"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.exphistogram.summary":"summary"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":3600000,"_doc_count":10,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"attributes":{},"metrics":{"exphistogram.summary":{"sum":1.0,"value_count":10}},"resource":{},"scope":{},"_metric_names_hash":"6a10ca190ae63c5"}`),
 			},
 		}
@@ -1642,7 +1637,7 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.foo.bar":"gauge_long","metrics.foo":"gauge_long","metrics.foo.bar.baz":"gauge_long"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.foo.bar":"gauge_long","metrics.foo":"gauge_long","metrics.foo.bar.baz":"gauge_long"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":0,"data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"metrics":{"foo":0,"foo.bar":0,"foo.bar.baz":0},"resource":{},"scope":{},"_metric_names_hash":"9c732a69b35274fe"}`),
 			},
 		}
@@ -1679,11 +1674,11 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"summary_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"summary_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"foo":{"sum":1.5,"value_count":1}}}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"summary_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"metric.foo":"summary_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T01:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"foo":{"sum":2.0,"value_count":3}}}`),
 			},
 		}
@@ -1781,7 +1776,7 @@ func TestExporterMetrics(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"ecs.counter":"double_metrics","ecs.gauge":"double_metrics","ecs.histogram":"histogram_metrics","ecs.summary":"summary_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"ecs.counter":"double_metrics","ecs.gauge":"double_metrics","ecs.histogram":"histogram_metrics","ecs.summary":"summary_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"ecs":{"counter":2.0,"gauge":1.0,"histogram":{"counts":[1,2,3,4],"values":[0.5,1.5,2.5,3.0]},"summary":{"sum":5.0,"value_count":10}}}`),
 			},
 		}
@@ -2030,11 +2025,11 @@ func TestExporterMetrics_Grouping(t *testing.T) {
 		mustSendMetricsWithCtx(ctx, t, exporter, metrics)
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"foo":"double_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"foo":"double_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"foo":1.0,"a":"c"}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"bar":"double_metrics","baz":"double_metrics"}}}`),
+				Action:   []byte(`{"create":{"_index":"metrics-generic-default","dynamic_templates":{"bar":"double_metrics","baz":"double_metrics"},"require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"bar":1.0,"baz":1.0,"a":"b"}`),
 			},
 		}
@@ -2192,15 +2187,10 @@ func TestExporterTraces(t *testing.T) {
 	})
 
 	t.Run("publish with ecs mapping mode sets require_data_stream", func(t *testing.T) {
-		done := make(chan struct{}, 1)
-		server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "true", r.URL.Query().Get("require_data_stream"))
-
-			w.WriteHeader(http.StatusOK)
-			select {
-			case done <- struct{}{}:
-			default:
-			}
+		rec := newBulkRecorder()
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			rec.Record(docs)
+			return itemsAllOK(docs)
 		})
 
 		exporter := newTestTracesExporter(t, server.URL)
@@ -2210,7 +2200,9 @@ func TestExporterTraces(t *testing.T) {
 			client.Info{Metadata: client.NewMetadata(map[string][]string{"X-Elastic-Mapping-Mode": {"ecs"}})},
 		)
 		mustSendTracesWithCtx(ctx, t, exporter, traces)
-		<-done
+
+		docs := rec.WaitItems(1)
+		assert.JSONEq(t, `{"create":{"_index":"traces-generic-default","require_data_stream":true}}`, string(docs[0].Action))
 	})
 
 	t.Run("publish with elasticsearch.index", func(t *testing.T) {
@@ -2382,11 +2374,11 @@ func TestExporterTraces(t *testing.T) {
 
 		expected := []itemRequest{
 			{
-				Action:   []byte(`{"create":{"_index":"traces-generic.otel-default"}}`),
+				Action:   []byte(`{"create":{"_index":"traces-generic.otel-default","require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"3600000.0","attributes":{"attr.foo":"attr.bar"},"data_stream":{"dataset":"generic.otel","namespace":"default","type":"traces"},"dropped_attributes_count":2,"dropped_events_count":3,"dropped_links_count":4,"duration":3600000000000,"kind":"Unspecified","links":[{"attributes":{"link.attr.foo":"link.attr.bar"},"dropped_attributes_count":11,"span_id":"0100000000000000","trace_id":"01000000000000000000000000000000","trace_state":"bar"}],"name":"name","resource":{"attributes":{"resource.foo":"resource.bar"}},"scope":{},"status":{},"trace_state":"foo"}`),
 			},
 			{
-				Action:   []byte(`{"create":{"_index":"logs-generic.otel-default"}}`),
+				Action:   []byte(`{"create":{"_index":"logs-generic.otel-default","require_data_stream":true}}`),
 				Document: []byte(`{"@timestamp":"0.0","event_name":"exception","attributes":{"event.attr.foo":"event.attr.bar","event.name":"exception"},"event_name":"exception","data_stream":{"dataset":"generic.otel","namespace":"default","type":"logs"},"dropped_attributes_count":1,"resource":{"attributes":{"resource.foo":"resource.bar"}},"scope":{}}`),
 			},
 		}


### PR DESCRIPTION
## Summary

Move `require_data_stream` from bulk request query parameters to per-document bulk action metadata in the Elasticsearch exporter.

## Why

Maintainer feedback requested splitting this change into a dedicated PR and keeping it separate from broader request-splitting/retry architecture work.

## What changed

- Set `require_data_stream` on `docappender.BulkIndexerItem` action metadata (document level).
- Keep bulk-level `RequireDataStream` disabled to avoid query-string encoding for this parameter.
- Preserve existing endpoint query params, but explicitly remove `require_data_stream` from forwarded endpoint query parameters.
- Update logs/metrics/traces exporter tests to assert `require_data_stream` in action metadata.
- Add/refresh focused tests and benchmark coverage for payload overhead.
- Update docs/changelog wording to match document-level encoding behavior.

## Validation

- `make test` (exporter module): pass
- `make chlog-validate`: pass
- `go test -run '^$' -bench BenchmarkRequireDataStreamPayloadOverhead -benchmem`: pass

Benchmark payload sizes:
- 10 items: 1400 -> 1670 bytes
- 100 items: 14000 -> 16700 bytes
- 1000 items: 140000 -> 167000 bytes

Overhead is consistently ~27 bytes per item.

