### PR TITLE
[internal/metadataproviders] Fix response body leak and add status check in OpenShift provider

### DIFF
--- a/.chloggen/fix_46921.yaml
+++ b/.chloggen/fix_46921.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: internal/metadataproviders
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix HTTP response body leak in OpenShift metadata provider and add status code validation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46921]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Three methods in the OpenShift metadata provider (OpenShiftClusterVersion, Infrastructure,
+  K8SClusterVersion) were not closing the HTTP response body after making requests. This leaked
+  HTTP connections and file descriptors, which could exhaust the connection pool over time when
+  periodic refresh is enabled. The fix adds defer resp.Body.Close() and validates the HTTP
+  status code before attempting to decode the response.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/metadataproviders/openshift/metadata.go
+++ b/internal/metadataproviders/openshift/metadata.go
@@ -63,6 +63,10 @@ func (o *openshiftProvider) OpenShiftClusterVersion(ctx context.Context) (string
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OpenShift API returned status %s", resp.Status)
+	}
 	res := ocpClusterVersionAPIResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return "", err
@@ -79,6 +83,10 @@ func (o *openshiftProvider) Infrastructure(ctx context.Context) (*Infrastructure
 	resp, err := o.client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OpenShift API returned status %s", resp.Status)
 	}
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -107,6 +115,10 @@ func (o *openshiftProvider) K8SClusterVersion(ctx context.Context) (string, erro
 	resp, err := o.client.Do(req)
 	if err != nil {
 		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Kubernetes API returned status %s", resp.Status)
 	}
 	res := k8sClusterVersionAPIResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {

--- a/internal/metadataproviders/openshift/metadata_test.go
+++ b/internal/metadataproviders/openshift/metadata_test.go
@@ -329,3 +329,39 @@ func TestQueryEndpointCorrectInfrastructureOpenstack(t *testing.T) {
 	}
 	assert.Equal(t, expect, *got)
 }
+
+func TestOpenShiftClusterVersion_Non200Status(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	provider := NewProvider(ts.URL, "bad-token", nil)
+	_, err := provider.OpenShiftClusterVersion(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestInfrastructure_Non200Status(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	provider := NewProvider(ts.URL, "test-token", nil)
+	_, err := provider.Infrastructure(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestK8SClusterVersion_Non200Status(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	provider := NewProvider(ts.URL, "bad-token", nil)
+	_, err := provider.K8SClusterVersion(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The three HTTP methods in the OpenShift metadata provider (`OpenShiftClusterVersion`, `Infrastructure`, `K8SClusterVersion`) never close the response body after making requests. This can leak connections and file descriptors over time, especially when periodic refresh is enabled. Eventually, the collector runs out of file descriptors and cannot make new HTTP calls.

This change adds `defer resp.Body.Close()` to all three methods and also validates the HTTP status code before trying to decode the response. Previously, a 403 or 500 from the API would produce a confusing JSON decode error instead of a clear message about the actual status code.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46921

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests for non-200 status responses.