### PR TITLE
[receiver/hostmetrics] Add AIX to system scraper supported OS list

### DIFF
--- a/.chloggen/fix-hostmetrics-system-scraper-aix-support.yaml
+++ b/.chloggen/fix-hostmetrics-system-scraper-aix-support.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: receiver/host_metrics
+
+note: Add AIX to the system scraper's supported-OS allowlist.
+
+issues: [47095]
+
+subtext:
+
+change_logs: []

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/factory.go
@@ -14,9 +14,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata"
 )
 
+// Hardcoded supported-OS list pending mdatagen `supported_os` annotation support.
+// See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
+// migrate to a metadata.yaml declaration and drop the runtime.GOOS check once it lands.
 var (
-	supportedOS      = runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin"
-	errUnsupportedOS = errors.New("the system scraper is only available on Linux, Windows, or macOS")
+	supportedOS      = runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "aix"
+	errUnsupportedOS = errors.New("the system scraper is only available on Linux, Windows, macOS, or AIX")
 )
 
 // NewFactory for System scraper.


### PR DESCRIPTION
#### Description

Adds `aix` to the system scraper factory's supported-OS allowlist (the `supportedOS` boolean).

A code comment is added at the check site pointing to open-telemetry/opentelemetry-collector#15020, where mdatagen is being considered for `supported_os` annotations in `metadata.yaml`. When that mechanism lands, this hardcoded list should be migrated.

This replaces the earlier direction of probing gopsutil at runtime, per codeowner feedback on #47095 preferring a curated allowlist.

#### Link to tracking issue

Partially addresses #47095

#### Testing

Factory test updated to include AIX in the supported-OS set.
