### PR TITLE
[chore][pkg/ottl] Add micro-benchmarks for replaceAllPatterns function

### DIFF
--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -752,3 +752,85 @@ func Test_replaceAllPatterns_invalid_model(t *testing.T) {
 	assert.Nil(t, exprFunc)
 	assert.ErrorContains(t, err, "invalid mode")
 }
+
+func Benchmark_replaceAllPatterns_mode_value(b *testing.B) {
+	input := pcommon.NewMap()
+
+	input.PutStr("password", "12345678")
+
+	target := &ottl.StandardPMapGetSetter[pcommon.Map]{
+		Getter: func(_ context.Context, tCtx pcommon.Map) (pcommon.Map, error) { return tCtx, nil },
+		Setter: func(_ context.Context, tCtx pcommon.Map, m any) error {
+			if v, ok := m.(pcommon.Map); ok {
+				v.CopyTo(tCtx)
+				return nil
+			}
+			return errors.New("expected pcommon.Map")
+		},
+	}
+
+	pattern := &ottl.StandardStringGetter[pcommon.Map]{
+		Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return `sagext`, nil },
+	}
+
+	replacement := &ottl.StandardStringGetter[pcommon.Map]{
+		Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "***", nil },
+	}
+
+	emptyFunc := ottl.Optional[ottl.FunctionGetter[pcommon.Map]]{}
+	emptyFormat := ottl.Optional[ottl.StringGetter[pcommon.Map]]{}
+
+	exprFunc, err := replaceAllPatterns[pcommon.Map](target, modeValue, pattern, replacement, emptyFunc, emptyFormat)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		freshMap := pcommon.NewMap()
+
+		input.CopyTo(freshMap)
+		_, _ = exprFunc(b.Context(), freshMap)
+	}
+}
+
+func Benchmark_replaceAllPatterns_mode_key(b *testing.B) {
+	input := pcommon.NewMap()
+
+	input.PutStr("password", "12345678")
+
+	target := &ottl.StandardPMapGetSetter[pcommon.Map]{
+		Getter: func(_ context.Context, tCtx pcommon.Map) (pcommon.Map, error) { return tCtx, nil },
+		Setter: func(_ context.Context, tCtx pcommon.Map, m any) error {
+			if v, ok := m.(pcommon.Map); ok {
+				v.CopyTo(tCtx)
+				return nil
+			}
+			return errors.New("expected pcommon.Map")
+		},
+	}
+
+	pattern := &ottl.StandardStringGetter[pcommon.Map]{
+		Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return `password`, nil },
+	}
+
+	replacement := &ottl.StandardStringGetter[pcommon.Map]{
+		Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "***", nil },
+	}
+
+	emptyFunc := ottl.Optional[ottl.FunctionGetter[pcommon.Map]]{}
+	emptyFormat := ottl.Optional[ottl.StringGetter[pcommon.Map]]{}
+
+	exprFunc, err := replaceAllPatterns[pcommon.Map](target, modeKey, pattern, replacement, emptyFunc, emptyFormat)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		freshMap := pcommon.NewMap()
+		input.CopyTo(freshMap)
+
+		_, _ = exprFunc(b.Context(), freshMap)
+	}
+}


### PR DESCRIPTION
#### Description
Adds micro-benchmarks to `func_replace_all_patterns_test.go` to establish a performance baseline for the `modeKey` and `modeValue` execution paths. 

Since this function handles heavy map mutations and regular expression evaluations inside a loop, these benchmarks are necessary to track memory allocation overhead and prevent future performance regressions in the OTTL.

#### Link to tracking issue
N/A - Establishing a performance baseline for future optimization.

#### Testing
Added `Benchmark_replaceAllPatterns_mode_value` and `Benchmark_replaceAllPatterns_mode_key`. Executed locally to verify map mutation isolation and memory profiling. 

**Results:**

goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz

Benchmark_replaceAllPatterns_mode_value-8        185643          6547 ns/op        1557 B/op         26 allocs/op
Benchmark_replaceAllPatterns_mode_key-8          113134         10540 ns/op        2305 B/op         27 allocs/op

#### Documentation
N/A - internal benchmark tests only.