### PR TITLE
[pkg/ottl] Added logging for functions that truncate or discard attributes

### DIFF
--- a/.chloggen/enhancement_add_logging_attribute_limit.yaml
+++ b/.chloggen/enhancement_add_logging_attribute_limit.yaml
@@ -15,7 +15,7 @@ issues: [9730]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: "Added logging to the `truncate_all` and `limit` function for each attribute that was truncated or discarded as per the opentelemetry specification on attribute-limits"
+subtext: "Added logging to the `truncate_all` and `limit` function for each record that had attribute truncated or discarded as per the opentelemetry specification on attribute-limits"
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/enhancement_add_logging_attribute_limit.yaml
+++ b/.chloggen/enhancement_add_logging_attribute_limit.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added logging to functions as per opentelemetry specification
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [9730]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "Added logging to the `truncate_all` and `limit` function for each attribute that was truncated or discarded as per the opentelemetry specification on attribute-limits"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/enhancement_add_logging_attribute_limit.yaml
+++ b/.chloggen/enhancement_add_logging_attribute_limit.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added logging to functions as per opentelemetry specification
+note: Added debug-level logging when functions truncate or discard attributes
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [9730]
@@ -15,7 +15,7 @@ issues: [9730]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: "Added logging to the `truncate_all` and `limit` function for each record that had attribute truncated or discarded as per the opentelemetry specification on attribute-limits"
+subtext: "Added logging to the `truncate_all` and `limit` functions for each record that had attributes truncated or discarded, as per the OpenTelemetry specification on attribute limits"
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -23,17 +24,17 @@ func NewLimitFactory[K any]() ottl.Factory[K] {
 	return ottl.NewFactory("limit", &LimitArguments[K]{}, createLimitFunction[K])
 }
 
-func createLimitFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+func createLimitFunction[K any](fCtx ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
 	args, ok := oArgs.(*LimitArguments[K])
 
 	if !ok {
 		return nil, errors.New("LimitFactory args must be of type *LimitArguments[K]")
 	}
 
-	return limit(args.Target, args.Limit, args.PriorityKeys)
+	return limit(args.Target, args.Limit, args.PriorityKeys, fCtx.Set.Logger)
 }
 
-func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []string) (ottl.ExprFunc[K], error) {
+func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []string, logger *zap.Logger) (ottl.ExprFunc[K], error) {
 	if limit < 0 {
 		return nil, fmt.Errorf("invalid limit for limit function, %d cannot be negative", limit)
 	}
@@ -65,6 +66,7 @@ func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []stri
 			}
 		}
 
+		removed := []string{}
 		val.RemoveIf(func(key string, _ pcommon.Value) bool {
 			if _, ok := keep[key]; ok {
 				return false
@@ -73,10 +75,14 @@ func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []stri
 				count++
 				return false
 			}
+			removed = append(removed, key)
 			return true
 		})
 		// TODO: Write log when limiting is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
+		if len(removed) != 0 {
+			logger.Debug(fmt.Sprintf("discarded %d values", len(removed)), zap.Strings("discarded", removed))
+		}
 		return nil, target.Set(ctx, tCtx, val)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -75,11 +75,11 @@ func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []stri
 				count++
 				return false
 			}
-			removed = append(removed, key)
+			if logger.Core().Enabled(zap.DebugLevel) {
+				removed = append(removed, key)
+			}
 			return true
 		})
-		// TODO: Write log when limiting is performed
-		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
 		if len(removed) != 0 {
 			logger.Debug(fmt.Sprintf("discarded %d values", len(removed)), zap.Strings("discarded", removed))
 		}

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -66,7 +66,8 @@ func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []stri
 			}
 		}
 
-		removed := []string{}
+		var removed []string
+		debugEnabled := logger.Core().Enabled(zap.DebugLevel)
 		val.RemoveIf(func(key string, _ pcommon.Value) bool {
 			if _, ok := keep[key]; ok {
 				return false
@@ -75,13 +76,13 @@ func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []stri
 				count++
 				return false
 			}
-			if logger.Core().Enabled(zap.DebugLevel) {
+			if debugEnabled {
 				removed = append(removed, key)
 			}
 			return true
 		})
 		if len(removed) != 0 {
-			logger.Debug(fmt.Sprintf("discarded %d values", len(removed)), zap.Strings("discarded", removed))
+			logger.Debug(fmt.Sprintf("discarded %d values", len(removed)), zap.Strings("keys", removed))
 		}
 		return nil, target.Set(ctx, tCtx, val)
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -115,7 +116,7 @@ func Test_limit(t *testing.T) {
 				},
 			}
 
-			exprFunc, err := limit(target, tt.limit, tt.keep)
+			exprFunc, err := limit(target, tt.limit, tt.keep, zap.NewNop())
 			require.NoError(t, err)
 
 			result, err := exprFunc(nil, scenarioMap)
@@ -155,7 +156,7 @@ func Test_limit_validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := limit(tt.target, tt.limit, tt.keep)
+			_, err := limit(tt.target, tt.limit, tt.keep, zap.NewNop())
 			assert.Error(t, err)
 		})
 	}
@@ -172,7 +173,7 @@ func Test_limit_bad_input(t *testing.T) {
 		},
 	}
 
-	exprFunc, err := limit[any](target, 1, []string{})
+	exprFunc, err := limit[any](target, 1, []string{}, zap.NewNop())
 	require.NoError(t, err)
 	_, err = exprFunc(nil, input)
 	assert.Error(t, err)
@@ -188,7 +189,7 @@ func Test_limit_get_nil(t *testing.T) {
 		},
 	}
 
-	exprFunc, err := limit[any](target, 1, []string{})
+	exprFunc, err := limit[any](target, 1, []string{}, zap.NewNop())
 	require.NoError(t, err)
 	_, err = exprFunc(nil, nil)
 	assert.Error(t, err)

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"go.uber.org/zap"
 )
 
 type TruncateAllArguments[K any] struct {
@@ -22,17 +23,17 @@ func NewTruncateAllFactory[K any]() ottl.Factory[K] {
 	return ottl.NewFactory("truncate_all", &TruncateAllArguments[K]{}, createTruncateAllFunction[K])
 }
 
-func createTruncateAllFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+func createTruncateAllFunction[K any](fCtx ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
 	args, ok := oArgs.(*TruncateAllArguments[K])
 
 	if !ok {
 		return nil, errors.New("TruncateAllFactory args must be of type *TruncateAllArguments[K]")
 	}
 
-	return TruncateAll(args.Target, args.Limit, args.Utf8Safe)
+	return TruncateAll(args.Target, args.Limit, args.Utf8Safe, fCtx.Set.Logger)
 }
 
-func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl.Optional[bool]) (ottl.ExprFunc[K], error) {
+func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl.Optional[bool], logger *zap.Logger) (ottl.ExprFunc[K], error) {
 	if limit < 0 {
 		return nil, fmt.Errorf("invalid limit for truncate_all function, %d cannot be negative", limit)
 	}
@@ -44,7 +45,8 @@ func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl
 		if err != nil {
 			return nil, err
 		}
-		for _, value := range val.All() {
+		truncated := []string{}
+		for key, value := range val.All() {
 			stringVal := value.Str()
 			if int64(len(stringVal)) > limit {
 				truncateAt := int(limit)
@@ -55,10 +57,12 @@ func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl
 					}
 				}
 				value.SetStr(stringVal[:truncateAt])
+				truncated = append(truncated, fmt.Sprintf("'%s': '%s' -> '%s'", key, stringVal, stringVal[:truncateAt]))
 			}
 		}
-		// TODO: Write log when truncation is performed
-		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
+		if len(truncated) != 0 {
+			logger.Debug(fmt.Sprintf("truncated %d values", len(truncated)), zap.Strings("truncated", truncated))
+		}
 		return nil, target.Set(ctx, tCtx, val)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -9,8 +9,9 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 type TruncateAllArguments[K any] struct {

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -46,7 +46,8 @@ func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl
 		if err != nil {
 			return nil, err
 		}
-		truncated := []string{}
+		var truncated []string
+		debugEnabled := logger.Core().Enabled(zap.DebugLevel)
 		for key, value := range val.All() {
 			stringVal := value.Str()
 			if int64(len(stringVal)) > limit {
@@ -58,13 +59,13 @@ func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl
 					}
 				}
 				value.SetStr(stringVal[:truncateAt])
-				if logger.Core().Enabled(zap.DebugLevel) {
+				if debugEnabled {
 					truncated = append(truncated, key)
 				}
 			}
 		}
 		if len(truncated) != 0 {
-			logger.Debug(fmt.Sprintf("truncated %d values", len(truncated)), zap.Strings("truncated", truncated))
+			logger.Debug(fmt.Sprintf("truncated %d values", len(truncated)), zap.Strings("keys", truncated))
 		}
 		return nil, target.Set(ctx, tCtx, val)
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -58,7 +58,9 @@ func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64, utf8Safe ottl
 					}
 				}
 				value.SetStr(stringVal[:truncateAt])
-				truncated = append(truncated, fmt.Sprintf("'%s': '%s' -> '%s'", key, stringVal, stringVal[:truncateAt]))
+				if logger.Core().Enabled(zap.DebugLevel) {
+					truncated = append(truncated, key)
+				}
 			}
 		}
 		if len(truncated) != 0 {

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -83,7 +84,7 @@ func Test_truncateAll(t *testing.T) {
 				},
 			}
 
-			exprFunc, err := TruncateAll(target, tt.limit, ottl.Optional[bool]{})
+			exprFunc, err := TruncateAll(target, tt.limit, ottl.Optional[bool]{}, zap.NewNop())
 			require.NoError(t, err)
 
 			_, err = exprFunc(nil, scenarioMap)
@@ -155,7 +156,7 @@ func Test_truncateAll_UTF8(t *testing.T) {
 			}
 
 			utf8SafeOpt := ottl.NewTestingOptional(true)
-			exprFunc, err := TruncateAll(target, tt.limit, utf8SafeOpt)
+			exprFunc, err := TruncateAll(target, tt.limit, utf8SafeOpt, zap.NewNop())
 			require.NoError(t, err)
 
 			_, err = exprFunc(nil, scenarioMap)
@@ -169,7 +170,7 @@ func Test_truncateAll_UTF8(t *testing.T) {
 }
 
 func Test_truncateAll_validation(t *testing.T) {
-	_, err := TruncateAll[any](&ottl.StandardPMapGetSetter[any]{}, -1, ottl.Optional[bool]{})
+	_, err := TruncateAll[any](&ottl.StandardPMapGetSetter[any]{}, -1, ottl.Optional[bool]{}, zap.NewNop())
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "invalid limit for truncate_all function, -1 cannot be negative")
 }
@@ -185,7 +186,7 @@ func Test_truncateAll_bad_input(t *testing.T) {
 		},
 	}
 
-	exprFunc, err := TruncateAll[any](target, 1, ottl.Optional[bool]{})
+	exprFunc, err := TruncateAll[any](target, 1, ottl.Optional[bool]{}, zap.NewNop())
 	require.NoError(t, err)
 
 	_, err = exprFunc(nil, input)
@@ -202,7 +203,7 @@ func Test_truncateAll_get_nil(t *testing.T) {
 		},
 	}
 
-	exprFunc, err := TruncateAll[any](target, 1, ottl.Optional[bool]{})
+	exprFunc, err := TruncateAll[any](target, 1, ottl.Optional[bool]{}, zap.NewNop())
 	require.NoError(t, err)
 
 	_, err = exprFunc(nil, nil)


### PR DESCRIPTION
#### Description
Added logging to the `truncate_all` and `limit` function for each record that had attribute truncated or discarded as per the opentelemetry specification on attribute-limits

#### Link to tracking issue
Fixes #9730 

#### Testing
The function signature for truncate_all and limit was changed to include the logger instance so I added zap.NewNop() to the test to make sure the test still runs

#### Documentation
https://opentelemetry.io/docs/specs/otel/common/#attribute-limits