### PR TITLE
connector/signaltometricsconnector: reduce hot-path allocations

### DIFF
--- a/.chloggen/signaltometrics-reduce-hot-path-allocs.yaml
+++ b/.chloggen/signaltometrics-reduce-hot-path-allocs.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/signal_to_metrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce per-signal allocations in the hot path by replacing attribute map allocation with a pooled hash-based ID check, 
+      and caching filtered resource attributes per metric definition within each resource batch.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47184]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -53,16 +53,29 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 	processedMetrics.ResourceMetrics().EnsureCapacity(td.ResourceSpans().Len())
 	aggregator := aggregator.NewAggregator[*ottlspan.TransformContext](processedMetrics, sm.errorMode, sm.logger)
 
+	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
+	// a single ResourceSpan. Nil until first match
+	var (
+		resAttrsCache      []pcommon.Map
+		resAttrsCacheReady []bool
+	)
+
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceSpan := td.ResourceSpans().At(i)
 		resourceAttrs := resourceSpan.Resource().Attributes()
+		// Reset cache for this new resource span
+		resAttrsCache = resAttrsCache[:0]
+		resAttrsCacheReady = resAttrsCacheReady[:0]
+
 		for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
 			scopeSpan := resourceSpan.ScopeSpans().At(j)
 			for k := 0; k < scopeSpan.Spans().Len(); k++ {
 				span := scopeSpan.Spans().At(k)
 				spanAttrs := span.Attributes()
-				for _, md := range sm.spanMetricDefs {
-					filteredSpanAttrs, ok := md.FilterAttributes(spanAttrs)
+				for mdIdx, md := range sm.spanMetricDefs {
+					// FilterAttributesID checks required attrs and returns a hash ID
+					// without allocating a pcommon.Map
+					attrID, ok := md.FilterAttributesID(spanAttrs)
 					if !ok {
 						continue
 					}
@@ -83,8 +96,17 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 						}
 					}
 
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
-					err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredSpanAttrs, 1)
+					// Lazy-compute and cache filtered resource attrs per metric def
+					for len(resAttrsCache) <= mdIdx {
+						resAttrsCache = append(resAttrsCache, pcommon.Map{})
+						resAttrsCacheReady = append(resAttrsCacheReady, false)
+					}
+					if !resAttrsCacheReady[mdIdx] {
+						resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
+						resAttrsCacheReady[mdIdx] = true
+					}
+
+					err := aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], spanAttrs, attrID, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -105,17 +127,40 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(m.ResourceMetrics().Len())
 	aggregator := aggregator.NewAggregator[*ottldatapoint.TransformContext](processedMetrics, sm.errorMode, sm.logger)
+
+	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
+	// a single ResourceMetric. Nil until first match
+	var (
+		resAttrsCache      []pcommon.Map
+		resAttrsCacheReady []bool
+	)
+
 	for i := 0; i < m.ResourceMetrics().Len(); i++ {
 		resourceMetric := m.ResourceMetrics().At(i)
 		resourceAttrs := resourceMetric.Resource().Attributes()
+		// Reset cache for this new resource metric
+		resAttrsCache = resAttrsCache[:0]
+		resAttrsCacheReady = resAttrsCacheReady[:0]
+
 		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
 			scopeMetric := resourceMetric.ScopeMetrics().At(j)
 			for k := 0; k < scopeMetric.Metrics().Len(); k++ {
 				metrics := scopeMetric.Metrics()
 				metric := metrics.At(k)
-				for _, md := range sm.dpMetricDefs {
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
-					aggregate := func(dp any, dpAttrs pcommon.Map) error {
+				for mdIdx, md := range sm.dpMetricDefs {
+					// aggregate is called only when a DP passes the attribute filter.
+					// filteredResAttrs is computed lazily inside and cached per metric-def
+					// index within the current ResourceMetric
+					aggregate := func(dp any, originalDPAttrs pcommon.Map, attrID [16]byte) error {
+						// Lazy-compute and cache filtered resource attrs
+						for len(resAttrsCache) <= mdIdx {
+							resAttrsCache = append(resAttrsCache, pcommon.Map{})
+							resAttrsCacheReady = append(resAttrsCacheReady, false)
+						}
+						if !resAttrsCacheReady[mdIdx] {
+							resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
+							resAttrsCacheReady[mdIdx] = true
+						}
 						// The transform context is created from original attributes so that the
 						// OTTL expressions are also applied on the original attributes.
 						tCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetric, metric, dp)
@@ -130,7 +175,7 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 								return nil
 							}
 						}
-						return aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, dpAttrs, 1)
+						return aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], originalDPAttrs, attrID, 1)
 					}
 
 					//exhaustive:enforce
@@ -139,11 +184,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						dps := metric.Gauge().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
 							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
 							if !ok {
 								continue
 							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
@@ -151,11 +196,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						dps := metric.Sum().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
 							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
 							if !ok {
 								continue
 							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
@@ -163,11 +208,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						dps := metric.Summary().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
 							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
 							if !ok {
 								continue
 							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
@@ -175,11 +220,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						dps := metric.Histogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
 							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
 							if !ok {
 								continue
 							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
@@ -187,11 +232,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						dps := metric.ExponentialHistogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
 							dp := dps.At(l)
-							filteredDPAttrs, ok := md.FilterAttributes(dp.Attributes())
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
 							if !ok {
 								continue
 							}
-							if err := aggregate(dp, filteredDPAttrs); err != nil {
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
@@ -214,16 +259,30 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(logs.ResourceLogs().Len())
 	aggregator := aggregator.NewAggregator[*ottllog.TransformContext](processedMetrics, sm.errorMode, sm.logger)
+
+	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
+	// a single ResourceLog. Nil until first match (Exp4: lazy allocation).
+	var (
+		resAttrsCache      []pcommon.Map
+		resAttrsCacheReady []bool
+	)
+
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
 		resourceLog := logs.ResourceLogs().At(i)
 		resourceAttrs := resourceLog.Resource().Attributes()
+		// Reset cache for this new resource log (keep backing array).
+		resAttrsCache = resAttrsCache[:0]
+		resAttrsCacheReady = resAttrsCacheReady[:0]
+
 		for j := 0; j < resourceLog.ScopeLogs().Len(); j++ {
 			scopeLog := resourceLog.ScopeLogs().At(j)
 			for k := 0; k < scopeLog.LogRecords().Len(); k++ {
 				log := scopeLog.LogRecords().At(k)
 				logAttrs := log.Attributes()
-				for _, md := range sm.logMetricDefs {
-					filteredLogAttrs, ok := md.FilterAttributes(logAttrs)
+				for mdIdx, md := range sm.logMetricDefs {
+					// FilterAttributesID checks required attrs and returns a hash ID
+					// without allocating a pcommon.Map (Exp8).
+					attrID, ok := md.FilterAttributesID(logAttrs)
 					if !ok {
 						continue
 					}
@@ -243,8 +302,18 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 							continue
 						}
 					}
-					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
-					err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredLogAttrs, 1)
+
+					// Lazy-compute and cache filtered resource attrs per metric def (Exp2+3).
+					for len(resAttrsCache) <= mdIdx {
+						resAttrsCache = append(resAttrsCache, pcommon.Map{})
+						resAttrsCacheReady = append(resAttrsCacheReady, false)
+					}
+					if !resAttrsCacheReady[mdIdx] {
+						resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
+						resAttrsCacheReady[mdIdx] = true
+					}
+
+					err := aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], logAttrs, attrID, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -278,7 +347,9 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 				profileAttrs := pprofile.FromAttributeIndices(profiles.Dictionary().AttributeTable(), profile, profiles.Dictionary())
 
 				for _, md := range sm.profileMetricDefs {
-					filteredProfileAttrs, ok := md.FilterAttributes(profileAttrs)
+					// FilterAttributesID checks required attrs and returns a hash ID
+					// without allocating a pcommon.Map (Exp8).
+					attrID, ok := md.FilterAttributesID(profileAttrs)
 					if !ok {
 						continue
 					}
@@ -299,7 +370,7 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 						}
 					}
 					filteredResAttrs := md.FilterResourceAttributes(resourceAttrs, sm.collectorInstanceInfo)
-					if err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredProfileAttrs, 1); err != nil {
+					if err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, profileAttrs, attrID, 1); err != nil {
 						tCtx.Close()
 						return err
 					}

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/connector/signa
 go 1.25.0
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/lightstep/go-expohisto v1.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.148.0
@@ -33,7 +34,6 @@ require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/antchfx/xmlquery v1.5.0 // indirect
 	github.com/antchfx/xpath v1.3.6 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elastic/go-grok v0.3.1 // indirect
 	github.com/elastic/lunes v0.2.0 // indirect

--- a/connector/signaltometricsconnector/internal/aggregator/aggregator.go
+++ b/connector/signaltometricsconnector/internal/aggregator/aggregator.go
@@ -53,7 +53,8 @@ func (a *Aggregator[K]) Aggregate(
 	ctx context.Context,
 	tCtx K,
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	defaultCount int64,
 ) error {
 	switch md.Key.Type {
@@ -67,7 +68,7 @@ func (a *Aggregator[K]) Aggregate(
 		if err != nil {
 			return a.handleError(err)
 		}
-		if err := a.aggregateValueCount(md, resAttrs, srcAttrs, val, count); err != nil {
+		if err := a.aggregateValueCount(md, resAttrs, originalSrcAttrs, attrID, val, count); err != nil {
 			return a.handleError(err)
 		}
 	case pmetric.MetricTypeHistogram:
@@ -80,7 +81,7 @@ func (a *Aggregator[K]) Aggregate(
 		if err != nil {
 			return a.handleError(err)
 		}
-		if err := a.aggregateValueCount(md, resAttrs, srcAttrs, val, count); err != nil {
+		if err := a.aggregateValueCount(md, resAttrs, originalSrcAttrs, attrID, val, count); err != nil {
 			return a.handleError(err)
 		}
 	case pmetric.MetricTypeSum:
@@ -90,11 +91,11 @@ func (a *Aggregator[K]) Aggregate(
 		}
 		switch v := raw.(type) {
 		case int64:
-			if err := a.aggregateInt(md, resAttrs, srcAttrs, v); err != nil {
+			if err := a.aggregateInt(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
 				return a.handleError(err)
 			}
 		case float64:
-			if err := a.aggregateDouble(md, resAttrs, srcAttrs, v); err != nil {
+			if err := a.aggregateDouble(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
 				return a.handleError(err)
 			}
 		default:
@@ -117,7 +118,7 @@ func (a *Aggregator[K]) Aggregate(
 		}
 		switch v := raw.(type) {
 		case int64, float64:
-			if err := a.aggregateGauge(md, resAttrs, srcAttrs, v); err != nil {
+			if err := a.aggregateGauge(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
 				return a.handleError(err)
 			}
 		default:
@@ -227,11 +228,11 @@ func (a *Aggregator[K]) Finalize(mds []model.MetricDef[K]) {
 
 func (a *Aggregator[K]) aggregateInt(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	v int64,
 ) error {
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.sums[md.Key]; !ok {
 		a.sums[md.Key] = make(map[[16]byte]map[[16]byte]*sumDP)
 	}
@@ -239,7 +240,7 @@ func (a *Aggregator[K]) aggregateInt(
 		a.sums[md.Key][resID] = make(map[[16]byte]*sumDP)
 	}
 	if _, ok := a.sums[md.Key][resID][attrID]; !ok {
-		a.sums[md.Key][resID][attrID] = newSumDP(srcAttrs, false)
+		a.sums[md.Key][resID][attrID] = newSumDP(md.FilterAttributesUnchecked(originalSrcAttrs), false)
 	}
 	a.sums[md.Key][resID][attrID].AggregateInt(v)
 	return nil
@@ -247,11 +248,11 @@ func (a *Aggregator[K]) aggregateInt(
 
 func (a *Aggregator[K]) aggregateDouble(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	v float64,
 ) error {
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.sums[md.Key]; !ok {
 		a.sums[md.Key] = make(map[[16]byte]map[[16]byte]*sumDP)
 	}
@@ -259,7 +260,7 @@ func (a *Aggregator[K]) aggregateDouble(
 		a.sums[md.Key][resID] = make(map[[16]byte]*sumDP)
 	}
 	if _, ok := a.sums[md.Key][resID][attrID]; !ok {
-		a.sums[md.Key][resID][attrID] = newSumDP(srcAttrs, true)
+		a.sums[md.Key][resID][attrID] = newSumDP(md.FilterAttributesUnchecked(originalSrcAttrs), true)
 	}
 	a.sums[md.Key][resID][attrID].AggregateDouble(v)
 	return nil
@@ -267,11 +268,11 @@ func (a *Aggregator[K]) aggregateDouble(
 
 func (a *Aggregator[K]) aggregateGauge(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	v any,
 ) error {
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.gauges[md.Key]; !ok {
 		a.gauges[md.Key] = make(map[[16]byte]map[[16]byte]*gaugeDP)
 	}
@@ -279,7 +280,7 @@ func (a *Aggregator[K]) aggregateGauge(
 		a.gauges[md.Key][resID] = make(map[[16]byte]*gaugeDP)
 	}
 	if _, ok := a.gauges[md.Key][resID][attrID]; !ok {
-		a.gauges[md.Key][resID][attrID] = newGaugeDP(srcAttrs)
+		a.gauges[md.Key][resID][attrID] = newGaugeDP(md.FilterAttributesUnchecked(originalSrcAttrs))
 	}
 	a.gauges[md.Key][resID][attrID].Aggregate(v)
 	return nil
@@ -287,7 +288,8 @@ func (a *Aggregator[K]) aggregateGauge(
 
 func (a *Aggregator[K]) aggregateValueCount(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	value float64, count int64,
 ) error {
 	if count == 0 {
@@ -295,7 +297,6 @@ func (a *Aggregator[K]) aggregateValueCount(
 		return nil
 	}
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.valueCounts[md.Key]; !ok {
 		a.valueCounts[md.Key] = make(map[[16]byte]map[[16]byte]*valueCountDP)
 	}
@@ -303,7 +304,7 @@ func (a *Aggregator[K]) aggregateValueCount(
 		a.valueCounts[md.Key][resID] = make(map[[16]byte]*valueCountDP)
 	}
 	if _, ok := a.valueCounts[md.Key][resID][attrID]; !ok {
-		a.valueCounts[md.Key][resID][attrID] = newValueCountDP(md, srcAttrs)
+		a.valueCounts[md.Key][resID][attrID] = newValueCountDP(md, md.FilterAttributesUnchecked(originalSrcAttrs))
 	}
 	a.valueCounts[md.Key][resID][attrID].Aggregate(value, count)
 	return nil

--- a/connector/signaltometricsconnector/internal/model/attrhash.go
+++ b/connector/signaltometricsconnector/internal/model/attrhash.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/internal/model"
+
+import (
+	"encoding/binary"
+	"math"
+	"sync"
+
+	"github.com/cespare/xxhash/v2"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// attrHashBuf is a pooled byte buffer used to compute a 128-bit hash of a
+// filtered attribute set without allocating a pcommon.Map.
+type attrHashBuf struct {
+	buf []byte
+}
+
+var attrHashBufPool = sync.Pool{
+	New: func() any {
+		return &attrHashBuf{buf: make([]byte, 0, 256)}
+	},
+}
+
+// sum128 returns a 128-bit hash of b.buf using the same two-pass xxhash
+// algorithm as pdatautil.MapHash.
+func (b *attrHashBuf) sum128() [16]byte {
+	var result [16]byte
+	h := xxhash.Sum64(b.buf)
+	binary.LittleEndian.PutUint64(result[:8], h)
+	b.buf = append(b.buf, 0)
+	h = xxhash.Sum64(b.buf)
+	b.buf = b.buf[:len(b.buf)-1]
+	binary.LittleEndian.PutUint64(result[8:], h)
+	return result
+}
+
+// appendAttrValue appends a type-tagged encoding of v to buf.
+func appendAttrValue(buf []byte, v pcommon.Value) []byte {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		buf = append(buf, 'S')
+		s := v.Str()
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(s)))
+		buf = append(buf, l[:]...)
+		buf = append(buf, s...)
+	case pcommon.ValueTypeInt:
+		buf = append(buf, 'I')
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], uint64(v.Int()))
+		buf = append(buf, b[:]...)
+	case pcommon.ValueTypeDouble:
+		buf = append(buf, 'D')
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], math.Float64bits(v.Double()))
+		buf = append(buf, b[:]...)
+	case pcommon.ValueTypeBool:
+		buf = append(buf, 'B')
+		if v.Bool() {
+			buf = append(buf, 1)
+		} else {
+			buf = append(buf, 0)
+		}
+	default:
+		// bytes, map, slice: encode as string representation (rare for attributes)
+		buf = append(buf, 'O')
+		s := v.AsString()
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(s)))
+		buf = append(buf, l[:]...)
+		buf = append(buf, s...)
+	}
+	return buf
+}

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -6,6 +6,7 @@ package model // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -132,11 +133,14 @@ type MetricDef[K any] struct {
 	Key                       MetricKey
 	IncludeResourceAttributes []AttributeKeyValue
 	Attributes                []AttributeKeyValue
-	Conditions                *ottl.ConditionSequence[K]
-	ExponentialHistogram      *ExponentialHistogram[K]
-	ExplicitHistogram         *ExplicitHistogram[K]
-	Sum                       *Sum[K]
-	Gauge                     *Gauge[K]
+	// sortedAttrs is Attributes sorted alphabetically by key, used for
+	// deterministic hash computation in FilterAttributesID.
+	sortedAttrs          []AttributeKeyValue
+	Conditions           *ottl.ConditionSequence[K]
+	ExponentialHistogram *ExponentialHistogram[K]
+	ExplicitHistogram    *ExplicitHistogram[K]
+	Sum                  *Sum[K]
+	Gauge                *Gauge[K]
 }
 
 func (md *MetricDef[K]) FromMetricInfo(
@@ -156,6 +160,15 @@ func (md *MetricDef[K]) FromMetricInfo(
 	md.Attributes, err = parseAttributeConfigs(mi.Attributes)
 	if err != nil {
 		return fmt.Errorf("failed to parse attribute config: %w", err)
+	}
+	// Pre-sort a copy of Attributes by key for deterministic hash computation
+	// in FilterAttributesID.
+	if len(md.Attributes) > 0 {
+		md.sortedAttrs = make([]AttributeKeyValue, len(md.Attributes))
+		copy(md.sortedAttrs, md.Attributes)
+		sort.Slice(md.sortedAttrs, func(i, j int) bool {
+			return md.sortedAttrs[i].Key < md.sortedAttrs[j].Key
+		})
 	}
 	if len(mi.Conditions) > 0 {
 		conditions, err := parser.ParseConditions(mi.Conditions)
@@ -243,6 +256,52 @@ func (md *MetricDef[K]) FilterAttributes(attrs pcommon.Map) (pcommon.Map, bool) 
 		}
 	}
 	return filterAttributes(attrs, md.Attributes, len(md.Attributes)), true
+}
+
+// FilterAttributesID returns a 128-bit hash that identifies the filtered
+// attribute set for the given source attributes, without allocating a
+// pcommon.Map. The returned hash is equivalent in purpose to
+// pdatautil.MapHash applied to the result of FilterAttributes, but uses a
+// different (internal-only) encoding. Returns false if any required attribute
+// is absent.
+//
+// This is used in conjunction with FilterAttributesUnchecked: call
+// FilterAttributesID first to check presence and compute the DP lookup key,
+// then call FilterAttributesUnchecked only when a new DP must be created.
+func (md *MetricDef[K]) FilterAttributesID(attrs pcommon.Map) ([16]byte, bool) {
+	for _, filter := range md.Attributes {
+		if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty || filter.Optional {
+			continue
+		}
+		if _, ok := attrs.Get(filter.Key); !ok {
+			return [16]byte{}, false
+		}
+	}
+	hb := attrHashBufPool.Get().(*attrHashBuf)
+	hb.buf = hb.buf[:0]
+	for _, filter := range md.sortedAttrs {
+		v, ok := attrs.Get(filter.Key)
+		if ok {
+			hb.buf = append(hb.buf, filter.Key...)
+			hb.buf = append(hb.buf, 0) // key-value separator
+			hb.buf = appendAttrValue(hb.buf, v)
+		} else if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty {
+			hb.buf = append(hb.buf, filter.Key...)
+			hb.buf = append(hb.buf, 0)
+			hb.buf = appendAttrValue(hb.buf, filter.DefaultValue)
+		}
+		// Optional key absent: not included in hash
+	}
+	id := hb.sum128()
+	attrHashBufPool.Put(hb)
+	return id, true
+}
+
+// FilterAttributesUnchecked creates a filtered pcommon.Map from attrs without
+// re-checking for required attribute presence. It must only be called after
+// FilterAttributesID has returned true for the same attrs.
+func (md *MetricDef[K]) FilterAttributesUnchecked(attrs pcommon.Map) pcommon.Map {
+	return filterAttributes(attrs, md.Attributes, len(md.Attributes))
 }
 
 func filterAttributes(attrs pcommon.Map, filters []AttributeKeyValue, expectedLen int) pcommon.Map {


### PR DESCRIPTION

#### Description

  **1. Replace FilterAttributes with a hash-only ID check**

 - `FilterAttributes` allocates a `pcommon.Map` on every (signal × metric-def) combination to check required attribute presence and derive the datapoint lookup key. Most of the time this map is discarded immediately (condition not matched, DP already exists in the aggregation map).
 - Add `FilterAttributesID` which computes a 128-bit xxhash of the filtered attribute set using a pooled `[]byte` scratch buffer, with no heap allocation. The full `pcommon.Map` is now only allocated via `FilterAttributesUnchecked` when a genuinely new datapoint is created (aggregation map cache miss).
- The pooled buffer (`attrHashBuf`) holds no cross-call state - it is borrowed, written into, hashed, and returned immediately, making it safe under concurrent use.

  **2. Cache FilterResourceAttributes per (resource, metric-def)**
 - `FilterResourceAttributes` was called once per (signal × metric-def) even when the same resource was shared across many signals (e.g. all spans in a ResourceSpan batch). Add a local `resAttrsCache` slice in each `Consume*` method that caches the result per metric-def index, reset at each new resource boundary. The slice is nil until the first matching signal, avoiding any allocation when no signals match.
 
**Benchmarks** (Apple M1 Max, `benchstat` over 6 runs × 3s each):
```
  goos: darwin
  goarch: arm64
  cpu: Apple M1 Max
                          │    before    │              after                  │
                          │   sec/op     │   sec/op      vs base               │
  ConnectorWithTraces-10    7.838µ ± 7%   7.325µ ±  3%   -6.55% (p=0.002 n=6)
  ConnectorWithMetrics-10   3.274µ ± 2%   1.046µ ± 19%  -68.05% (p=0.002 n=6)
  geomean                   2.316µ        1.595µ         -31.11%

                          │    before    │              after                  │
                          │    B/op      │    B/op       vs base               │
  ConnectorWithTraces-10   6.831Ki ± 0%   6.218Ki ± 0%   -8.98% (p=0.002 n=6)
  ConnectorWithMetrics-10   2920.0 ± 0%    328.0 ± 0%   -88.77% (p=0.002 n=6)
  geomean                   1.841Ki         881.5        -53.24%

                          │    before    │              after                  │
                          │  allocs/op   │  allocs/op    vs base               │
  ConnectorWithTraces-10    120.00 ± 0%    94.00 ± 0%   -21.67% (p=0.002 n=6)
  ConnectorWithMetrics-10    98.00 ± 0%     8.00 ± 0%   -91.84% (p=0.002 n=6)
  geomean                     45.48         18.19        -60.01%

```