### PR TITLE
[chore] add unit tests for stanzaerrors package

### DIFF
--- a/pkg/stanza/stanzaerrors/details_test.go
+++ b/pkg/stanza/stanzaerrors/details_test.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package stanzaerrors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+type mockEncoder struct {
+	zapcore.ObjectEncoder
+	added map[string]string
+}
+
+func (e *mockEncoder) AddString(key, value string) {
+	if e.added == nil {
+		e.added = make(map[string]string)
+	}
+	e.added[key] = value
+}
+
+func TestErrorDetailsMarshalLogObject(t *testing.T) {
+	details := ErrorDetails{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	encoder := &mockEncoder{}
+	err := details.MarshalLogObject(encoder)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, encoder.added)
+}
+
+func TestCreateDetails(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected ErrorDetails
+	}{
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: ErrorDetails{},
+		},
+		{
+			name:     "even number of elements",
+			input:    []string{"key1", "val1", "key2", "val2"},
+			expected: ErrorDetails{"key1": "val1", "key2": "val2"},
+		},
+		{
+			name:     "odd number of elements",
+			input:    []string{"key1", "val1", "key2"},
+			expected: ErrorDetails{"key1": "val1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			details := createDetails(tc.input)
+			require.Equal(t, tc.expected, details)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Added complete unit tests for `pkg/stanza/stanzaerrors/details.go`. Checks `createDetails` array construction bounds (odd counts and empty elements) and checks that `MarshalLogObject` correctly relays logs to `zapcore`.

## Motivation and Context
Solidifying confidence in the Stanza custom logging wrapper logic ensures error conditions don't silently mask values or trigger `index out of bounds` errors, improving overall collector resiliency and debuggability.

## Type of change
- [x] Quality improvement / Test addition