### PR TITLE
[receiver/hostmetrics] Fix duplicate rootPath prefix in filesystem mountpoint translation

### DIFF
--- a/.chloggen/hostmetricsreceiver-fix-double-rootpath-prefix.yaml
+++ b/.chloggen/hostmetricsreceiver-fix-double-rootpath-prefix.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/hostmetrics
+component: receiver/host_metrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix duplicate rootPath prefix in filesystem mountpoint translation

--- a/.chloggen/hostmetricsreceiver-fix-double-rootpath-prefix.yaml
+++ b/.chloggen/hostmetricsreceiver-fix-double-rootpath-prefix.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/hostmetricsreceiver
+component: receiver/hostmetrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix duplicate rootPath prefix in filesystem mountpoint translation

--- a/.chloggen/hostmetricsreceiver-fix-double-rootpath-prefix.yaml
+++ b/.chloggen/hostmetricsreceiver-fix-double-rootpath-prefix.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicate rootPath prefix in filesystem mountpoint translation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47083]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When gopsutil falls back to reading /proc/self/mountinfo, the reported
+  mountpoints already contain the rootPath prefix. This caused
+  translateMountpoint to add it a second time, resulting in incorrect paths
+  like /hostfs/hostfs/data.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -175,12 +175,23 @@ func translateMountpoint(ctx context.Context, rootPath, mountpoint string) strin
 		}
 	}
 
-	// gopsutil first reads /<rootPath>/proc/1/mountinfo, and if this fails it reads /<rootPath>/proc/self/mountinfo as a fallback.
-	// /<rootPath>/proc/1/mountinfo contains the mountpoints from the perspective of PID 1 on the host (without rootPath prefix)
-	// /<rootPath>/proc/self/mountinfo contains the mountpoints from the perspective of the collector process (with the rootPath prefix)
+	// gopsutil first reads <rootPath>/proc/1/mountinfo, and if this fails it reads <rootPath>/proc/self/mountinfo as a fallback.
+	// If the collector process runs in a different mount namespace than PID 1 on the host (e.g. on Kubernetes):
+	//
+	// <rootPath>/proc/1/mountinfo contains the mountpoints from the perspective of PID 1 on the host (without rootPath prefix)
+	// <rootPath>/proc/self/mountinfo contains the mountpoints from the perspective of the collector process (with the rootPath prefix)
+	//
+	// Example on Fedora 43:
+	// $ docker run -v /:/hostfs:ro alpine cat /hostfs/proc/1/mountinfo | grep ext4
+	// 61 73 259:2 / /boot rw,relatime shared:84 - ext4 /dev/nvme0n1p2 rw,seclabel
+	//
+	// $ docker run -v /:/hostfs:ro alpine cat /hostfs/proc/self/mountinfo | grep ext4
+	// 5111 5048 259:2 / /hostfs/boot ro,relatime master:84 - ext4 /dev/nvme0n1p2 rw,seclabel
+	//
 	// Therefore, do not add rootPath if the mountpath has already a rootPath prefix.
 	sep := string(filepath.Separator)
-	if rootPath != "" && strings.HasPrefix(filepath.Clean(mountpoint)+sep, filepath.Clean(rootPath)+sep) {
+	if rootPath != "" && rootPath != sep &&
+		strings.HasPrefix(filepath.Clean(mountpoint)+sep, filepath.Clean(rootPath)+sep) {
 		return mountpoint
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -174,5 +174,15 @@ func translateMountpoint(ctx context.Context, rootPath, mountpoint string) strin
 			return mountpoint
 		}
 	}
+
+	// gopsutil first reads /<rootPath>/proc/1/mountinfo, and if this fails it reads /<rootPath>/proc/self/mountinfo as a fallback.
+	// /<rootPath>/proc/1/mountinfo contains the mountpoints from the perspective of PID 1 on the host (without rootPath prefix)
+	// /<rootPath>/proc/self/mountinfo contains the mountpoints from the perspective of the collector process (with the rootPath prefix)
+	// Therefore, do not add rootPath if the mountpath has already a rootPath prefix.
+	sep := string(filepath.Separator)
+	if rootPath != "" && strings.HasPrefix(filepath.Clean(mountpoint)+sep, filepath.Clean(rootPath)+sep) {
+		return mountpoint
+	}
+
 	return filepath.Join(rootPath, mountpoint)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -617,10 +617,17 @@ func TestTranslateMountpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.WithValue(t.Context(), common.EnvKey, tt.env)
+			env := make(common.EnvMap, len(tt.env))
+			for k, v := range tt.env {
+				env[k] = filepath.FromSlash(v)
+			}
+			ctx := context.WithValue(t.Context(), common.EnvKey, env)
 
-			result := translateMountpoint(ctx, tt.rootPath, tt.mountpoint)
-			assert.Equal(t, tt.expected, result)
+			// translateMountpoint() runs conditionally filepath.Join(), which runs filepath.Clean(),
+			// which replaces / with the platform-specific path separator.
+			// Therefore, use filepath.FromSlash() here to account for differences in path separator between platforms.
+			result := translateMountpoint(ctx, filepath.FromSlash(tt.rootPath), filepath.FromSlash(tt.mountpoint))
+			assert.Equal(t, filepath.FromSlash(tt.expected), result)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -554,6 +554,77 @@ func TestScrape_UtilizationExcludesReservedBlocks(t *testing.T) {
 	assert.Equal(t, 0.63, actual, "utilization should be Used/(Used+Free), not Used/Total")
 }
 
+func TestTranslateMountpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		rootPath   string
+		mountpoint string
+		env        common.EnvMap
+		expected   string
+	}{
+		{
+			name:       "empty rootPath",
+			rootPath:   "",
+			mountpoint: "/data",
+			expected:   "/data",
+		},
+		{
+			name:       "rootPath is filesystem root",
+			rootPath:   "/",
+			mountpoint: "/data",
+			expected:   "/data",
+		},
+		{
+			name:       "rootPath prepended to mountpoint",
+			rootPath:   "/hostfs",
+			mountpoint: "/data",
+			expected:   "/hostfs/data",
+		},
+		{
+			name:       "mountpoint already has rootPath prefix",
+			rootPath:   "/hostfs",
+			mountpoint: "/hostfs/data",
+			expected:   "/hostfs/data",
+		},
+		{
+			name:       "mountpoint already has rootPath prefix, rootPath has trailing slash",
+			rootPath:   "/hostfs/",
+			mountpoint: "/hostfs/data",
+			expected:   "/hostfs/data",
+		},
+		{
+			name:       "mountpoint equals rootPath",
+			rootPath:   "/hostfs",
+			mountpoint: "/hostfs",
+			expected:   "/hostfs",
+		},
+		{
+			name:       "mountpoint has rootPath as partial prefix",
+			rootPath:   "/host",
+			mountpoint: "/hostdata",
+			expected:   "/host/hostdata",
+		},
+		{
+			name:       "HOST_PROC_MOUNTINFO set skips translation",
+			rootPath:   "/hostfs",
+			mountpoint: "/data",
+			env: common.EnvMap{
+				common.HostProcMountinfo: "/proc/1/mountinfo",
+			},
+			expected: "/data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(t.Context(), common.EnvKey, tt.env)
+
+			result := translateMountpoint(ctx, tt.rootPath, tt.mountpoint)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func isUnix() bool {
 	return slices.Contains([]string{"linux", "darwin", "freebsd", "openbsd", "solaris"}, runtime.GOOS)
 }


### PR DESCRIPTION
#### Description
Fix duplicate `root_path` prefix in filesystem mountpoint translation when using the **filesystem** scraper with `root_path`:

When `gopsutil` falls back to reading `/<rootPath>/proc/self/mountinfo` because access to `/<rootPath>/proc/1/mountinfo` is denied, the reported mountpoints already contain the rootPath prefix. This causes `translateMountpoint()` to add it a second time, resulting in incorrect paths like `/hostfs/hostfs/data`.

Fix: Skip prepending rootPath when the mountpoint already starts with it.

#### Link to tracking issue
no open issue

#### Testing
Added unit tests to evaluate the new logic in `translateMountpoint()`.
Performed manual tests on OpenShift (OpenShift blocks access to `/<rootPath>/proc/1/mountinfo` and therefore the fallback `/<rootPath>/proc/self/mountinfo` is used, which exhibits the bug).

#### Documentation
Added changelog and code comment.