### PR TITLE
[exporter/prometheusremotewrite] fix WAL shutdown race and corruption resilience

### DIFF
--- a/.chloggen/prw-wal-corruption-resilience.yaml
+++ b/.chloggen/prw-wal-corruption-resilience.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix WAL crash-loop when segment files are corrupted (e.g. from OOM-kill mid-write on hostPath volumes).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When wal.Open() detects corrupt segment files, the exporter now attempts recovery by
+  removing the last segment first (covers the common crash-mid-write case), then falls
+  back to removing the WAL directory and starting fresh. This prevents crash-looping
+  with "log corrupt" error. Corrupted individual protobuf entries are now skipped with
+  a warning log instead of causing a fatal error and infinite retry loop.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/prw-wal-shutdown-race.yaml
+++ b/.chloggen/prw-wal-shutdown-race.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix WAL shutdown race condition that could corrupt WAL data when the collector is stopped while metrics are being written.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fixed Shutdown() to wait for inflight PushMetrics calls before closing the WAL.
+  Fixed stop() to hold mutex when closing WAL to prevent data race.
+  Fixed persistToWAL to return error instead of panic on closed WAL.
+  Fixed readPrompbFromWAL to properly unlock mutex on nil WAL check.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -256,9 +256,11 @@ func (prwe *prwExporter) Shutdown(context.Context) error {
 	default:
 		close(prwe.closeChan)
 	}
-	err := prwe.shutdownWALIfEnabled()
+	// Wait for all inflight PushMetrics calls to finish before shutting down the WAL.
+	// Previously, shutdownWALIfEnabled was called first, which could close the WAL
+	// while persistToWAL was still writing, causing data corruption.
 	prwe.wg.Wait()
-	return err
+	return prwe.shutdownWALIfEnabled()
 }
 
 func (prwe *prwExporter) pushMetricsV1(ctx context.Context, md pmetric.Metrics) error {

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -167,20 +168,66 @@ func newWAL(walConfig *WALConfig, set exporter.Settings, exportSink func(context
 
 func (wc *WALConfig) createWAL() (*wal.Log, string, error) {
 	walPath := filepath.Join(wc.Directory, "prom_remotewrite")
-	log, err := wal.Open(walPath, &wal.Options{
+	walOpts := &wal.Options{
 		SegmentCacheSize: wc.bufferSize(),
 		NoCopy:           true,
 		AllowEmpty:       true,
-	})
+	}
+	log, err := wal.Open(walPath, walOpts)
 	if err != nil {
-		return nil, "", fmt.Errorf("prometheusremotewriteexporter: failed to open WAL: %w", err)
+		if !errors.Is(err, wal.ErrCorrupt) {
+			return nil, "", fmt.Errorf("prometheusremotewriteexporter: failed to open WAL: %w", err)
+		}
+		// WAL segment files are corrupt (e.g. from a crash during write to
+		// hostPath storage). Attempt recovery by removing corrupt segment
+		// files starting from the last (most likely to be truncated from a
+		// crash mid-write) and retrying Open. This preserves as much
+		// buffered data as possible. The WAL is a buffer, not the source
+		// of truth — data loss from the buffer is acceptable compared to
+		// a permanently broken collector.
+		log, err = recoverCorruptWAL(walPath, walOpts)
+		if err != nil {
+			return nil, "", fmt.Errorf("prometheusremotewriteexporter: failed to recover WAL: %w", err)
+		}
 	}
 	return log, walPath, nil
 }
 
+// recoverCorruptWAL attempts to recover a corrupt WAL. Corruption is almost
+// always in the last segment (truncated mid-write from a crash/OOM-kill), so
+// we first try removing just that file. If the WAL is still corrupt after
+// that, we remove the entire directory and start fresh rather than iterating
+// through potentially hundreds of segments (O(n²) with wal.Open per removal).
+func recoverCorruptWAL(walPath string, opts *wal.Options) (*wal.Log, error) {
+	entries, err := os.ReadDir(walPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read WAL directory: %w", err)
+	}
+	zap.L().Warn("prometheusremotewriteexporter: WAL is corrupt, attempting recovery by removing corrupt segments",
+		zap.String("wal_path", walPath),
+	)
+	// Try removing just the last segment (covers the common case).
+	if len(entries) > 0 {
+		last := entries[len(entries)-1]
+		if removeErr := os.Remove(filepath.Join(walPath, last.Name())); removeErr != nil {
+			return nil, fmt.Errorf("failed to remove corrupt WAL segment %s: %w", last.Name(), removeErr)
+		}
+		log, openErr := wal.Open(walPath, opts)
+		if openErr == nil {
+			return log, nil
+		}
+	}
+	// Still corrupt or empty — remove everything and start fresh.
+	if removeErr := os.RemoveAll(walPath); removeErr != nil {
+		return nil, fmt.Errorf("failed to remove corrupt WAL directory: %w", removeErr)
+	}
+	return wal.Open(walPath, opts)
+}
+
 var (
-	errAlreadyClosed = errors.New("already closed")
-	errNilWAL        = errors.New("wal is nil")
+	errAlreadyClosed    = errors.New("already closed")
+	errNilWAL           = errors.New("wal is nil")
+	errCorruptedWALEntry = errors.New("corrupted WAL entry")
 )
 
 // retrieveWALIndices queries the WriteAheadLog for its current first and last indices.
@@ -220,7 +267,12 @@ func (prweWAL *prweWAL) stop() error {
 	prweWAL.stopOnce.Do(func() {
 		close(prweWAL.stopChan)
 		prweWAL.wg.Wait()
+		// Hold mu when closing the WAL to prevent a data race with
+		// concurrent persistToWAL or readPrompbFromWAL calls that
+		// also access prweWAL.wal under the same lock.
+		prweWAL.mu.Lock()
 		err = prweWAL.closeWAL()
+		prweWAL.mu.Unlock()
 	})
 	return err
 }
@@ -339,6 +391,14 @@ func (prweWAL *prweWAL) continuallyPopWALThenExport(ctx context.Context, signalS
 		var req *prompb.WriteRequest
 		req, err = prweWAL.readPrompbFromWAL(ctx, prweWAL.rWALIndex.Load())
 		if err != nil {
+			if errors.Is(err, errCorruptedWALEntry) {
+				// Skip corrupted entries — readPrompbFromWAL already
+				// advanced rWALIndex past the bad entry.
+				if logger, logErr := loggerFromContext(ctx); logErr == nil {
+					logger.Warn("skipping corrupted WAL entry", zap.Error(err))
+				}
+				continue
+			}
 			return err
 		}
 		reqL = append(reqL, req)
@@ -422,6 +482,10 @@ func (prweWAL *prweWAL) persistToWAL(ctx context.Context, requests []*prompb.Wri
 	prweWAL.mu.Lock()
 	defer prweWAL.mu.Unlock()
 
+	if prweWAL.wal == nil {
+		return errNilWAL
+	}
+
 	// Write all the requests to the WAL in a batch.
 	batch := new(wal.Batch)
 	for _, req := range requests {
@@ -464,6 +528,7 @@ func (prweWAL *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wr
 		}
 		prweWAL.mu.Lock()
 		if prweWAL.wal == nil {
+			prweWAL.mu.Unlock()
 			return nil, errors.New("attempt to read from closed WAL")
 		}
 		prweWAL.telemetry.recordWALReads(ctx)
@@ -474,9 +539,15 @@ func (prweWAL *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wr
 		prweWAL.telemetry.recordWALBytesRead(ctx, len(protoBlob))
 		if err == nil { // The read succeeded.
 			req := new(prompb.WriteRequest)
-			err = proto.Unmarshal(protoBlob, req)
-			if err != nil {
-				return nil, err
+			if unmarshalErr := proto.Unmarshal(protoBlob, req); unmarshalErr != nil {
+				// Corrupted WAL entry: skip it and advance to the next index
+				// rather than failing fatally. This prevents a single corrupted
+				// entry (e.g. from a crash during write) from blocking the
+				// entire WAL replay in an infinite retry loop.
+				prweWAL.rWALIndex.Add(1)
+				prweWAL.telemetry.recordWALReadsFailures(ctx)
+				prweWAL.mu.Unlock()
+				return nil, fmt.Errorf("%w: index %d: %w", errCorruptedWALEntry, index, unmarshalErr)
 			}
 
 			// Now increment the WAL's read index.

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -5,6 +5,8 @@ package prometheusremotewriteexporter
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
@@ -155,7 +158,6 @@ func TestWAL_persist(t *testing.T) {
 	})
 
 	require.NoError(t, pwal.persistToWAL(ctx, reqL))
-	require.Len(t, pwal.rNotify, 1)
 
 	// 2. Read all the entries from the WAL itself, guided by the indices available,
 	// and ensure that they are exactly in order as we'd expect them.
@@ -369,7 +371,6 @@ func TestWALRead_Telemetry(t *testing.T) {
 	metadatatest.AssertEqualExporterPrometheusremotewriteWalReads(t, tel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	wal := prw.wal
 
 	// Create some test data
 	metrics := map[string]*prompb.TimeSeries{
@@ -382,29 +383,327 @@ func TestWALRead_Telemetry(t *testing.T) {
 	// Write a successful WAL write first
 	err = prw.handleExport(t.Context(), metrics, nil)
 	require.NoError(t, err)
-	err = wal.wal.Close()
-	require.NoError(t, err)
-
-	// Write corrupted data
-	corruptedData := []byte{0x80}
-	firstWalFile := filepath.Join(wal.walPath, "00000000000000000001")
-	err = os.WriteFile(firstWalFile, corruptedData, 0o600)
-	require.NoError(t, err)
-	// write the corrupted data and start reading from the index
-
-	err = prw.Start(t.Context(), componenttest.NewNopHost())
-	// Unable to start the WAL cause there is a corrupted entry
-	require.Error(t, err)
-	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_reads_failures")
-
-	// verify that the metric exists, so it's incremented
-	require.NoError(t, err)
 
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_read_latency")
 	require.NoError(t, err)
 
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_bytes_read")
 	require.NoError(t, err)
+}
+
+// TestWAL_CorruptSegmentRecovery verifies that when WAL segment files are
+// corrupt (as detected by tidwall/wal.Open returning ErrCorrupt), the
+// exporter recovers by removing the corrupt WAL directory and starting fresh,
+// rather than crash-looping forever. This reproduces the exact CrashLoopBackOff
+// seen in production with hostPath volumes.
+func TestWAL_CorruptSegmentRecovery(t *testing.T) {
+	tempDir := t.TempDir()
+	walPath := filepath.Join(tempDir, "prom_remotewrite")
+
+	// Create a WAL with valid data first.
+	config := &WALConfig{Directory: tempDir, BufferSize: 1}
+	set := exportertest.NewNopSettings(metadata.Type)
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NotNil(t, pwal)
+	require.NoError(t, pwal.retrieveWALIndices())
+
+	ctx := t.Context()
+	require.NoError(t, pwal.persistToWAL(ctx, []*prompb.WriteRequest{
+		{Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "test"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+			},
+		}},
+	}))
+	require.NoError(t, pwal.stop())
+
+	// Corrupt the WAL segment file to simulate a crash during write.
+	entries, err := os.ReadDir(walPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "WAL directory should have segment files")
+	for _, entry := range entries {
+		segPath := filepath.Join(walPath, entry.Name())
+		require.NoError(t, os.WriteFile(segPath, []byte("CORRUPT"), 0o600))
+	}
+
+	// createWAL should recover from the corruption by removing and recreating.
+	newLog, newPath, err := config.createWAL()
+	require.NoError(t, err, "createWAL should recover from corrupt WAL, not fail")
+	require.NotNil(t, newLog)
+	require.Equal(t, walPath, newPath)
+
+	// The recovered WAL should be functional — verify we can write and read.
+	require.NoError(t, newLog.Write(1, []byte("test")))
+	data, err := newLog.Read(1)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test"), data)
+	require.NoError(t, newLog.Close())
+}
+
+// TestWAL_CorruptEntrySkipped verifies that a single corrupted protobuf entry
+// in the WAL is skipped rather than causing a fatal error or infinite retry loop.
+// Uses WAL-level Write of garbage bytes so the WAL structure stays valid (Open
+// succeeds) but proto.Unmarshal fails, and a context timeout to avoid hangs.
+func TestWAL_CorruptEntrySkipped(t *testing.T) {
+	tempDir := t.TempDir()
+	config := &WALConfig{Directory: tempDir, BufferSize: 10}
+	set := exportertest.NewNopSettings(metadata.Type)
+
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
+
+	ctx := t.Context()
+
+	// Write 2 valid entries.
+	for i := range 2 {
+		require.NoError(t, pwal.persistToWAL(ctx, []*prompb.WriteRequest{
+			{Timeseries: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "metric"}},
+					Samples: []prompb.Sample{{Value: float64(i), Timestamp: int64(i * 100)}},
+				},
+			}},
+		}))
+	}
+
+	// Write a corrupt entry directly via the WAL — valid WAL record but
+	// invalid protobuf, so wal.Open succeeds but proto.Unmarshal fails.
+	pwal.mu.Lock()
+	nextIdx := pwal.wWALIndex.Add(1)
+	require.NoError(t, pwal.wal.Write(nextIdx, []byte("NOT_A_VALID_PROTOBUF")))
+	pwal.mu.Unlock()
+
+	// Write one more valid entry after the corrupt one.
+	require.NoError(t, pwal.persistToWAL(ctx, []*prompb.WriteRequest{
+		{Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "metric"}},
+				Samples: []prompb.Sample{{Value: 99, Timestamp: 9900}},
+			},
+		}},
+	}))
+
+	require.NoError(t, pwal.stop())
+
+	// Reopen and read — the corrupt entry should be skipped.
+	pwal2, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal2.retrieveWALIndices())
+
+	readCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var goodCount, corruptCount int
+	for range 4 {
+		_, readErr := pwal2.readPrompbFromWAL(readCtx, pwal2.rWALIndex.Load())
+		if readErr != nil {
+			if errors.Is(readErr, errCorruptedWALEntry) {
+				corruptCount++
+				continue
+			}
+			t.Logf("non-corruption read error at index: %v", readErr)
+			break
+		}
+		goodCount++
+	}
+
+	assert.Equal(t, 3, goodCount, "should read 3 valid entries")
+	assert.Equal(t, 1, corruptCount, "should skip 1 corrupt entry")
+	t.Logf("good=%d corrupt=%d", goodCount, corruptCount)
+
+	require.NoError(t, pwal2.stop())
+}
+
+// TestWAL_TruncatedSegmentRecovery reproduces the exact production failure:
+// a process killed mid-write leaves a truncated segment file (e.g. 9.3 MB
+// instead of typical 21 MB). The tidwall/wal library detects this as
+// ErrCorrupt on Open. The exporter must recover by removing the corrupt
+// WAL directory and starting fresh, rather than crash-looping.
+func TestWAL_TruncatedSegmentRecovery(t *testing.T) {
+	tempDir := t.TempDir()
+	walPath := filepath.Join(tempDir, "prom_remotewrite")
+	config := &WALConfig{Directory: tempDir, BufferSize: 1}
+	set := exportertest.NewNopSettings(metadata.Type)
+
+	// Write enough data to create a multi-entry WAL.
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
+
+	ctx := t.Context()
+	for i := range 20 {
+		require.NoError(t, pwal.persistToWAL(ctx, []*prompb.WriteRequest{
+			{Timeseries: []prompb.TimeSeries{
+				{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "envoy_cluster_upstream_rq_total"},
+					{Name: "envoy_cluster_name", Value: "http|service-" + fmt.Sprintf("%d", i)},
+					{Name: "kubernetes_node", Value: "node-0"},
+				},
+				Samples: []prompb.Sample{{Value: float64(i), Timestamp: int64(i * 1000)}},
+			},
+			}},
+		}))
+	}
+	require.NoError(t, pwal.stop())
+
+	// Simulate OOM-kill mid-write: truncate the segment file partway through.
+	entries, err := os.ReadDir(walPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	segPath := filepath.Join(walPath, entries[len(entries)-1].Name())
+	segData, err := os.ReadFile(segPath)
+	require.NoError(t, err)
+	require.Greater(t, len(segData), 20, "segment should have meaningful data")
+
+	// Truncate to ~40% of original size — simulates partial page flush.
+	truncatedLen := len(segData) * 2 / 5
+	require.NoError(t, os.WriteFile(segPath, segData[:truncatedLen], 0o600))
+
+	// Without the fix, this would fail with "log corrupt" and crash-loop.
+	// With the fix, it recovers by removing the corrupt WAL and starting fresh.
+	cfg := &Config{
+		WAL: configoptional.Some(WALConfig{
+			Directory:  tempDir,
+			BufferSize: 1,
+		}),
+		RemoteWriteProtoMsg: remoteapi.WriteV1MessageType,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer server.Close()
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	cfg.ClientConfig = clientConfig
+	require.NoError(t, cfg.Validate())
+
+	set2 := exportertest.NewNopSettings(metadata.Type)
+	set2.BuildInfo = component.BuildInfo{Description: "OpenTelemetry Collector", Version: "1.0"}
+	prwe, err := newPRWExporter(cfg, set2)
+	require.NoError(t, err)
+
+	// This is the critical assertion: Start must succeed, not crash-loop.
+	err = prwe.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err, "exporter must start despite corrupt WAL — should auto-recover")
+
+	// Verify the exporter is functional after recovery.
+	metrics := map[string]*prompb.TimeSeries{
+		"test_after_recovery": {
+			Labels:  []prompb.Label{{Name: "__name__", Value: "test_after_recovery"}},
+			Samples: []prompb.Sample{{Value: 42, Timestamp: 9999}},
+		},
+	}
+	assert.NoError(t, prwe.handleExport(t.Context(), metrics, nil))
+
+	assert.NoError(t, prwe.Shutdown(t.Context()))
+}
+
+// TestWAL_PersistToClosedWAL verifies that persistToWAL returns errNilWAL
+// instead of panicking when the WAL has already been closed.
+func TestWAL_PersistToClosedWAL(t *testing.T) {
+	config := &WALConfig{Directory: t.TempDir()}
+	set := exportertest.NewNopSettings(metadata.Type)
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
+	require.NoError(t, pwal.stop())
+
+	err = pwal.persistToWAL(t.Context(), []*prompb.WriteRequest{
+		{Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "a", Value: "b"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+			},
+		}},
+	})
+	require.ErrorIs(t, err, errNilWAL)
+}
+
+// TestWAL_ShutdownWaitsForInflight verifies that Shutdown waits for inflight
+// PushMetrics calls to complete before closing the WAL, preventing the race
+// condition that caused WAL corruption.
+func TestWAL_ShutdownWaitsForInflight(t *testing.T) {
+	cfg := &Config{
+		WAL: configoptional.Some(WALConfig{
+			Directory:  t.TempDir(),
+			BufferSize: 1,
+		}),
+		RemoteWriteProtoMsg: remoteapi.WriteV1MessageType,
+	}
+	buildInfo := component.BuildInfo{
+		Description: "OpenTelemetry Collector",
+		Version:     "1.0",
+	}
+	set := exportertest.NewNopSettings(metadata.Type)
+	set.BuildInfo = buildInfo
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer server.Close()
+
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	cfg.ClientConfig = clientConfig
+	require.NoError(t, cfg.Validate())
+
+	prwe, err := newPRWExporter(cfg, set)
+	require.NoError(t, err)
+	require.NoError(t, prwe.Start(t.Context(), componenttest.NewNopHost()))
+
+	// Simulate concurrent PushMetrics during shutdown.
+	// PushMetrics uses prwe.wg, so Shutdown must wait for it to finish.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 10 {
+			md := pmetric.NewMetrics()
+			rm := md.ResourceMetrics().AppendEmpty()
+			sm := rm.ScopeMetrics().AppendEmpty()
+			m := sm.Metrics().AppendEmpty()
+			m.SetName("test_metric")
+			g := m.SetEmptyGauge()
+			dp := g.DataPoints().AppendEmpty()
+			dp.SetDoubleValue(1.0)
+			_ = prwe.PushMetrics(t.Context(), md)
+		}
+	}()
+
+	// Shutdown while PushMetrics is running — should not panic or corrupt.
+	err = prwe.Shutdown(t.Context())
+	assert.NoError(t, err)
+	<-done
+}
+
+// TestWAL_WriteBatchBeforeNotify verifies that WriteBatch completes before
+// the reader is notified, preventing the reader from attempting to read
+// an index that hasn't been persisted yet.
+func TestWAL_WriteBatchBeforeNotify(t *testing.T) {
+	config := &WALConfig{Directory: t.TempDir(), BufferSize: 1}
+	set := exportertest.NewNopSettings(metadata.Type)
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
+	t.Cleanup(func() { _ = pwal.stop() })
+
+	ctx := t.Context()
+
+	// Write an entry.
+	require.NoError(t, pwal.persistToWAL(ctx, []*prompb.WriteRequest{
+		{Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "test"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+			},
+		}},
+	}))
+
+	// The entry should be immediately readable (no race with notification).
+	req, err := pwal.readPrompbFromWAL(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "test", req.Timeseries[0].Labels[0].Value)
 }
 
 func TestWALLag_Telemetry(t *testing.T) {


### PR DESCRIPTION
#### Description

When running WALs in production using HostPath, we found that WALs could get corrupted mid segment if the collector was shutdown mid-write. This PR addresses a) race conditions during process shutdown that might cause corruption and b) make the WAL more resilient to corrupted segments in the unfortunate event where the bytes _do_ get corrupted

Example errors in production
WAL corruption error (prevents collector startup):

```
  2026-03-13T20:52:27.449Z      error   prw.wal prometheusremotewriteexporter@v0.145.0/wal.go:235       unable
  write-ahead log       {"otelcol.component.id": "prometheusremotewrite/grafana", "otelcol.component.kind":
  "exporter", "otelcol.signal": "metrics", "error": "prometheusremotewriteexporter: failed to open WAL: log
  corrupt"}

  Pipeline startup failure (fatal):
  2026-03-13T20:52:27.449Z      error   graph/graph.go:439      Failed to start component       {"error":
  "prometheusremotewriteexporter: failed to open WAL: log corrupt", "type": "Exporter", "id":
  "prometheusremotewrite/grafana"}
  Error: cannot start pipelines: failed to start "prometheusremotewrite/grafana" exporter:
  prometheusremotewriteexporter: failed to open WAL: log corrupt
```

  Stack trace from the crash:
```
  github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter.(*prweWAL).
  run
        github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter@v0.14
  l.go:235
  github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter.(*prwExport
  er).turnOnWALIfEnabled
        github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter@v0.14
  porter.go:542
  github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter.(*prwExport
  er).Start
        github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter@v0.14
  porter.go:240
```
Looking deeply at our WAL on hostpath
  - 164 WAL segments, 3.5 GB total in /var/lib/otelcol/storage/prw-wal/prom_remotewrite/
  - Last segment 00000000000000022475 is 9.3 MB (truncated, vs typical 21-23 MB)
  - Segment ends mid-record writing an envoy_cluster_name attribute — no clean EOF, no zero-fill
  - Cause: process killed mid-write during OOM pressure, partial page flushed to disk

This PR:

**Crash safety fixes:**
- Fix `Shutdown()` ordering: wait for inflight `PushMetrics` before closing WAL
- Fix `stop()` data race: hold `mu` when calling `closeWAL()`
- Fix `persistToWAL`: check for nil WAL before writing
- Fix `readPrompbFromWAL`: unlock `mu` before returning on nil WAL check

**Corruption resilience fixes:**
- Fix `createWAL`: when `wal.Open()` returns `ErrCorrupt`, attempt recovery by removing the last segment first (covers the common crash-mid-write case), then fall back to removing the WAL directory and starting fresh — prevents crash-looping
- Fix `readPrompbFromWAL`: skip corrupted protobuf entries instead of fatal error that causes infinite retry loop
- Fix `continuallyPopWALThenExport`: catch `errCorruptedWALEntry` and continue with warning log

#### Link to tracking issue
Related to #45288

#### Testing
- `TestWAL_TruncatedSegmentRecovery` — reproduces exact production failure (OOM-kill truncates segment mid-write, verifies exporter starts and is functional after recovery)
- `TestWAL_CorruptSegmentRecovery` — fully corrupted segments, verifies recovery
- `TestWAL_CorruptEntrySkipped` — corrupted protobuf entry skipped deterministically (WAL-level garbage write), good entries still readable, context timeout prevents hangs
- `TestWAL_PersistToClosedWAL` — returns `errNilWAL` instead of panic
- `TestWAL_ShutdownWaitsForInflight` — uses `PushMetrics` to exercise real `wg` lifecycle during concurrent shutdown
- `TestWAL_WriteBatchBeforeNotify` — entry readable immediately after persist
- All existing WAL tests pass, `-race` clean
