### PR TITLE
fix(clickhouseexporter): quote cluster name in ON CLUSTER clause

### DIFF
--- a/.chloggen/fix_clickhouse-cluster-name-quoting.yaml
+++ b/.chloggen/fix_clickhouse-cluster-name-quoting.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component:  exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Quote cluster_name in ON CLUSTER clause to support names with special characters (e.g. dashes), preventing schema creation failures.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46946]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -313,5 +314,6 @@ func (cfg *Config) clusterString() string {
 	if cfg.ClusterName == "" {
 		return ""
 	}
-	return fmt.Sprintf("ON CLUSTER `%s`", cfg.ClusterName)
+	escaped := strings.ReplaceAll(cfg.ClusterName, "`", "``")
+	return fmt.Sprintf("ON CLUSTER `%s`", escaped)
 }

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -313,6 +313,5 @@ func (cfg *Config) clusterString() string {
 	if cfg.ClusterName == "" {
 		return ""
 	}
-
-	return fmt.Sprintf("ON CLUSTER %s", cfg.ClusterName)
+	return fmt.Sprintf("ON CLUSTER `%s`", cfg.ClusterName)
 }

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -663,6 +663,10 @@ func TestClusterString(t *testing.T) {
 			input:    "ch-cluster",
 			expected: "ON CLUSTER `ch-cluster`",
 		},
+		{
+			input:    "my`cluster",
+			expected: "ON CLUSTER `my``cluster`",
+		},
 	}
 
 	for i, tt := range tests {

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -660,8 +660,8 @@ func TestClusterString(t *testing.T) {
 			expected: "ON CLUSTER `cluster a b`",
 		},
 		{
-            input:     "ch-cluster",
-			expected:  "ON CLUSTER `ch-cluster`",
+			input:    "ch-cluster",
+			expected: "ON CLUSTER `ch-cluster`",
 		},
 	}
 

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -653,11 +653,15 @@ func TestClusterString(t *testing.T) {
 		},
 		{
 			input:    "cluster_a_b",
-			expected: "ON CLUSTER cluster_a_b",
+			expected: "ON CLUSTER `cluster_a_b`",
 		},
 		{
 			input:    "cluster a b",
-			expected: "ON CLUSTER cluster a b",
+			expected: "ON CLUSTER `cluster a b`",
+		},
+		{
+            input:     "ch-cluster",
+			expected:  "ON CLUSTER `ch-cluster`",
 		},
 	}
 


### PR DESCRIPTION
### Fixes: #46946
 Fixes schema creation failure in ``ClickHouseexporter`` when ``cluster_name`` contains special characters (e.g. `-`) by quoting the   identifier in the ON CLUSTER clause. Updates tests to cover quoted cluster names.