### PR TITLE
[receiver/awslambda] support random access to S3

### DIFF
--- a/.chloggen/awslambdareceiver-readerat.yaml
+++ b/.chloggen/awslambdareceiver-readerat.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awslambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support random-access reading non-gzipped data with the io.ReaderAt interface
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38861]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This adds support for streaming through Parquet files, rather than having to read the entire file into memory.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -4,7 +4,6 @@
 package awslambdareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver"
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -32,9 +31,6 @@ import (
 
 // s3StreamBatchSize defines the size of data chunks read from S3 object stream for processing.
 const s3StreamBatchSize = 10_000_000 // 10MB chunks
-
-// readerBufferSize defines the buffer size for buffered readers.
-const readerBufferSize = 128 * 1024 // 128KB buffer size
 
 type (
 	handlerRegistry map[eventType]lambdaEventHandler
@@ -189,28 +185,23 @@ func (s *s3Handler) handle(ctx context.Context, event json.RawMessage) error {
 		return nil
 	}
 
-	reader, err := s.s3Service.GetReader(ctx, parsedEvent.S3.Bucket.Name, parsedEvent.S3.Object.URLDecodedKey)
+	s3Reader, err := s.s3Service.GetReader(ctx, parsedEvent.S3.Bucket.Name, parsedEvent.S3.Object.URLDecodedKey, parsedEvent.S3.Object.Size)
 	if err != nil {
 		return err
 	}
+	defer s3Reader.Close()
 
-	wrappedReader, err := gunzipIfNeeded(reader)
-	if err != nil {
-		return fmt.Errorf("failed to derive reader with wrapper: %w", err)
-	}
-
-	defer func() {
-		if gzReader, ok := wrappedReader.(*gzip.Reader); ok {
-			_ = gzReader.Close()
+	var reader io.Reader = s3Reader
+	if strings.HasSuffix(parsedEvent.S3.Object.URLDecodedKey, ".gz") {
+		gzReader, gzErr := gzip.NewReader(s3Reader)
+		if gzErr != nil {
+			return fmt.Errorf("failed to create gzip reader: %w", gzErr)
 		}
-	}()
-
-	err = s.decodeF(ctx, wrappedReader, parsedEvent)
-	if err != nil {
-		return err
+		defer gzReader.Close()
+		reader = gzReader
 	}
 
-	return nil
+	return s.decodeF(ctx, reader, parsedEvent)
 }
 
 func (*s3Handler) parseEvent(raw json.RawMessage) (event events.S3EventRecord, err error) {
@@ -287,24 +278,6 @@ func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMe
 	}
 
 	return nil
-}
-
-// gunzipIfNeeded checks if the provided reader is a gzipped stream and returns a reader with gunzip wrapping if needed.
-func gunzipIfNeeded(r io.Reader) (io.Reader, error) {
-	buf := bufio.NewReaderSize(r, readerBufferSize)
-	header, err := buf.Peek(2)
-	if err != nil {
-		return nil, err
-	}
-	// gzip magic number: 0x1f 0x8b
-	if header[0] == 0x1f && header[1] == 0x8b {
-		gr, err := gzip.NewReader(buf)
-		if err != nil {
-			return nil, err
-		}
-		return gr, nil
-	}
-	return buf, nil
 }
 
 func enrichS3Logs(logs plog.Logs, event events.S3EventRecord) {

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -140,7 +140,7 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 						S3: events.S3Entity{
 							Bucket: events.S3Bucket{Name: "test-bucket", Arn: "arn:aws:s3:::test-bucket"},
 							Object: events.S3Object{
-								Key:  "test-file.txt",
+								Key:  "test-file.txt.gz",
 								Size: 10,
 							},
 						},
@@ -149,7 +149,7 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 			},
 			s3MockContent: s3Content{
 				bucketName: "test-bucket",
-				objectKey:  "test-file.txt",
+				objectKey:  "test-file.txt.gz",
 				data:       compressData(t, []byte("Logs in Gzip S3 object")),
 			},
 			extension:     internal.NewDefaultS3LogsDecoder(),
@@ -221,14 +221,21 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			s3Service := internal.NewMockS3Service(ctr)
 			s3Service.EXPECT().
-				GetReader(gomock.Any(), test.s3MockContent.bucketName, test.s3MockContent.objectKey).
-				Return(io.NopCloser(bytes.NewReader(test.s3MockContent.data)), nil).
+				GetReader(gomock.Any(), test.s3MockContent.bucketName, test.s3MockContent.objectKey, gomock.Any()).
+				Return(internal.NewBytesS3ObjectReader(test.s3MockContent.data), nil).
 				AnyTimes()
 
 			handler := newS3LogsHandler(s3Service, zap.NewNop(), test.extension, test.eventConsumer)
 
+			// Set the S3 object size to match the mock data so that
+			// io.NewSectionReader in the handler sees the correct length.
+			s3Event := test.s3Event
+			if len(s3Event.Records) > 0 && len(test.s3MockContent.data) > 0 {
+				s3Event.Records[0].S3.Object.Size = int64(len(test.s3MockContent.data))
+			}
+
 			var event json.RawMessage
-			event, err := json.Marshal(test.s3Event)
+			event, err := json.Marshal(s3Event)
 			require.NoError(t, err)
 
 			errP := handler.handle(t.Context(), event)
@@ -478,7 +485,7 @@ func TestConsumerErrorHandling(t *testing.T) {
 					Bucket: events.S3Bucket{Name: "test-bucket", Arn: "arn:aws:s3:::test-bucket"},
 					Object: events.S3Object{
 						Key:  "test-file.txt",
-						Size: 10,
+						Size: int64(len("object content")),
 					},
 				},
 			},
@@ -512,8 +519,8 @@ func TestConsumerErrorHandling(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			s3Service := internal.NewMockS3Service(ctr)
-			s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(io.NopCloser(bytes.NewReader([]byte("object content"))), nil).
+			s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(internal.NewBytesS3ObjectReader([]byte("object content")), nil).
 				Times(1)
 
 			handler := newS3LogsHandler(s3Service, zap.NewNop(), &customLogUnmarshaler{}, &noOpLogsConsumer{err: test.consumerErr})

--- a/receiver/awslambdareceiver/internal/mock_s3_service.go
+++ b/receiver/awslambdareceiver/internal/mock_s3_service.go
@@ -11,7 +11,6 @@ package internal
 
 import (
 	context "context"
-	io "io"
 	reflect "reflect"
 
 	s3 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -102,6 +101,74 @@ func (mr *Mocks3APIMockRecorder) ListObjectsV2(ctx, params any, optFns ...any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsV2", reflect.TypeOf((*Mocks3API)(nil).ListObjectsV2), varargs...)
 }
 
+// MockS3ObjectReader is a mock of S3ObjectReader interface.
+type MockS3ObjectReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockS3ObjectReaderMockRecorder
+	isgomock struct{}
+}
+
+// MockS3ObjectReaderMockRecorder is the mock recorder for MockS3ObjectReader.
+type MockS3ObjectReaderMockRecorder struct {
+	mock *MockS3ObjectReader
+}
+
+// NewMockS3ObjectReader creates a new mock instance.
+func NewMockS3ObjectReader(ctrl *gomock.Controller) *MockS3ObjectReader {
+	mock := &MockS3ObjectReader{ctrl: ctrl}
+	mock.recorder = &MockS3ObjectReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockS3ObjectReader) EXPECT() *MockS3ObjectReaderMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockS3ObjectReader) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockS3ObjectReaderMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockS3ObjectReader)(nil).Close))
+}
+
+// Read mocks base method.
+func (m *MockS3ObjectReader) Read(p []byte) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Read", p)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockS3ObjectReaderMockRecorder) Read(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockS3ObjectReader)(nil).Read), p)
+}
+
+// ReadAt mocks base method.
+func (m *MockS3ObjectReader) ReadAt(p []byte, off int64) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadAt", p, off)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadAt indicates an expected call of ReadAt.
+func (mr *MockS3ObjectReaderMockRecorder) ReadAt(p, off any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAt", reflect.TypeOf((*MockS3ObjectReader)(nil).ReadAt), p, off)
+}
+
 // MockS3Service is a mock of S3Service interface.
 type MockS3Service struct {
 	ctrl     *gomock.Controller
@@ -141,18 +208,18 @@ func (mr *MockS3ServiceMockRecorder) DeleteObject(ctx, bucketName, objectKey any
 }
 
 // GetReader mocks base method.
-func (m *MockS3Service) GetReader(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
+func (m *MockS3Service) GetReader(ctx context.Context, bucketName, objectKey string, objectSize int64) (S3ObjectReader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReader", ctx, bucketName, objectKey)
-	ret0, _ := ret[0].(io.ReadCloser)
+	ret := m.ctrl.Call(m, "GetReader", ctx, bucketName, objectKey, objectSize)
+	ret0, _ := ret[0].(S3ObjectReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetReader indicates an expected call of GetReader.
-func (mr *MockS3ServiceMockRecorder) GetReader(ctx, bucketName, objectKey any) *gomock.Call {
+func (mr *MockS3ServiceMockRecorder) GetReader(ctx, bucketName, objectKey, objectSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReader", reflect.TypeOf((*MockS3Service)(nil).GetReader), ctx, bucketName, objectKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReader", reflect.TypeOf((*MockS3Service)(nil).GetReader), ctx, bucketName, objectKey, objectSize)
 }
 
 // ListObjects mocks base method.

--- a/receiver/awslambdareceiver/internal/s3.go
+++ b/receiver/awslambdareceiver/internal/s3.go
@@ -4,13 +4,24 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver/internal"
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+const (
+	// readBufferSize is the buffer size for sequential streaming reads.
+	readBufferSize = 128 * 1024 // 128 KB
+	// defaultChunkSize is the size of each cached chunk for S3 range reads.
+	defaultChunkSize = 4 * 1024 * 1024 // 4 MB
+	// defaultMaxCachedChunks is the maximum number of chunks held in the LRU cache.
+	defaultMaxCachedChunks = 8
 )
 
 // s3API abstracts out the S3 APIs allowing mocking for tests
@@ -20,9 +31,19 @@ type s3API interface {
 	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
+// S3ObjectReader provides access to an S3 object. It supports both sequential
+// streaming via io.Reader (single GET) and random access via io.ReaderAt
+// (chunk-cached range GETs). The concrete type also exposes a Size() int64
+// method, discoverable via type assertion.
+type S3ObjectReader interface {
+	io.Reader
+	io.ReaderAt
+	io.Closer
+}
+
 // S3Service define services exposed for consumers
 type S3Service interface {
-	GetReader(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error)
+	GetReader(ctx context.Context, bucketName, objectKey string, objectSize int64) (S3ObjectReader, error)
 	ReadObject(ctx context.Context, bucketName, objectKey string) ([]byte, error)
 	ListObjects(ctx context.Context, bucketName, continuationToken, prefix string) (*s3.ListObjectsV2Output, error)
 	DeleteObject(ctx context.Context, bucketName, objectKey string) error
@@ -70,14 +91,167 @@ func (s *s3ServiceClient) ReadObject(ctx context.Context, bucketName, objectKey 
 	return body, nil
 }
 
-func (s *s3ServiceClient) GetReader(ctx context.Context, bucketName, objectKey string) (io.ReadCloser, error) {
-	params := s3.GetObjectInput{Bucket: &bucketName, Key: &objectKey}
-	out, err := s.api.GetObject(ctx, &params)
-	if err != nil {
-		return nil, fmt.Errorf("unable to to obtain file object with key %s from bucket %s: %w", objectKey, bucketName, err)
+func (s *s3ServiceClient) GetReader(_ context.Context, bucketName, objectKey string, objectSize int64) (S3ObjectReader, error) {
+	return &s3ObjectReader{
+		api:       s.api,
+		bucket:    bucketName,
+		key:       objectKey,
+		size:      objectSize,
+		chunkSize: defaultChunkSize,
+		maxChunks: defaultMaxCachedChunks,
+		cache:     make(map[int64][]byte),
+	}, nil
+}
+
+// s3ObjectReader implements S3ObjectReader. Sequential reads via Read() use a
+// single streaming GET (lazy-initialized on first call). Random access via
+// ReadAt() uses chunk-cached range GETs.
+type s3ObjectReader struct {
+	api    s3API
+	bucket string
+	key    string
+	size   int64
+
+	// Streaming read state (lazy, initialized on first Read call).
+	bodyCloser io.Closer     // original S3 response body, for Close()
+	bodyReader *bufio.Reader // buffered wrapper, for Read()
+
+	// Chunk cache for ReadAt.
+	chunkSize int64
+	maxChunks int
+
+	mu         sync.Mutex
+	cache      map[int64][]byte // chunkIndex -> data
+	cacheOrder []int64          // LRU order, most recent at end
+}
+
+// Read implements io.Reader using a single streaming GET request, lazily
+// initialized on the first call. This is the most efficient path for
+// sequential consumption (e.g. gzipped or line-delimited content).
+func (r *s3ObjectReader) Read(p []byte) (int, error) {
+	if r.bodyReader == nil {
+		out, err := r.api.GetObject(context.Background(), &s3.GetObjectInput{
+			Bucket: &r.bucket,
+			Key:    &r.key,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("S3 streaming GET for %s/%s failed: %w", r.bucket, r.key, err)
+		}
+		r.bodyCloser = out.Body
+		r.bodyReader = bufio.NewReaderSize(out.Body, readBufferSize)
+	}
+	return r.bodyReader.Read(p)
+}
+
+// Size returns the object size in bytes.
+func (r *s3ObjectReader) Size() int64 { return r.size }
+
+// ReadAt implements io.ReaderAt. It reads from the S3 object at the given
+// offset using chunk-aligned range GETs with an LRU cache to minimize API calls.
+func (r *s3ObjectReader) ReadAt(p []byte, off int64) (int, error) {
+	if off >= r.size {
+		return 0, io.EOF
 	}
 
-	return out.Body, nil
+	totalRead := 0
+	for totalRead < len(p) && off < r.size {
+		chunkIdx := off / r.chunkSize
+		chunkData, err := r.getChunk(chunkIdx)
+		if err != nil {
+			if totalRead > 0 {
+				return totalRead, err
+			}
+			return 0, err
+		}
+
+		offsetInChunk := off - chunkIdx*r.chunkSize
+		n := copy(p[totalRead:], chunkData[offsetInChunk:])
+		totalRead += n
+		off += int64(n)
+	}
+
+	if totalRead < len(p) {
+		return totalRead, io.EOF
+	}
+	return totalRead, nil
+}
+
+// Close releases the streaming body (if opened) and cached data.
+func (r *s3ObjectReader) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache = nil
+	r.cacheOrder = nil
+	if r.bodyCloser != nil {
+		return r.bodyCloser.Close()
+	}
+	return nil
+}
+
+// getChunk returns the data for the given chunk index, fetching it via a range
+// GET if not already cached.
+func (r *s3ObjectReader) getChunk(idx int64) ([]byte, error) {
+	r.mu.Lock()
+	if data, ok := r.cache[idx]; ok {
+		r.touchLRU(idx)
+		r.mu.Unlock()
+		return data, nil
+	}
+	r.mu.Unlock()
+
+	// Fetch the chunk outside the lock to allow concurrent reads to other chunks.
+	start := idx * r.chunkSize
+	end := start + r.chunkSize - 1
+	if end >= r.size {
+		end = r.size - 1
+	}
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+
+	out, err := r.api.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: &r.bucket,
+		Key:    &r.key,
+		Range:  &rangeHeader,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("S3 range GET for chunk %d of %s/%s failed: %w", idx, r.bucket, r.key, err)
+	}
+	defer out.Body.Close()
+
+	data, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading S3 range response for chunk %d: %w", idx, err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Another goroutine may have fetched the same chunk concurrently.
+	if existing, ok := r.cache[idx]; ok {
+		r.touchLRU(idx)
+		return existing, nil
+	}
+
+	// Evict if at capacity.
+	for len(r.cache) >= r.maxChunks && len(r.cacheOrder) > 0 {
+		evict := r.cacheOrder[0]
+		r.cacheOrder = r.cacheOrder[1:]
+		delete(r.cache, evict)
+	}
+
+	r.cache[idx] = data
+	r.cacheOrder = append(r.cacheOrder, idx)
+	return data, nil
+}
+
+// touchLRU moves idx to the end of the LRU order. Must be called with mu held.
+func (r *s3ObjectReader) touchLRU(idx int64) {
+	for i, v := range r.cacheOrder {
+		if v == idx {
+			r.cacheOrder = append(r.cacheOrder[:i], r.cacheOrder[i+1:]...)
+			break
+		}
+	}
+	r.cacheOrder = append(r.cacheOrder, idx)
 }
 
 func (s *s3ServiceClient) ListObjects(ctx context.Context, bucketName, continuationToken, prefix string) (*s3.ListObjectsV2Output, error) {

--- a/receiver/awslambdareceiver/internal/s3_test.go
+++ b/receiver/awslambdareceiver/internal/s3_test.go
@@ -6,11 +6,13 @@ package internal
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.uber.org/mock/gomock"
@@ -118,6 +120,199 @@ func TestS3ServiceDeleteObject(t *testing.T) {
 		err := client.DeleteObject(t.Context(), bucketName, objectKey)
 		require.NoError(t, err)
 	})
+}
+
+// mockGetObjectForData returns a DoAndReturn function that serves range GETs from data.
+func mockGetObjectForData(t *testing.T, data []byte) func(any, *s3.GetObjectInput, ...any) (*s3.GetObjectOutput, error) {
+	t.Helper()
+	return func(_ any, input *s3.GetObjectInput, _ ...any) (*s3.GetObjectOutput, error) {
+		var start, end int64
+		_, err := fmt.Sscanf(*input.Range, "bytes=%d-%d", &start, &end)
+		require.NoError(t, err)
+		body := io.NopCloser(io.NewSectionReader(NewBytesS3ObjectReader(data), start, end-start+1))
+		return &s3.GetObjectOutput{Body: body}, nil
+	}
+}
+
+func newTestReader(api s3API, data []byte, chunkSize int64, maxChunks int) *s3ObjectReader {
+	return &s3ObjectReader{
+		api:       api,
+		bucket:    "test-bucket",
+		key:       "test-key",
+		size:      int64(len(data)),
+		chunkSize: chunkSize,
+		maxChunks: maxChunks,
+		cache:     make(map[int64][]byte),
+	}
+}
+
+func TestS3ObjectReader_ReadAt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	api := NewMocks3API(ctrl)
+	data := []byte("Hello, World! This is test data for ReadAt.")
+
+	reader := newTestReader(api, data, 10, 8)
+	defer reader.Close()
+
+	api.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(mockGetObjectForData(t, data)).AnyTimes()
+
+	// Read from the middle of the data.
+	buf := make([]byte, 5)
+	n, err := reader.ReadAt(buf, 7)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "World", string(buf))
+
+	// Read spanning two chunks.
+	buf = make([]byte, 8)
+	n, err = reader.ReadAt(buf, 8)
+	require.NoError(t, err)
+	assert.Equal(t, 8, n)
+	assert.Equal(t, "orld! Th", string(buf))
+}
+
+func TestS3ObjectReader_ReadAt_EOF(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	api := NewMocks3API(ctrl)
+	data := []byte("short")
+
+	reader := newTestReader(api, data, 10, 4)
+	defer reader.Close()
+
+	api.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(mockGetObjectForData(t, data)).AnyTimes()
+
+	// Read past end returns io.EOF.
+	buf := make([]byte, 10)
+	n, err := reader.ReadAt(buf, 0)
+	assert.Equal(t, 5, n)
+	assert.ErrorIs(t, err, io.EOF)
+
+	// Read at exactly size returns io.EOF with 0 bytes.
+	n, err = reader.ReadAt(buf, 5)
+	assert.Equal(t, 0, n)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestS3ObjectReader_ChunkCaching(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	api := NewMocks3API(ctrl)
+	data := []byte("0123456789ABCDEF")
+
+	reader := newTestReader(api, data, 8, 4)
+	defer reader.Close()
+
+	// Expect exactly 1 call for chunk 0 — the second read should hit the cache.
+	api.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(mockGetObjectForData(t, data)).Times(1)
+
+	buf := make([]byte, 4)
+	_, err := reader.ReadAt(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "0123", string(buf))
+
+	// Second read within the same chunk — no new API call.
+	_, err = reader.ReadAt(buf, 4)
+	require.NoError(t, err)
+	assert.Equal(t, "4567", string(buf))
+}
+
+func TestS3ObjectReader_LRUEviction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	api := NewMocks3API(ctrl)
+	data := []byte("0123456789ABCDEFGHIJKLMNOPQRst")
+
+	reader := newTestReader(api, data, 10, 2)
+	defer reader.Close()
+
+	callCount := 0
+	api.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx any, input *s3.GetObjectInput, opts ...any) (*s3.GetObjectOutput, error) {
+			callCount++
+			return mockGetObjectForData(t, data)(ctx, input, opts)
+		}).AnyTimes()
+
+	buf := make([]byte, 1)
+
+	// Load chunk 0.
+	_, err := reader.ReadAt(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	// Load chunk 1 — cache now has [0, 1].
+	_, err = reader.ReadAt(buf, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+
+	// Load chunk 2 — evicts chunk 0 (LRU), cache now has [1, 2].
+	_, err = reader.ReadAt(buf, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 3, callCount)
+
+	// Re-read chunk 1 — still cached.
+	_, err = reader.ReadAt(buf, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 3, callCount)
+
+	// Re-read chunk 0 — was evicted, must fetch again.
+	_, err = reader.ReadAt(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 4, callCount)
+}
+
+func TestS3ObjectReader_Close(t *testing.T) {
+	reader := &s3ObjectReader{
+		size:      100,
+		chunkSize: 10,
+		maxChunks: 4,
+		cache:     map[int64][]byte{0: []byte("data")},
+	}
+
+	err := reader.Close()
+	require.NoError(t, err)
+	assert.Nil(t, reader.cache)
+	assert.Nil(t, reader.cacheOrder)
+}
+
+func TestS3ObjectReader_Read(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	api := NewMocks3API(ctrl)
+	data := []byte("streaming content here")
+
+	reader := newTestReader(api, data, 10, 4)
+	defer reader.Close()
+
+	// Expect a single full-object GET (no Range header).
+	api.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, input *s3.GetObjectInput, _ ...any) (*s3.GetObjectOutput, error) {
+			assert.Nil(t, input.Range, "streaming Read should not use Range header")
+			return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}, nil
+		}).Times(1)
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestS3ObjectReader_Size(t *testing.T) {
+	reader := &s3ObjectReader{size: 12345}
+	assert.Equal(t, int64(12345), reader.Size())
+}
+
+func TestS3ServiceGetReader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	api := NewMocks3API(ctrl)
+	client := s3ServiceClient{api: api}
+
+	reader, err := client.GetReader(t.Context(), "bucket", "key", 42)
+	require.NoError(t, err)
+
+	objReader, ok := reader.(*s3ObjectReader)
+	require.True(t, ok)
+	assert.Equal(t, int64(42), objReader.size)
+	assert.Equal(t, "bucket", objReader.bucket)
+	assert.Equal(t, "key", objReader.key)
 }
 
 type mockReaderCloser struct {

--- a/receiver/awslambdareceiver/internal/s3_test_helper.go
+++ b/receiver/awslambdareceiver/internal/s3_test_helper.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver/internal"
+
+import "bytes"
+
+// bytesS3ObjectReader wraps a bytes.Reader to implement S3ObjectReader.
+type bytesS3ObjectReader struct {
+	*bytes.Reader
+}
+
+func (bytesS3ObjectReader) Close() error { return nil }
+
+// NewBytesS3ObjectReader returns an S3ObjectReader backed by in-memory data.
+// Intended for use in tests.
+func NewBytesS3ObjectReader(data []byte) S3ObjectReader {
+	return &bytesS3ObjectReader{Reader: bytes.NewReader(data)}
+}

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -3,7 +3,6 @@
 package awslambdareceiver
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -58,9 +57,9 @@ func TestCreateLogs(t *testing.T) {
 
 	// Test data - mock S3 file content
 	testData := []byte("version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status\n2 627286350134 eni-0377aa710071c557e 172.31.31.124 140.82.121.6 52718 443 6 13 3777 1751375679 ENDTIME ACCEPT OK\n")
-	s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any()).
+	s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
-		Return(io.NopCloser(bytes.NewReader(testData)), nil)
+		Return(internal.NewBytesS3ObjectReader(testData), nil)
 
 	// Register the extension with the same component ID as S3Encoding
 	// This is required: the extension ID must match cfg.S3Encoding
@@ -132,9 +131,9 @@ func TestCreateMetrics(t *testing.T) {
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
 	s3Provider.EXPECT().GetService(gomock.Any()).AnyTimes().Return(s3Service, nil)
-	s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any()).
+	s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
-		Return(io.NopCloser(bytes.NewReader([]byte("dummy data"))), nil)
+		Return(internal.NewBytesS3ObjectReader([]byte("dummy data")), nil)
 
 	host := mockHost{GetFunc: func() map[component.ID]component.Component {
 		return map[component.ID]component.Component{

--- a/receiver/awslambdareceiver/testdata/s3_log_expected_gzip.yaml
+++ b/receiver/awslambdareceiver/testdata/s3_log_expected_gzip.yaml
@@ -15,7 +15,7 @@ resourceLogs:
             stringValue: arn:aws:s3:::test-bucket
         - key: aws.s3.key
           value:
-            stringValue: test-file.txt
+            stringValue: test-file.txt.gz
     scopeLogs:
       - logRecords:
           - body:


### PR DESCRIPTION
#### Description

Add `io.ReaderAt` support to `S3Service.GetReader`. `ReadAt` uses chunk-cached range GETs (4MB chunks, 8-chunk LRU) to minimise S3 API calls. Read uses a single streaming GET for sequential access. Gzip detection is now filename-based (.gz suffix) rather than magic-byte peeking, which avoids consuming bytes from the stream.

This enables efficient streaming through Parquet files, which requires random access to read metadata footer and row groups.

Assisted-by: Claude Opus 4.6

#### Link to tracking issue

Relates to #38861 (Parquet stream decoding)

#### Testing

TODO

#### Documentation

Updated README