### PR TITLE
docs(redactionprocessor): clarify precedence rules between allowed an…

### DIFF
--- a/.chloggen/clarify-redaction-precedence.yaml
+++ b/.chloggen/clarify-redaction-precedence.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
-component: redactionprocessor
+component: processor/redaction
 note: Clarify precedence rules between allowed and blocked keys for deterministic behavior.
 issues: [43826]

--- a/.chloggen/clarify-redaction-precedence.yaml
+++ b/.chloggen/clarify-redaction-precedence.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: redactionprocessor
+note: Clarify precedence rules between allowed and blocked keys for deterministic behavior.
+issues: [43826]

--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -153,6 +153,16 @@ processors:
 ```
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed
+
+### Precedence Rules
+
+When both `allowed_keys` and `blocked_keys` are defined, the following logic applies:
+
+1. **Strict Precedence:** `allowed_keys` always takes precedence over `blocked_keys`.
+2. **Conflict Handling:** If a key matches a pattern in both lists, it is **retained** (not redacted/blocked).
+3. **Default Behavior:** If `allowed_keys` is configured but empty, all attributes will be removed unless `allow_all_keys` is explicitly set to `true`.
+
+
 examples on using the processor.
 
 ### Attributes Processor for Metrics vs. [Metric Transform Processor](../metricstransformprocessor)


### PR DESCRIPTION
…d blocked keys

Following the ambiguity reported in issue #43826, this commit explicitly  documents that 'allowed_keys' (or allowed_values) has strict precedence  over 'blocked_keys'.

- Added 'Precedence Rules' section to README.md.
- Formalized the deterministic behavior for agentic and high-scale workflows.
- Cleaned up the diff to ensure zero unrelated changes.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
