### PR TITLE
[receiver/hostmetrics] Add AIX process scraper implementation

### DIFF
--- a/.chloggen/fix-hostmetrics-aix-process-scraper.yaml
+++ b/.chloggen/fix-hostmetrics-aix-process-scraper.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: receiver/host_metrics
+
+note: Add AIX-specific process scraper implementation.
+
+issues: [47095]
+
+subtext: |
+  Implements AIX versions of the platform-specific process scraper hooks
+  (CPU time/utilization recording, process name, executable, and command
+  extraction), replacing the previous empty stubs that the "others"
+  fallback provided.
+
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_aix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_aix.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build aix
+
+package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
+)
+
+// firstFieldRegex matches the first whitespace-delimited field of a command
+// line (the executable). Compiled once at package load rather than on every
+// getProcessExecutable call.
+var firstFieldRegex = regexp.MustCompile(`^\S+`)
+
+func (s *processScraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.Iowait, metadata.AttributeStateWait)
+}
+
+func (s *processScraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.User, metadata.AttributeStateUser)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.System, metadata.AttributeStateSystem)
+	s.mb.RecordProcessCPUUtilizationDataPoint(now, cpuUtilization.Iowait, metadata.AttributeStateWait)
+}
+
+func getProcessName(ctx context.Context, proc processHandle, _ string) (string, error) {
+	name, err := proc.NameWithContext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return name, nil
+}
+
+func getProcessCgroup(_ context.Context, _ processHandle) (string, error) {
+	return "", nil
+}
+
+func getProcessExecutable(ctx context.Context, proc processHandle) (string, error) {
+	cmdline, err := proc.CmdlineWithContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	exe := firstFieldRegex.FindString(cmdline)
+
+	return exe, nil
+}
+
+func getProcessCommand(ctx context.Context, proc processHandle) (*commandMetadata, error) {
+	cmdline, err := proc.CmdlineWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	command := &commandMetadata{command: cmdline, commandLine: cmdline}
+	return command, nil
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !linux && !windows && !darwin && !freebsd
+//go:build !linux && !windows && !darwin && !freebsd && !aix
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 


### PR DESCRIPTION
#### Description

Adds the AIX-specific implementation of the process scraper (`process_scraper_aix.go`). The factory allowlist bump is in #47096.

This stacks on #47100/#47101, which together ensure that metrics not supported on AIX (`process.context_switches`, `process.handles`) are disabled at startup with a warning rather than spamming errors every scrape cycle. The earlier `scrapeAndAppendContextSwitchMetrics` no-op override is no longer needed under the validation-only fallback and has been removed.

#### Link to tracking issue

Partially addresses #47095

#### Testing

Existing process scraper tests cover the AIX path via build-tagged files. Cross-compile verified with `GOOS=aix GOARCH=ppc64`.
