### PR TITLE
[chore][exporter/awss3] log object keys uploaded to s3

### DIFF
--- a/exporter/awss3exporter/exporter.go
+++ b/exporter/awss3exporter/exporter.go
@@ -75,7 +75,7 @@ func (e *s3Exporter) start(ctx context.Context, host component.Host) error {
 
 	e.marshaler = m
 
-	up, err := newUploadManager(ctx, e.config, e.signalType, m.format(), m.compressed())
+	up, err := newUploadManager(ctx, e.config, e.logger, e.signalType, m.format(), m.compressed())
 	if err != nil {
 		return err
 	}

--- a/exporter/awss3exporter/internal/upload/writer.go
+++ b/exporter/awss3exporter/internal/upload/writer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/tilinna/clock"
 	"go.opentelemetry.io/collector/config/configcompression"
+	"go.uber.org/zap"
 )
 
 type Manager interface {
@@ -30,6 +31,7 @@ type UploadOptions struct {
 }
 
 type s3manager struct {
+	logger       *zap.Logger
 	bucket       string
 	builder      *PartitionKeyBuilder
 	uploader     *transfermanager.Client
@@ -39,8 +41,9 @@ type s3manager struct {
 
 var _ Manager = (*s3manager)(nil)
 
-func NewS3Manager(bucket string, builder *PartitionKeyBuilder, service *s3.Client, storageClass s3types.StorageClass, opts ...ManagerOpt) Manager {
+func NewS3Manager(logger *zap.Logger, bucket string, builder *PartitionKeyBuilder, service *s3.Client, storageClass s3types.StorageClass, opts ...ManagerOpt) Manager {
 	manager := &s3manager{
+		logger:       logger,
 		bucket:       bucket,
 		builder:      builder,
 		uploader:     transfermanager.New(service),
@@ -84,9 +87,10 @@ func (sw *s3manager) Upload(ctx context.Context, data []byte, opts *UploadOption
 		}
 	}
 
+	key := sw.builder.Build(now, overridePrefix)
 	uploadInput := &transfermanager.UploadObjectInput{
 		Bucket:       aws.String(overrideBucket),
-		Key:          aws.String(sw.builder.Build(now, overridePrefix)),
+		Key:          aws.String(key),
 		Body:         content,
 		StorageClass: transfermanagertypes.StorageClass(sw.storageClass),
 		ACL:          transfermanagertypes.ObjectCannedACL(sw.acl),
@@ -97,6 +101,7 @@ func (sw *s3manager) Upload(ctx context.Context, data []byte, opts *UploadOption
 		uploadInput.ContentEncoding = aws.String(encoding)
 	}
 
+	sw.logger.Debug("uploading object", zap.String("bucket", overrideBucket), zap.String("key", key))
 	_, err = sw.uploader.UploadObject(ctx, uploadInput)
 	return err
 }

--- a/exporter/awss3exporter/internal/upload/writer_test.go
+++ b/exporter/awss3exporter/internal/upload/writer_test.go
@@ -18,12 +18,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tilinna/clock"
 	"go.opentelemetry.io/collector/config/configcompression"
+	"go.uber.org/zap"
 )
 
 func TestNewS3Manager(t *testing.T) {
 	t.Parallel()
 
 	sm := NewS3Manager(
+		zap.NewNop(),
 		"my-bucket",
 		&PartitionKeyBuilder{},
 		s3.New(s3.Options{}),
@@ -296,6 +298,7 @@ func TestS3ManagerUpload(t *testing.T) {
 			t.Cleanup(s.Close)
 
 			sm := NewS3Manager(
+				zap.NewNop(),
 				"my-bucket",
 				&PartitionKeyBuilder{
 					PartitionPrefix: "telemetry",

--- a/exporter/awss3exporter/s3_writer.go
+++ b/exporter/awss3exporter/s3_writer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter/internal/upload"
 )
@@ -22,6 +23,7 @@ import (
 func newUploadManager(
 	ctx context.Context,
 	conf *Config,
+	logger *zap.Logger,
 	metadata string,
 	format string,
 	isCompressed bool,
@@ -100,6 +102,7 @@ func newUploadManager(
 	}
 
 	return upload.NewS3Manager(
+		logger,
 		conf.S3Uploader.S3Bucket,
 		&upload.PartitionKeyBuilder{
 			PartitionBasePrefix:   conf.S3Uploader.S3BasePrefix,

--- a/exporter/awss3exporter/s3_writer_test.go
+++ b/exporter/awss3exporter/s3_writer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config/configcompression"
+	"go.uber.org/zap"
 )
 
 func TestNewUploadManager(t *testing.T) {
@@ -63,6 +64,7 @@ func TestNewUploadManager(t *testing.T) {
 			sm, err := newUploadManager(
 				t.Context(),
 				tc.conf,
+				zap.NewNop(),
 				"metrics",
 				"otlp",
 				false,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
plumb the logger through to the upload manager and add a debug log for the object keys being written to S3. I want something similar to what we have in the [clickhouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/exporter_logs.go#L186)

