### PR TITLE
[receiver/namedpipe] rename to `named_pipe` with deprecated alias `namedpipe`

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -290,7 +290,7 @@ components:
     - receiver/mongodb
     - receiver/mongodb_atlas
     - receiver/mysql
-    - receiver/namedpipe
+    - receiver/named_pipe
     - receiver/netflow
     - receiver/nginx
     - receiver/nsxt

--- a/.chloggen/rename-named-pipe-receiver.yaml
+++ b/.chloggen/rename-named-pipe-receiver.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: deprecation
+
+component: receiver/named_pipe
+
+note: Rename `namedpipe` receiver to `named_pipe` with deprecated alias `namedpipe`.
+
+issues: [45339]
+
+subtext:
+
+change_logs: [user]

--- a/.schemagen.yaml
+++ b/.schemagen.yaml
@@ -25,7 +25,7 @@ allowedRefs:
   - go.opentelemetry.io/collector
   - github.com/open-telemetry/opentelemetry-collector-contrib
 componentOverrides:
-  receiver/namedpipe:
+  receiver/named_pipe:
     configName: 'NamedPipeConfig'
   receiver/file_log:
     configName: 'FileLogConfig'

--- a/cmd/schemagen/README.md
+++ b/cmd/schemagen/README.md
@@ -77,7 +77,7 @@ allowedRefs:
   - go.opentelemetry.io/collector
   - github.com/open-telemetry/opentelemetry-collector-contrib
 componentOverrides:
-  receiver/namedpipe:
+  receiver/named_pipe:
     configName: 'NamedPipeConfig'
   receiver/file_log:
     configName: 'FileLogConfig'

--- a/receiver/namedpipereceiver/README.md
+++ b/receiver/namedpipereceiver/README.md
@@ -22,7 +22,6 @@ This receiver supports opening a Unix Named Pipe (aka FIFO), and reading logs fr
 
 Named pipes are only supported on Unix operating systems.
 
-
 ## Configuration
 
 The following settings are required:
@@ -31,9 +30,18 @@ The following settings are required:
 
 The following settings are optional:
 
-- `mode`: The mode bits to set on the opened pipe (default: 666)
+- `mode`: The mode bits to set on the opened pipe (default: 0666)
 
 ## Example Configuration
+
+```yaml
+receivers:
+  named_pipe:
+    path: /tmp/pipe
+    mode: 0600
+```
+
+The deprecated component type `namedpipe` is still accepted:
 
 ```yaml
 receivers:

--- a/receiver/namedpipereceiver/config.schema.yaml
+++ b/receiver/namedpipereceiver/config.schema.yaml
@@ -1,4 +1,4 @@
-description: NamedPipeConfig defines configuration for the namedpipe receiver
+description: NamedPipeConfig defines configuration for the named_pipe receiver
 type: object
 allOf:
   - $ref: /pkg/stanza/operator/input/namedpipe.config

--- a/receiver/namedpipereceiver/generated_component_test.go
+++ b/receiver/namedpipereceiver/generated_component_test.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
-var typ = component.MustNewType("namedpipe")
+var typ = component.MustNewType("named_pipe")
 
 func TestComponentFactoryType(t *testing.T) {
 	require.Equal(t, typ, NewFactory().Type())

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumertest v0.149.0
 	go.opentelemetry.io/collector/pdata v1.55.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.149.0
+	go.opentelemetry.io/collector/receiver/xreceiver v0.149.0
 	go.uber.org/zap v1.27.1
 )
 
@@ -61,7 +62,6 @@ require (
 	go.opentelemetry.io/collector/pipeline v1.55.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.149.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.149.0 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.149.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect

--- a/receiver/namedpipereceiver/internal/metadata/generated_status.go
+++ b/receiver/namedpipereceiver/internal/metadata/generated_status.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("namedpipe")
-	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
+	Type           = component.MustNewType("named_pipe")
+	DeprecatedType = component.MustNewType("namedpipe")
+	ScopeName      = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
 )
 
 const (

--- a/receiver/namedpipereceiver/metadata.yaml
+++ b/receiver/namedpipereceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: Named Pipe Receiver
-type: namedpipe
+type: named_pipe
+deprecated_type: namedpipe
 
 description: |
   This receiver supports opening a Unix Named Pipe (aka FIFO), and reading logs from it.

--- a/receiver/namedpipereceiver/namedpipe.go
+++ b/receiver/namedpipereceiver/namedpipe.go
@@ -6,6 +6,7 @@ package namedpipereceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/consumerretry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
@@ -14,8 +15,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver/internal/metadata"
 )
 
+// NewFactory creates a factory for the named_pipe receiver.
 func NewFactory() receiver.Factory {
-	return adapter.NewFactory(&ReceiverType{}, metadata.LogsStability)
+	return adapter.NewFactory(&ReceiverType{}, metadata.LogsStability,
+		xreceiver.WithDeprecatedTypeAlias(metadata.DeprecatedType),
+	)
 }
 
 type ReceiverType struct{}
@@ -50,7 +54,7 @@ func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*NamedPipeConfig).BaseConfig
 }
 
-// NamedPipeConfig defines configuration for the namedpipe receiver
+// NamedPipeConfig defines configuration for the named_pipe receiver
 type NamedPipeConfig struct {
 	InputConfig        namedpipe.Config `mapstructure:",squash"`
 	adapter.BaseConfig `mapstructure:",squash"`

--- a/receiver/namedpipereceiver/namedpipe_test.go
+++ b/receiver/namedpipereceiver/namedpipe_test.go
@@ -41,6 +41,21 @@ func TestLoadConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
+	sub, err := cm.Sub(component.MustNewID("named_pipe").String())
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	assert.NoError(t, xconfmap.Validate(cfg))
+	assert.Equal(t, testdataConfigYaml(), cfg)
+}
+
+func TestLoadConfigDeprecatedTypeAlias(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config-deprecated.yaml"))
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
 	sub, err := cm.Sub(component.MustNewID("namedpipe").String())
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(cfg))

--- a/receiver/namedpipereceiver/testdata/config-deprecated.yaml
+++ b/receiver/namedpipereceiver/testdata/config-deprecated.yaml
@@ -1,4 +1,4 @@
-named_pipe:
+namedpipe:
   path: /tmp/pipe
   mode: 0600
   encoding: utf-8

--- a/reports/distributions/contrib.yaml
+++ b/reports/distributions/contrib.yaml
@@ -188,7 +188,7 @@ components:
         - mongodb
         - mongodb_atlas
         - mysql
-        - namedpipe
+        - named_pipe
         - netflow
         - nginx
         - nsxt


### PR DESCRIPTION
Part of:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45339

First commit only has the rename, the second commit updates all references I found.