### PR TITLE
Migrate to new bare metal runner (Ubuntu 24)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   labels:
-    - oracle-bare-metal-64cpu-512gb-x86-64
+    - oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
 
 config-variables: null
 

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     if: ${{ github.actor != 'dependabot[bot]' &&  github.repository_owner == 'open-telemetry' }}
     outputs:
       loadtest_matrix: ${{ steps.splitloadtest.outputs.loadtest_matrix }}
@@ -45,7 +45,7 @@ jobs:
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
   loadtest:
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     needs: [setup-environment]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Old runner:

- name: `oracle-bare-metal-64cpu-512gb-x86-64`
- 512gb memory
- Oracle Linux 8

New runner:

-  name: `oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`
- 1024gb memory
-  Ubuntu 24

I realize this could have some impact on benchmark baselines, so please post on https://github.com/open-telemetry/community/issues/3333 once you have migrated and are comfortable with the old one being removed.
