### PR TITLE
prometheusreceiver: fix test flake by using assert.Eventually

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -855,11 +855,13 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 	// Wait for consumer to receive all expected scrapes (deterministic, replaces polling).
 	cms.Wait(t, 30*time.Second)
 
-	assert.Eventually(t, func() bool {
-		m := cms.AllMetrics()
-		pR := splitMetricsByTarget(m)
+	// Wait for per-target scrape counts, capturing the snapshot used for validation.
+	var pResults map[string][]pmetric.ResourceMetrics
+	require.Eventually(t, func() bool {
+		metrics := cms.AllMetrics()
+		pResults = splitMetricsByTarget(metrics)
 		for _, target := range targets[:len(mp.endpoints)] {
-			scrapes := pR[getTargetName(target)]
+			scrapes := pResults[getTargetName(target)]
 
 			// There may be an additional scrape entry between when the mock server provided
 			// all responses and when we capture the metrics.  It will be ignored later.

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -872,15 +872,9 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 		return true
 	}, 10*time.Second, 10*time.Millisecond, "failed to receive expected scrapes")
 
-	// This begins the processing of the scrapes collected by the receiver
-	metrics := cms.AllMetrics()
-	// split and store results by target name
-	pResults = splitMetricsByTarget(metrics)
-	lep := len(mp.endpoints)
-
 	// loop to validate outputs for each targets
 	// Stop once we have evaluated all expected results, any others are superfluous.
-	for _, target := range targets[:lep] {
+	for _, target := range targets[:len(mp.endpoints)] {
 		t.Run(target.name, func(t *testing.T) {
 			scrapes := pResults[getTargetName(target)]
 			if !target.validateScrapes {

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -875,7 +875,7 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 	// This begins the processing of the scrapes collected by the receiver
 	metrics := cms.AllMetrics()
 	// split and store results by target name
-	pResults := splitMetricsByTarget(metrics)
+	pResults = splitMetricsByTarget(metrics)
 	lep := len(mp.endpoints)
 
 	// loop to validate outputs for each targets

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -151,13 +151,26 @@ func (s *signalingSink) Wait(t *testing.T, timeout time.Duration) {
 func countExpectedScrapes(targets []*testData) int {
 	count := 0
 	for _, target := range targets {
-		for _, p := range target.pages {
-			if p.code != 404 {
-				count++
-			}
-		}
+		count += getTargetExpectedScrapes(target)
 	}
 	return count
+}
+
+func getTargetExpectedScrapes(target *testData) int {
+	wantTotal := 0
+	for _, p := range target.pages {
+		if p.code != 404 {
+			wantTotal++
+		}
+	}
+	return wantTotal
+}
+
+func getTargetName(target *testData) string {
+	if target.relabeledJob != "" {
+		return target.relabeledJob
+	}
+	return target.name
 }
 
 // -------------------------
@@ -842,26 +855,34 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 	// Wait for consumer to receive all expected scrapes (deterministic, replaces polling).
 	cms.Wait(t, 30*time.Second)
 
+	assert.Eventually(t, func() bool {
+		m := cms.AllMetrics()
+		pR := splitMetricsByTarget(m)
+		for _, target := range targets[:len(mp.endpoints)] {
+			scrapes := pR[getTargetName(target)]
+
+			// There may be an additional scrape entry between when the mock server provided
+			// all responses and when we capture the metrics.  It will be ignored later.
+			if len(scrapes) < getTargetExpectedScrapes(target) {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 10*time.Millisecond, "failed to receive expected scrapes")
+
 	// This begins the processing of the scrapes collected by the receiver
 	metrics := cms.AllMetrics()
 	// split and store results by target name
 	pResults := splitMetricsByTarget(metrics)
-	lres, lep := len(pResults), len(mp.endpoints)
-	// There may be an additional scrape entry between when the mock server provided
-	// all responses and when we capture the metrics.  It will be ignored later.
-	assert.GreaterOrEqualf(t, lres, lep, "want at least %d targets, but got %v\n", lep, lres)
+	lep := len(mp.endpoints)
 
 	// loop to validate outputs for each targets
 	// Stop once we have evaluated all expected results, any others are superfluous.
 	for _, target := range targets[:lep] {
 		t.Run(target.name, func(t *testing.T) {
-			name := target.name
-			if target.relabeledJob != "" {
-				name = target.relabeledJob
-			}
-			scrapes := pResults[name]
+			scrapes := pResults[getTargetName(target)]
 			if !target.validateScrapes {
-				scrapes = getValidScrapes(t, pResults[name], target)
+				scrapes = getValidScrapes(t, scrapes, target)
 			}
 			target.validateFunc(t, target, scrapes)
 		})


### PR DESCRIPTION
#### Description

This makes the test server ignore failed (up=0) scrapes, and wait for a successful one (up=1).  It is roughly equivalent to wrapping the test in an assert.Eventually.  Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45772. cc @aknuds1 

It is possible for scrapes to fail because they can be interrupted by service discovery reloading. The next one will succeed in that case.

Alternatively, we could make the reload interval longer (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/403381c830447542705719756ba2cb4afcec27ca/receiver/prometheusreceiver/metrics_receiver_test.go#L1650), but that will just make the flakes less likely.  Overall, it seems fine to just ignore failed scrapes since the point of the tests is to check the end-to-end translation, not to test the reliability of the scraper.

#### Link to tracking issue

Addresses the latest flake here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42892#issuecomment-4087328479

Gemini helped me debug and write this PR, but I've reviewed the rationale and tweaked the implementation as needed.