### PR TITLE
receiver/awsfirehose: deprecate built-in encodings

### DIFF
--- a/.chloggen/firehose-deprecate-builtin-unmarshalers.yaml
+++ b/.chloggen/firehose-deprecate-builtin-unmarshalers.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awsfirehose
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate built-in unmarshalers (cwlogs, cwmetrics, otlp_v1) in favor of encoding extensions."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45830]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Use the aws_logs_encoding extension (format: cloudwatch) instead of cwlogs,
+  and the awscloudwatchmetricstreams_encoding extension instead of cwmetrics (format: json)
+  or otlp_v1 (format: opentelemetry1.0).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awsfirehosereceiver/README.md
+++ b/receiver/awsfirehosereceiver/README.md
@@ -25,16 +25,22 @@ Example:
 receivers:
   awsfirehose:
     endpoint: 0.0.0.0:4433
-    record_type: cwmetrics
+    encoding: awscloudwatchmetricstreams_encoding
     access_key: "some_access_key"
     tls:
       cert_file: server.crt
       key_file: server.key
+
+extensions:
+  awscloudwatchmetricstreams_encoding:
+    format: json
 ```
+
 The configuration includes the OpenTelemetry collector's server [confighttp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp#server-configuration),
 which allows for a variety of settings. Only the most relevant ones will be discussed here, but all are available.
-The AWS Kinesis Data Firehose Delivery Streams currently only support HTTPS endpoints using port 443. This can be potentially circumvented
-using a Load Balancer.
+
+The Amazon Data Firehose Delivery Streams currently only support HTTPS endpoints using port 443.
+This can be potentially circumvented using a Load Balancer.
 
 ### endpoint:
 The address:port to bind the listener to.
@@ -52,46 +58,64 @@ A `cert_file` and `key_file` are required.
 
 The ID of an [encoding extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding) for decoding logs or metrics.
 This configuration also supports the built-in encodings listed in the [Encodings](#encodings) section.
-If no encoding is specified, then the receiver will default to a signal-specific encoding: `cwmetrics` for metrics, and `cwlogs` for logs.
 
-### record_type:
+If no encoding is specified, then the receiver will default to a signal-specific encoding: `cwmetrics` for metrics, and `cwlogs` for logs.
+In the future, the default encodings will be removed, and it will be required to specify an encoding extension.
+
+### record\_type:
 
 Deprecated, use `encoding` instead. `record_type` will be removed in a future release; it is an alias for `encoding`.
 
-### access_key (Optional):
+### access\_key (Optional):
 The access key to be checked on each request received. This can be set when creating or updating the delivery stream.
 See [documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for details.
 
 ## Encodings
 
-### cwmetrics
-The encoding for the CloudWatch metric stream. Expects the format for the records to be JSON.
-See [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html) for details.
+Any encoding extension can be used with this receiver. There are additionally built-in encodings, which are deprecated.
+In the future it will be required to specify an encoding extension, and the built-in encodings will be removed.
 
-### cwlogs
-The encoding for the CloudWatch log stream. Expects the format for the records to be JSON.
-For example:
+### cwmetrics (deprecated)
 
-```json
-{
-  "messageType": "DATA_MESSAGE",
-  "owner": "111122223333",
-  "logGroup": "my-log-group",
-  "logStream": "my-log-stream",
-  "subscriptionFilters": ["my-subscription-filter"],
-  "logEvents": [
-    {
-      "id": "123",
-      "timestamp": 1725544035523,
-      "message": "My log message."
-    }
-  ]
-}
+The built-in `cwmetrics` encoding is deprecated and will be removed in a future version.
+Use the [`awscloudwatchmetricstreams_encoding`](../../extension/encoding/awscloudwatchmetricstreamsencodingextension)
+extension with `format: json` instead.
+
+```yaml
+extensions:
+  awscloudwatchmetricstreams_encoding:
+    format: json
+receivers:
+  awsfirehose:
+    encoding: awscloudwatchmetricstreams_encoding
 ```
 
-### otlp_v1
+### cwlogs (deprecated)
 
-The OTLP v1 encoding as produced by CloudWatch metric streams.
-See [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-100.html) for details.
+The built-in `cwlogs` encoding is deprecated and will be removed in a future version.
+Use the [`aws_logs_encoding`](../../extension/encoding/awslogsencodingextension) extension with
+`format: cloudwatch` instead.
 
+```yaml
+extensions:
+  aws_logs_encoding:
+    format: cloudwatch
+receivers:
+  awsfirehose:
+    encoding: aws_logs_encoding
+```
 
+### otlp\_v1 (deprecated)
+
+The built-in `otlp_v1` encoding is deprecated and will be removed in a future version.
+Use the [`awscloudwatchmetricstreams_encoding`](../../extension/encoding/awscloudwatchmetricstreamsencodingextension)
+extension with `format: opentelemetry1.0` instead.
+
+```yaml
+extensions:
+  awscloudwatchmetricstreams_encoding:
+    format: opentelemetry1.0
+receivers:
+  awsfirehose:
+    encoding: awscloudwatchmetricstreams_encoding
+```

--- a/receiver/awsfirehosereceiver/config.go
+++ b/receiver/awsfirehosereceiver/config.go
@@ -19,8 +19,12 @@ type Config struct {
 	// endpoint, so TLSs must be used to enable that.
 	confighttp.ServerConfig `mapstructure:",squash"`
 	// Encoding identifies the encoding of records received from
-	// Firehose. Defaults to telemetry-specific encodings: "cwlog"
-	// for logs, and "cwmetrics" for metrics.
+	// Firehose.
+	//
+	// Defaults to telemetry-specific encodings: "cwlog" for logs,
+	// and "cwmetrics" for metrics. This default behavior is
+	// deprecated as of v0.149.0, and in the future it will be
+	// required to specify the encoding explicitly.
 	Encoding string `mapstructure:"encoding"`
 	// RecordType is an alias for Encoding for backwards compatibility.
 	// It is an error to specify both encoding and record_type.

--- a/receiver/awsfirehosereceiver/config.schema.yaml
+++ b/receiver/awsfirehosereceiver/config.schema.yaml
@@ -4,7 +4,7 @@ properties:
     description: AccessKey is checked against the one received with each request. This can be set when creating or updating the Firehose delivery stream.
     $ref: go.opentelemetry.io/collector/config/configopaque.string
   encoding:
-    description: 'Encoding identifies the encoding of records received from Firehose. Defaults to telemetry-specific encodings: "cwlog" for logs, and "cwmetrics" for metrics.'
+    description: 'Encoding identifies the encoding of records received from Firehose. Defaults to telemetry-specific encodings: "cwlog" for logs, and "cwmetrics" for metrics. This default behavior is deprecated as of v0.149.0, and in the future it will be required to specify the encoding explicitly.'
     type: string
   record_type:
     description: 'RecordType is an alias for Encoding for backwards compatibility. It is an error to specify both encoding and record_type. Deprecated: [v0.121.0] use Encoding instead.'

--- a/receiver/awsfirehosereceiver/logs_receiver.go
+++ b/receiver/awsfirehosereceiver/logs_receiver.go
@@ -67,7 +67,10 @@ func (c *logsConsumer) Start(_ context.Context, host component.Host) error {
 		}
 	}
 	if encoding == cwlog.TypeStr {
-		// TODO: make cwlogs an encoding extension
+		c.settings.Logger.Warn(
+			"The built-in \"cwlogs\" encoding is deprecated and will be removed in a future version. " +
+				"Use the \"aws_logs_encoding\" encoding extension with format \"cloudwatch\" instead.",
+		)
 		c.unmarshaler = cwlog.NewUnmarshaler(c.settings.Logger, c.settings.BuildInfo)
 	} else {
 		unmarshaler, err := loadEncodingExtension[plog.Unmarshaler](host, encoding, "logs")

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -67,9 +67,16 @@ func (c *metricsConsumer) Start(ctx context.Context, host component.Host) error 
 	}
 	switch encoding {
 	case cwmetricstream.TypeStr:
-		// TODO: make cwmetrics an encoding extension
+		c.settings.Logger.Warn(
+			"The built-in \"cwmetrics\" encoding is deprecated and will be removed in a future version. " +
+				"Use the \"awscloudwatchmetricstreams_encoding\" encoding extension with format \"json\" instead.",
+		)
 		c.unmarshaler = cwmetricstream.NewUnmarshaler(c.settings.Logger, c.settings.BuildInfo)
 	case "otlp_v1":
+		c.settings.Logger.Warn(
+			"The built-in \"otlp_v1\" encoding is deprecated and will be removed in a future version. " +
+				"Use the \"awscloudwatchmetricstreams_encoding\" encoding extension with format \"opentelemetry1.0\" instead.",
+		)
 		unmarshaler, err := c.newUnmarshalerFromEncoding(ctx, encoding, "opentelemetry1.0")
 		if err != nil {
 			return err


### PR DESCRIPTION
#### Description

Deprecate the built-in encodings, and direct users to the equivalent encoding extensions.

#### Link to tracking issue

Relates to #45830

#### Testing

Confirmed that warnings are logged when the built-in encodings are used, e.g. when no encoding is specified at all.

#### Documentation

Updated README.