### PR TITLE
[chore] fix ocb-add-replaces.sh picking up untracked go.mod files

### DIFF
--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -11,7 +11,7 @@ CONFIG_OUT="cmd/$DIR/builder-config-replaced.yaml"
 
 cp "$CONFIG_IN" "$CONFIG_OUT"
 
-local_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort)
+local_mods=$(git ls-files "*/go.mod" "go.mod" | xargs -I{} dirname {} | sort)
 for mod_path in $local_mods; do
     mod=${mod_path#"."} # remove initial dot
     echo "  - github.com/open-telemetry/opentelemetry-collector-contrib$mod => ../..$mod" >> "$CONFIG_OUT"


### PR DESCRIPTION
Use git ls-files instead of find to enumerate go.mod paths, so that generated/untracked files (e.g. cmd/otelcontribcol/go.mod created by genotelcontribcol) are not included as replace directives in the builder config. This fixes make update-otel failing after the gen steps run.
