### PR TITLE
[processor/transform] Normalize aggregate_on_attributes behavior with feature gate

### DIFF
--- a/.chloggen/46049-normalize-aggregate-on-attributes.yaml
+++ b/.chloggen/46049-normalize-aggregate-on-attributes.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: processor/transform
+note: "Introduce the `processor.transform.AggregateOnAttributesRequireAttributes` alpha feature gate to normalize `aggregate_on_attributes` behavior. When the attributes parameter is omitted, a warning is now logged. When the gate is enabled, the parameter is required."
+issues: [46049]
+subtext:
+change_logs: [user]
+

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -545,6 +545,8 @@ The optional `attributes` argument controls which datapoint attributes are kept 
 - `[]` (empty list): all datapoint attributes are removed. Aggregation is performed across all data points in the metric.
 - `[...]` (list of attribute keys): only the specified data point attributes are kept. All other attributes are removed, and aggregation is performed by grouping on the remaining attributes.
 
+**Deprecation notice:** Calling `aggregate_on_attributes` without the `attributes` parameter is deprecated because it is a no-op. A warning is now logged when this is detected. The `processor.transform.AggregateOnAttributesRequireAttributes` feature gate (alpha) can be enabled to make this parameter required. See [#46049](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46049).
+
 **NOTE:** This function is supported only in `metric` context.
 
 The following metric types can be aggregated:

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics.go
@@ -8,11 +8,20 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/aggregateutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
+)
+
+var aggregateOnAttributesRequireAttributesGate = featuregate.GlobalRegistry().MustRegister(
+	"processor.transform.AggregateOnAttributesRequireAttributes",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, the aggregate_on_attributes function requires the 'attributes' parameter to be set explicitly. Omitting it is currently a no-op and will be removed in a future version."),
+	featuregate.WithRegisterFromVersion("v0.148.0"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46049"),
 )
 
 type aggregateOnAttributesArguments struct {
@@ -24,7 +33,7 @@ func newAggregateOnAttributesFactory() ottl.Factory[*ottlmetric.TransformContext
 	return ottl.NewFactory("aggregate_on_attributes", &aggregateOnAttributesArguments{}, createAggregateOnAttributesFunction)
 }
 
-func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+func createAggregateOnAttributesFunction(fCtx ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*aggregateOnAttributesArguments)
 
 	if !ok {
@@ -34,6 +43,18 @@ func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Argu
 	t, err := aggregateutil.ConvertToAggregationFunction(args.AggregationFunction)
 	if err != nil {
 		return nil, fmt.Errorf("invalid aggregation function: '%s', valid options: %s", err.Error(), aggregateutil.GetSupportedAggregationFunctionsList())
+	}
+
+	if args.Attributes.IsEmpty() {
+		if aggregateOnAttributesRequireAttributesGate.IsEnabled() {
+			return nil, errors.New("the 'attributes' parameter is required when the " +
+				"processor.transform.AggregateOnAttributesRequireAttributes feature gate is enabled. " +
+				"Omitting it is a no-op; either pass the desired attributes list or remove the statement")
+		}
+		fCtx.Set.Logger.Warn("aggregate_on_attributes called without the 'attributes' parameter, which is a no-op. " +
+			"This will be required in a future version. " +
+			"Either pass the desired attributes list (e.g. aggregate_on_attributes(\"sum\", [\"attr1\"])) or remove the statement. " +
+			"See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46049 for more details.")
 	}
 
 	return AggregateOnAttributes(t, args.Attributes)

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
@@ -9,7 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/aggregateutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -464,4 +468,41 @@ func getTestExponentialHistogramMetricMultiple() pmetric.Metric {
 	input2.SetSum(12.66)
 
 	return metricInput
+}
+
+func Test_aggregateOnAttributes_featureGateEnabled_omittedAttributes_returnsError(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set(
+		"processor.transform.AggregateOnAttributesRequireAttributes", true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(
+			"processor.transform.AggregateOnAttributesRequireAttributes", false))
+	}()
+
+	fCtx := ottl.FunctionContext{
+		Set: componenttest.NewNopTelemetrySettings(),
+	}
+	args := &aggregateOnAttributesArguments{
+		AggregationFunction: "sum",
+		Attributes:          ottl.Optional[[]string]{}, // omitted
+	}
+	_, err := createAggregateOnAttributesFunction(fCtx, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attributes' parameter is required")
+}
+
+func Test_aggregateOnAttributes_featureGateDisabled_omittedAttributes_logsWarning(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	settings := componenttest.NewNopTelemetrySettings()
+	settings.Logger = zap.New(core)
+
+	fCtx := ottl.FunctionContext{Set: settings}
+	args := &aggregateOnAttributesArguments{
+		AggregationFunction: "sum",
+		Attributes:          ottl.Optional[[]string]{}, // omitted
+	}
+	exprFunc, err := createAggregateOnAttributesFunction(fCtx, args)
+	require.NoError(t, err)
+	assert.NotNil(t, exprFunc)
+	assert.Equal(t, 1, observed.Len())
+	assert.Contains(t, observed.All()[0].Message, "aggregate_on_attributes called without the 'attributes' parameter")
 }


### PR DESCRIPTION
CLOSED IT IN FAVOUR OF #46309  WHICH I MISSED, MY BAD
### Description

Currently, the `aggregate_on_attributes` function has an inconsistent behavior when the `attributes` parameter is omitted vs passed as an empty slice `[]`:

- `aggregate_on_attributes("sum")` -- attributes omitted --> `FilterAttrs` receives `nil` --> **skips filtering entirely** --> all attributes are kept --> effectively a **no-op**
- `aggregate_on_attributes("sum", [])` -- empty slice --> `FilterAttrs` clears all attributes --> all datapoints merge into one

This is a user trap: calling the function without the second argument looks like it should aggregate everything, but it silently does nothing useful (only merges datapoints that already share identical attribute sets).

This PR introduces the first step of the migration plan outlined in #46049 by @edmocosta :

- **Registers an alpha feature gate** (`processor.transform.AggregateOnAttributesRequireAttributes`) to control the breaking change
- **Logs a warning** at parse time when the `attributes` parameter is omitted (gate disabled), informing users to either pass the desired attributes list or remove the no-op statement
- **Returns an error** when the `attributes` parameter is omitted and the gate is enabled, making the parameter required
- **Updates README** with a deprecation notice
- **Adds tests** for both gate-enabled (error path) and gate-disabled (warning log path) behaviors

No behavioral change occurs with the gate disabled (default) -- existing configs continue to work, they just get a warning.

#### Testing

- Added test verifying that omitting `attributes` with the gate **enabled** returns an error
- Added test verifying that omitting `attributes` with the gate **disabled** logs a warning
- All existing `aggregate_on_attributes` tests continue to pass

#### Documentation

- Updated `processor/transformprocessor/README.md` with a deprecation notice for omitting the `attributes` parameter