### PR TITLE
[internal/coreinternal] Add HTTP error utility tests

### DIFF
--- a/internal/coreinternal/errorutil/http_test.go
+++ b/internal/coreinternal/errorutil/http_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package errorutil
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+func TestGetHTTPStatusCodeFromError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "retryable error maps to service unavailable",
+			err:  errors.New("retryable"),
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "permanent error maps to bad request",
+			err:  consumererror.NewPermanent(errors.New("permanent")),
+			want: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, GetHTTPStatusCodeFromError(tt.err))
+		})
+	}
+}
+
+func TestHTTPErrorWritesStatusAndMessage(t *testing.T) {
+	t.Parallel()
+
+	err := consumererror.NewPermanent(errors.New("bad payload"))
+	recorder := httptest.NewRecorder()
+
+	HTTPError(recorder, err)
+
+	resp := recorder.Result()
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, "Permanent error: bad payload\n", string(body))
+}
+
+func TestHTTPErrorWithNilErrorDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+
+	HTTPError(recorder, nil)
+
+	resp := recorder.Result()
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, string(body))
+}


### PR DESCRIPTION
# Description

This PR adds unit tests for the previously untested `http.go` file in the `internal/coreinternal/errorutil` package, which maps consumer errors to HTTP response codes for several HTTP-based receivers.

## Changes

New file: `internal/coreinternal/errorutil/http_test.go`

## Tests Added

| Test | What it validates |
| --- | --- |
| `TestGetHTTPStatusCodeFromError` | Retryable errors map to `503 Service Unavailable` and permanent errors map to `400 Bad Request` |
| `TestHTTPErrorWritesStatusAndMessage` | `HTTPError()` writes the expected status code and error message body for permanent errors |
| `TestHTTPErrorWithNilErrorDoesNothing` | `HTTPError()` leaves the response untouched when called with `nil` |

## Motivation

`internal/coreinternal/errorutil/http.go` contains shared retry classification logic that is used by multiple receivers. The behavior is simple, but it directly affects client-visible HTTP responses and retry semantics. This PR adds direct coverage for the status mapping and response-writing paths so regressions are easier to catch.

## Testing

```bash
cd internal/coreinternal && go test ./errorutil -run "TestGetHTTPStatusCodeFromError|TestHTTPError" -v
cd internal/coreinternal && make lint
```

All tests pass and module lint is clean.
