### PR TITLE
[chore][connector/signaltometrics]Minor refactor, filter resource after conditions check

### DIFF
--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -163,17 +163,6 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						}
 						attrID := md.ComputeAttributesHash(dpAttrs, resolvedAttrs)
 
-						if len(resAttrsCache) == 0 {
-							resAttrsCache = make([]pcommon.Map, len(sm.dpMetricDefs))
-						}
-						if resAttrsCache[mdIdx] == (pcommon.Map{}) {
-							resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
-							if resErr != nil {
-								return fmt.Errorf("failed to resolve resource attributes: %w", resErr)
-							}
-							resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, resolvedResAttrs, sm.collectorInstanceInfo)
-						}
-
 						if md.Conditions != nil {
 							var match bool
 							match, err = md.Conditions.Eval(ctx, tCtx)
@@ -185,6 +174,18 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 								return nil
 							}
 						}
+
+						if len(resAttrsCache) == 0 {
+							resAttrsCache = make([]pcommon.Map, len(sm.dpMetricDefs))
+						}
+						if resAttrsCache[mdIdx] == (pcommon.Map{}) {
+							resolvedResAttrs, resErr := md.ResolveIncludeResourceAttributes(ctx, tCtx)
+							if resErr != nil {
+								return fmt.Errorf("failed to resolve resource attributes: %w", resErr)
+							}
+							resAttrsCache[mdIdx] = md.FilterResourceAttributes(resourceAttrs, resolvedResAttrs, sm.collectorInstanceInfo)
+						}
+
 						filterAttrs := func() (pcommon.Map, error) {
 							return md.FilterAttributes(dpAttrs, resolvedAttrs), nil
 						}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

A small refactor on top of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47197 PR to change the order of calling resource filter. The new order ensures that resource filtering is not called if conditions are not met for metrics - for other signals the order was already optimized

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
