### PR TITLE
[reciever/azureeventhub] Add distributed partition ownership

### DIFF
--- a/.chloggen/dylan_azure-event-hubs-distributed.yaml
+++ b/.chloggen/dylan_azure-event-hubs-distributed.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azureeventhub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for Azure Event Hubs distributed processing. This allows the receiver to automatically coordinate partition ownership and checkpointing across multiple collector instances via Azure Blob Storage.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46595]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dylan_azure-event-hubs-distributed.yaml
+++ b/.chloggen/dylan_azure-event-hubs-distributed.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/azureeventhub
+component: receiver/azure_event_hub
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add support for Azure Event Hubs distributed processing. This allows the receiver to automatically coordinate partition ownership and checkpointing across multiple collector instances via Azure Blob Storage.

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -118,6 +118,52 @@ extensions:
     directory: /var/lib/otelcol/eventhub
 ```
 
+#### Distributed Consumption with Blob Checkpoint Store
+
+For deployments with multiple collector instances, the receiver supports distributed consumption using Azure Blob Storage for checkpoint coordination. This uses the Azure SDK's [Processor](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2#Processor) to dynamically assign partitions across instances.
+
+When `blob_checkpoint_store` is configured, the receiver automatically:
+- Coordinates partition ownership across collector instances via blob leases
+- Checkpoints progress to Azure Blob Storage
+- Rebalances partitions when instances are added or removed
+
+**Prerequisites:**
+- The blob container must already exist before starting the collector
+- All collector instances must use the same consumer group and container
+
+**Note:** `blob_checkpoint_store` is mutually exclusive with `partition`, `offset`, and `storage` — the Processor manages partition assignment and checkpointing.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `blob_checkpoint_store.connection` | string | * | | Azure Blob Storage connection string. Required when not using `auth`. |
+| `blob_checkpoint_store.storage_account_url` | string | * | | Blob service URL (e.g., `https://myaccount.blob.core.windows.net`). Required when using `auth`. |
+| `blob_checkpoint_store.container_name` | string | Yes | | Blob container for checkpoint data. |
+
+\* One of `connection` or `storage_account_url` is required depending on authentication method.
+
+```yaml
+# With connection strings
+receivers:
+  azure_event_hub:
+    connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+    blob_checkpoint_store:
+      connection: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net
+      container_name: eventhub-checkpoints
+```
+
+```yaml
+# With auth extension
+receivers:
+  azure_event_hub:
+    event_hub:
+      name: hubName
+      namespace: namespace.servicebus.windows.net
+    auth: azureauth
+    blob_checkpoint_store:
+      storage_account_url: https://myaccount.blob.core.windows.net
+      container_name: eventhub-checkpoints
+```
+
 #### Custom Time Formats and Partitioning
 
 ```yaml

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -50,6 +50,18 @@ Either `connection` or `auth` must be specified.
 | `offset` | string | No | `""` | Starting offset. Only applicable when `partition` is set. |
 | `storage` | string | No | | ID of a [storage extension] for checkpoint persistence. |
 
+### Distributed Consumption Settings
+
+When `blob_checkpoint_store` is set, the receiver uses the Azure SDK [Processor](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2#Processor) to coordinate partition ownership across multiple collector instances via Azure Blob Storage. This is mutually exclusive with `partition`, `offset`, and `storage`.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `blob_checkpoint_store.connection` | string | * | | Azure Blob Storage connection string. Required when not using `auth`. |
+| `blob_checkpoint_store.storage_account_url` | string | * | | Blob service URL (e.g., `https://myaccount.blob.core.windows.net`). Required when using `auth`. |
+| `blob_checkpoint_store.container_name` | string | Yes | | Blob container for checkpoint data. Must already exist before starting the collector. |
+
+\* One of `connection` or `storage_account_url` is required.
+
 ### Polling Settings
 
 | Field | Type | Required | Default | Description |
@@ -120,8 +132,6 @@ extensions:
 
 #### Distributed Consumption with Blob Checkpoint Store
 
-For deployments with multiple collector instances, the receiver supports distributed consumption using Azure Blob Storage for checkpoint coordination. This uses the Azure SDK's [Processor](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2#Processor) to dynamically assign partitions across instances.
-
 When `blob_checkpoint_store` is configured, the receiver automatically:
 - Coordinates partition ownership across collector instances via blob leases
 - Checkpoints progress to Azure Blob Storage
@@ -130,16 +140,6 @@ When `blob_checkpoint_store` is configured, the receiver automatically:
 **Prerequisites:**
 - The blob container must already exist before starting the collector
 - All collector instances must use the same consumer group and container
-
-**Note:** `blob_checkpoint_store` is mutually exclusive with `partition`, `offset`, and `storage` — the Processor manages partition assignment and checkpointing.
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `blob_checkpoint_store.connection` | string | * | | Azure Blob Storage connection string. Required when not using `auth`. |
-| `blob_checkpoint_store.storage_account_url` | string | * | | Blob service URL (e.g., `https://myaccount.blob.core.windows.net`). Required when using `auth`. |
-| `blob_checkpoint_store.container_name` | string | Yes | | Blob container for checkpoint data. |
-
-\* One of `connection` or `storage_account_url` is required depending on authentication method.
 
 ```yaml
 # With connection strings

--- a/receiver/azureeventhubreceiver/config.go
+++ b/receiver/azureeventhubreceiver/config.go
@@ -37,9 +37,27 @@ type Config struct {
 	TimeFormats              TimeFormat     `mapstructure:"time_formats"`
 	MetricAggregation        string         `mapstructure:"metric_aggregation"`
 
+	// BlobCheckpointStore enables distributed consumption using Azure Blob Storage
+	// for checkpoint coordination. When configured, the receiver uses the Azure SDK
+	// Processor for dynamic partition assignment across multiple collector instances.
+	BlobCheckpointStore *BlobCheckpointStoreConfig `mapstructure:"blob_checkpoint_store"`
+
 	// azeventhub lib specific
 	PollRate      int `mapstructure:"poll_rate"`
 	MaxPollEvents int `mapstructure:"max_poll_events"`
+}
+
+// BlobCheckpointStoreConfig defines the configuration for Azure Blob Storage
+// based checkpoint coordination used in distributed consumption mode.
+type BlobCheckpointStoreConfig struct {
+	// Connection is the connection string for Azure Blob Storage.
+	// Required when the parent config does not use auth.
+	Connection string `mapstructure:"connection"`
+	// StorageAccountURL is the blob service URL (e.g., https://myaccount.blob.core.windows.net).
+	// Required when the parent config uses auth.
+	StorageAccountURL string `mapstructure:"storage_account_url"`
+	// ContainerName is the blob container used for checkpoint data. Required.
+	ContainerName string `mapstructure:"container_name"`
 }
 
 // EventHubConfig defines the configuration for an Azure Event Hub when
@@ -84,5 +102,24 @@ func (config *Config) Validate() error {
 	if config.Partition == "" && config.Offset != "" {
 		return errors.New("cannot use 'offset' without 'partition'")
 	}
+
+	if config.BlobCheckpointStore != nil {
+		if config.BlobCheckpointStore.ContainerName == "" {
+			return errors.New("blob_checkpoint_store.container_name is required")
+		}
+		if config.Auth == nil && config.BlobCheckpointStore.Connection == "" {
+			return errors.New("blob_checkpoint_store.connection is required when not using auth")
+		}
+		if config.Auth != nil && config.BlobCheckpointStore.StorageAccountURL == "" {
+			return errors.New("blob_checkpoint_store.storage_account_url is required when using auth")
+		}
+		if config.Partition != "" || config.Offset != "" {
+			return errors.New("blob_checkpoint_store is mutually exclusive with partition and offset")
+		}
+		if config.StorageID != nil {
+			return errors.New("blob_checkpoint_store is mutually exclusive with storage")
+		}
+	}
+
 	return nil
 }

--- a/receiver/azureeventhubreceiver/config.schema.yaml
+++ b/receiver/azureeventhubreceiver/config.schema.yaml
@@ -1,4 +1,17 @@
 $defs:
+  blob_checkpoint_store_config:
+    description: BlobCheckpointStoreConfig defines the configuration for Azure Blob Storage based checkpoint coordination used in distributed consumption mode.
+    type: object
+    properties:
+      connection:
+        description: Connection is the connection string for Azure Blob Storage. Required when the parent config does not use auth.
+        type: string
+      container_name:
+        description: ContainerName is the blob container used for checkpoint data. Required.
+        type: string
+      storage_account_url:
+        description: StorageAccountURL is the blob service URL (e.g., https://myaccount.blob.core.windows.net). Required when the parent config uses auth.
+        type: string
   event_hub_config:
     description: EventHubConfig defines the configuration for an Azure Event Hub when using authentication.
     type: object
@@ -32,6 +45,10 @@ properties:
     x-pointer: true
     type: string
     x-customType: go.opentelemetry.io/collector/component.ID
+  blob_checkpoint_store:
+    description: BlobCheckpointStore enables distributed consumption using Azure Blob Storage for checkpoint coordination. When configured, the receiver uses the Azure SDK Processor for dynamic partition assignment across multiple collector instances.
+    x-pointer: true
+    $ref: blob_checkpoint_store_config
   connection:
     type: string
   event_hub:

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -77,6 +77,50 @@ func TestLoadConfig(t *testing.T) {
 			id:                  component.NewIDWithName(metadata.Type, "auth_missing_namespace"),
 			expectedErrContains: "event_hub.namespace is required when using auth",
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "blob_checkpoint_store"),
+			expected: &Config{
+				Connection: "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName",
+				BlobCheckpointStore: &BlobCheckpointStoreConfig{
+					Connection:    "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net",
+					ContainerName: "eventhub-checkpoints",
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "blob_checkpoint_store_auth"),
+			expected: &Config{
+				EventHub: EventHubConfig{
+					Name:      "hubName",
+					Namespace: "namespace.servicebus.windows.net",
+				},
+				Auth: &authID,
+				BlobCheckpointStore: &BlobCheckpointStoreConfig{
+					StorageAccountURL: "https://myaccount.blob.core.windows.net",
+					ContainerName:     "eventhub-checkpoints",
+				},
+			},
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "blob_checkpoint_store_missing_container"),
+			expectedErrContains: "blob_checkpoint_store.container_name is required",
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "blob_checkpoint_store_missing_connection"),
+			expectedErrContains: "blob_checkpoint_store.connection is required when not using auth",
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "blob_checkpoint_store_auth_missing_url"),
+			expectedErrContains: "blob_checkpoint_store.storage_account_url is required when using auth",
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "blob_checkpoint_store_with_partition"),
+			expectedErrContains: "blob_checkpoint_store is mutually exclusive with partition and offset",
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "blob_checkpoint_store_with_storage"),
+			expectedErrContains: "blob_checkpoint_store is mutually exclusive with storage",
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -47,7 +47,6 @@ type eventhubHandler struct {
 	settings       receiver.Settings
 	cancel         context.CancelFunc
 	storageClient  storage.Client
-	processor      *azeventhubs.Processor      // non-nil when in distributed mode
 	consumerClient *azeventhubs.ConsumerClient // non-nil when in distributed mode
 	wg             sync.WaitGroup              // tracks goroutines spawned by runDistributed
 }
@@ -113,7 +112,6 @@ func (h *eventhubHandler) runDistributed(ctx context.Context, host component.Hos
 	if err != nil {
 		return err
 	}
-	h.processor = processor
 	h.consumerClient = consumerClient
 
 	// Dispatch partition clients as the Processor assigns them.

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -125,7 +125,6 @@ func (h *eventhubHandler) runDistributed(ctx context.Context, host component.Hos
 				return
 			}
 			h.wg.Go(func() {
-				defer partitionClient.Close(context.Background())
 				processPartitionEvents(ctx, partitionClient, h.newMessageHandler, h.config, h.settings.Logger)
 			})
 		}

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -57,11 +57,13 @@ func shouldInitializeStorageClient(storageClient storage.Client, storageID *comp
 
 func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 	ctx, h.cancel = context.WithCancel(ctx)
-
 	if h.config.BlobCheckpointStore != nil {
 		return h.runDistributed(ctx, host)
 	}
+	return h.runSingle(ctx, host)
+}
 
+func (h *eventhubHandler) runSingle(ctx context.Context, host component.Host) error {
 	if shouldInitializeStorageClient(h.storageClient, h.config.StorageID) { // set manually for testing.
 		storageClient, err := adapter.GetStorageClient(ctx, host, h.config.StorageID, h.settings.ID)
 		if err != nil {

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/receiver"
@@ -45,6 +46,7 @@ type eventhubHandler struct {
 	settings      receiver.Settings
 	cancel        context.CancelFunc
 	storageClient storage.Client
+	processor     *azeventhubs.Processor // non-nil when in distributed mode
 }
 
 func shouldInitializeStorageClient(storageClient storage.Client, storageID *component.ID) bool {
@@ -53,6 +55,10 @@ func shouldInitializeStorageClient(storageClient storage.Client, storageID *comp
 
 func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 	ctx, h.cancel = context.WithCancel(ctx)
+
+	if h.config.BlobCheckpointStore != nil {
+		return h.runDistributed(ctx, host)
+	}
 
 	if shouldInitializeStorageClient(h.storageClient, h.config.StorageID) { // set manually for testing.
 		storageClient, err := adapter.GetStorageClient(ctx, host, h.config.StorageID, h.settings.ID)
@@ -95,6 +101,38 @@ func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (h *eventhubHandler) runDistributed(ctx context.Context, host component.Host) error {
+	h.settings.Logger.Info("Starting distributed Event Hub consumption with blob checkpoint store")
+
+	processor, err := createProcessor(h.config, host, h.settings.Logger)
+	if err != nil {
+		return err
+	}
+	h.processor = processor
+
+	// Dispatch partition clients as the Processor assigns them
+	go func() {
+		for {
+			partitionClient := processor.NextPartitionClient(ctx)
+			if partitionClient == nil {
+				// Processor has stopped
+				return
+			}
+			go processPartitionEvents(ctx, partitionClient, h.newMessageHandler, h.config, h.settings.Logger)
+		}
+	}()
+
+	// Run the processor's load balancer in a background goroutine.
+	// It returns when the context is cancelled.
+	go func() {
+		if err := processor.Run(ctx); err != nil {
+			h.settings.Logger.Error("Processor exited with error", zap.Error(err))
+		}
+	}()
+
+	return nil
 }
 
 func (h *eventhubHandler) setUpOnePartition(ctx context.Context, partitionID string, applyOffset bool) error {

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -6,6 +6,7 @@ package azureeventhubreceiver // import "github.com/open-telemetry/opentelemetry
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
@@ -40,13 +41,15 @@ type hubRuntimeInfo struct {
 var errNoConfig = errors.New("Configuration error, hub not accessible")
 
 type eventhubHandler struct {
-	hub           hubWrapper
-	dataConsumer  dataConsumer
-	config        *Config
-	settings      receiver.Settings
-	cancel        context.CancelFunc
-	storageClient storage.Client
-	processor     *azeventhubs.Processor // non-nil when in distributed mode
+	hub            hubWrapper
+	dataConsumer   dataConsumer
+	config         *Config
+	settings       receiver.Settings
+	cancel         context.CancelFunc
+	storageClient  storage.Client
+	processor      *azeventhubs.Processor      // non-nil when in distributed mode
+	consumerClient *azeventhubs.ConsumerClient // non-nil when in distributed mode
+	wg             sync.WaitGroup              // tracks goroutines spawned by runDistributed
 }
 
 func shouldInitializeStorageClient(storageClient storage.Client, storageID *component.ID) bool {
@@ -106,31 +109,35 @@ func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 func (h *eventhubHandler) runDistributed(ctx context.Context, host component.Host) error {
 	h.settings.Logger.Info("Starting distributed Event Hub consumption with blob checkpoint store")
 
-	processor, err := createProcessor(h.config, host, h.settings.Logger)
+	processor, consumerClient, err := createProcessor(h.config, host, h.settings.Logger)
 	if err != nil {
 		return err
 	}
 	h.processor = processor
+	h.consumerClient = consumerClient
 
-	// Dispatch partition clients as the Processor assigns them
-	go func() {
+	// Dispatch partition clients as the Processor assigns them.
+	h.wg.Go(func() {
 		for {
 			partitionClient := processor.NextPartitionClient(ctx)
 			if partitionClient == nil {
 				// Processor has stopped
 				return
 			}
-			go processPartitionEvents(ctx, partitionClient, h.newMessageHandler, h.config, h.settings.Logger)
+			h.wg.Go(func() {
+				defer partitionClient.Close(context.Background())
+				processPartitionEvents(ctx, partitionClient, h.newMessageHandler, h.config, h.settings.Logger)
+			})
 		}
-	}()
+	})
 
 	// Run the processor's load balancer in a background goroutine.
 	// It returns when the context is cancelled.
-	go func() {
+	h.wg.Go(func() {
 		if err := processor.Run(ctx); err != nil {
 			h.settings.Logger.Error("Processor exited with error", zap.Error(err))
 		}
-	}()
+	})
 
 	return nil
 }
@@ -179,6 +186,17 @@ func (h *eventhubHandler) close(ctx context.Context) error {
 	}
 	if h.cancel != nil {
 		h.cancel()
+	}
+
+	// Wait for goroutines spawned by runDistributed to finish before closing
+	// the consumer client they depend on.
+	h.wg.Wait()
+
+	if h.consumerClient != nil {
+		if err := h.consumerClient.Close(ctx); err != nil {
+			errs = errors.Join(errs, err)
+		}
+		h.consumerClient = nil
 	}
 
 	return errs

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -444,7 +444,7 @@ func processPartitionEvents(
 		events, err := partitionClient.ReceiveEvents(timeout, maxPollEvents, nil)
 		cancelTimeout()
 
-		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 			var eventHubError *azeventhubs.Error
 			if errors.As(err, &eventHubError) && eventHubError.Code == azeventhubs.ErrorCodeOwnershipLost {
 				logger.Info("Partition ownership lost, stopping processing", zap.String("partition", partitionClient.PartitionID()))

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -53,8 +53,8 @@ type azPartitionClient interface {
 	ReceiveEvents(ctx context.Context, maxBatchSize int, options *azeventhubs.ReceiveEventsOptions) ([]*azeventhubs.ReceivedEventData, error)
 }
 
-func getPollConfig(config *Config) (maxPollEvents, pollRate int) {
-	maxPollEvents, pollRate = 100, 5
+func getPollConfig(config *Config) (int, int) {
+	maxPollEvents, pollRate := 100, 5
 	if config != nil {
 		if config.MaxPollEvents != 0 {
 			maxPollEvents = config.MaxPollEvents
@@ -63,7 +63,7 @@ func getPollConfig(config *Config) (maxPollEvents, pollRate int) {
 			pollRate = config.PollRate
 		}
 	}
-	return
+	return maxPollEvents, pollRate
 }
 
 func getConsumerGroup(config *Config) string {
@@ -346,14 +346,15 @@ func createBlobCheckpointStore(config *Config, host component.Host, logger *zap.
 	blobCfg := config.BlobCheckpointStore
 
 	var containerClient *container.Client
-	var err error
 
-	if blobCfg.Connection != "" {
+	switch {
+	case blobCfg.Connection != "":
+		var err error
 		containerClient, err = container.NewClientFromConnectionString(blobCfg.Connection, blobCfg.ContainerName, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create blob container client from connection string: %w", err)
 		}
-	} else if config.Auth != nil {
+	case config.Auth != nil:
 		ext, ok := host.GetExtensions()[*config.Auth]
 		if !ok {
 			return nil, fmt.Errorf("failed to resolve auth extension %q for blob checkpoint store", *config.Auth)
@@ -362,7 +363,6 @@ func createBlobCheckpointStore(config *Config, host component.Host, logger *zap.
 		if !ok {
 			return nil, fmt.Errorf("extension %q does not implement azcore.TokenCredential", *config.Auth)
 		}
-
 		containerURL, err := url.JoinPath(blobCfg.StorageAccountURL, blobCfg.ContainerName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct container URL: %w", err)
@@ -371,7 +371,7 @@ func createBlobCheckpointStore(config *Config, host component.Host, logger *zap.
 		if err != nil {
 			return nil, fmt.Errorf("failed to create blob container client with auth: %w", err)
 		}
-	} else {
+	default:
 		return nil, errors.New("blob checkpoint store requires either a connection string or auth extension")
 	}
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -422,6 +422,7 @@ func processPartitionEvents(
 	logger *zap.Logger,
 ) {
 	logger.Debug("Starting distributed processing for partition", zap.String("partition", partitionClient.PartitionID()))
+	defer partitionClient.Close(context.Background())
 
 	maxPollEvents := 100
 	pollRate := 5
@@ -459,7 +460,7 @@ func processPartitionEvents(
 				AzEventData: ev,
 			}); err != nil {
 				logger.Error("Error processing event in distributed mode", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))
-				continue
+				break
 			}
 			lastSuccessful = ev
 		}

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -447,7 +447,7 @@ func processPartitionEvents(
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 			var eventHubError *azeventhubs.Error
 			if errors.As(err, &eventHubError) && eventHubError.Code == azeventhubs.ErrorCodeOwnershipLost {
-				logger.Info("Partition ownership lost, stopping processing", zap.String("partition", partitionClient.PartitionID()))
+				logger.Debug("Partition ownership lost, stopping processing", zap.String("partition", partitionClient.PartitionID()))
 				return
 			}
 			logger.Error("Error receiving events in distributed mode", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/checkpoints"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.uber.org/zap"
@@ -331,4 +333,140 @@ func (p *partitionListener) setErr(err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.err = err
+}
+
+// createBlobCheckpointStore creates an Azure Blob Storage-backed checkpoint store
+// for use with the distributed Processor.
+func createBlobCheckpointStore(config *Config, host component.Host, logger *zap.Logger) (azeventhubs.CheckpointStore, error) {
+	blobCfg := config.BlobCheckpointStore
+
+	var containerClient *container.Client
+	var err error
+
+	if blobCfg.Connection != "" {
+		containerClient, err = container.NewClientFromConnectionString(blobCfg.Connection, blobCfg.ContainerName, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create blob container client from connection string: %w", err)
+		}
+	} else if config.Auth != nil {
+		ext, ok := host.GetExtensions()[*config.Auth]
+		if !ok {
+			return nil, fmt.Errorf("failed to resolve auth extension %q for blob checkpoint store", *config.Auth)
+		}
+		credential, ok := ext.(azcore.TokenCredential)
+		if !ok {
+			return nil, fmt.Errorf("extension %q does not implement azcore.TokenCredential", *config.Auth)
+		}
+
+		containerURL := strings.TrimRight(blobCfg.StorageAccountURL, "/") + "/" + blobCfg.ContainerName
+		containerClient, err = container.NewClient(containerURL, credential, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create blob container client with auth: %w", err)
+		}
+	} else {
+		return nil, errors.New("blob checkpoint store requires either a connection string or auth extension")
+	}
+
+	store, err := checkpoints.NewBlobStore(containerClient, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create blob checkpoint store: %w", err)
+	}
+
+	logger.Info("Created blob checkpoint store", zap.String("container", blobCfg.ContainerName))
+	return store, nil
+}
+
+// createProcessor creates an Azure Event Hub Processor for distributed consumption.
+func createProcessor(config *Config, host component.Host, logger *zap.Logger) (*azeventhubs.Processor, error) {
+	consumerGroup := getConsumerGroup(config)
+	consumerClient, err := createConsumerClient(config, host, consumerGroup, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create consumer client for processor: %w", err)
+	}
+
+	checkpointStore, err := createBlobCheckpointStore(config, host, logger)
+	if err != nil {
+		// Close the consumer client if checkpoint store creation fails
+		consumerClient.Close(context.Background())
+		return nil, err
+	}
+
+	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, nil)
+	if err != nil {
+		consumerClient.Close(context.Background())
+		return nil, fmt.Errorf("failed to create processor: %w", err)
+	}
+
+	return processor, nil
+}
+
+// processorPartitionClient is an interface for the subset of
+// azeventhubs.ProcessorPartitionClient methods used by processPartitionEvents.
+// This enables testing without requiring a real Azure connection.
+type processorPartitionClient interface {
+	PartitionID() string
+	ReceiveEvents(ctx context.Context, count int, options *azeventhubs.ReceiveEventsOptions) ([]*azeventhubs.ReceivedEventData, error)
+	UpdateCheckpoint(ctx context.Context, latestEvent *azeventhubs.ReceivedEventData, options *azeventhubs.UpdateCheckpointOptions) error
+	Close(ctx context.Context) error
+}
+
+// processPartitionEvents receives and processes events from a single partition
+// assigned by the Processor. It mirrors the polling loop in Receive() but uses
+// the Processor's checkpoint mechanism instead of local storage.
+func processPartitionEvents(
+	ctx context.Context,
+	partitionClient processorPartitionClient,
+	handler hubHandler,
+	config *Config,
+	logger *zap.Logger,
+) {
+	defer partitionClient.Close(context.Background())
+
+	logger.Info("Starting distributed processing for partition", zap.String("partition", partitionClient.PartitionID()))
+
+	maxPollEvents := 100
+	pollRate := 5
+	if config != nil {
+		if config.MaxPollEvents != 0 {
+			maxPollEvents = config.MaxPollEvents
+		}
+		if config.PollRate != 0 {
+			pollRate = config.PollRate
+		}
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		timeout, cancelTimeout := context.WithTimeout(ctx, time.Second*time.Duration(pollRate))
+		events, err := partitionClient.ReceiveEvents(timeout, maxPollEvents, nil)
+		cancelTimeout()
+
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			var eventHubError *azeventhubs.Error
+			if errors.As(err, &eventHubError) && eventHubError.Code == azeventhubs.ErrorCodeOwnershipLost {
+				logger.Info("Partition ownership lost, stopping processing", zap.String("partition", partitionClient.PartitionID()))
+				return
+			}
+			logger.Error("Error receiving events in distributed mode", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))
+			continue
+		}
+
+		for _, ev := range events {
+			if err := handler(ctx, &azureEvent{
+				AzEventData: ev,
+			}); err != nil {
+				logger.Error("Error processing event in distributed mode", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))
+				continue
+			}
+		}
+
+		if len(events) > 0 {
+			if err := partitionClient.UpdateCheckpoint(ctx, events[len(events)-1], nil); err != nil {
+				logger.Error("Error updating checkpoint", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))
+			}
+		}
+	}
 }

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -377,27 +377,28 @@ func createBlobCheckpointStore(config *Config, host component.Host, logger *zap.
 }
 
 // createProcessor creates an Azure Event Hub Processor for distributed consumption.
-func createProcessor(config *Config, host component.Host, logger *zap.Logger) (*azeventhubs.Processor, error) {
+// It returns both the Processor and the ConsumerClient so the caller can close the
+// client on shutdown (the Processor does not take ownership of closing it).
+func createProcessor(config *Config, host component.Host, logger *zap.Logger) (*azeventhubs.Processor, *azeventhubs.ConsumerClient, error) {
 	consumerGroup := getConsumerGroup(config)
 	consumerClient, err := createConsumerClient(config, host, consumerGroup, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create consumer client for processor: %w", err)
+		return nil, nil, fmt.Errorf("failed to create consumer client for processor: %w", err)
 	}
 
 	checkpointStore, err := createBlobCheckpointStore(config, host, logger)
 	if err != nil {
-		// Close the consumer client if checkpoint store creation fails
 		consumerClient.Close(context.Background())
-		return nil, err
+		return nil, nil, err
 	}
 
 	processor, err := azeventhubs.NewProcessor(consumerClient, checkpointStore, nil)
 	if err != nil {
 		consumerClient.Close(context.Background())
-		return nil, fmt.Errorf("failed to create processor: %w", err)
+		return nil, nil, fmt.Errorf("failed to create processor: %w", err)
 	}
 
-	return processor, nil
+	return processor, consumerClient, nil
 }
 
 // processorPartitionClient is an interface for the subset of
@@ -420,9 +421,7 @@ func processPartitionEvents(
 	config *Config,
 	logger *zap.Logger,
 ) {
-	defer partitionClient.Close(context.Background())
-
-	logger.Info("Starting distributed processing for partition", zap.String("partition", partitionClient.PartitionID()))
+	logger.Debug("Starting distributed processing for partition", zap.String("partition", partitionClient.PartitionID()))
 
 	maxPollEvents := 100
 	pollRate := 5
@@ -454,6 +453,7 @@ func processPartitionEvents(
 			continue
 		}
 
+		var lastSuccessful *azeventhubs.ReceivedEventData
 		for _, ev := range events {
 			if err := handler(ctx, &azureEvent{
 				AzEventData: ev,
@@ -461,10 +461,11 @@ func processPartitionEvents(
 				logger.Error("Error processing event in distributed mode", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))
 				continue
 			}
+			lastSuccessful = ev
 		}
 
-		if len(events) > 0 {
-			if err := partitionClient.UpdateCheckpoint(ctx, events[len(events)-1], nil); err != nil {
+		if lastSuccessful != nil {
+			if err := partitionClient.UpdateCheckpoint(ctx, lastSuccessful, nil); err != nil {
 				logger.Error("Error updating checkpoint", zap.Error(err), zap.String("partition", partitionClient.PartitionID()))
 			}
 		}

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +51,19 @@ func (c *checkpointSeqNumber) UnmarshalJSON(data []byte) error {
 type azPartitionClient interface {
 	Close(ctx context.Context) error
 	ReceiveEvents(ctx context.Context, maxBatchSize int, options *azeventhubs.ReceiveEventsOptions) ([]*azeventhubs.ReceivedEventData, error)
+}
+
+func getPollConfig(config *Config) (maxPollEvents, pollRate int) {
+	maxPollEvents, pollRate = 100, 5
+	if config != nil {
+		if config.MaxPollEvents != 0 {
+			maxPollEvents = config.MaxPollEvents
+		}
+		if config.PollRate != 0 {
+			pollRate = config.PollRate
+		}
+	}
+	return
 }
 
 func getConsumerGroup(config *Config) string {
@@ -206,21 +220,12 @@ func (h *hubWrapperAzeventhubImpl) Receive(ctx context.Context, partitionID stri
 			defer close(w.done)
 			defer pc.Close(ctx)
 
+			maxPollEvents, pollRate := getPollConfig(h.config)
 			for {
 				if ctx.Err() != nil {
 					return
 				}
 
-				maxPollEvents := 100
-				pollRate := 5
-				if h.config != nil {
-					if h.config.MaxPollEvents != 0 {
-						maxPollEvents = h.config.MaxPollEvents
-					}
-					if h.config.PollRate != 0 {
-						pollRate = h.config.PollRate
-					}
-				}
 				timeout, cancelTimeout := context.WithTimeout(ctx, time.Second*time.Duration(pollRate))
 				events, err := pc.ReceiveEvents(timeout, maxPollEvents, nil)
 				cancelTimeout()
@@ -358,7 +363,10 @@ func createBlobCheckpointStore(config *Config, host component.Host, logger *zap.
 			return nil, fmt.Errorf("extension %q does not implement azcore.TokenCredential", *config.Auth)
 		}
 
-		containerURL := strings.TrimRight(blobCfg.StorageAccountURL, "/") + "/" + blobCfg.ContainerName
+		containerURL, err := url.JoinPath(blobCfg.StorageAccountURL, blobCfg.ContainerName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct container URL: %w", err)
+		}
 		containerClient, err = container.NewClient(containerURL, credential, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create blob container client with auth: %w", err)
@@ -412,8 +420,7 @@ type processorPartitionClient interface {
 }
 
 // processPartitionEvents receives and processes events from a single partition
-// assigned by the Processor. It mirrors the polling loop in Receive() but uses
-// the Processor's checkpoint mechanism instead of local storage.
+// assigned by the Processor.
 func processPartitionEvents(
 	ctx context.Context,
 	partitionClient processorPartitionClient,
@@ -424,16 +431,7 @@ func processPartitionEvents(
 	logger.Debug("Starting distributed processing for partition", zap.String("partition", partitionClient.PartitionID()))
 	defer partitionClient.Close(context.Background())
 
-	maxPollEvents := 100
-	pollRate := 5
-	if config != nil {
-		if config.MaxPollEvents != 0 {
-			maxPollEvents = config.MaxPollEvents
-		}
-		if config.PollRate != 0 {
-			pollRate = config.PollRate
-		}
-	}
+	maxPollEvents, pollRate := getPollConfig(config)
 
 	for {
 		if ctx.Err() != nil {

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -274,6 +274,157 @@ func TestEventhubHandler_newLegacyMessageHandler(t *testing.T) {
 	assert.NoError(t, ehHandler.close(t.Context()))
 }
 
+func TestEventhubHandler_runDistributed_skipsNonDistributed(t *testing.T) {
+	// Verify that the non-distributed path still works when BlobCheckpointStore is nil
+	config := createDefaultConfig()
+	config.(*Config).Connection = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
+
+	ehHandler := &eventhubHandler{
+		settings:     receivertest.NewNopSettings(metadata.Type),
+		dataConsumer: &mockDataConsumer{},
+		config:       config.(*Config),
+	}
+	ehHandler.hub = &mockHubWrapper{}
+
+	// BlobCheckpointStore is nil, so it should take the non-distributed path
+	assert.Nil(t, ehHandler.config.BlobCheckpointStore)
+	assert.NoError(t, ehHandler.run(t.Context(), componenttest.NewNopHost()))
+	assert.Nil(t, ehHandler.processor)
+	assert.NoError(t, ehHandler.close(t.Context()))
+}
+
+func TestProcessPartitionEvents_contextCancelled(t *testing.T) {
+	// Verify that processPartitionEvents returns when context is cancelled
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	eventsReceived := make(chan struct{})
+	mockPC := &mockProcessorPartitionClient{
+		partitionID: "0",
+		onReceive: func() ([]*azeventhubs.ReceivedEventData, error) {
+			close(eventsReceived)
+			return nil, context.Canceled
+		},
+	}
+
+	config := &Config{
+		PollRate:      1,
+		MaxPollEvents: 10,
+	}
+
+	processPartitionEvents(ctx, mockPC, func(_ context.Context, _ *azureEvent) error {
+		return nil
+	}, config, zap.NewNop())
+
+	assert.True(t, mockPC.closed)
+}
+
+func TestProcessPartitionEvents_ownershipLost(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	mockPC := &mockProcessorPartitionClient{
+		partitionID: "0",
+		onReceive: func() ([]*azeventhubs.ReceivedEventData, error) {
+			return nil, &azeventhubs.Error{Code: azeventhubs.ErrorCodeOwnershipLost}
+		},
+	}
+
+	config := &Config{
+		PollRate:      1,
+		MaxPollEvents: 10,
+	}
+
+	processPartitionEvents(ctx, mockPC, func(_ context.Context, _ *azureEvent) error {
+		return nil
+	}, config, zap.NewNop())
+
+	assert.True(t, mockPC.closed)
+}
+
+func TestProcessPartitionEvents_processesEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	now := time.Now()
+	callCount := 0
+	var receivedEvents []*azureEvent
+
+	mockPC := &mockProcessorPartitionClient{
+		partitionID: "1",
+		onReceive: func() ([]*azeventhubs.ReceivedEventData, error) {
+			callCount++
+			if callCount == 1 {
+				return []*azeventhubs.ReceivedEventData{
+					{
+						EventData: azeventhubs.EventData{
+							Body: []byte("event1"),
+						},
+						EnqueuedTime:   &now,
+						SequenceNumber: 1,
+					},
+					{
+						EventData: azeventhubs.EventData{
+							Body: []byte("event2"),
+						},
+						EnqueuedTime:   &now,
+						SequenceNumber: 2,
+					},
+				}, nil
+			}
+			cancel()
+			return nil, context.Canceled
+		},
+	}
+
+	config := &Config{
+		PollRate:      1,
+		MaxPollEvents: 10,
+	}
+
+	processPartitionEvents(ctx, mockPC, func(_ context.Context, event *azureEvent) error {
+		receivedEvents = append(receivedEvents, event)
+		return nil
+	}, config, zap.NewNop())
+
+	assert.Len(t, receivedEvents, 2)
+	assert.Equal(t, []byte("event1"), receivedEvents[0].AzEventData.Body)
+	assert.Equal(t, []byte("event2"), receivedEvents[1].AzEventData.Body)
+	assert.True(t, mockPC.checkpointUpdated)
+	assert.Equal(t, int64(2), mockPC.lastCheckpointSeq)
+	assert.True(t, mockPC.closed)
+}
+
+// mockProcessorPartitionClient implements the methods used by processPartitionEvents
+// via duck-typing. Since processPartitionEvents takes *azeventhubs.ProcessorPartitionClient
+// (a concrete type), we test it indirectly via the real type or use this mock for unit tests
+// by refactoring to use an interface. For now, these are integration-style tests.
+type mockProcessorPartitionClient struct {
+	partitionID       string
+	closed            bool
+	checkpointUpdated bool
+	lastCheckpointSeq int64
+	onReceive         func() ([]*azeventhubs.ReceivedEventData, error)
+}
+
+func (m *mockProcessorPartitionClient) PartitionID() string {
+	return m.partitionID
+}
+
+func (m *mockProcessorPartitionClient) ReceiveEvents(_ context.Context, _ int, _ *azeventhubs.ReceiveEventsOptions) ([]*azeventhubs.ReceivedEventData, error) {
+	return m.onReceive()
+}
+
+func (m *mockProcessorPartitionClient) UpdateCheckpoint(_ context.Context, event *azeventhubs.ReceivedEventData, _ *azeventhubs.UpdateCheckpointOptions) error {
+	m.checkpointUpdated = true
+	m.lastCheckpointSeq = event.SequenceNumber
+	return nil
+}
+
+func (m *mockProcessorPartitionClient) Close(_ context.Context) error {
+	m.closed = true
+	return nil
+}
+
 func TestEventhubHandler_closeWithStorageClient(t *testing.T) {
 	config := createDefaultConfig()
 	config.(*Config).Connection = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -289,7 +289,6 @@ func TestEventhubHandler_runDistributed_skipsNonDistributed(t *testing.T) {
 	// BlobCheckpointStore is nil, so it should take the non-distributed path
 	assert.Nil(t, ehHandler.config.BlobCheckpointStore)
 	assert.NoError(t, ehHandler.run(t.Context(), componenttest.NewNopHost()))
-	assert.Nil(t, ehHandler.processor)
 	assert.NoError(t, ehHandler.close(t.Context()))
 }
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -298,11 +298,9 @@ func TestProcessPartitionEvents_contextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
-	eventsReceived := make(chan struct{})
 	mockPC := &mockProcessorPartitionClient{
 		partitionID: "0",
 		onReceive: func() ([]*azeventhubs.ReceivedEventData, error) {
-			close(eventsReceived)
 			return nil, context.Canceled
 		},
 	}
@@ -394,10 +392,8 @@ func TestProcessPartitionEvents_processesEvents(t *testing.T) {
 	assert.True(t, mockPC.closed)
 }
 
-// mockProcessorPartitionClient implements the methods used by processPartitionEvents
-// via duck-typing. Since processPartitionEvents takes *azeventhubs.ProcessorPartitionClient
-// (a concrete type), we test it indirectly via the real type or use this mock for unit tests
-// by refactoring to use an interface. For now, these are integration-style tests.
+// mockProcessorPartitionClient implements the processorPartitionClient interface
+// for use in unit tests without requiring a real Azure connection.
 type mockProcessorPartitionClient struct {
 	partitionID       string
 	closed            bool

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.148.0

--- a/receiver/azureeventhubreceiver/go.sum
+++ b/receiver/azureeventhubreceiver/go.sum
@@ -8,8 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2 h1:EBiOwZY
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2/go.mod h1:NjuxmUsBJ0Ya9Xxjhjo06bj3/QB4C8z838I5S88UtQQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0 h1:4hGvxD72TluuFIXVr8f4XkKZfqAa7Pj61t0jmQ7+kes=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0/go.mod h1:TSH7DcFItwAufy0Lz+Ft2cyopExCpxbOxI5SkH4dRNo=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 h1:ZJJNFaQ86GVKQ9ehwqyAFE6pIfyicpuJ8IkVaPBc6/4=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3/go.mod h1:URuDvhmATVKqHBH9/0nOiNKk0+YcwfQ3WkK5PqHKxc8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
 github.com/Azure/go-amqp v1.5.0 h1:GRiQK1VhrNFbyx5VlmI6BsA1FCp27W5rb9kxOZScnTo=
 github.com/Azure/go-amqp v1.5.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=

--- a/receiver/azureeventhubreceiver/testdata/config.yaml
+++ b/receiver/azureeventhubreceiver/testdata/config.yaml
@@ -34,3 +34,50 @@ azure_event_hub/auth_missing_namespace:
   auth: azureauth
   event_hub:
     name: hub
+
+azure_event_hub/blob_checkpoint_store:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  blob_checkpoint_store:
+    connection: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net
+    container_name: eventhub-checkpoints
+
+azure_event_hub/blob_checkpoint_store_auth:
+  event_hub:
+    name: hubName
+    namespace: namespace.servicebus.windows.net
+  auth: azureauth
+  blob_checkpoint_store:
+    storage_account_url: https://myaccount.blob.core.windows.net
+    container_name: eventhub-checkpoints
+
+azure_event_hub/blob_checkpoint_store_missing_container:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  blob_checkpoint_store:
+    connection: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net
+
+azure_event_hub/blob_checkpoint_store_missing_connection:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  blob_checkpoint_store:
+    container_name: eventhub-checkpoints
+
+azure_event_hub/blob_checkpoint_store_auth_missing_url:
+  event_hub:
+    name: hubName
+    namespace: namespace.servicebus.windows.net
+  auth: azureauth
+  blob_checkpoint_store:
+    container_name: eventhub-checkpoints
+
+azure_event_hub/blob_checkpoint_store_with_partition:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  partition: "0"
+  blob_checkpoint_store:
+    connection: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net
+    container_name: eventhub-checkpoints
+
+azure_event_hub/blob_checkpoint_store_with_storage:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  storage: file_storage
+  blob_checkpoint_store:
+    connection: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net
+    container_name: eventhub-checkpoints


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The Azure Event Hub SDK supports distributed consumption using Azure Blob Storage.
https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/messaging/azeventhubs

This PR adds the additional configuration options needed to configure a storage container to enable distributed consumption and the logic needed to perform that. 

Options added:
`blob_checkpoint_store.connection`
`blob_checkpoint_store.storage_account_url`
`blob_checkpoint_store.container_name`

The connection string can be used if you are not using the Azure auth extension, or the storage account URL can be used in the case where a user is using the Azure auth extension. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46595

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added unit testing for new functionality
- Set up multiple collectors and ingested Azure Event Hub events. Periodically created and destroyed collectors to ensure the distributed consumption worked correctly

<!--Describe the documentation added.-->
#### Documentation
- Updated `readme` with new options

<!--Please delete paragraphs that you did not use before submitting.-->
