### PR TITLE
[chore][k8sattributes] Add warning when deprecated attributes are enabled

### DIFF
--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -81,6 +81,31 @@ func (kp *kubernetesprocessor) Start(_ context.Context, host component.Host) err
 		}
 	}
 
+	if kp.rules.ContainerImageTag {
+		kp.logger.Warn(
+			"[WARNING] container.image.tag is being renamed to container.image.tags per Semantic Conventions. " +
+				"Consider switching to the new schema by enabling the processor.k8sattributes.EmitV1K8sConventions and " +
+				"processor.k8sattributes.DontEmitV0K8sConventions feature gates. " +
+				"See processor README section 'Semantic Conventions Compatibility' for details.",
+		)
+	}
+	if len(kp.rules.Labels) > 0 {
+		kp.logger.Warn(
+			"[WARNING] Pod label extraction attributes are being renamed (e.g. k8s.pod.labels.<key> -> k8s.pod.label.<key>) per Semantic Conventions. " +
+				"Consider switching to the new schema by enabling the processor.k8sattributes.EmitV1K8sConventions and " +
+				"processor.k8sattributes.DontEmitV0K8sConventions feature gates. " +
+				"See processor README section 'Semantic Conventions Compatibility' for details.",
+		)
+	}
+	if len(kp.rules.Annotations) > 0 {
+		kp.logger.Warn(
+			"[WARNING] Pod annotation extraction attributes are being renamed (e.g. k8s.pod.annotations.<key> -> k8s.pod.annotation.<key>) per Semantic Conventions. " +
+				"Consider switching to the new schema by enabling the processor.k8sattributes.EmitV1K8sConventions and " +
+				"processor.k8sattributes.DontEmitV0K8sConventions feature gates. " +
+				"See processor README section 'Semantic Conventions Compatibility' for details.",
+		)
+	}
+
 	// This might have been set by an option already
 	if kp.kc == nil {
 		err := kp.initKubeClient(kp.telemetrySettings, kubeClientProvider)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Some attributes are being renamed to follow SemConv. See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#semantic-conventions-compatibility.

We need to log a warning accordingly when those are enabled to ensure that users are informed before the transition.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46932

