### PR TITLE
[ci] reduce govulncheck paralelism

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           go-version: oldstable
       - name: Run `govulncheck`
-        run: make -j2 gogovulncheck GROUP=${{ matrix.group }}
+        run: make gogovulncheck GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
   checks:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The govulncheck CI is now failing on receiver-2 matrix. I reproduced it locally simulating within a container with 7GB of RAM and it only works now if we remove the -j2 parallelism.

I have tried to limit with GOMEMLIMIT and GOGC with lower values but no luck.

This is a quick fix to stabilize the CI, and I can open an issue to look into make it faster and safe later.

See: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/23191112862/job/67390129428