### PR TITLE
[exporter/kafka]Fix validation for topic_from_metadata_key

### DIFF
--- a/.chloggen/kafkaexporter-fix-topic-from-metadata-validation.yaml
+++ b/.chloggen/kafkaexporter-fix-topic-from-metadata-validation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes the validation for `topic_from_metadat_key` to use partition keys.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46994]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/kafkaexporter-fix-topic-from-metadata-validation.yaml
+++ b/.chloggen/kafkaexporter-fix-topic-from-metadata-validation.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: exporter/kafka
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fixes the validation for `topic_from_metadat_key` to use partition keys.
+note: Fixes the validation for `topic_from_metadata_key` to use partition keys.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46994]
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -6,6 +6,7 @@ package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	"go.opentelemetry.io/collector/component"
@@ -23,7 +24,7 @@ var errLogsPartitionExclusive = errors.New(
 )
 
 var (
-	errTopicMetadataKeyNotIncluded        = errors.New("topic_from_metadata_key must be present in include_metadata_keys")
+	errTopicMetadataKeyNotIncluded        = errors.New("topic_from_metadata_key must be present in sending_queue::batch::partition::metadata_keys if batching is enabled")
 	errBatchPartitionMetadataKeysRequired = errors.New("sending_queue::batch::partition::metadata_keys must be configured when include_metadata_keys is set and batching is enabled")
 	errIncludeMetadataKeysNotPartitioned  = errors.New("sending_queue::batch::partition::metadata_keys must include all include_metadata_keys values")
 )
@@ -83,73 +84,10 @@ func (c *Config) Validate() error {
 	if c.PartitionLogsByResourceAttributes && c.PartitionLogsByTraceID {
 		return errLogsPartitionExclusive
 	}
-	if err := validateBatchPartitionerKeys(c.QueueBatchConfig, c.IncludeMetadataKeys); err != nil {
+	if err := validateBatchPartitionerKeys(c); err != nil {
 		return err
 	}
-
-	if err := validateTopicFromMetadataKey(c.Logs.TopicFromMetadataKey, c.IncludeMetadataKeys); err != nil {
-		return fmt.Errorf("logs::topic_from_metadata_key: %w", err)
-	}
-	if err := validateTopicFromMetadataKey(c.Metrics.TopicFromMetadataKey, c.IncludeMetadataKeys); err != nil {
-		return fmt.Errorf("metrics::topic_from_metadata_key: %w", err)
-	}
-	if err := validateTopicFromMetadataKey(c.Traces.TopicFromMetadataKey, c.IncludeMetadataKeys); err != nil {
-		return fmt.Errorf("traces::topic_from_metadata_key: %w", err)
-	}
-	if err := validateTopicFromMetadataKey(c.Profiles.TopicFromMetadataKey, c.IncludeMetadataKeys); err != nil {
-		return fmt.Errorf("profiles::topic_from_metadata_key: %w", err)
-	}
 	return nil
-}
-
-func validateBatchPartitionerKeys(queueBatchConfig configoptional.Optional[exporterhelper.QueueBatchConfig], includeMetadataKeys []string) error {
-	if len(includeMetadataKeys) == 0 || !isBatchingEnabled(queueBatchConfig) {
-		return nil
-	}
-
-	partitionMetadataKeys := queueBatchConfig.Get().Batch.Get().Partition.MetadataKeys
-	if len(partitionMetadataKeys) == 0 {
-		return errBatchPartitionMetadataKeysRequired
-	}
-
-	partitionMetadataKeySet := make(map[string]struct{}, len(partitionMetadataKeys))
-	for _, key := range partitionMetadataKeys {
-		partitionMetadataKeySet[key] = struct{}{}
-	}
-
-	for _, includeKey := range includeMetadataKeys {
-		if _, ok := partitionMetadataKeySet[includeKey]; !ok {
-			return fmt.Errorf("%w: missing %q from sending_queue::batch::partition::metadata_keys=%v",
-				errIncludeMetadataKeysNotPartitioned,
-				includeKey,
-				partitionMetadataKeys,
-			)
-		}
-	}
-
-	return nil
-}
-
-func isBatchingEnabled(queueBatchConfig configoptional.Optional[exporterhelper.QueueBatchConfig]) bool {
-	if !queueBatchConfig.HasValue() {
-		return false
-	}
-
-	return queueBatchConfig.Get().Batch.HasValue()
-}
-
-func validateTopicFromMetadataKey(topicFromMetadataKey string, includeMetadataKeys []string) error {
-	if topicFromMetadataKey == "" {
-		return nil
-	}
-	if slices.Contains(includeMetadataKeys, topicFromMetadataKey) {
-		return nil
-	}
-	return fmt.Errorf("%w: %q not found in include_metadata_keys=%v",
-		errTopicMetadataKeyNotIncluded,
-		topicFromMetadataKey,
-		includeMetadataKeys,
-	)
 }
 
 // SignalConfig holds signal-specific configuration for the Kafka exporter.
@@ -173,4 +111,74 @@ type SignalConfig struct {
 	//
 	// Defaults to "otlp_proto".
 	Encoding string `mapstructure:"encoding"`
+}
+
+// validateBatchPartitionerKeys validates the partition keys if sending_queue::batch is enabled.
+// The exporter relies on a few client metadata keys to be present, if configured, in the final
+// batch that needs to be exported, however, since batching removes all client metadata keys by
+// default we need to ensure proper partitioning is configured to keep the required metadata.
+func validateBatchPartitionerKeys(c *Config) error {
+	if !isBatchingEnabled(c.QueueBatchConfig) {
+		return nil
+	}
+
+	partitionMetadataKeys := c.QueueBatchConfig.Get().Batch.Get().Partition.MetadataKeys
+	partitionMetadataKeySet := make(map[string]struct{}, len(partitionMetadataKeys))
+	for _, key := range partitionMetadataKeys {
+		partitionMetadataKeySet[key] = struct{}{}
+	}
+
+	// Validate if include_metadata_keys are included in partition keys
+	if len(c.IncludeMetadataKeys) != 0 {
+		if len(partitionMetadataKeys) == 0 {
+			return errBatchPartitionMetadataKeysRequired
+		}
+		for _, includeKey := range c.IncludeMetadataKeys {
+			if _, ok := partitionMetadataKeySet[includeKey]; !ok {
+				return fmt.Errorf("%w: missing %q from sending_queue::batch::partition::metadata_keys=%v",
+					errIncludeMetadataKeysNotPartitioned,
+					includeKey,
+					partitionMetadataKeys,
+				)
+			}
+		}
+	}
+
+	// Validate if topic_from_metadata_key is included in partition_keys
+	if err := validateTopicFromMetadataKey(c.Logs.TopicFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("logs::topic_from_metadata_key: %w", err)
+	}
+	if err := validateTopicFromMetadataKey(c.Metrics.TopicFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("metrics::topic_from_metadata_key: %w", err)
+	}
+	if err := validateTopicFromMetadataKey(c.Traces.TopicFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("traces::topic_from_metadata_key: %w", err)
+	}
+	if err := validateTopicFromMetadataKey(c.Profiles.TopicFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("profiles::topic_from_metadata_key: %w", err)
+	}
+
+	return nil
+}
+
+func isBatchingEnabled(queueBatchConfig configoptional.Optional[exporterhelper.QueueBatchConfig]) bool {
+	if !queueBatchConfig.HasValue() {
+		return false
+	}
+
+	return queueBatchConfig.Get().Batch.HasValue()
+}
+
+func validateTopicFromMetadataKey(topicFromMetadataKey string, partitionKeysSet map[string]struct{}) error {
+	if topicFromMetadataKey == "" {
+		return nil
+	}
+	if _, ok := partitionKeysSet[topicFromMetadataKey]; !ok {
+		return fmt.Errorf("%w: %q not found in partition keys=%v",
+			errTopicMetadataKeyNotIncluded,
+			topicFromMetadataKey,
+			slices.Collect(maps.Keys(partitionKeysSet)),
+		)
+	}
+	return nil
 }

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -152,7 +152,7 @@ func TestLoadConfig(t *testing.T) {
 						}
 						batch.FlushTimeout = 200 * time.Millisecond
 						batch.MinSize = 8192
-						batch.Partition.MetadataKeys = []string{"metadata_key", "another_key"}
+						batch.Partition.MetadataKeys = []string{"metadata_key", "another_key", "kafka_topic"}
 						return batch
 					}())
 					return queue
@@ -160,20 +160,24 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig: configkafka.NewDefaultClientConfig(),
 				Producer:     configkafka.NewDefaultProducerConfig(),
 				Logs: SignalConfig{
-					Topic:    "otlp_logs",
-					Encoding: "otlp_proto",
+					Topic:                "otlp_logs",
+					TopicFromMetadataKey: "kafka_topic",
+					Encoding:             "otlp_proto",
 				},
 				Metrics: SignalConfig{
-					Topic:    "otlp_metrics",
-					Encoding: "otlp_proto",
+					Topic:                "otlp_metrics",
+					TopicFromMetadataKey: "kafka_topic",
+					Encoding:             "otlp_proto",
 				},
 				Traces: SignalConfig{
-					Topic:    "otlp_spans",
-					Encoding: "otlp_proto",
+					Topic:                "otlp_spans",
+					TopicFromMetadataKey: "kafka_topic",
+					Encoding:             "otlp_proto",
 				},
 				Profiles: SignalConfig{
-					Topic:    "otlp_profiles",
-					Encoding: "otlp_proto",
+					Topic:                "otlp_profiles",
+					TopicFromMetadataKey: "kafka_topic",
+					Encoding:             "otlp_proto",
 				},
 				IncludeMetadataKeys: []string{"metadata_key"},
 			},

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -209,7 +209,7 @@ func TestLoadConfigFailed(t *testing.T) {
 		},
 		{
 			id:            component.NewIDWithName(metadata.Type, ""),
-			errorContains: `logs::topic_from_metadata_key: topic_from_metadata_key must be present in include_metadata_keys: "missing_metadata_key" not found in include_metadata_keys=[]`,
+			errorContains: `logs::topic_from_metadata_key: topic_from_metadata_key must be present in sending_queue::batch::partition::metadata_keys`,
 			configFile:    "config-topic-from-metadata-failed.yaml",
 		},
 		{

--- a/exporter/kafkaexporter/testdata/config-topic-from-metadata-failed.yaml
+++ b/exporter/kafkaexporter/testdata/config-topic-from-metadata-failed.yaml
@@ -1,5 +1,9 @@
 kafka:
   brokers:
     - "foo:123"
+  sending_queue:
+    enabled: true
+    batch:
+      sizer: bytes
   logs:
     topic_from_metadata_key: missing_metadata_key

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -50,6 +50,14 @@ kafka/per_signal_encoding:
 kafka/metadata_batch_valid:
   include_metadata_keys:
     - metadata_key
+  logs:
+    topic_from_metadata_key: kafka_topic
+  metrics:
+    topic_from_metadata_key: kafka_topic
+  traces:
+    topic_from_metadata_key: kafka_topic
+  profiles:
+    topic_from_metadata_key: kafka_topic
   sending_queue:
     enabled: true
     batch:
@@ -58,3 +66,4 @@ kafka/metadata_batch_valid:
         metadata_keys:
           - metadata_key
           - another_key
+          - kafka_topic


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
With the change in direction between https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46764 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46848 the validation for checking `topic_from_metadata_key` went from a validation to a bug under certain conditions. In the current code, it checks for `topic_form_metadata_key` to be present in `include_metadata_keys` which is entirely independent of partition keys (configured by `sending_queue::batch::partition::metadata_keys`).

The current check <strike>is a bug which doesn't accomplish anything</strike> is a bug if NO batching is configured but topic_from_metadata_key is used (it will fail due to the topic from metadata key missing from the include metadata keys). Under other conditions, when batching is defined, this will result in a condition where the topic from metadata key MUST be added to the kafka record header - something not always desirable. #46848 decouples partitioning keys and metadata keys and this PR builds on that to keep the same isolation for topic from metadata key.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tests updated

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Please delete paragraphs that you did not use before submitting.-->
