### PR TITLE
[exporter/kafka] add support for partitioning kafka records

### DIFF
--- a/.chloggen/kafka-partition-extension.yaml
+++ b/.chloggen/kafka-partition-extension.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: exporter/kafkaexporter
+component: exporter/kafka
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add support for partitioning kafka records 

--- a/.chloggen/kafka-partition-extension.yaml
+++ b/.chloggen/kafka-partition-extension.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: Add support for partitioning records 
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: | 
+  Add support for RoundRobin and LeastBackup partitioning strategies, as well as custom partitioners
+  provided by RecordPartitionerExtension implementations. Users can implement their own partitioning logic 
+  and plug it into the kafka exporter via the RecordPartitionerExtension interface.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46931]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/kafka-partition-extension.yaml
+++ b/.chloggen/kafka-partition-extension.yaml
@@ -4,13 +4,10 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: Add support for partitioning records 
+component: exporter/kafkaexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: | 
-  Add support for RoundRobin and LeastBackup partitioning strategies, as well as custom partitioners
-  provided by RecordPartitionerExtension implementations. Users can implement their own partitioning logic 
-  and plug it into the kafka exporter via the RecordPartitionerExtension interface.
+note: Add support for partitioning kafka records 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46931]
@@ -18,7 +15,11 @@ issues: [46931]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  Add support for RoundRobin and LeastBackup partitioning strategies, as well as custom partitioners
+  provided by RecordPartitionerExtension implementations. Users can implement their own partitioning logic 
+  and plug it into the kafka exporter via the RecordPartitionerExtension interface.
+
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -52,13 +52,14 @@ The following settings can be optionally configured:
 - `partition_metrics_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in metric messages sent to kafka.
 - `partition_logs_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in log messages sent to kafka.
 - `partition_logs_by_trace_id` (default = false): configures the exporter to partition log messages by trace ID, if the log record has one associated. Note: `partition_logs_by_resource_attributes` and `partition_logs_by_trace_id` are mutually exclusive, and enabling both will lead to an error.
-- `record_partitioner`: configures the Kafka-level record partitioner. When unset, the default sarama-compatible sticky key partitioner is used.
-  - `type`: The partitioner strategy. Valid values are:
-    - `sarama_compatible` (default): Sticky key partitioner using Sarama-compatible FNV-1a hashing.
-    - `round_robin`: Distributes records evenly across all partitions.
-    - `least_backup`: Sends records to the partition with the fewest in-flight messages.
-    - `custom`: Delegates partitioning to a custom extension.
-  - `extension`: The ID of a cusom partitioner extension to be used.
+- `record_partitioner`: Configures the Kafka record partitioning strategy. **At most one** option may be set. If multiple partitioners are configured, an error will be returned. If none is configured, the default is `sticky_key` with a Sarama-compatible hasher (preserving previous behavior).
+  - `sticky_key`: Uses a sticky-key partitioner.
+    - `hasher`: The hash algorithm used for key-based partition assignment.
+      - `sarama_compat` (default): Uses Sarama-compatible FNV-1a hashing.
+      - `murmur2`: Uses Murmur2 hashing
+  - `round_robin`: Distributes records evenly across all available partitions in round-robin order.
+  - `least_backup`: Routes each record to the partition with the fewest buffered (in-flight) records.
+  - `extension`: The component ID of a custom partitioner extension. When set, partitioning is delegated to the specified extension.
 - `tls`: see [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) for the full set of available options. Set to `tls: insecure: false` explicitly when using `AWS_MSK_IAM_OAUTHBEARER` as the authentication method.
 - `auth`
   - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)
@@ -173,7 +174,7 @@ The destination topic can be defined in a few different ways and takes priority 
 Kafka topics are partitioned, meaning a topic is spread over a number of “buckets” located on different Kafka brokers.
 The exporter supports multiple strategies to control how records are distributed across kafka partitions within a topic. 
 
-Available strategies for partitioning are `sarama_compatible`, `round_robin`, `least_backup` and `custom`
+Available strategies for partitioning are `sticky_key`, `sticky`,  `round_robin`, `least_backup` and `extension`
 
 ### Using custom partitioner
 
@@ -185,7 +186,6 @@ exporters:
     brokers:
       - localhost:9092
     record_partitioner:
-      type: custom
       extension: my_custom_partitioner
   
 extensions:

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -167,3 +167,37 @@ The destination topic can be defined in a few different ways and takes priority 
 2. Otherwise, if `topic_from_attribute` is configured, and the corresponding attribute is found on the ingested data, the value of this attribute is used.
 3. If a prior component in the collector pipeline sets the topic on the context via the `topic.WithTopic` function (from the `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic` package), the value set in the context is used.
 4. Finally, the `<signal>::topic` configuration is used for the signal-specific destination topic.
+
+## Partitioning Kafka Records
+
+Kafka topics are partitioned, meaning a topic is spread over a number of “buckets” located on different Kafka brokers.
+The exporter supports multiple strategies to control how records are distributed across kafka partitions within a topic. 
+
+Available strategies for partitioning are `sarama_compatible`, `round_robin`, `least_backup` and `custom`
+
+### Using custom partitioner
+
+The Kafka exporter allows you to define a custom partitioning strategy via an extension. A sample config for custom partitioner would look like:
+
+```yaml
+exporters:
+  kafka:
+    brokers:
+      - localhost:9092
+    record_partitioner:
+      type: custom
+      extension: my_custom_partitioner
+  
+extensions:
+  my_custom_partitioner:
+    # your extension-specific configuration here
+
+# rest of the pipeline config
+```
+
+Use custom partitioner if:
+- Built-in strategies (round_robin, least_backup, etc.) don’t fit your needs
+- You require domain-specific routing logic
+
+> [!NOTE]
+> The custom partitioner extension must implement the RecordPartitionerExtension interface (see [partitioner.go](./partitioner.go)).

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -171,10 +171,9 @@ The destination topic can be defined in a few different ways and takes priority 
 
 ## Partitioning Kafka Records
 
-Kafka topics are partitioned, meaning a topic is spread over a number of “buckets” located on different Kafka brokers.
 The exporter supports multiple strategies to control how records are distributed across kafka partitions within a topic. 
 
-Available strategies for partitioning are `sticky_key`, `sticky`,  `round_robin`, `least_backup` and `extension`
+Available strategies for partitioning are `sticky_key`, `sticky`, `round_robin`, `least_backup` and `extension`
 
 ### Using custom partitioner
 

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -54,11 +54,11 @@ The following settings can be optionally configured:
 - `partition_logs_by_trace_id` (default = false): configures the exporter to partition log messages by trace ID, if the log record has one associated. Note: `partition_logs_by_resource_attributes` and `partition_logs_by_trace_id` are mutually exclusive, and enabling both will lead to an error.
 - `record_partitioner`: configures the Kafka-level record partitioner. When unset, the default sarama-compatible sticky key partitioner is used.
   - `type`: The partitioner strategy. Valid values are:
-    - `""` or `sarama_compatible`: Sticky key partitioner using Sarama-compatible FNV-1a hashing.
+    - `sarama_compatible` (default): Sticky key partitioner using Sarama-compatible FNV-1a hashing.
     - `round_robin`: Distributes records evenly across all partitions.
     - `least_backup`: Sends records to the partition with the fewest in-flight messages.
     - `custom`: Delegates partitioning to a custom extension.
-  - `custom`: The ID of a cusom partitioner extension to be used.
+  - `extension`: The ID of a cusom partitioner extension to be used.
 - `tls`: see [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) for the full set of available options. Set to `tls: insecure: false` explicitly when using `AWS_MSK_IAM_OAUTHBEARER` as the authentication method.
 - `auth`
   - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -52,6 +52,13 @@ The following settings can be optionally configured:
 - `partition_metrics_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in metric messages sent to kafka.
 - `partition_logs_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in log messages sent to kafka.
 - `partition_logs_by_trace_id` (default = false): configures the exporter to partition log messages by trace ID, if the log record has one associated. Note: `partition_logs_by_resource_attributes` and `partition_logs_by_trace_id` are mutually exclusive, and enabling both will lead to an error.
+- `record_partitioner`: configures the Kafka-level record partitioner. When unset, the default sarama-compatible sticky key partitioner is used.
+  - `type`: The partitioner strategy. Valid values are:
+    - `""` or `sarama_compatible`: Sticky key partitioner using Sarama-compatible FNV-1a hashing.
+    - `round_robin`: Distributes records evenly across all partitions.
+    - `least_backup`: Sends records to the partition with the fewest in-flight messages.
+    - `custom`: Delegates partitioning to a custom extension.
+  - `custom`: The ID of a cusom partitioner extension to be used.
 - `tls`: see [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) for the full set of available options. Set to `tls: insecure: false` explicitly when using `AWS_MSK_IAM_OAUTHBEARER` as the authentication method.
 - `auth`
   - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -56,6 +56,9 @@ type RecordPartitionerConfig struct {
 	// Extension is the component ID of an extension implementing RecordPartitionerExtension.
 	// Setting this field delegates partition assignment to that extension.
 	Extension *component.ID `mapstructure:"extension"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // StickyKeyPartitionerConfig configures the StickyKeyPartitioner.
@@ -65,6 +68,9 @@ type StickyKeyPartitionerConfig struct {
 	//   - "sarama_compat": Sarama-compatible FNV-1a hashing (SaramaCompatHasher).
 	//   - "murmur2": Murmur2 hashing.
 	Hasher string `mapstructure:"hasher"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *StickyKeyPartitionerConfig) Validate() error {

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -50,7 +50,6 @@ type RecordPartitionerConfig struct {
 }
 
 func (c *RecordPartitionerConfig) Validate() error {
-	fmt.Println(c.Type)
 	switch c.Type {
 	case RecordPartitionerTypeSaramaCompatible,
 		RecordPartitionerTypeRoundRobin,

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -19,6 +19,11 @@ import (
 
 var _ component.Config = (*Config)(nil)
 
+var (
+	errRecordPartitionerUnknownType = errors.New("unknown partitioner type")
+	errRecordPartitionerExtRequired = errors.New("partitioner.extension must be set when type is \"extension\"")
+)
+
 var errLogsPartitionExclusive = errors.New(
 	"partition_logs_by_resource_attributes and partition_logs_by_trace_id cannot both be enabled",
 )
@@ -28,6 +33,36 @@ var (
 	errBatchPartitionMetadataKeysRequired = errors.New("sending_queue::batch::partition::metadata_keys must be configured when include_metadata_keys is set and batching is enabled")
 	errIncludeMetadataKeysNotPartitioned  = errors.New("sending_queue::batch::partition::metadata_keys must include all include_metadata_keys values")
 )
+
+// RecordPartitionerConfig configures the strategy used to assign Kafka records to partitions.
+type RecordPartitionerConfig struct {
+	// Type is the partitioning strategy. Valid values are:
+	//   - "" or "sarama_compatible" (default): sticky key partitioner with Sarama-compatible FNV-1a hashing
+	//   - "sticky": franz-go StickyKeyPartitioner with murmur2 hashing
+	//   - "round_robin": round-robin across all available partitions
+	//   - "least_backup": routes to the partition with fewest in-flight records
+	//   - "extension": delegates to an extension implementing RecordPartitionerExtension
+	Type string `mapstructure:"type"`
+
+	// Extension is the component ID of an extension implementing RecordPartitionerExtension.
+	// Required when Type is "extension"; must be empty for all other types.
+	Extension *component.ID `mapstructure:"extension,omitempty"`
+}
+
+func (c *RecordPartitionerConfig) Validate() error {
+	switch c.Type {
+	case "", RecordPartitionerTypeSaramaCompatible,
+		RecordPartitionerTypeRoundRobin,
+		RecordPartitionerTypeLeastBackup:
+	case RecordPartitionerTypeExtension:
+		if c.Extension == nil {
+			return errRecordPartitionerExtRequired
+		}
+	default:
+		return fmt.Errorf("%w: %q", errRecordPartitionerUnknownType, c.Type)
+	}
+	return nil
+}
 
 // Config defines configuration for Kafka exporter.
 type Config struct {
@@ -78,11 +113,20 @@ type Config struct {
 	// selection falls back to the Kafka client’s default strategy. Resource
 	// attributes are not used for the key when this option is enabled.
 	PartitionLogsByTraceID bool `mapstructure:"partition_logs_by_trace_id"`
+
+	// RecordPartitioner configures how Kafka records are assigned to partitions.
+	// The default ("sarama_compatible") retains the legacy Sarama-compatible hashing
+	// behaviour. Set to "sticky", "round_robin", or "least_backup" to use one of the
+	// built-in franz-go partitioners, or "extension" to delegate to a custom extension.
+	RecordPartitioner RecordPartitionerConfig `mapstructure:"record_partitioner"`
 }
 
 func (c *Config) Validate() error {
 	if c.PartitionLogsByResourceAttributes && c.PartitionLogsByTraceID {
 		return errLogsPartitionExclusive
+	}
+	if err := c.RecordPartitioner.Validate(); err != nil {
+		return fmt.Errorf("record_partitioner: %w", err)
 	}
 	if err := validateBatchPartitionerKeys(c); err != nil {
 		return err

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
@@ -20,8 +22,7 @@ import (
 var _ component.Config = (*Config)(nil)
 
 var (
-	errRecordPartitionerUnknownType = errors.New("unknown partitioner type")
-	errRecordPartitionerExtRequired = errors.New("partitioner.extension must be set when type is \"extension\"")
+	errRecordPartitionerMultipleSet = errors.New("at most one record_partitioner strategy may be configured")
 )
 
 var errLogsPartitionExclusive = errors.New(
@@ -34,33 +35,87 @@ var (
 	errIncludeMetadataKeysNotPartitioned  = errors.New("sending_queue::batch::partition::metadata_keys must include all include_metadata_keys values")
 )
 
+const (
+	HasherSaramaCompat = "sarama_compat"
+	HasherMurmur2      = "murmur2"
+)
+
 // RecordPartitionerConfig configures the strategy used to assign Kafka records to partitions.
+// At most one field should be set.
 type RecordPartitionerConfig struct {
-	// Type is the partitioning strategy. Valid values are:
-	//   - "" or "sarama_compatible" (default): sticky key partitioner with Sarama-compatible FNV-1a hashing
-	//   - "sticky": franz-go StickyKeyPartitioner with murmur2 hashing
-	//   - "round_robin": round-robin across all available partitions
-	//   - "least_backup": routes to the partition with fewest in-flight records
-	//   - "extension": delegates to an extension implementing RecordPartitionerExtension
-	Type string `mapstructure:"type"`
+	// StickyKey uses StickyKeyPartitioner.
+	// When a record key is set, the partition is derived from the key hash.
+	StickyKey *StickyKeyPartitionerConfig `mapstructure:"sticky_key"`
+
+	// RoundRobin distributes records evenly across all available partitions in round-robin order.
+	RoundRobin *struct{} `mapstructure:"round_robin"`
+
+	// LeastBackup routes each record to the partition with the fewest buffered records.
+	LeastBackup *struct{} `mapstructure:"least_backup"`
 
 	// Extension is the component ID of an extension implementing RecordPartitionerExtension.
-	// Required when Type is "extension"; must be empty for all other types.
-	Extension *component.ID `mapstructure:"extension,omitempty"`
+	// Setting this field delegates partition assignment to that extension.
+	Extension *component.ID `mapstructure:"extension"`
+}
+
+// StickyKeyPartitionerConfig configures the StickyKeyPartitioner.
+type StickyKeyPartitionerConfig struct {
+	// Hasher is the hash algorithm used for key-based partition assignment.
+	// Valid values: "sarama_compat" (default).
+	//   - "sarama_compat": Sarama-compatible FNV-1a hashing (SaramaCompatHasher).
+	//   - "murmur2": Murmur2 hashing.
+	Hasher string `mapstructure:"hasher"`
+}
+
+func (c *StickyKeyPartitionerConfig) Validate() error {
+	switch c.Hasher {
+	case "", HasherSaramaCompat, HasherMurmur2:
+		return nil
+	default:
+		return fmt.Errorf("sticky_key: unknown hasher %q, valid values are %q, %q",
+			c.Hasher, HasherSaramaCompat, HasherMurmur2)
+	}
 }
 
 func (c *RecordPartitionerConfig) Validate() error {
-	switch c.Type {
-	case RecordPartitionerTypeSaramaCompatible,
-		RecordPartitionerTypeRoundRobin,
-		RecordPartitionerTypeLeastBackup:
-	case RecordPartitionerTypeCustom:
-		if c.Extension == nil {
-			return errRecordPartitionerExtRequired
+	// verify that at most one partitioner type is set by counting the number of non-nil pointer fields in this struct.
+	v := reflect.ValueOf(c).Elem()
+	set := 0
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		// Count non-nil pointer fields
+		if field.Kind() == reflect.Ptr && !field.IsNil() {
+			set++
 		}
-	default:
-		return fmt.Errorf("%w: %q", errRecordPartitionerUnknownType, c.Type)
 	}
+
+	if set > 1 {
+		return errRecordPartitionerMultipleSet
+	}
+
+	if c.StickyKey != nil {
+		return c.StickyKey.Validate()
+	}
+
+	return nil
+}
+
+func (c *RecordPartitionerConfig) Unmarshal(conf *confmap.Conf) error {
+	// Use reflection to clear all fields
+	v := reflect.ValueOf(c).Elem()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		// Clear the field by setting it to its zero value
+		if field.CanSet() {
+			field.Set(reflect.Zero(field.Type()))
+		}
+	}
+
+	if err := conf.Unmarshal(c); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -23,6 +23,7 @@ var _ component.Config = (*Config)(nil)
 
 var (
 	errRecordPartitionerMultipleSet = errors.New("at most one record_partitioner strategy may be configured")
+	errRecordPartitionerMissing     = errors.New("no partitioner type configured")
 )
 
 var errLogsPartitionExclusive = errors.New(
@@ -98,7 +99,9 @@ func (c *RecordPartitionerConfig) Validate() error {
 	if set > 1 {
 		return errRecordPartitionerMultipleSet
 	}
-
+	if set == 0 {
+		return errRecordPartitionerMissing
+	}
 	if c.StickyKey != nil {
 		return c.StickyKey.Validate()
 	}
@@ -108,7 +111,8 @@ func (c *RecordPartitionerConfig) Validate() error {
 
 func (c *RecordPartitionerConfig) Unmarshal(conf *confmap.Conf) error {
 	// Use reflection to clear all fields
-	// This is done to ensure that default partioner is not retained when Unmarshaling. Doing so will ensure that only one partitioner is set at a time and the validation will work as expected.
+	// This is done to ensure that default partioner is not retained when Unmarshaling.
+	// Doing so will ensure that only one partitioner is set at a time and the validation will work as expected.
 	v := reflect.ValueOf(c).Elem()
 
 	for i := 0; i < v.NumField(); i++ {

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -50,11 +50,12 @@ type RecordPartitionerConfig struct {
 }
 
 func (c *RecordPartitionerConfig) Validate() error {
+	fmt.Println(c.Type)
 	switch c.Type {
-	case "", RecordPartitionerTypeSaramaCompatible,
+	case RecordPartitionerTypeSaramaCompatible,
 		RecordPartitionerTypeRoundRobin,
 		RecordPartitionerTypeLeastBackup:
-	case RecordPartitionerTypeExtension:
+	case RecordPartitionerTypeCustom:
 		if c.Extension == nil {
 			return errRecordPartitionerExtRequired
 		}

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 
 	"go.opentelemetry.io/collector/component"
@@ -85,17 +84,19 @@ func (c *StickyKeyPartitionerConfig) Validate() error {
 }
 
 func (c *RecordPartitionerConfig) Validate() error {
-	// verify that at most one partitioner type is set by counting the number of non-nil pointer fields in this struct.
-	v := reflect.ValueOf(c).Elem()
 	set := 0
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		// Count non-nil pointer fields
-		if field.Kind() == reflect.Ptr && !field.IsNil() {
-			set++
-		}
+	if c.StickyKey != nil {
+		set++
 	}
-
+	if c.RoundRobin != nil {
+		set++
+	}
+	if c.LeastBackup != nil {
+		set++
+	}
+	if c.Extension != nil {
+		set++
+	}
 	if set > 1 {
 		return errRecordPartitionerMultipleSet
 	}
@@ -110,24 +111,12 @@ func (c *RecordPartitionerConfig) Validate() error {
 }
 
 func (c *RecordPartitionerConfig) Unmarshal(conf *confmap.Conf) error {
-	// Use reflection to clear all fields
-	// This is done to ensure that default partioner is not retained when Unmarshaling.
-	// Doing so will ensure that only one partitioner is set at a time and the validation will work as expected.
-	v := reflect.ValueOf(c).Elem()
-
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		// Clear the field by setting it to its zero value
-		if field.CanSet() {
-			field.Set(reflect.Zero(field.Type()))
-		}
+	if len(conf.ToStringMap()) == 0 {
+		// no partitioner configured, will use default.
+		return nil
 	}
-
-	if err := conf.Unmarshal(c); err != nil {
-		return err
-	}
-
-	return nil
+	*c = RecordPartitionerConfig{}
+	return conf.Unmarshal(c)
 }
 
 // Config defines configuration for Kafka exporter.

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -116,7 +116,7 @@ type Config struct {
 
 	// RecordPartitioner configures how Kafka records are assigned to partitions.
 	// The default ("sarama_compatible") retains the legacy Sarama-compatible hashing
-	// behaviour. Set to "sticky", "round_robin", or "least_backup" to use one of the
+	// behavior. Set to "sticky", "round_robin", or "least_backup" to use one of the
 	// built-in franz-go partitioners, or "extension" to delegate to a custom extension.
 	RecordPartitioner RecordPartitionerConfig `mapstructure:"record_partitioner"`
 }

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -69,7 +69,7 @@ type StickyKeyPartitionerConfig struct {
 
 func (c *StickyKeyPartitionerConfig) Validate() error {
 	switch c.Hasher {
-	case "", HasherSaramaCompat, HasherMurmur2:
+	case HasherSaramaCompat, HasherMurmur2:
 		return nil
 	default:
 		return fmt.Errorf("sticky_key: unknown hasher %q, valid values are %q, %q",

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -102,6 +102,7 @@ func (c *RecordPartitionerConfig) Validate() error {
 
 func (c *RecordPartitionerConfig) Unmarshal(conf *confmap.Conf) error {
 	// Use reflection to clear all fields
+	// This is done to ensure that default partioner is not retained when Unmarshaling. Doing so will ensure that only one partitioner is set at a time and the validation will work as expected.
 	v := reflect.ValueOf(c).Elem()
 
 	for i := 0; i < v.NumField(); i++ {

--- a/exporter/kafkaexporter/config.schema.yaml
+++ b/exporter/kafkaexporter/config.schema.yaml
@@ -1,16 +1,25 @@
 $defs:
   record_partitioner_config:
-    description: RecordPartitionerConfig configures the strategy used to assign Kafka records to partitions.
+    description: RecordPartitionerConfig configures the strategy used to assign Kafka records to partitions. At most one field should be set.
     type: object
     properties:
       extension:
-        description: Extension is the component ID of an extension implementing RecordPartitionerExtension. Required when Type is "extension"; must be empty for all other types.
+        description: Extension is the component ID of an extension implementing RecordPartitionerExtension. Setting this field delegates partition assignment to that extension.
         x-pointer: true
         type: string
         x-customType: go.opentelemetry.io/collector/component.ID
-      type:
-        description: 'Type is the partitioning strategy. Valid values are: - "" or "sarama_compatible" (default): sticky key partitioner with Sarama-compatible FNV-1a hashing - "sticky": franz-go StickyKeyPartitioner with murmur2 hashing - "round_robin": round-robin across all available partitions - "least_backup": routes to the partition with fewest in-flight records - "extension": delegates to an extension implementing RecordPartitionerExtension'
-        type: string
+      least_backup:
+        description: LeastBackup routes each record to the partition with the fewest buffered records.
+        x-pointer: true
+        type: object
+      round_robin:
+        description: RoundRobin distributes records evenly across all available partitions in round-robin order.
+        x-pointer: true
+        type: object
+      sticky_key:
+        description: StickyKey uses StickyKeyPartitioner. When a record key is set, the partition is derived from the key hash.
+        x-pointer: true
+        $ref: sticky_key_partitioner_config
   signal_config:
     description: SignalConfig holds signal-specific configuration for the Kafka exporter.
     type: object
@@ -23,6 +32,13 @@ $defs:
         type: string
       topic_from_metadata_key:
         description: TopicFromMetadataKey holds the name of the metadata key to use as the topic name for this signal type. If this is set, it takes precedence over the topic name set in the topic field.
+        type: string
+  sticky_key_partitioner_config:
+    description: StickyKeyPartitionerConfig configures the StickyKeyPartitioner.
+    type: object
+    properties:
+      hasher:
+        description: 'Hasher is the hash algorithm used for key-based partition assignment. Valid values: "sarama_compat" (default). - "sarama_compat": Sarama-compatible FNV-1a hashing (SaramaCompatHasher). - "murmur2": Murmur2 hashing.'
         type: string
 description: Config defines configuration for Kafka exporter.
 type: object

--- a/exporter/kafkaexporter/config.schema.yaml
+++ b/exporter/kafkaexporter/config.schema.yaml
@@ -1,4 +1,16 @@
 $defs:
+  record_partitioner_config:
+    description: RecordPartitionerConfig configures the strategy used to assign Kafka records to partitions.
+    type: object
+    properties:
+      extension:
+        description: Extension is the component ID of an extension implementing RecordPartitionerExtension. Required when Type is "extension"; must be empty for all other types.
+        x-pointer: true
+        type: string
+        x-customType: go.opentelemetry.io/collector/component.ID
+      type:
+        description: 'Type is the partitioning strategy. Valid values are: - "" or "sarama_compatible" (default): sticky key partitioner with Sarama-compatible FNV-1a hashing - "sticky": franz-go StickyKeyPartitioner with murmur2 hashing - "round_robin": round-robin across all available partitions - "least_backup": routes to the partition with fewest in-flight records - "extension": delegates to an extension implementing RecordPartitionerExtension'
+        type: string
   signal_config:
     description: SignalConfig holds signal-specific configuration for the Kafka exporter.
     type: object
@@ -43,6 +55,9 @@ properties:
   profiles:
     description: Profiles holds configuration about how profiles should be sent to Kafka.
     $ref: signal_config
+  record_partitioner:
+    description: RecordPartitioner configures how Kafka records are assigned to partitions. The default ("sarama_compatible") retains the legacy Sarama-compatible hashing behavior. Set to "sticky", "round_robin", or "least_backup" to use one of the built-in franz-go partitioners, or "extension" to delegate to a custom extension.
+    $ref: record_partitioner_config
   sending_queue:
     x-optional: true
     $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -81,11 +81,11 @@ func TestLoadConfig(t *testing.T) {
 				PartitionMetricsByResourceAttributes: true,
 				PartitionLogsByResourceAttributes:    true,
 				PartitionLogsByTraceID:               false,
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "sarama_compat",
 					},
-				},
+				}),
 			},
 		},
 		{
@@ -100,9 +100,9 @@ func TestLoadConfig(t *testing.T) {
 				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
 				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
 				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					RoundRobin: &struct{}{},
-				},
+				}),
 			},
 		},
 		{
@@ -117,9 +117,9 @@ func TestLoadConfig(t *testing.T) {
 				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
 				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
 				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					LeastBackup: &struct{}{},
-				},
+				}),
 			},
 		},
 		{
@@ -134,11 +134,11 @@ func TestLoadConfig(t *testing.T) {
 				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
 				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
 				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "sarama_compat",
 					},
-				},
+				}),
 			},
 		},
 		{
@@ -153,11 +153,11 @@ func TestLoadConfig(t *testing.T) {
 				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
 				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
 				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "murmur2",
 					},
-				},
+				}),
 			},
 		},
 		{
@@ -188,11 +188,11 @@ func TestLoadConfig(t *testing.T) {
 				IncludeMetadataKeys: []string{
 					"metadata_key",
 				},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "sarama_compat",
 					},
-				},
+				}),
 			},
 		},
 		{
@@ -219,11 +219,11 @@ func TestLoadConfig(t *testing.T) {
 					Topic:    "otlp_profiles",
 					Encoding: "per_signal_encoding",
 				},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "sarama_compat",
 					},
-				},
+				}),
 			},
 		},
 		{
@@ -267,11 +267,11 @@ func TestLoadConfig(t *testing.T) {
 					Encoding:             "otlp_proto",
 				},
 				IncludeMetadataKeys: []string{"metadata_key"},
-				RecordPartitioner: RecordPartitionerConfig{
+				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "sarama_compat",
 					},
-				},
+				}),
 			},
 		},
 	}

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -82,7 +82,9 @@ func TestLoadConfig(t *testing.T) {
 				PartitionLogsByResourceAttributes:    true,
 				PartitionLogsByTraceID:               false,
 				RecordPartitioner: RecordPartitionerConfig{
-					Type: "sarama_compatible",
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "sarama_compat",
+					},
 				},
 			},
 		},
@@ -99,7 +101,7 @@ func TestLoadConfig(t *testing.T) {
 				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
 				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
 				RecordPartitioner: RecordPartitionerConfig{
-					Type: RecordPartitionerTypeRoundRobin,
+					RoundRobin: &struct{}{},
 				},
 			},
 		},
@@ -116,7 +118,45 @@ func TestLoadConfig(t *testing.T) {
 				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
 				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
 				RecordPartitioner: RecordPartitionerConfig{
-					Type: RecordPartitionerTypeLeastBackup,
+					LeastBackup: &struct{}{},
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "sticky_key_partitioner"),
+			expected: &Config{
+				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
+				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+				ClientConfig:     configkafka.NewDefaultClientConfig(),
+				Producer:         configkafka.NewDefaultProducerConfig(),
+				Logs:             SignalConfig{Topic: defaultLogsTopic, Encoding: defaultLogsEncoding},
+				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
+				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
+				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
+				RecordPartitioner: RecordPartitionerConfig{
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "sarama_compat",
+					},
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "sticky_key_partitioner_murmur2"),
+			expected: &Config{
+				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
+				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+				ClientConfig:     configkafka.NewDefaultClientConfig(),
+				Producer:         configkafka.NewDefaultProducerConfig(),
+				Logs:             SignalConfig{Topic: defaultLogsTopic, Encoding: defaultLogsEncoding},
+				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
+				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
+				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
+				RecordPartitioner: RecordPartitionerConfig{
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "murmur2",
+					},
 				},
 			},
 		},
@@ -149,7 +189,9 @@ func TestLoadConfig(t *testing.T) {
 					"metadata_key",
 				},
 				RecordPartitioner: RecordPartitionerConfig{
-					Type: "sarama_compatible",
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "sarama_compat",
+					},
 				},
 			},
 		},
@@ -178,7 +220,9 @@ func TestLoadConfig(t *testing.T) {
 					Encoding: "per_signal_encoding",
 				},
 				RecordPartitioner: RecordPartitionerConfig{
-					Type: "sarama_compatible",
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "sarama_compat",
+					},
 				},
 			},
 		},
@@ -224,7 +268,9 @@ func TestLoadConfig(t *testing.T) {
 				},
 				IncludeMetadataKeys: []string{"metadata_key"},
 				RecordPartitioner: RecordPartitionerConfig{
-					Type: "sarama_compatible",
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "sarama_compat",
+					},
 				},
 			},
 		},
@@ -273,13 +319,13 @@ func TestLoadConfigFailed(t *testing.T) {
 			configFile:    "config-batch-partition-validation-failed.yaml",
 		},
 		{
-			id:            component.NewIDWithName(metadata.Type, "invalid_partitioner"),
-			errorContains: errRecordPartitionerUnknownType.Error(),
+			id:            component.NewIDWithName(metadata.Type, "multiple_partitioner"),
+			errorContains: errRecordPartitionerMultipleSet.Error(),
 			configFile:    "config-partitioning-failed.yaml",
 		},
 		{
-			id:            component.NewIDWithName(metadata.Type, "extension_not_set"),
-			errorContains: errRecordPartitionerExtRequired.Error(),
+			id:            component.NewIDWithName(metadata.Type, "invalid_sticky_key_hasher"),
+			errorContains: `sticky_key: unknown hasher "invalid_hasher", valid values are "sarama_compat", "murmur2"`,
 			configFile:    "config-partitioning-failed.yaml",
 		},
 	}

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -84,6 +84,40 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "round_robin_partitioner"),
+			expected: &Config{
+				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
+				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+				ClientConfig:     configkafka.NewDefaultClientConfig(),
+				Producer:         configkafka.NewDefaultProducerConfig(),
+				Logs:             SignalConfig{Topic: defaultLogsTopic, Encoding: defaultLogsEncoding},
+				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
+				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
+				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
+				RecordPartitioner: RecordPartitionerConfig{
+					Type: RecordPartitionerTypeRoundRobin,
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "least_backup_partitioner"),
+			expected: &Config{
+				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
+				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+				ClientConfig:     configkafka.NewDefaultClientConfig(),
+				Producer:         configkafka.NewDefaultProducerConfig(),
+				Logs:             SignalConfig{Topic: defaultLogsTopic, Encoding: defaultLogsEncoding},
+				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
+				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
+				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
+				RecordPartitioner: RecordPartitionerConfig{
+					Type: RecordPartitionerTypeLeastBackup,
+				},
+			},
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "per_signal_topic"),
 			expected: &Config{
 				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -81,6 +81,9 @@ func TestLoadConfig(t *testing.T) {
 				PartitionMetricsByResourceAttributes: true,
 				PartitionLogsByResourceAttributes:    true,
 				PartitionLogsByTraceID:               false,
+				RecordPartitioner: RecordPartitionerConfig{
+					Type: "sarama_compatible",
+				},
 			},
 		},
 		{
@@ -145,6 +148,9 @@ func TestLoadConfig(t *testing.T) {
 				IncludeMetadataKeys: []string{
 					"metadata_key",
 				},
+				RecordPartitioner: RecordPartitionerConfig{
+					Type: "sarama_compatible",
+				},
 			},
 		},
 		{
@@ -170,6 +176,9 @@ func TestLoadConfig(t *testing.T) {
 				Profiles: SignalConfig{
 					Topic:    "otlp_profiles",
 					Encoding: "per_signal_encoding",
+				},
+				RecordPartitioner: RecordPartitionerConfig{
+					Type: "sarama_compatible",
 				},
 			},
 		},
@@ -214,6 +223,9 @@ func TestLoadConfig(t *testing.T) {
 					Encoding:             "otlp_proto",
 				},
 				IncludeMetadataKeys: []string{"metadata_key"},
+				RecordPartitioner: RecordPartitionerConfig{
+					Type: "sarama_compatible",
+				},
 			},
 		},
 	}
@@ -259,6 +271,16 @@ func TestLoadConfigFailed(t *testing.T) {
 			id:            component.NewIDWithName(metadata.Type, "not_superset_batch_partitioner_keys"),
 			errorContains: `sending_queue::batch::partition::metadata_keys must include all include_metadata_keys values: missing "required_key" from sending_queue::batch::partition::metadata_keys=[metadata_key]`,
 			configFile:    "config-batch-partition-validation-failed.yaml",
+		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "invalid_partitioner"),
+			errorContains: errRecordPartitionerUnknownType.Error(),
+			configFile:    "config-partitioning-failed.yaml",
+		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "extension_not_set"),
+			errorContains: errRecordPartitionerExtRequired.Error(),
+			configFile:    "config-partitioning-failed.yaml",
 		},
 	}
 

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -76,7 +76,9 @@ func createDefaultConfig() component.Config {
 		PartitionLogsByResourceAttributes:    defaultPartitionLogsByResourceAttributesEnabled,
 		PartitionLogsByTraceID:               defaultPartitionLogsByTraceIDEnabled,
 		RecordPartitioner: RecordPartitionerConfig{
-			Type: RecordPartitionerTypeSaramaCompatible,
+			StickyKey: &StickyKeyPartitionerConfig{
+				Hasher: HasherSaramaCompat,
+			},
 		},
 	}
 }

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -75,6 +75,9 @@ func createDefaultConfig() component.Config {
 		PartitionMetricsByResourceAttributes: defaultPartitionMetricsByResourceAttributesEnabled,
 		PartitionLogsByResourceAttributes:    defaultPartitionLogsByResourceAttributesEnabled,
 		PartitionLogsByTraceID:               defaultPartitionLogsByTraceIDEnabled,
+		RecordPartitioner: RecordPartitionerConfig{
+			Type: RecordPartitionerTypeSaramaCompatible,
+		},
 	}
 }
 

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -86,6 +86,11 @@ func (e *kafkaExporter[T]) Start(ctx context.Context, host component.Host) (err 
 		return err
 	}
 
+	partitionerOpt, err := buildPartitionerOpt(e.cfg.RecordPartitioner, host)
+	if err != nil {
+		return fmt.Errorf("failed to configure record partitioner: %w", err)
+	}
+
 	producer, err := kafka.NewFranzSyncProducer(
 		ctx,
 		host,
@@ -94,6 +99,7 @@ func (e *kafkaExporter[T]) Start(ctx context.Context, host component.Host) (err 
 		e.cfg.TimeoutSettings.Timeout,
 		e.logger,
 		kgo.WithHooks(kafkaclient.NewFranzProducerMetrics(tb)),
+		partitionerOpt,
 	)
 	if err != nil {
 		return err

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -39,28 +39,59 @@ type RecordPartitionerExtension interface {
 	GetPartitioner() kgo.Partitioner
 }
 
+// func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.Opt, error) {
+// 	switch cfg.Type {
+// 	case RecordPartitionerTypeSaramaCompatible:
+// 		return kgo.RecordPartitioner(kafka.NewSaramaCompatPartitioner()), nil
+// 	case RecordPartitionerTypeRoundRobin:
+// 		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil
+// 	case RecordPartitionerTypeLeastBackup:
+// 		return kgo.RecordPartitioner(kgo.LeastBackupPartitioner()), nil
+// 	case RecordPartitionerTypeCustom:
+// 		if cfg.Extension == nil {
+// 			return nil, errRecordPartitionerExtRequired
+// 		}
+// 		ext, ok := host.GetExtensions()[*cfg.Extension]
+// 		if !ok {
+// 			return nil, fmt.Errorf("partitioner extension %q not found", cfg.Extension)
+// 		}
+// 		partExt, ok := ext.(RecordPartitionerExtension)
+// 		if !ok {
+// 			return nil, fmt.Errorf("extension %q does not implement RecordPartitionerExtension", cfg.Extension)
+// 		}
+// 		return kgo.RecordPartitioner(partExt.GetPartitioner()), nil
+// 	default:
+// 		return nil, fmt.Errorf("unknown partitioner type %q", cfg.Type)
+// 	}
+// }
+
 func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.Opt, error) {
-	switch cfg.Type {
-	case RecordPartitionerTypeSaramaCompatible:
-		return kgo.RecordPartitioner(kafka.NewSaramaCompatPartitioner()), nil
-	case RecordPartitionerTypeRoundRobin:
-		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil
-	case RecordPartitionerTypeLeastBackup:
-		return kgo.RecordPartitioner(kgo.LeastBackupPartitioner()), nil
-	case RecordPartitionerTypeCustom:
-		if cfg.Extension == nil {
-			return nil, errRecordPartitionerExtRequired
+	if cfg.StickyKey != nil {
+		switch cfg.StickyKey.Hasher {
+		case HasherSaramaCompat:
+			return kgo.RecordPartitioner(kgo.StickyKeyPartitioner(kafka.NewSaramaCompatHasher())), nil
+		case HasherMurmur2:
+			return kgo.RecordPartitioner(kgo.StickyKeyPartitioner(nil)), nil
+		default:
+			return nil, fmt.Errorf("unknown sticky key hasher type %q", cfg.StickyKey.Hasher)
 		}
+	}
+	if cfg.RoundRobin != nil {
+		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil
+	}
+	if cfg.LeastBackup != nil {
+		return kgo.RecordPartitioner(kgo.LeastBackupPartitioner()), nil
+	}
+	if cfg.Extension != nil {
 		ext, ok := host.GetExtensions()[*cfg.Extension]
 		if !ok {
-			return nil, fmt.Errorf("partitioner extension %q not found", cfg.Extension)
+			return nil, fmt.Errorf("partitioner extension %q not found", *cfg.Extension)
 		}
 		partExt, ok := ext.(RecordPartitionerExtension)
 		if !ok {
-			return nil, fmt.Errorf("extension %q does not implement RecordPartitionerExtension", cfg.Extension)
+			return nil, fmt.Errorf("extension %q does not implement RecordPartitionerExtension", *cfg.Extension)
 		}
 		return kgo.RecordPartitioner(partExt.GetPartitioner()), nil
-	default:
-		return nil, fmt.Errorf("unknown partitioner type %q", cfg.Type)
 	}
+	return nil, fmt.Errorf("no partitioner type configured")
 }

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -48,5 +48,7 @@ func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.
 		}
 		return kgo.RecordPartitioner(partExt.GetPartitioner()), nil
 	}
-	return nil, fmt.Errorf("no partitioner type configured")
+	// in practice, this shouldn't happen.
+	// The config validation should catch the case where no partitioner is set.
+	return nil, errRecordPartitionerMissing
 }

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -26,9 +26,9 @@ const (
 	// buffered records, which can reduce produce latency under uneven load.
 	RecordPartitionerTypeLeastBackup = "least_backup"
 
-	// RecordPartitionerTypeExtension delegates partitioning to a user-provided extension
+	// RecordPartitionerTypeCustom delegates partitioning to a user-provided extension
 	// that implements RecordPartitionerExtension.
-	RecordPartitionerTypeExtension = "custom"
+	RecordPartitionerTypeCustom = "custom"
 )
 
 // RecordPartitionerExtension is implemented by extensions that supply a custom Kafka record
@@ -47,7 +47,7 @@ func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.
 		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil
 	case RecordPartitionerTypeLeastBackup:
 		return kgo.RecordPartitioner(kgo.LeastBackupPartitioner()), nil
-	case RecordPartitionerTypeExtension:
+	case RecordPartitionerTypeCustom:
 		if cfg.Extension == nil {
 			return nil, errRecordPartitionerExtRequired
 		}

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+
+import (
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
+)
+
+const (
+	// RecordPartitionerTypeSaramaCompatible is the default partitioner. It uses a sticky
+	// key partitioner with Sarama-compatible FNV-1a hashing when a record key is set,
+	// and a random sticky partition when no key is set.
+	RecordPartitionerTypeSaramaCompatible = "sarama_compatible"
+
+	// RecordPartitionerTypeRoundRobin distributes records evenly across all available
+	// partitions in a round-robin fashion, regardless of the record key.
+	RecordPartitionerTypeRoundRobin = "round_robin"
+
+	// RecordPartitionerTypeLeastBackup routes each record to the partition with the fewest
+	// buffered records, which can reduce produce latency under uneven load.
+	RecordPartitionerTypeLeastBackup = "least_backup"
+
+	// RecordPartitionerTypeExtension delegates partitioning to a user-provided extension
+	// that implements RecordPartitionerExtension.
+	RecordPartitionerTypeExtension = "custom"
+)
+
+// RecordPartitionerExtension is implemented by extensions that supply a custom Kafka record
+// partitioner for use with the kafka exporter.
+type RecordPartitionerExtension interface {
+	component.Component
+
+	GetPartitioner() kgo.Partitioner
+}
+
+func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.Opt, error) {
+	switch cfg.Type {
+	case "", RecordPartitionerTypeSaramaCompatible:
+		return kgo.RecordPartitioner(kafka.NewSaramaCompatPartitioner()), nil
+	case RecordPartitionerTypeRoundRobin:
+		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil
+	case RecordPartitionerTypeLeastBackup:
+		return kgo.RecordPartitioner(kgo.LeastBackupPartitioner()), nil
+	case RecordPartitionerTypeExtension:
+		if cfg.Extension == nil {
+			return nil, errRecordPartitionerExtRequired
+		}
+		ext, ok := host.GetExtensions()[*cfg.Extension]
+		if !ok {
+			return nil, fmt.Errorf("partitioner extension %q not found", cfg.Extension)
+		}
+		partExt, ok := ext.(RecordPartitionerExtension)
+		if !ok {
+			return nil, fmt.Errorf("extension %q does not implement RecordPartitionerExtension", cfg.Extension)
+		}
+		return kgo.RecordPartitioner(partExt.GetPartitioner()), nil
+	default:
+		return nil, fmt.Errorf("unknown partitioner type %q", cfg.Type)
+	}
+}

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -41,7 +41,7 @@ type RecordPartitionerExtension interface {
 
 func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.Opt, error) {
 	switch cfg.Type {
-	case "", RecordPartitionerTypeSaramaCompatible:
+	case RecordPartitionerTypeSaramaCompatible:
 		return kgo.RecordPartitioner(kafka.NewSaramaCompatPartitioner()), nil
 	case RecordPartitionerTypeRoundRobin:
 		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil

--- a/exporter/kafkaexporter/partitioner.go
+++ b/exporter/kafkaexporter/partitioner.go
@@ -12,25 +12,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
 )
 
-const (
-	// RecordPartitionerTypeSaramaCompatible is the default partitioner. It uses a sticky
-	// key partitioner with Sarama-compatible FNV-1a hashing when a record key is set,
-	// and a random sticky partition when no key is set.
-	RecordPartitionerTypeSaramaCompatible = "sarama_compatible"
-
-	// RecordPartitionerTypeRoundRobin distributes records evenly across all available
-	// partitions in a round-robin fashion, regardless of the record key.
-	RecordPartitionerTypeRoundRobin = "round_robin"
-
-	// RecordPartitionerTypeLeastBackup routes each record to the partition with the fewest
-	// buffered records, which can reduce produce latency under uneven load.
-	RecordPartitionerTypeLeastBackup = "least_backup"
-
-	// RecordPartitionerTypeCustom delegates partitioning to a user-provided extension
-	// that implements RecordPartitionerExtension.
-	RecordPartitionerTypeCustom = "custom"
-)
-
 // RecordPartitionerExtension is implemented by extensions that supply a custom Kafka record
 // partitioner for use with the kafka exporter.
 type RecordPartitionerExtension interface {
@@ -38,32 +19,6 @@ type RecordPartitionerExtension interface {
 
 	GetPartitioner() kgo.Partitioner
 }
-
-// func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.Opt, error) {
-// 	switch cfg.Type {
-// 	case RecordPartitionerTypeSaramaCompatible:
-// 		return kgo.RecordPartitioner(kafka.NewSaramaCompatPartitioner()), nil
-// 	case RecordPartitionerTypeRoundRobin:
-// 		return kgo.RecordPartitioner(kgo.RoundRobinPartitioner()), nil
-// 	case RecordPartitionerTypeLeastBackup:
-// 		return kgo.RecordPartitioner(kgo.LeastBackupPartitioner()), nil
-// 	case RecordPartitionerTypeCustom:
-// 		if cfg.Extension == nil {
-// 			return nil, errRecordPartitionerExtRequired
-// 		}
-// 		ext, ok := host.GetExtensions()[*cfg.Extension]
-// 		if !ok {
-// 			return nil, fmt.Errorf("partitioner extension %q not found", cfg.Extension)
-// 		}
-// 		partExt, ok := ext.(RecordPartitionerExtension)
-// 		if !ok {
-// 			return nil, fmt.Errorf("extension %q does not implement RecordPartitionerExtension", cfg.Extension)
-// 		}
-// 		return kgo.RecordPartitioner(partExt.GetPartitioner()), nil
-// 	default:
-// 		return nil, fmt.Errorf("unknown partitioner type %q", cfg.Type)
-// 	}
-// }
 
 func buildPartitionerOpt(cfg RecordPartitionerConfig, host component.Host) (kgo.Opt, error) {
 	if cfg.StickyKey != nil {

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -25,14 +25,14 @@ type mockPartitionerExtension struct {
 	partitioner kgo.Partitioner
 }
 
-func (m *mockPartitionerExtension) Start(context.Context, component.Host) error { return nil }
-func (m *mockPartitionerExtension) Shutdown(context.Context) error              { return nil }
-func (m *mockPartitionerExtension) GetPartitioner() kgo.Partitioner             { return m.partitioner }
+func (*mockPartitionerExtension) Start(context.Context, component.Host) error { return nil }
+func (*mockPartitionerExtension) Shutdown(context.Context) error              { return nil }
+func (m *mockPartitionerExtension) GetPartitioner() kgo.Partitioner           { return m.partitioner }
 
 type notAPartitionerExtension struct{}
 
-func (n *notAPartitionerExtension) Start(context.Context, component.Host) error { return nil }
-func (n *notAPartitionerExtension) Shutdown(context.Context) error              { return nil }
+func (*notAPartitionerExtension) Start(context.Context, component.Host) error { return nil }
+func (*notAPartitionerExtension) Shutdown(context.Context) error              { return nil }
 
 type mockHostWithExtensions struct {
 	component.Host

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -80,10 +79,10 @@ func TestRecordPartitionerConfig_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.cfg.Validate()
 			if tt.wantErr == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 			}
 		})
 	}
@@ -154,10 +153,10 @@ func TestBuildPartitionerOpt(t *testing.T) {
 			opt, err := buildPartitionerOpt(tt.cfg, tt.host)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
-				assert.NotNil(t, opt)
+				require.NotNil(t, opt)
 			} else {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 			}
 		})
 	}
@@ -245,7 +244,7 @@ func TestRecordPartitioner_RoundRobin(t *testing.T) {
 
 	require.Len(t, records, numPartitions)
 	partitions := partitionSet(records)
-	assert.Len(t, partitions, numPartitions,
+	require.Len(t, partitions, numPartitions,
 		"round-robin should spread %d records across all %d partitions", numPartitions, numPartitions)
 }
 
@@ -272,7 +271,34 @@ func TestRecordPartitioner_SaramaCompatible_SameKeyConsistency(t *testing.T) {
 
 	require.Len(t, records, numRecords)
 	partitions := partitionSet(records)
-	assert.Len(t, partitions, 1,
+	require.Len(t, partitions, 1,
+		"all records with the same key should land on the same partition")
+}
+
+func TestRecordPartitioner_SaramaCompatible_Murmur2(t *testing.T) {
+	const numPartitions = 4
+	const topic = "sarama-key-topic"
+	const numRecords = 6
+
+	client, brokers := newPartitioningProducer(t,
+		RecordPartitionerConfig{
+			StickyKey: &StickyKeyPartitionerConfig{
+				Hasher: HasherMurmur2,
+			},
+		},
+		componenttest.NewNopHost(), numPartitions, topic,
+	)
+
+	key := []byte("stable-key")
+	keys := make([][]byte, numRecords)
+	for i := range keys {
+		keys[i] = key
+	}
+	records := produceAndFetch(t, client, brokers, topic, keys)
+
+	require.Len(t, records, numRecords)
+	partitions := partitionSet(records)
+	require.Len(t, partitions, 1,
 		"all records with the same key should land on the same partition")
 }
 
@@ -292,7 +318,7 @@ func TestRecordPartitioner_SaramaCompatible_DifferentKeys(t *testing.T) {
 	records := produceAndFetch(t, client, brokers, topic, keys)
 
 	require.Len(t, records, 2)
-	assert.NotEqual(t, records[0].Partition, records[1].Partition,
+	require.NotEqual(t, records[0].Partition, records[1].Partition,
 		"distinct keys should land on distinct partitions")
 }
 
@@ -300,14 +326,28 @@ func TestRecordPartitioner_LeastBackup(t *testing.T) {
 	const numPartitions = 3
 	const topic = "lb-topic"
 
+	// LeastBackup picks the partition with the smallest producer buffer.
+	// If multiple partitions are tied, franz-go randomly chooses one of them.
+	//
+	// When linger=0 and we send one record at a time (ProduceSync),
+	// each send completes before the next partition is picked. That keeps
+	// all buffers roughly equal, so each record is effectively sent to a
+	// random partition.
+	//
+	// due to this randomness, a small number of messages might still all land on the same partition.
+	// that's why we use large number of records.
+	const numRecords = 50
+
 	client, brokers := newPartitioningProducer(t,
 		RecordPartitionerConfig{LeastBackup: &struct{}{}},
 		componenttest.NewNopHost(), numPartitions, topic,
 	)
 
-	nils := make([][]byte, numPartitions)
-	records := produceAndFetch(t, client, brokers, topic, nils)
-	assert.Len(t, records, numPartitions, "all records should be produced successfully")
+	records := produceAndFetch(t, client, brokers, topic, make([][]byte, numRecords))
+	require.Len(t, records, numRecords)
+
+	partitions := partitionSet(records)
+	require.Len(t, partitions, numPartitions)
 }
 
 func TestRecordPartitioner_Extension_CustomRouting(t *testing.T) {
@@ -339,7 +379,7 @@ func TestRecordPartitioner_Extension_CustomRouting(t *testing.T) {
 
 	require.Len(t, records, numRecords)
 	for _, r := range records {
-		assert.Equal(t, int32(0), r.Partition,
+		require.Equal(t, int32(0), r.Partition,
 			"extension partitioner (always-zero) should route all records to partition 0")
 	}
 }

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -1,0 +1,349 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkaexporter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
+)
+
+type mockPartitionerExtension struct {
+	partitioner kgo.Partitioner
+}
+
+func (m *mockPartitionerExtension) Start(context.Context, component.Host) error { return nil }
+func (m *mockPartitionerExtension) Shutdown(context.Context) error              { return nil }
+func (m *mockPartitionerExtension) GetPartitioner() kgo.Partitioner             { return m.partitioner }
+
+type notAPartitionerExtension struct{}
+
+func (n *notAPartitionerExtension) Start(context.Context, component.Host) error { return nil }
+func (n *notAPartitionerExtension) Shutdown(context.Context) error              { return nil }
+
+type mockHostWithExtensions struct {
+	component.Host
+	extensions map[component.ID]component.Component
+}
+
+func (h *mockHostWithExtensions) GetExtensions() map[component.ID]component.Component {
+	return h.extensions
+}
+
+func TestRecordPartitionerConfig_Validate(t *testing.T) {
+	extID := component.MustNewID("my_partitioner")
+
+	tests := []struct {
+		name    string
+		cfg     RecordPartitionerConfig
+		wantErr string
+	}{
+		{
+			name: "empty type (default)",
+			cfg:  RecordPartitionerConfig{},
+		},
+		{
+			name: "sarama_compatible",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
+		},
+		{
+			name: "round_robin",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeRoundRobin},
+		},
+		{
+			name: "least_backup",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeLeastBackup},
+		},
+		{
+			name: "extension with ID",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+		},
+		{
+			name:    "extension without ID",
+			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeExtension},
+			wantErr: errRecordPartitionerExtRequired.Error(),
+		},
+		{
+			name:    "unknown type",
+			cfg:     RecordPartitionerConfig{Type: "bogus"},
+			wantErr: errRecordPartitionerUnknownType.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildPartitionerOpt(t *testing.T) {
+	extID := component.MustNewID("my_partitioner")
+	customPartitioner := kgo.RoundRobinPartitioner()
+	ext := &mockPartitionerExtension{partitioner: customPartitioner}
+
+	hostWithExt := &mockHostWithExtensions{
+		Host: componenttest.NewNopHost(),
+		extensions: map[component.ID]component.Component{
+			extID: ext,
+		},
+	}
+	compID := component.MustNewID("missing")
+
+	tests := []struct {
+		name    string
+		cfg     RecordPartitionerConfig
+		host    component.Host
+		wantErr string
+	}{
+		{
+			name: "default (empty type)",
+			cfg:  RecordPartitionerConfig{},
+			host: componenttest.NewNopHost(),
+		},
+		{
+			name: "sarama_compatible",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
+			host: componenttest.NewNopHost(),
+		},
+		{
+			name: "round_robin",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeRoundRobin},
+			host: componenttest.NewNopHost(),
+		},
+		{
+			name: "least_backup",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeLeastBackup},
+			host: componenttest.NewNopHost(),
+		},
+		{
+			name: "extension",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+			host: hostWithExt,
+		},
+		{
+			name:    "extension not found",
+			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &compID},
+			host:    componenttest.NewNopHost(),
+			wantErr: `partitioner extension "missing" not found`,
+		},
+		{
+			name: "extension does not implement RecordPartitionerExtension",
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+			host: &mockHostWithExtensions{
+				Host: componenttest.NewNopHost(),
+				extensions: map[component.ID]component.Component{
+					extID: &notAPartitionerExtension{},
+				},
+			},
+			wantErr: `does not implement RecordPartitionerExtension`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt, err := buildPartitionerOpt(tt.cfg, tt.host)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				assert.NotNil(t, opt)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// newPartitioningProducer creates a kgo producer backed by a mock cluster with
+// numPartitions partitions for topic.
+func newPartitioningProducer(
+	t *testing.T,
+	cfg RecordPartitionerConfig,
+	host component.Host,
+	numPartitions int,
+	topic string,
+) (*kgo.Client, []string) {
+	t.Helper()
+	cluster, kcfg := kafkatest.NewCluster(t, kfake.SeedTopics(int32(numPartitions), topic))
+
+	partOpt, err := buildPartitionerOpt(cfg, host)
+	require.NoError(t, err)
+
+	producerCfg := configkafka.NewDefaultProducerConfig()
+	producerCfg.Linger = 0 // disable linger so each ProduceSync is its own batch
+	client, err := kafka.NewFranzSyncProducer(
+		t.Context(), host, kcfg, producerCfg,
+		5*time.Second, zap.NewNop(),
+		partOpt,
+	)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+	return client, cluster.ListenAddrs()
+}
+
+func produceAndFetch(t *testing.T, client *kgo.Client, brokers []string, topic string, keys [][]byte) []*kgo.Record {
+	t.Helper()
+	for _, key := range keys {
+		r := &kgo.Record{Topic: topic, Value: []byte("value")}
+		if key != nil {
+			r.Key = key
+		}
+		require.NoError(t, client.ProduceSync(t.Context(), r).FirstErr())
+	}
+
+	clientOpts := []kgo.Opt{
+		kgo.SeedBrokers(brokers...),
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumerGroup("group-id-" + topic),
+	}
+	consumer, err := kgo.NewClient(clientOpts...)
+	require.NoError(t, err)
+	defer consumer.Close()
+
+	want := len(keys)
+	var records []*kgo.Record
+	for len(records) < want {
+		fetches := consumer.PollRecords(t.Context(), want-len(records))
+		require.NoError(t, fetches.Err())
+		fetches.EachRecord(func(r *kgo.Record) {
+			records = append(records, r)
+		})
+	}
+	return records
+}
+
+// partitionSet collects the unique partition numbers from a slice of records.
+func partitionSet(records []*kgo.Record) map[int32]struct{} {
+	m := make(map[int32]struct{}, len(records))
+	for _, r := range records {
+		m[r.Partition] = struct{}{}
+	}
+	return m
+}
+
+func TestRecordPartitioner_RoundRobin(t *testing.T) {
+	const numPartitions = 3
+	const topic = "rr-topic"
+
+	client, brokers := newPartitioningProducer(t,
+		RecordPartitionerConfig{Type: RecordPartitionerTypeRoundRobin},
+		componenttest.NewNopHost(), numPartitions, topic,
+	)
+
+	// Send one record per partition, keyless, each in its own ProduceSync.
+	nils := make([][]byte, numPartitions)
+	records := produceAndFetch(t, client, brokers, topic, nils)
+
+	require.Len(t, records, numPartitions)
+	partitions := partitionSet(records)
+	assert.Len(t, partitions, numPartitions,
+		"round-robin should spread %d records across all %d partitions", numPartitions, numPartitions)
+}
+
+func TestRecordPartitioner_SaramaCompatible_SameKeyConsistency(t *testing.T) {
+	const numPartitions = 4
+	const topic = "sarama-key-topic"
+	const numRecords = 6
+
+	client, brokers := newPartitioningProducer(t,
+		RecordPartitionerConfig{}, // default = sarama_compatible
+		componenttest.NewNopHost(), numPartitions, topic,
+	)
+
+	key := []byte("stable-key")
+	keys := make([][]byte, numRecords)
+	for i := range keys {
+		keys[i] = key
+	}
+	records := produceAndFetch(t, client, brokers, topic, keys)
+
+	require.Len(t, records, numRecords)
+	partitions := partitionSet(records)
+	assert.Len(t, partitions, 1,
+		"all records with the same key should land on the same partition")
+}
+
+func TestRecordPartitioner_SaramaCompatible_DifferentKeys(t *testing.T) {
+	const numPartitions = 8
+	const topic = "sarama-diff-keys-topic"
+
+	client, brokers := newPartitioningProducer(t,
+		RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
+		componenttest.NewNopHost(), numPartitions, topic,
+	)
+
+	// These two keys are known to hash to different FNV-1a buckets mod 8.
+	keys := [][]byte{[]byte("key-alpha"), []byte("key-beta")}
+	records := produceAndFetch(t, client, brokers, topic, keys)
+
+	require.Len(t, records, 2)
+	assert.NotEqual(t, records[0].Partition, records[1].Partition,
+		"distinct keys should land on distinct partitions")
+}
+
+func TestRecordPartitioner_LeastBackup(t *testing.T) {
+	const numPartitions = 3
+	const topic = "lb-topic"
+
+	client, brokers := newPartitioningProducer(t,
+		RecordPartitionerConfig{Type: RecordPartitionerTypeLeastBackup},
+		componenttest.NewNopHost(), numPartitions, topic,
+	)
+
+	nils := make([][]byte, numPartitions)
+	records := produceAndFetch(t, client, brokers, topic, nils)
+	assert.Len(t, records, numPartitions, "all records should be produced successfully")
+}
+
+func TestRecordPartitioner_Extension_CustomRouting(t *testing.T) {
+	const numPartitions = 4
+	const topic = "ext-partition-topic"
+	const numRecords = 6
+
+	// alwaysZeroPartitioner routes every record to partition 0.
+	alwaysZero := kgo.BasicConsistentPartitioner(func(string) func(*kgo.Record, int) int {
+		return func(_ *kgo.Record, _ int) int { return 0 }
+	})
+
+	extID := component.MustNewID("always_zero")
+	host := &mockHostWithExtensions{
+		Host: componenttest.NewNopHost(),
+		extensions: map[component.ID]component.Component{
+			extID: &mockPartitionerExtension{partitioner: alwaysZero},
+		},
+	}
+
+	client, brokers := newPartitioningProducer(t,
+		RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+		host, numPartitions, topic,
+	)
+
+	// Mix of keyed and keyless records; the custom partitioner should ignore keys.
+	keys := [][]byte{nil, []byte("k1"), nil, []byte("k2"), nil, []byte("k3")}
+	records := produceAndFetch(t, client, brokers, topic, keys)
+
+	require.Len(t, records, numRecords)
+	for _, r := range records {
+		assert.Equal(t, int32(0), r.Partition,
+			"extension partitioner (always-zero) should route all records to partition 0")
+	}
+}

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -45,6 +45,7 @@ func (h *mockHostWithExtensions) GetExtensions() map[component.ID]component.Comp
 
 func TestRecordPartitionerConfig_Validate(t *testing.T) {
 	extID := component.MustNewID("my_partitioner")
+	unknownExtID := component.MustNewID("unknown")
 
 	tests := []struct {
 		name    string
@@ -52,30 +53,26 @@ func TestRecordPartitionerConfig_Validate(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "sarama_compatible",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
+			name: "sarama_compat",
+			cfg: RecordPartitionerConfig{StickyKey: &StickyKeyPartitionerConfig{
+				Hasher: "sarama_compat",
+			}},
 		},
 		{
 			name: "round_robin",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeRoundRobin},
+			cfg:  RecordPartitionerConfig{RoundRobin: &struct{}{}},
 		},
 		{
 			name: "least_backup",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeLeastBackup},
+			cfg:  RecordPartitionerConfig{LeastBackup: &struct{}{}},
 		},
 		{
 			name: "extension with ID",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
+			cfg:  RecordPartitionerConfig{Extension: &extID},
 		},
 		{
-			name:    "extension without ID",
-			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeCustom},
-			wantErr: errRecordPartitionerExtRequired.Error(),
-		},
-		{
-			name:    "unknown type",
-			cfg:     RecordPartitionerConfig{Type: "bogus"},
-			wantErr: errRecordPartitionerUnknownType.Error(),
+			name: "unknown extension",
+			cfg:  RecordPartitionerConfig{Extension: &unknownExtID},
 		},
 	}
 
@@ -112,34 +109,36 @@ func TestBuildPartitionerOpt(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "sarama_compatible",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
+			name: "sarama_compat",
+			cfg: RecordPartitionerConfig{StickyKey: &StickyKeyPartitionerConfig{
+				Hasher: HasherSaramaCompat,
+			}},
 			host: componenttest.NewNopHost(),
 		},
 		{
 			name: "round_robin",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeRoundRobin},
+			cfg:  RecordPartitionerConfig{RoundRobin: &struct{}{}},
 			host: componenttest.NewNopHost(),
 		},
 		{
 			name: "least_backup",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeLeastBackup},
+			cfg:  RecordPartitionerConfig{LeastBackup: &struct{}{}},
 			host: componenttest.NewNopHost(),
 		},
 		{
 			name: "extension",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
+			cfg:  RecordPartitionerConfig{Extension: &extID},
 			host: hostWithExt,
 		},
 		{
 			name:    "extension not found",
-			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &compID},
+			cfg:     RecordPartitionerConfig{Extension: &compID},
 			host:    componenttest.NewNopHost(),
 			wantErr: `partitioner extension "missing" not found`,
 		},
 		{
 			name: "extension does not implement RecordPartitionerExtension",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
+			cfg:  RecordPartitionerConfig{Extension: &extID},
 			host: &mockHostWithExtensions{
 				Host: componenttest.NewNopHost(),
 				extensions: map[component.ID]component.Component{
@@ -236,7 +235,7 @@ func TestRecordPartitioner_RoundRobin(t *testing.T) {
 	const topic = "rr-topic"
 
 	client, brokers := newPartitioningProducer(t,
-		RecordPartitionerConfig{Type: RecordPartitionerTypeRoundRobin},
+		RecordPartitionerConfig{RoundRobin: &struct{}{}},
 		componenttest.NewNopHost(), numPartitions, topic,
 	)
 
@@ -257,7 +256,9 @@ func TestRecordPartitioner_SaramaCompatible_SameKeyConsistency(t *testing.T) {
 
 	client, brokers := newPartitioningProducer(t,
 		RecordPartitionerConfig{
-			Type: RecordPartitionerTypeSaramaCompatible,
+			StickyKey: &StickyKeyPartitionerConfig{
+				Hasher: HasherSaramaCompat,
+			},
 		},
 		componenttest.NewNopHost(), numPartitions, topic,
 	)
@@ -280,7 +281,9 @@ func TestRecordPartitioner_SaramaCompatible_DifferentKeys(t *testing.T) {
 	const topic = "sarama-diff-keys-topic"
 
 	client, brokers := newPartitioningProducer(t,
-		RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
+		RecordPartitionerConfig{StickyKey: &StickyKeyPartitionerConfig{
+			Hasher: HasherSaramaCompat,
+		}},
 		componenttest.NewNopHost(), numPartitions, topic,
 	)
 
@@ -298,7 +301,7 @@ func TestRecordPartitioner_LeastBackup(t *testing.T) {
 	const topic = "lb-topic"
 
 	client, brokers := newPartitioningProducer(t,
-		RecordPartitionerConfig{Type: RecordPartitionerTypeLeastBackup},
+		RecordPartitionerConfig{LeastBackup: &struct{}{}},
 		componenttest.NewNopHost(), numPartitions, topic,
 	)
 
@@ -326,7 +329,7 @@ func TestRecordPartitioner_Extension_CustomRouting(t *testing.T) {
 	}
 
 	client, brokers := newPartitioningProducer(t,
-		RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
+		RecordPartitionerConfig{Extension: &extID},
 		host, numPartitions, topic,
 	)
 

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -112,11 +112,6 @@ func TestBuildPartitionerOpt(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "default (empty type)",
-			cfg:  RecordPartitionerConfig{},
-			host: componenttest.NewNopHost(),
-		},
-		{
 			name: "sarama_compatible",
 			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
 			host: componenttest.NewNopHost(),
@@ -261,7 +256,9 @@ func TestRecordPartitioner_SaramaCompatible_SameKeyConsistency(t *testing.T) {
 	const numRecords = 6
 
 	client, brokers := newPartitioningProducer(t,
-		RecordPartitionerConfig{}, // default = sarama_compatible
+		RecordPartitionerConfig{
+			Type: RecordPartitionerTypeSaramaCompatible,
+		},
 		componenttest.NewNopHost(), numPartitions, topic,
 	)
 

--- a/exporter/kafkaexporter/partitioner_test.go
+++ b/exporter/kafkaexporter/partitioner_test.go
@@ -52,10 +52,6 @@ func TestRecordPartitionerConfig_Validate(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "empty type (default)",
-			cfg:  RecordPartitionerConfig{},
-		},
-		{
 			name: "sarama_compatible",
 			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeSaramaCompatible},
 		},
@@ -69,11 +65,11 @@ func TestRecordPartitionerConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "extension with ID",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
 		},
 		{
 			name:    "extension without ID",
-			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeExtension},
+			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeCustom},
 			wantErr: errRecordPartitionerExtRequired.Error(),
 		},
 		{
@@ -137,18 +133,18 @@ func TestBuildPartitionerOpt(t *testing.T) {
 		},
 		{
 			name: "extension",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
 			host: hostWithExt,
 		},
 		{
 			name:    "extension not found",
-			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &compID},
+			cfg:     RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &compID},
 			host:    componenttest.NewNopHost(),
 			wantErr: `partitioner extension "missing" not found`,
 		},
 		{
 			name: "extension does not implement RecordPartitionerExtension",
-			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+			cfg:  RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
 			host: &mockHostWithExtensions{
 				Host: componenttest.NewNopHost(),
 				extensions: map[component.ID]component.Component{
@@ -333,7 +329,7 @@ func TestRecordPartitioner_Extension_CustomRouting(t *testing.T) {
 	}
 
 	client, brokers := newPartitioningProducer(t,
-		RecordPartitionerConfig{Type: RecordPartitionerTypeExtension, Extension: &extID},
+		RecordPartitionerConfig{Type: RecordPartitionerTypeCustom, Extension: &extID},
 		host, numPartitions, topic,
 	)
 

--- a/exporter/kafkaexporter/testdata/config-partitioning-failed.yaml
+++ b/exporter/kafkaexporter/testdata/config-partitioning-failed.yaml
@@ -45,3 +45,9 @@ kafka/per_signal_encoding:
     encoding: per_signal_encoding
   profiles:
     encoding: per_signal_encoding
+kafka/invalid_partitioner:
+  record_partitioner:
+    type: invalid_partitioner
+kafka/extension_not_set:
+  record_partitioner:
+    type: custom

--- a/exporter/kafkaexporter/testdata/config-partitioning-failed.yaml
+++ b/exporter/kafkaexporter/testdata/config-partitioning-failed.yaml
@@ -45,9 +45,14 @@ kafka/per_signal_encoding:
     encoding: per_signal_encoding
   profiles:
     encoding: per_signal_encoding
-kafka/invalid_partitioner:
+kafka/multiple_partitioner:
   record_partitioner:
-    type: invalid_partitioner
+    round_robin: {}
+    least_backup: {}
 kafka/extension_not_set:
   record_partitioner:
-    type: custom
+    extension: ""
+kafka/invalid_sticky_key_hasher:
+  record_partitioner:
+    sticky_key:
+      hasher: invalid_hasher

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -47,6 +47,21 @@ kafka/per_signal_encoding:
     encoding: per_signal_encoding
   profiles:
     encoding: per_signal_encoding
+kafka/round_robin_partitioner:
+  brokers:
+    - "localhost:9092"
+  record_partitioner:
+    type: round_robin
+kafka/least_backup_partitioner:
+  brokers:
+    - "localhost:9092"
+  record_partitioner:
+    type: least_backup
+kafka/sticky_partitioner:
+  brokers:
+    - "localhost:9092"
+  record_partitioner:
+    type: sticky
 kafka/metadata_batch_valid:
   include_metadata_keys:
     - metadata_key

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -51,17 +51,24 @@ kafka/round_robin_partitioner:
   brokers:
     - "localhost:9092"
   record_partitioner:
-    type: round_robin
+    round_robin: {}
 kafka/least_backup_partitioner:
   brokers:
     - "localhost:9092"
   record_partitioner:
-    type: least_backup
-kafka/sticky_partitioner:
+    least_backup: {}
+kafka/sticky_key_partitioner:
   brokers:
     - "localhost:9092"
   record_partitioner:
-    type: sticky
+    sticky_key:
+      hasher: sarama_compat
+kafka/sticky_key_partitioner_murmur2:
+  brokers:
+    - "localhost:9092"
+  record_partitioner:
+    sticky_key:
+      hasher: murmur2
 kafka/metadata_batch_valid:
   include_metadata_keys:
     - metadata_key

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -373,7 +373,13 @@ func compressionCodec(compression string) kgo.CompressionCodec {
 }
 
 func NewSaramaCompatPartitioner() kgo.Partitioner {
-	return kgo.StickyKeyPartitioner(kgo.SaramaCompatHasher(saramaHashFn))
+	return kgo.StickyKeyPartitioner(NewSaramaCompatHasher())
+}
+
+// NewSaramaCompatHasher returns a PartitionerHasher that replicates the default
+// Sarama partitioning behavior: FNV-1a hashing with Sarama's int32 sign convention.
+func NewSaramaCompatHasher() kgo.PartitionerHasher {
+	return kgo.SaramaCompatHasher(saramaHashFn)
 }
 
 func saramaHashFn(b []byte) uint32 {

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -62,7 +62,7 @@ func NewFranzSyncProducer(
 	}
 	// Prepend a default sarama-compatible partitioner so that callers can override
 	// it by appending their own kgo.RecordPartitioner option in opts.
-	opts = append([]kgo.Opt{kgo.RecordPartitioner(NewSaramaCompatPartitioner())}, opts...)
+	opts = append([]kgo.Opt{kgo.RecordPartitioner(newSaramaCompatPartitioner())}, opts...)
 	opts, err := commonOpts(ctx, host, clientCfg, logger, append(
 		opts,
 		kgo.ProduceRequestTimeout(timeout),
@@ -372,7 +372,7 @@ func compressionCodec(compression string) kgo.CompressionCodec {
 	}
 }
 
-func NewSaramaCompatPartitioner() kgo.Partitioner {
+func newSaramaCompatPartitioner() kgo.Partitioner {
 	return kgo.StickyKeyPartitioner(NewSaramaCompatHasher())
 }
 

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -60,14 +60,13 @@ func NewFranzSyncProducer(
 	default:
 		codec = codec.WithLevel(int(cfg.CompressionParams.Level))
 	}
+	// Prepend a default sarama-compatible partitioner so that callers can override
+	// it by appending their own kgo.RecordPartitioner option in opts.
+	opts = append([]kgo.Opt{kgo.RecordPartitioner(NewSaramaCompatPartitioner())}, opts...)
 	opts, err := commonOpts(ctx, host, clientCfg, logger, append(
 		opts,
 		kgo.ProduceRequestTimeout(timeout),
 		kgo.ProducerBatchCompression(codec),
-		// Use the UniformBytesPartitioner that is the default in franz-go with
-		// the legacy compatibility sarama hashing to avoid hashing to different
-		// partitions in case partitioning is enabled.
-		kgo.RecordPartitioner(newSaramaCompatPartitioner()),
 		kgo.ProducerLinger(cfg.Linger),
 		kgo.ProducerBatchMaxBytes(int32(cfg.MaxMessageBytes)),
 		kgo.MaxBufferedRecords(cfg.FlushMaxMessages),
@@ -373,7 +372,7 @@ func compressionCodec(compression string) kgo.CompressionCodec {
 	}
 }
 
-func newSaramaCompatPartitioner() kgo.Partitioner {
+func NewSaramaCompatPartitioner() kgo.Partitioner {
 	return kgo.StickyKeyPartitioner(kgo.SaramaCompatHasher(saramaHashFn))
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds support for partitioning records based on known partitioners exposed by franz-go library. 
A new config, `record_partitioner` is exposed for this purpose. Moreover, users can also implement their own partitioning logic by implementing a new extension and implementing the `RecordPartitionerExtension` interface in the extension. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46931

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added

<!--Describe the documentation added.-->
#### Documentation

Added

<!--Please delete paragraphs that you did not use before submitting.-->
