### PR TITLE
[chore] Add paulojmdias as codeowner for filelog receiver and fileconsumer package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,7 +174,7 @@ pkg/pdatautil/                                                   @open-telemetry
 pkg/resourcetotelemetry/                                         @open-telemetry/collector-contrib-approvers @mx-psi
 pkg/sampling/                                                    @open-telemetry/collector-contrib-approvers @kentquirk @jmacd
 pkg/stanza/                                                      @open-telemetry/collector-contrib-approvers @andrzej-stencel
-pkg/stanza/fileconsumer/                                         @open-telemetry/collector-contrib-approvers @andrzej-stencel
+pkg/stanza/fileconsumer/                                         @open-telemetry/collector-contrib-approvers @andrzej-stencel @paulojmdias
 pkg/stanza/operator/input/journald/                              @open-telemetry/collector-contrib-approvers @belimawr @namco1992
 pkg/status/                                                      @open-telemetry/collector-contrib-approvers @evan-bradley
 pkg/translator/azure/                                            @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
@@ -265,7 +265,7 @@ receiver/elasticsearchreceiver/                                  @open-telemetry
 receiver/envoyalsreceiver/                                       @open-telemetry/collector-contrib-approvers @evan-bradley @zirain
 receiver/expvarreceiver/                                         @open-telemetry/collector-contrib-approvers @jamesmoessis @MovieStoreGuy
 receiver/faroreceiver/                                           @open-telemetry/collector-contrib-approvers @dehaansa @rlankfo @mar4uk
-receiver/filelogreceiver/                                        @open-telemetry/collector-contrib-approvers @andrzej-stencel
+receiver/filelogreceiver/                                        @open-telemetry/collector-contrib-approvers @andrzej-stencel @paulojmdias
 receiver/filestatsreceiver/                                      @open-telemetry/collector-contrib-approvers @atoulme
 receiver/flinkmetricsreceiver/                                   @open-telemetry/collector-contrib-approvers @JonathanWamsley
 receiver/fluentforwardreceiver/                                  @open-telemetry/collector-contrib-approvers @dmitryax

--- a/pkg/stanza/fileconsumer/metadata.yaml
+++ b/pkg/stanza/fileconsumer/metadata.yaml
@@ -6,7 +6,7 @@ status:
   stability:
     beta: [logs]
   codeowners:
-    active: [andrzej-stencel]
+    active: [andrzej-stencel, paulojmdias]
     emeritus: [djaglowski]
 
 feature_gates:

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -10,7 +10,7 @@ This receiver tails and parses logs from files.
 | Distributions | [contrib], [k8s] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Ffilelog%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Ffilelog) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Ffilelog%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Ffilelog) |
 | Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=receiver_filelog)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=receiver_filelog&displayType=list) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@andrzej-stencel](https://www.github.com/andrzej-stencel) \| Seeking more code owners! |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@andrzej-stencel](https://www.github.com/andrzej-stencel), [@paulojmdias](https://www.github.com/paulojmdias) \| Seeking more code owners! |
 | Emeritus      | [@djaglowski](https://www.github.com/djaglowski) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta

--- a/receiver/filelogreceiver/metadata.yaml
+++ b/receiver/filelogreceiver/metadata.yaml
@@ -10,7 +10,7 @@ status:
     beta: [logs]
   distributions: [contrib, k8s]
   codeowners:
-    active: [andrzej-stencel]
+    active: [andrzej-stencel, paulojmdias]
     emeritus: [djaglowski]
     seeking_new: true
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

I would like to propose adding myself as a codeowner for the filelog receiver and fileconsumer packages. I already did some PRs, handled issues, and I accept the challenge to help maintain those components.

Some recent important improvements that I proposed:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45097
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46739

All the PRs and issues in which I was involved:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Apr%20involves%3Apaulojmdias%20label%3Apkg%2Fstanza%2Ffileconsumer
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Apr%20involves%3Apaulojmdias%20label%3Areceiver%2Ffilelog
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Apaulojmdias+label%3Apkg%2Fstanza%2Ffileconsumer
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Apaulojmdias+label%3Areceiver%2Ffilelog

This was discussed in person at KubeCon EU. Thanks for your vote of confidence @andrzej-stencel 🙏 