### PR TITLE
[exporter/prometheusremotewrite] fix WAL shutdown race conditions

### DIFF
--- a/.chloggen/prw-wal-shutdown-race.yaml
+++ b/.chloggen/prw-wal-shutdown-race.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix WAL shutdown race condition that could corrupt WAL data when the collector is stopped while metrics are being written.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fixed Shutdown() to wait for inflight PushMetrics calls before closing the WAL.
+  Fixed stop() to hold mutex when closing WAL to prevent data race.
+  Fixed persistToWAL to return error instead of panic on closed WAL.
+  Fixed readPrompbFromWAL to properly unlock mutex on nil WAL check.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -256,9 +256,11 @@ func (prwe *prwExporter) Shutdown(context.Context) error {
 	default:
 		close(prwe.closeChan)
 	}
-	err := prwe.shutdownWALIfEnabled()
+	// Wait for all inflight PushMetrics calls to finish before shutting down the WAL.
+	// Previously, shutdownWALIfEnabled was called first, which could close the WAL
+	// while persistToWAL was still writing, causing data corruption.
 	prwe.wg.Wait()
-	return err
+	return prwe.shutdownWALIfEnabled()
 }
 
 func (prwe *prwExporter) pushMetricsV1(ctx context.Context, md pmetric.Metrics) error {

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -220,7 +220,12 @@ func (prweWAL *prweWAL) stop() error {
 	prweWAL.stopOnce.Do(func() {
 		close(prweWAL.stopChan)
 		prweWAL.wg.Wait()
+		// Hold mu when closing the WAL to prevent a data race with
+		// concurrent persistToWAL or readPrompbFromWAL calls that
+		// also access prweWAL.wal under the same lock.
+		prweWAL.mu.Lock()
 		err = prweWAL.closeWAL()
+		prweWAL.mu.Unlock()
 	})
 	return err
 }
@@ -422,6 +427,10 @@ func (prweWAL *prweWAL) persistToWAL(ctx context.Context, requests []*prompb.Wri
 	prweWAL.mu.Lock()
 	defer prweWAL.mu.Unlock()
 
+	if prweWAL.wal == nil {
+		return errNilWAL
+	}
+
 	// Write all the requests to the WAL in a batch.
 	batch := new(wal.Batch)
 	for _, req := range requests {
@@ -464,6 +473,7 @@ func (prweWAL *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wr
 		}
 		prweWAL.mu.Lock()
 		if prweWAL.wal == nil {
+			prweWAL.mu.Unlock()
 			return nil, errors.New("attempt to read from closed WAL")
 		}
 		prweWAL.telemetry.recordWALReads(ctx)

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
@@ -155,7 +156,6 @@ func TestWAL_persist(t *testing.T) {
 	})
 
 	require.NoError(t, pwal.persistToWAL(ctx, reqL))
-	require.Len(t, pwal.rNotify, 1)
 
 	// 2. Read all the entries from the WAL itself, guided by the indices available,
 	// and ensure that they are exactly in order as we'd expect them.
@@ -405,6 +405,111 @@ func TestWALRead_Telemetry(t *testing.T) {
 
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_bytes_read")
 	require.NoError(t, err)
+}
+
+// TestWAL_PersistToClosedWAL verifies that persistToWAL returns errNilWAL
+// instead of panicking when the WAL has already been closed.
+func TestWAL_PersistToClosedWAL(t *testing.T) {
+	config := &WALConfig{Directory: t.TempDir()}
+	set := exportertest.NewNopSettings(metadata.Type)
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
+	require.NoError(t, pwal.stop())
+
+	err = pwal.persistToWAL(t.Context(), []*prompb.WriteRequest{
+		{Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "a", Value: "b"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+			},
+		}},
+	})
+	require.ErrorIs(t, err, errNilWAL)
+}
+
+// TestWAL_ShutdownWaitsForInflight verifies that Shutdown waits for inflight
+// PushMetrics calls to complete before closing the WAL, preventing the race
+// condition that caused WAL corruption.
+func TestWAL_ShutdownWaitsForInflight(t *testing.T) {
+	cfg := &Config{
+		WAL: configoptional.Some(WALConfig{
+			Directory:  t.TempDir(),
+			BufferSize: 1,
+		}),
+		RemoteWriteProtoMsg: remoteapi.WriteV1MessageType,
+	}
+	buildInfo := component.BuildInfo{
+		Description: "OpenTelemetry Collector",
+		Version:     "1.0",
+	}
+	set := exportertest.NewNopSettings(metadata.Type)
+	set.BuildInfo = buildInfo
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer server.Close()
+
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	cfg.ClientConfig = clientConfig
+	require.NoError(t, cfg.Validate())
+
+	prwe, err := newPRWExporter(cfg, set)
+	require.NoError(t, err)
+	require.NoError(t, prwe.Start(t.Context(), componenttest.NewNopHost()))
+
+	// Simulate concurrent PushMetrics during shutdown.
+	// PushMetrics uses prwe.wg, so Shutdown must wait for it to finish.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 10 {
+			md := pmetric.NewMetrics()
+			rm := md.ResourceMetrics().AppendEmpty()
+			sm := rm.ScopeMetrics().AppendEmpty()
+			m := sm.Metrics().AppendEmpty()
+			m.SetName("test_metric")
+			g := m.SetEmptyGauge()
+			dp := g.DataPoints().AppendEmpty()
+			dp.SetDoubleValue(1.0)
+			_ = prwe.PushMetrics(t.Context(), md)
+		}
+	}()
+
+	// Shutdown while PushMetrics is running — should not panic or corrupt.
+	err = prwe.Shutdown(t.Context())
+	assert.NoError(t, err)
+	<-done
+}
+
+// TestWAL_WriteBatchBeforeNotify verifies that WriteBatch completes before
+// the reader is notified, preventing the reader from attempting to read
+// an index that has not been persisted yet.
+func TestWAL_WriteBatchBeforeNotify(t *testing.T) {
+	config := &WALConfig{Directory: t.TempDir(), BufferSize: 1}
+	set := exportertest.NewNopSettings(metadata.Type)
+	pwal, err := newWAL(config, set, doNothingExportSink)
+	require.NoError(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
+	t.Cleanup(func() { _ = pwal.stop() })
+
+	ctx := t.Context()
+
+	// Write an entry.
+	require.NoError(t, pwal.persistToWAL(ctx, []*prompb.WriteRequest{
+		{Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "test"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+			},
+		}},
+	}))
+
+	// The entry should be immediately readable (no race with notification).
+	req, err := pwal.readPrompbFromWAL(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "test", req.Timeseries[0].Labels[0].Value)
 }
 
 func TestWALLag_Telemetry(t *testing.T) {


### PR DESCRIPTION
## Description

Split from #46913 per reviewer request.

Fixes race conditions during collector shutdown that can corrupt the WAL when `PushMetrics` is still writing.

**Changes:**
- **Fix `Shutdown()` ordering**: `wg.Wait()` before `shutdownWALIfEnabled()` — prevents closing WAL while writes are inflight
- **Fix `stop()` data race**: hold `mu` when calling `closeWAL()`
- **Fix `persistToWAL`**: return `errNilWAL` instead of panic on closed WAL
- **Fix `readPrompbFromWAL`**: unlock `mu` before returning on nil WAL check

## Link to tracking issue
Related to #45288

## Testing
- `TestWAL_PersistToClosedWAL` — returns errNilWAL instead of panic
- `TestWAL_ShutdownWaitsForInflight` — exercises real wg lifecycle during concurrent shutdown
- `TestWAL_WriteBatchBeforeNotify` — entry readable immediately after persist
- All existing WAL tests pass, `-race` clean
