### PR TITLE
[receiver/windowseventlog] Utilize WaitForSingleObject instead of polling

### DIFF
--- a/.chloggen/fix_wait-for-single-object.yaml
+++ b/.chloggen/fix_wait-for-single-object.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/windowseventlog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Utilize Windows Event API WaitForSingleObject instead of polling
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47091]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/internal/metadata/generated_feature_gates.go
+++ b/pkg/stanza/internal/metadata/generated_feature_gates.go
@@ -37,3 +37,11 @@ var StanzaSynchronousLogEmitterFeatureGate = featuregate.GlobalRegistry().MustRe
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35456"),
 	featuregate.WithRegisterFromVersion("v0.122.0"),
 )
+
+var StanzaWindowsEventDrivenScrapingFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"stanza.windows.eventDrivenScraping",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, switches the Windows Event receiver to an event-driven scraping model using WaitForSingleObject."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47091"),
+	featuregate.WithRegisterFromVersion("v0.104.0"),
+)

--- a/pkg/stanza/metadata.yaml
+++ b/pkg/stanza/metadata.yaml
@@ -35,3 +35,9 @@ feature_gates:
       Prevents possible data loss in Stanza-based receivers by emitting logs synchronously.
     from_version: v0.122.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35456
+  - id: stanza.windows.eventDrivenScraping
+    stage: alpha
+    description: >-
+      When enabled, switches the Windows Event receiver to an event-driven scraping model using WaitForSingleObject.
+    from_version: v0.104.0
+    reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47091

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sys/windows"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
@@ -183,6 +184,10 @@ func (i *Input) Stop() error {
 		i.cancel()
 	}
 
+	if i.subscription.signalEvent != 0 {
+		_ = windows.SetEvent(i.subscription.signalEvent)
+	}
+
 	i.wg.Wait()
 
 	var errs error
@@ -204,15 +209,26 @@ func (i *Input) Stop() error {
 func (i *Input) pollAndRead(ctx context.Context) {
 	defer i.wg.Done()
 
+	useEventDriven := metadata.StanzaWindowsEventDrivenScrapingFeatureGate.IsEnabled()
+
 	for {
 		i.eventsReadInPollCycle = 0
 
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(i.pollInterval):
-			i.read(ctx)
+		if useEventDriven && i.subscription.signalEvent != 0 {
+			_, _ = windows.WaitForSingleObject(i.subscription.signalEvent, windows.INFINITE)
+		} else {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(i.pollInterval):
+			}
 		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		i.read(ctx)
 	}
 }
 

--- a/pkg/stanza/operator/input/windows/input_test.go
+++ b/pkg/stanza/operator/input/windows/input_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/sys/windows"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
@@ -511,4 +513,53 @@ func TestInputRead_Batching(t *testing.T) {
 	assert.Equal(t, requiredNextCalls, nextCalls)
 	assert.Equal(t, maxEventsToEmit, processedEvents)
 	assert.Equal(t, input.currentMaxReads, input.maxReads)
+}
+
+// TestInput_EventDrivenScraping_Lifecycle ensures that when the event-driven feature gate is enabled,
+// the Input goroutine correctly blocks on the signal event and wakes up gracefully on Stop().
+func TestInput_EventDrivenScraping_Lifecycle(t *testing.T) {
+	// Enable the alpha feature gate for this test
+	require.NoError(t, featuregate.GlobalRegistry().Set(metadata.StanzaWindowsEventDrivenScrapingFeatureGate.ID(), true))
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(metadata.StanzaWindowsEventDrivenScrapingFeatureGate.ID(), false)
+	}()
+
+	// Mock EvtSubscribe and EvtClose to succeed without needing a real Windows Event channel
+	originalEvtSubscribe := evtSubscribe
+	originalEvtClose := evtClose
+	defer func() {
+		evtSubscribe = originalEvtSubscribe
+		evtClose = originalEvtClose
+	}()
+
+	evtSubscribe = func(_ uintptr, _ windows.Handle, _, _ *uint16, _, _, _ uintptr, _ uint32) (uintptr, error) {
+		return 42, nil // Return a dummy handle on success
+	}
+	evtClose = func(_ uintptr) error {
+		return nil
+	}
+
+	input := newTestInput()
+	input.channel = "test-channel"
+	input.startAt = "beginning"
+	input.pollInterval = 1 * time.Second
+
+	persister := testutil.NewMockPersister("")
+
+	err := input.Start(persister)
+	require.NoError(t, err)
+
+	// Verify Stop() correctly unblocks the infinite wait
+	done := make(chan struct{})
+	go func() {
+		err := input.Stop()
+		assert.NoError(t, err)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Stop() timed out, likely deadlocked on WaitForSingleObject")
+	}
 }

--- a/pkg/stanza/operator/input/windows/subscription.go
+++ b/pkg/stanza/operator/input/windows/subscription.go
@@ -16,6 +16,7 @@ import (
 // Subscription is a subscription to a windows eventlog channel.
 type Subscription struct {
 	handle        uintptr
+	signalEvent   windows.Handle
 	Server        string
 	startAt       string
 	sessionHandle uintptr
@@ -36,9 +37,6 @@ func (s *Subscription) Open(startAt string, sessionHandle uintptr, channel strin
 	if err != nil {
 		return fmt.Errorf("failed to create signal handle: %w", err)
 	}
-	defer func() {
-		_ = windows.CloseHandle(signalEvent)
-	}()
 
 	if channel != "" && query != nil {
 		return errors.New("can not supply both query and channel")
@@ -63,6 +61,7 @@ func (s *Subscription) Open(startAt string, sessionHandle uintptr, channel strin
 	}
 
 	s.handle = subscriptionHandle
+	s.signalEvent = signalEvent
 	s.startAt = startAt
 	s.sessionHandle = sessionHandle
 	s.channel = channel
@@ -79,6 +78,11 @@ func (s *Subscription) Close() error {
 
 	if err := evtClose(s.handle); err != nil {
 		return fmt.Errorf("failed to close subscription handle: %w", err)
+	}
+
+	if s.signalEvent != 0 {
+		_ = windows.CloseHandle(s.signalEvent)
+		s.signalEvent = 0
 	}
 
 	s.handle = 0


### PR DESCRIPTION
Fixes #47091