### PR TITLE
[exporter/prometheus]: Add exemplar support for exponential histograms

### DIFF
--- a/.chloggen/47159.yaml
+++ b/.chloggen/47159.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: fix
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: exporter/prometheus

--- a/.chloggen/47159.yaml
+++ b/.chloggen/47159.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: exporter/prometheus

--- a/.chloggen/47159.yaml
+++ b/.chloggen/47159.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Exemplar support for exponential histograms in Prometheus exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47159]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -260,6 +260,8 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 		sumVal = dp.Sum()
 	}
 
+	exemplars := convertExemplars(dp.Exemplars())
+
 	m, err := prometheus.NewConstNativeHistogram(
 		desc,
 		dp.Count(),
@@ -274,6 +276,13 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(exemplars) > 0 {
+		m, err = prometheus.NewMetricWithExemplars(m, exemplars...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if c.sendTimestamps {

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -260,8 +260,6 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 		sumVal = dp.Sum()
 	}
 
-	exemplars := convertExemplars(dp.Exemplars())
-
 	m, err := prometheus.NewConstNativeHistogram(
 		desc,
 		dp.Count(),
@@ -278,6 +276,7 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 		return nil, err
 	}
 
+	exemplars := convertExemplars(dp.Exemplars())
 	if len(exemplars) > 0 {
 		m, err = prometheus.NewMetricWithExemplars(m, exemplars...)
 		if err != nil {

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -287,6 +287,48 @@ func TestConvertMonotonicSumExemplar(t *testing.T) {
 	exemplarsEqual(t, exemplar, promCounter.GetExemplar())
 }
 
+func TestConvertExponentialHistogramExemplar(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("test_metric")
+	metric.SetDescription("this is test metric")
+	metric.SetUnit("T")
+
+	expHist := metric.SetEmptyExponentialHistogram()
+	expHist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+	expDP := expHist.DataPoints().AppendEmpty()
+	expDP.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+	expDP.SetCount(7)
+	expDP.SetSum(1)
+	expDP.SetScale(0)
+	expDP.SetZeroThreshold(1)
+	expDP.SetZeroCount(1)
+	expDP.Positive().SetOffset(-1)
+	expDP.Positive().BucketCounts().FromRaw([]uint64{2, 4})
+	expDP.Attributes().PutStr("foo", "bar")
+
+	ex := expDP.Exemplars().AppendEmpty()
+	setTestExemplarWithDoubleValue(ex, 3.0)
+
+	pMap := pcommon.NewMap()
+	c := newCollector(&Config{}, zap.NewNop())
+	c.accumulator = &mockAccumulator{
+		metrics:            []pmetric.Metric{metric},
+		resourceAttributes: pMap,
+	}
+
+	pbMetric, err := c.convertExponentialHistogram(metric, pMap, "test", "1.0.0", "http://test.com", pcommon.NewMap())
+	require.NoError(t, err)
+
+	m := io_prometheus_client.Metric{}
+	require.NoError(t, pbMetric.Write(&m))
+
+	h := m.GetHistogram()
+	require.NotNil(t, h)
+	require.Len(t, h.GetExemplars(), 1)
+	exemplarsEqual(t, ex, h.GetExemplars()[0])
+}
+
 // errorCheckCore keeps track of logged errors
 type errorCheckCore struct {
 	errorMessages []string


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Exponential histograms exported as Prometheus native histograms has missing exemplar data. This will add exemplars to exported exponential histogram.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47159 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added `TestConvertExponentialHistogramExemplar` that test the exemplars support with exponential histograms

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
