### PR TITLE
[receiver/hostmetrics] Handle nil PageFaultsStat in process scraper

### DIFF
--- a/.chloggen/fix-hostmetrics-nil-pagefaults.yaml
+++ b/.chloggen/fix-hostmetrics-nil-pagefaults.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/hostmetrics
+
+note: Handle nil PageFaultsStat in process scraper to prevent panic on zombie processes.
+
+issues: [47095]
+
+subtext:
+
+change_logs: []

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -372,6 +372,9 @@ func (s *processScraper) scrapeAndAppendPagingMetric(ctx context.Context, now pc
 	if err != nil {
 		return err
 	}
+	if pageFaultsStat == nil {
+		return nil
+	}
 
 	s.mb.RecordProcessPagingFaultsDataPoint(now, int64(pageFaultsStat.MajorFaults), metadata.AttributePagingFaultTypeMajor)
 	s.mb.RecordProcessPagingFaultsDataPoint(now, int64(pageFaultsStat.MinorFaults), metadata.AttributePagingFaultTypeMinor)


### PR DESCRIPTION
#### Description
`PageFaultsWithContext` can return `nil` without an error for zombie processes (where `/proc/<pid>/status` doesn't exist). The scraper dereferences this without checking, causing a panic. Found while testing AIX platform support with pending gopsutil changes, where zombie processes in the process table triggered the crash.

This adds a nil check and returns early when there's no data to record.

#### Link to tracking issue
Partially addresses #47095

#### Testing
All existing tests pass. The nil case occurs at runtime with zombie processes which are difficult to reproduce deterministically in unit tests.

#### Documentation
No documentation changes needed.
