### PR TITLE
[exporter/kafkaexporter] Add actual and max message bytes size in Error

### DIFF
--- a/.chloggen/feat-kafkaexporter-logging.yaml
+++ b/.chloggen/feat-kafkaexporter-logging.yaml
@@ -1,0 +1,7 @@
+# Use this changelog template to create an entry for release notes.
+change_type: enhancement
+component: exporter/kafka
+note: Include message size and configured max in MessageTooLarge errors
+issues: [46766]
+subtext:
+change_logs: [user]

--- a/.chloggen/feat-kafkaexporter-logging.yaml
+++ b/.chloggen/feat-kafkaexporter-logging.yaml
@@ -1,7 +1,0 @@
-# Use this changelog template to create an entry for release notes.
-change_type: enhancement
-component: exporter/kafka
-note: Include message size and configured max in MessageTooLarge errors
-issues: [46766]
-subtext:
-change_logs: [user]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -98,7 +98,7 @@ The following settings can be optionally configured:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
 - `producer`
-  - `max_message_bytes` (default = 1000000) the maximum permitted size of a message in bytes
+  - `max_message_bytes` (default = 1000000) the maximum permitted size of a message in bytes, calculated before compression.
   - `required_acks` (default = 1) controls when a message is regarded as transmitted. <https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#acks>
   - `compression` (default = 'none') the compression used when producing messages to kafka. The options are: `none`, `gzip`, `snappy`, `lz4`, and `zstd` <https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#compression-type>
   - `compression_params`

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
@@ -67,21 +67,22 @@ func (p *FranzSyncProducer) ExportData(ctx context.Context, msgs Messages) error
 	result := p.client.ProduceSync(ctx, messages...)
 	var errs []error
 	for _, r := range result {
-		if r.Err != nil {
-			var err error
-			if errors.Is(r.Err, kerr.MessageTooLarge) {
-				err = fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic,
-					&MessageTooLargeError{RecordBytes: recordUserSize(r.Record), MaxMessageBytes: p.maxMessageBytes, Err: r.Err})
-			} else {
-				err = fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic, r.Err)
-			}
-			// check if its defined as a non-retriable error by franzgo
-			kgoErr := &kerr.Error{}
-			if errors.As(r.Err, &kgoErr) && !kgoErr.Retriable {
-				err = consumererror.NewPermanent(err)
-			}
-			errs = append(errs, err)
+		if r.Err == nil {
+			continue
 		}
+		var err error
+		if errors.Is(r.Err, kerr.MessageTooLarge) {
+			err = fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic,
+				&MessageTooLargeError{RecordBytes: recordUserSize(r.Record), MaxMessageBytes: p.maxMessageBytes, Err: r.Err})
+		} else {
+			err = fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic, r.Err)
+		}
+		// check if its defined as a non-retriable error by franzgo
+		kgoErr := &kerr.Error{}
+		if errors.As(r.Err, &kgoErr) && !kgoErr.Retriable {
+			err = consumererror.NewPermanent(err)
+		}
+		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
 }

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
@@ -13,21 +13,50 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
+// MessageTooLargeError wraps a MessageTooLarge Kafka error with the actual
+// record size that caused the rejection. The size is computed the same way as
+// franz-go's Record.userSize: len(Key) + len(Value) + Σ(len(header.Key) + len(header.Value)).
+type MessageTooLargeError struct {
+	// RecordBytes is the user-visible size of the record (key + value + headers).
+	RecordBytes int
+	// MaxMessageBytes is the configured producer max message size.
+	MaxMessageBytes int
+	Err             error
+}
+
+func (e *MessageTooLargeError) Error() string {
+	return fmt.Sprintf("record size %d exceeds max %d: %s", e.RecordBytes, e.MaxMessageBytes, e.Err.Error())
+}
+func (e *MessageTooLargeError) Unwrap() error { return e.Err }
+
+// recordUserSize returns the user-visible size of a kgo.Record, matching
+// franz-go's internal userSize calculation.
+func recordUserSize(r *kgo.Record) int {
+	s := len(r.Key) + len(r.Value)
+	for _, h := range r.Headers {
+		s += len(h.Key) + len(h.Value)
+	}
+	return s
+}
+
 // FranzSyncProducer is a wrapper around the franz-go client that implements
 // the Producer interface. Allowing us to use the franz-go client while
 // maintaining compatibility with the existing Kafka exporter code.
 type FranzSyncProducer struct {
-	client       *kgo.Client
-	metadataKeys []string
+	client          *kgo.Client
+	metadataKeys    []string
+	maxMessageBytes int
 }
 
 // NewFranzSyncProducer Franz-go producer from a kgo.Client and a Messenger.
 func NewFranzSyncProducer(client *kgo.Client,
 	metadataKeys []string,
+	maxMessageBytes int,
 ) *FranzSyncProducer {
 	return &FranzSyncProducer{
-		client:       client,
-		metadataKeys: metadataKeys,
+		client:          client,
+		metadataKeys:    metadataKeys,
+		maxMessageBytes: maxMessageBytes,
 	}
 }
 
@@ -39,7 +68,13 @@ func (p *FranzSyncProducer) ExportData(ctx context.Context, msgs Messages) error
 	var errs []error
 	for _, r := range result {
 		if r.Err != nil {
-			err := fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic, r.Err)
+			var err error
+			if errors.Is(r.Err, kerr.MessageTooLarge) {
+				err = fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic,
+					&MessageTooLargeError{RecordBytes: recordUserSize(r.Record), MaxMessageBytes: p.maxMessageBytes, Err: r.Err})
+			} else {
+				err = fmt.Errorf("error exporting to topic %q: %w", r.Record.Topic, r.Err)
+			}
 			// check if its defined as a non-retriable error by franzgo
 			kgoErr := &kerr.Error{}
 			if errors.As(r.Err, &kgoErr) && !kgoErr.Retriable {

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_test.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_test.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkaclient
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/marshaler"
+)
+
+func TestExportData_MessageTooLarge(t *testing.T) {
+	const (
+		topic           = "test-topic"
+		maxMessageBytes = 512
+	)
+	cluster, err := kfake.NewCluster(kfake.SeedTopics(1, topic))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(cluster.ListenAddrs()...),
+		kgo.ProducerBatchMaxBytes(int32(maxMessageBytes)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	producer := NewFranzSyncProducer(client, nil, maxMessageBytes)
+
+	// Create a message larger than maxMessageBytes to trigger MessageTooLarge.
+	largeValue := []byte(strings.Repeat("x", maxMessageBytes*2))
+	msgs := Messages{
+		Count: 1,
+		TopicMessages: []TopicMessages{{
+			Topic: topic,
+			Messages: []marshaler.Message{{
+				Value: largeValue,
+			}},
+		}},
+	}
+
+	err = producer.ExportData(t.Context(), msgs)
+	require.Error(t, err)
+
+	// Verify the error is permanent and wraps MessageTooLarge.
+	assert.True(t, consumererror.IsPermanent(err), "expected permanent error")
+	require.ErrorAs(t, err, &kerr.MessageTooLarge, "expected MessageTooLarge error")
+
+	// Verify the error wraps MessageTooLargeError with correct sizes.
+	var msgTooLarge *MessageTooLargeError
+	require.ErrorAs(t, err, &msgTooLarge)
+	assert.Equal(t, len(largeValue), msgTooLarge.RecordBytes)
+	assert.Equal(t, maxMessageBytes, msgTooLarge.MaxMessageBytes)
+
+	// Verify sizes appear in the error string for pipeline-level visibility.
+	assert.Contains(t, err.Error(), "record size")
+	assert.Contains(t, err.Error(), "exceeds max")
+}

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_test.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_test.go
@@ -52,7 +52,7 @@ func TestExportData_MessageTooLarge(t *testing.T) {
 
 	// Verify the error is permanent and wraps MessageTooLarge.
 	assert.True(t, consumererror.IsPermanent(err), "expected permanent error")
-	require.ErrorAs(t, err, &kerr.MessageTooLarge, "expected MessageTooLarge error")
+	require.ErrorIs(t, err, kerr.MessageTooLarge, "expected MessageTooLarge error")
 
 	// Verify the error wraps MessageTooLargeError with correct sizes.
 	var msgTooLarge *MessageTooLargeError

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -5,6 +5,7 @@ package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 
@@ -99,6 +100,7 @@ func (e *kafkaExporter[T]) Start(ctx context.Context, host component.Host) (err 
 	}
 	e.producer = kafkaclient.NewFranzSyncProducer(producer,
 		e.cfg.IncludeMetadataKeys,
+		e.cfg.Producer.MaxMessageBytes,
 	)
 	return nil
 }
@@ -154,11 +156,19 @@ func (e *kafkaExporter[T]) exportData(ctx context.Context, data T) error {
 		}
 	} else {
 		for _, mi := range m.TopicMessages {
-			e.logger.Error("kafka records export failed",
+			fields := []zap.Field{
 				zap.Int("records", len(mi.Messages)),
 				zap.String("topic", mi.Topic),
-				zap.Error(err),
-			)
+			}
+			var msgTooLarge *kafkaclient.MessageTooLargeError
+			if errors.As(err, &msgTooLarge) {
+				fields = append(fields,
+					zap.Int("actual_message_bytes", msgTooLarge.RecordBytes),
+					zap.Int("max_message_bytes", msgTooLarge.MaxMessageBytes),
+				)
+			}
+			fields = append(fields, zap.Error(err))
+			e.logger.Error("kafka records export failed", fields...)
 		}
 	}
 	return err

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -156,19 +156,18 @@ func (e *kafkaExporter[T]) exportData(ctx context.Context, data T) error {
 		}
 	} else {
 		for _, mi := range m.TopicMessages {
-			fields := []zap.Field{
+			e.logger.Error("kafka records export failed",
 				zap.Int("records", len(mi.Messages)),
 				zap.String("topic", mi.Topic),
-			}
-			var msgTooLarge *kafkaclient.MessageTooLargeError
-			if errors.As(err, &msgTooLarge) {
-				fields = append(fields,
-					zap.Int("actual_message_bytes", msgTooLarge.RecordBytes),
-					zap.Int("max_message_bytes", msgTooLarge.MaxMessageBytes),
-				)
-			}
-			fields = append(fields, zap.Error(err))
-			e.logger.Error("kafka records export failed", fields...)
+				zap.Error(err),
+			)
+		}
+		var msgTooLarge *kafkaclient.MessageTooLargeError
+		if errors.As(err, &msgTooLarge) {
+			e.logger.Error("kafka record exceeds max message size",
+				zap.Int("actual_message_bytes", msgTooLarge.RecordBytes),
+				zap.Int("max_message_bytes", msgTooLarge.MaxMessageBytes),
+			)
 		}
 	}
 	return err

--- a/exporter/kafkaexporter/kafka_exporter_e2e_bench_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_e2e_bench_test.go
@@ -50,7 +50,7 @@ func configureExporterBench[T any](
 	messenger, err := exp.newMessenger(componenttest.NewNopHost())
 	require.NoError(b, err)
 	exp.messenger = messenger
-	exp.producer = kafkaclient.NewFranzSyncProducer(client, cfg.IncludeMetadataKeys)
+	exp.producer = kafkaclient.NewFranzSyncProducer(client, cfg.IncludeMetadataKeys, cfg.Producer.MaxMessageBytes)
 
 	b.Cleanup(func() { exp.Close(b.Context()) })
 }

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -1299,7 +1299,7 @@ func configureExporter[T any](tb testing.TB,
 	require.NoError(tb, err, "failed to create messenger for metrics")
 
 	exp.messenger = messenger
-	exp.producer = kafkaclient.NewFranzSyncProducer(client, cfg.IncludeMetadataKeys)
+	exp.producer = kafkaclient.NewFranzSyncProducer(client, cfg.IncludeMetadataKeys, cfg.Producer.MaxMessageBytes)
 
 	tb.Cleanup(func() { assert.NoError(tb, exp.Close(tb.Context())) })
 	return cluster


### PR DESCRIPTION
#### Description
Proposition that when a MessageTooLarge error occurs to include the actual message size and the configured maximum in the error log.

#### Link to tracking issue
Fixes #46766

#### Testing
Added `TestExportData_MessageTooLarge` test.

#### Documentation
Added information about how message size is calculated in the README.