### PR TITLE
[chore] [extension/sigv4auth] Fix broken credentials docs link

### DIFF
--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -68,7 +68,7 @@ service:
 
 ## Notes
 
-* The collector must have valid AWS credentials as used by the [AWS SDK for Go](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials)
+* The collector must have valid AWS credentials as used by the [AWS SDK for Go](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials)
 
 
 ## Assume Role with Web Identity


### PR DESCRIPTION
## Description

The AWS SDK for Go v2 documentation site (`aws.github.io/aws-sdk-go-v2`) has been fully taken down — the entire domain returns 404. The credentials documentation has moved to the official AWS docs site.

This PR updates the broken link in `extension/sigv4authextension/README.md` to point to the new location.

**Old URL:** `https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials` (404)
**New URL:** `https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials` (verified working, same `#specifying-credentials` anchor)

Fixes #46989

## Link to tracking issue

Fixes #46989