### PR TITLE
prometheusreceiver: attempt to fix flaky tests

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -197,7 +197,6 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *PromConfig, error)
 		job["job_name"] = tds[i].name
 		job["metrics_path"] = metricPaths[i]
 		job["scrape_interval"] = "100ms"
-		job["scrape_timeout"] = "50ms"
 		job["static_configs"] = []map[string]any{{"targets": []string{u.Host}}}
 		jobs = append(jobs, job)
 	}


### PR DESCRIPTION
#### Description

Remove the scrape_timeout from the mock prometheus server. This is the only place in testing where we set a scrape timeout, and seems to be linked to the tests that are flaky (from what I can tell).

#### Link to tracking issue
Attempt to address https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42892

@ArthurSens 