### PR TITLE
[pkg/stanza] fix `severity_parser` with `parse_ints`

### DIFF
--- a/.chloggen/fix-severity-parser.yaml
+++ b/.chloggen/fix-severity-parser.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix severity parser to work with JSON parser with `parse_ints: true`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47209]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/helper/severity.go
+++ b/pkg/stanza/operator/helper/severity.go
@@ -57,6 +57,12 @@ func (m severityMap) find(value any) (entry.Severity, string, error) {
 			return severity, strV, nil
 		}
 		return entry.Default, strV, nil
+	case int64:
+		strV := strconv.FormatInt(v, 10)
+		if severity, ok := m[strV]; ok {
+			return severity, strV, nil
+		}
+		return entry.Default, strV, nil
 	case float64:
 		if v != float64(int(v)) {
 			return entry.Default, "", fmt.Errorf("type %T cannot be a severity unless it is a whole number", v)

--- a/pkg/stanza/operator/helper/severity_test.go
+++ b/pkg/stanza/operator/helper/severity_test.go
@@ -242,6 +242,20 @@ func TestSeverityParser(t *testing.T) {
 			overwriteText: true,
 		},
 		{
+			name:     "custom-int64",
+			sample:   int64(1234),
+			mapping:  map[string]any{"error": 1234},
+			expected: entry.Error,
+		},
+		{
+			name:          "custom-int64-overwrite-text",
+			sample:        int64(1234),
+			mapping:       map[string]any{"error": 1234},
+			expected:      entry.Error,
+			expectedText:  "ERROR",
+			overwriteText: true,
+		},
+		{
 			name:     "mixed-list-string",
 			sample:   "ThiS Is BaD",
 			mapping:  map[string]any{"error": []any{"NOOOOOOO", "this is bad", 1234}},


### PR DESCRIPTION
#### Description

Fixes Severity parser working with JSON parser with `parse_ints` enabled.

#### Link to tracking issue

- Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47209

#### Testing

Added unit test.