### PR TITLE
[pkg/ottl]: add bitwise AND (&) and OR (|) operators

### DIFF
--- a/.chloggen/ottl-bitwise-operators.yaml
+++ b/.chloggen/ottl-bitwise-operators.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+component: pkg/ottl
+issues: [45560]
+note: |
+  Add bitwise AND (&) and OR (|) operators for int64 values in math expressions.
+  Bitwise AND (&) and OR (|) can now be used in OTTL math expressions.
+  They operate on int64 values only and follow standard precedence:
+  multiply/divide > add/subtract > bitwise AND > bitwise OR
+  Example:
+  set(attributes["masked"], attributes["flags"] & 0xFF)
+default_service_change: false

--- a/pkg/ottl/LANGUAGE.md
+++ b/pkg/ottl/LANGUAGE.md
@@ -197,9 +197,14 @@ When defining an OTTL function, if the function needs to take an Enum then the f
 
 ### Math Expressions
 
-Math Expressions represent arithmetic calculations.  They support `+`, `-`, `*`, and `/`, along with `()` for grouping.
+Math Expressions represent arithmetic calculations.  They support `+`, `-`, `*`, `/`, `&` (bitwise AND), and `|` (bitwise OR), along with `()` for grouping.
 
 Math Expressions currently support `int64`, `float64`, `time.Time` and `time.Duration`.
+
+#### Arithmetic operators
+
+For `int64` and `float64`, all arithmetic operators (`+`, `-`, `*`, `/`) are supported.
+
 For `time.Time` and `time.Duration`, only `+` and `-` are supported with the following rules:
 - A `time.Time` `-` a `time.Time` yields a `time.Duration`.
 - A `time.Duration` `+` a `time.Time` yields a `time.Time`.
@@ -208,11 +213,31 @@ For `time.Time` and `time.Duration`, only `+` and `-` are supported with the fol
 - A `time.Duration` `+` a `time.Duration` yields a `time.Duration`.
 - A `time.Duration` `-` a `time.Duration` yields a `time.Duration`.
 
-Math Expressions support `Paths` and `Editors` that return supported types.
-Note that `*` and `/` take precedence over `+` and `-`.
-Also note that `time.Time` and `time.Duration` can only be used with `+` and `-`.
+#### Bitwise operators
+
+The bitwise operators `&` (AND) and `|` (OR) operate only on `int64` values. Using them with `float64`, `time.Time`, or `time.Duration` operands will result in an error.
+
+Example bitwise expressions:
+- `attributes["flags"] & 0x01` — test if a flag bit is set
+- `attributes["a"] | attributes["b"]` — combine flag values
+
+#### Operator precedence
+
+Operators are listed below from highest to lowest precedence. Operators on the same line have the same precedence.
+
+| Precedence | Operators   | Description              |
+|------------|-------------|--------------------------|
+| 1 (highest)| `*` `/`     | Multiplication, Division |
+| 2          | `+` `-`     | Addition, Subtraction    |
+| 3          | `&`         | Bitwise AND              |
+| 4 (lowest) | `\|`        | Bitwise OR               |
+
 Operations that share the same level of precedence will be executed in the order that they appear in the Math Expression.
 Math Expressions can be grouped with parentheses to override evaluation precedence.
+
+#### Type rules
+
+Math Expressions support `Paths` and `Editors` that return supported types.
 Math Expressions that mix `int64` and `float64` will result in an error.
 It is up to the function using the Math Expression to determine what to do with that error and the default return value of `nil`.
 Division by zero is gracefully handled with an error, but other arithmetic operations that would result in a panic will still result in a panic.
@@ -225,7 +250,8 @@ Example Math Expressions
 - `1 + 1`
 - `end_time_unix_nano - end_time_unix_nano`
 - `sum([1, 2, 3, 4]) + (10 / 1) - 1`
-
+- `attributes["flags"] & 0xFF`
+- `attributes["a"] | attributes["b"] & attributes["c"]`
 
 ### Boolean Expressions
 

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -1459,8 +1459,8 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(
-	attributes["test"], 
-	ParseSeverity(severity_number, 
+	attributes["test"],
+	ParseSeverity(severity_number,
 		{
 			"error":[
 				{"equals": ["err"]},
@@ -1812,6 +1812,41 @@ func Test_e2e_ottl_features(t *testing.T) {
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "SCTP", 12))`,
 			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:4KOPjy2bsV43uY/mf4HtwyZkwqM=")
+			},
+		},
+		{
+			name:      "bitwise AND with literals",
+			statement: `set(attributes["result"], 255 & 15)`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutInt("result", 15)
+			},
+		},
+		{
+			name:      "bitwise OR with literals",
+			statement: `set(attributes["result"], 5 | 3)`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutInt("result", 7)
+			},
+		},
+		{
+			name:      "bitwise AND precedence over OR",
+			statement: `set(attributes["result"], 5 | 3 & 6)`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutInt("result", 7)
+			},
+		},
+		{
+			name:      "bitwise with arithmetic precedence",
+			statement: `set(attributes["result"], 1 + 2 | 4)`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutInt("result", 7)
+			},
+		},
+		{
+			name:      "bitwise with parentheses",
+			statement: `set(attributes["result"], (5 | 3) & 6)`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutInt("result", 6)
 			},
 		},
 	}

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -235,7 +235,7 @@ func (a *argument) accept(v grammarVisitor) {
 // mathExpression, function call, or literal.
 type value struct {
 	IsNil          *isNil           `parser:"( @Nil"`
-	Literal        *mathExprLiteral `parser:"| @@ (?! OpAddSub | OpMultDiv)"`
+	Literal        *mathExprLiteral `parser:"| @@ (?! OpAddSub | OpMultDiv | OpBitwiseAnd | OpBitwiseOr)"`
 	MathExpression *mathExpression  `parser:"| @@"`
 	Bytes          *byteSlice       `parser:"| @Bytes"`
 	String         *string          `parser:"| @String"`
@@ -436,20 +436,72 @@ func (r *opAddSubTerm) accept(v grammarVisitor) {
 	}
 }
 
-type mathExpression struct {
+type bitwiseAndTerm struct {
 	Left  *addSubTerm     `parser:"@@"`
 	Right []*opAddSubTerm `parser:"@@*"`
+}
+
+func (m *bitwiseAndTerm) accept(v grammarVisitor) {
+	if m.Left != nil {
+		m.Left.accept(v)
+	}
+	for _, r := range m.Right {
+		if r != nil {
+			r.accept(v)
+		}
+	}
+}
+
+type opBitwiseAndTerm struct {
+	Operator mathOp          `parser:"@OpBitwiseAnd"`
+	Term     *bitwiseAndTerm `parser:"@@"`
+}
+
+func (o *opBitwiseAndTerm) accept(v grammarVisitor) {
+	if o.Term != nil {
+		o.Term.accept(v)
+	}
+}
+
+type bitwiseOrTerm struct {
+	Left  *bitwiseAndTerm     `parser:"@@"`
+	Right []*opBitwiseAndTerm `parser:"@@*"`
+}
+
+func (m *bitwiseOrTerm) accept(v grammarVisitor) {
+	if m.Left != nil {
+		m.Left.accept(v)
+	}
+	for _, r := range m.Right {
+		if r != nil {
+			r.accept(v)
+		}
+	}
+}
+
+type opBitwiseOrTerm struct {
+	Operator mathOp         `parser:"@OpBitwiseOr"`
+	Term     *bitwiseOrTerm `parser:"@@"`
+}
+
+func (o *opBitwiseOrTerm) accept(v grammarVisitor) {
+	if o.Term != nil {
+		o.Term.accept(v)
+	}
+}
+
+type mathExpression struct {
+	Left  *bitwiseOrTerm     `parser:"@@"`
+	Right []*opBitwiseOrTerm `parser:"@@*"`
 }
 
 func (m *mathExpression) accept(v grammarVisitor) {
 	if m.Left != nil {
 		m.Left.accept(v)
 	}
-	if m.Right != nil {
-		for _, r := range m.Right {
-			if r != nil {
-				r.accept(v)
-			}
+	for _, r := range m.Right {
+		if r != nil {
+			r.accept(v)
 		}
 	}
 }
@@ -461,6 +513,8 @@ const (
 	sub
 	mult
 	div
+	bitwiseAnd
+	bitwiseOr
 )
 
 var mathOpTable = map[string]mathOp{
@@ -468,6 +522,8 @@ var mathOpTable = map[string]mathOp{
 	"-": sub,
 	"*": mult,
 	"/": div,
+	"&": bitwiseAnd,
+	"|": bitwiseOr,
 }
 
 func (m *mathOp) Capture(values []string) error {
@@ -489,6 +545,10 @@ func (m *mathOp) String() string {
 		return "*"
 	case div:
 		return "/"
+	case bitwiseAnd:
+		return "&"
+	case bitwiseOr:
+		return "|"
 	default:
 		return "UNKNOWN OP!"
 	}
@@ -510,6 +570,8 @@ func buildLexer() *lexer.StatefulDefinition {
 		{Name: `OpOr`, Pattern: `\b(or)\b`},
 		{Name: `OpAnd`, Pattern: `\b(and)\b`},
 		{Name: `OpComparison`, Pattern: `==|!=|>=|<=|>|<`},
+		{Name: `OpBitwiseAnd`, Pattern: `&`},
+		{Name: `OpBitwiseOr`, Pattern: `\|`},
 		{Name: `OpAddSub`, Pattern: `\+|\-`},
 		{Name: `OpMultDiv`, Pattern: `\/|\*`},
 		{Name: `Boolean`, Pattern: `\b(true|false)\b`},

--- a/pkg/ottl/lexer_test.go
+++ b/pkg/ottl/lexer_test.go
@@ -94,8 +94,16 @@ func Test_lexer(t *testing.T) {
 			{"OpNot", "not"},
 			{"Boolean", "false"},
 		}},
-		{"nothing_recognizable", "|", true, []result{
-			{"", ""},
+		{"bitwise_or", "|", false, []result{
+			{"OpBitwiseOr", "|"},
+		}},
+		{"bitwise_and", "&", false, []result{{"OpBitwiseAnd", "&"}}},
+		{"bitwise_expression", "3 & 5 | 1", false, []result{
+			{"Int", "3"},
+			{"OpBitwiseAnd", "&"},
+			{"Int", "5"},
+			{"OpBitwiseOr", "|"},
+			{"Int", "1"},
 		}},
 		{"basic_ident_expr", `set(attributes["bytes"], 0x0102030405060708)`, false, []result{
 			{"Lowercase", "set"},

--- a/pkg/ottl/math.go
+++ b/pkg/ottl/math.go
@@ -11,18 +11,17 @@ import (
 )
 
 func (p *Parser[K]) evaluateMathExpression(expr *mathExpression) (Getter[K], error) {
-	mainGetter, err := p.evaluateAddSubTerm(expr.Left)
+	mainGetter, err := p.evaluateBitwiseOrTerm(expr.Left)
 	if err != nil {
 		return nil, err
 	}
 	for _, rhs := range expr.Right {
-		getter, err := p.evaluateAddSubTerm(rhs.Term)
+		getter, err := p.evaluateBitwiseOrTerm(rhs.Term)
 		if err != nil {
 			return nil, err
 		}
 		mainGetter = attemptMathOperation(mainGetter, rhs.Operator, getter)
 	}
-
 	return mainGetter, nil
 }
 
@@ -85,6 +84,36 @@ func (p *Parser[K]) evaluateMathValue(val *mathValue) (Getter[K], error) {
 	}
 }
 
+func (p *Parser[K]) evaluateBitwiseOrTerm(term *bitwiseOrTerm) (Getter[K], error) {
+	mainGetter, err := p.evaluateBitwiseAndTerm(term.Left)
+	if err != nil {
+		return nil, err
+	}
+	for _, rhs := range term.Right {
+		getter, err := p.evaluateBitwiseAndTerm(rhs.Term)
+		if err != nil {
+			return nil, err
+		}
+		mainGetter = attemptMathOperation(mainGetter, rhs.Operator, getter)
+	}
+	return mainGetter, nil
+}
+
+func (p *Parser[K]) evaluateBitwiseAndTerm(term *bitwiseAndTerm) (Getter[K], error) {
+	mainGetter, err := p.evaluateAddSubTerm(term.Left)
+	if err != nil {
+		return nil, err
+	}
+	for _, rhs := range term.Right {
+		getter, err := p.evaluateAddSubTerm(rhs.Term)
+		if err != nil {
+			return nil, err
+		}
+		mainGetter = attemptMathOperation(mainGetter, rhs.Operator, getter)
+	}
+	return mainGetter, nil
+}
+
 func negateGetter[K any](baseGetter Getter[K]) Getter[K] {
 	return &exprGetter[K]{
 		expr: Expr[K]{
@@ -117,6 +146,14 @@ func attemptMathOperation[K any](lhs Getter[K], op mathOp, rhs Getter[K]) Getter
 				y, err := rhs.Get(ctx, tCtx)
 				if err != nil {
 					return nil, err
+				}
+				if op == bitwiseAnd || op == bitwiseOr {
+					xInt, xOk := x.(int64)
+					yInt, yOk := y.(int64)
+					if !xOk || !yOk {
+						return nil, fmt.Errorf("bitwise operations require int64 operands, got %T and %T", x, y)
+					}
+					return performBitwiseOp(xInt, yInt, op)
 				}
 				switch newX := x.(type) {
 				case int64:
@@ -230,4 +267,14 @@ func performOp[N int64 | float64](x, y N, op mathOp) (N, error) {
 		return x / y, nil
 	}
 	return 0, fmt.Errorf("invalid operation %v", op)
+}
+
+func performBitwiseOp(x, y int64, op mathOp) (int64, error) {
+	switch op {
+	case bitwiseAnd:
+		return x & y, nil
+	case bitwiseOr:
+		return x | y, nil
+	}
+	return 0, fmt.Errorf("invalid bitwise operation %v", op)
 }

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -98,6 +98,17 @@ func sum[K any](ints []int64) (ExprFunc[K], error) {
 	}, nil
 }
 
+func wrapMathExpr(left *addSubTerm, right []*opAddSubTerm) *mathExpression {
+	return &mathExpression{
+		Left: &bitwiseOrTerm{
+			Left: &bitwiseAndTerm{
+				Left:  left,
+				Right: right,
+			},
+		},
+	}
+}
+
 func Test_evaluateMathExpression(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -314,6 +325,61 @@ func Test_evaluateMathExpression(t *testing.T) {
 			input:    "+3.1",
 			expected: 3.1,
 		},
+		{
+			name:     "bitwise AND",
+			input:    "3 & 1",
+			expected: int64(1),
+		},
+		{
+			name:     "bitwise OR",
+			input:    "5 | 2",
+			expected: int64(7),
+		},
+		{
+			name:     "bitwise AND with hex",
+			input:    "255 & 15",
+			expected: int64(15),
+		},
+		{
+			name:     "bitwise OR identity",
+			input:    "0 | 42",
+			expected: int64(42),
+		},
+		{
+			name:     "bitwise AND precedence over OR",
+			input:    "5 | 3 & 6",
+			expected: int64(7),
+		},
+		{
+			name:     "bitwise ops lower precedence than addition",
+			input:    "1 + 2 & 7",
+			expected: int64(3),
+		},
+		{
+			name:     "bitwise OR lower precedence than addition",
+			input:    "1 + 2 | 4",
+			expected: int64(7),
+		},
+		{
+			name:     "bitwise with parentheses",
+			input:    "(5 | 3) & 6",
+			expected: int64(6),
+		},
+		{
+			name:     "complex bitwise and arithmetic",
+			input:    "2 * 3 & 5 | 1",
+			expected: int64(5),
+		},
+		{
+			name:     "bitwise AND with paths",
+			input:    "one & two",
+			expected: int64(0),
+		},
+		{
+			name:     "bitwise OR with paths",
+			input:    "one | two",
+			expected: int64(3),
+		},
 	}
 
 	functions := CreateFactoryMap(
@@ -361,8 +427,8 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 		},
 		{
 			name: "time div time",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -383,7 +449,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: div,
 						Term: &addSubTerm{
@@ -409,13 +475,13 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			errorMsg: "only addition and subtraction supported",
 		},
 		{
 			name: "dur mult dur",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -431,7 +497,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: mult,
 						Term: &addSubTerm{
@@ -452,13 +518,13 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			errorMsg: "only addition and subtraction supported",
 		},
 		{
 			name: "time add int",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -479,7 +545,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -491,13 +557,13 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			errorMsg: "time.Time must be added to time.Duration",
 		},
 		{
 			name: "dur sub int",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -513,7 +579,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -525,13 +591,13 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			errorMsg: "time.Duration must be subtracted from time.Duration",
 		},
 		{
 			name: "time add time",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -552,7 +618,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -578,13 +644,13 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			errorMsg: "time.Time must be added to time.Duration",
 		},
 		{
 			name: "dur sub time",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -600,7 +666,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -626,8 +692,18 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			errorMsg: "time.Duration must be subtracted from time.Duration",
+		},
+		{
+			name:     "bitwise AND with float",
+			input:    "3.0 & 1",
+			errorMsg: "bitwise operations require int64 operands",
+		},
+		{
+			name:     "bitwise OR with float",
+			input:    "5 | 2.0",
+			errorMsg: "bitwise operations require int64 operands",
 		},
 	}
 
@@ -677,6 +753,9 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 				result, err := getter.Get(t.Context(), nil)
 				assert.Nil(t, result)
 				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.ErrorContains(t, err, tt.errorMsg)
+				}
 			}
 		})
 	}
@@ -719,8 +798,8 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 	}{
 		{
 			name: "time sub time, no difference",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -741,7 +820,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -767,13 +846,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: zeroSecs,
 		},
 		{
 			name: "time sub time",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -794,7 +873,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -820,13 +899,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: -fourtySevenHourseFourtyTwoMinutesTwentySevenSecs,
 		},
 		{
 			name: "dur add time",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -842,7 +921,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -868,13 +947,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: time.Date(2000, 1, 1, 10, 0, 0, 0, time.Local),
 		},
 		{
 			name: "time add dur",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -895,7 +974,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -916,13 +995,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: time.Date(2023, 2, 15, 10, 0, 0, 0, time.Local),
 		},
 		{
 			name: "time add dur, complex dur",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -943,7 +1022,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -964,13 +1043,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: time.Date(2023, 2, 4, 1, 2, 3, 0, time.Local),
 		},
 		{
 			name: "time sub dur, complex dur",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -991,7 +1070,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -1012,13 +1091,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: time.Date(2023, 3, 14, 6, 0, 1, 0, time.Local),
 		},
 		{
 			name: "time sub dur, nanosecs",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -1039,7 +1118,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -1060,13 +1139,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: time.Date(2023, 4, 30, 23, 59, 59, 999999900, time.Local),
 		},
 		{
 			name: "dur add dur, complex durs",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -1082,7 +1161,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -1103,13 +1182,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: oneHundredOne,
 		},
 		{
 			name: "dur add dur, zero dur",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -1125,7 +1204,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: add,
 						Term: &addSubTerm{
@@ -1146,13 +1225,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: oneThousandHours,
 		},
 		{
 			name: "dur sub dur, zero dur",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -1168,7 +1247,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -1189,13 +1268,13 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: -threeTwentyEightMins,
 		},
 		{
 			name: "dur sub dur, complex durs",
-			mathExpr: &mathExpression{
-				Left: &addSubTerm{
+			mathExpr: wrapMathExpr(
+				&addSubTerm{
 					Left: &mathValue{
 						Literal: &mathExprLiteral{
 							Converter: &converter{
@@ -1211,7 +1290,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-				Right: []*opAddSubTerm{
+				[]*opAddSubTerm{
 					{
 						Operator: sub,
 						Term: &addSubTerm{
@@ -1232,7 +1311,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						},
 					},
 				},
-			},
+			),
 			expected: tenHoursetc,
 		},
 	}

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1308,20 +1308,24 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								MathExpression: &mathExpression{
-									Left: &addSubTerm{
-										Left: &mathValue{
-											Literal: &mathExprLiteral{
-												Int: ottltest.Intp(1000),
-											},
-										},
-									},
-									Right: []*opAddSubTerm{
-										{
-											Operator: sub,
-											Term: &addSubTerm{
+									Left: &bitwiseOrTerm{
+										Left: &bitwiseAndTerm{
+											Left: &addSubTerm{
 												Left: &mathValue{
 													Literal: &mathExprLiteral{
-														Int: ottltest.Intp(600),
+														Int: ottltest.Intp(1000),
+													},
+												},
+											},
+											Right: []*opAddSubTerm{
+												{
+													Operator: sub,
+													Term: &addSubTerm{
+														Left: &mathValue{
+															Literal: &mathExprLiteral{
+																Int: ottltest.Intp(600),
+															},
+														},
 													},
 												},
 											},
@@ -1338,28 +1342,32 @@ func Test_parse(t *testing.T) {
 							Comparison: &comparison{
 								Left: value{
 									MathExpression: &mathExpression{
-										Left: &addSubTerm{
-											Left: &mathValue{
-												Literal: &mathExprLiteral{
-													Int: ottltest.Intp(1),
-												},
-											},
-										},
-										Right: []*opAddSubTerm{
-											{
-												Operator: add,
-												Term: &addSubTerm{
+										Left: &bitwiseOrTerm{
+											Left: &bitwiseAndTerm{
+												Left: &addSubTerm{
 													Left: &mathValue{
 														Literal: &mathExprLiteral{
 															Int: ottltest.Intp(1),
 														},
 													},
-													Right: []*opMultDivValue{
-														{
-															Operator: mult,
-															Value: &mathValue{
+												},
+												Right: []*opAddSubTerm{
+													{
+														Operator: add,
+														Term: &addSubTerm{
+															Left: &mathValue{
 																Literal: &mathExprLiteral{
-																	Int: ottltest.Intp(2),
+																	Int: ottltest.Intp(1),
+																},
+															},
+															Right: []*opMultDivValue{
+																{
+																	Operator: mult,
+																	Value: &mathValue{
+																		Literal: &mathExprLiteral{
+																			Int: ottltest.Intp(2),
+																		},
+																	},
 																},
 															},
 														},
@@ -1372,30 +1380,34 @@ func Test_parse(t *testing.T) {
 								Op: eq,
 								Right: value{
 									MathExpression: &mathExpression{
-										Left: &addSubTerm{
-											Left: &mathValue{
-												Literal: &mathExprLiteral{
-													Path: &path{
-														Pos: lexer.Position{
-															Offset: 55,
-															Line:   1,
-															Column: 56,
-														},
-														Fields: []field{
-															{
-																Name: "three",
+										Left: &bitwiseOrTerm{
+											Left: &bitwiseAndTerm{
+												Left: &addSubTerm{
+													Left: &mathValue{
+														Literal: &mathExprLiteral{
+															Path: &path{
+																Pos: lexer.Position{
+																	Offset: 55,
+																	Line:   1,
+																	Column: 56,
+																},
+																Fields: []field{
+																	{
+																		Name: "three",
+																	},
+																},
 															},
 														},
 													},
-												},
-											},
-											Right: []*opMultDivValue{
-												{
-													Operator: div,
-													Value: &mathValue{
-														Literal: &mathExprLiteral{
-															Converter: &converter{
-																Function: "One",
+													Right: []*opMultDivValue{
+														{
+															Operator: div,
+															Value: &mathValue{
+																Literal: &mathExprLiteral{
+																	Converter: &converter{
+																		Function: "One",
+																	},
+																},
 															},
 														},
 													},
@@ -1518,28 +1530,32 @@ func Test_parseCondition_full(t *testing.T) {
 						Comparison: &comparison{
 							Left: value{
 								MathExpression: &mathExpression{
-									Left: &addSubTerm{
-										Left: &mathValue{
-											Literal: &mathExprLiteral{
-												Int: ottltest.Intp(1),
-											},
-										},
-									},
-									Right: []*opAddSubTerm{
-										{
-											Operator: add,
-											Term: &addSubTerm{
+									Left: &bitwiseOrTerm{
+										Left: &bitwiseAndTerm{
+											Left: &addSubTerm{
 												Left: &mathValue{
 													Literal: &mathExprLiteral{
 														Int: ottltest.Intp(1),
 													},
 												},
-												Right: []*opMultDivValue{
-													{
-														Operator: mult,
-														Value: &mathValue{
+											},
+											Right: []*opAddSubTerm{
+												{
+													Operator: add,
+													Term: &addSubTerm{
+														Left: &mathValue{
 															Literal: &mathExprLiteral{
-																Int: ottltest.Intp(2),
+																Int: ottltest.Intp(1),
+															},
+														},
+														Right: []*opMultDivValue{
+															{
+																Operator: mult,
+																Value: &mathValue{
+																	Literal: &mathExprLiteral{
+																		Int: ottltest.Intp(2),
+																	},
+																},
 															},
 														},
 													},
@@ -1552,30 +1568,34 @@ func Test_parseCondition_full(t *testing.T) {
 							Op: eq,
 							Right: value{
 								MathExpression: &mathExpression{
-									Left: &addSubTerm{
-										Left: &mathValue{
-											Literal: &mathExprLiteral{
-												Path: &path{
-													Pos: lexer.Position{
-														Offset: 13,
-														Line:   1,
-														Column: 14,
-													},
-													Fields: []field{
-														{
-															Name: "three",
+									Left: &bitwiseOrTerm{
+										Left: &bitwiseAndTerm{
+											Left: &addSubTerm{
+												Left: &mathValue{
+													Literal: &mathExprLiteral{
+														Path: &path{
+															Pos: lexer.Position{
+																Offset: 13,
+																Line:   1,
+																Column: 14,
+															},
+															Fields: []field{
+																{
+																	Name: "three",
+																},
+															},
 														},
 													},
 												},
-											},
-										},
-										Right: []*opMultDivValue{
-											{
-												Operator: div,
-												Value: &mathValue{
-													Literal: &mathExprLiteral{
-														Converter: &converter{
-															Function: "One",
+												Right: []*opMultDivValue{
+													{
+														Operator: div,
+														Value: &mathValue{
+															Literal: &mathExprLiteral{
+																Converter: &converter{
+																	Function: "One",
+																},
+															},
 														},
 													},
 												},


### PR DESCRIPTION
## Description

This PR adds bitwise AND (`&`) and OR (`|`) as native operators in OTTL math expressions, addressing the first part of #45560.

These operators enable bitwise flag manipulation directly in OTTL statements without requiring custom converter functions:
```yaml
transform:
  log_statements:
    - context: log
      statements:
        - set(attributes["masked"], attributes["flags"] & 0xFF)
        - set(attributes["combined"], attributes["a"] | attributes["b"])
```

## Implementation

Bitwise operators are implemented as grammar-level operators, following the same architecture as the existing arithmetic operators (`+`, `-`, `*`, `/`).

**Grammar changes (`grammar.go`):**
- Added `OpBitwiseAnd` and `OpBitwiseOr` lexer tokens
- Added `bitwiseAndTerm`, `opBitwiseAndTerm`, `bitwiseOrTerm`, `opBitwiseOrTerm` AST nodes
- Rewired `mathExpression` to route through the new precedence levels
- Updated `value` lookahead to include new tokens

**Evaluation changes (`math.go`):**
- Added `evaluateBitwiseOrTerm` and `evaluateBitwiseAndTerm` evaluation functions
- Added `performBitwiseOp` for int64-only bitwise execution
- Bitwise ops on non-int64 operands return a clear error

**Operator precedence (highest → lowest):**

| Precedence | Operators | Description |
|---|---|---|
| 1 | `*` `/` | Multiplication, Division |
| 2 | `+` `-` | Addition, Subtraction |
| 3 | `&` | Bitwise AND |
| 4 | `\|` | Bitwise OR |

This matches the precedence in Go, C, Java, and Python.

## Type constraints

- Operands must be `int64`. Using `float64`, `time.Time`, or `time.Duration` returns an error: `"bitwise operations require int64 operands"`.

## Testing

- **Unit tests (`math_test.go`):** 11 new passing tests covering AND, OR, precedence, paths, parentheses, mixed arithmetic+bitwise
- **Error tests (`math_test.go`):** 2 new tests verifying float operand rejection
- **Lexer tests (`lexer_test.go`):** 3 new tests for `&`, `|` tokens and combined expressions
- **Parser tests (`parser_test.go`):** existing ASTs updated for new grammar structure
- **E2E tests (`e2e/e2e_test.go`):** 5 new integration tests through the full parser --> evaluator pipeline
- **Manual verification:** built `otelcontribcol`, tested with transform processor + OTLP HTTP receiver + debug exporter, all 6 expressions produced correct results

## Scope

This PR implements `&` and `|` only. Remaining bitwise operators (`^`, `~`, `<<`, `>>`) can follow in subsequent PRs once this approach is validated by code owners.
