### PR TITLE
[chore][pkg/stanza/fileconsumer] Remove unused archivePollsToArchiveKey constant

### DIFF
--- a/pkg/stanza/fileconsumer/internal/archive/archive.go
+++ b/pkg/stanza/fileconsumer/internal/archive/archive.go
@@ -20,8 +20,7 @@ import (
 )
 
 const (
-	archiveIndexKey          = "knownFilesArchiveIndex"
-	archivePollsToArchiveKey = "knonwFilesPollsToArchive"
+	archiveIndexKey = "knownFilesArchiveIndex"
 )
 
 type Archive interface {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Remove unused `archivePollsToArchiveKey` constant from `archive.go`. The constant is not referenced anywhere in the repository and contains a typo (`"knonwFiles"` instead of `"knownFiles"`).