### PR TITLE
[connector/signaltometrics]OTTL based dynamic attribute filtering

### DIFF
--- a/.chloggen/signaltometricsconnector-ottl-expression-attributes.yaml
+++ b/.chloggen/signaltometricsconnector-ottl-expression-attributes.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: connector/signal_to_metrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `ottl_expression` support in `include_resource_attributes` and `attributes` for dynamic attribute key resolution at runtime
+note: Add `keys_expression` support in `include_resource_attributes` and `attributes` for dynamic attribute key resolution at runtime
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46884]
@@ -16,9 +16,9 @@ issues: [46884]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  The `ottl_expression` field allows specifying an OTTL value expression that resolves to a list
+  The `keys_expression` field allows specifying an OTTL value expression that resolves to a list
   of attribute keys at runtime. This enables dynamic resource attribute filtering based on runtime
-  data such as client metadata. Exactly one of `key` or `ottl_expression` must be set per entry.
+  data such as client metadata. Exactly one of `key` or `keys_expression` must be set per entry.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/signaltometricsconnector-ottl-expression-attributes.yaml
+++ b/.chloggen/signaltometricsconnector-ottl-expression-attributes.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/signal_to_metrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `ottl_expression` support in `include_resource_attributes` and `attributes` for dynamic attribute key resolution at runtime
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46884]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `ottl_expression` field allows specifying an OTTL value expression that resolves to a list
+  of attribute keys at runtime. This enables dynamic resource attribute filtering based on runtime
+  data such as client metadata. Exactly one of `key` or `ottl_expression` must be set per entry.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/signaltometricsconnector/README.md
+++ b/connector/signaltometricsconnector/README.md
@@ -219,10 +219,13 @@ attributes:
     default_value: bar
   - key: datapoint.baz
     optional: true
+  - keys_expression: otelcol.client.metadata["x-dynamic-attributes"]
 ```
 
+Each attribute entry must have exactly one of `key` or `keys_expression` set.
+
 If attributes are specified then a separate metric will be generated for each unique
-set of attribute values. There are three behaviors that can be configured for an
+set of attribute values. There are four behaviors that can be configured for an
 attribute:
 
 - Without any extra parameters: `datapoint.foo` in the above yaml is an example
@@ -243,6 +246,13 @@ attribute:
   attributes are not present in the incoming signal, the signal will be processed
   and will produce a metric given all other non-optional attributes are present
   or have a default value defined.
+- With `keys_expression`: The OTTL value expression is evaluated at runtime and
+  must return a list of attribute keys (`pcommon.Slice` or `[]string`). Each resolved
+  key is looked up in the signal's attributes and included in the output metric.
+  If the expression returns `nil` (e.g. missing client metadata), it is treated as
+  an empty list. Expression evaluation errors are governed by the `error_mode`
+  configuration. The `optional` and `default_value` options can be combined with
+  `keys_expression` and apply to each resolved key.
 
 Note that resource attributes are handled differently, check the resource attributes
 section for more details on this. Think of `attributes` as conditional filters for
@@ -300,7 +310,10 @@ include_resource_attributes:
     default_value: bar
   - key: resource.baz # Optional resource.baz attribute is added if present
     optional: true
+  - keys_expression: otelcol.client.metadata["x-dynamic-resource-attributes"]
 ```
+
+Each entry must have exactly one of `key` or `keys_expression` set.
 
 With the above configuration the produced metrics would have the following
 resource attributes:
@@ -315,6 +328,17 @@ resource attributes:
   are basically an include list, the `optional` option is a no-op i.e. the resource
   attributes with `optional` set to `true` behaves identical to an attribute configured
   without `default_value` or `optional`.
+- The `keys_expression` entry evaluates the OTTL value expression at runtime to
+  resolve a list of attribute keys. The expression must return a list of strings
+  (`pcommon.Slice` or `[]string`). Each resolved key is looked up in the resource
+  attributes and included in the output metric. If the expression returns `nil`
+  (e.g. missing client metadata), it is treated as an empty list. Expression
+  evaluation errors are governed by the `error_mode` configuration. The `optional`
+  and `default_value` options can be combined with `keys_expression` and apply to
+  each resolved key. OTTL expressions for `include_resource_attributes` should
+  only reference resource-level paths (e.g. `resource.attributes`) or context-level
+  paths (e.g. `otelcol.client.metadata`), not signal-specific paths (e.g.
+  `attributes`, `span.*`, `log.*`).
 
 ### Single writer
 

--- a/connector/signaltometricsconnector/config/config.go
+++ b/connector/signaltometricsconnector/config/config.go
@@ -168,9 +168,14 @@ func (c *Config) Unmarshal(collectorCfg *confmap.Conf) error {
 }
 
 type Attribute struct {
-	Key          string `mapstructure:"key"`
-	Optional     bool   `mapstructure:"optional"`
-	DefaultValue any    `mapstructure:"default_value"`
+	Key string `mapstructure:"key"`
+	// OTTLExpression is an OTTL value expression that resolves to a list
+	// of attribute keys at runtime. The expression must return a
+	// pcommon.Slice or []string. Exactly one of Key or OTTLExpression
+	// must be set.
+	OTTLExpression string `mapstructure:"ottl_expression"`
+	Optional       bool   `mapstructure:"optional"`
+	DefaultValue   any    `mapstructure:"default_value"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -241,23 +246,37 @@ func (mi *MetricInfo) ensureDefaults() {
 	}
 }
 
-func (mi *MetricInfo) validateAttributes() error {
+// validateAttributeConfigs validates a list of Attribute configs. Each entry
+// must have exactly one of Key or OTTLExpression set. OTTL expressions are
+// parsed to verify syntax. The label parameter is used in error messages.
+func validateAttributeConfigs[K any](attrs []Attribute, parser ottl.Parser[K], label string) error {
 	tmp := pcommon.NewValueEmpty()
 	duplicate := map[string]struct{}{}
-	for _, attr := range mi.Attributes {
-		if attr.Key == "" {
-			return errors.New("attribute key missing")
+	for _, attr := range attrs {
+		hasKey := attr.Key != ""
+		hasExpr := attr.OTTLExpression != ""
+		if hasKey == hasExpr {
+			return fmt.Errorf("exactly one of key or ottl_expression must be set for %s", label)
+		}
+		if hasExpr {
+			if _, err := parser.ParseValueExpression(attr.OTTLExpression); err != nil {
+				return fmt.Errorf("failed to parse ottl_expression for %s: %w", label, err)
+			}
+		}
+		if hasKey {
+			if _, ok := duplicate[attr.Key]; ok {
+				return fmt.Errorf("duplicate key found in %s config: %s", label, attr.Key)
+			}
+			duplicate[attr.Key] = struct{}{}
 		}
 		if attr.DefaultValue != nil && attr.Optional {
-			return errors.New("only one of default_value or optional should be set")
+			return fmt.Errorf("only one of default_value or optional should be set for %s", label)
 		}
-		if _, ok := duplicate[attr.Key]; ok {
-			return fmt.Errorf("duplicate key found in attributes config: %s", attr.Key)
+		if attr.DefaultValue != nil {
+			if err := tmp.FromRaw(attr.DefaultValue); err != nil {
+				return fmt.Errorf("invalid default value specified for %s attribute %s", label, attr.Key)
+			}
 		}
-		if err := tmp.FromRaw(attr.DefaultValue); err != nil {
-			return fmt.Errorf("invalid default value specified for attribute %s", attr.Key)
-		}
-		duplicate[attr.Key] = struct{}{}
 	}
 	return nil
 }
@@ -310,7 +329,10 @@ func validateMetricInfo[K any](mi *MetricInfo, parser ottl.Parser[K]) error {
 	if mi.Name == "" {
 		return errors.New("missing required metric name configuration")
 	}
-	if err := mi.validateAttributes(); err != nil {
+	if err := validateAttributeConfigs(mi.IncludeResourceAttributes, parser, "include_resource_attributes"); err != nil {
+		return fmt.Errorf("include_resource_attributes validation failed: %w", err)
+	}
+	if err := validateAttributeConfigs(mi.Attributes, parser, "attributes"); err != nil {
 		return fmt.Errorf("attributes validation failed: %w", err)
 	}
 	if err := mi.validateHistogram(); err != nil {

--- a/connector/signaltometricsconnector/config/config.go
+++ b/connector/signaltometricsconnector/config/config.go
@@ -169,11 +169,11 @@ func (c *Config) Unmarshal(collectorCfg *confmap.Conf) error {
 
 type Attribute struct {
 	Key string `mapstructure:"key"`
-	// OTTLExpression is an OTTL value expression that resolves to a list
+	// KeysExpression is an OTTL value expression that resolves to a list
 	// of attribute keys at runtime. The expression must return a
-	// pcommon.Slice or []string. Exactly one of Key or OTTLExpression
+	// pcommon.Slice or []string. Exactly one of Key or KeysExpression
 	// must be set.
-	OTTLExpression string `mapstructure:"ottl_expression"`
+	KeysExpression string `mapstructure:"keys_expression"`
 	Optional       bool   `mapstructure:"optional"`
 	DefaultValue   any    `mapstructure:"default_value"`
 	// prevent unkeyed literal initialization
@@ -247,20 +247,20 @@ func (mi *MetricInfo) ensureDefaults() {
 }
 
 // validateAttributeConfigs validates a list of Attribute configs. Each entry
-// must have exactly one of Key or OTTLExpression set. OTTL expressions are
+// must have exactly one of Key or KeysExpression set. OTTL expressions are
 // parsed to verify syntax. The label parameter is used in error messages.
 func validateAttributeConfigs[K any](attrs []Attribute, parser ottl.Parser[K], label string) error {
 	tmp := pcommon.NewValueEmpty()
 	duplicate := map[string]struct{}{}
 	for _, attr := range attrs {
 		hasKey := attr.Key != ""
-		hasExpr := attr.OTTLExpression != ""
+		hasExpr := attr.KeysExpression != ""
 		if hasKey == hasExpr {
-			return fmt.Errorf("exactly one of key or ottl_expression must be set for %s", label)
+			return fmt.Errorf("exactly one of key or keys_expression must be set for %s", label)
 		}
 		if hasExpr {
-			if _, err := parser.ParseValueExpression(attr.OTTLExpression); err != nil {
-				return fmt.Errorf("failed to parse ottl_expression for %s: %w", label, err)
+			if _, err := parser.ParseValueExpression(attr.KeysExpression); err != nil {
+				return fmt.Errorf("failed to parse keys_expression for %s: %w", label, err)
 			}
 		}
 		if hasKey {

--- a/connector/signaltometricsconnector/config/config.schema.yaml
+++ b/connector/signaltometricsconnector/config/config.schema.yaml
@@ -6,6 +6,9 @@ $defs:
         x-customType: any
       key:
         type: string
+      keys_expression:
+        description: KeysExpression is an OTTL value expression that resolves to a list of attribute keys at runtime. The expression must return a pcommon.Slice or []string. Exactly one of Key or KeysExpression must be set.
+        type: string
       optional:
         type: boolean
   config:

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -62,14 +62,18 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 				span := scopeSpan.Spans().At(k)
 				spanAttrs := span.Attributes()
 				for _, md := range sm.spanMetricDefs {
-					filteredSpanAttrs, ok := md.FilterAttributes(spanAttrs)
-					if !ok {
+					if !md.MatchAttributes(spanAttrs) {
 						continue
 					}
-
 					// The transform context is created from original attributes so that the
 					// OTTL expressions are also applied on the original attributes.
 					tCtx := ottlspan.NewTransformContextPtr(resourceSpan, scopeSpan, span)
+					filteredSpanAttrs, err := md.FilterAttributes(ctx, tCtx, spanAttrs)
+					if err != nil {
+						tCtx.Close()
+						return fmt.Errorf("failed to filter attributes: %w", err)
+					}
+
 					if md.Conditions != nil {
 						match, err := md.Conditions.Eval(ctx, tCtx)
 						if err != nil {
@@ -83,8 +87,12 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 						}
 					}
 
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
-					err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredSpanAttrs, 1)
+					filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+					if err != nil {
+						tCtx.Close()
+						return fmt.Errorf("failed to filter resource attributes: %w", err)
+					}
+					err = aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredSpanAttrs, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -114,12 +122,19 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 				metrics := scopeMetric.Metrics()
 				metric := metrics.At(k)
 				for _, md := range sm.dpMetricDefs {
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
 					aggregate := func(dp any, dpAttrs pcommon.Map) error {
+						if !md.MatchAttributes(dpAttrs) {
+							return nil
+						}
 						// The transform context is created from original attributes so that the
 						// OTTL expressions are also applied on the original attributes.
 						tCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetric, metric, dp)
 						defer tCtx.Close()
+						filteredDPAttrs, err := md.FilterAttributes(ctx, tCtx, dpAttrs)
+						if err != nil {
+							return fmt.Errorf("failed to filter attributes: %w", err)
+						}
+
 						if md.Conditions != nil {
 							match, err := md.Conditions.Eval(ctx, tCtx)
 							if err != nil {
@@ -130,7 +145,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 								return nil
 							}
 						}
-						return aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, dpAttrs, 1)
+						filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+						if err != nil {
+							return fmt.Errorf("failed to filter resource attributes: %w", err)
+						}
+						return aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredDPAttrs, 1)
 					}
 
 					//exhaustive:enforce
@@ -138,60 +157,35 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 					case pmetric.MetricTypeGauge:
 						dps := metric.Gauge().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeSum:
 						dps := metric.Sum().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeSummary:
 						dps := metric.Summary().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeHistogram:
 						dps := metric.Histogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeExponentialHistogram:
 						dps := metric.ExponentialHistogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
@@ -223,14 +217,18 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 				log := scopeLog.LogRecords().At(k)
 				logAttrs := log.Attributes()
 				for _, md := range sm.logMetricDefs {
-					filteredLogAttrs, ok := md.FilterAttributes(logAttrs)
-					if !ok {
+					if !md.MatchAttributes(logAttrs) {
 						continue
 					}
-
 					// The transform context is created from original attributes so that the
 					// OTTL expressions are also applied on the original attributes.
 					tCtx := ottllog.NewTransformContextPtr(resourceLog, scopeLog, log)
+					filteredLogAttrs, err := md.FilterAttributes(ctx, tCtx, logAttrs)
+					if err != nil {
+						tCtx.Close()
+						return fmt.Errorf("failed to filter attributes: %w", err)
+					}
+
 					if md.Conditions != nil {
 						match, err := md.Conditions.Eval(ctx, tCtx)
 						if err != nil {
@@ -243,8 +241,12 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 							continue
 						}
 					}
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
-					err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredLogAttrs, 1)
+					filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+					if err != nil {
+						tCtx.Close()
+						return fmt.Errorf("failed to filter resource attributes: %w", err)
+					}
+					err = aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredLogAttrs, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -278,14 +280,18 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 				profileAttrs := pprofile.FromAttributeIndices(profiles.Dictionary().AttributeTable(), profile, profiles.Dictionary())
 
 				for _, md := range sm.profileMetricDefs {
-					filteredProfileAttrs, ok := md.FilterAttributes(profileAttrs)
-					if !ok {
+					if !md.MatchAttributes(profileAttrs) {
 						continue
 					}
-
 					// The transform context is created from original attributes so that the
 					// OTTL expressions are also applied on the original attributes.
 					tCtx := ottlprofile.NewTransformContextPtr(resourceProfile, scopeProfile, profile, profiles.Dictionary())
+					filteredProfileAttrs, err := md.FilterAttributes(ctx, tCtx, profileAttrs)
+					if err != nil {
+						tCtx.Close()
+						return fmt.Errorf("failed to filter attributes: %w", err)
+					}
+
 					if md.Conditions != nil {
 						match, err := md.Conditions.Eval(ctx, tCtx)
 						if err != nil {
@@ -298,7 +304,11 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 							continue
 						}
 					}
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
+					filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+					if err != nil {
+						tCtx.Close()
+						return fmt.Errorf("failed to filter resource attributes: %w", err)
+					}
 					if err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredProfileAttrs, 1); err != nil {
 						tCtx.Close()
 						return err

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -75,7 +75,8 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 					}
 
 					if md.Conditions != nil {
-						match, err := md.Conditions.Eval(ctx, tCtx)
+						var match bool
+						match, err = md.Conditions.Eval(ctx, tCtx)
 						if err != nil {
 							tCtx.Close()
 							return fmt.Errorf("failed to evaluate conditions: %w", err)
@@ -136,7 +137,8 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						}
 
 						if md.Conditions != nil {
-							match, err := md.Conditions.Eval(ctx, tCtx)
+							var match bool
+							match, err = md.Conditions.Eval(ctx, tCtx)
 							if err != nil {
 								return fmt.Errorf("failed to evaluate conditions: %w", err)
 							}
@@ -230,7 +232,8 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 					}
 
 					if md.Conditions != nil {
-						match, err := md.Conditions.Eval(ctx, tCtx)
+						var match bool
+						match, err = md.Conditions.Eval(ctx, tCtx)
 						if err != nil {
 							tCtx.Close()
 							return fmt.Errorf("failed to evaluate conditions: %w", err)
@@ -293,7 +296,8 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 					}
 
 					if md.Conditions != nil {
-						match, err := md.Conditions.Eval(ctx, tCtx)
+						var match bool
+						match, err = md.Conditions.Eval(ctx, tCtx)
 						if err != nil {
 							tCtx.Close()
 							return fmt.Errorf("failed to evaluate conditions: %w", err)

--- a/connector/signaltometricsconnector/connector_test.go
+++ b/connector/signaltometricsconnector/connector_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/confmap"
@@ -39,32 +40,44 @@ import (
 const testDataDir = "testdata"
 
 func TestConnectorWithTraces(t *testing.T) {
-	testCases := []string{
-		"sum",
-		"histograms",
-		"exponential_histograms",
-		"metric_identity",
-		"gauge",
+	testCases := []struct {
+		name           string
+		clientMetadata map[string][]string
+	}{
+		{name: "sum"},
+		{name: "histograms"},
+		{name: "exponential_histograms"},
+		{name: "metric_identity"},
+		{name: "gauge"},
+		{
+			name: "ottl_expression",
+			clientMetadata: map[string][]string{
+				"x-dynamic-resource-attributes": {"resource.foo"},
+			},
+		},
 	}
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
 	for _, tc := range testCases {
-		t.Run(tc, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			traceTestDataDir := filepath.Join(testDataDir, "traces")
 			inputTraces, err := golden.ReadTraces(filepath.Join(traceTestDataDir, "traces.yaml"))
 			require.NoError(t, err)
 
 			next := &consumertest.MetricsSink{}
-			tcTestDataDir := filepath.Join(traceTestDataDir, tc)
+			tcTestDataDir := filepath.Join(traceTestDataDir, tc.name)
 			factory, settings, cfg := setupConnector(t, tcTestDataDir)
-			connector, err := factory.CreateTracesToMetrics(ctx, settings, cfg, next)
+			connector, err := factory.CreateTracesToMetrics(t.Context(), settings, cfg, next)
 			require.NoError(t, err)
 			require.IsType(t, &signalToMetrics{}, connector)
 			expectedMetrics, err := golden.ReadMetrics(filepath.Join(tcTestDataDir, "output.yaml"))
 			require.NoError(t, err)
 
+			ctx := t.Context()
+			if tc.clientMetadata != nil {
+				ctx = client.NewContext(ctx, client.Info{
+					Metadata: client.NewMetadata(tc.clientMetadata),
+				})
+			}
 			require.NoError(t, connector.ConsumeTraces(ctx, inputTraces))
 			require.Len(t, next.AllMetrics(), 1)
 			assertAggregatedMetrics(t, expectedMetrics, next.AllMetrics()[0])

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.148.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/collector/client v1.54.1-0.20260320051400-372cc483b303
 	go.opentelemetry.io/collector/component v1.54.1-0.20260320051400-372cc483b303
 	go.opentelemetry.io/collector/component/componenttest v0.148.1-0.20260320051400-372cc483b303
 	go.opentelemetry.io/collector/config/configoptional v1.54.1-0.20260320051400-372cc483b303
@@ -63,7 +64,6 @@ require (
 	github.com/ua-parser/uap-go v0.0.0-20251207011819-db9adb27a0b8 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/client v1.54.1-0.20260320051400-372cc483b303 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.148.1-0.20260320051400-372cc483b303 // indirect
 	go.opentelemetry.io/collector/featuregate v1.54.1-0.20260320051400-372cc483b303 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.148.1-0.20260320051400-372cc483b303 // indirect

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -230,16 +230,9 @@ func (md *MetricDef[K]) FilterResourceAttributes(
 		return filteredAttributes, nil
 	}
 
-	filteredAttributes := pcommon.NewMap()
-	filteredAttributes.EnsureCapacity(len(md.IncludeResourceAttributes) + collectorInfo.Size())
-	for _, entry := range md.IncludeResourceAttributes {
-		if entry.Expression != nil {
-			if err := resolveOTTLResourceAttributes(ctx, tCtx, entry, attrs, filteredAttributes); err != nil {
-				return pcommon.Map{}, err
-			}
-			continue
-		}
-		copyResourceAttribute(entry.Key, entry.DefaultValue, attrs, filteredAttributes)
+	filteredAttributes, err := filterByEntries(ctx, tCtx, md.IncludeResourceAttributes, attrs, collectorInfo.Size())
+	if err != nil {
+		return pcommon.Map{}, err
 	}
 	collectorInfo.Copy(filteredAttributes)
 	return filteredAttributes, nil
@@ -269,18 +262,32 @@ func (md *MetricDef[K]) MatchAttributes(attrs pcommon.Map) bool {
 // MatchAttributes should be called before this method to avoid unnecessary
 // transform context creation.
 func (md *MetricDef[K]) FilterAttributes(ctx context.Context, tCtx K, attrs pcommon.Map) (pcommon.Map, error) {
-	filteredAttrs := pcommon.NewMap()
-	filteredAttrs.EnsureCapacity(len(md.Attributes))
-	for _, entry := range md.Attributes {
+	return filterByEntries(ctx, tCtx, md.Attributes, attrs, 0)
+}
+
+// filterByEntries iterates over attribute entries, resolving OTTL
+// expressions and copying static keys from src into a new map.
+// extraCapacity is added to the initial map capacity for entries
+// like CollectorInstanceInfo that are appended after filtering.
+func filterByEntries[K any](
+	ctx context.Context,
+	tCtx K,
+	entries []AttributeEntry[K],
+	src pcommon.Map,
+	extraCapacity int,
+) (pcommon.Map, error) {
+	dst := pcommon.NewMap()
+	dst.EnsureCapacity(len(entries) + extraCapacity)
+	for _, entry := range entries {
 		if entry.Expression != nil {
-			if err := resolveOTTLAttributes(ctx, tCtx, entry, attrs, filteredAttrs); err != nil {
+			if err := resolveOTTLExpression(ctx, tCtx, entry, src, dst); err != nil {
 				return pcommon.Map{}, err
 			}
 			continue
 		}
-		copyResourceAttribute(entry.Key, entry.DefaultValue, attrs, filteredAttrs)
+		copyAttribute(entry.Key, entry.DefaultValue, src, dst)
 	}
-	return filteredAttrs, nil
+	return dst, nil
 }
 
 func parseAttributeEntries[K any](
@@ -319,7 +326,9 @@ func parseAttributeEntries[K any](
 	return entries, nil
 }
 
-func resolveOTTLAttributes[K any](
+// resolveOTTLExpression evaluates the OTTL expression to get a list of
+// attribute keys and copies matching attributes from src to dst.
+func resolveOTTLExpression[K any](
 	ctx context.Context,
 	tCtx K,
 	entry AttributeEntry[K],
@@ -327,45 +336,22 @@ func resolveOTTLAttributes[K any](
 ) error {
 	result, err := entry.Expression.Eval(ctx, tCtx)
 	if err != nil {
-		return fmt.Errorf("failed to evaluate ottl_expression for attributes: %w", err)
+		return fmt.Errorf("failed to evaluate ottl_expression: %w", err)
 	}
 	if result == nil {
 		return nil
 	}
 	keys, err := extractStringSlice(result)
 	if err != nil {
-		return fmt.Errorf("ottl_expression for attributes must return a list of strings: %w", err)
+		return fmt.Errorf("ottl_expression must return a list of strings: %w", err)
 	}
 	for _, key := range keys {
-		copyResourceAttribute(key, entry.DefaultValue, src, dst)
+		copyAttribute(key, entry.DefaultValue, src, dst)
 	}
 	return nil
 }
 
-func resolveOTTLResourceAttributes[K any](
-	ctx context.Context,
-	tCtx K,
-	entry AttributeEntry[K],
-	src, dst pcommon.Map,
-) error {
-	result, err := entry.Expression.Eval(ctx, tCtx)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate ottl_expression for include_resource_attributes: %w", err)
-	}
-	if result == nil {
-		return nil
-	}
-	keys, err := extractStringSlice(result)
-	if err != nil {
-		return fmt.Errorf("ottl_expression for include_resource_attributes must return a list of strings: %w", err)
-	}
-	for _, key := range keys {
-		copyResourceAttribute(key, entry.DefaultValue, src, dst)
-	}
-	return nil
-}
-
-func copyResourceAttribute(key string, defaultValue pcommon.Value, src, dst pcommon.Map) {
+func copyAttribute(key string, defaultValue pcommon.Value, src, dst pcommon.Map) {
 	if attr, ok := src.Get(key); ok {
 		attr.CopyTo(dst.PutEmpty(key))
 		return

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -4,6 +4,7 @@
 package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/internal/model"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -14,12 +15,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
-
-type AttributeKeyValue struct {
-	Key          string
-	Optional     bool
-	DefaultValue pcommon.Value
-}
 
 type MetricKey struct {
 	Name        string
@@ -128,10 +123,22 @@ func (s *Gauge[K]) fromConfig(
 	return nil
 }
 
+// AttributeEntry represents a single entry in include_resource_attributes
+// or attributes. Exactly one of Key or Expression must be set.
+type AttributeEntry[K any] struct {
+	// Key is a static attribute key.
+	Key string
+	// Expression is a parsed OTTL value expression that resolves to a
+	// list of attribute keys (pcommon.Slice or []string) at runtime.
+	Expression   *ottl.ValueExpression[K]
+	Optional     bool
+	DefaultValue pcommon.Value
+}
+
 type MetricDef[K any] struct {
 	Key                       MetricKey
-	IncludeResourceAttributes []AttributeKeyValue
-	Attributes                []AttributeKeyValue
+	IncludeResourceAttributes []AttributeEntry[K]
+	Attributes                []AttributeEntry[K]
 	Conditions                *ottl.ConditionSequence[K]
 	ExponentialHistogram      *ExponentialHistogram[K]
 	ExplicitHistogram         *ExplicitHistogram[K]
@@ -149,11 +156,11 @@ func (md *MetricDef[K]) FromMetricInfo(
 	md.Key.Description = mi.Description
 
 	var err error
-	md.IncludeResourceAttributes, err = parseAttributeConfigs(mi.IncludeResourceAttributes)
+	md.IncludeResourceAttributes, err = parseAttributeEntries(mi.IncludeResourceAttributes, parser)
 	if err != nil {
 		return fmt.Errorf("failed to parse include resource attribute config: %w", err)
 	}
-	md.Attributes, err = parseAttributeConfigs(mi.Attributes)
+	md.Attributes, err = parseAttributeEntries(mi.Attributes, parser)
 	if err != nil {
 		return fmt.Errorf("failed to parse attribute config: %w", err)
 	}
@@ -205,78 +212,184 @@ func (md *MetricDef[K]) FromMetricInfo(
 // attributes are only filtered if the list is specified, otherwise all the
 // resource attributes are used for creating the metrics from the metric
 // definition.
+//
+// For entries with an OTTL expression, the expression is evaluated at
+// runtime to resolve a list of attribute keys. The expression must return
+// a pcommon.Slice or []string. A nil result is treated as an empty list.
 func (md *MetricDef[K]) FilterResourceAttributes(
+	ctx context.Context,
+	tCtx K,
 	attrs pcommon.Map,
 	collectorInfo CollectorInstanceInfo,
-) pcommon.Map {
-	var filteredAttributes pcommon.Map
-	switch {
-	case len(md.IncludeResourceAttributes) == 0:
-		filteredAttributes = pcommon.NewMap()
+) (pcommon.Map, error) {
+	if len(md.IncludeResourceAttributes) == 0 {
+		filteredAttributes := pcommon.NewMap()
 		filteredAttributes.EnsureCapacity(attrs.Len() + collectorInfo.Size())
 		attrs.CopyTo(filteredAttributes)
-	default:
-		expectedLen := len(md.IncludeResourceAttributes) + collectorInfo.Size()
-		filteredAttributes = filterAttributes(attrs, md.IncludeResourceAttributes, expectedLen)
+		collectorInfo.Copy(filteredAttributes)
+		return filteredAttributes, nil
+	}
+
+	filteredAttributes := pcommon.NewMap()
+	filteredAttributes.EnsureCapacity(len(md.IncludeResourceAttributes) + collectorInfo.Size())
+	for _, entry := range md.IncludeResourceAttributes {
+		if entry.Expression != nil {
+			if err := resolveOTTLResourceAttributes(ctx, tCtx, entry, attrs, filteredAttributes); err != nil {
+				return pcommon.Map{}, err
+			}
+			continue
+		}
+		copyResourceAttribute(entry.Key, entry.DefaultValue, attrs, filteredAttributes)
 	}
 	collectorInfo.Copy(filteredAttributes)
-	return filteredAttributes
+	return filteredAttributes, nil
+}
+
+// MatchAttributes checks if all required static key attributes are
+// present in the given map. This is a cheap pre-check that does not
+// require a transform context and can be used to skip expensive
+// transform context creation when the entity should not be processed.
+// OTTL expression entries and entries with default values or optional
+// flag are not checked.
+func (md *MetricDef[K]) MatchAttributes(attrs pcommon.Map) bool {
+	for _, filter := range md.Attributes {
+		if filter.Expression != nil || filter.DefaultValue.Type() != pcommon.ValueTypeEmpty || filter.Optional {
+			continue
+		}
+		if _, ok := attrs.Get(filter.Key); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // FilterAttributes filters event attributes (datapoint, logrecord, spans)
 // based on the `Attributes` selected for the metric definition. If no
-// attributes are selected then an empty `pcommon.Map` is returned. Note
-// that, this filtering differs from resource attribute filtering as
-// in attribute filtering if any of the configured attributes is not present
-// in the data being processed then that metric definition is not processed.
-// The method returns a bool signaling if the filter was successful and metric
-// should be processed. If the bool value is false then the returned map
-// should not be used.
-func (md *MetricDef[K]) FilterAttributes(attrs pcommon.Map) (pcommon.Map, bool) {
-	// Figure out if all the attributes are available, saves allocation
-	for _, filter := range md.Attributes {
-		if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty || filter.Optional {
-			continue
-		}
-		if _, ok := attrs.Get(filter.Key); !ok {
-			return pcommon.Map{}, false
-		}
-	}
-	return filterAttributes(attrs, md.Attributes, len(md.Attributes)), true
-}
-
-func filterAttributes(attrs pcommon.Map, filters []AttributeKeyValue, expectedLen int) pcommon.Map {
+// attributes are selected then an empty `pcommon.Map` is returned.
+// MatchAttributes should be called before this method to avoid unnecessary
+// transform context creation.
+func (md *MetricDef[K]) FilterAttributes(ctx context.Context, tCtx K, attrs pcommon.Map) (pcommon.Map, error) {
 	filteredAttrs := pcommon.NewMap()
-	filteredAttrs.EnsureCapacity(expectedLen)
-	for _, filter := range filters {
-		if attr, ok := attrs.Get(filter.Key); ok {
-			attr.CopyTo(filteredAttrs.PutEmpty(filter.Key))
+	filteredAttrs.EnsureCapacity(len(md.Attributes))
+	for _, entry := range md.Attributes {
+		if entry.Expression != nil {
+			if err := resolveOTTLAttributes(ctx, tCtx, entry, attrs, filteredAttrs); err != nil {
+				return pcommon.Map{}, err
+			}
 			continue
 		}
-		if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty {
-			filter.DefaultValue.CopyTo(filteredAttrs.PutEmpty(filter.Key))
-		}
+		copyResourceAttribute(entry.Key, entry.DefaultValue, attrs, filteredAttrs)
 	}
-	return filteredAttrs
+	return filteredAttrs, nil
 }
 
-func parseAttributeConfigs(cfgs []config.Attribute) ([]AttributeKeyValue, error) {
+func parseAttributeEntries[K any](
+	cfgs []config.Attribute,
+	parser ottl.Parser[K],
+) ([]AttributeEntry[K], error) {
 	var errs []error
-	kvs := make([]AttributeKeyValue, len(cfgs))
-	for i, attr := range cfgs {
+	entries := make([]AttributeEntry[K], 0, len(cfgs))
+	for _, attr := range cfgs {
 		val := pcommon.NewValueEmpty()
 		if err := val.FromRaw(attr.DefaultValue); err != nil {
 			errs = append(errs, err)
+			continue
 		}
-		kvs[i] = AttributeKeyValue{
-			Key:          attr.Key,
+		entry := AttributeEntry[K]{
 			Optional:     attr.Optional,
 			DefaultValue: val,
 		}
+		if attr.OTTLExpression != "" {
+			expr, err := parser.ParseValueExpression(attr.OTTLExpression)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(
+					"failed to parse ottl_expression %q: %w", attr.OTTLExpression, err,
+				))
+				continue
+			}
+			entry.Expression = expr
+		} else {
+			entry.Key = attr.Key
+		}
+		entries = append(entries, entry)
 	}
-
 	if len(errs) > 0 {
 		return nil, errors.Join(errs...)
 	}
-	return kvs, nil
+	return entries, nil
+}
+
+func resolveOTTLAttributes[K any](
+	ctx context.Context,
+	tCtx K,
+	entry AttributeEntry[K],
+	src, dst pcommon.Map,
+) error {
+	result, err := entry.Expression.Eval(ctx, tCtx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate ottl_expression for attributes: %w", err)
+	}
+	if result == nil {
+		return nil
+	}
+	keys, err := extractStringSlice(result)
+	if err != nil {
+		return fmt.Errorf("ottl_expression for attributes must return a list of strings: %w", err)
+	}
+	for _, key := range keys {
+		copyResourceAttribute(key, entry.DefaultValue, src, dst)
+	}
+	return nil
+}
+
+func resolveOTTLResourceAttributes[K any](
+	ctx context.Context,
+	tCtx K,
+	entry AttributeEntry[K],
+	src, dst pcommon.Map,
+) error {
+	result, err := entry.Expression.Eval(ctx, tCtx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate ottl_expression for include_resource_attributes: %w", err)
+	}
+	if result == nil {
+		return nil
+	}
+	keys, err := extractStringSlice(result)
+	if err != nil {
+		return fmt.Errorf("ottl_expression for include_resource_attributes must return a list of strings: %w", err)
+	}
+	for _, key := range keys {
+		copyResourceAttribute(key, entry.DefaultValue, src, dst)
+	}
+	return nil
+}
+
+func copyResourceAttribute(key string, defaultValue pcommon.Value, src, dst pcommon.Map) {
+	if attr, ok := src.Get(key); ok {
+		attr.CopyTo(dst.PutEmpty(key))
+		return
+	}
+	if defaultValue.Type() != pcommon.ValueTypeEmpty {
+		defaultValue.CopyTo(dst.PutEmpty(key))
+	}
+}
+
+func extractStringSlice(val any) ([]string, error) {
+	switch v := val.(type) {
+	case pcommon.Slice:
+		keys := make([]string, 0, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			elem := v.At(i)
+			if elem.Type() != pcommon.ValueTypeStr {
+				return nil, fmt.Errorf("expected string element at index %d, got %s", i, elem.Type())
+			}
+			keys = append(keys, elem.Str())
+		}
+		return keys, nil
+	case []string:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T, expected pcommon.Slice or []string", val)
+	}
 }

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -280,7 +280,7 @@ func filterByEntries[K any](
 	dst.EnsureCapacity(len(entries) + extraCapacity)
 	for _, entry := range entries {
 		if entry.Expression != nil {
-			if err := resolveOTTLExpression(ctx, tCtx, entry, src, dst); err != nil {
+			if err := resolveKeysExpression(ctx, tCtx, entry, src, dst); err != nil {
 				return pcommon.Map{}, err
 			}
 			continue
@@ -306,11 +306,11 @@ func parseAttributeEntries[K any](
 			Optional:     attr.Optional,
 			DefaultValue: val,
 		}
-		if attr.OTTLExpression != "" {
-			expr, err := parser.ParseValueExpression(attr.OTTLExpression)
+		if attr.KeysExpression != "" {
+			expr, err := parser.ParseValueExpression(attr.KeysExpression)
 			if err != nil {
 				errs = append(errs, fmt.Errorf(
-					"failed to parse ottl_expression %q: %w", attr.OTTLExpression, err,
+					"failed to parse keys_expression %q: %w", attr.KeysExpression, err,
 				))
 				continue
 			}
@@ -326,9 +326,9 @@ func parseAttributeEntries[K any](
 	return entries, nil
 }
 
-// resolveOTTLExpression evaluates the OTTL expression to get a list of
+// resolveKeysExpression evaluates the OTTL expression to get a list of
 // attribute keys and copies matching attributes from src to dst.
-func resolveOTTLExpression[K any](
+func resolveKeysExpression[K any](
 	ctx context.Context,
 	tCtx K,
 	entry AttributeEntry[K],
@@ -336,14 +336,14 @@ func resolveOTTLExpression[K any](
 ) error {
 	result, err := entry.Expression.Eval(ctx, tCtx)
 	if err != nil {
-		return fmt.Errorf("failed to evaluate ottl_expression: %w", err)
+		return fmt.Errorf("failed to evaluate keys_expression: %w", err)
 	}
 	if result == nil {
 		return nil
 	}
 	keys, err := extractStringSlice(result)
 	if err != nil {
-		return fmt.Errorf("ottl_expression must return a list of strings: %w", err)
+		return fmt.Errorf("keys_expression must return a list of strings: %w", err)
 	}
 	for _, key := range keys {
 		copyAttribute(key, entry.DefaultValue, src, dst)

--- a/connector/signaltometricsconnector/internal/model/model_test.go
+++ b/connector/signaltometricsconnector/internal/model/model_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,7 +29,7 @@ func TestFilterResourceAttributes(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		name                      string
-		includeResourceAttributes []AttributeKeyValue
+		includeResourceAttributes []AttributeEntry[*ottlspan.TransformContext]
 		expected                  map[string]any
 	}{
 		{
@@ -46,23 +47,23 @@ func TestFilterResourceAttributes(t *testing.T) {
 		},
 		{
 			name: "include_resource_attributes_configured",
-			includeResourceAttributes: []AttributeKeyValue{
-				testAttributeKeyValue(t, "key.1", false, nil),
+			includeResourceAttributes: []AttributeEntry[*ottlspan.TransformContext]{
+				testAttributeEntry(t, "key.1", false, nil),
 				// Optional does not change the behavior for resource attribute
 				// filtering.
-				testAttributeKeyValue(t, "key.2", true, nil),
+				testAttributeEntry(t, "key.2", true, nil),
 				// With default value configured and the attribute present, default
 				// value will be ignored.
-				testAttributeKeyValue(t, "key.3", false, 500),
+				testAttributeEntry(t, "key.3", false, 500),
 				// With default value, even if the attribute is missing, it will
 				// be added to the output.
-				testAttributeKeyValue(t, "key.302", false, "anything"),
+				testAttributeEntry(t, "key.302", false, "anything"),
 				// Without default value, the resource attribute will be ignored
 				// if not present in the input
-				testAttributeKeyValue(t, "key.404", false, nil),
+				testAttributeEntry(t, "key.404", false, nil),
 				// Optional does not change the behavior for resource attribute
 				// filtering.
-				testAttributeKeyValue(t, "key.412", true, nil),
+				testAttributeEntry(t, "key.412", true, nil),
 			},
 			expected: map[string]any{
 				// Include resource attributes are filtered
@@ -84,10 +85,13 @@ func TestFilterResourceAttributes(t *testing.T) {
 			}
 			inputResourceAttrsM := pcommon.NewMap()
 			require.NoError(t, inputResourceAttrsM.FromRaw(inputAttributes))
-			actual := md.FilterResourceAttributes(
+			actual, err := md.FilterResourceAttributes(
+				context.Background(),
+				nil, // no transform context needed for static key tests
 				inputResourceAttrsM,
 				testCollectorInstanceInfo(t),
 			)
+			require.NoError(t, err)
 			assert.Empty(t, cmp.Diff(tc.expected, actual.AsRaw()))
 		})
 	}
@@ -102,7 +106,7 @@ func TestFilterAttributes(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		name               string
-		attributes         []AttributeKeyValue
+		attributes         []AttributeEntry[*ottlspan.TransformContext]
 		expectedDecision   bool           // whether to process the entity or not
 		expectedAttributes map[string]any // map of filtered attributes
 	}{
@@ -120,25 +124,25 @@ func TestFilterAttributes(t *testing.T) {
 			// are absent in the incoming entity then the entity is not
 			// processed.
 			name: "attributes_configured_but_missing",
-			attributes: []AttributeKeyValue{
-				testAttributeKeyValue(t, "key.1", false, nil),
+			attributes: []AttributeEntry[*ottlspan.TransformContext]{
+				testAttributeEntry(t, "key.1", false, nil),
 				// The below key has optional defined so should not
 				// affect the processing decision.
-				testAttributeKeyValue(t, "key.2", true, nil),
+				testAttributeEntry(t, "key.2", true, nil),
 				// Below attribute would be missing in the input metric and
 				// should return false to signal not to process the entity.
-				testAttributeKeyValue(t, "key.404", false, nil),
+				testAttributeEntry(t, "key.404", false, nil),
 			},
 			expectedDecision: false,
 		},
 		{
 			name: "attributes_configured_with_optional",
-			attributes: []AttributeKeyValue{
-				testAttributeKeyValue(t, "key.1", false, nil),
+			attributes: []AttributeEntry[*ottlspan.TransformContext]{
+				testAttributeEntry(t, "key.1", false, nil),
 				// The below two key has optional defined so should not
 				// affect the processing decision.
-				testAttributeKeyValue(t, "key.2", true, nil),
-				testAttributeKeyValue(t, "key.412", true, nil),
+				testAttributeEntry(t, "key.2", true, nil),
+				testAttributeEntry(t, "key.412", true, nil),
 			},
 			expectedDecision: true,
 			expectedAttributes: map[string]any{
@@ -153,12 +157,69 @@ func TestFilterAttributes(t *testing.T) {
 			}
 			inputAttrM := pcommon.NewMap()
 			require.NoError(t, inputAttrM.FromRaw(inputAttributes))
-			actual, ok := md.FilterAttributes(inputAttrM)
+			ok := md.MatchAttributes(inputAttrM)
 			assert.Equal(t, tc.expectedDecision, ok)
 			if ok {
-				// Only if the decision is true, the map should be compared
+				actual, err := md.FilterAttributes(context.Background(), nil, inputAttrM)
+				require.NoError(t, err)
 				assert.Empty(t, cmp.Diff(tc.expectedAttributes, actual.AsRaw()))
 			}
+		})
+	}
+}
+
+func TestExtractStringSlice(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    any
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name: "pcommon_slice",
+			input: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("labels.foo")
+				s.AppendEmpty().SetStr("labels.bar")
+				return s
+			}(),
+			expected: []string{"labels.foo", "labels.bar"},
+		},
+		{
+			name:     "string_slice",
+			input:    []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name: "pcommon_slice_non_string_element",
+			input: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(42)
+				return s
+			}(),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported_type",
+			input:   42,
+			wantErr: true,
+		},
+		{
+			name: "empty_pcommon_slice",
+			input: func() pcommon.Slice {
+				return pcommon.NewSlice()
+			}(),
+			expected: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := extractStringSlice(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }
@@ -171,19 +232,19 @@ func testCollectorInstanceInfo(t *testing.T) CollectorInstanceInfo {
 	return NewCollectorInstanceInfo(set)
 }
 
-func testAttributeKeyValue(
+func testAttributeEntry(
 	t *testing.T,
 	k string,
 	optional bool,
 	val any,
-) AttributeKeyValue {
+) AttributeEntry[*ottlspan.TransformContext] {
 	t.Helper()
 
 	defaultVal := pcommon.NewValueEmpty()
 	if val != nil {
 		require.NoError(t, defaultVal.FromRaw(val))
 	}
-	return AttributeKeyValue{
+	return AttributeEntry[*ottlspan.TransformContext]{
 		Key:          k,
 		Optional:     optional,
 		DefaultValue: defaultVal,

--- a/connector/signaltometricsconnector/internal/model/model_test.go
+++ b/connector/signaltometricsconnector/internal/model/model_test.go
@@ -4,7 +4,6 @@
 package model
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -86,7 +85,7 @@ func TestFilterResourceAttributes(t *testing.T) {
 			inputResourceAttrsM := pcommon.NewMap()
 			require.NoError(t, inputResourceAttrsM.FromRaw(inputAttributes))
 			actual, err := md.FilterResourceAttributes(
-				context.Background(),
+				t.Context(),
 				nil, // no transform context needed for static key tests
 				inputResourceAttrsM,
 				testCollectorInstanceInfo(t),
@@ -160,7 +159,7 @@ func TestFilterAttributes(t *testing.T) {
 			ok := md.MatchAttributes(inputAttrM)
 			assert.Equal(t, tc.expectedDecision, ok)
 			if ok {
-				actual, err := md.FilterAttributes(context.Background(), nil, inputAttrM)
+				actual, err := md.FilterAttributes(t.Context(), nil, inputAttrM)
 				require.NoError(t, err)
 				assert.Empty(t, cmp.Diff(tc.expectedAttributes, actual.AsRaw()))
 			}
@@ -205,10 +204,8 @@ func TestExtractStringSlice(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty_pcommon_slice",
-			input: func() pcommon.Slice {
-				return pcommon.NewSlice()
-			}(),
+			name:     "empty_pcommon_slice",
+			input:    pcommon.NewSlice(),
 			expected: []string{},
 		},
 	} {

--- a/connector/signaltometricsconnector/testdata/traces/ottl_expression/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/ottl_expression/config.yaml
@@ -1,0 +1,10 @@
+signal_to_metrics:
+  spans:
+    - name: with_dynamic_resource_attrs
+      description: Spans with dynamically resolved resource attributes from client metadata
+      unit: s
+      include_resource_attributes:
+        - ottl_expression: otelcol.client.metadata["x-dynamic-resource-attributes"]
+      sum:
+        value: Int(Seconds(end_time - start_time))
+        monotonic: true

--- a/connector/signaltometricsconnector/testdata/traces/ottl_expression/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/ottl_expression/config.yaml
@@ -4,7 +4,7 @@ signal_to_metrics:
       description: Spans with dynamically resolved resource attributes from client metadata
       unit: s
       include_resource_attributes:
-        - ottl_expression: otelcol.client.metadata["x-dynamic-resource-attributes"]
+        - keys_expression: otelcol.client.metadata["x-dynamic-resource-attributes"]
       sum:
         value: Int(Seconds(end_time - start_time))
         monotonic: true

--- a/connector/signaltometricsconnector/testdata/traces/ottl_expression/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/ottl_expression/output.yaml
@@ -1,0 +1,22 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.foo
+          value:
+            stringValue: foo
+        - key: signal_to_metrics.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+    scopeMetrics:
+      - metrics:
+          - description: Spans with dynamically resolved resource attributes from client metadata
+            name: with_dynamic_resource_attrs
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "29"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+            unit: s
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector


### PR DESCRIPTION
  ## Summary

  Adds an `ottl_expression` field to the `Attribute` config struct, enabling dynamic attribute key resolution at runtime
  for both `include_resource_attributes` and `attributes`. This is an alternative to #46884 that avoids custom OTTL
  functions entirely.

  The OTTL expression evaluates to a list of attribute keys (`pcommon.Slice` or `[]string`) at runtime. Each resolved key
   is looked up in the source attributes and included in the output. This enables use cases like dynamically selecting
   attributes based on `client.Metadata` or other cases which can be accessed by ottl:

  ```yaml
  include_resource_attributes:
    - key: service.name
    - ottl_expression: otelcol.client.metadata["x-dynamic-resource-attributes"]
      optional: true
```

  Benchmark results (vs main)


| Benchmark | Time | Memory | Allocs |
|-----------|------|--------|--------|
| Traces    | ~0%  | ~0%    | ~0%    |
| Metrics   | -28% | -49%   | -18%   |
| Logs      | ~0%  | ~0%    | ~0%    |

  Test plan

  - Unit tests added/updated

  🤖 Generated with Claude Code

  Alternative to #46884