### PR TITLE
Fixing Readme for PostgreSQL receiver by changing  postgesql to PostgreSQL

### DIFF
--- a/receiver/postgresqlreceiver/README.md
+++ b/receiver/postgresqlreceiver/README.md
@@ -60,8 +60,8 @@ The following settings are required to create a database connection:
 
 The following settings are optional:
 
-- `endpoint` (default = `localhost:5432`): The endpoint of the postgresql server. Whether using TCP or Unix sockets, this value should be `host:port`. If `transport` is set to `unix`, the endpoint will internally be translated from `host:port` to `/host.s.PGSQL.port`
-- `transport` (default = `tcp`): The transport protocol being used to connect to postgresql. Available options are `tcp` and `unix`.
+- `endpoint` (default = `localhost:5432`): The endpoint of the PostgreSQL server. Whether using TCP or Unix sockets, this value should be `host:port`. If `transport` is set to `unix`, the endpoint will internally be translated from `host:port` to `/host.s.PGSQL.port`
+- `transport` (default = `tcp`): The transport protocol being used to connect to PostgreSQL. Available options are `tcp` and `unix`.
 
 - `databases` (default = `[]`): The list of databases for which the receiver will attempt to collect statistics. If an empty list is provided, the receiver will attempt to collect statistics for all non-template databases.
 
@@ -69,7 +69,7 @@ The following settings are optional:
 
 The following settings are also optional and nested under `tls` to help configure client transport security
 
-- `insecure` (default = `false`): Whether to enable client transport security for the postgresql connection.
+- `insecure` (default = `false`): Whether to enable client transport security for the PostgreSQL connection.
 - `insecure_skip_verify` (default = `true`): Whether to validate server name and certificate if client transport security is enabled.
 - `cert_file` (default = `$HOME/.postgresql/postgresql.crt`): A certificate used for client authentication, if necessary.
 - `key_file` (default = `$HOME/.postgresql/postgresql.key`): An SSL key used for client authentication, if necessary.
@@ -79,7 +79,7 @@ The following settings are also optional and nested under `tls` to help configur
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Query Sample Collection
-We provide functionality to collect the query sample from postgresql. It will get historical query 
+We provide functionality to collect the query sample from PostgreSQL. It will get historical query 
 from `pg_stat_activity`. To enable it, you will need the following configuration
 ```
 ...
@@ -100,7 +100,7 @@ The following options are available:
 against `pg_stat_activity`.
 
 ### Top Query Collection
-We provide functionality to collect the most executed queries from postgresql. It will get data from `pg_stat_statements` and report incremental value of `total_exec_time`, `total_plan_time`, `calls`, `rows`, `shared_blks_dirtied`, `shared_blks_hit`, `shared_blks_read`, `shared_blks_written`, `temp_blks_read`, `temp_blks_written`. To enable it, you will need the following configuration
+We provide functionality to collect the most executed queries from PostgreSQL. It will get data from `pg_stat_statements` and report incremental value of `total_exec_time`, `total_plan_time`, `calls`, `rows`, `shared_blks_dirtied`, `shared_blks_hit`, `shared_blks_read`, `shared_blks_written`, `temp_blks_read`, `temp_blks_written`. To enable it, you will need the following configuration
 ```
 ...
     events:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Change to use common naming convention for PostgreSQL in receiver/postgresqlreceiver/README.md.  For configuration part it have remain in lower case i.e. postgresql.  
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
verified receiver/postgresqlreceiver/README.md
<!--Describe the documentation added.-->
#### Documentation
Update receiver/postgresqlreceiver/README.md  to replace postgresql with PostgreSQL in docs sections. For config it remains to postgresql.
<!--Please delete paragraphs that you did not use before submitting.-->
