### PR TITLE
[stanza/recombine]: fix stop ticker inside mutex in Stop() to prevent …

### DIFF
--- a/pkg/stanza/operator/transformer/recombine/transformer.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer.go
@@ -85,13 +85,17 @@ func (t *Transformer) flushLoop() {
 
 func (t *Transformer) Stop() error {
 	t.Lock()
-	defer t.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	t.flushAllSources(ctx, t.Write)
 
+	// Stop the ticker and close the shutdown channel while still holding the
+	// lock.  This prevents the flusher goroutine from re-entering
+	// flushAllSources between our unlock and the channel close.
+	t.ticker.Stop()
 	close(t.chClose)
+	t.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
### Description
This PR fixes a shutdown race in recombine by stopping ticker operations under proper synchronization in Stop(). It also removes a temporary PR notes markdown file that was accidentally included earlier.

### Motivation and Context
Without this fix, shutdown timing could race under load and lead to unstable behavior. The synchronization change makes stop semantics safer and more deterministic.

### Type of change
Bug fix / Reliability improvement