### PR TITLE
receiver/kafka: topic/partition/offset metadata

### DIFF
--- a/.chloggen/kafkareceiver-metadata.yaml
+++ b/.chloggen/kafkareceiver-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add kafka.topic, kafka.partition, kafka.offset to client metadata
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45931]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -172,9 +172,17 @@ Available only for logs:
 - `json`: the payload is decoded as JSON and inserted as the body of a log record.
 - `azure_resource_logs`: the payload is converted from Azure Resource Logs format to OTel format.
 
-### Message header propagation
+### Message metadata propagation
 
-The Kafka receiver will extract Kafka message headers and include them as request metadata (context).
+The Kafka receiver includes the following record metadata as request metadata (context) for each
+consumed message:
+
+- `kafka.topic`: the topic the message was consumed from
+- `kafka.partition`: the partition the message was consumed from
+- `kafka.offset`: the offset of the message within the partition
+
+Additionally, all Kafka message headers are included in the request metadata.
+
 This metadata can then be used throughout the pipeline, for example to set attributes using the
 [attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md).
 
@@ -208,8 +216,8 @@ receivers:
 
 #### Header extraction
 
-In addition to propagating Kafka message headers as metadata as described above in
-[Message header propagation](#message-header-propagation), the Kafka receiver can also
+In addition to propagating Kafka message metadata as described above in
+[Message metadata propagation](#message-metadata-propagation), the Kafka receiver can also
 be configured to extract and attach specific headers as resource attributes. e.g.
 
 ```yaml

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -6,6 +6,7 @@ package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"context"
 	"iter"
+	"strconv"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -373,7 +374,7 @@ func processMessage[T plog.Logs | pmetric.Metrics | ptrace.Traces | pprofile.Pro
 		)
 	}
 
-	ctx = contextWithHeaders(ctx, record.Headers)
+	ctx = contextWithMetadata(ctx, record)
 
 	obsCtx := handler.startObsReport(ctx)
 	data, n, err := handler.unmarshalData(record.Value)
@@ -444,12 +445,13 @@ func newExponentialBackOff(config configretry.BackOffConfig) *backoff.Exponentia
 	return backOff
 }
 
-func contextWithHeaders(ctx context.Context, headers []kgo.RecordHeader) context.Context {
-	if len(headers) == 0 {
-		return ctx
+func contextWithMetadata(ctx context.Context, record *kgo.Record) context.Context {
+	m := map[string][]string{
+		"kafka.topic":     {record.Topic},
+		"kafka.partition": {strconv.FormatInt(int64(record.Partition), 10)},
+		"kafka.offset":    {strconv.FormatInt(record.Offset, 10)},
 	}
-	m := make(map[string][]string, len(headers))
-	for _, h := range headers {
+	for _, h := range record.Headers {
 		m[h.Key] = append(m[h.Key], string(h.Value))
 	}
 	return client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(m)})

--- a/receiver/kafkareceiver/kafka_receiver_bench_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_bench_test.go
@@ -10,37 +10,43 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-func BenchmarkContextWithHeaders(b *testing.B) {
+func BenchmarkContextWithMetadata(b *testing.B) {
 	baseCtx := b.Context()
 	tests := []struct {
-		name    string
-		headers []kgo.RecordHeader
+		name   string
+		record *kgo.Record
 	}{
 		{
-			name:    "no headers",
-			headers: nil,
+			name:   "no headers",
+			record: &kgo.Record{Topic: "test-topic", Partition: 0, Offset: 42},
 		},
 		{
 			name: "1 header",
-			headers: []kgo.RecordHeader{
-				{Key: "trace-id", Value: []byte("abc123")},
+			record: &kgo.Record{
+				Topic: "test-topic", Partition: 0, Offset: 42,
+				Headers: []kgo.RecordHeader{
+					{Key: "trace-id", Value: []byte("abc123")},
+				},
 			},
 		},
 		{
 			name: "5 headers",
-			headers: []kgo.RecordHeader{
-				{Key: "trace-id", Value: []byte("abc123")},
-				{Key: "span-id", Value: []byte("def456")},
-				{Key: "tenant", Value: []byte("acme")},
-				{Key: "source", Value: []byte("app1")},
-				{Key: "env", Value: []byte("prod")},
+			record: &kgo.Record{
+				Topic: "test-topic", Partition: 0, Offset: 42,
+				Headers: []kgo.RecordHeader{
+					{Key: "trace-id", Value: []byte("abc123")},
+					{Key: "span-id", Value: []byte("def456")},
+					{Key: "tenant", Value: []byte("acme")},
+					{Key: "source", Value: []byte("app1")},
+					{Key: "env", Value: []byte("prod")},
+				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			for b.Loop() {
-				_ = contextWithHeaders(baseCtx, tt.headers)
+				_ = contextWithMetadata(baseCtx, tt.record)
 			}
 		})
 	}

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -135,6 +135,11 @@ func TestReceiver_Headers_Metadata(t *testing.T) {
 				for key, values := range testcase.expected {
 					assert.Equal(t, values, info.Metadata.Get(key))
 				}
+
+				// Verify Kafka record metadata is always present.
+				assert.Equal(t, []string{"otlp_spans"}, info.Metadata.Get("kafka.topic"))
+				assert.Equal(t, []string{"0"}, info.Metadata.Get("kafka.partition"))
+				assert.Equal(t, []string{"0"}, info.Metadata.Get("kafka.offset"))
 			})
 		})
 	}


### PR DESCRIPTION
#### Description

Enhance the Kafka receiver to inject the Kafka topic, partition, and offset as client metadata.
These can then be accessed, for example, by the transform processor to copy into attributes.

#### Link to tracking issue

Fixes #45931

#### Testing

Tests added.

#### Documentation

Updated README