### PR TITLE
[receiver/hostmetrics] Warn and disable process.context_switches and process.paging.faults on unsupported platforms

### DIFF
--- a/.chloggen/fix-hostmetrics-context-switches-validation.yaml
+++ b/.chloggen/fix-hostmetrics-context-switches-validation.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: receiver/host_metrics
+
+note: Warn and disable process.context_switches at startup on platforms where it is not supported, instead of logging an error every scrape cycle.
+
+issues: [47095]
+
+subtext: |
+  process.context_switches is only supported on Linux. Previously, enabling it on other
+  platforms would spam "not implemented" errors on every scrape cycle for every process.
+  The factory now checks for this at construction, logs a single warning, and disables
+  the metric so the hot path is never exercised.
+
+change_logs: [user]

--- a/.chloggen/fix-hostmetrics-paging-faults-validation.yaml
+++ b/.chloggen/fix-hostmetrics-paging-faults-validation.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: receiver/host_metrics
+
+note: Warn and disable process.paging.faults at startup on platforms where it is not supported, instead of logging an error every scrape cycle.
+
+issues: [47095]
+
+subtext: |
+  process.paging.faults is only supported on Linux. Previously, enabling it on other
+  platforms would spam "not implemented" errors on every scrape cycle for every process.
+  The factory now checks for this at construction, logs a single warning, and disables
+  the metric so the hot path is never exercised.
+
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
@@ -39,7 +39,10 @@ func createMetricsScraper(
 		return nil, errors.New("process scraper only available on Linux, Windows, macOS, FreeBSD, or AIX")
 	}
 
-	s, err := newProcessScraper(settings, cfg.(*Config))
+	pCfg := cfg.(*Config)
+	validatePlatformEnabledMetrics(pCfg, settings.Logger)
+
+	s, err := newProcessScraper(settings, pCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
+
+import (
+	"go.uber.org/zap"
+)
+
+// validatePlatformEnabledMetrics disables metrics that are not supported on this platform
+// and logs a warning once so the user can correct their config.
+//
+// Hand-written fallback pending mdatagen `supported_os` annotation support.
+// See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
+// replace this with the generated equivalent once it lands.
+func validatePlatformEnabledMetrics(_ *Config, _ *zap.Logger) {
+	// All currently-gated metrics are supported on Linux.
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestValidatePlatformEnabledMetrics_Linux_LeavesContextSwitchesEnabled(t *testing.T) {
 	cfg := &Config{
-		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
 	cfg.Metrics.ProcessContextSwitches.Enabled = true
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package processscraper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+)
+
+func TestValidatePlatformEnabledMetrics_Linux_LeavesContextSwitchesEnabled(t *testing.T) {
+	cfg := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.ProcessContextSwitches.Enabled = true
+
+	validatePlatformEnabledMetrics(cfg, zap.NewNop())
+
+	assert.True(t, cfg.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should remain enabled on Linux")
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others.go
@@ -20,4 +20,8 @@ func validatePlatformEnabledMetrics(cfg *Config, logger *zap.Logger) {
 		logger.Warn("process.context_switches is only supported on Linux; disabling metric on this platform")
 		cfg.Metrics.ProcessContextSwitches.Enabled = false
 	}
+	if cfg.Metrics.ProcessPagingFaults.Enabled {
+		logger.Warn("process.paging.faults is only supported on Linux; disabling metric on this platform")
+		cfg.Metrics.ProcessPagingFaults.Enabled = false
+	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
+
+import (
+	"go.uber.org/zap"
+)
+
+// validatePlatformEnabledMetrics disables metrics that are not supported on this platform
+// and logs a warning once so the user can correct their config.
+//
+// Hand-written fallback pending mdatagen `supported_os` annotation support.
+// See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
+// replace this with the generated equivalent once it lands.
+func validatePlatformEnabledMetrics(cfg *Config, logger *zap.Logger) {
+	if cfg.Metrics.ProcessContextSwitches.Enabled {
+		logger.Warn("process.context_switches is only supported on Linux; disabling metric on this platform")
+		cfg.Metrics.ProcessContextSwitches.Enabled = false
+	}
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
@@ -31,6 +31,22 @@ func TestValidatePlatformEnabledMetrics_NonLinux_DisablesContextSwitches(t *test
 	assert.Contains(t, logs.All()[0].Message, "process.context_switches")
 }
 
+func TestValidatePlatformEnabledMetrics_NonLinux_DisablesPagingFaults(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.ProcessPagingFaults.Enabled = true
+
+	validatePlatformEnabledMetrics(cfg, logger)
+
+	assert.False(t, cfg.Metrics.ProcessPagingFaults.Enabled, "process.paging.faults should be disabled on non-Linux")
+	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
+	assert.Contains(t, logs.All()[0].Message, "process.paging.faults")
+}
+
 func TestValidatePlatformEnabledMetrics_NonLinux_NoopWhenDisabled(t *testing.T) {
 	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
@@ -39,9 +55,11 @@ func TestValidatePlatformEnabledMetrics_NonLinux_NoopWhenDisabled(t *testing.T) 
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}
 	cfg.Metrics.ProcessContextSwitches.Enabled = false
+	cfg.Metrics.ProcessPagingFaults.Enabled = false
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
 	assert.False(t, cfg.Metrics.ProcessContextSwitches.Enabled)
-	assert.Equal(t, 0, logs.Len(), "no log when metric was not enabled")
+	assert.False(t, cfg.Metrics.ProcessPagingFaults.Enabled)
+	assert.Equal(t, 0, logs.Len(), "no log when metrics were not enabled")
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package processscraper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+)
+
+func TestValidatePlatformEnabledMetrics_NonLinux_DisablesContextSwitches(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.ProcessContextSwitches.Enabled = true
+
+	validatePlatformEnabledMetrics(cfg, logger)
+
+	assert.False(t, cfg.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should be disabled on non-Linux")
+	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
+	assert.Contains(t, logs.All()[0].Message, "process.context_switches")
+}
+
+func TestValidatePlatformEnabledMetrics_NonLinux_NoopWhenDisabled(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.ProcessContextSwitches.Enabled = false
+
+	validatePlatformEnabledMetrics(cfg, logger)
+
+	assert.False(t, cfg.Metrics.ProcessContextSwitches.Enabled)
+	assert.Equal(t, 0, logs.Len(), "no log when metric was not enabled")
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
@@ -20,7 +20,7 @@ func TestValidatePlatformEnabledMetrics_NonLinux_DisablesContextSwitches(t *test
 	logger := zap.New(core)
 
 	cfg := &Config{
-		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
 	cfg.Metrics.ProcessContextSwitches.Enabled = true
 
@@ -36,7 +36,7 @@ func TestValidatePlatformEnabledMetrics_NonLinux_DisablesPagingFaults(t *testing
 	logger := zap.New(core)
 
 	cfg := &Config{
-		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
 	cfg.Metrics.ProcessPagingFaults.Enabled = true
 
@@ -52,7 +52,7 @@ func TestValidatePlatformEnabledMetrics_NonLinux_NoopWhenDisabled(t *testing.T) 
 	logger := zap.New(core)
 
 	cfg := &Config{
-		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
 	cfg.Metrics.ProcessContextSwitches.Enabled = false
 	cfg.Metrics.ProcessPagingFaults.Enabled = false


### PR DESCRIPTION
#### Description

Per codeowner feedback on #47095 (see also [this comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47095#issuecomment-4305100695) approving scope expansion to other same-pattern metrics), replaces the earlier file-split approach with a warn-and-disable fallback implemented directly in hostmetrics. At factory construction, a platform-specific validation function runs once: if a Linux-only process metric is enabled on a platform where gopsutil doesn't support it, it logs a warning and disables the metric. No per-scrape error spam, no silent drops.

Covers:
- `process.context_switches` (Linux-only — gopsutil reads `/proc/[tid]/stat`)
- `process.paging.faults` (Linux-only — gopsutil reads `/proc/<pid>/stat`)

The shared scrape methods are unchanged; the existing `if !Enabled { return nil }` short-circuit handles the disabled case, so the unsupported gopsutil path is never reached.

This is an interim. The strategic target is `supported_os` annotations in `metadata.yaml` tracked in open-telemetry/opentelemetry-collector#15020; once that lands, this hand-written validation should be migrated to the generated path.

#### Link to tracking issue

Partially addresses #47095

#### Testing

Unit tests for the new validation function on Linux and non-Linux platforms covering both metrics.
