### PR TITLE
[receiver/hostmetrics] Enable re-aggregation for process and system scrapers

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/config.schema.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/config.schema.yaml
@@ -11,6 +11,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "type"
+            default:
+              - "type"
       process.cpu.time:
         description: "ProcessCPUTimeMetricConfig provides config for the process.cpu.time metric."
         type: object
@@ -18,6 +34,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "state"
+            default:
+              - "state"
       process.cpu.utilization:
         description: "ProcessCPUUtilizationMetricConfig provides config for the process.cpu.utilization metric."
         type: object
@@ -25,6 +57,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "state"
+            default:
+              - "state"
       process.disk.io:
         description: "ProcessDiskIoMetricConfig provides config for the process.disk.io metric."
         type: object
@@ -32,6 +80,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       process.disk.operations:
         description: "ProcessDiskOperationsMetricConfig provides config for the process.disk.operations metric."
         type: object
@@ -39,6 +103,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       process.handles:
         description: "ProcessHandlesMetricConfig provides config for the process.handles metric."
         type: object
@@ -81,6 +161,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "type"
+            default:
+              - "type"
       process.signals_pending:
         description: "ProcessSignalsPendingMetricConfig provides config for the process.signals_pending metric."
         type: object

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config.go
@@ -3,17 +3,447 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// ProcessContextSwitchesMetricAttributeKey specifies the key of an attribute for the process.context_switches metric.
+type ProcessContextSwitchesMetricAttributeKey string
+
+const (
+	ProcessContextSwitchesMetricAttributeKeyContextSwitchType ProcessContextSwitchesMetricAttributeKey = "type"
+)
+
+// ProcessContextSwitchesMetricConfig provides config for the process.context_switches metric.
+type ProcessContextSwitchesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessContextSwitchesMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessContextSwitchesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessContextSwitchesMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessContextSwitchesMetricAttributeKeyContextSwitchType:
+		default:
+			return fmt.Errorf("metric process.context_switches doesn't have an attribute %v, valid attributes: [type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ProcessCPUTimeMetricAttributeKey specifies the key of an attribute for the process.cpu.time metric.
+type ProcessCPUTimeMetricAttributeKey string
+
+const (
+	ProcessCPUTimeMetricAttributeKeyState ProcessCPUTimeMetricAttributeKey = "state"
+)
+
+// ProcessCPUTimeMetricConfig provides config for the process.cpu.time metric.
+type ProcessCPUTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessCPUTimeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessCPUTimeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessCPUTimeMetricAttributeKeyState:
+		default:
+			return fmt.Errorf("metric process.cpu.time doesn't have an attribute %v, valid attributes: [state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ProcessCPUUtilizationMetricAttributeKey specifies the key of an attribute for the process.cpu.utilization metric.
+type ProcessCPUUtilizationMetricAttributeKey string
+
+const (
+	ProcessCPUUtilizationMetricAttributeKeyState ProcessCPUUtilizationMetricAttributeKey = "state"
+)
+
+// ProcessCPUUtilizationMetricConfig provides config for the process.cpu.utilization metric.
+type ProcessCPUUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessCPUUtilizationMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessCPUUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessCPUUtilizationMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessCPUUtilizationMetricAttributeKeyState:
+		default:
+			return fmt.Errorf("metric process.cpu.utilization doesn't have an attribute %v, valid attributes: [state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ProcessDiskIoMetricAttributeKey specifies the key of an attribute for the process.disk.io metric.
+type ProcessDiskIoMetricAttributeKey string
+
+const (
+	ProcessDiskIoMetricAttributeKeyDirection ProcessDiskIoMetricAttributeKey = "direction"
+)
+
+// ProcessDiskIoMetricConfig provides config for the process.disk.io metric.
+type ProcessDiskIoMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessDiskIoMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessDiskIoMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessDiskIoMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessDiskIoMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric process.disk.io doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ProcessDiskOperationsMetricAttributeKey specifies the key of an attribute for the process.disk.operations metric.
+type ProcessDiskOperationsMetricAttributeKey string
+
+const (
+	ProcessDiskOperationsMetricAttributeKeyDirection ProcessDiskOperationsMetricAttributeKey = "direction"
+)
+
+// ProcessDiskOperationsMetricConfig provides config for the process.disk.operations metric.
+type ProcessDiskOperationsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessDiskOperationsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessDiskOperationsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessDiskOperationsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessDiskOperationsMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric process.disk.operations doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ProcessHandlesMetricConfig provides config for the process.handles metric.
+type ProcessHandlesMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ProcessHandlesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessMemoryUsageMetricConfig provides config for the process.memory.usage metric.
+type ProcessMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessMemoryUtilizationMetricConfig provides config for the process.memory.utilization metric.
+type ProcessMemoryUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessMemoryUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessMemoryVirtualMetricConfig provides config for the process.memory.virtual metric.
+type ProcessMemoryVirtualMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessMemoryVirtualMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessOpenFileDescriptorsMetricConfig provides config for the process.open_file_descriptors metric.
+type ProcessOpenFileDescriptorsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessOpenFileDescriptorsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessPagingFaultsMetricAttributeKey specifies the key of an attribute for the process.paging.faults metric.
+type ProcessPagingFaultsMetricAttributeKey string
+
+const (
+	ProcessPagingFaultsMetricAttributeKeyPagingFaultType ProcessPagingFaultsMetricAttributeKey = "type"
+)
+
+// ProcessPagingFaultsMetricConfig provides config for the process.paging.faults metric.
+type ProcessPagingFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessPagingFaultsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessPagingFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessPagingFaultsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessPagingFaultsMetricAttributeKeyPagingFaultType:
+		default:
+			return fmt.Errorf("metric process.paging.faults doesn't have an attribute %v, valid attributes: [type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ProcessSignalsPendingMetricConfig provides config for the process.signals_pending metric.
+type ProcessSignalsPendingMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessSignalsPendingMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessThreadsMetricConfig provides config for the process.threads metric.
+type ProcessThreadsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessThreadsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ProcessUptimeMetricConfig provides config for the process.uptime metric.
+type ProcessUptimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ProcessUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,64 +459,76 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for process metrics.
 type MetricsConfig struct {
-	ProcessContextSwitches     MetricConfig `mapstructure:"process.context_switches"`
-	ProcessCPUTime             MetricConfig `mapstructure:"process.cpu.time"`
-	ProcessCPUUtilization      MetricConfig `mapstructure:"process.cpu.utilization"`
-	ProcessDiskIo              MetricConfig `mapstructure:"process.disk.io"`
-	ProcessDiskOperations      MetricConfig `mapstructure:"process.disk.operations"`
-	ProcessHandles             MetricConfig `mapstructure:"process.handles"`
-	ProcessMemoryUsage         MetricConfig `mapstructure:"process.memory.usage"`
-	ProcessMemoryUtilization   MetricConfig `mapstructure:"process.memory.utilization"`
-	ProcessMemoryVirtual       MetricConfig `mapstructure:"process.memory.virtual"`
-	ProcessOpenFileDescriptors MetricConfig `mapstructure:"process.open_file_descriptors"`
-	ProcessPagingFaults        MetricConfig `mapstructure:"process.paging.faults"`
-	ProcessSignalsPending      MetricConfig `mapstructure:"process.signals_pending"`
-	ProcessThreads             MetricConfig `mapstructure:"process.threads"`
-	ProcessUptime              MetricConfig `mapstructure:"process.uptime"`
+	ProcessContextSwitches     ProcessContextSwitchesMetricConfig     `mapstructure:"process.context_switches"`
+	ProcessCPUTime             ProcessCPUTimeMetricConfig             `mapstructure:"process.cpu.time"`
+	ProcessCPUUtilization      ProcessCPUUtilizationMetricConfig      `mapstructure:"process.cpu.utilization"`
+	ProcessDiskIo              ProcessDiskIoMetricConfig              `mapstructure:"process.disk.io"`
+	ProcessDiskOperations      ProcessDiskOperationsMetricConfig      `mapstructure:"process.disk.operations"`
+	ProcessHandles             ProcessHandlesMetricConfig             `mapstructure:"process.handles"`
+	ProcessMemoryUsage         ProcessMemoryUsageMetricConfig         `mapstructure:"process.memory.usage"`
+	ProcessMemoryUtilization   ProcessMemoryUtilizationMetricConfig   `mapstructure:"process.memory.utilization"`
+	ProcessMemoryVirtual       ProcessMemoryVirtualMetricConfig       `mapstructure:"process.memory.virtual"`
+	ProcessOpenFileDescriptors ProcessOpenFileDescriptorsMetricConfig `mapstructure:"process.open_file_descriptors"`
+	ProcessPagingFaults        ProcessPagingFaultsMetricConfig        `mapstructure:"process.paging.faults"`
+	ProcessSignalsPending      ProcessSignalsPendingMetricConfig      `mapstructure:"process.signals_pending"`
+	ProcessThreads             ProcessThreadsMetricConfig             `mapstructure:"process.threads"`
+	ProcessUptime              ProcessUptimeMetricConfig              `mapstructure:"process.uptime"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		ProcessContextSwitches: MetricConfig{
+		ProcessContextSwitches: ProcessContextSwitchesMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []ProcessContextSwitchesMetricAttributeKey{ProcessContextSwitchesMetricAttributeKeyContextSwitchType},
+		},
+		ProcessCPUTime: ProcessCPUTimeMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []ProcessCPUTimeMetricAttributeKey{ProcessCPUTimeMetricAttributeKeyState},
+		},
+		ProcessCPUUtilization: ProcessCPUUtilizationMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []ProcessCPUUtilizationMetricAttributeKey{ProcessCPUUtilizationMetricAttributeKeyState},
+		},
+		ProcessDiskIo: ProcessDiskIoMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []ProcessDiskIoMetricAttributeKey{ProcessDiskIoMetricAttributeKeyDirection},
+		},
+		ProcessDiskOperations: ProcessDiskOperationsMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []ProcessDiskOperationsMetricAttributeKey{ProcessDiskOperationsMetricAttributeKeyDirection},
+		},
+		ProcessHandles: ProcessHandlesMetricConfig{
 			Enabled: false,
 		},
-		ProcessCPUTime: MetricConfig{
+		ProcessMemoryUsage: ProcessMemoryUsageMetricConfig{
 			Enabled: true,
 		},
-		ProcessCPUUtilization: MetricConfig{
+		ProcessMemoryUtilization: ProcessMemoryUtilizationMetricConfig{
 			Enabled: false,
 		},
-		ProcessDiskIo: MetricConfig{
+		ProcessMemoryVirtual: ProcessMemoryVirtualMetricConfig{
 			Enabled: true,
 		},
-		ProcessDiskOperations: MetricConfig{
+		ProcessOpenFileDescriptors: ProcessOpenFileDescriptorsMetricConfig{
 			Enabled: false,
 		},
-		ProcessHandles: MetricConfig{
+		ProcessPagingFaults: ProcessPagingFaultsMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []ProcessPagingFaultsMetricAttributeKey{ProcessPagingFaultsMetricAttributeKeyPagingFaultType},
+		},
+		ProcessSignalsPending: ProcessSignalsPendingMetricConfig{
 			Enabled: false,
 		},
-		ProcessMemoryUsage: MetricConfig{
-			Enabled: true,
-		},
-		ProcessMemoryUtilization: MetricConfig{
+		ProcessThreads: ProcessThreadsMetricConfig{
 			Enabled: false,
 		},
-		ProcessMemoryVirtual: MetricConfig{
-			Enabled: true,
-		},
-		ProcessOpenFileDescriptors: MetricConfig{
-			Enabled: false,
-		},
-		ProcessPagingFaults: MetricConfig{
-			Enabled: false,
-		},
-		ProcessSignalsPending: MetricConfig{
-			Enabled: false,
-		},
-		ProcessThreads: MetricConfig{
-			Enabled: false,
-		},
-		ProcessUptime: MetricConfig{
+		ProcessUptime: ProcessUptimeMetricConfig{
 			Enabled: false,
 		},
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,46 +27,58 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ProcessContextSwitches: MetricConfig{
+					ProcessContextSwitches: ProcessContextSwitchesMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessContextSwitchesMetricAttributeKey{ProcessContextSwitchesMetricAttributeKeyContextSwitchType},
+					},
+					ProcessCPUTime: ProcessCPUTimeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessCPUTimeMetricAttributeKey{ProcessCPUTimeMetricAttributeKeyState},
+					},
+					ProcessCPUUtilization: ProcessCPUUtilizationMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ProcessCPUUtilizationMetricAttributeKey{ProcessCPUUtilizationMetricAttributeKeyState},
+					},
+					ProcessDiskIo: ProcessDiskIoMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessDiskIoMetricAttributeKey{ProcessDiskIoMetricAttributeKeyDirection},
+					},
+					ProcessDiskOperations: ProcessDiskOperationsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessDiskOperationsMetricAttributeKey{ProcessDiskOperationsMetricAttributeKeyDirection},
+					},
+					ProcessHandles: ProcessHandlesMetricConfig{
 						Enabled: true,
 					},
-					ProcessCPUTime: MetricConfig{
+					ProcessMemoryUsage: ProcessMemoryUsageMetricConfig{
 						Enabled: true,
 					},
-					ProcessCPUUtilization: MetricConfig{
+					ProcessMemoryUtilization: ProcessMemoryUtilizationMetricConfig{
 						Enabled: true,
 					},
-					ProcessDiskIo: MetricConfig{
+					ProcessMemoryVirtual: ProcessMemoryVirtualMetricConfig{
 						Enabled: true,
 					},
-					ProcessDiskOperations: MetricConfig{
+					ProcessOpenFileDescriptors: ProcessOpenFileDescriptorsMetricConfig{
 						Enabled: true,
 					},
-					ProcessHandles: MetricConfig{
+					ProcessPagingFaults: ProcessPagingFaultsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessPagingFaultsMetricAttributeKey{ProcessPagingFaultsMetricAttributeKeyPagingFaultType},
+					},
+					ProcessSignalsPending: ProcessSignalsPendingMetricConfig{
 						Enabled: true,
 					},
-					ProcessMemoryUsage: MetricConfig{
+					ProcessThreads: ProcessThreadsMetricConfig{
 						Enabled: true,
 					},
-					ProcessMemoryUtilization: MetricConfig{
-						Enabled: true,
-					},
-					ProcessMemoryVirtual: MetricConfig{
-						Enabled: true,
-					},
-					ProcessOpenFileDescriptors: MetricConfig{
-						Enabled: true,
-					},
-					ProcessPagingFaults: MetricConfig{
-						Enabled: true,
-					},
-					ProcessSignalsPending: MetricConfig{
-						Enabled: true,
-					},
-					ProcessThreads: MetricConfig{
-						Enabled: true,
-					},
-					ProcessUptime: MetricConfig{
+					ProcessUptime: ProcessUptimeMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -85,46 +98,58 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ProcessContextSwitches: MetricConfig{
+					ProcessContextSwitches: ProcessContextSwitchesMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessContextSwitchesMetricAttributeKey{ProcessContextSwitchesMetricAttributeKeyContextSwitchType},
+					},
+					ProcessCPUTime: ProcessCPUTimeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessCPUTimeMetricAttributeKey{ProcessCPUTimeMetricAttributeKeyState},
+					},
+					ProcessCPUUtilization: ProcessCPUUtilizationMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ProcessCPUUtilizationMetricAttributeKey{ProcessCPUUtilizationMetricAttributeKeyState},
+					},
+					ProcessDiskIo: ProcessDiskIoMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessDiskIoMetricAttributeKey{ProcessDiskIoMetricAttributeKeyDirection},
+					},
+					ProcessDiskOperations: ProcessDiskOperationsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessDiskOperationsMetricAttributeKey{ProcessDiskOperationsMetricAttributeKeyDirection},
+					},
+					ProcessHandles: ProcessHandlesMetricConfig{
 						Enabled: false,
 					},
-					ProcessCPUTime: MetricConfig{
+					ProcessMemoryUsage: ProcessMemoryUsageMetricConfig{
 						Enabled: false,
 					},
-					ProcessCPUUtilization: MetricConfig{
+					ProcessMemoryUtilization: ProcessMemoryUtilizationMetricConfig{
 						Enabled: false,
 					},
-					ProcessDiskIo: MetricConfig{
+					ProcessMemoryVirtual: ProcessMemoryVirtualMetricConfig{
 						Enabled: false,
 					},
-					ProcessDiskOperations: MetricConfig{
+					ProcessOpenFileDescriptors: ProcessOpenFileDescriptorsMetricConfig{
 						Enabled: false,
 					},
-					ProcessHandles: MetricConfig{
+					ProcessPagingFaults: ProcessPagingFaultsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []ProcessPagingFaultsMetricAttributeKey{ProcessPagingFaultsMetricAttributeKeyPagingFaultType},
+					},
+					ProcessSignalsPending: ProcessSignalsPendingMetricConfig{
 						Enabled: false,
 					},
-					ProcessMemoryUsage: MetricConfig{
+					ProcessThreads: ProcessThreadsMetricConfig{
 						Enabled: false,
 					},
-					ProcessMemoryUtilization: MetricConfig{
-						Enabled: false,
-					},
-					ProcessMemoryVirtual: MetricConfig{
-						Enabled: false,
-					},
-					ProcessOpenFileDescriptors: MetricConfig{
-						Enabled: false,
-					},
-					ProcessPagingFaults: MetricConfig{
-						Enabled: false,
-					},
-					ProcessSignalsPending: MetricConfig{
-						Enabled: false,
-					},
-					ProcessThreads: MetricConfig{
-						Enabled: false,
-					},
-					ProcessUptime: MetricConfig{
+					ProcessUptime: ProcessUptimeMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -144,7 +169,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ProcessContextSwitchesMetricConfig{}, ProcessCPUTimeMetricConfig{}, ProcessCPUUtilizationMetricConfig{}, ProcessDiskIoMetricConfig{}, ProcessDiskOperationsMetricConfig{}, ProcessHandlesMetricConfig{}, ProcessMemoryUsageMetricConfig{}, ProcessMemoryUtilizationMetricConfig{}, ProcessMemoryVirtualMetricConfig{}, ProcessOpenFileDescriptorsMetricConfig{}, ProcessPagingFaultsMetricConfig{}, ProcessSignalsPendingMetricConfig{}, ProcessThreadsMetricConfig{}, ProcessUptimeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -11,6 +12,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/scraper"
 	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeContextSwitchType specifies the value context_switch_type attribute.
@@ -188,9 +196,10 @@ type metricInfo struct {
 }
 
 type metricProcessContextSwitches struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        ProcessContextSwitchesMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []int64                            // slice containing number of aggregated datapoints at each index
 }
 
 // init fills process.context_switches metric with initial data.
@@ -202,17 +211,48 @@ func (m *metricProcessContextSwitches) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricProcessContextSwitches) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, contextSwitchTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessContextSwitchesMetricAttributeKeyContextSwitchType) {
+		dp.Attributes().PutStr("type", contextSwitchTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("type", contextSwitchTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -225,13 +265,18 @@ func (m *metricProcessContextSwitches) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessContextSwitches) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessContextSwitches(cfg MetricConfig) metricProcessContextSwitches {
+func newMetricProcessContextSwitches(cfg ProcessContextSwitchesMetricConfig) metricProcessContextSwitches {
 	m := metricProcessContextSwitches{config: cfg}
 
 	if cfg.Enabled {
@@ -242,9 +287,10 @@ func newMetricProcessContextSwitches(cfg MetricConfig) metricProcessContextSwitc
 }
 
 type metricProcessCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric             // data buffer for generated metric.
+	config        ProcessCPUTimeMetricConfig // metric config provided by user.
+	capacity      int                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills process.cpu.time metric with initial data.
@@ -256,17 +302,48 @@ func (m *metricProcessCPUTime) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricProcessCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessCPUTimeMetricAttributeKeyState) {
+		dp.Attributes().PutStr("state", stateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("state", stateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -279,13 +356,18 @@ func (m *metricProcessCPUTime) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessCPUTime) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessCPUTime(cfg MetricConfig) metricProcessCPUTime {
+func newMetricProcessCPUTime(cfg ProcessCPUTimeMetricConfig) metricProcessCPUTime {
 	m := metricProcessCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -296,9 +378,10 @@ func newMetricProcessCPUTime(cfg MetricConfig) metricProcessCPUTime {
 }
 
 type metricProcessCPUUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                    // data buffer for generated metric.
+	config        ProcessCPUUtilizationMetricConfig // metric config provided by user.
+	capacity      int                               // max observed number of data points added to the metric.
+	aggDataPoints []float64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills process.cpu.utilization metric with initial data.
@@ -308,17 +391,48 @@ func (m *metricProcessCPUUtilization) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricProcessCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessCPUUtilizationMetricAttributeKeyState) {
+		dp.Attributes().PutStr("state", stateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("state", stateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -331,13 +445,18 @@ func (m *metricProcessCPUUtilization) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessCPUUtilization) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessCPUUtilization(cfg MetricConfig) metricProcessCPUUtilization {
+func newMetricProcessCPUUtilization(cfg ProcessCPUUtilizationMetricConfig) metricProcessCPUUtilization {
 	m := metricProcessCPUUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -348,9 +467,10 @@ func newMetricProcessCPUUtilization(cfg MetricConfig) metricProcessCPUUtilizatio
 }
 
 type metricProcessDiskIo struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric            // data buffer for generated metric.
+	config        ProcessDiskIoMetricConfig // metric config provided by user.
+	capacity      int                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                   // slice containing number of aggregated datapoints at each index
 }
 
 // init fills process.disk.io metric with initial data.
@@ -362,17 +482,48 @@ func (m *metricProcessDiskIo) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricProcessDiskIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessDiskIoMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -385,13 +536,18 @@ func (m *metricProcessDiskIo) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessDiskIo) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessDiskIo(cfg MetricConfig) metricProcessDiskIo {
+func newMetricProcessDiskIo(cfg ProcessDiskIoMetricConfig) metricProcessDiskIo {
 	m := metricProcessDiskIo{config: cfg}
 
 	if cfg.Enabled {
@@ -402,9 +558,10 @@ func newMetricProcessDiskIo(cfg MetricConfig) metricProcessDiskIo {
 }
 
 type metricProcessDiskOperations struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                    // data buffer for generated metric.
+	config        ProcessDiskOperationsMetricConfig // metric config provided by user.
+	capacity      int                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills process.disk.operations metric with initial data.
@@ -416,17 +573,48 @@ func (m *metricProcessDiskOperations) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricProcessDiskOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessDiskOperationsMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -439,13 +627,18 @@ func (m *metricProcessDiskOperations) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessDiskOperations) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessDiskOperations(cfg MetricConfig) metricProcessDiskOperations {
+func newMetricProcessDiskOperations(cfg ProcessDiskOperationsMetricConfig) metricProcessDiskOperations {
 	m := metricProcessDiskOperations{config: cfg}
 
 	if cfg.Enabled {
@@ -456,9 +649,9 @@ func newMetricProcessDiskOperations(cfg MetricConfig) metricProcessDiskOperation
 }
 
 type metricProcessHandles struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   ProcessHandlesMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills process.handles metric with initial data.
@@ -497,7 +690,7 @@ func (m *metricProcessHandles) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessHandles(cfg MetricConfig) metricProcessHandles {
+func newMetricProcessHandles(cfg ProcessHandlesMetricConfig) metricProcessHandles {
 	m := metricProcessHandles{config: cfg}
 
 	if cfg.Enabled {
@@ -508,9 +701,9 @@ func newMetricProcessHandles(cfg MetricConfig) metricProcessHandles {
 }
 
 type metricProcessMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   ProcessMemoryUsageMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills process.memory.usage metric with initial data.
@@ -549,7 +742,7 @@ func (m *metricProcessMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessMemoryUsage(cfg MetricConfig) metricProcessMemoryUsage {
+func newMetricProcessMemoryUsage(cfg ProcessMemoryUsageMetricConfig) metricProcessMemoryUsage {
 	m := metricProcessMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -560,9 +753,9 @@ func newMetricProcessMemoryUsage(cfg MetricConfig) metricProcessMemoryUsage {
 }
 
 type metricProcessMemoryUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   ProcessMemoryUtilizationMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills process.memory.utilization metric with initial data.
@@ -599,7 +792,7 @@ func (m *metricProcessMemoryUtilization) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessMemoryUtilization(cfg MetricConfig) metricProcessMemoryUtilization {
+func newMetricProcessMemoryUtilization(cfg ProcessMemoryUtilizationMetricConfig) metricProcessMemoryUtilization {
 	m := metricProcessMemoryUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -610,9 +803,9 @@ func newMetricProcessMemoryUtilization(cfg MetricConfig) metricProcessMemoryUtil
 }
 
 type metricProcessMemoryVirtual struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   ProcessMemoryVirtualMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills process.memory.virtual metric with initial data.
@@ -651,7 +844,7 @@ func (m *metricProcessMemoryVirtual) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessMemoryVirtual(cfg MetricConfig) metricProcessMemoryVirtual {
+func newMetricProcessMemoryVirtual(cfg ProcessMemoryVirtualMetricConfig) metricProcessMemoryVirtual {
 	m := metricProcessMemoryVirtual{config: cfg}
 
 	if cfg.Enabled {
@@ -662,9 +855,9 @@ func newMetricProcessMemoryVirtual(cfg MetricConfig) metricProcessMemoryVirtual 
 }
 
 type metricProcessOpenFileDescriptors struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   ProcessOpenFileDescriptorsMetricConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
 }
 
 // init fills process.open_file_descriptors metric with initial data.
@@ -703,7 +896,7 @@ func (m *metricProcessOpenFileDescriptors) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessOpenFileDescriptors(cfg MetricConfig) metricProcessOpenFileDescriptors {
+func newMetricProcessOpenFileDescriptors(cfg ProcessOpenFileDescriptorsMetricConfig) metricProcessOpenFileDescriptors {
 	m := metricProcessOpenFileDescriptors{config: cfg}
 
 	if cfg.Enabled {
@@ -714,9 +907,10 @@ func newMetricProcessOpenFileDescriptors(cfg MetricConfig) metricProcessOpenFile
 }
 
 type metricProcessPagingFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        ProcessPagingFaultsMetricConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills process.paging.faults metric with initial data.
@@ -728,17 +922,48 @@ func (m *metricProcessPagingFaults) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricProcessPagingFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pagingFaultTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessPagingFaultsMetricAttributeKeyPagingFaultType) {
+		dp.Attributes().PutStr("type", pagingFaultTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("type", pagingFaultTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -751,13 +976,18 @@ func (m *metricProcessPagingFaults) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessPagingFaults) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessPagingFaults(cfg MetricConfig) metricProcessPagingFaults {
+func newMetricProcessPagingFaults(cfg ProcessPagingFaultsMetricConfig) metricProcessPagingFaults {
 	m := metricProcessPagingFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -768,9 +998,9 @@ func newMetricProcessPagingFaults(cfg MetricConfig) metricProcessPagingFaults {
 }
 
 type metricProcessSignalsPending struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   ProcessSignalsPendingMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills process.signals_pending metric with initial data.
@@ -809,7 +1039,7 @@ func (m *metricProcessSignalsPending) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessSignalsPending(cfg MetricConfig) metricProcessSignalsPending {
+func newMetricProcessSignalsPending(cfg ProcessSignalsPendingMetricConfig) metricProcessSignalsPending {
 	m := metricProcessSignalsPending{config: cfg}
 
 	if cfg.Enabled {
@@ -820,9 +1050,9 @@ func newMetricProcessSignalsPending(cfg MetricConfig) metricProcessSignalsPendin
 }
 
 type metricProcessThreads struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   ProcessThreadsMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills process.threads metric with initial data.
@@ -861,7 +1091,7 @@ func (m *metricProcessThreads) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessThreads(cfg MetricConfig) metricProcessThreads {
+func newMetricProcessThreads(cfg ProcessThreadsMetricConfig) metricProcessThreads {
 	m := metricProcessThreads{config: cfg}
 
 	if cfg.Enabled {
@@ -872,9 +1102,9 @@ func newMetricProcessThreads(cfg MetricConfig) metricProcessThreads {
 }
 
 type metricProcessUptime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   ProcessUptimeMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills process.uptime metric with initial data.
@@ -911,7 +1141,7 @@ func (m *metricProcessUptime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricProcessUptime(cfg MetricConfig) metricProcessUptime {
+func newMetricProcessUptime(cfg ProcessUptimeMetricConfig) metricProcessUptime {
 	m := metricProcessUptime{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,29 +66,53 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := scrapertest.NewNopSettings(scrapertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["ProcessContextSwitches"] = mb.metricProcessContextSwitches.config.AggregationStrategy
+			aggMap["ProcessCPUTime"] = mb.metricProcessCPUTime.config.AggregationStrategy
+			aggMap["ProcessCPUUtilization"] = mb.metricProcessCPUUtilization.config.AggregationStrategy
+			aggMap["ProcessDiskIo"] = mb.metricProcessDiskIo.config.AggregationStrategy
+			aggMap["ProcessDiskOperations"] = mb.metricProcessDiskOperations.config.AggregationStrategy
+			aggMap["ProcessPagingFaults"] = mb.metricProcessPagingFaults.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
 			allMetricsCount++
 			mb.RecordProcessContextSwitchesDataPoint(ts, 1, AttributeContextSwitchTypeInvoluntary)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessContextSwitchesDataPoint(ts, 3, AttributeContextSwitchTypeVoluntary)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordProcessCPUTimeDataPoint(ts, 1, AttributeStateSystem)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessCPUTimeDataPoint(ts, 3, AttributeStateUser)
+			}
 
 			allMetricsCount++
 			mb.RecordProcessCPUUtilizationDataPoint(ts, 1, AttributeStateSystem)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessCPUUtilizationDataPoint(ts, 3, AttributeStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordProcessDiskIoDataPoint(ts, 1, AttributeDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessDiskIoDataPoint(ts, 3, AttributeDirectionWrite)
+			}
 
 			allMetricsCount++
 			mb.RecordProcessDiskOperationsDataPoint(ts, 1, AttributeDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessDiskOperationsDataPoint(ts, 3, AttributeDirectionWrite)
+			}
 
 			allMetricsCount++
 			mb.RecordProcessHandlesDataPoint(ts, 1)
@@ -103,6 +133,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordProcessPagingFaultsDataPoint(ts, 1, AttributePagingFaultTypeMajor)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessPagingFaultsDataPoint(ts, 3, AttributePagingFaultTypeMinor)
+			}
 
 			allMetricsCount++
 			mb.RecordProcessSignalsPendingDataPoint(ts, 1)
@@ -124,6 +157,14 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetProcessPid(11)
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricProcessContextSwitches.aggDataPoints)
+				assert.Empty(t, mb.metricProcessCPUTime.aggDataPoints)
+				assert.Empty(t, mb.metricProcessCPUUtilization.aggDataPoints)
+				assert.Empty(t, mb.metricProcessDiskIo.aggDataPoints)
+				assert.Empty(t, mb.metricProcessDiskOperations.aggDataPoints)
+				assert.Empty(t, mb.metricProcessPagingFaults.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -151,88 +192,221 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "process.context_switches":
-					assert.False(t, validatedMetrics["process.context_switches"], "Found a duplicate in the metrics slice: process.context_switches")
-					validatedMetrics["process.context_switches"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of times the process has been context switched.", mi.Description())
-					assert.Equal(t, "{count}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					contextSwitchTypeAttrVal, ok := dp.Attributes().Get("type")
-					assert.True(t, ok)
-					assert.Equal(t, "involuntary", contextSwitchTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.context_switches"], "Found a duplicate in the metrics slice: process.context_switches")
+						validatedMetrics["process.context_switches"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of times the process has been context switched.", mi.Description())
+						assert.Equal(t, "{count}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						contextSwitchTypeAttrVal, ok := dp.Attributes().Get("type")
+						assert.True(t, ok)
+						assert.Equal(t, "involuntary", contextSwitchTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["process.context_switches"], "Found a duplicate in the metrics slice: process.context_switches")
+						validatedMetrics["process.context_switches"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of times the process has been context switched.", mi.Description())
+						assert.Equal(t, "{count}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["process.context_switches"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("type")
+						assert.False(t, ok)
+					}
 				case "process.cpu.time":
-					assert.False(t, validatedMetrics["process.cpu.time"], "Found a duplicate in the metrics slice: process.cpu.time")
-					validatedMetrics["process.cpu.time"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Total CPU seconds broken down by different states.", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					stateAttrVal, ok := dp.Attributes().Get("state")
-					assert.True(t, ok)
-					assert.Equal(t, "system", stateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.cpu.time"], "Found a duplicate in the metrics slice: process.cpu.time")
+						validatedMetrics["process.cpu.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Total CPU seconds broken down by different states.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						stateAttrVal, ok := dp.Attributes().Get("state")
+						assert.True(t, ok)
+						assert.Equal(t, "system", stateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["process.cpu.time"], "Found a duplicate in the metrics slice: process.cpu.time")
+						validatedMetrics["process.cpu.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Total CPU seconds broken down by different states.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["process.cpu.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("state")
+						assert.False(t, ok)
+					}
 				case "process.cpu.utilization":
-					assert.False(t, validatedMetrics["process.cpu.utilization"], "Found a duplicate in the metrics slice: process.cpu.utilization")
-					validatedMetrics["process.cpu.utilization"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Percentage of total CPU time used by the process since last scrape, expressed as a value between 0 and 1. On the first scrape, no data point is emitted for this metric.", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					stateAttrVal, ok := dp.Attributes().Get("state")
-					assert.True(t, ok)
-					assert.Equal(t, "system", stateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.cpu.utilization"], "Found a duplicate in the metrics slice: process.cpu.utilization")
+						validatedMetrics["process.cpu.utilization"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Percentage of total CPU time used by the process since last scrape, expressed as a value between 0 and 1. On the first scrape, no data point is emitted for this metric.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						stateAttrVal, ok := dp.Attributes().Get("state")
+						assert.True(t, ok)
+						assert.Equal(t, "system", stateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["process.cpu.utilization"], "Found a duplicate in the metrics slice: process.cpu.utilization")
+						validatedMetrics["process.cpu.utilization"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Percentage of total CPU time used by the process since last scrape, expressed as a value between 0 and 1. On the first scrape, no data point is emitted for this metric.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["process.cpu.utilization"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("state")
+						assert.False(t, ok)
+					}
 				case "process.disk.io":
-					assert.False(t, validatedMetrics["process.disk.io"], "Found a duplicate in the metrics slice: process.disk.io")
-					validatedMetrics["process.disk.io"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Disk bytes transferred.", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.disk.io"], "Found a duplicate in the metrics slice: process.disk.io")
+						validatedMetrics["process.disk.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Disk bytes transferred.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["process.disk.io"], "Found a duplicate in the metrics slice: process.disk.io")
+						validatedMetrics["process.disk.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Disk bytes transferred.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["process.disk.io"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "process.disk.operations":
-					assert.False(t, validatedMetrics["process.disk.operations"], "Found a duplicate in the metrics slice: process.disk.operations")
-					validatedMetrics["process.disk.operations"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of disk operations performed by the process.", mi.Description())
-					assert.Equal(t, "{operations}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.disk.operations"], "Found a duplicate in the metrics slice: process.disk.operations")
+						validatedMetrics["process.disk.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of disk operations performed by the process.", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["process.disk.operations"], "Found a duplicate in the metrics slice: process.disk.operations")
+						validatedMetrics["process.disk.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of disk operations performed by the process.", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["process.disk.operations"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "process.handles":
 					assert.False(t, validatedMetrics["process.handles"], "Found a duplicate in the metrics slice: process.handles")
 					validatedMetrics["process.handles"] = true
@@ -302,22 +476,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "process.paging.faults":
-					assert.False(t, validatedMetrics["process.paging.faults"], "Found a duplicate in the metrics slice: process.paging.faults")
-					validatedMetrics["process.paging.faults"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of page faults the process has made.", mi.Description())
-					assert.Equal(t, "{faults}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					pagingFaultTypeAttrVal, ok := dp.Attributes().Get("type")
-					assert.True(t, ok)
-					assert.Equal(t, "major", pagingFaultTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.paging.faults"], "Found a duplicate in the metrics slice: process.paging.faults")
+						validatedMetrics["process.paging.faults"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of page faults the process has made.", mi.Description())
+						assert.Equal(t, "{faults}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						pagingFaultTypeAttrVal, ok := dp.Attributes().Get("type")
+						assert.True(t, ok)
+						assert.Equal(t, "major", pagingFaultTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["process.paging.faults"], "Found a duplicate in the metrics slice: process.paging.faults")
+						validatedMetrics["process.paging.faults"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of page faults the process has made.", mi.Description())
+						assert.Equal(t, "{faults}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["process.paging.faults"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("type")
+						assert.False(t, ok)
+					}
 				case "process.signals_pending":
 					assert.False(t, validatedMetrics["process.signals_pending"], "Found a duplicate in the metrics slice: process.signals_pending")
 					validatedMetrics["process.signals_pending"] = true

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/testdata/config.yaml
@@ -3,14 +3,19 @@ all_set:
   metrics:
     process.context_switches:
       enabled: true
+      attributes: ["type"]
     process.cpu.time:
       enabled: true
+      attributes: ["state"]
     process.cpu.utilization:
       enabled: true
+      attributes: ["state"]
     process.disk.io:
       enabled: true
+      attributes: ["direction"]
     process.disk.operations:
       enabled: true
+      attributes: ["direction"]
     process.handles:
       enabled: true
     process.memory.usage:
@@ -23,6 +28,60 @@ all_set:
       enabled: true
     process.paging.faults:
       enabled: true
+      attributes: ["type"]
+    process.signals_pending:
+      enabled: true
+    process.threads:
+      enabled: true
+    process.uptime:
+      enabled: true
+  resource_attributes:
+    process.cgroup:
+      enabled: true
+    process.command:
+      enabled: true
+    process.command_line:
+      enabled: true
+    process.executable.name:
+      enabled: true
+    process.executable.path:
+      enabled: true
+    process.owner:
+      enabled: true
+    process.parent_pid:
+      enabled: true
+    process.pid:
+      enabled: true
+reaggregate_set:
+  metrics:
+    process.context_switches:
+      enabled: true
+      attributes: []
+    process.cpu.time:
+      enabled: true
+      attributes: []
+    process.cpu.utilization:
+      enabled: true
+      attributes: []
+    process.disk.io:
+      enabled: true
+      attributes: []
+    process.disk.operations:
+      enabled: true
+      attributes: []
+    process.handles:
+      enabled: true
+    process.memory.usage:
+      enabled: true
+    process.memory.utilization:
+      enabled: true
+    process.memory.virtual:
+      enabled: true
+    process.open_file_descriptors:
+      enabled: true
+    process.paging.faults:
+      enabled: true
+      attributes: []
     process.signals_pending:
       enabled: true
     process.threads:
@@ -50,14 +109,19 @@ none_set:
   metrics:
     process.context_switches:
       enabled: false
+      attributes: ["type"]
     process.cpu.time:
       enabled: false
+      attributes: ["state"]
     process.cpu.utilization:
       enabled: false
+      attributes: ["state"]
     process.disk.io:
       enabled: false
+      attributes: ["direction"]
     process.disk.operations:
       enabled: false
+      attributes: ["direction"]
     process.handles:
       enabled: false
     process.memory.usage:
@@ -70,6 +134,7 @@ none_set:
       enabled: false
     process.paging.faults:
       enabled: false
+      attributes: ["type"]
     process.signals_pending:
       enabled: false
     process.threads:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -1,5 +1,7 @@
 type: process
 
+reaggregation_enabled: true
+
 status:
   class: scraper
   stability:
@@ -14,6 +16,7 @@ resource_attributes:
   process.cgroup:
     description: cgroup associated with the process (Linux only).
     enabled: false
+    requirement_level: opt_in
     type: string
   process.command:
     description: >-
@@ -21,6 +24,7 @@ resource_attributes:
       systems, can be set to the zeroth string in proc/[pid]/cmdline. On Windows, can
       be set to the first parameter extracted from GetCommandLineW.
     enabled: true
+    requirement_level: recommended
     type: string
   process.command_line:
     description: >-
@@ -29,6 +33,7 @@ resource_attributes:
       set this if you have to assemble it just for monitoring; use
       process.command_args instead.
     enabled: true
+    requirement_level: opt_in
     type: string
   process.executable.name:
     description: >-
@@ -36,6 +41,7 @@ resource_attributes:
       Name in proc/[pid]/status. On Windows, can be set to the base name of
       GetProcessImageFileNameW.
     enabled: true
+    requirement_level: required
     type: string
   process.executable.path:
     description: >-
@@ -43,18 +49,22 @@ resource_attributes:
       the target of proc/[pid]/exe. On Windows, can be set to the result of
       GetProcessImageFileNameW.
     enabled: true
+    requirement_level: recommended
     type: string
   process.owner:
     description: The username of the user that owns the process.
     enabled: true
+    requirement_level: recommended
     type: string
   process.parent_pid:
     description: Parent Process identifier (PPID).
     enabled: true
+    requirement_level: opt_in
     type: int
   process.pid:
     description: Process identifier (PID).
     enabled: true
+    requirement_level: required
     type: int
 
 attributes:
@@ -63,20 +73,24 @@ attributes:
     description: Type of context switched.
     type: string
     enum: [involuntary, voluntary]
+    requirement_level: recommended
   direction:
     description: Direction of flow of bytes (read or write).
     type: string
     enum: [read, write]
+    requirement_level: recommended
 
   paging_fault_type:
     name_override: type
     description: Type of memory paging fault.
     type: string
     enum: [major, minor]
+    requirement_level: recommended
   state:
     description: Breakdown of CPU usage by type.
     type: string
     enum: [system, user, wait]
+    requirement_level: recommended
 
 metrics:
   process.context_switches:

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_config.go
@@ -6,13 +6,13 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// SystemUptimeMetricConfig provides config for the system.uptime metric.
+type SystemUptimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *SystemUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -28,12 +28,12 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for system metrics.
 type MetricsConfig struct {
-	SystemUptime MetricConfig `mapstructure:"system.uptime"`
+	SystemUptime SystemUptimeMetricConfig `mapstructure:"system.uptime"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		SystemUptime: MetricConfig{
+		SystemUptime: SystemUptimeMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,7 +27,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SystemUptime: MetricConfig{
+					SystemUptime: SystemUptimeMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -36,7 +37,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SystemUptime: MetricConfig{
+					SystemUptime: SystemUptimeMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -46,7 +47,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SystemUptimeMetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_metrics.go
@@ -12,6 +12,13 @@ import (
 	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
 )
 
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
+)
+
 var MetricsInfo = metricsInfo{
 	SystemUptime: metricInfo{
 		Name: "system.uptime",
@@ -27,9 +34,9 @@ type metricInfo struct {
 }
 
 type metricSystemUptime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric           // data buffer for generated metric.
+	config   SystemUptimeMetricConfig // metric config provided by user.
+	capacity int                      // max observed number of data points added to the metric.
 }
 
 // init fills system.uptime metric with initial data.
@@ -66,7 +73,7 @@ func (m *metricSystemUptime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSystemUptime(cfg MetricConfig) metricSystemUptime {
+func newMetricSystemUptime(cfg SystemUptimeMetricConfig) metricSystemUptime {
 	m := metricSystemUptime{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -37,6 +38,11 @@ func TestMetricsBuilder(t *testing.T) {
 			resAttrsSet: testDataSetAll,
 		},
 		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
+		},
+		{
 			name:        "none_set",
 			metricsSet:  testDataSetNone,
 			resAttrsSet: testDataSetNone,
@@ -53,7 +59,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -64,6 +72,8 @@ func TestMetricsBuilder(t *testing.T) {
 
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/internal/metadata/testdata/config.yaml
@@ -3,6 +3,10 @@ all_set:
   metrics:
     system.uptime:
       enabled: true
+reaggregate_set:
+  metrics:
+    system.uptime:
+      enabled: true
 none_set:
   metrics:
     system.uptime:

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/metadata.yaml
@@ -1,5 +1,7 @@
 type: system
 
+reaggregation_enabled: true
+
 status:
   class: scraper
   stability:


### PR DESCRIPTION
Part of #46386.

Enables the re-aggregation feature for the two remaining `hostmetrics` scrapers.

## process scraper

- Sets `reaggregation_enabled: true`
- Classifies **metric attributes** as `recommended` (all four: `context_switch_type`, `direction`, `paging_fault_type`, `state`) — these are useful breakdowns but operators may want to aggregate them away
- Classifies **resource attributes** by their role in process identity:

| Attribute | Level | Rationale |
|-----------|-------|-----------|
| `process.pid` | `required` | Uniquely identifies the process; dropping it conflates all processes |
| `process.executable.name` | `required` | Primary process identifier |
| `process.command` | `recommended` | Useful context, safe to drop for cross-process aggregation |
| `process.executable.path` | `recommended` | Full path is helpful but optional |
| `process.owner` | `recommended` | Username grouping; drop when not needed |
| `process.command_line` | `opt_in` | Verbose; already enabled by default but high-cardinality |
| `process.parent_pid` | `opt_in` | Rarely needed for aggregation |
| `process.cgroup` | `opt_in` | Linux-only; already `enabled: false` |

## system scraper

- Sets `reaggregation_enabled: true`
- No attribute classification needed: the single metric `system.uptime` has an empty `attributes: []` list

## Validation

- All existing tests pass: `go test ./internal/scraper/processscraper/... ./internal/scraper/systemscraper/...`
- Generated code regenerated via `make generate`