### PR TITLE
perf(exporter/kafka): cache OTel attribute sets in producer metrics hooks

### DIFF
--- a/.chloggen/kafkaexporter-cache-producer-attrs.yaml
+++ b/.chloggen/kafkaexporter-cache-producer-attrs.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Cache OTel metric attribute sets in OnBrokerE2E hook to reduce per-export allocations
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47186]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `OnBrokerE2E` previously rebuilt `attribute.NewSet` + `metric.WithAttributeSet` on every
+    call. The set of distinct (nodeID, host, outcome) combinations is bounded by
+    2 × number-of-brokers, so the computed `MeasurementOption` is now cached per key.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
@@ -92,6 +92,12 @@ func (fpm *FranzProducerMetrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ n
 			attribute.String("server.address", meta.Host),
 		)),
 	)
+	// Evict cached attribute sets for this broker so that nodes which come
+	// and go over time do not cause unbounded growth of brokerE2EOpts.
+	fpm.brokerE2EMu.Lock()
+	delete(fpm.brokerE2EOpts, brokerKey{nodeID: meta.NodeID, host: meta.Host, outcome: "success"})
+	delete(fpm.brokerE2EOpts, brokerKey{nodeID: meta.NodeID, host: meta.Host, outcome: "failure"})
+	fpm.brokerE2EMu.Unlock()
 }
 
 var _ kgo.HookBrokerThrottle = (*FranzProducerMetrics)(nil)

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
@@ -6,6 +6,7 @@ package kafkaclient // import "github.com/open-telemetry/opentelemetry-collector
 import (
 	"context"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -16,20 +17,55 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/metadata"
 )
 
+// brokerKey is the cache key for per-broker attribute sets used in OnBrokerE2E.
+// The set of distinct (nodeID, host, outcome) combinations is bounded by
+// 2 × number-of-brokers (success + failure), so the cache never grows unboundedly.
+type brokerKey struct {
+	nodeID  int32
+	host    string
+	outcome string // "success" | "failure"
+}
+
 // FranzProducerMetrics implements the relevant franz-go hook interfaces to
 // record the metrics defined in the metadata telemetry.
 type FranzProducerMetrics struct {
-	tb *metadata.TelemetryBuilder
+	tb            *metadata.TelemetryBuilder
+	brokerE2EMu   sync.RWMutex
+	brokerE2EOpts map[brokerKey]metric.MeasurementOption
 }
 
 // NewFranzProducerMetrics creates an instance of FranzProducerMetrics from metadata TelemetryBuilder.
-func NewFranzProducerMetrics(tb *metadata.TelemetryBuilder) FranzProducerMetrics {
-	return FranzProducerMetrics{tb: tb}
+func NewFranzProducerMetrics(tb *metadata.TelemetryBuilder) *FranzProducerMetrics {
+	return &FranzProducerMetrics{
+		tb:            tb,
+		brokerE2EOpts: make(map[brokerKey]metric.MeasurementOption),
+	}
 }
 
-var _ kgo.HookBrokerConnect = FranzProducerMetrics{}
+// brokerE2EOpt returns a cached MeasurementOption for the given key, building
+// and storing it on first use.
+func (fpm *FranzProducerMetrics) brokerE2EOpt(k brokerKey) metric.MeasurementOption {
+	fpm.brokerE2EMu.RLock()
+	opt, ok := fpm.brokerE2EOpts[k]
+	fpm.brokerE2EMu.RUnlock()
+	if ok {
+		return opt
+	}
+	attrs := attribute.NewSet(
+		attribute.String("node_id", kgo.NodeName(k.nodeID)),
+		attribute.String("server.address", k.host),
+		attribute.String("outcome", k.outcome),
+	)
+	opt = metric.WithAttributeSet(attrs)
+	fpm.brokerE2EMu.Lock()
+	fpm.brokerE2EOpts[k] = opt
+	fpm.brokerE2EMu.Unlock()
+	return opt
+}
 
-func (fpm FranzProducerMetrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
+var _ kgo.HookBrokerConnect = (*FranzProducerMetrics)(nil)
+
+func (fpm *FranzProducerMetrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
 	outcome := "success"
 	if err != nil {
 		outcome = "failure"
@@ -45,9 +81,9 @@ func (fpm FranzProducerMetrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.
 	)
 }
 
-var _ kgo.HookBrokerDisconnect = FranzProducerMetrics{}
+var _ kgo.HookBrokerDisconnect = (*FranzProducerMetrics)(nil)
 
-func (fpm FranzProducerMetrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
+func (fpm *FranzProducerMetrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
 	fpm.tb.KafkaBrokerClosed.Add(
 		context.Background(),
 		1,
@@ -58,9 +94,9 @@ func (fpm FranzProducerMetrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ ne
 	)
 }
 
-var _ kgo.HookBrokerThrottle = FranzProducerMetrics{}
+var _ kgo.HookBrokerThrottle = (*FranzProducerMetrics)(nil)
 
-func (fpm FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
+func (fpm *FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
 	attrs := attribute.NewSet(
 		attribute.String("node_id", kgo.NodeName(meta.NodeID)),
 		attribute.String("server.address", meta.Host),
@@ -78,9 +114,9 @@ func (fpm FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, thrott
 	)
 }
 
-var _ kgo.HookBrokerE2E = FranzProducerMetrics{}
+var _ kgo.HookBrokerE2E = (*FranzProducerMetrics)(nil)
 
-func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, key int16, e2e kgo.BrokerE2E) {
+func (fpm *FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, key int16, e2e kgo.BrokerE2E) {
 	// Do not pollute producer metrics with non-produce requests
 	if kmsg.Key(key) != kmsg.Produce {
 		return
@@ -90,29 +126,25 @@ func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, key int16, 
 	if e2e.Err() != nil {
 		outcome = "failure"
 	}
-	attrs := attribute.NewSet(
-		attribute.String("node_id", kgo.NodeName(meta.NodeID)),
-		attribute.String("server.address", meta.Host),
-		attribute.String("outcome", outcome),
-	)
+	opt := fpm.brokerE2EOpt(brokerKey{nodeID: meta.NodeID, host: meta.Host, outcome: outcome})
 	// KafkaExporterLatency is deprecated in favor of KafkaExporterWriteLatency.
 	fpm.tb.KafkaExporterLatency.Record(
 		context.Background(),
 		e2e.DurationE2E().Milliseconds()+e2e.WriteWait.Milliseconds(),
-		metric.WithAttributeSet(attrs),
+		opt,
 	)
 	fpm.tb.KafkaExporterWriteLatency.Record(
 		context.Background(),
 		e2e.DurationE2E().Seconds()+e2e.WriteWait.Seconds(),
-		metric.WithAttributeSet(attrs),
+		opt,
 	)
 }
 
-var _ kgo.HookProduceBatchWritten = FranzProducerMetrics{}
+var _ kgo.HookProduceBatchWritten = (*FranzProducerMetrics)(nil)
 
 // OnProduceBatchWritten is called when a batch has been produced.
 // https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#HookProduceBatchWritten
-func (fpm FranzProducerMetrics) OnProduceBatchWritten(meta kgo.BrokerMetadata, topic string, partition int32, m kgo.ProduceBatchMetrics) {
+func (fpm *FranzProducerMetrics) OnProduceBatchWritten(meta kgo.BrokerMetadata, topic string, partition int32, m kgo.ProduceBatchMetrics) {
 	attrs := attribute.NewSet(
 		attribute.String("node_id", kgo.NodeName(meta.NodeID)),
 		attribute.String("server.address", meta.Host),
@@ -145,13 +177,13 @@ func (fpm FranzProducerMetrics) OnProduceBatchWritten(meta kgo.BrokerMetadata, t
 	)
 }
 
-var _ kgo.HookProduceRecordUnbuffered = FranzProducerMetrics{}
+var _ kgo.HookProduceRecordUnbuffered = (*FranzProducerMetrics)(nil)
 
 // OnProduceRecordUnbuffered records the number of produced messages that were
 // not produced due to errors. The successfully produced records is recorded by
 // `OnProduceBatchWritten`.
 // https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#HookProduceRecordUnbuffered
-func (fpm FranzProducerMetrics) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
+func (fpm *FranzProducerMetrics) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 	if err == nil {
 		return // Covered by OnProduceBatchWritten.
 	}

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics_test.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics_test.go
@@ -321,6 +321,23 @@ func TestFranzProducerMetrics(t *testing.T) {
 			metricdatatest.IgnoreTimestamp(),
 		)
 	})
+	t.Run("should evict broker E2E cache on disconnect", func(t *testing.T) {
+		testTel := componenttest.NewTelemetry()
+		tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
+		require.NoError(t, err)
+		defer tb.Shutdown()
+		fpm := NewFranzProducerMetrics(tb)
+		meta := kgo.BrokerMetadata{NodeID: 1, Host: "broker1"}
+
+		// Populate the cache for both outcomes.
+		fpm.OnBrokerE2E(meta, int16(kmsg.Produce), kgo.BrokerE2E{})
+		fpm.OnBrokerE2E(meta, int16(kmsg.Produce), kgo.BrokerE2E{WriteErr: errors.New("oops")})
+		require.Len(t, fpm.brokerE2EOpts, 2)
+
+		// Disconnect should evict both entries.
+		fpm.OnBrokerDisconnect(meta, nil)
+		require.Empty(t, fpm.brokerE2EOpts)
+	})
 	t.Run("should report the metrics when OnBrokerThrottle hook is called", func(t *testing.T) {
 		testTel := componenttest.NewTelemetry()
 		tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())


### PR DESCRIPTION

#### Description

 - `OnBrokerE2E` calls `attribute.NewSet` + `metric.WithAttributeSet` on every invocation, which fires synchronously inside `ProduceSync` on the export hot path. The set of distinct `(nodeID, host, outcome)` combinations is bounded by `2 × number-of-brokers` (success + failure), so the computed `metric.MeasurementOption` is cached per key using a`sync.RWMutex`-guarded map. The cache is populated once per key; all subsequent calls are zero-allocation reads.

 - `OnProduceBatchWritten` is intentionally left uncached — its `topic` attribute can be per-tenant in multi-tenant deployments (e.g. derived from a routing metadata key), which would cause the cache to grow unboundedly with tenant count.


  ## Benchmarks

  `go test -bench=. -benchmem -count=6`, compared with `benchstat`. Apple M1 Max.

  ### Hook benchmarks (`internal/kafkaclient`)

```
                       │    before     │           after            │
                       │    sec/op     │   sec/op    vs base        │
  OnBrokerE2E              │  394.7n ± 2%  │  188.9n ± 1%  -52.15%     │
  OnProduceBatchWritten    │  749.6n ± 2%  │  711.9n ± 6%  ~ (p=0.026) │

                       │    B/op       │   B/op     vs base         │
  OnBrokerE2E              │  272.0 ± 0%   │   32.0 ± 0%  -88.24%      │
  OnProduceBatchWritten    │  472.0 ± 0%   │  472.0 ± 0%  ~ (unchanged) │

                       │  allocs/op    │ allocs/op  vs base         │
  OnBrokerE2E              │   5.000 ± 0%  │  2.000 ± 0%  -60.00%      │
  OnProduceBatchWritten    │   6.000 ± 0%  │  6.000 ± 0%  ~ (unchanged) │

  ### End-to-end sequential export (real in-memory Kafka cluster)

                            │   allocs/op   │ allocs/op  vs base          │
  All 6 benchmarks              │   97.00 ± 0%  │  94.00 ± 0%  -3.09%         │
                                │               │  (p=0.002, n=6)              │

                            │    B/op       │    B/op    vs base           │
  TracesExporterSeq/batch_1     │  7.114Ki ± 1% │  6.856Ki ± 1%   -3.62%      │
  TracesExporterSeq/batch_10    │  9.762Ki ± 0% │  9.523Ki ± 1%   -2.45%      │
  LogsExporterSeq/batch_1       │  6.969Ki ± 1% │  6.732Ki ± 1%   -3.40%      │
  MetricsExporterSeq/batch_1    │  7.001Ki ± 1% │  6.756Ki ± 1%   -3.49%      │
  geomean                       │  8.272Ki      │  8.029Ki        -2.94%       │


```

#### Testing
 + Existing tests covers the flow 
 
