### PR TITLE
Set the default collection of query_samples to false

### DIFF
--- a/.chloggen/mysql-default-set.yaml
+++ b/.chloggen/mysql-default-set.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set default collection of query_sample events to false.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46902]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This change is breaking because it disables the default collection of query_sample events. These events will need to be enabled manually if desired.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -669,6 +669,16 @@ events:
     enabled: false
 ```
 
+## Optional Events
+
+The following events are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+events:
+  <event_name>:
+    enabled: true
+```
+
 ### db.server.query_sample
 
 Query sample collection enables monitoring of current running database statements.
@@ -694,16 +704,6 @@ This provides real-time visibility into active queries, helping users monitor da
 | client.port | TCP port used by the client. | Any Int |
 | network.peer.address | IP address of the peer client. | Any Str |
 | network.peer.port | TCP port used by the peer client. | Any Int |
-
-## Optional Events
-
-The following events are not emitted by default. Each of them can be enabled by applying the following configuration:
-
-```yaml
-events:
-  <event_name>:
-    enabled: true
-```
 
 ### db.server.top_query
 

--- a/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
@@ -996,7 +996,7 @@ $defs:
         properties:
           enabled:
             type: boolean
-            default: true
+            default: false
       db.server.top_query:
         description: EventConfig provides common config for a  db.server.top_query event.
         type: object

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -2335,7 +2335,7 @@ type EventsConfig struct {
 func DefaultEventsConfig() EventsConfig {
 	return EventsConfig{
 		DbServerQuerySample: EventConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		DbServerTopQuery: EventConfig{
 			Enabled: false,

--- a/receiver/mysqlreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_logs_test.go
@@ -127,7 +127,7 @@ func TestLogsBuilder(t *testing.T) {
 
 			defaultEventsCount := 0
 			allEventsCount := 0
-			defaultEventsCount++
+
 			allEventsCount++
 			lb.RecordDbServerQuerySampleEvent(ctx, timestamp, AttributeDbSystemNameMysql, 23, "user.name-val", "db.namespace-val", "mysql.threads.processlist_command-val", "mysql.threads.processlist_state-val", "db.query.text-val", "mysql.events_statements_current.digest-val", 14, "mysql.wait_type-val", 37.100000, "client.address-val", 11, "network.peer.address-val", 17)
 

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -271,7 +271,7 @@ attributes:
     requirement_level: recommended
 events:
   db.server.query_sample:
-    enabled: true
+    enabled: false
     description: |
       Query sample collection enables monitoring of current running database statements.
       This provides real-time visibility into active queries, helping users monitor database activity and performance as part of their observability pipeline.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Taking a look at mysqlreceiver implementation, I noticed that the query samples setting in metadata.yaml is defaulted to true.

line 273-274
```
db.server.query_sample:
    enabled: true
```
while top_query is set correctly to false

line 295-296
```
 db.server.top_query:
    enabled: false
```
This should not be the case and users of the receiver should explicitly enable it. We need to also set db.server.query_sample to false.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46902

<!--Describe what testing was performed and which tests were added.-->
#### Testing
no test changes necessary, confirmed

<!--Describe the documentation added.-->
#### Documentation
updated docs
