### PR TITLE
[receiver/awslambda] Metadata enrichment through context

### DIFF
--- a/.chloggen/feat_aws-lambda-enrich-context-with-metadata.yaml
+++ b/.chloggen/feat_aws-lambda-enrich-context-with-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awslambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enrich context with AWS Lambda receiver metadata for S3 logs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47046]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -59,6 +59,16 @@ S3 events are handled in the following manner:
   - Custom encoding: Use specified encoding extension (for example, `aws_logs_encoding` for AWS log formats)
   - Metrics use `awscloudwatchmetricstreams_encoding` extension by default
 
+Following metadata is available through Client Info metadata for both logs and metrics.
+This is available through Context to be used by any downstream component (for example, processors):
+
+| Metadata Key   | Description                                                          |
+|----------------|----------------------------------------------------------------------|
+| cloud.provider | Set using `semconv.CloudProviderKey`and always set to `aws`          |
+| cloud.region   | Set using `semconv.CloudRegionKey` and contains the S3 bucket region |
+| aws.s3.bucket  | Set using `semconv.AWSS3BucketKey` and contains the S3 bucket name   |
+| aws.s3.key     | Set using `semconv.AWSS3KeyKey` and contains the S3 object key       |
+
 ### CloudWatch Logs subscription
 
 CloudWatch Logs events are handled in the following manner:

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -62,12 +62,13 @@ S3 events are handled in the following manner:
 Following metadata is available through Client Info metadata for both logs and metrics.
 This is available through Context to be used by any downstream component (for example, processors):
 
-| Metadata Key   | Description          |
-|----------------|----------------------|
-| cloud.provider | Value is `aws`       |
-| cloud.region   | The S3 bucket region |
-| aws.s3.bucket  | The S3 bucket name   |
-| aws.s3.key     | The S3 object key    |
+| Metadata Key       | Description          |
+|--------------------|----------------------|
+| cloud.provider     | Value is `aws`       |
+| cloud.region       | The S3 bucket region |
+| aws.s3.bucket.name | The S3 bucket name   |
+| aws.s3.bucket.arn  | The S3 bucket ARN    |
+| aws.s3.key         | The S3 object key    |
 
 ### CloudWatch Logs subscription
 

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -52,23 +52,26 @@ Sections below summarize how each event source is handled.
 
 S3 events are handled in the following manner:
 
-- Received S3 event notification (for example, using Lambda trigger on `s3:ObjectCreated:*`)
+- Receive S3 event notification (for example, using Lambda trigger on `s3:ObjectCreated:*`)
 - Download S3 object payload
 - Decode payload using the configured encoding extension
   - Default encoding: Preserve S3 object content as-is
   - Custom encoding: Use specified encoding extension (for example, `aws_logs_encoding` for AWS log formats)
   - Metrics use `awscloudwatchmetricstreams_encoding` extension by default
 
-Following metadata is available through Client Info metadata for both logs and metrics.
-This is available through Context to be used by any downstream component (for example, processors):
+The following metadata is available through `client.Info` for both logs and metrics S3 events.
+This metadata is added to the request context and can be accessed by any downstream component in the pipeline (for example, processors):
 
 | Metadata Key       | Description          |
 |--------------------|----------------------|
-| cloud.provider     | Value is `aws`       |
 | cloud.region       | The S3 bucket region |
 | aws.s3.bucket.name | The S3 bucket name   |
 | aws.s3.bucket.arn  | The S3 bucket ARN    |
 | aws.s3.key         | The S3 object key    |
+
+> [!NOTE]
+> Static metadata such as `cloud.provider` are not available through `client.Info`.
+> These can be added using processors (for example, the resource processor).
 
 ### CloudWatch Logs subscription
 

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -62,12 +62,12 @@ S3 events are handled in the following manner:
 Following metadata is available through Client Info metadata for both logs and metrics.
 This is available through Context to be used by any downstream component (for example, processors):
 
-| Metadata Key   | Description                                                          |
-|----------------|----------------------------------------------------------------------|
-| cloud.provider | Set using `semconv.CloudProviderKey`and always set to `aws`          |
-| cloud.region   | Set using `semconv.CloudRegionKey` and contains the S3 bucket region |
-| aws.s3.bucket  | Set using `semconv.AWSS3BucketKey` and contains the S3 bucket name   |
-| aws.s3.key     | Set using `semconv.AWSS3KeyKey` and contains the S3 object key       |
+| Metadata Key   | Description          |
+|----------------|----------------------|
+| cloud.provider | Value is `aws`       |
+| cloud.region   | The S3 bucket region |
+| aws.s3.bucket  | The S3 bucket name   |
+| aws.s3.key     | The S3 object key    |
 
 ### CloudWatch Logs subscription
 

--- a/receiver/awslambdareceiver/benchmark_test.go
+++ b/receiver/awslambdareceiver/benchmark_test.go
@@ -4,13 +4,11 @@
 package awslambdareceiver
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 
@@ -38,13 +36,7 @@ func BenchmarkHandleS3Notification(b *testing.B) {
 	service := internal.NewMockS3Service(gomock.NewController(b))
 	service.EXPECT().ReadObject(gomock.Any(), bucket, object).Return([]byte("bucket content"), nil).AnyTimes()
 
-	consumer := noOpLogsConsumer{}
-	// Wrap the consumer to match the new s3EventConsumerFunc signature
-	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-		enrichS3Logs(logs, event)
-		return consumer.ConsumeLogs(ctx, logs)
-	}
-	handler := newS3LogsHandler(service, zap.NewNop(), &customLogUnmarshaler{}, logsConsumer)
+	handler := newS3LogsHandler(service, zap.NewNop(), &customLogUnmarshaler{}, &noOpLogsConsumer{})
 
 	b.Run("HandleS3Event", func(b *testing.B) {
 		b.ReportAllocs()

--- a/receiver/awslambdareceiver/go.mod
+++ b/receiver/awslambdareceiver/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xstreamencoding v0.148.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/collector/client v1.54.1-0.20260326211300-c04f6776a74c
 	go.opentelemetry.io/collector/component v1.54.1-0.20260326211300-c04f6776a74c
 	go.opentelemetry.io/collector/component/componenttest v0.148.1-0.20260326211300-c04f6776a74c
 	go.opentelemetry.io/collector/confmap v1.54.1-0.20260326211300-c04f6776a74c

--- a/receiver/awslambdareceiver/go.sum
+++ b/receiver/awslambdareceiver/go.sum
@@ -97,6 +97,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/collector/client v1.54.1-0.20260326211300-c04f6776a74c h1:3pUN1DiHqBazEKEYBIbsm99FcnrWctUcLtMMKFrOoqg=
+go.opentelemetry.io/collector/client v1.54.1-0.20260326211300-c04f6776a74c/go.mod h1:4ODFLlgYmMEA+GNy96Qsn6Gi2PwFQFNUScvv5vVTyfE=
 go.opentelemetry.io/collector/component v1.54.1-0.20260326211300-c04f6776a74c h1:Clo4qT+1/PX74Qys9ImDcuyay9LQ744yzXf3MC2rWio=
 go.opentelemetry.io/collector/component v1.54.1-0.20260326211300-c04f6776a74c/go.mod h1:yUMBYsySY/sDcXm8kOzEoZxt+JLdala6hxzSW0npOxY=
 go.opentelemetry.io/collector/component/componenttest v0.148.1-0.20260326211300-c04f6776a74c h1:y4xCKelni0EL8/No6P5NKiEwvbhsCX8cVVzfknWe/y8=

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -329,7 +329,6 @@ func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {
 // which can be used for further processing and correlation in the pipeline.
 func getEnrichedContext(ctx context.Context, event events.S3EventRecord) context.Context {
 	metadata := map[string][]string{}
-	metadata[string(conventions.CloudProviderKey)] = []string{conventions.CloudProviderAWS.Value.AsString()}
 	metadata[string(conventions.CloudRegionKey)] = []string{event.AWSRegion}
 	metadata["aws.s3.bucket.name"] = []string{event.S3.Bucket.Name}
 	metadata["aws.s3.bucket.arn"] = []string{event.S3.Bucket.Arn}

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	gojson "github.com/goccy/go-json"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -115,7 +116,7 @@ func newS3LogsHandler(
 			}
 
 			enrichS3Logs(logs, event)
-			if err = consumer(ctx, event, logs); err != nil {
+			if err = consumer(getEnrichedContext(ctx, event), event, logs); err != nil {
 				return checkConsumerErrorAndWrap(err)
 			}
 		}
@@ -155,7 +156,7 @@ func newS3MetricsHandler(
 				return fmt.Errorf("failed to decode S3 metrics: %w", err)
 			}
 
-			if err := consumer(ctx, event, metrics); err != nil {
+			if err := consumer(getEnrichedContext(ctx, event), event, metrics); err != nil {
 				return checkConsumerErrorAndWrap(err)
 			}
 		}
@@ -313,6 +314,7 @@ func gunzipIfNeeded(r io.Reader) (io.Reader, error) {
 func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {
 	for _, resourceLogs := range logs.ResourceLogs().All() {
 		resourceAttrs := resourceLogs.Resource().Attributes()
+
 		resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
 		resourceAttrs.PutStr(string(conventions.CloudRegionKey), event.AWSRegion)
 		resourceAttrs.PutStr(string(conventions.AWSS3BucketKey), event.S3.Bucket.Name)
@@ -324,6 +326,18 @@ func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {
 			}
 		}
 	}
+}
+
+func getEnrichedContext(ctx context.Context, event events.S3EventRecord) context.Context {
+	metadata := map[string][]string{}
+	metadata[string(conventions.CloudProviderKey)] = []string{conventions.CloudProviderAWS.Value.AsString()}
+	metadata[string(conventions.CloudRegionKey)] = []string{event.AWSRegion}
+	metadata[string(conventions.AWSS3BucketKey)] = []string{event.S3.Bucket.Name}
+	metadata[string(conventions.AWSS3KeyKey)] = []string{event.S3.Object.Key}
+
+	info := client.Info{}
+	info.Metadata = client.NewMetadata(metadata)
+	return client.NewContext(ctx, info)
 }
 
 // checkConsumerErrorAndWrap is a helper to process errors returned from consumer functions.

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	gojson "github.com/goccy/go-json"
 	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -35,13 +36,8 @@ const s3StreamBatchSize = 10_000_000 // 10MB chunks
 // readerBufferSize defines the buffer size for buffered readers.
 const readerBufferSize = 128 * 1024 // 128KB buffer size
 
-type emits interface {
-	plog.Logs | pmetric.Metrics
-}
-
 type (
-	s3EventConsumerFunc[T emits] func(context.Context, events.S3EventRecord, T) error
-	handlerRegistry              map[eventType]lambdaEventHandler
+	handlerRegistry map[eventType]lambdaEventHandler
 )
 
 type handlerProvider interface {
@@ -94,7 +90,7 @@ func newS3LogsHandler(
 	service internal.S3Service,
 	baseLogger *zap.Logger,
 	logsDecoder encoding.LogsDecoderFactory,
-	consumer s3EventConsumerFunc[plog.Logs],
+	consumer consumer.Logs,
 ) *s3Handler {
 	logDecodeF := func(ctx context.Context, reader io.Reader, event events.S3EventRecord) error {
 		var decoder encoding.LogsDecoder
@@ -116,7 +112,7 @@ func newS3LogsHandler(
 			}
 
 			enrichS3Logs(logs, event)
-			if err = consumer(getEnrichedContext(ctx, event), event, logs); err != nil {
+			if err = consumer.ConsumeLogs(getEnrichedContext(ctx, event), logs); err != nil {
 				return checkConsumerErrorAndWrap(err)
 			}
 		}
@@ -135,7 +131,7 @@ func newS3MetricsHandler(
 	service internal.S3Service,
 	baseLogger *zap.Logger,
 	metricsDecoder encoding.MetricsDecoderFactory,
-	consumer s3EventConsumerFunc[pmetric.Metrics],
+	consumer consumer.Metrics,
 ) *s3Handler {
 	metricDecodeF := func(ctx context.Context, reader io.Reader, event events.S3EventRecord) error {
 		var decoder encoding.MetricsDecoder
@@ -156,7 +152,7 @@ func newS3MetricsHandler(
 				return fmt.Errorf("failed to decode S3 metrics: %w", err)
 			}
 
-			if err := consumer(getEnrichedContext(ctx, event), event, metrics); err != nil {
+			if err := consumer.ConsumeMetrics(getEnrichedContext(ctx, event), metrics); err != nil {
 				return checkConsumerErrorAndWrap(err)
 			}
 		}
@@ -234,12 +230,12 @@ func (*s3Handler) parseEvent(raw json.RawMessage) (event events.S3EventRecord, e
 // cwLogsSubscriptionHandler is specialized in CloudWatch log stream subscription filter events
 type cwLogsSubscriptionHandler struct {
 	logsDecoder encoding.LogsDecoderFactory
-	consumer    func(context.Context, plog.Logs) error
+	consumer    consumer.Logs
 }
 
 func newCWLogsSubscriptionHandler(
 	logsDecoder encoding.LogsDecoderFactory,
-	consumer func(context.Context, plog.Logs) error,
+	consumer consumer.Logs,
 ) *cwLogsSubscriptionHandler {
 	return &cwLogsSubscriptionHandler{
 		logsDecoder: logsDecoder,
@@ -285,7 +281,7 @@ func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMe
 
 			return fmt.Errorf("failed to decode S3 logs: %w", err)
 		}
-		if err = c.consumer(ctx, logs); err != nil {
+		if err = c.consumer.ConsumeLogs(ctx, logs); err != nil {
 			return checkConsumerErrorAndWrap(err)
 		}
 	}
@@ -328,6 +324,8 @@ func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {
 	}
 }
 
+// getEnrichedContext creates a new context with metadata extracted from the S3 event,
+// which can be used for further processing and correlation in the pipeline.
 func getEnrichedContext(ctx context.Context, event events.S3EventRecord) context.Context {
 	metadata := map[string][]string{}
 	metadata[string(conventions.CloudProviderKey)] = []string{conventions.CloudProviderAWS.Value.AsString()}

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -313,7 +313,8 @@ func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {
 
 		resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
 		resourceAttrs.PutStr(string(conventions.CloudRegionKey), event.AWSRegion)
-		resourceAttrs.PutStr(string(conventions.AWSS3BucketKey), event.S3.Bucket.Name)
+		resourceAttrs.PutStr("aws.s3.bucket.name", event.S3.Bucket.Name)
+		resourceAttrs.PutStr("aws.s3.bucket.arn", event.S3.Bucket.Arn)
 		resourceAttrs.PutStr(string(conventions.AWSS3KeyKey), event.S3.Object.Key)
 
 		for _, scopeLogs := range resourceLogs.ScopeLogs().All() {
@@ -330,7 +331,8 @@ func getEnrichedContext(ctx context.Context, event events.S3EventRecord) context
 	metadata := map[string][]string{}
 	metadata[string(conventions.CloudProviderKey)] = []string{conventions.CloudProviderAWS.Value.AsString()}
 	metadata[string(conventions.CloudRegionKey)] = []string{event.AWSRegion}
-	metadata[string(conventions.AWSS3BucketKey)] = []string{event.S3.Bucket.Name}
+	metadata["aws.s3.bucket.name"] = []string{event.S3.Bucket.Name}
+	metadata["aws.s3.bucket.arn"] = []string{event.S3.Bucket.Arn}
 	metadata[string(conventions.AWSS3KeyKey)] = []string{event.S3.Object.Key}
 
 	info := client.Info{}

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -404,6 +404,7 @@ func TestEnrichments(t *testing.T) {
 			SchemaVersion: "",
 			Bucket: events.S3Bucket{
 				Name: "bucket-name",
+				Arn:  "arn:aws:s3:::bucket-name",
 			},
 			Object: events.S3Object{
 				Key: "object-key",
@@ -435,9 +436,13 @@ func TestEnrichments(t *testing.T) {
 			require.True(t, b)
 			require.Equal(t, "us-east-1", v.AsString())
 
-			v, b = resourceAttrs.Get("aws.s3.bucket")
+			v, b = resourceAttrs.Get("aws.s3.bucket.name")
 			require.True(t, b)
 			require.Equal(t, "bucket-name", v.AsString())
+
+			v, b = resourceAttrs.Get("aws.s3.bucket.arn")
+			require.True(t, b)
+			require.Equal(t, "arn:aws:s3:::bucket-name", v.AsString())
 
 			v, b = resourceAttrs.Get("aws.s3.key")
 			require.True(t, b)
@@ -457,7 +462,8 @@ func TestEnrichments(t *testing.T) {
 
 		require.Equal(t, "aws", metadata.Get("cloud.provider")[0])
 		require.Equal(t, "us-east-1", metadata.Get("cloud.region")[0])
-		require.Equal(t, "bucket-name", metadata.Get("aws.s3.bucket")[0])
+		require.Equal(t, "bucket-name", metadata.Get("aws.s3.bucket.name")[0])
+		require.Equal(t, "arn:aws:s3:::bucket-name", metadata.Get("aws.s3.bucket.arn")[0])
 		require.Equal(t, "object-key", metadata.Get("aws.s3.key")[0])
 	})
 }

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -460,7 +460,6 @@ func TestEnrichments(t *testing.T) {
 		info := client.FromContext(enrichedCtx)
 		metadata := info.Metadata
 
-		require.Equal(t, "aws", metadata.Get("cloud.provider")[0])
 		require.Equal(t, "us-east-1", metadata.Get("cloud.region")[0])
 		require.Equal(t, "bucket-name", metadata.Get("aws.s3.bucket.name")[0])
 		require.Equal(t, "arn:aws:s3:::bucket-name", metadata.Get("aws.s3.bucket.arn")[0])

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -225,13 +225,7 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 				Return(io.NopCloser(bytes.NewReader(test.s3MockContent.data)), nil).
 				AnyTimes()
 
-			// Wrap the consumer to match the new s3EventConsumerFunc signature
-			logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-				enrichS3Logs(logs, event)
-				return test.eventConsumer.ConsumeLogs(ctx, logs)
-			}
-
-			handler := newS3LogsHandler(s3Service, zap.NewNop(), test.extension, logsConsumer)
+			handler := newS3LogsHandler(s3Service, zap.NewNop(), test.extension, test.eventConsumer)
 
 			var event json.RawMessage
 			event, err := json.Marshal(test.s3Event)
@@ -317,13 +311,7 @@ func TestS3HandlerParseEvent(t *testing.T) {
 	s3Service := internal.NewMockS3Service(ctr)
 	s3Service.EXPECT().ReadObject(gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("S3 content"), nil).AnyTimes()
 
-	var consumer noOpLogsConsumer
-	// Wrap the consumer to match the new s3EventConsumerFunc signature
-	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-		enrichS3Logs(logs, event)
-		return consumer.ConsumeLogs(ctx, logs)
-	}
-	handler := newS3LogsHandler(s3Service, zap.NewNop(), &customLogUnmarshaler{}, logsConsumer)
+	handler := newS3LogsHandler(s3Service, zap.NewNop(), &customLogUnmarshaler{}, &noOpLogsConsumer{})
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -391,7 +379,7 @@ func TestHandleCloudwatchLogEvent(t *testing.T) {
 			lambdaEvent, err := json.Marshal(cwEvent)
 			require.NoError(t, err)
 
-			handler := newCWLogsSubscriptionHandler(test.extension, test.eventConsumer.ConsumeLogs)
+			handler := newCWLogsSubscriptionHandler(test.extension, test.eventConsumer)
 
 			err = handler.handle(t.Context(), lambdaEvent)
 			if test.expectedErr != "" {
@@ -523,12 +511,7 @@ func TestConsumerErrorHandling(t *testing.T) {
 				Return(io.NopCloser(bytes.NewReader([]byte("object content"))), nil).
 				Times(1)
 
-			// Consumer that returns the test error
-			logsConsumer := func(_ context.Context, _ events.S3EventRecord, _ plog.Logs) error {
-				return test.consumerErr
-			}
-
-			handler := newS3LogsHandler(s3Service, zap.NewNop(), &customLogUnmarshaler{}, logsConsumer)
+			handler := newS3LogsHandler(s3Service, zap.NewNop(), &customLogUnmarshaler{}, &noOpLogsConsumer{err: test.consumerErr})
 
 			event, err := json.Marshal(mockEvent)
 			require.NoError(t, err)

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -402,16 +403,8 @@ func TestHandleCloudwatchLogEvent(t *testing.T) {
 	}
 }
 
-func TestEnrichS3Logs(t *testing.T) {
+func TestEnrichments(t *testing.T) {
 	t.Parallel()
-
-	// given
-	logs := plog.NewLogs()
-
-	rl := logs.ResourceLogs().AppendEmpty()
-	sl := rl.ScopeLogs()
-	lr := sl.AppendEmpty().LogRecords()
-	lr.AppendEmpty()
 
 	observedTimestamp := time.UnixMilli(1765574662915)
 	expectedTimestamp := pcommon.NewTimestampFromTime(observedTimestamp)
@@ -430,35 +423,55 @@ func TestEnrichS3Logs(t *testing.T) {
 		},
 	}
 
+	// given
+	logs := plog.NewLogs()
+
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs()
+	lr := sl.AppendEmpty().LogRecords()
+	lr.AppendEmpty()
+
 	// when
 	enrichS3Logs(logs, s3Record)
+	enrichedCtx := getEnrichedContext(t.Context(), s3Record)
 
-	// then
-	for _, resource := range logs.ResourceLogs().All() {
-		resourceAttrs := resource.Resource().Attributes()
+	t.Run("Validate log enrichment", func(t *testing.T) {
+		for _, resource := range logs.ResourceLogs().All() {
+			resourceAttrs := resource.Resource().Attributes()
 
-		v, b := resourceAttrs.Get("cloud.provider")
-		require.True(t, b)
-		require.Equal(t, "aws", v.AsString())
+			v, b := resourceAttrs.Get("cloud.provider")
+			require.True(t, b)
+			require.Equal(t, "aws", v.AsString())
 
-		v, b = resourceAttrs.Get("cloud.region")
-		require.True(t, b)
-		require.Equal(t, "us-east-1", v.AsString())
+			v, b = resourceAttrs.Get("cloud.region")
+			require.True(t, b)
+			require.Equal(t, "us-east-1", v.AsString())
 
-		v, b = resourceAttrs.Get("aws.s3.bucket")
-		require.True(t, b)
-		require.Equal(t, "bucket-name", v.AsString())
+			v, b = resourceAttrs.Get("aws.s3.bucket")
+			require.True(t, b)
+			require.Equal(t, "bucket-name", v.AsString())
 
-		v, b = resourceAttrs.Get("aws.s3.key")
-		require.True(t, b)
-		require.Equal(t, "object-key", v.AsString())
+			v, b = resourceAttrs.Get("aws.s3.key")
+			require.True(t, b)
+			require.Equal(t, "object-key", v.AsString())
 
-		for _, scope := range resource.ScopeLogs().All() {
-			for _, logRecord := range scope.LogRecords().All() {
-				require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+			for _, scope := range resource.ScopeLogs().All() {
+				for _, logRecord := range scope.LogRecords().All() {
+					require.Equal(t, expectedTimestamp, logRecord.ObservedTimestamp())
+				}
 			}
 		}
-	}
+	})
+
+	t.Run("Validate context enrichment", func(t *testing.T) {
+		info := client.FromContext(enrichedCtx)
+		metadata := info.Metadata
+
+		require.Equal(t, "aws", metadata.Get("cloud.provider")[0])
+		require.Equal(t, "us-east-1", metadata.Get("cloud.region")[0])
+		require.Equal(t, "bucket-name", metadata.Get("aws.s3.bucket")[0])
+		require.Equal(t, "object-key", metadata.Get("aws.s3.key")[0])
+	})
 }
 
 func TestConsumerErrorHandling(t *testing.T) {

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -251,7 +251,7 @@ func newLogsHandler(
 	// Wrapper function that sets observed timestamp for S3 logs
 	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
 		enrichS3Logs(logs, event)
-		return next.ConsumeLogs(ctx, logs)
+		return next.ConsumeLogs(getEnrichedContext(ctx, event), logs)
 	}
 
 	cwDecoder := internal.NewDefaultCWLogsDecoder()

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -12,14 +12,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/extension"
-	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
@@ -248,12 +245,6 @@ func newLogsHandler(
 		return nil, fmt.Errorf("unable to load the S3 service: %w", err)
 	}
 
-	// Wrapper function that sets observed timestamp for S3 logs
-	logsConsumer := func(ctx context.Context, event events.S3EventRecord, logs plog.Logs) error {
-		enrichS3Logs(logs, event)
-		return next.ConsumeLogs(getEnrichedContext(ctx, event), logs)
-	}
-
 	cwDecoder := internal.NewDefaultCWLogsDecoder()
 	if cfg.CloudWatch.Encoding != "" {
 		logger.Info("Using configured CloudWatch encoding for logs", zap.String("encoding", cfg.CloudWatch.Encoding))
@@ -266,8 +257,8 @@ func newLogsHandler(
 
 	// Register handlers. Logs supports S3 and CloudWatch Logs subscription events.
 	registry := make(handlerRegistry)
-	registry[s3Event] = newS3LogsHandler(s3Service, logger, s3LogsDecoder, logsConsumer)
-	registry[cwEvent] = newCWLogsSubscriptionHandler(cwDecoder, next.ConsumeLogs)
+	registry[s3Event] = newS3LogsHandler(s3Service, logger, s3LogsDecoder, next)
+	registry[cwEvent] = newCWLogsSubscriptionHandler(cwDecoder, next)
 
 	return newHandlerProvider(registry), nil
 }
@@ -310,13 +301,9 @@ func newMetricsHandler(
 		return nil, fmt.Errorf("unable to load the S3 service: %w", err)
 	}
 
-	metricConsumer := func(ctx context.Context, _ events.S3EventRecord, metrics pmetric.Metrics) error {
-		return next.ConsumeMetrics(ctx, metrics)
-	}
-
 	// Register handlers. Metrics supports S3 events.
 	registry := make(handlerRegistry)
-	registry[s3Event] = newS3MetricsHandler(s3Service, set.Logger, decoder, metricConsumer)
+	registry[s3Event] = newS3MetricsHandler(s3Service, set.Logger, decoder, next)
 
 	return newHandlerProvider(registry), nil
 }

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -101,7 +101,8 @@ func TestCreateLogs(t *testing.T) {
 	// Check that S3 metadata is present in the context
 	require.Contains(t, m.Get("cloud.provider"), "aws")
 	require.Contains(t, m.Get("cloud.region"), "us-east-1")
-	require.Contains(t, m.Get("aws.s3.bucket"), "test-bucket")
+	require.Contains(t, m.Get("aws.s3.bucket.name"), "test-bucket")
+	require.Contains(t, m.Get("aws.s3.bucket.arn"), "arn:aws:s3:::test-bucket")
 	require.Contains(t, m.Get("aws.s3.key"), "test-file.txt")
 }
 
@@ -173,7 +174,8 @@ func TestCreateMetrics(t *testing.T) {
 	// Check that S3 metadata is present in the context
 	require.Contains(t, m.Get("cloud.provider"), "aws")
 	require.Contains(t, m.Get("cloud.region"), "us-east-1")
-	require.Contains(t, m.Get("aws.s3.bucket"), "test-bucket")
+	require.Contains(t, m.Get("aws.s3.bucket.name"), "test-bucket")
+	require.Contains(t, m.Get("aws.s3.bucket.arn"), "arn:aws:s3:::test-bucket")
 	require.Contains(t, m.Get("aws.s3.key"), "test-file.txt")
 }
 

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -77,6 +78,7 @@ func TestCreateLogs(t *testing.T) {
 	// Process an S3 event notification.
 	lambdaEvent, err := json.Marshal(events.S3Event{
 		Records: []events.S3EventRecord{{
+			AWSRegion:   "us-east-1",
 			EventSource: "aws:s3",
 			S3: events.S3Entity{
 				Bucket: events.S3Bucket{Name: "test-bucket", Arn: "arn:aws:s3:::test-bucket"},
@@ -90,6 +92,17 @@ func TestCreateLogs(t *testing.T) {
 
 	// Verify logs were sent to the sink
 	require.NotZero(t, sink.LogRecordCount(), "Expected logs to be sent to sink")
+
+	// Validate context enrichment with S3 metadata
+	contexts := sink.Contexts()
+	require.Len(t, contexts, 1, "Expected one context for the consumed logs")
+	m := client.FromContext(contexts[0]).Metadata
+
+	// Check that S3 metadata is present in the context
+	require.Contains(t, m.Get("cloud.provider"), "aws")
+	require.Contains(t, m.Get("cloud.region"), "us-east-1")
+	require.Contains(t, m.Get("aws.s3.bucket"), "test-bucket")
+	require.Contains(t, m.Get("aws.s3.key"), "test-file.txt")
 }
 
 func TestCreateMetrics(t *testing.T) {
@@ -137,6 +150,7 @@ func TestCreateMetrics(t *testing.T) {
 	// Process an S3 event notification.
 	lambdaEvent, err := json.Marshal(events.S3Event{
 		Records: []events.S3EventRecord{{
+			AWSRegion:   "us-east-1",
 			EventSource: "aws:s3",
 			S3: events.S3Entity{
 				Bucket: events.S3Bucket{Name: "test-bucket", Arn: "arn:aws:s3:::test-bucket"},
@@ -150,6 +164,17 @@ func TestCreateMetrics(t *testing.T) {
 
 	// Verify metrics were sent to the sink
 	require.NotZero(t, sink.DataPointCount(), "Expected metrics to be sent to sink")
+
+	// Validate context enrichment with S3 metadata
+	contexts := sink.Contexts()
+	require.Len(t, contexts, 1, "Expected one context for the consumed logs")
+	m := client.FromContext(contexts[0]).Metadata
+
+	// Check that S3 metadata is present in the context
+	require.Contains(t, m.Get("cloud.provider"), "aws")
+	require.Contains(t, m.Get("cloud.region"), "us-east-1")
+	require.Contains(t, m.Get("aws.s3.bucket"), "test-bucket")
+	require.Contains(t, m.Get("aws.s3.key"), "test-file.txt")
 }
 
 func TestStartRequiresLambdaEnvironment(t *testing.T) {

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -99,7 +99,6 @@ func TestCreateLogs(t *testing.T) {
 	m := client.FromContext(contexts[0]).Metadata
 
 	// Check that S3 metadata is present in the context
-	require.Contains(t, m.Get("cloud.provider"), "aws")
 	require.Contains(t, m.Get("cloud.region"), "us-east-1")
 	require.Contains(t, m.Get("aws.s3.bucket.name"), "test-bucket")
 	require.Contains(t, m.Get("aws.s3.bucket.arn"), "arn:aws:s3:::test-bucket")
@@ -172,7 +171,6 @@ func TestCreateMetrics(t *testing.T) {
 	m := client.FromContext(contexts[0]).Metadata
 
 	// Check that S3 metadata is present in the context
-	require.Contains(t, m.Get("cloud.provider"), "aws")
 	require.Contains(t, m.Get("cloud.region"), "us-east-1")
 	require.Contains(t, m.Get("aws.s3.bucket.name"), "test-bucket")
 	require.Contains(t, m.Get("aws.s3.bucket.arn"), "arn:aws:s3:::test-bucket")

--- a/receiver/awslambdareceiver/testdata/s3_log_expected_gzip.yaml
+++ b/receiver/awslambdareceiver/testdata/s3_log_expected_gzip.yaml
@@ -7,16 +7,18 @@ resourceLogs:
         - key: cloud.region
           value:
             stringValue: us-east-1
-        - key: aws.s3.bucket
+        - key: aws.s3.bucket.name
           value:
             stringValue: test-bucket
+        - key: aws.s3.bucket.arn
+          value:
+            stringValue: arn:aws:s3:::test-bucket
         - key: aws.s3.key
           value:
             stringValue: test-file.txt
     scopeLogs:
       - logRecords:
-          - attributes:
-            body:
+          - body:
               stringValue: Logs in Gzip S3 object
             observedTimeUnixNano: "1764625361000000000"
         scope:

--- a/receiver/awslambdareceiver/testdata/s3_log_expected_string.yaml
+++ b/receiver/awslambdareceiver/testdata/s3_log_expected_string.yaml
@@ -7,16 +7,18 @@ resourceLogs:
         - key: cloud.region
           value:
             stringValue: us-east-1
-        - key: aws.s3.bucket
+        - key: aws.s3.bucket.name
           value:
             stringValue: test-bucket
+        - key: aws.s3.bucket.arn
+          value:
+            stringValue: arn:aws:s3:::test-bucket
         - key: aws.s3.key
           value:
             stringValue: test-file.txt
     scopeLogs:
       - logRecords:
-          - attributes:
-            body:
+          - body:
               stringValue: Some log in S3 object
             observedTimeUnixNano: "1764625361000000000"
         scope:


### PR DESCRIPTION
#### Description

This PR enhance the AWS Lambda receiver by adding S3 trigger metadata to Client Info Metadata, which is accessible by downstream consumers.

For example, these metadata can be now extracted by the Attributes Processor. Users can then use ottl statements to access and populate any custom attributes. 

The table below summarize available metadata,

| Metadata Key       | Description          |
|--------------------|----------------------|
| cloud.region       | The S3 bucket region |
| aws.s3.bucket.name | The S3 bucket name   |
| aws.s3.bucket.arn  | The S3 bucket ARN    |
| aws.s3.key         | The S3 object key    |

Note - `aws.s3.bucket.arn` is a new addition. Also, static metadata are not available through Client info and are expected to be set by other means if needed.

#### Link to tracking issue

Alternate approach to closed PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46858

#### Testing

Updated tests to validate end to end functionality

#### Documentation

Updated documentation with available metadata through context. 
