### PR TITLE
[connector/signaltometrics]reduce hot-path allocations

### DIFF
--- a/.chloggen/signaltometrics-reduce-hot-path-allocs.yaml
+++ b/.chloggen/signaltometrics-reduce-hot-path-allocs.yaml
@@ -11,7 +11,7 @@ note: Reduce per-signal allocations in the hot path by replacing attribute map a
       and caching filtered resource attributes per metric definition within each resource batch.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [47184]
+issues: [47197]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/signaltometrics-reduce-hot-path-allocs.yaml
+++ b/.chloggen/signaltometrics-reduce-hot-path-allocs.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/signal_to_metrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce per-signal allocations in the hot path by replacing attribute map allocation with a pooled hash-based ID check, 
+      and caching filtered resource attributes per metric definition within each resource batch.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47184]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -53,16 +53,30 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 	processedMetrics.ResourceMetrics().EnsureCapacity(td.ResourceSpans().Len())
 	aggregator := aggregator.NewAggregator[*ottlspan.TransformContext](processedMetrics, sm.errorMode, sm.logger)
 
+	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
+	// a single ResourceSpan. Nil until first match.
+	var (
+		resAttrsCache      []pcommon.Map
+		resAttrsCacheReady []bool
+	)
+
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceSpan := td.ResourceSpans().At(i)
 		resourceAttrs := resourceSpan.Resource().Attributes()
+		// Reset cache for this new resource span
+		resAttrsCache = resAttrsCache[:0]
+		resAttrsCacheReady = resAttrsCacheReady[:0]
+
 		for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
 			scopeSpan := resourceSpan.ScopeSpans().At(j)
 			for k := 0; k < scopeSpan.Spans().Len(); k++ {
 				span := scopeSpan.Spans().At(k)
 				spanAttrs := span.Attributes()
-				for _, md := range sm.spanMetricDefs {
-					if !md.MatchAttributes(spanAttrs) {
+				for mdIdx, md := range sm.spanMetricDefs {
+					// FilterAttributesID checks required static-key attrs and
+					// returns a hash ID without allocating a pcommon.Map.
+					attrID, ok := md.FilterAttributesID(spanAttrs)
+					if !ok {
 						continue
 					}
 					// The transform context is created from original attributes so that the
@@ -88,12 +102,24 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 						}
 					}
 
-					filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-					if err != nil {
-						tCtx.Close()
-						return fmt.Errorf("failed to filter resource attributes: %w", err)
+					// Lazy-compute and cache filtered resource attrs per metric def.
+					for len(resAttrsCache) <= mdIdx {
+						resAttrsCache = append(resAttrsCache, pcommon.Map{})
+						resAttrsCacheReady = append(resAttrsCacheReady, false)
 					}
-					err = aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredSpanAttrs, 1)
+					if !resAttrsCacheReady[mdIdx] {
+						var filteredResAttrs pcommon.Map
+						filteredResAttrs, err = md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+						if err != nil {
+							tCtx.Close()
+							return fmt.Errorf("failed to filter resource attributes: %w", err)
+						}
+						resAttrsCache[mdIdx] = filteredResAttrs
+						resAttrsCacheReady[mdIdx] = true
+					}
+
+					_ = filteredSpanAttrs // filtered attrs used for conditions; aggregator uses original + hash
+					err = aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], spanAttrs, attrID, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -114,24 +140,51 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(m.ResourceMetrics().Len())
 	aggregator := aggregator.NewAggregator[*ottldatapoint.TransformContext](processedMetrics, sm.errorMode, sm.logger)
+
+	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
+	// a single ResourceMetric. Nil until first match.
+	var (
+		resAttrsCache      []pcommon.Map
+		resAttrsCacheReady []bool
+	)
+
 	for i := 0; i < m.ResourceMetrics().Len(); i++ {
 		resourceMetric := m.ResourceMetrics().At(i)
 		resourceAttrs := resourceMetric.Resource().Attributes()
+		// Reset cache for this new resource metric
+		resAttrsCache = resAttrsCache[:0]
+		resAttrsCacheReady = resAttrsCacheReady[:0]
+
 		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
 			scopeMetric := resourceMetric.ScopeMetrics().At(j)
 			for k := 0; k < scopeMetric.Metrics().Len(); k++ {
 				metrics := scopeMetric.Metrics()
 				metric := metrics.At(k)
-				for _, md := range sm.dpMetricDefs {
-					aggregate := func(dp any, dpAttrs pcommon.Map) error {
-						if !md.MatchAttributes(dpAttrs) {
-							return nil
+				for mdIdx, md := range sm.dpMetricDefs {
+					// aggregate is called only when a DP passes the attribute filter.
+					// filteredResAttrs is computed lazily inside and cached per metric-def
+					// index within the current ResourceMetric.
+					aggregate := func(dp any, originalDPAttrs pcommon.Map, attrID [16]byte) error {
+						// Lazy-compute and cache filtered resource attrs
+						for len(resAttrsCache) <= mdIdx {
+							resAttrsCache = append(resAttrsCache, pcommon.Map{})
+							resAttrsCacheReady = append(resAttrsCacheReady, false)
 						}
 						// The transform context is created from original attributes so that the
 						// OTTL expressions are also applied on the original attributes.
 						tCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetric, metric, dp)
 						defer tCtx.Close()
-						filteredDPAttrs, err := md.FilterAttributes(ctx, tCtx, dpAttrs)
+
+						if !resAttrsCacheReady[mdIdx] {
+							filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+							if err != nil {
+								return fmt.Errorf("failed to filter resource attributes: %w", err)
+							}
+							resAttrsCache[mdIdx] = filteredResAttrs
+							resAttrsCacheReady[mdIdx] = true
+						}
+
+						filteredDPAttrs, err := md.FilterAttributes(ctx, tCtx, originalDPAttrs)
 						if err != nil {
 							return fmt.Errorf("failed to filter attributes: %w", err)
 						}
@@ -147,11 +200,8 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 								return nil
 							}
 						}
-						filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-						if err != nil {
-							return fmt.Errorf("failed to filter resource attributes: %w", err)
-						}
-						return aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredDPAttrs, 1)
+						_ = filteredDPAttrs // filtered attrs used for conditions; aggregator uses original + hash
+						return aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], originalDPAttrs, attrID, 1)
 					}
 
 					//exhaustive:enforce
@@ -159,35 +209,60 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 					case pmetric.MetricTypeGauge:
 						dps := metric.Gauge().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
+							dp := dps.At(l)
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
+							if !ok {
+								continue
+							}
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeSum:
 						dps := metric.Sum().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
+							dp := dps.At(l)
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
+							if !ok {
+								continue
+							}
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeSummary:
 						dps := metric.Summary().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
+							dp := dps.At(l)
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
+							if !ok {
+								continue
+							}
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeHistogram:
 						dps := metric.Histogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
+							dp := dps.At(l)
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
+							if !ok {
+								continue
+							}
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeExponentialHistogram:
 						dps := metric.ExponentialHistogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
+							dp := dps.At(l)
+							attrID, ok := md.FilterAttributesID(dp.Attributes())
+							if !ok {
+								continue
+							}
+							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
 								return err
 							}
 						}
@@ -210,16 +285,31 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(logs.ResourceLogs().Len())
 	aggregator := aggregator.NewAggregator[*ottllog.TransformContext](processedMetrics, sm.errorMode, sm.logger)
+
+	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
+	// a single ResourceLog. Nil until first match.
+	var (
+		resAttrsCache      []pcommon.Map
+		resAttrsCacheReady []bool
+	)
+
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
 		resourceLog := logs.ResourceLogs().At(i)
 		resourceAttrs := resourceLog.Resource().Attributes()
+		// Reset cache for this new resource log (keep backing array).
+		resAttrsCache = resAttrsCache[:0]
+		resAttrsCacheReady = resAttrsCacheReady[:0]
+
 		for j := 0; j < resourceLog.ScopeLogs().Len(); j++ {
 			scopeLog := resourceLog.ScopeLogs().At(j)
 			for k := 0; k < scopeLog.LogRecords().Len(); k++ {
 				log := scopeLog.LogRecords().At(k)
 				logAttrs := log.Attributes()
-				for _, md := range sm.logMetricDefs {
-					if !md.MatchAttributes(logAttrs) {
+				for mdIdx, md := range sm.logMetricDefs {
+					// FilterAttributesID checks required static-key attrs and
+					// returns a hash ID without allocating a pcommon.Map.
+					attrID, ok := md.FilterAttributesID(logAttrs)
+					if !ok {
 						continue
 					}
 					// The transform context is created from original attributes so that the
@@ -244,12 +334,25 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 							continue
 						}
 					}
-					filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-					if err != nil {
-						tCtx.Close()
-						return fmt.Errorf("failed to filter resource attributes: %w", err)
+
+					// Lazy-compute and cache filtered resource attrs per metric def.
+					for len(resAttrsCache) <= mdIdx {
+						resAttrsCache = append(resAttrsCache, pcommon.Map{})
+						resAttrsCacheReady = append(resAttrsCacheReady, false)
 					}
-					err = aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredLogAttrs, 1)
+					if !resAttrsCacheReady[mdIdx] {
+						var filteredResAttrs pcommon.Map
+						filteredResAttrs, err = md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
+						if err != nil {
+							tCtx.Close()
+							return fmt.Errorf("failed to filter resource attributes: %w", err)
+						}
+						resAttrsCache[mdIdx] = filteredResAttrs
+						resAttrsCacheReady[mdIdx] = true
+					}
+
+					_ = filteredLogAttrs // filtered attrs used for conditions; aggregator uses original + hash
+					err = aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], logAttrs, attrID, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -283,7 +386,10 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 				profileAttrs := pprofile.FromAttributeIndices(profiles.Dictionary().AttributeTable(), profile, profiles.Dictionary())
 
 				for _, md := range sm.profileMetricDefs {
-					if !md.MatchAttributes(profileAttrs) {
+					// FilterAttributesID checks required static-key attrs and
+					// returns a hash ID without allocating a pcommon.Map.
+					attrID, ok := md.FilterAttributesID(profileAttrs)
+					if !ok {
 						continue
 					}
 					// The transform context is created from original attributes so that the
@@ -313,7 +419,8 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 						tCtx.Close()
 						return fmt.Errorf("failed to filter resource attributes: %w", err)
 					}
-					if err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, filteredProfileAttrs, 1); err != nil {
+					_ = filteredProfileAttrs // filtered attrs used for conditions; aggregator uses original + hash
+					if err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, profileAttrs, attrID, 1); err != nil {
 						tCtx.Close()
 						return err
 					}

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -55,9 +55,11 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 	// resAttrsCache lazily caches the filtered resource attributes per
 	// metric definition within a resource. Since resource attributes are
 	// constant for all signals within a resource, the result only needs
-	// to be computed once per metric definition per resource. A zero-value
-	// pcommon.Map indicates the entry has not been computed yet.
-	resAttrsCache := make([]pcommon.Map, len(sm.spanMetricDefs))
+	// to be computed once per metric definition per resource. The slice
+	// is allocated on the first match and reused across resources via
+	// clear(). A zero-value pcommon.Map entry indicates it has not been
+	// computed yet for the current resource.
+	var resAttrsCache []pcommon.Map
 
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceSpan := td.ResourceSpans().At(i)
@@ -94,6 +96,9 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 						}
 					}
 
+					if len(resAttrsCache) == 0 {
+						resAttrsCache = make([]pcommon.Map, len(sm.spanMetricDefs))
+					}
 					if resAttrsCache[mdIdx] == (pcommon.Map{}) {
 						resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
 						if resErr != nil {
@@ -130,9 +135,11 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 	// resAttrsCache lazily caches the filtered resource attributes per
 	// metric definition within a resource. Since resource attributes are
 	// constant for all signals within a resource, the result only needs
-	// to be computed once per metric definition per resource. A zero-value
-	// pcommon.Map indicates the entry has not been computed yet.
-	resAttrsCache := make([]pcommon.Map, len(sm.dpMetricDefs))
+	// to be computed once per metric definition per resource. The slice
+	// is allocated on the first match and reused across resources via
+	// clear(). A zero-value pcommon.Map entry indicates it has not been
+	// computed yet for the current resource.
+	var resAttrsCache []pcommon.Map
 
 	for i := 0; i < m.ResourceMetrics().Len(); i++ {
 		resourceMetric := m.ResourceMetrics().At(i)
@@ -156,6 +163,9 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						}
 						attrID := md.ComputeAttributesHash(dpAttrs, resolvedAttrs)
 
+						if len(resAttrsCache) == 0 {
+							resAttrsCache = make([]pcommon.Map, len(sm.dpMetricDefs))
+						}
 						if resAttrsCache[mdIdx] == (pcommon.Map{}) {
 							resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
 							if resErr != nil {
@@ -240,9 +250,11 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 	// resAttrsCache lazily caches the filtered resource attributes per
 	// metric definition within a resource. Since resource attributes are
 	// constant for all signals within a resource, the result only needs
-	// to be computed once per metric definition per resource. A zero-value
-	// pcommon.Map indicates the entry has not been computed yet.
-	resAttrsCache := make([]pcommon.Map, len(sm.logMetricDefs))
+	// to be computed once per metric definition per resource. The slice
+	// is allocated on the first match and reused across resources via
+	// clear(). A zero-value pcommon.Map entry indicates it has not been
+	// computed yet for the current resource.
+	var resAttrsCache []pcommon.Map
 
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
 		resourceLog := logs.ResourceLogs().At(i)
@@ -279,6 +291,9 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 						}
 					}
 
+					if len(resAttrsCache) == 0 {
+						resAttrsCache = make([]pcommon.Map, len(sm.logMetricDefs))
+					}
 					if resAttrsCache[mdIdx] == (pcommon.Map{}) {
 						resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
 						if resErr != nil {
@@ -315,9 +330,11 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 	// resAttrsCache lazily caches the filtered resource attributes per
 	// metric definition within a resource. Since resource attributes are
 	// constant for all signals within a resource, the result only needs
-	// to be computed once per metric definition per resource. A zero-value
-	// pcommon.Map indicates the entry has not been computed yet.
-	resAttrsCache := make([]pcommon.Map, len(sm.profileMetricDefs))
+	// to be computed once per metric definition per resource. The slice
+	// is allocated on the first match and reused across resources via
+	// clear(). A zero-value pcommon.Map entry indicates it has not been
+	// computed yet for the current resource.
+	var resAttrsCache []pcommon.Map
 
 	for i := 0; i < profiles.ResourceProfiles().Len(); i++ {
 		resourceProfile := profiles.ResourceProfiles().At(i)
@@ -355,6 +372,9 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 						}
 					}
 
+					if len(resAttrsCache) == 0 {
+						resAttrsCache = make([]pcommon.Map, len(sm.profileMetricDefs))
+					}
 					if resAttrsCache[mdIdx] == (pcommon.Map{}) {
 						resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
 						if resErr != nil {

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -52,41 +52,33 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(td.ResourceSpans().Len())
 	aggregator := aggregator.NewAggregator[*ottlspan.TransformContext](processedMetrics, sm.errorMode, sm.logger)
-
-	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
-	// a single ResourceSpan. Nil until first match.
-	var (
-		resAttrsCache      []pcommon.Map
-		resAttrsCacheReady []bool
-	)
+	// resAttrsCache lazily caches the filtered resource attributes per
+	// metric definition within a resource. Since resource attributes are
+	// constant for all signals within a resource, the result only needs
+	// to be computed once per metric definition per resource. A zero-value
+	// pcommon.Map indicates the entry has not been computed yet.
+	resAttrsCache := make([]pcommon.Map, len(sm.spanMetricDefs))
 
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceSpan := td.ResourceSpans().At(i)
 		resourceAttrs := resourceSpan.Resource().Attributes()
-		// Reset cache for this new resource span
-		resAttrsCache = resAttrsCache[:0]
-		resAttrsCacheReady = resAttrsCacheReady[:0]
-
+		clear(resAttrsCache)
 		for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
 			scopeSpan := resourceSpan.ScopeSpans().At(j)
 			for k := 0; k < scopeSpan.Spans().Len(); k++ {
 				span := scopeSpan.Spans().At(k)
 				spanAttrs := span.Attributes()
 				for mdIdx, md := range sm.spanMetricDefs {
-					// FilterAttributesID checks required static-key attrs and
-					// returns a hash ID without allocating a pcommon.Map.
-					attrID, ok := md.FilterAttributesID(spanAttrs)
-					if !ok {
+					if !md.MatchAttributes(spanAttrs) {
 						continue
 					}
-					// The transform context is created from original attributes so that the
-					// OTTL expressions are also applied on the original attributes.
 					tCtx := ottlspan.NewTransformContextPtr(resourceSpan, scopeSpan, span)
-					filteredSpanAttrs, err := md.FilterAttributes(ctx, tCtx, spanAttrs)
+					resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()
-						return fmt.Errorf("failed to filter attributes: %w", err)
+						return fmt.Errorf("failed to resolve attributes: %w", err)
 					}
+					attrID := md.ComputeAttributesHash(spanAttrs, resolvedAttrs)
 
 					if md.Conditions != nil {
 						var match bool
@@ -102,24 +94,19 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 						}
 					}
 
-					// Lazy-compute and cache filtered resource attrs per metric def.
-					for len(resAttrsCache) <= mdIdx {
-						resAttrsCache = append(resAttrsCache, pcommon.Map{})
-						resAttrsCacheReady = append(resAttrsCacheReady, false)
-					}
-					if !resAttrsCacheReady[mdIdx] {
-						var filteredResAttrs pcommon.Map
-						filteredResAttrs, err = md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-						if err != nil {
+					if resAttrsCache[mdIdx] == (pcommon.Map{}) {
+						resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
+						if resErr != nil {
 							tCtx.Close()
-							return fmt.Errorf("failed to filter resource attributes: %w", err)
+							return fmt.Errorf("failed to resolve resource attributes: %w", resErr)
 						}
-						resAttrsCache[mdIdx] = filteredResAttrs
-						resAttrsCacheReady[mdIdx] = true
+						resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, resolvedResAttrs, sm.collectorInstanceInfo)
 					}
 
-					_ = filteredSpanAttrs // filtered attrs used for conditions; aggregator uses original + hash
-					err = aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], spanAttrs, attrID, 1)
+					filterAttrs := func() (pcommon.Map, error) {
+						return md.FilterAttributes(spanAttrs, resolvedAttrs), nil
+					}
+					err = aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], attrID, filterAttrs, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -140,53 +127,41 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(m.ResourceMetrics().Len())
 	aggregator := aggregator.NewAggregator[*ottldatapoint.TransformContext](processedMetrics, sm.errorMode, sm.logger)
-
-	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
-	// a single ResourceMetric. Nil until first match.
-	var (
-		resAttrsCache      []pcommon.Map
-		resAttrsCacheReady []bool
-	)
+	// resAttrsCache lazily caches the filtered resource attributes per
+	// metric definition within a resource. Since resource attributes are
+	// constant for all signals within a resource, the result only needs
+	// to be computed once per metric definition per resource. A zero-value
+	// pcommon.Map indicates the entry has not been computed yet.
+	resAttrsCache := make([]pcommon.Map, len(sm.dpMetricDefs))
 
 	for i := 0; i < m.ResourceMetrics().Len(); i++ {
 		resourceMetric := m.ResourceMetrics().At(i)
 		resourceAttrs := resourceMetric.Resource().Attributes()
-		// Reset cache for this new resource metric
-		resAttrsCache = resAttrsCache[:0]
-		resAttrsCacheReady = resAttrsCacheReady[:0]
-
+		clear(resAttrsCache)
 		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
 			scopeMetric := resourceMetric.ScopeMetrics().At(j)
 			for k := 0; k < scopeMetric.Metrics().Len(); k++ {
 				metrics := scopeMetric.Metrics()
 				metric := metrics.At(k)
 				for mdIdx, md := range sm.dpMetricDefs {
-					// aggregate is called only when a DP passes the attribute filter.
-					// filteredResAttrs is computed lazily inside and cached per metric-def
-					// index within the current ResourceMetric.
-					aggregate := func(dp any, originalDPAttrs pcommon.Map, attrID [16]byte) error {
-						// Lazy-compute and cache filtered resource attrs
-						for len(resAttrsCache) <= mdIdx {
-							resAttrsCache = append(resAttrsCache, pcommon.Map{})
-							resAttrsCacheReady = append(resAttrsCacheReady, false)
+					aggregate := func(dp any, dpAttrs pcommon.Map) error {
+						if !md.MatchAttributes(dpAttrs) {
+							return nil
 						}
-						// The transform context is created from original attributes so that the
-						// OTTL expressions are also applied on the original attributes.
 						tCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetric, metric, dp)
 						defer tCtx.Close()
-
-						if !resAttrsCacheReady[mdIdx] {
-							filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-							if err != nil {
-								return fmt.Errorf("failed to filter resource attributes: %w", err)
-							}
-							resAttrsCache[mdIdx] = filteredResAttrs
-							resAttrsCacheReady[mdIdx] = true
-						}
-
-						filteredDPAttrs, err := md.FilterAttributes(ctx, tCtx, originalDPAttrs)
+						resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 						if err != nil {
-							return fmt.Errorf("failed to filter attributes: %w", err)
+							return fmt.Errorf("failed to resolve attributes: %w", err)
+						}
+						attrID := md.ComputeAttributesHash(dpAttrs, resolvedAttrs)
+
+						if resAttrsCache[mdIdx] == (pcommon.Map{}) {
+							resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
+							if resErr != nil {
+								return fmt.Errorf("failed to resolve resource attributes: %w", resErr)
+							}
+							resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, resolvedResAttrs, sm.collectorInstanceInfo)
 						}
 
 						if md.Conditions != nil {
@@ -200,8 +175,10 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 								return nil
 							}
 						}
-						_ = filteredDPAttrs // filtered attrs used for conditions; aggregator uses original + hash
-						return aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], originalDPAttrs, attrID, 1)
+						filterAttrs := func() (pcommon.Map, error) {
+							return md.FilterAttributes(dpAttrs, resolvedAttrs), nil
+						}
+						return aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], attrID, filterAttrs, 1)
 					}
 
 					//exhaustive:enforce
@@ -209,60 +186,35 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 					case pmetric.MetricTypeGauge:
 						dps := metric.Gauge().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							attrID, ok := md.FilterAttributesID(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeSum:
 						dps := metric.Sum().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							attrID, ok := md.FilterAttributesID(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeSummary:
 						dps := metric.Summary().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							attrID, ok := md.FilterAttributesID(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeHistogram:
 						dps := metric.Histogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							attrID, ok := md.FilterAttributesID(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
 					case pmetric.MetricTypeExponentialHistogram:
 						dps := metric.ExponentialHistogram().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
-							dp := dps.At(l)
-							attrID, ok := md.FilterAttributesID(dp.Attributes())
-							if !ok {
-								continue
-							}
-							if err := aggregate(dp, dp.Attributes(), attrID); err != nil {
+							if err := aggregate(dps.At(l), dps.At(l).Attributes()); err != nil {
 								return err
 							}
 						}
@@ -285,41 +237,33 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(logs.ResourceLogs().Len())
 	aggregator := aggregator.NewAggregator[*ottllog.TransformContext](processedMetrics, sm.errorMode, sm.logger)
-
-	// resAttrsCache caches FilterResourceAttributes results per metric-def index within
-	// a single ResourceLog. Nil until first match.
-	var (
-		resAttrsCache      []pcommon.Map
-		resAttrsCacheReady []bool
-	)
+	// resAttrsCache lazily caches the filtered resource attributes per
+	// metric definition within a resource. Since resource attributes are
+	// constant for all signals within a resource, the result only needs
+	// to be computed once per metric definition per resource. A zero-value
+	// pcommon.Map indicates the entry has not been computed yet.
+	resAttrsCache := make([]pcommon.Map, len(sm.logMetricDefs))
 
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
 		resourceLog := logs.ResourceLogs().At(i)
 		resourceAttrs := resourceLog.Resource().Attributes()
-		// Reset cache for this new resource log (keep backing array).
-		resAttrsCache = resAttrsCache[:0]
-		resAttrsCacheReady = resAttrsCacheReady[:0]
-
+		clear(resAttrsCache)
 		for j := 0; j < resourceLog.ScopeLogs().Len(); j++ {
 			scopeLog := resourceLog.ScopeLogs().At(j)
 			for k := 0; k < scopeLog.LogRecords().Len(); k++ {
 				log := scopeLog.LogRecords().At(k)
 				logAttrs := log.Attributes()
 				for mdIdx, md := range sm.logMetricDefs {
-					// FilterAttributesID checks required static-key attrs and
-					// returns a hash ID without allocating a pcommon.Map.
-					attrID, ok := md.FilterAttributesID(logAttrs)
-					if !ok {
+					if !md.MatchAttributes(logAttrs) {
 						continue
 					}
-					// The transform context is created from original attributes so that the
-					// OTTL expressions are also applied on the original attributes.
 					tCtx := ottllog.NewTransformContextPtr(resourceLog, scopeLog, log)
-					filteredLogAttrs, err := md.FilterAttributes(ctx, tCtx, logAttrs)
+					resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()
-						return fmt.Errorf("failed to filter attributes: %w", err)
+						return fmt.Errorf("failed to resolve attributes: %w", err)
 					}
+					attrID := md.ComputeAttributesHash(logAttrs, resolvedAttrs)
 
 					if md.Conditions != nil {
 						var match bool
@@ -335,24 +279,19 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 						}
 					}
 
-					// Lazy-compute and cache filtered resource attrs per metric def.
-					for len(resAttrsCache) <= mdIdx {
-						resAttrsCache = append(resAttrsCache, pcommon.Map{})
-						resAttrsCacheReady = append(resAttrsCacheReady, false)
-					}
-					if !resAttrsCacheReady[mdIdx] {
-						var filteredResAttrs pcommon.Map
-						filteredResAttrs, err = md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-						if err != nil {
+					if resAttrsCache[mdIdx] == (pcommon.Map{}) {
+						resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
+						if resErr != nil {
 							tCtx.Close()
-							return fmt.Errorf("failed to filter resource attributes: %w", err)
+							return fmt.Errorf("failed to resolve resource attributes: %w", resErr)
 						}
-						resAttrsCache[mdIdx] = filteredResAttrs
-						resAttrsCacheReady[mdIdx] = true
+						resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, resolvedResAttrs, sm.collectorInstanceInfo)
 					}
 
-					_ = filteredLogAttrs // filtered attrs used for conditions; aggregator uses original + hash
-					err = aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], logAttrs, attrID, 1)
+					filterAttrs := func() (pcommon.Map, error) {
+						return md.FilterAttributes(logAttrs, resolvedAttrs), nil
+					}
+					err = aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], attrID, filterAttrs, 1)
 					tCtx.Close()
 					if err != nil {
 						return err
@@ -373,33 +312,34 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 	processedMetrics := pmetric.NewMetrics()
 	processedMetrics.ResourceMetrics().EnsureCapacity(profiles.ResourceProfiles().Len())
 	aggregator := aggregator.NewAggregator[*ottlprofile.TransformContext](processedMetrics, sm.errorMode, sm.logger)
+	// resAttrsCache lazily caches the filtered resource attributes per
+	// metric definition within a resource. Since resource attributes are
+	// constant for all signals within a resource, the result only needs
+	// to be computed once per metric definition per resource. A zero-value
+	// pcommon.Map indicates the entry has not been computed yet.
+	resAttrsCache := make([]pcommon.Map, len(sm.profileMetricDefs))
 
 	for i := 0; i < profiles.ResourceProfiles().Len(); i++ {
 		resourceProfile := profiles.ResourceProfiles().At(i)
 		resourceAttrs := resourceProfile.Resource().Attributes()
-
+		clear(resAttrsCache)
 		for j := 0; j < resourceProfile.ScopeProfiles().Len(); j++ {
 			scopeProfile := resourceProfile.ScopeProfiles().At(j)
 
 			for k := 0; k < scopeProfile.Profiles().Len(); k++ {
 				profile := scopeProfile.Profiles().At(k)
 				profileAttrs := pprofile.FromAttributeIndices(profiles.Dictionary().AttributeTable(), profile, profiles.Dictionary())
-
-				for _, md := range sm.profileMetricDefs {
-					// FilterAttributesID checks required static-key attrs and
-					// returns a hash ID without allocating a pcommon.Map.
-					attrID, ok := md.FilterAttributesID(profileAttrs)
-					if !ok {
+				for mdIdx, md := range sm.profileMetricDefs {
+					if !md.MatchAttributes(profileAttrs) {
 						continue
 					}
-					// The transform context is created from original attributes so that the
-					// OTTL expressions are also applied on the original attributes.
 					tCtx := ottlprofile.NewTransformContextPtr(resourceProfile, scopeProfile, profile, profiles.Dictionary())
-					filteredProfileAttrs, err := md.FilterAttributes(ctx, tCtx, profileAttrs)
+					resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()
-						return fmt.Errorf("failed to filter attributes: %w", err)
+						return fmt.Errorf("failed to resolve attributes: %w", err)
 					}
+					attrID := md.ComputeAttributesHash(profileAttrs, resolvedAttrs)
 
 					if md.Conditions != nil {
 						var match bool
@@ -414,13 +354,20 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 							continue
 						}
 					}
-					filteredResAttrs, err := md.FilterResourceAttributes(ctx, tCtx, resourceAttrs, sm.collectorInstanceInfo)
-					if err != nil {
-						tCtx.Close()
-						return fmt.Errorf("failed to filter resource attributes: %w", err)
+
+					if resAttrsCache[mdIdx] == (pcommon.Map{}) {
+						resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
+						if resErr != nil {
+							tCtx.Close()
+							return fmt.Errorf("failed to resolve resource attributes: %w", resErr)
+						}
+						resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, resolvedResAttrs, sm.collectorInstanceInfo)
 					}
-					_ = filteredProfileAttrs // filtered attrs used for conditions; aggregator uses original + hash
-					if err := aggregator.Aggregate(ctx, tCtx, md, filteredResAttrs, profileAttrs, attrID, 1); err != nil {
+
+					filterAttrs := func() (pcommon.Map, error) {
+						return md.FilterAttributes(profileAttrs, resolvedAttrs), nil
+					}
+					if err := aggregator.Aggregate(ctx, tCtx, md, resAttrsCache[mdIdx], attrID, filterAttrs, 1); err != nil {
 						tCtx.Close()
 						return err
 					}

--- a/connector/signaltometricsconnector/connector_test.go
+++ b/connector/signaltometricsconnector/connector_test.go
@@ -55,6 +55,12 @@ func TestConnectorWithTraces(t *testing.T) {
 				"x-dynamic-resource-attributes": {"resource.foo"},
 			},
 		},
+		{
+			name: "ottl_expression_priority",
+			clientMetadata: map[string][]string{
+				"x-dynamic-attrs": {"db.system"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -186,154 +192,228 @@ func TestConnectorWithProfiles(t *testing.T) {
 	}
 }
 
+type benchCase struct {
+	name                      string
+	attrKey                   string
+	includeResourceAttributes []config.Attribute
+	clientMetadata            map[string][]string
+}
+
 func BenchmarkConnectorWithTraces(b *testing.B) {
-	factory := NewFactory()
-	settings := connectortest.NewNopSettings(metadata.Type)
-	settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
-	next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error {
-		return nil
-	})
-	require.NoError(b, err)
-
-	cfg := &config.Config{Spans: testMetricInfo(b)}
-	require.NoError(b, cfg.Unmarshal(confmap.New())) // set required fields to default
-	require.NoError(b, cfg.Validate())
-	connector, err := factory.CreateTracesToMetrics(b.Context(), settings, cfg, next)
-	require.NoError(b, err)
-	inputTraces, err := golden.ReadTraces("testdata/traces/traces.yaml")
-	require.NoError(b, err)
-
-	b.ReportAllocs()
-
-	for b.Loop() {
-		if err := connector.ConsumeTraces(b.Context(), inputTraces); err != nil {
-			b.Fatal(err)
-		}
+	benchCases := []benchCase{
+		{name: "no_match", attrKey: "nonexistent.attribute"},
+		{name: "all_match", attrKey: ""},
+		{name: "partial_match", attrKey: "http.response.status_code"},
+		{
+			name: "keys_expression",
+			includeResourceAttributes: []config.Attribute{
+				{KeysExpression: `otelcol.client.metadata["x-dynamic-resource-attributes"]`},
+			},
+			clientMetadata: map[string][]string{
+				"x-dynamic-resource-attributes": {"resource.foo"},
+			},
+		},
+	}
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			factory := NewFactory()
+			settings := connectortest.NewNopSettings(metadata.Type)
+			settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
+			next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error { return nil })
+			require.NoError(b, err)
+			cfg := &config.Config{Spans: benchMetricInfo(b, bc)}
+			require.NoError(b, cfg.Unmarshal(confmap.New()))
+			require.NoError(b, cfg.Validate())
+			connector, err := factory.CreateTracesToMetrics(b.Context(), settings, cfg, next)
+			require.NoError(b, err)
+			inputTraces, err := golden.ReadTraces("testdata/traces/traces.yaml")
+			require.NoError(b, err)
+			ctx := b.Context()
+			if bc.clientMetadata != nil {
+				ctx = client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(bc.clientMetadata)})
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := connector.ConsumeTraces(ctx, inputTraces); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
 func BenchmarkConnectorWithMetrics(b *testing.B) {
-	factory := NewFactory()
-	settings := connectortest.NewNopSettings(metadata.Type)
-	settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
-	next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error {
-		return nil
-	})
-	require.NoError(b, err)
-
-	cfg := &config.Config{Datapoints: testMetricInfo(b)}
-	require.NoError(b, cfg.Unmarshal(confmap.New())) // set required fields to default
-	require.NoError(b, cfg.Validate())
-	connector, err := factory.CreateMetricsToMetrics(b.Context(), settings, cfg, next)
-	require.NoError(b, err)
-	inputMetrics, err := golden.ReadMetrics("testdata/metrics/metrics.yaml")
-	require.NoError(b, err)
-
-	b.ReportAllocs()
-
-	for b.Loop() {
-		if err := connector.ConsumeMetrics(b.Context(), inputMetrics); err != nil {
-			b.Fatal(err)
-		}
+	benchCases := []benchCase{
+		{name: "no_match", attrKey: "nonexistent.attribute"},
+		{name: "all_match", attrKey: ""},
+		{name: "partial_match", attrKey: "datapoint.foo"},
+		{
+			name: "keys_expression",
+			includeResourceAttributes: []config.Attribute{
+				{KeysExpression: `otelcol.client.metadata["x-dynamic-resource-attributes"]`},
+			},
+			clientMetadata: map[string][]string{
+				"x-dynamic-resource-attributes": {"resource.foo"},
+			},
+		},
+	}
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			factory := NewFactory()
+			settings := connectortest.NewNopSettings(metadata.Type)
+			settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
+			next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error { return nil })
+			require.NoError(b, err)
+			cfg := &config.Config{Datapoints: benchMetricInfo(b, bc)}
+			require.NoError(b, cfg.Unmarshal(confmap.New()))
+			require.NoError(b, cfg.Validate())
+			connector, err := factory.CreateMetricsToMetrics(b.Context(), settings, cfg, next)
+			require.NoError(b, err)
+			inputMetrics, err := golden.ReadMetrics("testdata/metrics/metrics.yaml")
+			require.NoError(b, err)
+			ctx := b.Context()
+			if bc.clientMetadata != nil {
+				ctx = client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(bc.clientMetadata)})
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := connector.ConsumeMetrics(ctx, inputMetrics); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
 func BenchmarkConnectorWithLogs(b *testing.B) {
-	factory := NewFactory()
-	settings := connectortest.NewNopSettings(metadata.Type)
-	settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
-	next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error {
-		return nil
-	})
-	require.NoError(b, err)
-
-	cfg := &config.Config{Logs: testMetricInfo(b)}
-	require.NoError(b, cfg.Unmarshal(confmap.New())) // set required fields to default
-	require.NoError(b, cfg.Validate())
-	connector, err := factory.CreateLogsToMetrics(b.Context(), settings, cfg, next)
-	require.NoError(b, err)
-	inputLogs, err := golden.ReadLogs("testdata/logs/logs.yaml")
-	require.NoError(b, err)
-
-	b.ReportAllocs()
-
-	for b.Loop() {
-		if err := connector.ConsumeLogs(b.Context(), inputLogs); err != nil {
-			b.Fatal(err)
-		}
+	benchCases := []benchCase{
+		{name: "no_match", attrKey: "nonexistent.attribute"},
+		{name: "all_match", attrKey: ""},
+		{name: "partial_match", attrKey: "log.foo"},
+		{
+			name: "keys_expression",
+			includeResourceAttributes: []config.Attribute{
+				{KeysExpression: `otelcol.client.metadata["x-dynamic-resource-attributes"]`},
+			},
+			clientMetadata: map[string][]string{
+				"x-dynamic-resource-attributes": {"resource.foo"},
+			},
+		},
+	}
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			factory := NewFactory()
+			settings := connectortest.NewNopSettings(metadata.Type)
+			settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
+			next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error { return nil })
+			require.NoError(b, err)
+			cfg := &config.Config{Logs: benchMetricInfo(b, bc)}
+			require.NoError(b, cfg.Unmarshal(confmap.New()))
+			require.NoError(b, cfg.Validate())
+			connector, err := factory.CreateLogsToMetrics(b.Context(), settings, cfg, next)
+			require.NoError(b, err)
+			inputLogs, err := golden.ReadLogs("testdata/logs/logs.yaml")
+			require.NoError(b, err)
+			ctx := b.Context()
+			if bc.clientMetadata != nil {
+				ctx = client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(bc.clientMetadata)})
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := connector.ConsumeLogs(ctx, inputLogs); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
-// testMetricInfo creates a metric info with all metric types that could be used
-// for all the supported signals. To do this, it uses common OTTL funcs and literals.
-func testMetricInfo(b *testing.B) []config.MetricInfo {
-	b.Helper()
+func BenchmarkConnectorWithProfiles(b *testing.B) {
+	// Profile attributes: profile.foo (on some), profile.bar (on some).
+	benchCases := []benchCase{
+		{name: "no_match", attrKey: "nonexistent.attribute"},
+		{name: "all_match", attrKey: ""},
+		{name: "partial_match", attrKey: "profile.foo"},
+		{
+			name: "keys_expression",
+			includeResourceAttributes: []config.Attribute{
+				{KeysExpression: `otelcol.client.metadata["x-dynamic-resource-attributes"]`},
+			},
+			clientMetadata: map[string][]string{
+				"x-dynamic-resource-attributes": {"resource.foo"},
+			},
+		},
+	}
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			factory := NewFactory().(xconnector.Factory)
+			settings := connectortest.NewNopSettings(metadata.Type)
+			settings.Logger = zaptest.NewLogger(b, zaptest.Level(zapcore.DebugLevel))
+			next, err := consumer.NewMetrics(func(context.Context, pmetric.Metrics) error { return nil })
+			require.NoError(b, err)
+			cfg := &config.Config{Profiles: benchMetricInfo(b, bc)}
+			require.NoError(b, cfg.Unmarshal(confmap.New()))
+			require.NoError(b, cfg.Validate())
+			connector, err := factory.CreateProfilesToMetrics(b.Context(), settings, cfg, next)
+			require.NoError(b, err)
+			inputProfiles, err := golden.ReadProfiles("testdata/profiles/profiles.yaml")
+			require.NoError(b, err)
+			ctx := b.Context()
+			if bc.clientMetadata != nil {
+				ctx = client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(bc.clientMetadata)})
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := connector.ConsumeProfiles(ctx, inputProfiles); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
 
+func benchMetricInfo(b *testing.B, bc benchCase) []config.MetricInfo {
+	b.Helper()
+	var attrs []config.Attribute
+	if bc.attrKey != "" {
+		attrs = []config.Attribute{{Key: bc.attrKey}}
+	}
+	resAttrs := bc.includeResourceAttributes
+	if resAttrs == nil {
+		resAttrs = []config.Attribute{
+			{Key: "resource.foo"},
+			{Key: "404.attribute", DefaultValue: "test_404_attribute"},
+		}
+	}
 	return []config.MetricInfo{
 		{
-			Name:        "test.histogram",
-			Description: "Test histogram",
-			Unit:        "ms",
-			IncludeResourceAttributes: []config.Attribute{
-				{
-					Key: "resource.foo",
-				},
-				{
-					Key:          "404.attribute",
-					DefaultValue: "test_404_attribute",
-				},
-			},
-			Attributes: []config.Attribute{
-				{
-					Key: "http.response.status_code",
-				},
-			},
+			Name:                      "test.histogram",
+			Description:               "Test histogram",
+			Unit:                      "ms",
+			IncludeResourceAttributes: resAttrs,
+			Attributes:                attrs,
 			Histogram: configoptional.Some(config.Histogram{
 				Buckets: []float64{2, 4, 6, 8, 10, 50, 100, 200, 400, 800, 1000, 1400, 2000, 5000, 10_000, 15_000},
 				Value:   "1.4",
 			}),
 		},
 		{
-			Name:        "test.exphistogram",
-			Description: "Test exponential histogram",
-			Unit:        "ms",
-			IncludeResourceAttributes: []config.Attribute{
-				{
-					Key: "resource.foo",
-				},
-				{
-					Key:          "404.attribute",
-					DefaultValue: "test_404_attribute",
-				},
-			},
-			Attributes: []config.Attribute{
-				{
-					Key: "http.response.status_code",
-				},
-			},
+			Name:                      "test.exphistogram",
+			Description:               "Test exponential histogram",
+			Unit:                      "ms",
+			IncludeResourceAttributes: resAttrs,
+			Attributes:                attrs,
 			ExponentialHistogram: configoptional.Some(config.ExponentialHistogram{
 				Value:   "2.4",
 				MaxSize: 160,
 			}),
 		},
 		{
-			Name:        "test.sum",
-			Description: "Test sum",
-			Unit:        "ms",
-			IncludeResourceAttributes: []config.Attribute{
-				{
-					Key: "resource.foo",
-				},
-				{
-					Key:          "404.attribute",
-					DefaultValue: "test_404_attribute",
-				},
-			},
-			Attributes: []config.Attribute{
-				{
-					Key: "http.response.status_code",
-				},
-			},
+			Name:                      "test.sum",
+			Description:               "Test sum",
+			Unit:                      "ms",
+			IncludeResourceAttributes: resAttrs,
+			Attributes:                attrs,
 			Sum: configoptional.Some(config.Sum{
 				Value: "5.4",
 			}),

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/connector/signa
 go 1.25.0
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/lightstep/go-expohisto v1.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.148.0
@@ -34,7 +35,6 @@ require (
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/antchfx/xmlquery v1.5.0 // indirect
 	github.com/antchfx/xpath v1.3.6 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elastic/go-grok v0.3.1 // indirect
 	github.com/elastic/lunes v0.2.0 // indirect

--- a/connector/signaltometricsconnector/internal/aggregator/aggregator.go
+++ b/connector/signaltometricsconnector/internal/aggregator/aggregator.go
@@ -19,6 +19,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
 )
 
+// FilterAttrsFunc is a lazy function that produces a filtered attribute map.
+// It is only called when the aggregator encounters a new unique attribute
+// set and needs to create a datapoint. This avoids allocating a pcommon.Map
+// for every signal item.
+type FilterAttrsFunc func() (pcommon.Map, error)
+
 // Aggregator provides a single interface to update all metrics
 // datastructures. The required datastructure is selected using
 // the metric definition.
@@ -53,8 +59,9 @@ func (a *Aggregator[K]) Aggregate(
 	ctx context.Context,
 	tCtx K,
 	md model.MetricDef[K],
-	resAttrs, originalSrcAttrs pcommon.Map,
+	resAttrs pcommon.Map,
 	attrID [16]byte,
+	filterAttrs FilterAttrsFunc,
 	defaultCount int64,
 ) error {
 	switch md.Key.Type {
@@ -68,7 +75,7 @@ func (a *Aggregator[K]) Aggregate(
 		if err != nil {
 			return a.handleError(err)
 		}
-		if err := a.aggregateValueCount(md, resAttrs, originalSrcAttrs, attrID, val, count); err != nil {
+		if err := a.aggregateValueCount(md, resAttrs, attrID, filterAttrs, val, count); err != nil {
 			return a.handleError(err)
 		}
 	case pmetric.MetricTypeHistogram:
@@ -81,7 +88,7 @@ func (a *Aggregator[K]) Aggregate(
 		if err != nil {
 			return a.handleError(err)
 		}
-		if err := a.aggregateValueCount(md, resAttrs, originalSrcAttrs, attrID, val, count); err != nil {
+		if err := a.aggregateValueCount(md, resAttrs, attrID, filterAttrs, val, count); err != nil {
 			return a.handleError(err)
 		}
 	case pmetric.MetricTypeSum:
@@ -91,11 +98,11 @@ func (a *Aggregator[K]) Aggregate(
 		}
 		switch v := raw.(type) {
 		case int64:
-			if err := a.aggregateInt(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
+			if err := a.aggregateInt(md, resAttrs, attrID, filterAttrs, v); err != nil {
 				return a.handleError(err)
 			}
 		case float64:
-			if err := a.aggregateDouble(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
+			if err := a.aggregateDouble(md, resAttrs, attrID, filterAttrs, v); err != nil {
 				return a.handleError(err)
 			}
 		default:
@@ -118,7 +125,7 @@ func (a *Aggregator[K]) Aggregate(
 		}
 		switch v := raw.(type) {
 		case int64, float64:
-			if err := a.aggregateGauge(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
+			if err := a.aggregateGauge(md, resAttrs, attrID, filterAttrs, v); err != nil {
 				return a.handleError(err)
 			}
 		default:
@@ -228,8 +235,9 @@ func (a *Aggregator[K]) Finalize(mds []model.MetricDef[K]) {
 
 func (a *Aggregator[K]) aggregateInt(
 	md model.MetricDef[K],
-	resAttrs, originalSrcAttrs pcommon.Map,
+	resAttrs pcommon.Map,
 	attrID [16]byte,
+	filterAttrs FilterAttrsFunc,
 	v int64,
 ) error {
 	resID := a.getResourceID(resAttrs)
@@ -240,7 +248,11 @@ func (a *Aggregator[K]) aggregateInt(
 		a.sums[md.Key][resID] = make(map[[16]byte]*sumDP)
 	}
 	if _, ok := a.sums[md.Key][resID][attrID]; !ok {
-		a.sums[md.Key][resID][attrID] = newSumDP(md.FilterAttributesUnchecked(originalSrcAttrs), false)
+		filtered, err := filterAttrs()
+		if err != nil {
+			return err
+		}
+		a.sums[md.Key][resID][attrID] = newSumDP(filtered, false)
 	}
 	a.sums[md.Key][resID][attrID].AggregateInt(v)
 	return nil
@@ -248,8 +260,9 @@ func (a *Aggregator[K]) aggregateInt(
 
 func (a *Aggregator[K]) aggregateDouble(
 	md model.MetricDef[K],
-	resAttrs, originalSrcAttrs pcommon.Map,
+	resAttrs pcommon.Map,
 	attrID [16]byte,
+	filterAttrs FilterAttrsFunc,
 	v float64,
 ) error {
 	resID := a.getResourceID(resAttrs)
@@ -260,7 +273,11 @@ func (a *Aggregator[K]) aggregateDouble(
 		a.sums[md.Key][resID] = make(map[[16]byte]*sumDP)
 	}
 	if _, ok := a.sums[md.Key][resID][attrID]; !ok {
-		a.sums[md.Key][resID][attrID] = newSumDP(md.FilterAttributesUnchecked(originalSrcAttrs), true)
+		filtered, err := filterAttrs()
+		if err != nil {
+			return err
+		}
+		a.sums[md.Key][resID][attrID] = newSumDP(filtered, true)
 	}
 	a.sums[md.Key][resID][attrID].AggregateDouble(v)
 	return nil
@@ -268,8 +285,9 @@ func (a *Aggregator[K]) aggregateDouble(
 
 func (a *Aggregator[K]) aggregateGauge(
 	md model.MetricDef[K],
-	resAttrs, originalSrcAttrs pcommon.Map,
+	resAttrs pcommon.Map,
 	attrID [16]byte,
+	filterAttrs FilterAttrsFunc,
 	v any,
 ) error {
 	resID := a.getResourceID(resAttrs)
@@ -280,7 +298,11 @@ func (a *Aggregator[K]) aggregateGauge(
 		a.gauges[md.Key][resID] = make(map[[16]byte]*gaugeDP)
 	}
 	if _, ok := a.gauges[md.Key][resID][attrID]; !ok {
-		a.gauges[md.Key][resID][attrID] = newGaugeDP(md.FilterAttributesUnchecked(originalSrcAttrs))
+		filtered, err := filterAttrs()
+		if err != nil {
+			return err
+		}
+		a.gauges[md.Key][resID][attrID] = newGaugeDP(filtered)
 	}
 	a.gauges[md.Key][resID][attrID].Aggregate(v)
 	return nil
@@ -288,8 +310,9 @@ func (a *Aggregator[K]) aggregateGauge(
 
 func (a *Aggregator[K]) aggregateValueCount(
 	md model.MetricDef[K],
-	resAttrs, originalSrcAttrs pcommon.Map,
+	resAttrs pcommon.Map,
 	attrID [16]byte,
+	filterAttrs FilterAttrsFunc,
 	value float64, count int64,
 ) error {
 	if count == 0 {
@@ -304,7 +327,11 @@ func (a *Aggregator[K]) aggregateValueCount(
 		a.valueCounts[md.Key][resID] = make(map[[16]byte]*valueCountDP)
 	}
 	if _, ok := a.valueCounts[md.Key][resID][attrID]; !ok {
-		a.valueCounts[md.Key][resID][attrID] = newValueCountDP(md, md.FilterAttributesUnchecked(originalSrcAttrs))
+		filtered, err := filterAttrs()
+		if err != nil {
+			return err
+		}
+		a.valueCounts[md.Key][resID][attrID] = newValueCountDP(md, filtered)
 	}
 	a.valueCounts[md.Key][resID][attrID].Aggregate(value, count)
 	return nil

--- a/connector/signaltometricsconnector/internal/aggregator/aggregator.go
+++ b/connector/signaltometricsconnector/internal/aggregator/aggregator.go
@@ -53,7 +53,8 @@ func (a *Aggregator[K]) Aggregate(
 	ctx context.Context,
 	tCtx K,
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	defaultCount int64,
 ) error {
 	switch md.Key.Type {
@@ -67,7 +68,7 @@ func (a *Aggregator[K]) Aggregate(
 		if err != nil {
 			return a.handleError(err)
 		}
-		if err := a.aggregateValueCount(md, resAttrs, srcAttrs, val, count); err != nil {
+		if err := a.aggregateValueCount(md, resAttrs, originalSrcAttrs, attrID, val, count); err != nil {
 			return a.handleError(err)
 		}
 	case pmetric.MetricTypeHistogram:
@@ -80,7 +81,7 @@ func (a *Aggregator[K]) Aggregate(
 		if err != nil {
 			return a.handleError(err)
 		}
-		if err := a.aggregateValueCount(md, resAttrs, srcAttrs, val, count); err != nil {
+		if err := a.aggregateValueCount(md, resAttrs, originalSrcAttrs, attrID, val, count); err != nil {
 			return a.handleError(err)
 		}
 	case pmetric.MetricTypeSum:
@@ -90,11 +91,11 @@ func (a *Aggregator[K]) Aggregate(
 		}
 		switch v := raw.(type) {
 		case int64:
-			if err := a.aggregateInt(md, resAttrs, srcAttrs, v); err != nil {
+			if err := a.aggregateInt(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
 				return a.handleError(err)
 			}
 		case float64:
-			if err := a.aggregateDouble(md, resAttrs, srcAttrs, v); err != nil {
+			if err := a.aggregateDouble(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
 				return a.handleError(err)
 			}
 		default:
@@ -117,7 +118,7 @@ func (a *Aggregator[K]) Aggregate(
 		}
 		switch v := raw.(type) {
 		case int64, float64:
-			if err := a.aggregateGauge(md, resAttrs, srcAttrs, v); err != nil {
+			if err := a.aggregateGauge(md, resAttrs, originalSrcAttrs, attrID, v); err != nil {
 				return a.handleError(err)
 			}
 		default:
@@ -227,11 +228,11 @@ func (a *Aggregator[K]) Finalize(mds []model.MetricDef[K]) {
 
 func (a *Aggregator[K]) aggregateInt(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	v int64,
 ) error {
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.sums[md.Key]; !ok {
 		a.sums[md.Key] = make(map[[16]byte]map[[16]byte]*sumDP)
 	}
@@ -239,7 +240,7 @@ func (a *Aggregator[K]) aggregateInt(
 		a.sums[md.Key][resID] = make(map[[16]byte]*sumDP)
 	}
 	if _, ok := a.sums[md.Key][resID][attrID]; !ok {
-		a.sums[md.Key][resID][attrID] = newSumDP(srcAttrs, false)
+		a.sums[md.Key][resID][attrID] = newSumDP(md.FilterAttributesUnchecked(originalSrcAttrs), false)
 	}
 	a.sums[md.Key][resID][attrID].AggregateInt(v)
 	return nil
@@ -247,11 +248,11 @@ func (a *Aggregator[K]) aggregateInt(
 
 func (a *Aggregator[K]) aggregateDouble(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	v float64,
 ) error {
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.sums[md.Key]; !ok {
 		a.sums[md.Key] = make(map[[16]byte]map[[16]byte]*sumDP)
 	}
@@ -259,7 +260,7 @@ func (a *Aggregator[K]) aggregateDouble(
 		a.sums[md.Key][resID] = make(map[[16]byte]*sumDP)
 	}
 	if _, ok := a.sums[md.Key][resID][attrID]; !ok {
-		a.sums[md.Key][resID][attrID] = newSumDP(srcAttrs, true)
+		a.sums[md.Key][resID][attrID] = newSumDP(md.FilterAttributesUnchecked(originalSrcAttrs), true)
 	}
 	a.sums[md.Key][resID][attrID].AggregateDouble(v)
 	return nil
@@ -267,11 +268,11 @@ func (a *Aggregator[K]) aggregateDouble(
 
 func (a *Aggregator[K]) aggregateGauge(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	v any,
 ) error {
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.gauges[md.Key]; !ok {
 		a.gauges[md.Key] = make(map[[16]byte]map[[16]byte]*gaugeDP)
 	}
@@ -279,7 +280,7 @@ func (a *Aggregator[K]) aggregateGauge(
 		a.gauges[md.Key][resID] = make(map[[16]byte]*gaugeDP)
 	}
 	if _, ok := a.gauges[md.Key][resID][attrID]; !ok {
-		a.gauges[md.Key][resID][attrID] = newGaugeDP(srcAttrs)
+		a.gauges[md.Key][resID][attrID] = newGaugeDP(md.FilterAttributesUnchecked(originalSrcAttrs))
 	}
 	a.gauges[md.Key][resID][attrID].Aggregate(v)
 	return nil
@@ -287,7 +288,8 @@ func (a *Aggregator[K]) aggregateGauge(
 
 func (a *Aggregator[K]) aggregateValueCount(
 	md model.MetricDef[K],
-	resAttrs, srcAttrs pcommon.Map,
+	resAttrs, originalSrcAttrs pcommon.Map,
+	attrID [16]byte,
 	value float64, count int64,
 ) error {
 	if count == 0 {
@@ -295,7 +297,6 @@ func (a *Aggregator[K]) aggregateValueCount(
 		return nil
 	}
 	resID := a.getResourceID(resAttrs)
-	attrID := pdatautil.MapHash(srcAttrs)
 	if _, ok := a.valueCounts[md.Key]; !ok {
 		a.valueCounts[md.Key] = make(map[[16]byte]map[[16]byte]*valueCountDP)
 	}
@@ -303,7 +304,7 @@ func (a *Aggregator[K]) aggregateValueCount(
 		a.valueCounts[md.Key][resID] = make(map[[16]byte]*valueCountDP)
 	}
 	if _, ok := a.valueCounts[md.Key][resID][attrID]; !ok {
-		a.valueCounts[md.Key][resID][attrID] = newValueCountDP(md, srcAttrs)
+		a.valueCounts[md.Key][resID][attrID] = newValueCountDP(md, md.FilterAttributesUnchecked(originalSrcAttrs))
 	}
 	a.valueCounts[md.Key][resID][attrID].Aggregate(value, count)
 	return nil

--- a/connector/signaltometricsconnector/internal/model/attrhash.go
+++ b/connector/signaltometricsconnector/internal/model/attrhash.go
@@ -27,13 +27,13 @@ var attrHashBufPool = sync.Pool{
 // sum128 returns a 128-bit hash of b.buf using the same two-pass xxhash
 // algorithm as pdatautil.MapHash.
 func (b *attrHashBuf) sum128() [16]byte {
+	var d xxhash.Digest
 	var result [16]byte
-	h := xxhash.Sum64(b.buf)
-	binary.LittleEndian.PutUint64(result[:8], h)
-	b.buf = append(b.buf, 0)
-	h = xxhash.Sum64(b.buf)
-	b.buf = b.buf[:len(b.buf)-1]
-	binary.LittleEndian.PutUint64(result[8:], h)
+	d.Reset()
+	d.Write(b.buf)
+	d.Sum(result[:0])
+	d.Write([]byte{0})
+	d.Sum(result[:8])
 	return result
 }
 
@@ -43,20 +43,14 @@ func appendAttrValue(buf []byte, v pcommon.Value) []byte {
 	case pcommon.ValueTypeStr:
 		buf = append(buf, 'S')
 		s := v.Str()
-		var l [4]byte
-		binary.LittleEndian.PutUint32(l[:], uint32(len(s)))
-		buf = append(buf, l[:]...)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(len(s)))
 		buf = append(buf, s...)
 	case pcommon.ValueTypeInt:
 		buf = append(buf, 'I')
-		var b [8]byte
-		binary.LittleEndian.PutUint64(b[:], uint64(v.Int()))
-		buf = append(buf, b[:]...)
+		buf = binary.LittleEndian.AppendUint64(buf, uint64(v.Int()))
 	case pcommon.ValueTypeDouble:
 		buf = append(buf, 'D')
-		var b [8]byte
-		binary.LittleEndian.PutUint64(b[:], math.Float64bits(v.Double()))
-		buf = append(buf, b[:]...)
+		buf = binary.LittleEndian.AppendUint64(buf, math.Float64bits(v.Double()))
 	case pcommon.ValueTypeBool:
 		buf = append(buf, 'B')
 		if v.Bool() {
@@ -68,9 +62,7 @@ func appendAttrValue(buf []byte, v pcommon.Value) []byte {
 		// bytes, map, slice: encode as string representation (rare for attributes)
 		buf = append(buf, 'O')
 		s := v.AsString()
-		var l [4]byte
-		binary.LittleEndian.PutUint32(l[:], uint32(len(s)))
-		buf = append(buf, l[:]...)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(len(s)))
 		buf = append(buf, s...)
 	}
 	return buf

--- a/connector/signaltometricsconnector/internal/model/attrhash.go
+++ b/connector/signaltometricsconnector/internal/model/attrhash.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package model // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/internal/model"
+
+import (
+	"encoding/binary"
+	"math"
+	"sync"
+
+	"github.com/cespare/xxhash/v2"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// attrHashBuf is a pooled byte buffer used to compute a 128-bit hash of a
+// filtered attribute set without allocating a pcommon.Map.
+type attrHashBuf struct {
+	buf []byte
+}
+
+var attrHashBufPool = sync.Pool{
+	New: func() any {
+		return &attrHashBuf{buf: make([]byte, 0, 256)}
+	},
+}
+
+// sum128 returns a 128-bit hash of b.buf using the same two-pass xxhash
+// algorithm as pdatautil.MapHash.
+func (b *attrHashBuf) sum128() [16]byte {
+	var result [16]byte
+	h := xxhash.Sum64(b.buf)
+	binary.LittleEndian.PutUint64(result[:8], h)
+	b.buf = append(b.buf, 0)
+	h = xxhash.Sum64(b.buf)
+	b.buf = b.buf[:len(b.buf)-1]
+	binary.LittleEndian.PutUint64(result[8:], h)
+	return result
+}
+
+// appendAttrValue appends a type-tagged encoding of v to buf.
+func appendAttrValue(buf []byte, v pcommon.Value) []byte {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		buf = append(buf, 'S')
+		s := v.Str()
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(s)))
+		buf = append(buf, l[:]...)
+		buf = append(buf, s...)
+	case pcommon.ValueTypeInt:
+		buf = append(buf, 'I')
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], uint64(v.Int()))
+		buf = append(buf, b[:]...)
+	case pcommon.ValueTypeDouble:
+		buf = append(buf, 'D')
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], math.Float64bits(v.Double()))
+		buf = append(buf, b[:]...)
+	case pcommon.ValueTypeBool:
+		buf = append(buf, 'B')
+		if v.Bool() {
+			buf = append(buf, 1)
+		} else {
+			buf = append(buf, 0)
+		}
+	default:
+		// bytes, map, slice: encode as string representation (rare for attributes)
+		buf = append(buf, 'O')
+		s := v.AsString()
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(s)))
+		buf = append(buf, l[:]...)
+		buf = append(buf, s...)
+	}
+	return buf
+}

--- a/connector/signaltometricsconnector/internal/model/attrhash.go
+++ b/connector/signaltometricsconnector/internal/model/attrhash.go
@@ -30,9 +30,9 @@ func (b *attrHashBuf) sum128() [16]byte {
 	var d xxhash.Digest
 	var result [16]byte
 	d.Reset()
-	d.Write(b.buf)
+	_, _ = d.Write(b.buf)
 	d.Sum(result[:0])
-	d.Write([]byte{0})
+	_, _ = d.Write([]byte{0})
 	d.Sum(result[:8])
 	return result
 }

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -135,15 +136,28 @@ type AttributeEntry[K any] struct {
 	DefaultValue pcommon.Value
 }
 
+// AttributeKeyValue represents a static-key attribute entry used for
+// deterministic hash computation and unchecked filtering. It does not
+// support OTTL expressions.
+type AttributeKeyValue struct {
+	Key          string
+	Optional     bool
+	DefaultValue pcommon.Value
+}
+
 type MetricDef[K any] struct {
 	Key                       MetricKey
 	IncludeResourceAttributes []AttributeEntry[K]
 	Attributes                []AttributeEntry[K]
-	Conditions                *ottl.ConditionSequence[K]
-	ExponentialHistogram      *ExponentialHistogram[K]
-	ExplicitHistogram         *ExplicitHistogram[K]
-	Sum                       *Sum[K]
-	Gauge                     *Gauge[K]
+	// sortedAttrs is the static-key subset of Attributes sorted
+	// alphabetically by key, used for deterministic hash computation
+	// in FilterAttributesID.
+	sortedAttrs          []AttributeKeyValue
+	Conditions           *ottl.ConditionSequence[K]
+	ExponentialHistogram *ExponentialHistogram[K]
+	ExplicitHistogram    *ExplicitHistogram[K]
+	Sum                  *Sum[K]
+	Gauge                *Gauge[K]
 }
 
 func (md *MetricDef[K]) FromMetricInfo(
@@ -163,6 +177,26 @@ func (md *MetricDef[K]) FromMetricInfo(
 	md.Attributes, err = parseAttributeEntries(mi.Attributes, parser)
 	if err != nil {
 		return fmt.Errorf("failed to parse attribute config: %w", err)
+	}
+	// Pre-sort a copy of static-key Attributes by key for deterministic hash
+	// computation in FilterAttributesID. OTTL expression entries are excluded
+	// because they are resolved at runtime.
+	staticEntries := make([]AttributeKeyValue, 0, len(md.Attributes))
+	for _, entry := range md.Attributes {
+		if entry.Expression != nil {
+			continue
+		}
+		staticEntries = append(staticEntries, AttributeKeyValue{
+			Key:          entry.Key,
+			Optional:     entry.Optional,
+			DefaultValue: entry.DefaultValue,
+		})
+	}
+	if len(staticEntries) > 0 {
+		md.sortedAttrs = staticEntries
+		sort.Slice(md.sortedAttrs, func(i, j int) bool {
+			return md.sortedAttrs[i].Key < md.sortedAttrs[j].Key
+		})
 	}
 	if len(mi.Conditions) > 0 {
 		conditions, err := parser.ParseConditions(mi.Conditions)
@@ -256,6 +290,55 @@ func (md *MetricDef[K]) MatchAttributes(attrs pcommon.Map) bool {
 	return true
 }
 
+// FilterAttributesID returns a 128-bit hash that identifies the filtered
+// attribute set for the given source attributes, without allocating a
+// pcommon.Map. The returned hash is equivalent in purpose to
+// pdatautil.MapHash applied to the result of FilterAttributes, but uses a
+// different (internal-only) encoding. Returns false if any required
+// static-key attribute is absent.
+//
+// This only considers static-key entries in Attributes (not OTTL
+// expression entries). It is used in conjunction with
+// FilterAttributesUnchecked: call FilterAttributesID first to check
+// presence and compute the DP lookup key, then call
+// FilterAttributesUnchecked only when a new DP must be created.
+func (md *MetricDef[K]) FilterAttributesID(attrs pcommon.Map) ([16]byte, bool) {
+	for _, filter := range md.Attributes {
+		if filter.Expression != nil || filter.DefaultValue.Type() != pcommon.ValueTypeEmpty || filter.Optional {
+			continue
+		}
+		if _, ok := attrs.Get(filter.Key); !ok {
+			return [16]byte{}, false
+		}
+	}
+	hb := attrHashBufPool.Get().(*attrHashBuf)
+	hb.buf = hb.buf[:0]
+	for _, filter := range md.sortedAttrs {
+		v, ok := attrs.Get(filter.Key)
+		if ok {
+			hb.buf = append(hb.buf, filter.Key...)
+			hb.buf = append(hb.buf, 0) // key-value separator
+			hb.buf = appendAttrValue(hb.buf, v)
+		} else if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty {
+			hb.buf = append(hb.buf, filter.Key...)
+			hb.buf = append(hb.buf, 0)
+			hb.buf = appendAttrValue(hb.buf, filter.DefaultValue)
+		}
+		// Optional key absent: not included in hash
+	}
+	id := hb.sum128()
+	attrHashBufPool.Put(hb)
+	return id, true
+}
+
+// FilterAttributesUnchecked creates a filtered pcommon.Map from attrs
+// using only the static-key entries in Attributes, without re-checking
+// for required attribute presence. It must only be called after
+// FilterAttributesID has returned true for the same attrs.
+func (md *MetricDef[K]) FilterAttributesUnchecked(attrs pcommon.Map) pcommon.Map {
+	return filterAttributes(attrs, md.sortedAttrs, len(md.sortedAttrs))
+}
+
 // FilterAttributes filters event attributes (datapoint, logrecord, spans)
 // based on the `Attributes` selected for the metric definition. If no
 // attributes are selected then an empty `pcommon.Map` is returned.
@@ -288,6 +371,24 @@ func filterByEntries[K any](
 		copyAttribute(entry.Key, entry.DefaultValue, src, dst)
 	}
 	return dst, nil
+}
+
+// filterAttributes creates a filtered pcommon.Map from attrs using only
+// static-key AttributeKeyValue entries. This is used by
+// FilterAttributesUnchecked for the lazy-allocation path.
+func filterAttributes(attrs pcommon.Map, filters []AttributeKeyValue, expectedLen int) pcommon.Map {
+	filteredAttrs := pcommon.NewMap()
+	filteredAttrs.EnsureCapacity(expectedLen)
+	for _, filter := range filters {
+		if attr, ok := attrs.Get(filter.Key); ok {
+			attr.CopyTo(filteredAttrs.PutEmpty(filter.Key))
+			continue
+		}
+		if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty {
+			filter.DefaultValue.CopyTo(filteredAttrs.PutEmpty(filter.Key))
+		}
+	}
+	return filteredAttrs
 }
 
 func parseAttributeEntries[K any](

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -124,21 +124,19 @@ func (s *Gauge[K]) fromConfig(
 	return nil
 }
 
-// AttributeEntry represents a single entry in include_resource_attributes
+// attributeEntry represents a single entry in include_resource_attributes
 // or attributes. Exactly one of Key or Expression must be set.
-type AttributeEntry[K any] struct {
-	// Key is a static attribute key.
-	Key string
-	// Expression is a parsed OTTL value expression that resolves to a
-	// list of attribute keys (pcommon.Slice or []string) at runtime.
+type attributeEntry[K any] struct {
+	Key          string
 	Expression   *ottl.ValueExpression[K]
 	Optional     bool
 	DefaultValue pcommon.Value
 }
 
-// AttributeKeyValue represents a static-key attribute entry used for
-// deterministic hash computation and unchecked filtering. It does not
-// support OTTL expressions.
+// AttributeKeyValue represents a resolved attribute entry with a static
+// key. This is the output of ResolveAttributes and
+// ResolveIncludeResourceAttributes after OTTL expressions have been
+// evaluated and flattened into the final ordered list.
 type AttributeKeyValue struct {
 	Key          string
 	Optional     bool
@@ -147,17 +145,13 @@ type AttributeKeyValue struct {
 
 type MetricDef[K any] struct {
 	Key                       MetricKey
-	IncludeResourceAttributes []AttributeEntry[K]
-	Attributes                []AttributeEntry[K]
-	// sortedAttrs is the static-key subset of Attributes sorted
-	// alphabetically by key, used for deterministic hash computation
-	// in FilterAttributesID.
-	sortedAttrs          []AttributeKeyValue
-	Conditions           *ottl.ConditionSequence[K]
-	ExponentialHistogram *ExponentialHistogram[K]
-	ExplicitHistogram    *ExplicitHistogram[K]
-	Sum                  *Sum[K]
-	Gauge                *Gauge[K]
+	includeResourceAttributes []attributeEntry[K]
+	attributes                []attributeEntry[K]
+	Conditions                *ottl.ConditionSequence[K]
+	ExponentialHistogram      *ExponentialHistogram[K]
+	ExplicitHistogram         *ExplicitHistogram[K]
+	Sum                       *Sum[K]
+	Gauge                     *Gauge[K]
 }
 
 func (md *MetricDef[K]) FromMetricInfo(
@@ -170,33 +164,13 @@ func (md *MetricDef[K]) FromMetricInfo(
 	md.Key.Description = mi.Description
 
 	var err error
-	md.IncludeResourceAttributes, err = parseAttributeEntries(mi.IncludeResourceAttributes, parser)
+	md.includeResourceAttributes, err = parseAttributeEntries(mi.IncludeResourceAttributes, parser)
 	if err != nil {
 		return fmt.Errorf("failed to parse include resource attribute config: %w", err)
 	}
-	md.Attributes, err = parseAttributeEntries(mi.Attributes, parser)
+	md.attributes, err = parseAttributeEntries(mi.Attributes, parser)
 	if err != nil {
 		return fmt.Errorf("failed to parse attribute config: %w", err)
-	}
-	// Pre-sort a copy of static-key Attributes by key for deterministic hash
-	// computation in FilterAttributesID. OTTL expression entries are excluded
-	// because they are resolved at runtime.
-	staticEntries := make([]AttributeKeyValue, 0, len(md.Attributes))
-	for _, entry := range md.Attributes {
-		if entry.Expression != nil {
-			continue
-		}
-		staticEntries = append(staticEntries, AttributeKeyValue{
-			Key:          entry.Key,
-			Optional:     entry.Optional,
-			DefaultValue: entry.DefaultValue,
-		})
-	}
-	if len(staticEntries) > 0 {
-		md.sortedAttrs = staticEntries
-		sort.Slice(md.sortedAttrs, func(i, j int) bool {
-			return md.sortedAttrs[i].Key < md.sortedAttrs[j].Key
-		})
 	}
 	if len(mi.Conditions) > 0 {
 		conditions, err := parser.ParseConditions(mi.Conditions)
@@ -241,35 +215,19 @@ func (md *MetricDef[K]) FromMetricInfo(
 	return nil
 }
 
-// FilterResourceAttributes filters resource attributes based on the
-// `IncludeResourceAttributes` list for the metric definition. Resource
-// attributes are only filtered if the list is specified, otherwise all the
-// resource attributes are used for creating the metrics from the metric
-// definition.
-//
-// For entries with an OTTL expression, the expression is evaluated at
-// runtime to resolve a list of attribute keys. The expression must return
-// a pcommon.Slice or []string. A nil result is treated as an empty list.
-func (md *MetricDef[K]) FilterResourceAttributes(
-	ctx context.Context,
-	tCtx K,
-	attrs pcommon.Map,
-	collectorInfo CollectorInstanceInfo,
-) (pcommon.Map, error) {
-	if len(md.IncludeResourceAttributes) == 0 {
-		filteredAttributes := pcommon.NewMap()
-		filteredAttributes.EnsureCapacity(attrs.Len() + collectorInfo.Size())
-		attrs.CopyTo(filteredAttributes)
-		collectorInfo.Copy(filteredAttributes)
-		return filteredAttributes, nil
-	}
+// ResolveIncludeResourceAttributes evaluates OTTL expressions in
+// include_resource_attributes and returns a flat, ordered list of
+// AttributeKeyValue entries. Static entries are passed through as-is;
+// OTTL expression entries are evaluated and each resolved key becomes
+// a separate entry, preserving config ordering.
+func (md *MetricDef[K]) ResolveIncludeResourceAttributes(ctx context.Context, tCtx K) ([]AttributeKeyValue, error) {
+	return resolveEntries(ctx, tCtx, md.includeResourceAttributes)
+}
 
-	filteredAttributes, err := filterByEntries(ctx, tCtx, md.IncludeResourceAttributes, attrs, collectorInfo.Size())
-	if err != nil {
-		return pcommon.Map{}, err
-	}
-	collectorInfo.Copy(filteredAttributes)
-	return filteredAttributes, nil
+// ResolveAttributes evaluates OTTL expressions in attributes and
+// returns a flat, ordered list of AttributeKeyValue entries.
+func (md *MetricDef[K]) ResolveAttributes(ctx context.Context, tCtx K) ([]AttributeKeyValue, error) {
+	return resolveEntries(ctx, tCtx, md.attributes)
 }
 
 // MatchAttributes checks if all required static key attributes are
@@ -277,9 +235,11 @@ func (md *MetricDef[K]) FilterResourceAttributes(
 // require a transform context and can be used to skip expensive
 // transform context creation when the entity should not be processed.
 // OTTL expression entries and entries with default values or optional
-// flag are not checked.
+// flag are not checked — the presence of an expression entry means
+// there is a possibility of attributes resolving, so MatchAttributes
+// will not reject the entity on that basis.
 func (md *MetricDef[K]) MatchAttributes(attrs pcommon.Map) bool {
-	for _, filter := range md.Attributes {
+	for _, filter := range md.attributes {
 		if filter.Expression != nil || filter.DefaultValue.Type() != pcommon.ValueTypeEmpty || filter.Optional {
 			continue
 		}
@@ -290,120 +250,118 @@ func (md *MetricDef[K]) MatchAttributes(attrs pcommon.Map) bool {
 	return true
 }
 
-// FilterAttributesID returns a 128-bit hash that identifies the filtered
-// attribute set for the given source attributes, without allocating a
-// pcommon.Map. The returned hash is equivalent in purpose to
-// pdatautil.MapHash applied to the result of FilterAttributes, but uses a
-// different (internal-only) encoding. Returns false if any required
-// static-key attribute is absent.
-//
-// This only considers static-key entries in Attributes (not OTTL
-// expression entries). It is used in conjunction with
-// FilterAttributesUnchecked: call FilterAttributesID first to check
-// presence and compute the DP lookup key, then call
-// FilterAttributesUnchecked only when a new DP must be created.
-func (md *MetricDef[K]) FilterAttributesID(attrs pcommon.Map) ([16]byte, bool) {
-	for _, filter := range md.Attributes {
-		if filter.Expression != nil || filter.DefaultValue.Type() != pcommon.ValueTypeEmpty || filter.Optional {
-			continue
-		}
-		if _, ok := attrs.Get(filter.Key); !ok {
-			return [16]byte{}, false
-		}
-	}
+// ComputeAttributesHash returns a 128-bit hash that identifies the
+// filtered attribute set. The resolved list is sorted alphabetically
+// by key before hashing for determinism.
+func (*MetricDef[K]) ComputeAttributesHash(attrs pcommon.Map, resolved []AttributeKeyValue) [16]byte {
+	sorted := make([]AttributeKeyValue, len(resolved))
+	copy(sorted, resolved)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Key < sorted[j].Key
+	})
+
 	hb := attrHashBufPool.Get().(*attrHashBuf)
 	hb.buf = hb.buf[:0]
-	for _, filter := range md.sortedAttrs {
-		v, ok := attrs.Get(filter.Key)
+	for _, kv := range sorted {
+		v, ok := attrs.Get(kv.Key)
 		if ok {
-			hb.buf = append(hb.buf, filter.Key...)
-			hb.buf = append(hb.buf, 0) // key-value separator
-			hb.buf = appendAttrValue(hb.buf, v)
-		} else if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty {
-			hb.buf = append(hb.buf, filter.Key...)
+			hb.buf = append(hb.buf, kv.Key...)
 			hb.buf = append(hb.buf, 0)
-			hb.buf = appendAttrValue(hb.buf, filter.DefaultValue)
+			hb.buf = appendAttrValue(hb.buf, v)
+		} else if kv.DefaultValue.Type() != pcommon.ValueTypeEmpty {
+			hb.buf = append(hb.buf, kv.Key...)
+			hb.buf = append(hb.buf, 0)
+			hb.buf = appendAttrValue(hb.buf, kv.DefaultValue)
 		}
-		// Optional key absent: not included in hash
 	}
 	id := hb.sum128()
 	attrHashBufPool.Put(hb)
-	return id, true
+	return id
 }
 
-// FilterAttributesUnchecked creates a filtered pcommon.Map from attrs
-// using only the static-key entries in Attributes, without re-checking
-// for required attribute presence. It must only be called after
-// FilterAttributesID has returned true for the same attrs.
-func (md *MetricDef[K]) FilterAttributesUnchecked(attrs pcommon.Map) pcommon.Map {
-	return filterAttributes(attrs, md.sortedAttrs, len(md.sortedAttrs))
+// FilterResourceAttributes builds a pcommon.Map from the resolved
+// include_resource_attributes list. If the list is empty, all resource
+// attributes are copied. CollectorInstanceInfo is always appended.
+func (md *MetricDef[K]) FilterResourceAttributes(
+	attrs pcommon.Map,
+	resolved []AttributeKeyValue,
+	collectorInfo CollectorInstanceInfo,
+) pcommon.Map {
+	if len(md.includeResourceAttributes) == 0 {
+		filteredAttributes := pcommon.NewMap()
+		filteredAttributes.EnsureCapacity(attrs.Len() + collectorInfo.Size())
+		attrs.CopyTo(filteredAttributes)
+		collectorInfo.Copy(filteredAttributes)
+		return filteredAttributes
+	}
+
+	filteredAttributes := filterByResolved(attrs, resolved, collectorInfo.Size())
+	collectorInfo.Copy(filteredAttributes)
+	return filteredAttributes
 }
 
-// FilterAttributes filters event attributes (datapoint, logrecord, spans)
-// based on the `Attributes` selected for the metric definition. If no
-// attributes are selected then an empty `pcommon.Map` is returned.
-// MatchAttributes should be called before this method to avoid unnecessary
-// transform context creation.
-func (md *MetricDef[K]) FilterAttributes(ctx context.Context, tCtx K, attrs pcommon.Map) (pcommon.Map, error) {
-	return filterByEntries(ctx, tCtx, md.Attributes, attrs, 0)
+// FilterAttributes builds a pcommon.Map from the resolved attributes
+// list. Entries are applied in order so later entries override earlier
+// ones for the same key.
+func (*MetricDef[K]) FilterAttributes(attrs pcommon.Map, resolved []AttributeKeyValue) pcommon.Map {
+	return filterByResolved(attrs, resolved, 0)
 }
 
-// filterByEntries iterates over attribute entries, resolving OTTL
-// expressions and copying static keys from src into a new map.
-// extraCapacity is added to the initial map capacity for entries
-// like CollectorInstanceInfo that are appended after filtering.
-func filterByEntries[K any](
-	ctx context.Context,
-	tCtx K,
-	entries []AttributeEntry[K],
-	src pcommon.Map,
-	extraCapacity int,
-) (pcommon.Map, error) {
+// filterByResolved creates a pcommon.Map by iterating the resolved
+// AttributeKeyValue list in order. Later entries with the same key
+// override earlier ones.
+func filterByResolved(attrs pcommon.Map, resolved []AttributeKeyValue, extraCapacity int) pcommon.Map {
 	dst := pcommon.NewMap()
-	dst.EnsureCapacity(len(entries) + extraCapacity)
+	dst.EnsureCapacity(len(resolved) + extraCapacity)
+	for _, kv := range resolved {
+		copyAttribute(kv.Key, kv.DefaultValue, attrs, dst)
+	}
+	return dst
+}
+
+// resolveEntries evaluates OTTL expressions in entries and returns a
+// flat, ordered list of AttributeKeyValue. Static entries are passed
+// through; expression entries are expanded into one AttributeKeyValue
+// per resolved key.
+func resolveEntries[K any](ctx context.Context, tCtx K, entries []attributeEntry[K]) ([]AttributeKeyValue, error) {
+	resolved := make([]AttributeKeyValue, 0, len(entries))
 	for _, entry := range entries {
 		if entry.Expression != nil {
-			if err := resolveKeysExpression(ctx, tCtx, entry, src, dst); err != nil {
-				return pcommon.Map{}, err
+			keys, err := evalKeysExpression(ctx, tCtx, entry)
+			if err != nil {
+				return nil, err
+			}
+			for _, key := range keys {
+				resolved = append(resolved, AttributeKeyValue{
+					Key:          key,
+					Optional:     entry.Optional,
+					DefaultValue: entry.DefaultValue,
+				})
 			}
 			continue
 		}
-		copyAttribute(entry.Key, entry.DefaultValue, src, dst)
+		resolved = append(resolved, AttributeKeyValue{
+			Key:          entry.Key,
+			Optional:     entry.Optional,
+			DefaultValue: entry.DefaultValue,
+		})
 	}
-	return dst, nil
-}
-
-// filterAttributes creates a filtered pcommon.Map from attrs using only
-// static-key AttributeKeyValue entries. This is used by
-// FilterAttributesUnchecked for the lazy-allocation path.
-func filterAttributes(attrs pcommon.Map, filters []AttributeKeyValue, expectedLen int) pcommon.Map {
-	filteredAttrs := pcommon.NewMap()
-	filteredAttrs.EnsureCapacity(expectedLen)
-	for _, filter := range filters {
-		if attr, ok := attrs.Get(filter.Key); ok {
-			attr.CopyTo(filteredAttrs.PutEmpty(filter.Key))
-			continue
-		}
-		if filter.DefaultValue.Type() != pcommon.ValueTypeEmpty {
-			filter.DefaultValue.CopyTo(filteredAttrs.PutEmpty(filter.Key))
-		}
-	}
-	return filteredAttrs
+	return resolved, nil
 }
 
 func parseAttributeEntries[K any](
 	cfgs []config.Attribute,
 	parser ottl.Parser[K],
-) ([]AttributeEntry[K], error) {
+) ([]attributeEntry[K], error) {
 	var errs []error
-	entries := make([]AttributeEntry[K], 0, len(cfgs))
+	entries := make([]attributeEntry[K], 0, len(cfgs))
 	for _, attr := range cfgs {
 		val := pcommon.NewValueEmpty()
 		if err := val.FromRaw(attr.DefaultValue); err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		entry := AttributeEntry[K]{
+		entry := attributeEntry[K]{
 			Optional:     attr.Optional,
 			DefaultValue: val,
 		}
@@ -427,29 +385,26 @@ func parseAttributeEntries[K any](
 	return entries, nil
 }
 
-// resolveKeysExpression evaluates the OTTL expression to get a list of
-// attribute keys and copies matching attributes from src to dst.
-func resolveKeysExpression[K any](
+// evalKeysExpression evaluates the OTTL expression and returns the
+// resolved attribute keys. Returns nil (no error) if the expression
+// evaluates to nil.
+func evalKeysExpression[K any](
 	ctx context.Context,
 	tCtx K,
-	entry AttributeEntry[K],
-	src, dst pcommon.Map,
-) error {
+	entry attributeEntry[K],
+) ([]string, error) {
 	result, err := entry.Expression.Eval(ctx, tCtx)
 	if err != nil {
-		return fmt.Errorf("failed to evaluate keys_expression: %w", err)
+		return nil, fmt.Errorf("failed to evaluate keys_expression: %w", err)
 	}
 	if result == nil {
-		return nil
+		return nil, nil
 	}
 	keys, err := extractStringSlice(result)
 	if err != nil {
-		return fmt.Errorf("keys_expression must return a list of strings: %w", err)
+		return nil, fmt.Errorf("keys_expression must return a list of strings: %w", err)
 	}
-	for _, key := range keys {
-		copyAttribute(key, entry.DefaultValue, src, dst)
-	}
-	return nil
+	return keys, nil
 }
 
 func copyAttribute(key string, defaultValue pcommon.Value, src, dst pcommon.Map) {

--- a/connector/signaltometricsconnector/internal/model/model.go
+++ b/connector/signaltometricsconnector/internal/model/model.go
@@ -147,11 +147,30 @@ type MetricDef[K any] struct {
 	Key                       MetricKey
 	includeResourceAttributes []attributeEntry[K]
 	attributes                []attributeEntry[K]
-	Conditions                *ottl.ConditionSequence[K]
-	ExponentialHistogram      *ExponentialHistogram[K]
-	ExplicitHistogram         *ExplicitHistogram[K]
-	Sum                       *Sum[K]
-	Gauge                     *Gauge[K]
+	// hasExprResAttrs is true if any includeResourceAttributes entry
+	// has a keys_expression. When false, the static-only fast path
+	// skips OTTL evaluation and dedup overhead in
+	// ResolveIncludeResourceAttributes.
+	hasExprResAttrs bool
+	// hasExprAttrs is true if any attributes entry has a
+	// keys_expression. When false, the static-only fast path skips
+	// OTTL evaluation and dedup overhead in ResolveAttributes, and
+	// sortedStaticAttrs is used directly by ComputeAttributesHash
+	// to avoid per-call sorting.
+	hasExprAttrs bool
+	// sortedStaticAttrs is a pre-sorted copy of the static-key
+	// attributes, built at construction time. Used by
+	// ResolveAttributes (static fast path) and ComputeAttributesHash
+	// to avoid per-call allocation and sorting when there are no
+	// keys_expression entries.
+	sortedStaticAttrs []AttributeKeyValue
+	// sortedStaticResAttrs is the same for includeResourceAttributes.
+	sortedStaticResAttrs []AttributeKeyValue
+	Conditions           *ottl.ConditionSequence[K]
+	ExponentialHistogram *ExponentialHistogram[K]
+	ExplicitHistogram    *ExplicitHistogram[K]
+	Sum                  *Sum[K]
+	Gauge                *Gauge[K]
 }
 
 func (md *MetricDef[K]) FromMetricInfo(
@@ -172,6 +191,10 @@ func (md *MetricDef[K]) FromMetricInfo(
 	if err != nil {
 		return fmt.Errorf("failed to parse attribute config: %w", err)
 	}
+	// Detect whether any entries use keys_expression and pre-build
+	// sorted static attribute lists for the fast path.
+	md.hasExprResAttrs, md.sortedStaticResAttrs = buildStaticAttrs(md.includeResourceAttributes)
+	md.hasExprAttrs, md.sortedStaticAttrs = buildStaticAttrs(md.attributes)
 	if len(mi.Conditions) > 0 {
 		conditions, err := parser.ParseConditions(mi.Conditions)
 		if err != nil {
@@ -217,16 +240,25 @@ func (md *MetricDef[K]) FromMetricInfo(
 
 // ResolveIncludeResourceAttributes evaluates OTTL expressions in
 // include_resource_attributes and returns a flat, ordered list of
-// AttributeKeyValue entries. Static entries are passed through as-is;
-// OTTL expression entries are evaluated and each resolved key becomes
-// a separate entry, preserving config ordering.
+// AttributeKeyValue entries. When no keys_expression entries are
+// configured, the pre-built sortedStaticResAttrs is returned directly
+// without allocation or OTTL evaluation.
 func (md *MetricDef[K]) ResolveIncludeResourceAttributes(ctx context.Context, tCtx K) ([]AttributeKeyValue, error) {
+	if !md.hasExprResAttrs {
+		return md.sortedStaticResAttrs, nil
+	}
 	return resolveEntries(ctx, tCtx, md.includeResourceAttributes)
 }
 
 // ResolveAttributes evaluates OTTL expressions in attributes and
-// returns a flat, ordered list of AttributeKeyValue entries.
+// returns a flat, ordered list of AttributeKeyValue entries. When no
+// keys_expression entries are configured, the pre-built
+// sortedStaticAttrs is returned directly without allocation or OTTL
+// evaluation.
 func (md *MetricDef[K]) ResolveAttributes(ctx context.Context, tCtx K) ([]AttributeKeyValue, error) {
+	if !md.hasExprAttrs {
+		return md.sortedStaticAttrs, nil
+	}
 	return resolveEntries(ctx, tCtx, md.attributes)
 }
 
@@ -251,18 +283,13 @@ func (md *MetricDef[K]) MatchAttributes(attrs pcommon.Map) bool {
 }
 
 // ComputeAttributesHash returns a 128-bit hash that identifies the
-// filtered attribute set. The resolved list is sorted alphabetically
-// by key before hashing for determinism.
+// filtered attribute set. The resolved list is expected to be sorted
+// alphabetically by key (guaranteed by both resolveEntries and the
+// pre-sorted sortedStaticAttrs).
 func (*MetricDef[K]) ComputeAttributesHash(attrs pcommon.Map, resolved []AttributeKeyValue) [16]byte {
-	sorted := make([]AttributeKeyValue, len(resolved))
-	copy(sorted, resolved)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Key < sorted[j].Key
-	})
-
 	hb := attrHashBufPool.Get().(*attrHashBuf)
 	hb.buf = hb.buf[:0]
-	for _, kv := range sorted {
+	for _, kv := range resolved {
 		v, ok := attrs.Get(kv.Key)
 		if ok {
 			hb.buf = append(hb.buf, kv.Key...)
@@ -320,33 +347,72 @@ func filterByResolved(attrs pcommon.Map, resolved []AttributeKeyValue, extraCapa
 }
 
 // resolveEntries evaluates OTTL expressions in entries and returns a
-// flat, ordered list of AttributeKeyValue. Static entries are passed
-// through; expression entries are expanded into one AttributeKeyValue
-// per resolved key.
+// flat, deduplicated, sorted list of AttributeKeyValue. Entries are
+// processed in reverse so the last occurrence of each key (highest
+// priority) is kept and earlier duplicates are discarded. The result
+// is sorted alphabetically by key for deterministic hashing — this is
+// safe because dedup guarantees unique keys and pcommon.Map is
+// order-independent.
 func resolveEntries[K any](ctx context.Context, tCtx K, entries []attributeEntry[K]) ([]AttributeKeyValue, error) {
+	seen := make(map[string]struct{}, len(entries))
 	resolved := make([]AttributeKeyValue, 0, len(entries))
-	for _, entry := range entries {
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
 		if entry.Expression != nil {
 			keys, err := evalKeysExpression(ctx, tCtx, entry)
 			if err != nil {
 				return nil, err
 			}
-			for _, key := range keys {
+			for j := len(keys) - 1; j >= 0; j-- {
+				if _, ok := seen[keys[j]]; ok {
+					continue
+				}
+				seen[keys[j]] = struct{}{}
 				resolved = append(resolved, AttributeKeyValue{
-					Key:          key,
+					Key:          keys[j],
 					Optional:     entry.Optional,
 					DefaultValue: entry.DefaultValue,
 				})
 			}
 			continue
 		}
+		if _, ok := seen[entry.Key]; ok {
+			continue
+		}
+		seen[entry.Key] = struct{}{}
 		resolved = append(resolved, AttributeKeyValue{
 			Key:          entry.Key,
 			Optional:     entry.Optional,
 			DefaultValue: entry.DefaultValue,
 		})
 	}
+	sort.Slice(resolved, func(i, j int) bool {
+		return resolved[i].Key < resolved[j].Key
+	})
 	return resolved, nil
+}
+
+// buildStaticAttrs checks if any entries have OTTL expressions and
+// builds a pre-sorted list of static-key AttributeKeyValue entries.
+// Returns (hasExpr, sortedStaticAttrs).
+func buildStaticAttrs[K any](entries []attributeEntry[K]) (bool, []AttributeKeyValue) {
+	hasExpr := false
+	static := make([]AttributeKeyValue, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Expression != nil {
+			hasExpr = true
+			continue
+		}
+		static = append(static, AttributeKeyValue{
+			Key:          entry.Key,
+			Optional:     entry.Optional,
+			DefaultValue: entry.DefaultValue,
+		})
+	}
+	sort.Slice(static, func(i, j int) bool {
+		return static[i].Key < static[j].Key
+	})
+	return hasExpr, static
 }
 
 func parseAttributeEntries[K any](

--- a/connector/signaltometricsconnector/internal/model/model_test.go
+++ b/connector/signaltometricsconnector/internal/model/model_test.go
@@ -28,69 +28,52 @@ func TestFilterResourceAttributes(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		name                      string
-		includeResourceAttributes []AttributeEntry[*ottlspan.TransformContext]
+		includeResourceAttributes []attributeEntry[*ottlspan.TransformContext]
 		expected                  map[string]any
 	}{
 		{
 			name: "no_include_resource_attributes_configured",
 			expected: map[string]any{
-				// All resource attributes will be added as no
-				// include resource attributes specified
-				"key.1": "val.1",
-				"key.2": true,
-				"key.3": int64(11),
-				"key.4": "val.4",
-				// Collector instance info will be added
+				"key.1":                                 "val.1",
+				"key.2":                                 true,
+				"key.3":                                 int64(11),
+				"key.4":                                 "val.4",
 				"signal_to_metrics.service.instance.id": testServiceInstanceID,
 			},
 		},
 		{
 			name: "include_resource_attributes_configured",
-			includeResourceAttributes: []AttributeEntry[*ottlspan.TransformContext]{
+			includeResourceAttributes: []attributeEntry[*ottlspan.TransformContext]{
 				testAttributeEntry(t, "key.1", false, nil),
-				// Optional does not change the behavior for resource attribute
-				// filtering.
 				testAttributeEntry(t, "key.2", true, nil),
-				// With default value configured and the attribute present, default
-				// value will be ignored.
 				testAttributeEntry(t, "key.3", false, 500),
-				// With default value, even if the attribute is missing, it will
-				// be added to the output.
 				testAttributeEntry(t, "key.302", false, "anything"),
-				// Without default value, the resource attribute will be ignored
-				// if not present in the input
 				testAttributeEntry(t, "key.404", false, nil),
-				// Optional does not change the behavior for resource attribute
-				// filtering.
 				testAttributeEntry(t, "key.412", true, nil),
 			},
 			expected: map[string]any{
-				// Include resource attributes are filtered
-				"key.1": "val.1",
-				// Optional attributes are copied if present
-				"key.2": true,
-				// Default value is ignored if attribute is present
-				"key.3": int64(11),
-				// Resource attributes with default values are added
-				"key.302": "anything",
-				// Collector instance info will be added
+				"key.1":                                 "val.1",
+				"key.2":                                 true,
+				"key.3":                                 int64(11),
+				"key.302":                               "anything",
 				"signal_to_metrics.service.instance.id": testServiceInstanceID,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			md := MetricDef[*ottlspan.TransformContext]{
-				IncludeResourceAttributes: tc.includeResourceAttributes,
+				includeResourceAttributes: tc.includeResourceAttributes,
 			}
 			inputResourceAttrsM := pcommon.NewMap()
 			require.NoError(t, inputResourceAttrsM.FromRaw(inputAttributes))
-			actual, err := md.FilterResourceAttributes(
-				t.Context(),
-				nil, // no transform context needed for static key tests
+			// For static-only tests, resolved list matches the entries directly.
+			resolved, err := md.ResolveIncludeResourceAttributes(t.Context(), nil)
+			require.NoError(t, err)
+			actual := md.FilterResourceAttributes(
 				inputResourceAttrsM,
+				resolved,
 				testCollectorInstanceInfo(t),
 			)
-			require.NoError(t, err)
 			assert.Empty(t, cmp.Diff(tc.expected, actual.AsRaw()))
 		})
 	}
@@ -105,41 +88,28 @@ func TestFilterAttributes(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		name               string
-		attributes         []AttributeEntry[*ottlspan.TransformContext]
-		expectedDecision   bool           // whether to process the entity or not
-		expectedAttributes map[string]any // map of filtered attributes
+		attributes         []attributeEntry[*ottlspan.TransformContext]
+		expectedDecision   bool
+		expectedAttributes map[string]any
 	}{
 		{
 			name:               "no_attribute_configured",
 			expectedDecision:   true,
-			expectedAttributes: map[string]any{
-				// No attributes are filtered since nothing is configured.
-			},
+			expectedAttributes: map[string]any{},
 		},
 		{
-			// Attribute filter would process an entity (span, log record,
-			// datapoint) iff all the configured attributes, other than with
-			// optional, are present. If any of the required attributes
-			// are absent in the incoming entity then the entity is not
-			// processed.
 			name: "attributes_configured_but_missing",
-			attributes: []AttributeEntry[*ottlspan.TransformContext]{
+			attributes: []attributeEntry[*ottlspan.TransformContext]{
 				testAttributeEntry(t, "key.1", false, nil),
-				// The below key has optional defined so should not
-				// affect the processing decision.
 				testAttributeEntry(t, "key.2", true, nil),
-				// Below attribute would be missing in the input metric and
-				// should return false to signal not to process the entity.
 				testAttributeEntry(t, "key.404", false, nil),
 			},
 			expectedDecision: false,
 		},
 		{
 			name: "attributes_configured_with_optional",
-			attributes: []AttributeEntry[*ottlspan.TransformContext]{
+			attributes: []attributeEntry[*ottlspan.TransformContext]{
 				testAttributeEntry(t, "key.1", false, nil),
-				// The below two key has optional defined so should not
-				// affect the processing decision.
 				testAttributeEntry(t, "key.2", true, nil),
 				testAttributeEntry(t, "key.412", true, nil),
 			},
@@ -152,15 +122,16 @@ func TestFilterAttributes(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			md := MetricDef[*ottlspan.TransformContext]{
-				Attributes: tc.attributes,
+				attributes: tc.attributes,
 			}
 			inputAttrM := pcommon.NewMap()
 			require.NoError(t, inputAttrM.FromRaw(inputAttributes))
 			ok := md.MatchAttributes(inputAttrM)
 			assert.Equal(t, tc.expectedDecision, ok)
 			if ok {
-				actual, err := md.FilterAttributes(t.Context(), nil, inputAttrM)
+				resolved, err := md.ResolveAttributes(t.Context(), nil)
 				require.NoError(t, err)
+				actual := md.FilterAttributes(inputAttrM, resolved)
 				assert.Empty(t, cmp.Diff(tc.expectedAttributes, actual.AsRaw()))
 			}
 		})
@@ -234,14 +205,14 @@ func testAttributeEntry(
 	k string,
 	optional bool,
 	val any,
-) AttributeEntry[*ottlspan.TransformContext] {
+) attributeEntry[*ottlspan.TransformContext] {
 	t.Helper()
 
 	defaultVal := pcommon.NewValueEmpty()
 	if val != nil {
 		require.NoError(t, defaultVal.FromRaw(val))
 	}
-	return AttributeEntry[*ottlspan.TransformContext]{
+	return attributeEntry[*ottlspan.TransformContext]{
 		Key:          k,
 		Optional:     optional,
 		DefaultValue: defaultVal,

--- a/connector/signaltometricsconnector/internal/model/model_test.go
+++ b/connector/signaltometricsconnector/internal/model/model_test.go
@@ -10,14 +10,43 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector/internal/customottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 )
 
 const (
 	testServiceInstanceID = "627cc493-f310-47de-96bd-71410b7dec09"
 )
+
+// testMetricDef creates a MetricDef via the real FromMetricInfo path
+// with the given include_resource_attributes and attributes config.
+func testMetricDef(
+	t *testing.T,
+	includeResAttrs []config.Attribute,
+	attrs []config.Attribute,
+) MetricDef[*ottlspan.TransformContext] {
+	t.Helper()
+
+	parser, err := ottlspan.NewParser(
+		customottl.SpanFuncs(),
+		componenttest.NewNopTelemetrySettings(),
+	)
+	require.NoError(t, err)
+
+	mi := config.MetricInfo{
+		Name:                      "test.metric",
+		IncludeResourceAttributes: includeResAttrs,
+		Attributes:                attrs,
+		Sum:                       configoptional.Some(config.Sum{Value: "1"}),
+	}
+	var md MetricDef[*ottlspan.TransformContext]
+	require.NoError(t, md.FromMetricInfo(mi, parser, componenttest.NewNopTelemetrySettings()))
+	return md
+}
 
 func TestFilterResourceAttributes(t *testing.T) {
 	inputAttributes := map[string]any{
@@ -28,7 +57,7 @@ func TestFilterResourceAttributes(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		name                      string
-		includeResourceAttributes []attributeEntry[*ottlspan.TransformContext]
+		includeResourceAttributes []config.Attribute
 		expected                  map[string]any
 	}{
 		{
@@ -43,13 +72,13 @@ func TestFilterResourceAttributes(t *testing.T) {
 		},
 		{
 			name: "include_resource_attributes_configured",
-			includeResourceAttributes: []attributeEntry[*ottlspan.TransformContext]{
-				testAttributeEntry(t, "key.1", false, nil),
-				testAttributeEntry(t, "key.2", true, nil),
-				testAttributeEntry(t, "key.3", false, 500),
-				testAttributeEntry(t, "key.302", false, "anything"),
-				testAttributeEntry(t, "key.404", false, nil),
-				testAttributeEntry(t, "key.412", true, nil),
+			includeResourceAttributes: []config.Attribute{
+				{Key: "key.1"},
+				{Key: "key.2", Optional: true},
+				{Key: "key.3", DefaultValue: 500},
+				{Key: "key.302", DefaultValue: "anything"},
+				{Key: "key.404"},
+				{Key: "key.412", Optional: true},
 			},
 			expected: map[string]any{
 				"key.1":                                 "val.1",
@@ -61,12 +90,9 @@ func TestFilterResourceAttributes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			md := MetricDef[*ottlspan.TransformContext]{
-				includeResourceAttributes: tc.includeResourceAttributes,
-			}
+			md := testMetricDef(t, tc.includeResourceAttributes, nil)
 			inputResourceAttrsM := pcommon.NewMap()
 			require.NoError(t, inputResourceAttrsM.FromRaw(inputAttributes))
-			// For static-only tests, resolved list matches the entries directly.
 			resolved, err := md.ResolveIncludeResourceAttributes(t.Context(), nil)
 			require.NoError(t, err)
 			actual := md.FilterResourceAttributes(
@@ -88,7 +114,7 @@ func TestFilterAttributes(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		name               string
-		attributes         []attributeEntry[*ottlspan.TransformContext]
+		attributes         []config.Attribute
 		expectedDecision   bool
 		expectedAttributes map[string]any
 	}{
@@ -99,19 +125,19 @@ func TestFilterAttributes(t *testing.T) {
 		},
 		{
 			name: "attributes_configured_but_missing",
-			attributes: []attributeEntry[*ottlspan.TransformContext]{
-				testAttributeEntry(t, "key.1", false, nil),
-				testAttributeEntry(t, "key.2", true, nil),
-				testAttributeEntry(t, "key.404", false, nil),
+			attributes: []config.Attribute{
+				{Key: "key.1"},
+				{Key: "key.2", Optional: true},
+				{Key: "key.404"},
 			},
 			expectedDecision: false,
 		},
 		{
 			name: "attributes_configured_with_optional",
-			attributes: []attributeEntry[*ottlspan.TransformContext]{
-				testAttributeEntry(t, "key.1", false, nil),
-				testAttributeEntry(t, "key.2", true, nil),
-				testAttributeEntry(t, "key.412", true, nil),
+			attributes: []config.Attribute{
+				{Key: "key.1"},
+				{Key: "key.2", Optional: true},
+				{Key: "key.412", Optional: true},
 			},
 			expectedDecision: true,
 			expectedAttributes: map[string]any{
@@ -121,9 +147,7 @@ func TestFilterAttributes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			md := MetricDef[*ottlspan.TransformContext]{
-				attributes: tc.attributes,
-			}
+			md := testMetricDef(t, nil, tc.attributes)
 			inputAttrM := pcommon.NewMap()
 			require.NoError(t, inputAttrM.FromRaw(inputAttributes))
 			ok := md.MatchAttributes(inputAttrM)
@@ -198,23 +222,4 @@ func testCollectorInstanceInfo(t *testing.T) CollectorInstanceInfo {
 	set := componenttest.NewNopTelemetrySettings()
 	set.Resource.Attributes().PutStr("service.instance.id", testServiceInstanceID)
 	return NewCollectorInstanceInfo(set)
-}
-
-func testAttributeEntry(
-	t *testing.T,
-	k string,
-	optional bool,
-	val any,
-) attributeEntry[*ottlspan.TransformContext] {
-	t.Helper()
-
-	defaultVal := pcommon.NewValueEmpty()
-	if val != nil {
-		require.NoError(t, defaultVal.FromRaw(val))
-	}
-	return attributeEntry[*ottlspan.TransformContext]{
-		Key:          k,
-		Optional:     optional,
-		DefaultValue: defaultVal,
-	}
 }

--- a/connector/signaltometricsconnector/testdata/traces/ottl_expression_priority/config.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/ottl_expression_priority/config.yaml
@@ -1,0 +1,19 @@
+signal_to_metrics:
+  spans:
+    - name: with_priority_override
+      description: Test that static key defined after keys_expression overrides dynamic resolution
+      unit: s
+      include_resource_attributes:
+        - key: resource.foo
+      attributes:
+        # Dynamic entry first: resolves to ["db.system"]. For spans that
+        # have db.system, this picks up the actual value (e.g. "mysql").
+        - keys_expression: otelcol.client.metadata["x-dynamic-attrs"]
+          default_value: dynamic_override
+        # Static entry second: overrides db.system with a fixed default.
+        # Since this appears AFTER the dynamic entry, it should win.
+        - key: db.system
+          default_value: static_override
+      sum:
+        value: "1"
+        monotonic: true

--- a/connector/signaltometricsconnector/testdata/traces/ottl_expression_priority/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/ottl_expression_priority/output.yaml
@@ -1,0 +1,37 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.foo
+          value:
+            stringValue: foo
+        - key: signal_to_metrics.service.instance.id
+          value:
+            stringValue: 627cc493-f310-47de-96bd-71410b7dec09
+    scopeMetrics:
+      - metrics:
+          - description: Test that static key defined after keys_expression overrides dynamic resolution
+            name: with_priority_override
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                # 3 spans have db.system=mysql. Both the dynamic entry and
+                # the static entry resolve to the actual value "mysql"
+                # (default_value is only used when the key is absent).
+                - asInt: "3"
+                  attributes:
+                    - key: db.system
+                      value:
+                        stringValue: mysql
+                  timeUnixNano: "1000000"
+                # 4 spans do not have db.system. The dynamic entry finds
+                # nothing; the static entry applies default_value.
+                - asInt: "4"
+                  attributes:
+                    - key: db.system
+                      value:
+                        stringValue: static_override
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+            unit: s
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Building on top of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47185 PR to adapt it to the OTTL changes introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47177
  - Replace per-signal `FilterAttributes` map allocation with a pooled hash-based ID check (`ComputeAttributesHash`), deferring the actual `pcommon.Map` creation to a lazy `FilterAttrsFunc` closure that is only called when the aggregator encounters a new unique attribute set
  - Cache filtered resource attributes per metric definition within each resource batch (`resAttrsCache`), avoiding repeated OTTL expression evaluation and map allocation for the same resource
  - Add table-driven benchmarks for all 4 signal types (traces, metrics, logs, profiles) with `no_match`, `all_match`, `partial_match`, and `keys_expression` scenarios
  - Add `BenchmarkConnectorWithProfiles` (previously missing)
  - Add priority ordering e2e test (`ottl_expression_priority`) validating that later entries in the config override earlier ones

  ### Benchmark results (vs main, which includes #47177)

  | Benchmark | Time | Memory | Allocs |
  |-----------|------|--------|--------|
  | Traces/no_match | +14.9% | ~ | ~ |
  | **Traces/all_match** | **-15.7%** | **-34.2%** | **-60.4%** |
  | **Traces/partial_match** | **-8.0%** | **-9.2%** | **-21.7%** |
  | **Traces/keys_expression** | **-27.7%** | **-38.9%** | **-68.4%** |
  | Metrics/no_match | +6.1% | ~ | ~ |
  | **Metrics/all_match** | **-22.4%** | **-62.8%** | **-75.8%** |
  | **Metrics/partial_match** | **-25.6%** | **-56.2%** | **-69.0%** |
  | **Metrics/keys_expression** | **-38.1%** | **-68.5%** | **-83.4%** |
  | Logs/no_match | +12.5% | ~ | ~ |
  | **Logs/all_match** | **-11.7%** | **-20.3%** | **-43.1%** |
  | **Logs/partial_match** | **-9.8%** | **-11.9%** | **-24.3%** |
  | **Logs/keys_expression** | **-19.0%** | **-22.9%** | **-51.2%** |
  | Profiles/no_match | +7.0% | ~ | ~ |
  | **Profiles/all_match** | **-6.5%** | **-9.4%** | **-23.3%** |
  | Profiles/partial_match | +1.8% | +0.7% | +0.8% |
  | **Profiles/keys_expression** | **-11.7%** | **-10.5%** | **-31.0%** |

  \* `no_match` time regressions absolute values are very minimal (<100ns). Memory and allocs are identical to main.

  ## Test plan
  - [x] All existing e2e golden file tests pass (traces, metrics, logs, profiles)
  - [x] New `ottl_expression_priority` e2e test validates config ordering
  - [x] `make tidy`, `make fmt`, `make lint`, `make test` all pass

  Closes #47185 