### PR TITLE
[chore] internal/aws: remove unused errCodeThrottlingException constant

### DIFF
--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -24,8 +24,7 @@ import (
 
 const (
 	// this is the retry count, the total attempts will be at most retry count + 1.
-	defaultRetryCount          = 1
-	errCodeThrottlingException = "ThrottlingException"
+	defaultRetryCount = 1
 )
 
 var containerInsightsRegexPattern = regexp.MustCompile(`^/aws/.*containerinsights/.*/(performance|prometheus)$`)


### PR DESCRIPTION
## Summary

Remove the unused `errCodeThrottlingException` constant from `internal/aws/cwlogs/cwlog_client.go`. It is declared but never referenced anywhere in the codebase.

## Test plan

- No behavioral change; existing tests continue to pass.
