### PR TITLE
[exporter/clickhouse] Pre-size slices to reduce allocations

### DIFF
--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -159,7 +159,14 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td ptrace.Traces) er
 }
 
 func convertEvents(events ptrace.SpanEventSlice) (times []time.Time, names []string, attrs []column.IterableOrderedMap) {
-	for i := 0; i < events.Len(); i++ {
+	n := events.Len()
+	if n == 0 {
+		return nil, nil, nil
+	}
+	times = make([]time.Time, 0, n)
+	names = make([]string, 0, n)
+	attrs = make([]column.IterableOrderedMap, 0, n)
+	for i := range n {
 		event := events.At(i)
 		times = append(times, event.Timestamp().AsTime())
 		names = append(names, event.Name())
@@ -170,7 +177,15 @@ func convertEvents(events ptrace.SpanEventSlice) (times []time.Time, names []str
 }
 
 func convertLinks(links ptrace.SpanLinkSlice) (traceIDs, spanIDs, states []string, attrs []column.IterableOrderedMap) {
-	for i := 0; i < links.Len(); i++ {
+	n := links.Len()
+	if n == 0 {
+		return nil, nil, nil, nil
+	}
+	traceIDs = make([]string, 0, n)
+	spanIDs = make([]string, 0, n)
+	states = make([]string, 0, n)
+	attrs = make([]column.IterableOrderedMap, 0, n)
+	for i := range n {
 		link := links.At(i)
 		traceIDs = append(traceIDs, traceutil.TraceIDToHexOrEmptyString(link.TraceID()))
 		spanIDs = append(spanIDs, traceutil.SpanIDToHexOrEmptyString(link.SpanID()))

--- a/exporter/clickhouseexporter/exporter_traces_bench_test.go
+++ b/exporter/clickhouseexporter/exporter_traces_bench_test.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhouseexporter
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter/internal"
+)
+
+// tracesWithNEventsAndLinks creates a realistic traces payload where each span
+// has the given number of events and links, each with attributes. This models
+// a real-world scenario better than single-element test data.
+func tracesWithNEventsAndLinks(spans, eventsPerSpan, linksPerSpan int) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "bench-service")
+	rs.Resource().Attributes().PutStr("host.name", "bench-host")
+	rs.Resource().Attributes().PutStr("deployment.environment", "production")
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("io.opentelemetry.contrib.clickhouse")
+	ss.Scope().SetVersion("1.0.0")
+	ss.Scope().Attributes().PutStr("lib", "clickhouse")
+	timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := range spans {
+		s := ss.Spans().AppendEmpty()
+		s.SetTraceID([16]byte{1, 2, 3, byte(i)})
+		s.SetSpanID([8]byte{1, 2, 3, byte(i)})
+		s.SetParentSpanID([8]byte{1, 2, 4, byte(i)})
+		s.TraceState().FromRaw("key=value")
+		s.SetName("db.query")
+		s.SetKind(ptrace.SpanKindClient)
+		s.SetStartTimestamp(pcommon.NewTimestampFromTime(timestamp))
+		s.SetEndTimestamp(pcommon.NewTimestampFromTime(timestamp.Add(50 * time.Millisecond)))
+		s.Attributes().PutStr("db.system", "postgresql")
+		s.Attributes().PutStr("db.statement", "SELECT * FROM users WHERE id = $1")
+		s.Attributes().PutStr("net.peer.name", "db.example.com")
+		s.Status().SetCode(ptrace.StatusCodeOk)
+
+		for e := range eventsPerSpan {
+			event := s.Events().AppendEmpty()
+			event.SetName("log")
+			event.SetTimestamp(pcommon.NewTimestampFromTime(timestamp.Add(time.Duration(e) * time.Millisecond)))
+			event.Attributes().PutStr("level", "info")
+			event.Attributes().PutStr("message", "executing query")
+			event.Attributes().PutInt("attempt", int64(e))
+		}
+
+		for l := range linksPerSpan {
+			link := s.Links().AppendEmpty()
+			link.SetTraceID([16]byte{2, 3, 4, byte(l)})
+			link.SetSpanID([8]byte{2, 3, 4, byte(l)})
+			link.TraceState().FromRaw("linked=true")
+			link.Attributes().PutStr("link.type", "parent")
+			link.Attributes().PutStr("link.source", "upstream")
+		}
+	}
+
+	return traces
+}
+
+func BenchmarkConvertEvents(b *testing.B) {
+	for _, numEvents := range []int{1, 5, 10} {
+		traces := tracesWithNEventsAndLinks(1, numEvents, 0)
+		events := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Events()
+		b.Run(fmt.Sprintf("events=%d", numEvents), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				convertEvents(events)
+			}
+		})
+	}
+}
+
+func BenchmarkConvertLinks(b *testing.B) {
+	for _, numLinks := range []int{1, 5, 10} {
+		traces := tracesWithNEventsAndLinks(1, 0, numLinks)
+		links := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Links()
+		b.Run(fmt.Sprintf("links=%d", numLinks), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				convertLinks(links)
+			}
+		})
+	}
+}
+
+// BenchmarkTracesBatchPrep benchmarks the full data preparation path for a
+// batch of spans, including AttributesToMap and convert functions. This doesn't
+// include the actual batch.Append (which needs a DB), but covers all the
+// allocation-heavy work that happens before it.
+func BenchmarkTracesBatchPrep(b *testing.B) {
+	for _, numSpans := range []int{100, 1000} {
+		traces := tracesWithNEventsAndLinks(numSpans, 3, 2)
+		b.Run(fmt.Sprintf("spans=%d", numSpans), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				prepareTracesBatch(traces)
+			}
+		})
+	}
+}
+
+// prepareTracesBatch simulates the data preparation loop from pushTraceData
+// without the actual DB interaction.
+func prepareTracesBatch(td ptrace.Traces) {
+	rsSpans := td.ResourceSpans()
+	for i := range rsSpans.Len() {
+		spans := rsSpans.At(i)
+		res := spans.Resource()
+		resAttr := res.Attributes()
+		_ = internal.GetServiceName(resAttr)
+		_ = internal.AttributesToMap(res.Attributes())
+
+		for j := range spans.ScopeSpans().Len() {
+			scopeSpanRoot := spans.ScopeSpans().At(j)
+			scopeSpans := scopeSpanRoot.Spans()
+
+			for k := range scopeSpans.Len() {
+				span := scopeSpans.At(k)
+				_ = internal.AttributesToMap(span.Attributes())
+				convertEvents(span.Events())
+				convertLinks(span.Links())
+			}
+		}
+	}
+}

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -226,7 +226,14 @@ func (e *tracesJSONExporter) pushTraceData(ctx context.Context, td ptrace.Traces
 }
 
 func convertEventsJSON(events ptrace.SpanEventSlice) (times []time.Time, names, attrs []string, err error) {
-	for i := 0; i < events.Len(); i++ {
+	n := events.Len()
+	if n == 0 {
+		return nil, nil, nil, nil
+	}
+	times = make([]time.Time, 0, n)
+	names = make([]string, 0, n)
+	attrs = make([]string, 0, n)
+	for i := range n {
 		event := events.At(i)
 		times = append(times, event.Timestamp().AsTime())
 		names = append(names, event.Name())
@@ -238,11 +245,19 @@ func convertEventsJSON(events ptrace.SpanEventSlice) (times []time.Time, names, 
 		attrs = append(attrs, string(eventAttrBytes))
 	}
 
-	return times, names, attrs, err
+	return times, names, attrs, nil
 }
 
 func convertLinksJSON(links ptrace.SpanLinkSlice) (traceIDs, spanIDs, states, attrs []string, err error) {
-	for i := 0; i < links.Len(); i++ {
+	n := links.Len()
+	if n == 0 {
+		return nil, nil, nil, nil, nil
+	}
+	traceIDs = make([]string, 0, n)
+	spanIDs = make([]string, 0, n)
+	states = make([]string, 0, n)
+	attrs = make([]string, 0, n)
+	for i := range n {
 		link := links.At(i)
 		traceIDs = append(traceIDs, link.TraceID().String())
 		spanIDs = append(spanIDs, link.SpanID().String())
@@ -255,7 +270,7 @@ func convertLinksJSON(links ptrace.SpanLinkSlice) (traceIDs, spanIDs, states, at
 		attrs = append(attrs, string(linkAttrBytes))
 	}
 
-	return traceIDs, spanIDs, states, attrs, err
+	return traceIDs, spanIDs, states, attrs, nil
 }
 
 func (e *tracesJSONExporter) renderInsertTracesJSONSQL() {

--- a/exporter/clickhouseexporter/internal/metrics/bench_test.go
+++ b/exporter/clickhouseexporter/internal/metrics/bench_test.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func init() {
+	SetLogger(zap.NewNop())
+}
+
+// makeExemplars creates a realistic ExemplarSlice with n exemplars, each
+// having filtered attributes, timestamps, values, and trace/span IDs.
+func makeExemplars(n int) pmetric.ExemplarSlice {
+	exemplars := pmetric.NewExemplarSlice()
+	timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range n {
+		e := exemplars.AppendEmpty()
+		e.SetTimestamp(pcommon.NewTimestampFromTime(timestamp.Add(time.Duration(i) * time.Second)))
+		e.SetDoubleValue(float64(i) * 1.5)
+		e.FilteredAttributes().PutStr("key", "value")
+		e.FilteredAttributes().PutStr("key2", "value2")
+		e.SetSpanID([8]byte{1, 2, 3, byte(i)})
+		e.SetTraceID([16]byte{1, 2, 3, byte(i)})
+	}
+	return exemplars
+}
+
+func BenchmarkConvertExemplars(b *testing.B) {
+	for _, n := range []int{1, 3, 10} {
+		exemplars := makeExemplars(n)
+		b.Run(fmt.Sprintf("exemplars=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				convertExemplars(exemplars)
+			}
+		})
+	}
+}
+
+func BenchmarkConvertSliceToArraySet(b *testing.B) {
+	for _, n := range []int{5, 20, 100} {
+		slice := make([]uint64, n)
+		for i := range slice {
+			slice[i] = uint64(i)
+		}
+		b.Run(fmt.Sprintf("len=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				convertSliceToArraySet(slice)
+			}
+		})
+	}
+}
+
+func BenchmarkConvertValueAtQuantile(b *testing.B) {
+	for _, n := range []int{1, 5, 10} {
+		quantiles := pmetric.NewSummaryDataPointValueAtQuantileSlice()
+		for i := range n {
+			q := quantiles.AppendEmpty()
+			q.SetQuantile(float64(i) * 0.1)
+			q.SetValue(float64(i) * 10.0)
+		}
+		b.Run(fmt.Sprintf("quantiles=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				convertValueAtQuantile(quantiles)
+			}
+		})
+	}
+}
+
+// BenchmarkMetricsBatchPrep benchmarks the full data preparation path for
+// gauge metrics including AttributesToMap, GetServiceName, and convertExemplars.
+func BenchmarkMetricsBatchPrep(b *testing.B) {
+	for _, count := range []int{100, 1000} {
+		metrics := makeGaugeMetrics(count)
+		b.Run(fmt.Sprintf("datapoints=%d", count), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				for _, model := range metrics {
+					resAttr := AttributesToMap(model.metadata.ResAttr)
+					scopeAttr := AttributesToMap(model.metadata.ScopeInstr.Attributes())
+					serviceName := GetServiceName(model.metadata.ResAttr)
+					_ = resAttr
+					_ = scopeAttr
+					_ = serviceName
+					for i := 0; i < model.gauge.DataPoints().Len(); i++ {
+						dp := model.gauge.DataPoints().At(i)
+						_ = AttributesToMap(dp.Attributes())
+						convertExemplars(dp.Exemplars())
+						getValue(dp.IntValue(), dp.DoubleValue(), dp.ValueType())
+					}
+				}
+			}
+		})
+	}
+}
+
+func makeGaugeMetrics(count int) []*gaugeModel {
+	rm := pmetric.NewResourceMetrics()
+	rm.Resource().Attributes().PutStr("service.name", "bench-service")
+	rm.Resource().Attributes().PutStr("host.name", "bench-host")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("bench-scope")
+	sm.Scope().SetVersion("1.0.0")
+	sm.Scope().Attributes().PutStr("lib", "clickhouse")
+	timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("bench.gauge")
+	m.SetUnit("count")
+	m.SetDescription("benchmark gauge metric")
+	gauge := m.SetEmptyGauge()
+	for i := range count {
+		dp := gauge.DataPoints().AppendEmpty()
+		dp.SetIntValue(int64(i))
+		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(timestamp))
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamp))
+		dp.Attributes().PutStr("label1", "value1")
+		dp.Attributes().PutStr("label2", "value2")
+		e := dp.Exemplars().AppendEmpty()
+		e.SetTimestamp(pcommon.NewTimestampFromTime(timestamp))
+		e.SetIntValue(int64(i))
+		e.FilteredAttributes().PutStr("key", "value")
+		e.SetSpanID([8]byte{1, 2, 3, byte(i)})
+		e.SetTraceID([16]byte{1, 2, 3, byte(i)})
+	}
+
+	return []*gaugeModel{
+		{
+			metricName:        m.Name(),
+			metricDescription: m.Description(),
+			metricUnit:        m.Unit(),
+			metadata: &MetricsMetaData{
+				ResAttr:    rm.Resource().Attributes(),
+				ResURL:     "https://opentelemetry.io/schemas/1.4.0",
+				ScopeURL:   "https://opentelemetry.io/schemas/1.7.0",
+				ScopeInstr: sm.Scope(),
+			},
+			gauge: gauge,
+		},
+	}
+}

--- a/exporter/clickhouseexporter/internal/metrics/metrics_model.go
+++ b/exporter/clickhouseexporter/internal/metrics/metrics_model.go
@@ -114,14 +114,16 @@ func InsertMetrics(ctx context.Context, db driver.Conn, metricsMap map[pmetric.M
 }
 
 func convertExemplars(exemplars pmetric.ExemplarSlice) (clickhouse.ArraySet, clickhouse.ArraySet, clickhouse.ArraySet, clickhouse.ArraySet, clickhouse.ArraySet) {
-	var (
-		attrs    clickhouse.ArraySet
-		times    clickhouse.ArraySet
-		values   clickhouse.ArraySet
-		traceIDs clickhouse.ArraySet
-		spanIDs  clickhouse.ArraySet
-	)
-	for i := 0; i < exemplars.Len(); i++ {
+	n := exemplars.Len()
+	if n == 0 {
+		return nil, nil, nil, nil, nil
+	}
+	attrs := make(clickhouse.ArraySet, 0, n)
+	times := make(clickhouse.ArraySet, 0, n)
+	values := make(clickhouse.ArraySet, 0, n)
+	traceIDs := make(clickhouse.ArraySet, 0, n)
+	spanIDs := make(clickhouse.ArraySet, 0, n)
+	for i := range n {
 		exemplar := exemplars.At(i)
 		attrs = append(attrs, AttributesToMap(exemplar.FilteredAttributes()))
 		times = append(times, exemplar.Timestamp().AsTime())
@@ -185,7 +187,7 @@ func GetServiceName(resAttr pcommon.Map) string {
 }
 
 func convertSliceToArraySet[T any](slice []T) clickhouse.ArraySet {
-	var set clickhouse.ArraySet
+	set := make(clickhouse.ArraySet, 0, len(slice))
 	for _, item := range slice {
 		set = append(set, item)
 	}
@@ -193,11 +195,13 @@ func convertSliceToArraySet[T any](slice []T) clickhouse.ArraySet {
 }
 
 func convertValueAtQuantile(valueAtQuantile pmetric.SummaryDataPointValueAtQuantileSlice) (clickhouse.ArraySet, clickhouse.ArraySet) {
-	var (
-		quantiles clickhouse.ArraySet
-		values    clickhouse.ArraySet
-	)
-	for i := 0; i < valueAtQuantile.Len(); i++ {
+	n := valueAtQuantile.Len()
+	if n == 0 {
+		return nil, nil
+	}
+	quantiles := make(clickhouse.ArraySet, 0, n)
+	values := make(clickhouse.ArraySet, 0, n)
+	for i := range n {
 		value := valueAtQuantile.At(i)
 		quantiles = append(quantiles, value.Quantile())
 		values = append(values, value.Value())


### PR DESCRIPTION
#### Description

Pre-size all return slices in conversion functions to eliminate repeated reallocation via append from nil. Affected functions:

- convertEvents, convertLinks (traces)
- convertEventsJSON, convertLinksJSON (traces JSON)
- convertExemplars, convertSliceToArraySet, convertValueAtQuantile (metrics)

Also adds benchmarks for the affected code paths.

Traces benchstat:

```
                              │    old     │              new               │
                              │   sec/op   │   sec/op     vs base          │
ConvertEvents/events=1-12       129.4n ± 2%   112.3n ± 3%  -13.14% (p=0.002 n=6)
ConvertEvents/events=5-12       616.5n ± 6%   453.1n ± 1%  -26.50% (p=0.002 n=6)
ConvertEvents/events=10-12     1254.0n ± 2%   888.1n ± 3%  -29.18% (p=0.002 n=6)
ConvertLinks/links=1-12         156.7n ± 1%   140.8n ± 4%  -10.15% (p=0.002 n=6)
ConvertLinks/links=5-12         722.6n ± 2%   565.2n ± 5%  -21.78% (p=0.002 n=6)
ConvertLinks/links=10-12        1.473µ ± 4%   1.101µ ± 6%  -25.22% (p=0.002 n=6)
TracesBatchPrep/spans=100-12    74.03µ ± 1%   67.51µ ± 4%   -8.82% (p=0.002 n=6)
TracesBatchPrep/spans=1000-12   782.6µ ± 4%   732.8µ ± 5%   -6.37% (p=0.002 n=6)
geomean                         2.361µ        1.934µ       -18.08%

                              │     old      │              new               │
                              │    B/op      │    B/op       vs base          │
ConvertEvents/events=5-12       1440.0 ± 0%    1008.0 ± 0%  -30.00% (p=0.002 n=6)
ConvertEvents/events=10-12     2.984Ki ± 0%   1.953Ki ± 0%  -34.55% (p=0.002 n=6)
ConvertLinks/links=5-12        1.531Ki ± 0%   1.094Ki ± 0%  -28.57% (p=0.002 n=6)
ConvertLinks/links=10-12       3.312Ki ± 0%   2.188Ki ± 0%  -33.96% (p=0.002 n=6)
TracesBatchPrep/spans=100-12   126.7Ki ± 0%   117.3Ki ± 0%   -7.40% (p=0.002 n=6)
TracesBatchPrep/spans=1000-12  1.236Mi ± 0%   1.145Mi ± 0%   -7.41% (p=0.002 n=6)
geomean                        4.421Ki        3.581Ki       -19.00%

Metrics benchstat:

                                       │     old      │              new               │
                                       │    sec/op    │    sec/op     vs base          │
ConvertExemplars/exemplars=1-12          217.0n ±  3%   190.2n ±  9%  -12.39% (p=0.002 n=6)
ConvertSliceToArraySet/len=5-12          86.38n ±  1%   29.66n ±  4%  -65.66% (p=0.002 n=6)
ConvertSliceToArraySet/len=20-12        229.80n ±  7%   87.74n ±  2%  -61.82% (p=0.002 n=6)
ConvertSliceToArraySet/len=100-12        811.1n ± 100%  368.9n ±  6%  -54.52% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=1-12    31.31n ±  3%   24.85n ±  2%  -20.62% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=5-12   215.70n ±  2%   88.94n ± 10%  -58.77% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=10-12   371.7n ±  3%   189.8n ±  3%  -48.95% (p=0.002 n=6)
geomean                                  784.6n         506.7n        -35.41%

                                       │     old      │              new               │
                                       │    B/op      │    B/op       vs base          │
ConvertExemplars/exemplars=10-12        4.367Ki ± 0%   2.961Ki ± 0%  -32.20% (p=0.002 n=6)
ConvertSliceToArraySet/len=5-12          240.00 ± 0%     80.00 ± 0%  -66.67% (p=0.002 n=6)
ConvertSliceToArraySet/len=20-12         1008.0 ± 0%     320.0 ± 0%  -68.25% (p=0.002 n=6)
ConvertSliceToArraySet/len=100-12       4.359Ki ± 0%   1.750Ki ± 0%  -59.86% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=5-12    544.0 ± 0%     224.0 ± 0%   -58.82% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=10-12   1136.0 ± 0%    464.0 ± 0%   -59.15% (p=0.002 n=6)
geomean                                 1.688Ki        1.032Ki       -38.88%

                                       │  old allocs  │          new allocs              │
ConvertSliceToArraySet/len=5-12           4.000 ± 0%    1.000 ± 0%  -75.00% (p=0.002 n=6)
ConvertSliceToArraySet/len=20-12          6.000 ± 0%    1.000 ± 0%  -83.33% (p=0.002 n=6)
ConvertSliceToArraySet/len=100-12         8.000 ± 0%    1.000 ± 0%  -87.50% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=5-12     16.00 ± 0%    10.00 ± 0%  -37.50% (p=0.002 n=6)
ConvertValueAtQuantile/quantiles=10-12    28.00 ± 0%    20.00 ± 0%  -28.57% (p=0.002 n=6)
geomean                                   37.55         21.44       -42.91%
```

Assisted-by: Claude Opus 4.6

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46882




