### PR TITLE
[chore]add unit tests for helper regexp package

### DIFF
--- a/pkg/stanza/operator/helper/regexp_test.go
+++ b/pkg/stanza/operator/helper/regexp_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchValues(t *testing.T) {
+	testCases := []struct {
+		name          string
+		value         string
+		regexStr      string
+		expected      map[string]any
+		expectError   bool
+	}{
+		{
+			name:        "match with named groups",
+			value:       "2023-10-12 ERROR test log",
+			regexStr:    `^(?P<time>\d{4}-\d{2}-\d{2}) (?P<level>[A-Z]+) (?P<msg>.*)$`,
+			expected:    map[string]any{"time": "2023-10-12", "level": "ERROR", "msg": "test log"},
+			expectError: false,
+		},
+		{
+			name:        "no match",
+			value:       "completely different format",
+			regexStr:    `^(?P<time>\d{4}-\d{2}-\d{2}) (?P<level>[A-Z]+) (?P<msg>.*)$`,
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "unamed subexps ignored",
+			value:       "some value",
+			regexStr:    `^(some) (?P<named>value)$`,
+			expected:    map[string]any{"named": "value"},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			re := regexp.MustCompile(tc.regexStr)
+			actual, err := MatchValues(tc.value, re)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/stanza/operator/helper/regexp_test.go
+++ b/pkg/stanza/operator/helper/regexp_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestMatchValues(t *testing.T) {
 	testCases := []struct {
-		name          string
-		value         string
-		regexStr      string
-		expected      map[string]any
-		expectError   bool
+		name        string
+		value       string
+		regexStr    string
+		expected    map[string]any
+		expectError bool
 	}{
 		{
 			name:        "match with named groups",


### PR DESCRIPTION
## Description
This PR aims to tighten the reliability for `MatchValues` located at `pkg/stanza/operator/helper/regexp.go` by integrating full unit tests. We simulate combinations where the Regex matches, does not match, and verify that unnamed groups are explicitly skipped.

## Motivation and Context
Regular expression evaluations and mapping correctly drive essential pipelines within operators (e.g. routing or replacing properties). Validating that regexes output exactly bounded `map[string]any` configurations ensures data correctness down the pipeline. 

## Type of change
- [x] Quality improvement / Test addition