### PR TITLE
[internal/aws]: respect NO_PROXY env var in awsutil HTTP client

### DIFF
--- a/.chloggen/fix-awsutil-noproxy.yaml
+++ b/.chloggen/fix-awsutil-noproxy.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+component: internal/aws
+note: Respect NO_PROXY/no_proxy environment variables when using env-based proxy configuration in awsutil
+issues: [46892]
+subtext: |
+  When no explicit proxy_address was configured, the HTTP client manually read HTTPS_PROXY
+  and used http.ProxyURL which ignores NO_PROXY. Now delegates to http.ProxyFromEnvironment
+  which correctly handles all proxy environment variables.
+change_logs: [user]

--- a/internal/aws/awsutil/conn.go
+++ b/internal/aws/awsutil/conn.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -32,8 +31,7 @@ func newHTTPClient(logger *zap.Logger, maxIdle, requestTimeout int, noVerify boo
 		InsecureSkipVerify: noVerify,
 	}
 
-	finalProxyAddress := getProxyAddress(proxyAddress)
-	proxyURL, err := getProxyURL(finalProxyAddress)
+	proxyFunc, err := getProxyFunc(proxyAddress)
 	if err != nil {
 		logger.Error("unable to obtain proxy URL", zap.Error(err))
 		return nil, err
@@ -41,7 +39,7 @@ func newHTTPClient(logger *zap.Logger, maxIdle, requestTimeout int, noVerify boo
 	transport := &http.Transport{
 		MaxIdleConnsPerHost: maxIdle,
 		TLSClientConfig:     tls,
-		Proxy:               http.ProxyURL(proxyURL),
+		Proxy:               proxyFunc,
 	}
 
 	// is not enabled by default as we configure TLSClientConfig for supporting SSL to data plane.
@@ -58,30 +56,19 @@ func newHTTPClient(logger *zap.Logger, maxIdle, requestTimeout int, noVerify boo
 	return http, err
 }
 
-func getProxyAddress(proxyAddress string) string {
-	var finalProxyAddress string
-	switch {
-	case proxyAddress != "":
-		finalProxyAddress = proxyAddress
-
-	case proxyAddress == "" && os.Getenv("HTTPS_PROXY") != "":
-		finalProxyAddress = os.Getenv("HTTPS_PROXY")
-	default:
-		finalProxyAddress = ""
+// getProxyFunc returns an appropriate proxy function for http.Transport.
+// When no explicit proxyAddress is configured, it delegates to
+// http.ProxyFromEnvironment which correctly respects NO_PROXY.
+// When an explicit proxyAddress is configured, it uses http.ProxyURL.
+func getProxyFunc(proxyAddress string) (func(*http.Request) (*url.URL, error), error) {
+	if proxyAddress == "" {
+		return http.ProxyFromEnvironment, nil
 	}
-	return finalProxyAddress
-}
-
-func getProxyURL(finalProxyAddress string) (*url.URL, error) {
-	var proxyURL *url.URL
-	var err error
-	if finalProxyAddress != "" {
-		proxyURL, err = url.Parse(finalProxyAddress)
-	} else {
-		proxyURL = nil
-		err = nil
+	proxyURL, err := url.Parse(proxyAddress)
+	if err != nil {
+		return nil, err
 	}
-	return proxyURL, err
+	return http.ProxyURL(proxyURL), nil
 }
 
 func GetAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionSettings) (aws.Config, error) {

--- a/internal/aws/awsutil/conn_test.go
+++ b/internal/aws/awsutil/conn_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -178,91 +179,63 @@ func TestNewHTTPClientWithCustomTimeout(t *testing.T) {
 	assert.Equal(t, 60*time.Second, client.Timeout)
 }
 
-// Test getProxyAddress function
-func TestGetProxyAddress(t *testing.T) {
-	testCases := []struct {
-		name         string
-		proxyAddress string
-		envProxy     string
-		expected     string
-	}{
-		{
-			name:         "Explicit proxy address",
-			proxyAddress: "http://explicit.proxy.com",
-			envProxy:     "http://env.proxy.com",
-			expected:     "http://explicit.proxy.com",
-		},
-		{
-			name:         "Environment proxy address",
-			proxyAddress: "",
-			envProxy:     "http://env.proxy.com",
-			expected:     "http://env.proxy.com",
-		},
-		{
-			name:         "No proxy address",
-			proxyAddress: "",
-			envProxy:     "",
-			expected:     "",
-		},
-	}
+func TestNoProxyIsRespectedWhenUsingEnvProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://mitmproxy:8080")
+	t.Setenv("NO_PROXY", ".amazonaws.com,localhost,127.0.0.1")
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.envProxy != "" {
-				t.Setenv("HTTPS_PROXY", tc.envProxy)
-			} else {
-				t.Setenv("HTTPS_PROXY", "")
-			}
+	logger := zap.NewNop()
 
-			result := getProxyAddress(tc.proxyAddress)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
+	client, err := newHTTPClient(logger, 8, 30, false, "")
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "Transport should be *http.Transport")
+	require.NotNil(t, transport.Proxy, "Proxy function should not be nil")
+
+	req, err := http.NewRequest(http.MethodGet, "https://logs.eu-west-1.amazonaws.com/", http.NoBody)
+	require.NoError(t, err)
+
+	proxyURL, err := transport.Proxy(req)
+	assert.NoError(t, err)
+	assert.Nil(t, proxyURL,
+		"Proxy should be nil for hosts matching NO_PROXY, but got: %v — "+
+			"this proves NO_PROXY is not respected", proxyURL)
 }
 
-// Test getProxyURL function
-func TestGetProxyURL(t *testing.T) {
-	testCases := []struct {
-		name        string
-		proxyAddr   string
-		expectError bool
-		expectNil   bool
-	}{
-		{
-			name:        "Valid proxy URL",
-			proxyAddr:   "http://proxy.example.com:8080",
-			expectError: false,
-			expectNil:   false,
-		},
-		{
-			name:        "Empty proxy address",
-			proxyAddr:   "",
-			expectError: false,
-			expectNil:   true,
-		},
-		{
-			name:        "Invalid proxy URL",
-			proxyAddr:   "://invalid",
-			expectError: true,
-			expectNil:   false,
-		},
-	}
+func TestProxyIsUsedForNonExcludedHosts(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://mitmproxy:8080")
+	t.Setenv("NO_PROXY", ".amazonaws.com,localhost,127.0.0.1")
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			url, err := getProxyURL(tc.proxyAddr)
+	logger := zap.NewNop()
+	client, err := newHTTPClient(logger, 8, 30, false, "")
+	require.NoError(t, err)
 
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
 
-			if tc.expectNil {
-				assert.Nil(t, url)
-			} else if !tc.expectError {
-				assert.NotNil(t, url)
-			}
-		})
-	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/something", http.NoBody)
+	require.NoError(t, err)
+
+	proxyURL, err := transport.Proxy(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, proxyURL)
+	assert.Equal(t, "http://mitmproxy:8080", proxyURL.String())
+}
+
+func TestExplicitProxyAddressStillWorks(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://env.proxy:8080")
+	logger := zap.NewNop()
+	client, err := newHTTPClient(logger, 8, 30, false, "http://explicit.proxy:9090")
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	require.NoError(t, err)
+
+	proxyURL, err := transport.Proxy(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, proxyURL)
+	assert.Equal(t, "http://explicit.proxy:9090", proxyURL.String())
 }


### PR DESCRIPTION
fixes #46892

When no explicit `proxy_address` is configured, `newHTTPClient` in `internal/aws/awsutil/conn.go` manually reads `HTTPS_PROXY` via `getProxyAddress` and passes it to `http.ProxyURL`. This unconditionally routes **all** requests through the proxy, completely ignoring `NO_PROXY`/`no_proxy` environment variables.

This causes TLS failures for users running behind intercepting proxies (e.g. mitmproxy) who rely on `NO_PROXY` to bypass the proxy for AWS endpoints:
```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## Fix

Introduced `getProxyFunc` which:
- **Empty `proxy_address` (env-based proxy):** returns `http.ProxyFromEnvironment`, Go's stdlib function that correctly handles `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, and their lowercase variants.
- **Explicit `proxy_address` (config-based proxy):** returns `http.ProxyURL` as before — no behavior change.

## Tests

Added three tests to `conn_test.go`:
- `TestNoProxyIsRespectedWhenUsingEnvProxy` -- verifies proxy is bypassed for hosts matching `NO_PROXY`
- `TestProxyIsUsedForNonExcludedHosts` -- verifies proxy is still used for non-excluded hosts
- `TestExplicitProxyAddressStillWorks` -- verifies backward compatibility with explicit `proxy_address` config

## Note

`internal/aws/proxy/conn.go` has a similar pattern (its own `getProxyAddress`/`getProxyURL` with the same `http.ProxyURL` usage). Happy to fix that in this PR as well.

The old `getProxyAddress` and `getProxyURL` in `awsutil/conn.go` are now unused by production code (only their existing tests reference them). Happy to remove them too in this PR if preferred.