### PR TITLE
[receiver/hostmetrics] Add AIX to process scraper supported OS list

### DIFF
--- a/.chloggen/fix-hostmetrics-process-scraper-aix-support.yaml
+++ b/.chloggen/fix-hostmetrics-process-scraper-aix-support.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: receiver/host_metrics
+
+note: Add AIX to the process scraper's supported-OS allowlist. The AIX-specific scraper implementation is added separately.
+
+issues: [47095]
+
+subtext:
+
+change_logs: []

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
@@ -32,8 +32,11 @@ func createMetricsScraper(
 	settings scraper.Settings,
 	cfg component.Config,
 ) (scraper.Metrics, error) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" {
-		return nil, errors.New("process scraper only available on Linux, Windows, macOS, or FreeBSD")
+	// Hardcoded supported-OS list pending mdatagen `supported_os` annotation support.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
+	// migrate to a metadata.yaml declaration and drop the runtime.GOOS check once it lands.
+	if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" && runtime.GOOS != "aix" {
+		return nil, errors.New("process scraper only available on Linux, Windows, macOS, FreeBSD, or AIX")
 	}
 
 	s, err := newProcessScraper(settings, cfg.(*Config))

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory_test.go
@@ -25,7 +25,7 @@ func TestCreateResourceMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetrics(t.Context(), scrapertest.NewNopSettings(metadata.Type), cfg)
 
-	if runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "freebsd" {
+	if runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "freebsd" || runtime.GOOS == "aix" {
 		assert.NoError(t, err)
 		assert.NotNil(t, scraper)
 	} else {


### PR DESCRIPTION
#### Description

Adds `aix` to the process scraper factory's supported-OS allowlist. This is the minimum change needed to enable the process scraper on AIX; the AIX implementation itself is in #47102.

A code comment is added at the check site pointing to open-telemetry/opentelemetry-collector#15020, where mdatagen is being considered for `supported_os` annotations in `metadata.yaml`. When that mechanism lands, this hardcoded list should be migrated.

This replaces the earlier direction of probing gopsutil at runtime, per codeowner feedback on #47095 preferring a curated allowlist.

#### Link to tracking issue

Partially addresses #47095

#### Testing

Factory test updated to include AIX in the supported-OS set.
