### PR TITLE
[receiver/fluentforward] Fix ACK sent before pipeline processing, preventing backpressure

### DIFF
--- a/.chloggen/fluentforwardreceiver-fix-ack-backpressure.yaml
+++ b/.chloggen/fluentforwardreceiver-fix-ack-backpressure.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/fluentforward
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix fluentforward receiver sending ACK before pipeline processing, which prevented backpressure from reaching Fluent Bit clients.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46973]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/fluentforwardreceiver/collector.go
+++ b/receiver/fluentforwardreceiver/collector.go
@@ -20,13 +20,13 @@ import (
 // allocations and GC overhead.
 type collector struct {
 	nextConsumer     consumer.Logs
-	eventCh          <-chan event
+	eventCh          <-chan eventWithACK
 	logger           *zap.Logger
 	obsrecv          *receiverhelper.ObsReport
 	telemetryBuilder *metadata.TelemetryBuilder
 }
 
-func newCollector(eventCh <-chan event, next consumer.Logs, logger *zap.Logger, obsrecv *receiverhelper.ObsReport, telemetryBuilder *metadata.TelemetryBuilder) *collector {
+func newCollector(eventCh <-chan eventWithACK, next consumer.Logs, logger *zap.Logger, obsrecv *receiverhelper.ObsReport, telemetryBuilder *metadata.TelemetryBuilder) *collector {
 	return &collector{
 		nextConsumer:     next,
 		eventCh:          eventCh,
@@ -51,26 +51,40 @@ func (c *collector) processEvents(ctx context.Context) {
 			logSlice := rls.ScopeLogs().AppendEmpty().LogRecords()
 			e.LogRecords().MoveAndAppendTo(logSlice)
 
+			// Collect ACK channels from this event and any batched events.
+			var ackChs []chan error
+			if e.ackCh != nil {
+				ackChs = append(ackChs, e.ackCh)
+			}
+
 			// Pull out anything waiting on the eventCh to get better
 			// efficiency on LogResource allocations.
-			c.fillBufferUntilChanEmpty(logSlice)
+			ackChs = c.fillBufferUntilChanEmpty(logSlice, ackChs)
 
 			logRecordCount := out.LogRecordCount()
 			c.telemetryBuilder.FluentRecordsGenerated.Add(ctx, int64(logRecordCount))
 			obsCtx := c.obsrecv.StartLogsOp(ctx)
 			err := c.nextConsumer.ConsumeLogs(obsCtx, out)
 			c.obsrecv.EndLogsOp(obsCtx, "fluent", logRecordCount, err)
+
+			// Signal all waiting servers whether processing succeeded.
+			for _, ackCh := range ackChs {
+				ackCh <- err
+			}
 		}
 	}
 }
 
-func (c *collector) fillBufferUntilChanEmpty(dest plog.LogRecordSlice) {
+func (c *collector) fillBufferUntilChanEmpty(dest plog.LogRecordSlice, ackChs []chan error) []chan error {
 	for {
 		select {
 		case e := <-c.eventCh:
 			e.LogRecords().MoveAndAppendTo(dest)
+			if e.ackCh != nil {
+				ackChs = append(ackChs, e.ackCh)
+			}
 		default:
-			return
+			return ackChs
 		}
 	}
 }

--- a/receiver/fluentforwardreceiver/collector_test.go
+++ b/receiver/fluentforwardreceiver/collector_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fluentforwardreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestFillBufferUntilChanEmptyCollectsACKChannels(t *testing.T) {
+	eventCh := make(chan eventWithACK, 3)
+
+	// Create three events: two with ackCh, one without.
+	ackCh1 := make(chan error, 1)
+	ackCh2 := make(chan error, 1)
+
+	lr1 := plog.NewLogRecordSlice()
+	lr1.AppendEmpty().Body().SetStr("log1")
+
+	lr2 := plog.NewLogRecordSlice()
+	lr2.AppendEmpty().Body().SetStr("log2")
+
+	lr3 := plog.NewLogRecordSlice()
+	lr3.AppendEmpty().Body().SetStr("log3")
+
+	eventCh <- eventWithACK{event: &testEvent{logs: lr1}, ackCh: ackCh1}
+	eventCh <- eventWithACK{event: &testEvent{logs: lr2}, ackCh: nil}
+	eventCh <- eventWithACK{event: &testEvent{logs: lr3}, ackCh: ackCh2}
+
+	c := &collector{eventCh: eventCh}
+	dest := plog.NewLogRecordSlice()
+	var ackChs []chan error
+
+	ackChs = c.fillBufferUntilChanEmpty(dest, ackChs)
+
+	// All three events' log records should be merged.
+	require.Equal(t, 3, dest.Len())
+
+	// Only the two non-nil ackCh channels should be collected.
+	require.Len(t, ackChs, 2)
+	assert.Equal(t, ackCh1, ackChs[0])
+	assert.Equal(t, ackCh2, ackChs[1])
+}
+
+// testEvent is a minimal event implementation for unit tests.
+type testEvent struct {
+	logs plog.LogRecordSlice
+}
+
+func (*testEvent) DecodeMsg(_ *msgp.Reader) error {
+	return nil
+}
+
+func (e *testEvent) LogRecords() plog.LogRecordSlice {
+	return e.logs
+}
+
+func (*testEvent) Chunk() string {
+	return ""
+}
+
+func (*testEvent) Compressed() string {
+	return ""
+}

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -31,6 +31,15 @@ type event interface {
 	Compressed() string
 }
 
+// eventWithACK wraps an event with an optional channel that the collector
+// uses to signal back to the server whether pipeline processing succeeded.
+// This allows the server to defer sending the Fluent Forward ACK until after
+// ConsumeLogs() completes, enabling proper backpressure.
+type eventWithACK struct {
+	event
+	ackCh chan error // nil if no ACK is needed
+}
+
 type optionsMap map[string]any
 
 // Chunk returns the `chunk` option or blank string if it was not set.

--- a/receiver/fluentforwardreceiver/receiver.go
+++ b/receiver/fluentforwardreceiver/receiver.go
@@ -45,7 +45,7 @@ func newFluentReceiver(set receiver.Settings, conf *Config, next consumer.Logs) 
 		return nil, err
 	}
 
-	eventCh := make(chan event, eventChannelLength)
+	eventCh := make(chan eventWithACK, eventChannelLength)
 	collector := newCollector(eventCh, next, set.Logger, obsrecv, telemetryBuilder)
 
 	server := newServer(eventCh, set.Logger, telemetryBuilder)

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -5,11 +5,13 @@ package fluentforwardreceiver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -435,6 +438,37 @@ func TestReceiverShutdownRefusesNewConnections(t *testing.T) {
 	require.Error(t, err)
 }
 
+func setupServerWithConsumer(t *testing.T, next consumer.Logs) (func() net.Conn, *observer.ObservedLogs, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	logCore, logObserver := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.Logger = logger
+
+	conf := &Config{
+		ListenAddress: "127.0.0.1:0",
+	}
+
+	recv, err := newFluentReceiver(set, conf, next)
+	require.NoError(t, err)
+	require.NoError(t, recv.Start(ctx, componenttest.NewNopHost()))
+
+	connect := func() net.Conn {
+		conn, err := net.Dial("tcp", recv.(*fluentReceiver).listener.Addr().String())
+		require.NoError(t, err)
+		return conn
+	}
+
+	go func() {
+		<-ctx.Done()
+		assert.NoError(t, recv.Shutdown(ctx))
+	}()
+
+	return connect, logObserver, cancel
+}
+
 // TestReceiverShutdownClosesExistingConnections verifies the graceful shutdown of a receiver, ensuring existing connections will be closed.
 func TestReceiverShutdownClosesExistingConnections(t *testing.T) {
 	connect, next, _, cancel, receiver := setupServer(t)
@@ -461,4 +495,104 @@ func TestReceiverShutdownClosesExistingConnections(t *testing.T) {
 		_, err := conn.Write(eventBytes)
 		return err != nil
 	}, 5*time.Second, 1*time.Second)
+}
+
+func makeSampleEventWithChunk(tag, chunk string) []byte {
+	var b []byte
+
+	b = msgp.AppendArrayHeader(b, 4)
+	b = msgp.AppendString(b, tag)
+	b = msgp.AppendInt(b, 5000)
+	b = msgp.AppendMapHeader(b, 1)
+	b = msgp.AppendString(b, "a")
+	b = msgp.AppendFloat64(b, 5.0)
+	b = msgp.AppendMapStrStr(b, map[string]string{"chunk": chunk})
+	return b
+}
+
+// TestPipelineRejectionWithholdsACK verifies that when the pipeline rejects
+// data (e.g. memory_limiter refuses it), the ACK is not sent to the client.
+func TestPipelineRejectionWithholdsACK(t *testing.T) {
+	errConsumer := consumertest.NewErr(errors.New("pipeline full"))
+	connect, observedLogs, cancel := setupServerWithConsumer(t, errConsumer)
+	defer cancel()
+
+	conn := connect()
+	eventBytes := makeSampleEventWithChunk("my-tag", "chunk-123")
+	n, err := conn.Write(eventBytes)
+	require.NoError(t, err)
+	require.Equal(t, len(eventBytes), n)
+
+	// Wait for the pipeline to actually reject the data before checking
+	// that no ACK was sent. This ordering ensures the timeout below is
+	// meaningful (the rejection happened, not that processing hasn't started).
+	require.Eventually(t, func() bool {
+		return len(observedLogs.FilterMessageSnippet("Pipeline rejected data").All()) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// The server should NOT send an ACK when the pipeline rejects data.
+	// Set a short read deadline — we expect a timeout, not a response.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(500*time.Millisecond)))
+	resp := make([]byte, 1)
+	_, err = conn.Read(resp)
+	require.Error(t, err)
+	require.True(t, isTimeout(err), "expected timeout, got: %v", err)
+}
+
+// TestContextCancellationDuringACKWait verifies that if the context is
+// cancelled while the server is waiting for the pipeline to process a
+// chunked event, the connection handler exits cleanly.
+func TestContextCancellationDuringACKWait(t *testing.T) {
+	// blockingConsumer blocks until the gate channel is closed.
+	gate := make(chan struct{})
+	t.Cleanup(func() { close(gate) })
+	blockingConsumer := &gatedLogsConsumer{gate: gate}
+
+	connect, _, cancel := setupServerWithConsumer(t, blockingConsumer)
+
+	conn := connect()
+	eventBytes := makeSampleEventWithChunk("my-tag", "chunk-456")
+	n, err := conn.Write(eventBytes)
+	require.NoError(t, err)
+	require.Equal(t, len(eventBytes), n)
+
+	// Wait for the consumer to be called (server is now blocked on ackCh).
+	require.Eventually(t, func() bool {
+		return blockingConsumer.called()
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Cancel the context — this should unblock the server.
+	cancel()
+
+	// The connection should be closed by the server.
+	waitForConnectionClose(t, conn)
+}
+
+// gatedLogsConsumer blocks ConsumeLogs until the gate channel is closed.
+type gatedLogsConsumer struct {
+	gate      chan struct{}
+	wasCalled atomic.Bool
+}
+
+func (c *gatedLogsConsumer) ConsumeLogs(ctx context.Context, _ plog.Logs) error {
+	c.wasCalled.Store(true)
+	select {
+	case <-c.gate:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (*gatedLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (c *gatedLogsConsumer) called() bool {
+	return c.wasCalled.Load()
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -25,14 +25,14 @@ import (
 const readBufferSize = 10 * 1024
 
 type server struct {
-	outCh            chan<- event
+	outCh            chan<- eventWithACK
 	logger           *zap.Logger
 	telemetryBuilder *metadata.TelemetryBuilder
 	conns            map[net.Conn]struct{}
 	mu               sync.Mutex
 }
 
-func newServer(outCh chan<- event, logger *zap.Logger, telemetryBuilder *metadata.TelemetryBuilder) *server {
+func newServer(outCh chan<- eventWithACK, logger *zap.Logger, telemetryBuilder *metadata.TelemetryBuilder) *server {
 	return &server{
 		outCh:            outCh,
 		logger:           logger,
@@ -125,16 +125,36 @@ func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 
 		s.telemetryBuilder.FluentEventsParsed.Add(ctx, 1)
 
-		s.outCh <- e
+		chunk := e.Chunk()
 
-		// We must acknowledge the 'chunk' option if given. We could do this in
-		// another goroutine if it is too much of a bottleneck to reading
-		// messages -- this is the only thing that sends data back to the
-		// client.
-		if e.Chunk() != "" {
-			err := msgp.Encode(conn, internal.AckResponse{Ack: e.Chunk()})
-			if err != nil {
-				return fmt.Errorf("failed to acknowledge chunk %s: %w", e.Chunk(), err)
+		var ackCh chan error
+		if chunk != "" {
+			ackCh = make(chan error, 1)
+		}
+
+		s.outCh <- eventWithACK{event: e, ackCh: ackCh}
+
+		// Wait for the pipeline to finish processing before sending the ACK.
+		// Per the Fluent Forward Protocol Specification v1, the server MUST
+		// respond with an ACK only after processing the chunk. This enables
+		// proper backpressure: if ConsumeLogs() fails (e.g. memory_limiter
+		// refuses data), we don't ACK, so the client retains the chunk and
+		// can apply backpressure upstream.
+		if ackCh != nil {
+			select {
+			case err := <-ackCh:
+				if err != nil {
+					s.logger.Debug("Pipeline rejected data, not sending ACK",
+						zap.String("chunk", chunk),
+						zap.Error(err))
+					continue
+				}
+				err = msgp.Encode(conn, internal.AckResponse{Ack: chunk})
+				if err != nil {
+					return fmt.Errorf("failed to acknowledge chunk %s: %w", chunk, err)
+				}
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #46973

Defers sending Fluent Forward ACK responses until after `ConsumeLogs()` completes, enabling proper backpressure when the pipeline rejects data (e.g. `memory_limiter`).

### Changes

- **`conversion.go`**: New `eventWithACK` wrapper — pairs an event with an optional `chan error` for signaling pipeline result back to the connection handler.
- **`server.go`**: For chunked events, creates an `ackCh`, sends it with the event, and blocks until the collector signals success/failure. ACK is only sent on success; on failure, the ACK is withheld so the client retains and retries the chunk.
- **`collector.go`**: After `ConsumeLogs()`, signals all collected `ackCh` channels with the result. `fillBufferUntilChanEmpty` now also collects ACK channels from batched events.
- **`receiver.go`**: Channel type updated from `chan event` to `chan eventWithACK`.

### Design notes

- `ackCh` is `chan error` with buffer size 1 — collector never blocks on send, even if the server exits early via context cancellation.
- Non-chunked events (`ackCh == nil`) pass through with no blocking — same behavior as before.
- When events from multiple connections are batched into a single `ConsumeLogs` call, all share the same result. This is acceptable because pipeline errors (memory_limiter, exporter failures) are global.

## Test plan

- [x] `TestEventAcknowledgment` — existing happy-path ACK test still passes
- [x] `TestPipelineRejectionWithholdsACK` — verifies ACK is withheld when consumer returns error
- [x] `TestContextCancellationDuringACKWait` — verifies clean shutdown while blocked on ACK
- [x] `TestFillBufferUntilChanEmptyCollectsACKChannels` — unit test for ACK channel collection during batching
- [x] All existing tests pass with no modifications
- [x] Linter clean, changelog validated

Assisted-by: Claude Opus 4.6
