### PR TITLE
[chore] update new component docs make targets

### DIFF
--- a/docs/new-components.md
+++ b/docs/new-components.md
@@ -198,6 +198,7 @@ When donating a component to the community, break it down into separate PRs as f
     * `make checkapi`
     * `make goporto`
     * `make crosslink`
+    * `make tidylist`
     * `make gotidy`
     * `make genotelcontribcol`
     * `make genoteltestbedcol`
@@ -205,6 +206,8 @@ When donating a component to the community, break it down into separate PRs as f
     * `make multimod-verify`
     * `make generate-gh-issue-templates`
     * `make gengithub`
+    * `make genlabels`
+    * `make gencodecov`
     * `make addlicense`
 * **Second PR** should include the concrete implementation of the component. If the
   size of this PR is larger than the recommended size consider splitting it in


### PR DESCRIPTION
#### Description
Updated the list of make targets to run when contributing a new component to include a few missing targets required to pass CI:
- `make tidylist`
- `make genlabels`
- `make gencodecov`

I discovered these gaps while working on #47132 