### PR TITLE
Fix port collision flakes in correctness tests

### DIFF
--- a/testbed/correctnesstests/connectors/correctness_test.go
+++ b/testbed/correctnesstests/connectors/correctness_test.go
@@ -61,11 +61,6 @@ func testWithGoldenDataset(
 	require.NoError(t, err, "default components resulted in: %v", err)
 	runner := testbed.NewInProcessCollector(factories)
 	validator := testbed.NewCorrectTestValidator(sender.ProtocolName(), receiver.ProtocolName(), dataProvider)
-	config := correctnesstests.CreateConfigYaml(t, sender, receiver, connector, processors)
-	log.Println(config)
-	configCleanup, cfgErr := runner.PrepareConfig(t, config)
-	require.NoError(t, cfgErr, "collector configuration resulted in: %v", cfgErr)
-	defer configCleanup()
 	tc := testbed.NewTestCase(
 		t,
 		dataProvider,
@@ -78,8 +73,17 @@ func testWithGoldenDataset(
 	)
 	defer tc.Stop()
 
-	tc.EnableRecording()
 	tc.StartBackend()
+
+	// CreateConfigYaml must be called after StartBackend to ensure the receiver port is bound.
+	// This prevents CreateConfigYaml from picking the same port for Prometheus telemetry.
+	config := correctnesstests.CreateConfigYaml(t, sender, receiver, connector, processors)
+	log.Println(config)
+	configCleanup, cfgErr := runner.PrepareConfig(t, config)
+	require.NoError(t, cfgErr, "collector configuration resulted in: %v", cfgErr)
+	defer configCleanup()
+
+	tc.EnableRecording()
 	tc.StartAgent()
 
 	tc.StartLoad(testbed.LoadOptions{

--- a/testbed/correctnesstests/traces/correctness_test.go
+++ b/testbed/correctnesstests/traces/correctness_test.go
@@ -59,11 +59,6 @@ func testWithTracingGoldenDataset(
 	require.NoError(t, err, "default components resulted in: %v", err)
 	runner := testbed.NewInProcessCollector(factories)
 	validator := testbed.NewCorrectTestValidator(sender.ProtocolName(), receiver.ProtocolName(), dataProvider)
-	config := correctnesstests.CreateConfigYaml(t, sender, receiver, nil, processors)
-	log.Println(config)
-	configCleanup, cfgErr := runner.PrepareConfig(t, config)
-	require.NoError(t, cfgErr, "collector configuration resulted in: %v", cfgErr)
-	defer configCleanup()
 	tc := testbed.NewTestCase(
 		t,
 		dataProvider,
@@ -76,8 +71,17 @@ func testWithTracingGoldenDataset(
 	)
 	defer tc.Stop()
 
-	tc.EnableRecording()
 	tc.StartBackend()
+
+	// CreateConfigYaml must be called after StartBackend to ensure the receiver port is bound.
+	// This prevents CreateConfigYaml from picking the same port for Prometheus telemetry.
+	config := correctnesstests.CreateConfigYaml(t, sender, receiver, nil, processors)
+	log.Println(config)
+	configCleanup, cfgErr := runner.PrepareConfig(t, config)
+	require.NoError(t, cfgErr, "collector configuration resulted in: %v", cfgErr)
+	defer configCleanup()
+
+	tc.EnableRecording()
 	tc.StartAgent()
 
 	tc.StartLoad(testbed.LoadOptions{

--- a/testbed/correctnesstests/utils.go
+++ b/testbed/correctnesstests/utils.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"net"
 
 	"go.uber.org/zap"
 
@@ -35,6 +36,30 @@ func CreateConfigYaml(
 	connector testbed.DataConnector,
 	processors []ProcessorNameAndConfigBody,
 ) string {
+	var plannedPorts []int
+	if sender != nil {
+		if tcpAddr, ok := sender.GetEndpoint().(*net.TCPAddr); ok {
+			plannedPorts = append(plannedPorts, tcpAddr.Port)
+		}
+	}
+
+	// Avoid picking a telemetry port that is already planned for the sender.
+	// This prevents port collisions between the collector's Prometheus telemetry
+	// and the collector's receivers (sender endpoint), which can happen if CreateConfigYaml
+	// is called before the receivers are started (bound).
+	telemetryPort := testutil.GetAvailablePort(tb)
+	found := false
+	for !found {
+		found = true
+		for _, p := range plannedPorts {
+			if p == telemetryPort {
+				found = false
+				telemetryPort = testutil.GetAvailablePort(tb)
+				break
+			}
+		}
+	}
+
 	// Prepare extra processor config section and comma-separated list of extra processor
 	// names to use in corresponding "processors" settings.
 	processorsSections := ""
@@ -103,7 +128,7 @@ service:
 			receiver.GenConfigYAMLStr(),
 			processorsSections,
 			connector.GenConfigYAMLStr(),
-			testutil.GetAvailablePort(tb),
+			telemetryPort,
 			pipeline1,
 			sender.ProtocolName(),
 			processorsList,
@@ -146,7 +171,7 @@ service:
 		sender.GenConfigYAMLStr(),
 		receiver.GenConfigYAMLStr(),
 		processorsSections,
-		testutil.GetAvailablePort(tb),
+		telemetryPort,
 		pipeline1,
 		sender.ProtocolName(),
 		processorsList,

--- a/testbed/correctnesstests/utils.go
+++ b/testbed/correctnesstests/utils.go
@@ -6,11 +6,12 @@ package correctnesstests // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
-	"net"
 
 	"go.uber.org/zap"
 
@@ -48,16 +49,8 @@ func CreateConfigYaml(
 	// and the collector's receivers (sender endpoint), which can happen if CreateConfigYaml
 	// is called before the receivers are started (bound).
 	telemetryPort := testutil.GetAvailablePort(tb)
-	found := false
-	for !found {
-		found = true
-		for _, p := range plannedPorts {
-			if p == telemetryPort {
-				found = false
-				telemetryPort = testutil.GetAvailablePort(tb)
-				break
-			}
-		}
+	for slices.Contains(plannedPorts, telemetryPort) {
+		telemetryPort = testutil.GetAvailablePort(tb)
 	}
 
 	// Prepare extra processor config section and comma-separated list of extra processor


### PR DESCRIPTION
#### Description

I hit a testbed flake in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46905:

Run https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/23081256798/job/67050924673?pr=46905

This prevents the port defined in

```
service:
   telemetry:
     metrics:
       readers:
         - pull:
             exporter:
               prometheus:
```

Or ports already defined by the testbed sender from colliding with ports chosen by receivers or exporters.

#### Link to tracking issue

Not sure if there is an open issue or not.  I just saw it on my PR.
