### PR TITLE
Add service.name as a default-enabled resource attribute 

### DIFF
--- a/.chloggen/oracledb-unique-db-identifier.yaml
+++ b/.chloggen/oracledb-unique-db-identifier.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/oracledb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add service.name as a default-enabled resource attribute for unique database identification
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46176]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The receiver now emits `service.name` as a default resource attribute with the value `oracle`,
+  aligning with OpenTelemetry semantic conventions for database resources.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/oracledb-unique-db-identifier.yaml
+++ b/.chloggen/oracledb-unique-db-identifier.yaml
@@ -10,7 +10,7 @@ component: receiver/oracledb
 note: Add service.name as a default-enabled resource attribute for unique database identification
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [46176]
+issues: [47088]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -477,4 +477,4 @@ Collection of event metrics for top N queries, filtered based on the highest CPU
 | host.name | The host name of Oracle Server | Any Str | true |
 | oracledb.instance.name | The name of the instance that data is coming from. | Any Str | true |
 | service.instance.id | A unique identifier of the Oracle DB instance in the format host:port/serviceName. (defaults to 'unknown:1521', in case of error in generating this value) | Any Str | true |
-| service.name | Logical name of the service. Defaults to the db.system.name value: oracle. | Any Str | true |
+| service.name | Logical name of the service. Defaults to the db.system.name value: oracle.db. | Any Str | true |

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -477,3 +477,4 @@ Collection of event metrics for top N queries, filtered based on the highest CPU
 | host.name | The host name of Oracle Server | Any Str | true |
 | oracledb.instance.name | The name of the instance that data is coming from. | Any Str | true |
 | service.instance.id | A unique identifier of the Oracle DB instance in the format host:port/serviceName. (defaults to 'unknown:1521', in case of error in generating this value) | Any Str | true |
+| service.name | Logical name of the service. Defaults to the db.system.name value: oracle. | Any Str | true |

--- a/receiver/oracledbreceiver/generated_package_test.go
+++ b/receiver/oracledbreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package oracledbreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/oracledbreceiver/generated_package_test.go
+++ b/receiver/oracledbreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package oracledbreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -451,6 +451,33 @@ $defs:
             type: array
             items:
               $ref: go.opentelemetry.io/collector/filter.config
+      service.name:
+        description: ResourceAttributeConfig provides common config for a service.name resource attribute.
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          metrics_include:
+            description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          metrics_exclude:
+            description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          events_include:
+            description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          events_exclude:
+            description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for oracledb metrics builder.
     type: object

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1191,6 +1191,7 @@ type ResourceAttributesConfig struct {
 	HostName             ResourceAttributeConfig `mapstructure:"host.name"`
 	OracledbInstanceName ResourceAttributeConfig `mapstructure:"oracledb.instance.name"`
 	ServiceInstanceID    ResourceAttributeConfig `mapstructure:"service.instance.id"`
+	ServiceName          ResourceAttributeConfig `mapstructure:"service.name"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
@@ -1202,6 +1203,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		ServiceInstanceID: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		ServiceName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -163,6 +163,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					HostName:             ResourceAttributeConfig{Enabled: true},
 					OracledbInstanceName: ResourceAttributeConfig{Enabled: true},
 					ServiceInstanceID:    ResourceAttributeConfig{Enabled: true},
+					ServiceName:          ResourceAttributeConfig{Enabled: true},
 				},
 			},
 		},
@@ -307,6 +308,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					HostName:             ResourceAttributeConfig{Enabled: false},
 					OracledbInstanceName: ResourceAttributeConfig{Enabled: false},
 					ServiceInstanceID:    ResourceAttributeConfig{Enabled: false},
+					ServiceName:          ResourceAttributeConfig{Enabled: false},
 				},
 			},
 		},
@@ -355,6 +357,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 				HostName:             ResourceAttributeConfig{Enabled: true},
 				OracledbInstanceName: ResourceAttributeConfig{Enabled: true},
 				ServiceInstanceID:    ResourceAttributeConfig{Enabled: true},
+				ServiceName:          ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
@@ -363,6 +366,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 				HostName:             ResourceAttributeConfig{Enabled: false},
 				OracledbInstanceName: ResourceAttributeConfig{Enabled: false},
 				ServiceInstanceID:    ResourceAttributeConfig{Enabled: false},
+				ServiceName:          ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs.go
@@ -185,6 +185,12 @@ func NewLogsBuilder(lbc LogsBuilderConfig, settings receiver.Settings) *LogsBuil
 	if lbc.ResourceAttributes.ServiceInstanceID.EventsExclude != nil {
 		lb.resourceAttributeExcludeFilter["service.instance.id"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceInstanceID.EventsExclude)
 	}
+	if lbc.ResourceAttributes.ServiceName.EventsInclude != nil {
+		lb.resourceAttributeIncludeFilter["service.name"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceName.EventsInclude)
+	}
+	if lbc.ResourceAttributes.ServiceName.EventsExclude != nil {
+		lb.resourceAttributeExcludeFilter["service.name"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceName.EventsExclude)
+	}
 
 	return lb
 }

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
@@ -4,6 +4,9 @@ package metadata
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -11,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"testing"
-	"time"
 )
 
 type eventsTestDataSet int

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
@@ -4,9 +4,6 @@ package metadata
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -14,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"testing"
+	"time"
 )
 
 type eventsTestDataSet int

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
@@ -34,6 +34,7 @@ func TestLogsBuilderAppendLogRecord(t *testing.T) {
 	rb.SetHostName("host.name-val")
 	rb.SetOracledbInstanceName("oracledb.instance.name-val")
 	rb.SetServiceInstanceID("service.instance.id-val")
+	rb.SetServiceName("service.name-val")
 	res := rb.Emit()
 
 	// append the first log record
@@ -140,6 +141,7 @@ func TestLogsBuilder(t *testing.T) {
 			rb.SetHostName("host.name-val")
 			rb.SetOracledbInstanceName("oracledb.instance.name-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
+			rb.SetServiceName("service.name-val")
 			res := rb.Emit()
 			logs := lb.Emit(WithLogsResource(res))
 

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -2616,6 +2616,12 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	if mbc.ResourceAttributes.ServiceInstanceID.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["service.instance.id"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceInstanceID.MetricsExclude)
 	}
+	if mbc.ResourceAttributes.ServiceName.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["service.name"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceName.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.ServiceName.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["service.name"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceName.MetricsExclude)
+	}
 
 	for _, op := range options {
 		op.apply(mb)

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -243,6 +243,7 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetHostName("host.name-val")
 			rb.SetOracledbInstanceName("oracledb.instance.name-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
+			rb.SetServiceName("service.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {

--- a/receiver/oracledbreceiver/internal/metadata/generated_resource.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_resource.go
@@ -42,6 +42,13 @@ func (rb *ResourceBuilder) SetServiceInstanceID(val string) {
 	}
 }
 
+// SetServiceName sets provided value as "service.name" attribute.
+func (rb *ResourceBuilder) SetServiceName(val string) {
+	if rb.config.ServiceName.Enabled {
+		rb.res.Attributes().PutStr("service.name", val)
+	}
+}
+
 // Emit returns the built resource and resets the internal builder state.
 func (rb *ResourceBuilder) Emit() pcommon.Resource {
 	r := rb.res

--- a/receiver/oracledbreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_resource_test.go
@@ -16,15 +16,16 @@ func TestResourceBuilder(t *testing.T) {
 			rb.SetHostName("host.name-val")
 			rb.SetOracledbInstanceName("oracledb.instance.name-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
+			rb.SetServiceName("service.name-val")
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch tt {
 			case "default":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -45,6 +46,11 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, "service.instance.id-val", serviceInstanceIDAttrVal.Str())
+			}
+			serviceNameAttrVal, ok := res.Attributes().Get("service.name")
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, "service.name-val", serviceNameAttrVal.Str())
 			}
 		})
 	}

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -100,6 +100,8 @@ all_set:
       enabled: true
     service.instance.id:
       enabled: true
+    service.name:
+      enabled: true
 reaggregate_set:
   metrics:
     oracledb.consistent_gets:
@@ -200,6 +202,8 @@ reaggregate_set:
     oracledb.instance.name:
       enabled: true
     service.instance.id:
+      enabled: true
+    service.name:
       enabled: true
 none_set:
   metrics:
@@ -302,6 +306,8 @@ none_set:
       enabled: false
     service.instance.id:
       enabled: false
+    service.name:
+      enabled: false
 filter_set_include:
   resource_attributes:
     host.name:
@@ -317,6 +323,12 @@ filter_set_include:
       events_include:
         - regexp: ".*"
     service.instance.id:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+      events_include:
+        - regexp: ".*"
+    service.name:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -342,3 +354,9 @@ filter_set_exclude:
         - strict: "service.instance.id-val"
       events_exclude:
         - strict: "service.instance.id-val"
+    service.name:
+      enabled: true
+      metrics_exclude:
+        - strict: "service.name-val"
+      events_exclude:
+        - strict: "service.name-val"

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -28,6 +28,10 @@ resource_attributes:
     description: A unique identifier of the Oracle DB instance in the format host:port/serviceName. (defaults to 'unknown:1521', in case of error in generating this value)
     enabled: true
     type: string
+  service.name:
+    description: "Logical name of the service. Defaults to the db.system.name value: oracle."
+    enabled: true
+    type: string
 
 attributes:
   client.address:

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -29,7 +29,7 @@ resource_attributes:
     enabled: true
     type: string
   service.name:
-    description: "Logical name of the service. Defaults to the db.system.name value: oracle."
+    description: "Logical name of the service. Defaults to the db.system.name value: oracle.db."
     enabled: true
     type: string
 

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -873,7 +873,7 @@ func (s *oracleScraper) setupResourceBuilder(rb *metadata.ResourceBuilder) *meta
 	rb.SetOracledbInstanceName(s.instanceName)
 	rb.SetHostName(s.hostName)
 	rb.SetServiceInstanceID(s.serviceInstanceID)
-	rb.SetServiceName("oracle")
+	rb.SetServiceName("oracle.db")
 	return rb
 }
 

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -873,6 +873,7 @@ func (s *oracleScraper) setupResourceBuilder(rb *metadata.ResourceBuilder) *meta
 	rb.SetOracledbInstanceName(s.instanceName)
 	rb.SetHostName(s.hostName)
 	rb.SetServiceInstanceID(s.serviceInstanceID)
+	rb.SetServiceName("oracle")
 	return rb
 }
 

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -199,6 +199,96 @@ func TestScraper_Scrape(t *testing.T) {
 	}
 }
 
+func TestServiceNameResourceAttribute(t *testing.T) {
+	t.Run("metrics", func(t *testing.T) {
+		cfg := metadata.DefaultMetricsBuilderConfig()
+		scrpr := oracleScraper{
+			logger: zap.NewNop(),
+			mb:     metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+			dbProviderFunc: func() (*sql.DB, error) {
+				return nil, nil
+			},
+			clientProviderFunc: func(_ *sql.DB, s string, _ *zap.Logger) dbClient {
+				return &fakeDbClient{
+					Responses: [][]metricRow{
+						queryResponses[s],
+					},
+				}
+			},
+			id:                   component.ID{},
+			metricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+		}
+		err := scrpr.start(t.Context(), componenttest.NewNopHost())
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, scrpr.shutdown(t.Context())) }()
+
+		m, err := scrpr.scrape(t.Context())
+		require.NoError(t, err)
+
+		for i := 0; i < m.ResourceMetrics().Len(); i++ {
+			val, ok := m.ResourceMetrics().At(i).Resource().Attributes().Get("service.name")
+			require.True(t, ok, "service.name resource attribute missing on resource %d", i)
+			assert.Equal(t, "oracle", val.Str())
+		}
+	})
+
+	t.Run("logs", func(t *testing.T) {
+		var metricRowData []metricRow
+		metricRowFile := readFile("oracleQueryMetricsData.txt")
+		require.NoError(t, json.Unmarshal(metricRowFile, &metricRowData))
+
+		var logRowData []metricRow
+		logRowFile := readFile("oracleQueryPlanData.txt")
+		require.NoError(t, json.Unmarshal(logRowFile, &logRowData))
+
+		logsCfg := metadata.DefaultLogsBuilderConfig()
+		logsCfg.Events.DbServerTopQuery.Enabled = true
+		metricsCfg := metadata.DefaultMetricsBuilderConfig()
+		cacheValue := map[string]int64{"EXECUTIONS": 0}
+		lruCache, _ := lru.New[string, map[string]int64](500)
+		lruCache.Add("fxk8aq3nds8aw:0", cacheValue)
+
+		scrpr := oracleScraper{
+			logger: zap.NewNop(),
+			mb:     metadata.NewMetricsBuilder(metricsCfg, receivertest.NewNopSettings(metadata.Type)),
+			lb:     metadata.NewLogsBuilder(logsCfg, receivertest.NewNopSettings(metadata.Type)),
+			dbProviderFunc: func() (*sql.DB, error) {
+				return nil, nil
+			},
+			clientProviderFunc: func(_ *sql.DB, s string, _ *zap.Logger) dbClient {
+				if strings.Contains(s, "V$SQL_PLAN") {
+					return &fakeDbClient{Responses: [][]metricRow{logRowData}}
+				}
+				return &fakeDbClient{Responses: [][]metricRow{metricRowData}}
+			},
+			id:                   component.ID{},
+			metricsBuilderConfig: metricsCfg,
+			logsBuilderConfig:    logsCfg,
+			metricCache:          lruCache,
+			topQueryCollectCfg:   TopQueryCollection{MaxQuerySampleCount: 5000, TopQueryCount: 200},
+			instanceName:         "oraclehost:1521/ORCL",
+			hostName:             "oraclehost:1521",
+			obfuscator:           newObfuscator(),
+			serviceInstanceID:    getInstanceID("oraclehost:1521/ORCL", zap.NewNop()),
+		}
+		scrpr.logsBuilderConfig.Events.DbServerTopQuery.Enabled = true
+
+		err := scrpr.start(t.Context(), componenttest.NewNopHost())
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, scrpr.shutdown(t.Context())) }()
+
+		logs, err := scrpr.scrapeLogs(t.Context())
+		require.NoError(t, err)
+		require.Greater(t, logs.ResourceLogs().Len(), 0, "expected at least one ResourceLogs")
+
+		for i := 0; i < logs.ResourceLogs().Len(); i++ {
+			val, ok := logs.ResourceLogs().At(i).Resource().Attributes().Get("service.name")
+			require.True(t, ok, "service.name resource attribute missing on resource log %d", i)
+			assert.Equal(t, "oracle", val.Str())
+		}
+	})
+}
+
 func TestScraper_ScrapeTopNLogs(t *testing.T) {
 	var metricRowData []metricRow
 	var logRowData []metricRow

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -244,9 +244,9 @@ func TestServiceNameResourceAttribute(t *testing.T) {
 		logsCfg := metadata.DefaultLogsBuilderConfig()
 		logsCfg.Events.DbServerTopQuery.Enabled = true
 		metricsCfg := metadata.DefaultMetricsBuilderConfig()
-		cacheValue := map[string]int64{"EXECUTIONS": 0}
+		logsCacheValue := map[string]int64{"EXECUTIONS": 0}
 		lruCache, _ := lru.New[string, map[string]int64](500)
-		lruCache.Add("fxk8aq3nds8aw:0", cacheValue)
+		lruCache.Add("fxk8aq3nds8aw:0", logsCacheValue)
 
 		scrpr := oracleScraper{
 			logger: zap.NewNop(),
@@ -279,7 +279,7 @@ func TestServiceNameResourceAttribute(t *testing.T) {
 
 		logs, err := scrpr.scrapeLogs(t.Context())
 		require.NoError(t, err)
-		require.Greater(t, logs.ResourceLogs().Len(), 0, "expected at least one ResourceLogs")
+		require.Positive(t, logs.ResourceLogs().Len(), "expected at least one ResourceLogs")
 
 		for i := 0; i < logs.ResourceLogs().Len(); i++ {
 			val, ok := logs.ResourceLogs().At(i).Resource().Attributes().Get("service.name")

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -228,7 +228,7 @@ func TestServiceNameResourceAttribute(t *testing.T) {
 		for i := 0; i < m.ResourceMetrics().Len(); i++ {
 			val, ok := m.ResourceMetrics().At(i).Resource().Attributes().Get("service.name")
 			require.True(t, ok, "service.name resource attribute missing on resource %d", i)
-			assert.Equal(t, "oracle", val.Str())
+			assert.Equal(t, "oracle.db", val.Str())
 		}
 	})
 
@@ -284,7 +284,7 @@ func TestServiceNameResourceAttribute(t *testing.T) {
 		for i := 0; i < logs.ResourceLogs().Len(); i++ {
 			val, ok := logs.ResourceLogs().At(i).Resource().Attributes().Get("service.name")
 			require.True(t, ok, "service.name resource attribute missing on resource log %d", i)
-			assert.Equal(t, "oracle", val.Str())
+			assert.Equal(t, "oracle.db", val.Str())
 		}
 	})
 }

--- a/receiver/oracledbreceiver/testdata/expectedQueryTextAndPlanQuery.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedQueryTextAndPlanQuery.yaml
@@ -10,6 +10,9 @@ resourceLogs:
         - key: service.instance.id
           value:
             stringValue: oraclehost:1521/ORCL
+        - key: service.name
+          value:
+            stringValue: oracle
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/oracledbreceiver/testdata/expectedQueryTextAndPlanQuery.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedQueryTextAndPlanQuery.yaml
@@ -12,7 +12,7 @@ resourceLogs:
             stringValue: oraclehost:1521/ORCL
         - key: service.name
           value:
-            stringValue: oracle
+            stringValue: oracle.db
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/oracledbreceiver/testdata/expectedSamplesFile.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedSamplesFile.yaml
@@ -10,6 +10,9 @@ resourceLogs:
         - key: service.instance.id
           value:
             stringValue: oraclehost:1521/ORCL
+        - key: service.name
+          value:
+            stringValue: oracle
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/oracledbreceiver/testdata/expectedSamplesFile.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedSamplesFile.yaml
@@ -12,7 +12,7 @@ resourceLogs:
             stringValue: oraclehost:1521/ORCL
         - key: service.name
           value:
-            stringValue: oracle
+            stringValue: oracle.db
     scopeLogs:
       - logRecords:
           - attributes:


### PR DESCRIPTION
#### Summary
Add service.name as a default-enabled resource attribute with the value oracle.db,
aligning with OpenTelemetry semantic conventions for database resources.

#### Changes
Add service.name resource attribute to metadata.yaml (enabled by default, type string)
Set default value oracle.db in scraper.go via rb.SetServiceName()
Update generated files, golden test files, and config tests to reflect the new attribute

####  Linked Issues
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47088
