### PR TITLE
connector/signaltometricsconnector: pre-compute prefixed collector key

### DIFF
--- a/.chloggen/signaltometrics-precompute-collector-key.yaml
+++ b/.chloggen/signaltometrics-precompute-collector-key.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: connector/signaltometrics
+component: connector/signal_to_metrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Pre-compute prefixed collector key to avoid a string allocation on every signal processed.

--- a/.chloggen/signaltometrics-precompute-collector-key.yaml
+++ b/.chloggen/signaltometrics-precompute-collector-key.yaml
@@ -10,7 +10,7 @@ component: connector/signaltometrics
 note: Pre-compute prefixed collector key to avoid a string allocation on every signal processed.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47183]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/signaltometrics-precompute-collector-key.yaml
+++ b/.chloggen/signaltometrics-precompute-collector-key.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/signaltometrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pre-compute prefixed collector key to avoid a string allocation on every signal processed.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+ Pre-computing the collector key avoids a string allocation on every signal processed.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
@@ -13,6 +13,10 @@ import (
 
 var prefix = metadata.Type.String()
 
+// prefixedServiceInstanceIDKey is the service.instance.id key with the connector prefix,
+// pre-computed to avoid a string allocation on every Copy() call.
+var prefixedServiceInstanceIDKey = keyWithPrefix(string(conventions.ServiceInstanceIDKey))
+
 // CollectorInstanceInfo holds the attributes that could uniquely identify
 // the current collector instance. These attributes are initialized from the
 // telemetry settings. The CollectorInstanceInfo can copy these attributes,
@@ -46,7 +50,7 @@ func (info CollectorInstanceInfo) Size() int {
 func (info CollectorInstanceInfo) Copy(to pcommon.Map) {
 	to.EnsureCapacity(info.Size())
 	if info.serviceInstanceID != "" {
-		to.PutStr(keyWithPrefix(string(conventions.ServiceInstanceIDKey)), info.serviceInstanceID)
+		to.PutStr(prefixedServiceInstanceIDKey, info.serviceInstanceID)
 	}
 }
 


### PR DESCRIPTION
#### Description

 - Since the key is derived from package-level constants that never change at runtime, compute it once at package init and reuse it in Copy().This eliminates one string allocation per (signal × metric-def) processed by the connector, reducing steady-state GC pressure at high throughput.