### PR TITLE
[exporter/file] fix nil pointer dereference during shutdown

### DIFF
--- a/.chloggen/fix-fileexporter-race-condition.yaml
+++ b/.chloggen/fix-fileexporter-race-condition.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/file
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix race condition in fileExporter Shutdown causing nil pointer dereference panic when concurrent exports are in-flight"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46947]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Shutdown was setting e.writer = nil before the writer had fully shut down.
+  Added sync.RWMutex to fileExporter to protect concurrent access to e.writer
+  during Shutdown and consume calls. Added nil guard in export() to return
+  gracefully if called after Shutdown completes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-fileexporter-race-condition.yaml
+++ b/.chloggen/fix-fileexporter-race-condition.yaml
@@ -10,16 +10,18 @@ component: exporter/file
 note: "Fix race condition in fileExporter Shutdown causing nil pointer dereference panic when concurrent exports are in-flight"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [46947]
+issues: [46871]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
   Shutdown was setting e.writer = nil before the writer had fully shut down.
-  Added sync.RWMutex to fileExporter to protect concurrent access to e.writer
-  during Shutdown and consume calls. Added nil guard in export() to return
-  gracefully if called after Shutdown completes.
+  Moved mutex locking into export() and added a w.file == nil guard so calls
+  after shutdown return io.ErrClosedPipe instead of panicking. Added a
+  WaitGroup to fileWriter so shutdown waits for the flush goroutine to exit
+  before closing the file. Snapshot stopTicker under the lock to prevent
+  double-close if shutdown is called more than once.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -91,8 +91,7 @@ func (e *fileExporter) Shutdown(context.Context) error {
 		return nil
 	}
 	w := e.writer
-	defer func() {
-		e.writer = nil
-	}()
-	return w.shutdown()
+	err := w.shutdown()
+	e.writer = nil
+	return err
 }

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -91,6 +91,8 @@ func (e *fileExporter) Shutdown(context.Context) error {
 		return nil
 	}
 	w := e.writer
-	e.writer = nil
+	defer func() {
+		e.writer = nil
+	}()
 	return w.shutdown()
 }

--- a/exporter/fileexporter/file_writer.go
+++ b/exporter/fileexporter/file_writer.go
@@ -45,6 +45,7 @@ func exportMessageAsBuffer(w *fileWriter, buf []byte) error {
 }
 
 func (w *fileWriter) export(buf []byte) error {
+	// Ensure only one write operation happens at a time
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 	if w.file == nil {

--- a/exporter/fileexporter/file_writer.go
+++ b/exporter/fileexporter/file_writer.go
@@ -26,9 +26,6 @@ type fileWriter struct {
 }
 
 func exportMessageAsLine(w *fileWriter, buf []byte) error {
-	// Ensure only one write operation happens at a time.
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
 	if _, err := w.file.Write(buf); err != nil {
 		return err
 	}
@@ -39,9 +36,6 @@ func exportMessageAsLine(w *fileWriter, buf []byte) error {
 }
 
 func exportMessageAsBuffer(w *fileWriter, buf []byte) error {
-	// Ensure only one write operation happens at a time.
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
 	// write the size of each message before writing the message itself.  https://developers.google.com/protocol-buffers/docs/techniques
 	// each encoded object is preceded by 4 bytes (an unsigned 32 bit integer)
 	data := make([]byte, 4, 4+len(buf))
@@ -51,6 +45,11 @@ func exportMessageAsBuffer(w *fileWriter, buf []byte) error {
 }
 
 func (w *fileWriter) export(buf []byte) error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	if w.file == nil {
+		return io.ErrClosedPipe
+	}
 	return w.exporter(w, buf)
 }
 
@@ -102,7 +101,11 @@ func (w *fileWriter) shutdown() error {
 		close(w.stopTicker)
 		w.mutex.Unlock()
 	}
-	return w.file.Close()
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	err := w.file.Close()
+	w.file = nil
+	return err
 }
 
 func buildExportFunc(cfg *Config) func(w *fileWriter, buf []byte) error {

--- a/exporter/fileexporter/file_writer.go
+++ b/exporter/fileexporter/file_writer.go
@@ -73,9 +73,7 @@ func (w *fileWriter) startFlusher() {
 	w.stopTicker = stopCh
 	// Start the ticker.
 	w.flushTicker = time.NewTicker(w.flushInterval)
-	w.wg.Add(1)
-	go func() {
-		defer w.wg.Done()
+	w.wg.Go(func() {
 		for {
 			select {
 			case <-w.flushTicker.C:
@@ -87,7 +85,7 @@ func (w *fileWriter) startFlusher() {
 				return
 			}
 		}
-	}()
+	})
 }
 
 // Start starts the flush timer if set.

--- a/exporter/fileexporter/file_writer.go
+++ b/exporter/fileexporter/file_writer.go
@@ -23,6 +23,7 @@ type fileWriter struct {
 	flushInterval time.Duration
 	flushTicker   *time.Ticker
 	stopTicker    chan struct{}
+	wg            sync.WaitGroup
 }
 
 func exportMessageAsLine(w *fileWriter, buf []byte) error {
@@ -65,20 +66,24 @@ func (w *fileWriter) startFlusher() {
 		return
 	}
 
-	// Create the stop channel.
-	w.stopTicker = make(chan struct{})
+	// Create the stop channel and capture it locally so the goroutine
+	// always selects on the original channel value, even after shutdown
+	// nils out w.stopTicker.
+	stopCh := make(chan struct{})
+	w.stopTicker = stopCh
 	// Start the ticker.
 	w.flushTicker = time.NewTicker(w.flushInterval)
+	w.wg.Add(1)
 	go func() {
+		defer w.wg.Done()
 		for {
 			select {
 			case <-w.flushTicker.C:
 				w.mutex.Lock()
 				ff.flush()
 				w.mutex.Unlock()
-			case <-w.stopTicker:
+			case <-stopCh:
 				w.flushTicker.Stop()
-				w.flushTicker = nil
 				return
 			}
 		}
@@ -95,15 +100,25 @@ func (w *fileWriter) start() {
 // Shutdown stops the exporter and is invoked during shutdown.
 // It stops the flush ticker if set.
 func (w *fileWriter) shutdown() error {
-	// Stop the flush ticker.
-	if w.flushTicker != nil {
-		// Stop the go routine.
-		w.mutex.Lock()
-		close(w.stopTicker)
-		w.mutex.Unlock()
+	// Snapshot and nil out stopTicker under the lock to prevent a double-close
+	// if shutdown is called more than once.
+	w.mutex.Lock()
+	stopTicker := w.stopTicker
+	w.stopTicker = nil
+	w.mutex.Unlock()
+
+	if stopTicker != nil {
+		close(stopTicker)
+		// Wait for the flusher goroutine to finish before closing the file.
+		// Cannot hold w.mutex here because the goroutine acquires it on each tick.
+		w.wg.Wait()
 	}
+
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
+	if w.file == nil {
+		return nil
+	}
 	err := w.file.Close()
 	w.file = nil
 	return err


### PR DESCRIPTION
### Description
Fix nil pointer dereference panic in `fileexporter` during collector shutdown, caused by two concurrent race conditions:

1. `Shutdown()` sets `e.writer = nil` before `w.shutdown()` completes, exposing a window where concurrent consumers panic on nil
2. `export()` in `file_writer.go` lacked mutex protection, allowing it to race against shutdown() closing `w.file`

Fixes #46871 

### Testing
Manually tested shutdown under concurrent load. No dedicated regression test added as the race is non-deterministic; open to suggestions.

### Documentation
No documentation changes required.
