### PR TITLE
[extension/datadog] Add installation_method and os fields

### DIFF
--- a/extension/datadogextension/config.go
+++ b/extension/datadogextension/config.go
@@ -5,6 +5,9 @@ package datadogextension // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"errors"
+	"fmt"
+	"slices"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -27,6 +30,10 @@ type Config struct {
 	// DeploymentType indicates the type of deployment (gateway, daemonset, or unknown).
 	// Defaults to "unknown" if not set.
 	DeploymentType string `mapstructure:"deployment_type"`
+	// InstallationMethod indicates how the collector was installed.
+	// Valid values: "", "kubernetes", "bare-metal", "docker", "ecs-fargate", "eks-fargate".
+	// Defaults to "" (unset) if not configured.
+	InstallationMethod string `mapstructure:"installation_method"`
 }
 
 // Validate ensures that the configuration is valid.
@@ -47,6 +54,11 @@ func (c *Config) Validate() error {
 	// Set default if not provided
 	if c.DeploymentType == "" {
 		c.DeploymentType = "unknown"
+	}
+	// Validate installation_method if set
+	validInstallationMethods := []string{"", "kubernetes", "bare-metal", "docker", "ecs-fargate", "eks-fargate"}
+	if !slices.Contains(validInstallationMethods, c.InstallationMethod) {
+		return fmt.Errorf("installation_method must be one of: %s", strings.Join(validInstallationMethods[1:], ", "))
 	}
 	return nil
 }

--- a/extension/datadogextension/config_test.go
+++ b/extension/datadogextension/config_test.go
@@ -305,7 +305,7 @@ func TestConfig_InstallationMethodDefault(t *testing.T) {
 
 	err := cfg.Validate()
 	require.NoError(t, err)
-	assert.Equal(t, "", cfg.InstallationMethod, "InstallationMethod should default to empty string")
+	assert.Empty(t, cfg.InstallationMethod, "InstallationMethod should default to empty string")
 }
 
 func TestConfig_InstallationMethodValidValues(t *testing.T) {

--- a/extension/datadogextension/config_test.go
+++ b/extension/datadogextension/config_test.go
@@ -286,6 +286,74 @@ func TestConfig_DeploymentTypeDefault(t *testing.T) {
 	assert.Equal(t, "unknown", cfg.DeploymentType, "DeploymentType should default to 'unknown'")
 }
 
+func TestConfig_InstallationMethodDefault(t *testing.T) {
+	cfg := Config{
+		API: datadogconfig.APIConfig{
+			Site: datadogconfig.DefaultSite,
+			Key:  "1234567890abcdef1234567890abcdef",
+		},
+		HTTPConfig: &httpserver.Config{
+			ServerConfig: confighttp.ServerConfig{
+				NetAddr: confignet.AddrConfig{
+					Transport: confignet.TransportTypeTCP,
+					Endpoint:  "localhost:8080",
+				},
+			},
+			Path: "/metadata",
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+	assert.Equal(t, "", cfg.InstallationMethod, "InstallationMethod should default to empty string")
+}
+
+func TestConfig_InstallationMethodValidValues(t *testing.T) {
+	tests := []struct {
+		name               string
+		installationMethod string
+		expectError        bool
+	}{
+		{name: "empty is valid", installationMethod: "", expectError: false},
+		{name: "kubernetes is valid", installationMethod: "kubernetes", expectError: false},
+		{name: "bare-metal is valid", installationMethod: "bare-metal", expectError: false},
+		{name: "docker is valid", installationMethod: "docker", expectError: false},
+		{name: "ecs-fargate is valid", installationMethod: "ecs-fargate", expectError: false},
+		{name: "eks-fargate is valid", installationMethod: "eks-fargate", expectError: false},
+		{name: "invalid value fails", installationMethod: "invalid", expectError: true},
+		{name: "unknown is invalid", installationMethod: "unknown", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				API: datadogconfig.APIConfig{
+					Site: datadogconfig.DefaultSite,
+					Key:  "1234567890abcdef1234567890abcdef",
+				},
+				HTTPConfig: &httpserver.Config{
+					ServerConfig: confighttp.ServerConfig{
+						NetAddr: confignet.AddrConfig{
+							Transport: confignet.TransportTypeTCP,
+							Endpoint:  "localhost:8080",
+						},
+					},
+					Path: "/metadata",
+				},
+				InstallationMethod: tt.installationMethod,
+			}
+
+			err := cfg.Validate()
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "installation_method must be one of")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestConfig_DeploymentTypeValidValues(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -125,6 +125,7 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		e.configs.extension.API.Site,
 		fullConfig,
 		e.configs.extension.DeploymentType,
+		e.configs.extension.InstallationMethod,
 		buildInfo,
 		int64(payloadTTL),
 	)

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -359,6 +359,7 @@ func createTestOtelCollectorPayload() *payload.OtelCollectorPayload {
 		site,
 		fullConfig,
 		"unknown",
+		"",
 		buildInfo,
 		int64(payloadTTL),
 	)
@@ -567,6 +568,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 		"datadoghq.com",
 		fullConfig,
 		"unknown",
+		"",
 		buildInfo,
 		int64(payloadTTL),
 	)
@@ -730,6 +732,7 @@ func TestHTTPServerConfigIntegration(t *testing.T) {
 		"datadoghq.com",
 		"{}",
 		"unknown",
+		"",
 		buildInfo,
 		int64(payloadTTL),
 	)
@@ -826,6 +829,7 @@ func TestHTTPServerConcurrentAccess(t *testing.T) {
 		"datadoghq.com",
 		"{}",
 		"unknown",
+		"",
 		buildInfo,
 		int64(payloadTTL),
 	)

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -227,6 +227,8 @@ const successfulInstanceResponse = `{
     "health_status": "",
     "collector_resource_attributes": {},
     "collector_deployment_type": "unknown",
+    "collector_installation_method": "",
+    "os": "",
     "ttl": 900000000000
   },
   "uuid": "test-uuid"

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -7,6 +7,7 @@ package payload // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"encoding/json"
 	"errors"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
@@ -36,7 +37,9 @@ type OtelCollector struct {
 	FullConfiguration           string             `json:"full_configuration"` // JSON passed as string
 	HealthStatus                string             `json:"health_status"`      // JSON passed as string
 	CollectorResourceAttributes map[string]string  `json:"collector_resource_attributes"`
-	CollectorDeploymentType     string             `json:"collector_deployment_type"` // deployment type: gateway, daemonset, or unknown
+	CollectorDeploymentType     string             `json:"collector_deployment_type"`     // deployment type: gateway, daemonset, or unknown
+	CollectorInstallationMethod string             `json:"collector_installation_method"` // installation method: kubernetes, bare-metal, docker, ecs-fargate, eks-fargate, or ""
+	OS                          string             `json:"os"`                            // runtime operating system (runtime.GOOS)
 	TTL                         int64              `json:"ttl"`
 }
 
@@ -91,20 +94,23 @@ func PrepareOtelCollectorMetadata(
 	site,
 	fullConfig,
 	deploymentType string,
+	installationMethod string,
 	buildInfo CustomBuildInfo,
 	ttl int64,
 ) OtelCollector {
 	return OtelCollector{
-		HostKey:                 "",
-		Hostname:                hostname,
-		HostnameSource:          hostnameSource,
-		CollectorID:             hostname + "-" + extensionUUID,
-		CollectorVersion:        version,
-		ConfigSite:              site,
-		APIKeyUUID:              "",
-		BuildInfo:               buildInfo,
-		FullConfiguration:       fullConfig,
-		CollectorDeploymentType: deploymentType,
-		TTL:                     ttl,
+		HostKey:                     "",
+		Hostname:                    hostname,
+		HostnameSource:              hostnameSource,
+		CollectorID:                 hostname + "-" + extensionUUID,
+		CollectorVersion:            version,
+		ConfigSite:                  site,
+		APIKeyUUID:                  "",
+		BuildInfo:                   buildInfo,
+		FullConfiguration:           fullConfig,
+		CollectorDeploymentType:     deploymentType,
+		CollectorInstallationMethod: installationMethod,
+		OS:                          runtime.GOOS,
+		TTL:                         ttl,
 	}
 }

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -167,6 +167,7 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 		site,
 		fullConfig,
 		deploymentType,
+		"",
 		buildInfo,
 		int64(5*time.Minute*3),
 	)
@@ -435,6 +436,7 @@ func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 				"datadoghq.com",
 				"{}",
 				tt.deploymentType,
+				"",
 				buildInfo,
 				int64(5*time.Minute*3),
 			)
@@ -459,6 +461,66 @@ func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 			metadataMap, ok := jsonMap["otel_collector"].(map[string]any)
 			require.True(t, ok)
 			assert.Equal(t, tt.deploymentType, metadataMap["collector_deployment_type"])
+		})
+	}
+}
+
+func TestPrepareOtelCollectorMetadata_OS(t *testing.T) {
+	buildInfo := CustomBuildInfo{Command: "otelcol", Description: "Test Collector", Version: "1.0.0"}
+	metadata := PrepareOtelCollectorMetadata(
+		"test-host", "config", "test-uuid", "1.0.0", "datadoghq.com", "{}",
+		"unknown", "", buildInfo, int64(5*time.Minute*3),
+	)
+
+	assert.NotEmpty(t, metadata.OS)
+
+	payload := &OtelCollectorPayload{Hostname: "test-host", Timestamp: time.Now().UnixNano(), UUID: "test-uuid", Metadata: metadata}
+	jsonData, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var jsonMap map[string]any
+	err = json.Unmarshal(jsonData, &jsonMap)
+	require.NoError(t, err)
+
+	metadataMap, ok := jsonMap["otel_collector"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, metadataMap["os"])
+}
+
+func TestPrepareOtelCollectorMetadata_InstallationMethod(t *testing.T) {
+	tests := []struct {
+		name               string
+		installationMethod string
+	}{
+		{name: "empty installation method", installationMethod: ""},
+		{name: "kubernetes installation method", installationMethod: "kubernetes"},
+		{name: "bare-metal installation method", installationMethod: "bare-metal"},
+		{name: "docker installation method", installationMethod: "docker"},
+		{name: "ecs-fargate installation method", installationMethod: "ecs-fargate"},
+		{name: "eks-fargate installation method", installationMethod: "eks-fargate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildInfo := CustomBuildInfo{Command: "otelcol", Description: "Test Collector", Version: "1.0.0"}
+			metadata := PrepareOtelCollectorMetadata(
+				"test-host", "config", "test-uuid", "1.0.0", "datadoghq.com", "{}",
+				"unknown", tt.installationMethod, buildInfo, int64(5*time.Minute*3),
+			)
+
+			assert.Equal(t, tt.installationMethod, metadata.CollectorInstallationMethod)
+
+			payload := &OtelCollectorPayload{Hostname: "test-host", Timestamp: time.Now().UnixNano(), UUID: "test-uuid", Metadata: metadata}
+			jsonData, err := json.Marshal(payload)
+			require.NoError(t, err)
+
+			var jsonMap map[string]any
+			err = json.Unmarshal(jsonData, &jsonMap)
+			require.NoError(t, err)
+
+			metadataMap, ok := jsonMap["otel_collector"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.installationMethod, metadataMap["collector_installation_method"])
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds two new fields to the `datadogextension` fleet metadata payload:
- `os`: The operating system running the collector, auto populated from `runtime.GOOS`
- `collector_installation_method`: How the collector was installed, set via `extensions.datadog.installation_method`. Valid values: kubernetes, bare-metal, docker, ecs-fargate, eks-fargate, or "" (default, unset)

The `installation_method` field is intended to be set by deployment tooling (Helm, Operator, task definition templates, install scripts), but can also be manually set in the collector config.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests and ran locally

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
