### PR TITLE
Add exemplar support to OTTL-backed metric transforms into transformprocessor

### DIFF
--- a/.chloggen/ottlexemplar-context.yaml
+++ b/.chloggen/ottlexemplar-context.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: pkg/ottl
+
+note: "Add `ottlexemplar` context exposing per-exemplar fields (`time`, `filtered_attributes`, `double_value`, `int_value`, `trace_id`, `span_id`) for use in OTTL statements."
+
+issues: [47322]
+
+subtext:
+
+change_logs: [user, api]

--- a/.chloggen/transformprocessor-exemplar-context.yaml
+++ b/.chloggen/transformprocessor-exemplar-context.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: processor/transform
+
+note: "Wire `ottlexemplar` context into the transform processor, enabling `metric_statements` with `context: exemplar` to manipulate exemplar fields such as timestamps."
+
+issues: [47322]
+
+subtext:
+
+change_logs: [user]

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
@@ -98,6 +99,27 @@ func NewBoolExprForDataPointWithOptions(conditions []string, functions map[strin
 		return nil, err
 	}
 	c := ottldatapoint.NewConditionSequence(statements, set, ottldatapoint.WithConditionSequenceErrorMode(errorMode))
+	return &c, nil
+}
+
+// NewBoolExprForExemplar creates a BoolExpr[*ottlexemplar.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// The passed in functions should use the ottlexemplar.TransformContext.
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
+func NewBoolExprForExemplar(conditions []string, functions map[string]ottl.Factory[*ottlexemplar.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottlexemplar.TransformContext], error) {
+	return NewBoolExprForExemplarWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForExemplarWithOptions is like NewBoolExprForExemplar, but with additional options.
+func NewBoolExprForExemplarWithOptions(conditions []string, functions map[string]ottl.Factory[*ottlexemplar.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottlexemplar.TransformContext]) (*ottl.ConditionSequence[*ottlexemplar.TransformContext], error) {
+	parser, err := ottlexemplar.NewParser(functions, set, parserOptions...)
+	if err != nil {
+		return nil, err
+	}
+	statements, err := parser.ParseConditions(conditions)
+	if err != nil {
+		return nil, err
+	}
+	c := ottlexemplar.NewConditionSequence(statements, set, ottlexemplar.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }
 

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
@@ -43,6 +44,10 @@ func StandardMetricFuncs() map[string]ottl.Factory[*ottlmetric.TransformContext]
 
 func StandardDataPointFuncs() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
 	return ottlfuncs.StandardConverters[*ottldatapoint.TransformContext]()
+}
+
+func StandardExemplarFuncs() map[string]ottl.Factory[*ottlexemplar.TransformContext] {
+	return ottlfuncs.StandardConverters[*ottlexemplar.TransformContext]()
 }
 
 func StandardScopeFuncs() map[string]ottl.Factory[*ottlscope.TransformContext] {

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -51,6 +51,7 @@ To see a list of available Paths for each Open Telemetry Signal, checkout the li
 | `Span Event`            | [SpanEvent](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlspanevent/README.md)         |
 | `Metric`                | [Metric](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlmetric/README.md)               |
 | `Datapoint`             | [DataPoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottldatapoint/README.md)         |
+| `Exemplar`              | [Exemplar](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlexemplar/README.md)           |
 | `Log`                   | [Log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog/README.md)                     |
 | `Profile`               | [Profile](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlprofile/README.md)             |
 

--- a/pkg/ottl/contexts/README.md
+++ b/pkg/ottl/contexts/README.md
@@ -8,4 +8,4 @@ A Context's `PathExpressionParser` is what the OTTL will use to interpret a Path
 
 A Context's `EnumParser` is what the OTTL will use to interpret an Enum Symbol.  For the data model being represented, it should be able to handle any incoming Enum Symbol and return the appropriate Enum value.  It should return an error if the Enum Symbol is not known.  
 
-Context implementations for Traces, Metrics, and Logs are provided by this module.  It is recommended to use these contexts when using the OTTL to interact with OpenTelemetry traces, metrics, and logs. 
+Context implementations for Traces, Metrics, Logs, and Exemplars are provided by this module. It is recommended to use these contexts when using the OTTL to interact with OpenTelemetry traces, metrics, logs, and exemplars.

--- a/pkg/ottl/contexts/internal/ctxexemplar/context.go
+++ b/pkg/ottl/contexts/internal/ctxexemplar/context.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ctxexemplar // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxexemplar"
+
+import "go.opentelemetry.io/collector/pdata/pmetric"
+
+const (
+	Name   = "exemplar"
+	DocRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlexemplar"
+)
+
+type Context interface {
+	GetExemplar() pmetric.Exemplar
+}

--- a/pkg/ottl/contexts/internal/ctxexemplar/exemplar.go
+++ b/pkg/ottl/contexts/internal/ctxexemplar/exemplar.go
@@ -1,0 +1,155 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ctxexemplar // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxexemplar"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+)
+
+func PathGetSetter[K Context](path ottl.Path[K]) (ottl.GetSetter[K], error) {
+	if path == nil {
+		return nil, ctxerror.New("nil", "nil", Name, DocRef)
+	}
+	switch path.Name() {
+	case "time_unix_nano":
+		return accessExemplarTimeUnixNano[K](), nil
+	case "time":
+		return accessExemplarTime[K](), nil
+	case "double_value":
+		return accessExemplarDoubleValue[K](), nil
+	case "int_value":
+		return accessExemplarIntValue[K](), nil
+	case "trace_id":
+		return accessExemplarTraceID[K](), nil
+	case "span_id":
+		return accessExemplarSpanID[K](), nil
+	case "filtered_attributes":
+		if path.Keys() == nil {
+			return accessExemplarFilteredAttributes[K](), nil
+		}
+		return accessExemplarFilteredAttributesKey(path.Keys()), nil
+	default:
+		return nil, ctxerror.New(path.Name(), path.String(), Name, DocRef)
+	}
+}
+
+func accessExemplarTimeUnixNano[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().Timestamp().AsTime().UnixNano(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newTimestamp, ok := val.(int64); ok {
+				tCtx.GetExemplar().SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTimestamp)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessExemplarTime[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().Timestamp().AsTime(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newTimestamp, ok := val.(time.Time); ok {
+				tCtx.GetExemplar().SetTimestamp(pcommon.NewTimestampFromTime(newTimestamp))
+			}
+			return nil
+		},
+	}
+}
+
+func accessExemplarDoubleValue[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().DoubleValue(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newVal, ok := val.(float64); ok {
+				tCtx.GetExemplar().SetDoubleValue(newVal)
+			}
+			return nil
+		},
+	}
+}
+
+func accessExemplarIntValue[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().IntValue(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newVal, ok := val.(int64); ok {
+				tCtx.GetExemplar().SetIntValue(newVal)
+			}
+			return nil
+		},
+	}
+}
+
+func accessExemplarTraceID[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().TraceID(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newTraceID, ok := val.(pcommon.TraceID); ok {
+				tCtx.GetExemplar().SetTraceID(newTraceID)
+			}
+			return nil
+		},
+	}
+}
+
+func accessExemplarSpanID[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().SpanID(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newSpanID, ok := val.(pcommon.SpanID); ok {
+				tCtx.GetExemplar().SetSpanID(newSpanID)
+			}
+			return nil
+		},
+	}
+}
+
+func accessExemplarFilteredAttributes[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetExemplar().FilteredAttributes(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			return ctxutil.SetMap(tCtx.GetExemplar().FilteredAttributes(), val)
+		},
+	}
+}
+
+func accessExemplarFilteredAttributesKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (any, error) {
+			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetExemplar().FilteredAttributes(), key)
+		},
+		Setter: func(ctx context.Context, tCtx K, val any) error {
+			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetExemplar().FilteredAttributes(), key, val)
+		},
+	}
+}
+
+// ExemplarValueType returns the value type of the exemplar.
+// This is a convenience helper used by the public ottlexemplar context.
+func ExemplarValueType(e pmetric.Exemplar) pmetric.ExemplarValueType {
+	return e.ValueType()
+}

--- a/pkg/ottl/contexts/internal/ctxexemplar/exemplar_test.go
+++ b/pkg/ottl/contexts/internal/ctxexemplar/exemplar_test.go
@@ -1,0 +1,241 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ctxexemplar_test
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxexemplar"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
+)
+
+var (
+	traceID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID  = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	traceID2 = [16]byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+	spanID2  = [8]byte{8, 7, 6, 5, 4, 3, 2, 1}
+)
+
+func TestPathGetSetter(t *testing.T) {
+	refExemplar := createTelemetry()
+
+	newFilteredAttrs := pcommon.NewMap()
+	newFilteredAttrs.PutStr("hello", "world")
+
+	newPMap := pcommon.NewMap()
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]any)
+	newMap2 := make(map[string]any)
+	newMap2["k1"] = "string"
+	newMap["k2"] = newMap2
+
+	tests := []struct {
+		name              string
+		path              ottl.Path[*testContext]
+		orig              any
+		newVal            any
+		expectSetterError bool
+		modified          func(exemplar pmetric.Exemplar)
+	}{
+		{
+			name: "time_unix_nano",
+			path: &pathtest.Path[*testContext]{
+				N: "time_unix_nano",
+			},
+			orig:   int64(100_000_000),
+			newVal: int64(200_000_000),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+			},
+		},
+		{
+			name: "time",
+			path: &pathtest.Path[*testContext]{
+				N: "time",
+			},
+			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+			},
+		},
+		{
+			name: "double_value",
+			path: &pathtest.Path[*testContext]{
+				N: "double_value",
+			},
+			orig:   float64(1.5),
+			newVal: float64(2.5),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.SetDoubleValue(2.5)
+			},
+		},
+		{
+			name: "int_value",
+			path: &pathtest.Path[*testContext]{
+				N: "int_value",
+			},
+			orig:   int64(0),
+			newVal: int64(42),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.SetIntValue(42)
+			},
+		},
+		{
+			name: "trace_id",
+			path: &pathtest.Path[*testContext]{
+				N: "trace_id",
+			},
+			orig:   pcommon.TraceID(traceID),
+			newVal: pcommon.TraceID(traceID2),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.SetTraceID(pcommon.TraceID(traceID2))
+			},
+		},
+		{
+			name: "span_id",
+			path: &pathtest.Path[*testContext]{
+				N: "span_id",
+			},
+			orig:   pcommon.SpanID(spanID),
+			newVal: pcommon.SpanID(spanID2),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.SetSpanID(pcommon.SpanID(spanID2))
+			},
+		},
+		{
+			name: "filtered_attributes",
+			path: &pathtest.Path[*testContext]{
+				N: "filtered_attributes",
+			},
+			orig:   refExemplar.FilteredAttributes(),
+			newVal: newFilteredAttrs,
+			modified: func(exemplar pmetric.Exemplar) {
+				newFilteredAttrs.CopyTo(exemplar.FilteredAttributes())
+			},
+		},
+		{
+			name: "filtered_attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "filtered_attributes",
+			},
+			orig:   refExemplar.FilteredAttributes(),
+			newVal: newFilteredAttrs.AsRaw(),
+			modified: func(exemplar pmetric.Exemplar) {
+				_ = exemplar.FilteredAttributes().FromRaw(newFilteredAttrs.AsRaw())
+			},
+		},
+		{
+			name: "filtered_attributes string",
+			path: &pathtest.Path[*testContext]{
+				N: "filtered_attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("str"),
+					},
+				},
+			},
+			orig:   "val",
+			newVal: "newVal",
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.FilteredAttributes().PutStr("str", "newVal")
+			},
+		},
+		{
+			name: "filtered_attributes int",
+			path: &pathtest.Path[*testContext]{
+				N: "filtered_attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("int"),
+					},
+				},
+			},
+			orig:   int64(10),
+			newVal: int64(20),
+			modified: func(exemplar pmetric.Exemplar) {
+				exemplar.FilteredAttributes().PutInt("int", 20)
+			},
+		},
+	}
+
+	// Also test with explicit context prefix on the path.
+	for _, tt := range slices.Clone(tests) {
+		testWithContext := tt
+		testWithContext.name = "with_path_context:" + tt.name
+		pathWithContext := *tt.path.(*pathtest.Path[*testContext])
+		pathWithContext.C = ctxexemplar.Name
+		testWithContext.path = ottl.Path[*testContext](&pathWithContext)
+		tests = append(tests, testWithContext)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessor, err := ctxexemplar.PathGetSetter(tt.path)
+			require.NoError(t, err)
+
+			exemplar := createTelemetry()
+			tCtx := newTestContext(exemplar)
+
+			got, err := accessor.Get(t.Context(), tCtx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.orig, got)
+
+			err = accessor.Set(t.Context(), tCtx, tt.newVal)
+			if tt.expectSetterError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			exExemplar := createTelemetry()
+			tt.modified(exExemplar)
+			assert.Equal(t, exExemplar, exemplar)
+		})
+	}
+}
+
+func TestPathGetSetter_InvalidPath(t *testing.T) {
+	_, err := ctxexemplar.PathGetSetter[*testContext](&pathtest.Path[*testContext]{N: "unknown_field"})
+	assert.Error(t, err)
+}
+
+func TestPathGetSetter_NilPath(t *testing.T) {
+	_, err := ctxexemplar.PathGetSetter[*testContext](nil)
+	assert.Error(t, err)
+}
+
+func createTelemetry() pmetric.Exemplar {
+	exemplar := pmetric.NewExemplar()
+	exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
+	exemplar.SetDoubleValue(1.5)
+	exemplar.SetTraceID(pcommon.TraceID(traceID))
+	exemplar.SetSpanID(pcommon.SpanID(spanID))
+	exemplar.FilteredAttributes().PutStr("str", "val")
+	exemplar.FilteredAttributes().PutInt("int", 10)
+	return exemplar
+}
+
+type testContext struct {
+	exemplar pmetric.Exemplar
+}
+
+func (t *testContext) GetExemplar() pmetric.Exemplar {
+	return t.exemplar
+}
+
+func newTestContext(exemplar pmetric.Exemplar) *testContext {
+	return &testContext{exemplar: exemplar}
+}

--- a/pkg/ottl/contexts/ottlexemplar/README.md
+++ b/pkg/ottl/contexts/ottlexemplar/README.md
@@ -1,0 +1,34 @@
+# OTTL Exemplar Context
+
+The `exemplar` context allows OTTL statements to read and modify individual
+[exemplars](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exemplars)
+attached to metric datapoints.
+
+## Paths
+
+The following paths are supported. All paths also support access to parent
+contexts via their context prefix (e.g. `resource.attributes`, `metric.name`).
+
+| Path | Type | Description |
+|---|---|---|
+| `exemplar.time_unix_nano` | `int64` | Exemplar timestamp as Unix nanoseconds |
+| `exemplar.time` | `time.Time` | Exemplar timestamp as `time.Time` |
+| `exemplar.double_value` | `float64` | Double observation value |
+| `exemplar.int_value` | `int64` | Integer observation value |
+| `exemplar.trace_id` | `pcommon.TraceID` | Associated trace ID |
+| `exemplar.span_id` | `pcommon.SpanID` | Associated span ID |
+| `exemplar.filtered_attributes` | `pcommon.Map` | Attributes filtered from the original measurement |
+| `exemplar.filtered_attributes["key"]` | any | Individual filtered attribute value |
+| `exemplar.cache` | `pcommon.Map` | Mutable per-exemplar cache (not exported) |
+
+## Example: shift exemplar timestamps by a fixed offset
+
+```yaml
+processors:
+  transform/shift_timestamps:
+    error_mode: ignore
+    metric_statements:
+      - context: exemplar
+        statements:
+          - set(exemplar.time, exemplar.time + Duration("2h")) where exemplar.time_unix_nano != 0
+```

--- a/pkg/ottl/contexts/ottlexemplar/exemplar.go
+++ b/pkg/ottl/contexts/ottlexemplar/exemplar.go
@@ -1,0 +1,230 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlexemplar // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
+
+import (
+	"errors"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcache"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxdatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxexemplar"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxotelcol"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
+)
+
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
+
+// ContextName is the name of the context for exemplars.
+// Experimental: *NOTE* this constant is subject to change or removal in the future.
+const ContextName = ctxexemplar.Name
+
+var (
+	_ ctxresource.Context     = (*TransformContext)(nil)
+	_ ctxscope.Context        = (*TransformContext)(nil)
+	_ ctxmetric.Context       = (*TransformContext)(nil)
+	_ ctxdatapoint.Context    = (*TransformContext)(nil)
+	_ ctxexemplar.Context     = (*TransformContext)(nil)
+	_ zapcore.ObjectMarshaler = (*TransformContext)(nil)
+)
+
+// TransformContext represents an Exemplar and all its hierarchy.
+type TransformContext struct {
+	resourceMetrics pmetric.ResourceMetrics
+	scopeMetrics    pmetric.ScopeMetrics
+	metric          pmetric.Metric
+	dataPoint       any
+	exemplar        pmetric.Exemplar
+	cache           pcommon.Map
+}
+
+// MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	err := encoder.AddObject("resource", logging.Resource(tCtx.GetResource()))
+	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.GetInstrumentationScope())))
+	err = errors.Join(err, encoder.AddObject("metric", logging.Metric(tCtx.metric)))
+	err = errors.Join(err, encoder.AddObject("exemplar", logging.Exemplar(tCtx.exemplar)))
+	err = errors.Join(err, encoder.AddObject("cache", logging.Map(tCtx.cache)))
+	return err
+}
+
+// TransformContextOption represents an option for configuring a TransformContext.
+type TransformContextOption func(*TransformContext)
+
+// NewTransformContextPtr returns a new TransformContext from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dataPoint any, exemplar pmetric.Exemplar, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.resourceMetrics = resourceMetrics
+	tCtx.scopeMetrics = scopeMetrics
+	tCtx.metric = metric
+	tCtx.dataPoint = dataPoint
+	tCtx.exemplar = exemplar
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close returns the TransformContext to the pool.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.resourceMetrics = pmetric.ResourceMetrics{}
+	tCtx.scopeMetrics = pmetric.ScopeMetrics{}
+	tCtx.metric = pmetric.Metric{}
+	tCtx.dataPoint = nil
+	tCtx.exemplar = pmetric.Exemplar{}
+	tCtx.cache.Clear()
+	tcPool.Put(tCtx)
+}
+
+// GetExemplar returns the exemplar from the TransformContext.
+func (tCtx *TransformContext) GetExemplar() pmetric.Exemplar {
+	return tCtx.exemplar
+}
+
+// GetDataPoint returns the parent datapoint from the TransformContext.
+func (tCtx *TransformContext) GetDataPoint() any {
+	return tCtx.dataPoint
+}
+
+// GetMetric returns the metric from the TransformContext.
+func (tCtx *TransformContext) GetMetric() pmetric.Metric {
+	return tCtx.metric
+}
+
+// GetInstrumentationScope returns the instrumentation scope from the TransformContext.
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+	return tCtx.scopeMetrics.Scope()
+}
+
+// GetResource returns the resource from the TransformContext.
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
+	return tCtx.resourceMetrics.Resource()
+}
+
+// GetScopeSchemaURLItem returns the schema URL item for the scope from the TransformContext.
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+	return tCtx.scopeMetrics
+}
+
+// GetResourceSchemaURLItem returns the schema URL item for the resource from the TransformContext.
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+	return tCtx.resourceMetrics
+}
+
+// GetMetrics returns the metric slice from the TransformContext.
+func (tCtx *TransformContext) GetMetrics() pmetric.MetricSlice {
+	return tCtx.scopeMetrics.Metrics()
+}
+
+// EnablePathContextNames enables the support for path's context names on statements.
+// When this option is configured, all statement's paths must have a valid context prefix,
+// otherwise an error is reported.
+//
+// Experimental: *NOTE* this option is subject to change or removal in the future.
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
+			ctxexemplar.Name,
+			ctxdatapoint.Name,
+			ctxresource.Name,
+			ctxscope.LegacyName,
+			ctxscope.Name,
+			ctxmetric.Name,
+			ctxotelcol.Name,
+		})(p)
+	}
+}
+
+// StatementSequenceOption represents an option for configuring a statement sequence.
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
+
+// WithStatementSequenceErrorMode sets the error mode for a statement sequence.
+func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
+	}
+}
+
+// NewStatementSequence creates a new statement sequence with the provided statements and options.
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
+	s := ottl.NewStatementSequence(statements, telemetrySettings)
+	for _, op := range options {
+		op(&s)
+	}
+	return s
+}
+
+// ConditionSequenceOption represents an option for configuring a condition sequence.
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
+
+// WithConditionSequenceErrorMode sets the error mode for a condition sequence.
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
+	}
+}
+
+// NewConditionSequence creates a new condition sequence with the provided conditions and options.
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
+}
+
+// NewParser creates a new exemplar parser with the provided functions and options.
+func NewParser(
+	functions map[string]ottl.Factory[*TransformContext],
+	telemetrySettings component.TelemetrySettings,
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
+	return ctxcommon.NewParser(
+		functions,
+		telemetrySettings,
+		pathExpressionParser(getCache),
+		parseEnum,
+		options...,
+	)
+}
+
+func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
+	return nil, errors.New("exemplar context does not support enums")
+}
+
+func getCache(tCtx *TransformContext) pcommon.Map {
+	return tCtx.cache
+}
+
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
+	return ctxcommon.PathExpressionParser(
+		ctxexemplar.Name,
+		ctxexemplar.DocRef,
+		cacheGetter,
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
+			ctxmetric.Name:      ctxmetric.PathGetSetter[*TransformContext],
+			ctxdatapoint.Name:   ctxdatapoint.PathGetSetter[*TransformContext],
+			ctxexemplar.Name:    ctxexemplar.PathGetSetter[*TransformContext],
+			ctxotelcol.Name:     ctxotelcol.PathGetSetter[*TransformContext],
+		})
+}

--- a/pkg/ottl/contexts/ottlexemplar/exemplar_test.go
+++ b/pkg/ottl/contexts/ottlexemplar/exemplar_test.go
@@ -1,0 +1,358 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlexemplar
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxdatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxexemplar"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
+)
+
+func Test_newPathGetSetter(t *testing.T) {
+	_, _, _, _, refExemplar := createTelemetry()
+
+	newAttrs := pcommon.NewMap()
+	newAttrs.PutStr("hello", "world")
+
+	newCache := pcommon.NewMap()
+	newCache.PutStr("temp", "value")
+
+	tests := []struct {
+		name              string
+		path              ottl.Path[*TransformContext]
+		orig              any
+		newVal            any
+		expectSetterError bool
+		modified          func(exemplar pmetric.Exemplar, cache pcommon.Map)
+	}{
+		{
+			name: "time_unix_nano",
+			path: &pathtest.Path[*TransformContext]{
+				N: "time_unix_nano",
+			},
+			orig:   int64(100_000_000),
+			newVal: int64(200_000_000),
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+			},
+		},
+		{
+			name: "time",
+			path: &pathtest.Path[*TransformContext]{
+				N: "time",
+			},
+			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+			},
+		},
+		{
+			name: "double_value",
+			path: &pathtest.Path[*TransformContext]{
+				N: "double_value",
+			},
+			orig:   float64(1.5),
+			newVal: float64(3.0),
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.SetDoubleValue(3.0)
+			},
+		},
+		{
+			name: "int_value",
+			path: &pathtest.Path[*TransformContext]{
+				N: "int_value",
+			},
+			orig:   int64(0),
+			newVal: int64(42),
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.SetIntValue(42)
+			},
+		},
+		{
+			name: "trace_id",
+			path: &pathtest.Path[*TransformContext]{
+				N: "trace_id",
+			},
+			orig:   pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
+			newVal: pcommon.TraceID([16]byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}),
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.SetTraceID([16]byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1})
+			},
+		},
+		{
+			name: "span_id",
+			path: &pathtest.Path[*TransformContext]{
+				N: "span_id",
+			},
+			orig:   pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+			newVal: pcommon.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}),
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.SetSpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
+			},
+		},
+		{
+			name: "filtered_attributes",
+			path: &pathtest.Path[*TransformContext]{
+				N: "filtered_attributes",
+			},
+			orig:   refExemplar.FilteredAttributes(),
+			newVal: newAttrs,
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				newAttrs.CopyTo(exemplar.FilteredAttributes())
+			},
+		},
+		{
+			name: "filtered_attributes string",
+			path: &pathtest.Path[*TransformContext]{
+				N: "filtered_attributes",
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
+						S: ottltest.Strp("str"),
+					},
+				},
+			},
+			orig:   "val",
+			newVal: "newVal",
+			modified: func(exemplar pmetric.Exemplar, _ pcommon.Map) {
+				exemplar.FilteredAttributes().PutStr("str", "newVal")
+			},
+		},
+		{
+			name: "cache",
+			path: &pathtest.Path[*TransformContext]{
+				N: "cache",
+			},
+			orig:   pcommon.NewMap(),
+			newVal: newCache,
+			modified: func(_ pmetric.Exemplar, cache pcommon.Map) {
+				newCache.CopyTo(cache)
+			},
+		},
+		{
+			name: "cache access",
+			path: &pathtest.Path[*TransformContext]{
+				N: "cache",
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
+						S: ottltest.Strp("temp"),
+					},
+				},
+			},
+			orig:   nil,
+			newVal: "new value",
+			modified: func(_ pmetric.Exemplar, cache pcommon.Map) {
+				cache.PutStr("temp", "new value")
+			},
+		},
+	}
+	// Copy all test cases and set the path.Context value to ctxexemplar.Name.
+	// It ensures all existing field access also works when the path context is set.
+	for _, tt := range slices.Clone(tests) {
+		testWithContext := tt
+		testWithContext.name = "with_path_context:" + tt.name
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
+		pathWithContext.C = ctxexemplar.Name
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
+		tests = append(tests, testWithContext)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testCache := pcommon.NewMap()
+			cacheGetter := func(*TransformContext) pcommon.Map {
+				return testCache
+			}
+
+			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
+			require.NoError(t, err)
+
+			rm, sm, metric, dp, exemplar := createTelemetry()
+
+			tCtx := NewTransformContextPtr(rm, sm, metric, dp, exemplar)
+			defer tCtx.Close()
+
+			got, err := accessor.Get(t.Context(), tCtx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.orig, got)
+
+			err = accessor.Set(t.Context(), tCtx, tt.newVal)
+			if tt.expectSetterError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			_, _, _, _, exExemplar := createTelemetry()
+			exCache := pcommon.NewMap()
+			tt.modified(exExemplar, exCache)
+
+			assert.Equal(t, exExemplar, exemplar)
+			assert.Equal(t, exCache, testCache)
+		})
+	}
+}
+
+func Test_newPathGetSetter_higherContextPath(t *testing.T) {
+	rm := pmetric.NewResourceMetrics()
+	rm.Resource().Attributes().PutStr("foo", "bar")
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("scope")
+
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("my.metric")
+
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(1.5)
+
+	exemplar := dp.Exemplars().AppendEmpty()
+	exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
+
+	ctx := NewTransformContextPtr(rm, sm, metric, dp, exemplar)
+	defer ctx.Close()
+
+	tests := []struct {
+		name     string
+		path     ottl.Path[*TransformContext]
+		expected any
+	}{
+		{
+			name: "resource",
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
+						S: ottltest.Strp("foo"),
+					},
+				},
+			}},
+			expected: "bar",
+		},
+		{
+			name: "resource with context",
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
+					S: ottltest.Strp("foo"),
+				},
+			}},
+			expected: "bar",
+		},
+		{
+			name:     "instrumentation_scope",
+			path:     &pathtest.Path[*TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
+			expected: "scope",
+		},
+		{
+			name:     "instrumentation_scope with context",
+			path:     &pathtest.Path[*TransformContext]{C: "instrumentation_scope", N: "name"},
+			expected: "scope",
+		},
+		{
+			name:     "scope",
+			path:     &pathtest.Path[*TransformContext]{N: "scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
+			expected: "scope",
+		},
+		{
+			name:     "scope with context",
+			path:     &pathtest.Path[*TransformContext]{C: "scope", N: "name"},
+			expected: "scope",
+		},
+		{
+			name:     "metric",
+			path:     &pathtest.Path[*TransformContext]{N: "metric", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
+			expected: "my.metric",
+		},
+		{
+			name:     "metric with context",
+			path:     &pathtest.Path[*TransformContext]{C: "metric", N: "name"},
+			expected: "my.metric",
+		},
+		{
+			name:     "datapoint value_double with context",
+			path:     &pathtest.Path[*TransformContext]{C: "datapoint", N: "value_double"},
+			expected: float64(1.5),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessor, err := pathExpressionParser(getCache)(tt.path)
+			require.NoError(t, err)
+
+			got, err := accessor.Get(t.Context(), ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestHigherContextCacheAccessError(t *testing.T) {
+	higherContexts := []string{
+		ctxresource.Name,
+		ctxscope.Name,
+		ctxscope.LegacyName,
+		ctxmetric.Name,
+		ctxdatapoint.Name,
+	}
+	for _, higherContext := range higherContexts {
+		t.Run(higherContext, func(t *testing.T) {
+			path := &pathtest.Path[*TransformContext]{
+				N: "cache",
+				C: higherContext,
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
+						S: ottltest.Strp("key"),
+					},
+				},
+				FullPath: fmt.Sprintf("%s.cache[key]", higherContext),
+			}
+
+			_, err := pathExpressionParser(getCache)(path)
+			require.Error(t, err)
+			expectError := fmt.Sprintf(`replace "%s.cache[key]" with "exemplar.cache[key]"`, higherContext)
+			require.ErrorContains(t, err, expectError)
+		})
+	}
+}
+
+func createTelemetry() (pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, pmetric.NumberDataPoint, pmetric.Exemplar) {
+	rm := pmetric.NewResourceMetrics()
+	rm.Resource().Attributes().PutStr("resource_attr", "resource_val")
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("library")
+	sm.Scope().SetVersion("version")
+
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("my.metric")
+	metric.SetDescription("A test metric")
+
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(1.5)
+	dp.Attributes().PutStr("dp_attr", "dp_val")
+
+	exemplar := dp.Exemplars().AppendEmpty()
+	exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
+	exemplar.SetDoubleValue(1.5)
+	exemplar.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	exemplar.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	exemplar.FilteredAttributes().PutStr("str", "val")
+
+	return rm, sm, metric, dp, exemplar
+}

--- a/pkg/ottl/contexts/ottlexemplar/package_test.go
+++ b/pkg/ottl/contexts/ottlexemplar/package_test.go
@@ -1,0 +1,4 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlexemplar // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -54,14 +54,16 @@ and allows you to configure a list of statements for the processor to execute. T
 
 Within each `<signal_statements>` list, only certain OTTL Path prefixes can be used:
 
-| Signal             | Path Prefix Values                             |
-|--------------------|------------------------------------------------|
-| trace_statements   | `resource`, `scope`, `span`, and `spanevent`   |
-| metric_statements  | `resource`, `scope`, `metric`, and `datapoint` |
-| log_statements     | `resource`, `scope`, and `log`                 |
-| profile_statements | `resource`, `scope`, and `profile`             |
+| Signal             | Path Prefix Values                                         |
+|--------------------|------------------------------------------------------------|
+| trace_statements   | `resource`, `scope`, `span`, and `spanevent`               |
+| metric_statements  | `resource`, `scope`, `metric`, `datapoint`, and `exemplar` |
+| log_statements     | `resource`, `scope`, and `log`                             |
+| profile_statements | `resource`, `scope`, and `profile`                         |
 
 This means, for example, that you cannot use the Path `span.attributes` within the `log_statements` configuration section.
+
+For metrics, the `exemplar` context enables per-exemplar transforms, including exemplar timestamps, values, trace/span IDs, filtered attributes, and parent `resource`, `scope`, `metric`, and `datapoint` paths.
 
 `error_mode`: determines how the processor treats errors that occur while processing a statement.
 If the top-level `error_mode` is not specified, `propagate` will be used.

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
@@ -51,6 +52,7 @@ type Config struct {
 	logger      *zap.Logger
 
 	dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	exemplarFunctions  map[string]ottl.Factory[*ottlexemplar.TransformContext]
 	logFunctions       map[string]ottl.Factory[*ottllog.TransformContext]
 	metricFunctions    map[string]ottl.Factory[*ottlmetric.TransformContext]
 	spanEventFunctions map[string]ottl.Factory[*ottlspanevent.TransformContext]
@@ -158,7 +160,7 @@ func (c *Config) Validate() error {
 	}
 
 	if len(c.MetricStatements) > 0 {
-		pc, err := common.NewMetricParserCollection(component.TelemetrySettings{Logger: zap.NewNop()}, common.WithMetricParser(c.metricFunctions), common.WithDataPointParser(c.dataPointFunctions))
+		pc, err := common.NewMetricParserCollection(component.TelemetrySettings{Logger: zap.NewNop()}, common.WithMetricParser(c.metricFunctions), common.WithDataPointParser(c.dataPointFunctions), common.WithExemplarParser(c.exemplarFunctions))
 		if err != nil {
 			return err
 		}

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
@@ -34,18 +35,20 @@ import (
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 type transformProcessorFactory struct {
-	dataPointFunctions                  map[string]ottl.Factory[*ottldatapoint.TransformContext]
-	logFunctions                        map[string]ottl.Factory[*ottllog.TransformContext]
-	metricFunctions                     map[string]ottl.Factory[*ottlmetric.TransformContext]
-	spanEventFunctions                  map[string]ottl.Factory[*ottlspanevent.TransformContext]
-	spanFunctions                       map[string]ottl.Factory[*ottlspan.TransformContext]
-	profileFunctions                    map[string]ottl.Factory[*ottlprofile.TransformContext]
-	defaultDataPointFunctionsOverridden bool
-	defaultLogFunctionsOverridden       bool
-	defaultMetricFunctionsOverridden    bool
-	defaultSpanEventFunctionsOverridden bool
-	defaultSpanFunctionsOverridden      bool
-	defaultProfileFunctionsOverridden   bool
+	dataPointFunctions                   map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	exemplarFunctions                    map[string]ottl.Factory[*ottlexemplar.TransformContext]
+	logFunctions                         map[string]ottl.Factory[*ottllog.TransformContext]
+	metricFunctions                      map[string]ottl.Factory[*ottlmetric.TransformContext]
+	spanEventFunctions                   map[string]ottl.Factory[*ottlspanevent.TransformContext]
+	spanFunctions                        map[string]ottl.Factory[*ottlspan.TransformContext]
+	profileFunctions                     map[string]ottl.Factory[*ottlprofile.TransformContext]
+	defaultDataPointFunctionsOverridden  bool
+	defaultExemplarFunctionsOverridden   bool
+	defaultLogFunctionsOverridden        bool
+	defaultMetricFunctionsOverridden     bool
+	defaultSpanEventFunctionsOverridden  bool
+	defaultSpanFunctionsOverridden       bool
+	defaultProfileFunctionsOverridden    bool
 }
 
 // FactoryOption applies changes to transformProcessorFactory.
@@ -185,6 +188,7 @@ func NewFactory() processor.Factory {
 func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 	f := &transformProcessorFactory{
 		dataPointFunctions: defaultDataPointFunctionsMap(),
+		exemplarFunctions:  defaultExemplarFunctionsMap(),
 		logFunctions:       defaultLogFunctionsMap(),
 		metricFunctions:    defaultMetricFunctionsMap(),
 		spanEventFunctions: defaultSpanEventFunctionsMap(),
@@ -213,6 +217,7 @@ func (f *transformProcessorFactory) createDefaultConfig() component.Config {
 		LogStatements:      []common.ContextStatements{},
 		ProfileStatements:  []common.ContextStatements{},
 		dataPointFunctions: f.dataPointFunctions,
+		exemplarFunctions:  f.exemplarFunctions,
 		logFunctions:       f.logFunctions,
 		metricFunctions:    f.metricFunctions,
 		spanEventFunctions: f.spanEventFunctions,
@@ -284,7 +289,7 @@ func (f *transformProcessorFactory) createMetricsProcessor(
 			zap.Bool("metric", f.defaultMetricFunctionsOverridden),
 		)
 	}
-	proc, err := metrics.NewProcessor(oCfg.MetricStatements, oCfg.ErrorMode, set.TelemetrySettings, f.metricFunctions, f.dataPointFunctions)
+	proc, err := metrics.NewProcessor(oCfg.MetricStatements, oCfg.ErrorMode, set.TelemetrySettings, f.metricFunctions, f.dataPointFunctions, f.exemplarFunctions)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config for \"transform\" processor %w", err)
 	}

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -35,20 +35,20 @@ import (
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 type transformProcessorFactory struct {
-	dataPointFunctions                   map[string]ottl.Factory[*ottldatapoint.TransformContext]
-	exemplarFunctions                    map[string]ottl.Factory[*ottlexemplar.TransformContext]
-	logFunctions                         map[string]ottl.Factory[*ottllog.TransformContext]
-	metricFunctions                      map[string]ottl.Factory[*ottlmetric.TransformContext]
-	spanEventFunctions                   map[string]ottl.Factory[*ottlspanevent.TransformContext]
-	spanFunctions                        map[string]ottl.Factory[*ottlspan.TransformContext]
-	profileFunctions                     map[string]ottl.Factory[*ottlprofile.TransformContext]
-	defaultDataPointFunctionsOverridden  bool
-	defaultExemplarFunctionsOverridden   bool
-	defaultLogFunctionsOverridden        bool
-	defaultMetricFunctionsOverridden     bool
-	defaultSpanEventFunctionsOverridden  bool
-	defaultSpanFunctionsOverridden       bool
-	defaultProfileFunctionsOverridden    bool
+	dataPointFunctions                  map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	exemplarFunctions                   map[string]ottl.Factory[*ottlexemplar.TransformContext]
+	logFunctions                        map[string]ottl.Factory[*ottllog.TransformContext]
+	metricFunctions                     map[string]ottl.Factory[*ottlmetric.TransformContext]
+	spanEventFunctions                  map[string]ottl.Factory[*ottlspanevent.TransformContext]
+	spanFunctions                       map[string]ottl.Factory[*ottlspan.TransformContext]
+	profileFunctions                    map[string]ottl.Factory[*ottlprofile.TransformContext]
+	defaultDataPointFunctionsOverridden bool
+	defaultExemplarFunctionsOverridden  bool
+	defaultLogFunctionsOverridden       bool
+	defaultMetricFunctionsOverridden    bool
+	defaultSpanEventFunctionsOverridden bool
+	defaultSpanFunctionsOverridden      bool
+	defaultProfileFunctionsOverridden   bool
 }
 
 // FactoryOption applies changes to transformProcessorFactory.
@@ -72,6 +72,18 @@ func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.
 			factory.defaultDataPointFunctionsOverridden = true
 		}
 		factory.dataPointFunctions = mergeFunctionsToMap(factory.dataPointFunctions, dataPointFunctions)
+	}
+}
+
+// WithExemplarFunctionsNew will override the default OTTL exemplar context functions with the provided exemplarFunctions in the resulting processor.
+// Subsequent uses of WithExemplarFunctionsNew will merge the provided exemplarFunctions with the previously registered functions.
+func WithExemplarFunctionsNew(exemplarFunctions []ottl.Factory[*ottlexemplar.TransformContext]) FactoryOption {
+	return func(factory *transformProcessorFactory) {
+		if !factory.defaultExemplarFunctionsOverridden {
+			factory.exemplarFunctions = map[string]ottl.Factory[*ottlexemplar.TransformContext]{}
+			factory.defaultExemplarFunctionsOverridden = true
+		}
+		factory.exemplarFunctions = mergeFunctionsToMap(factory.exemplarFunctions, exemplarFunctions)
 	}
 }
 
@@ -283,9 +295,10 @@ func (f *transformProcessorFactory) createMetricsProcessor(
 ) (processor.Metrics, error) {
 	oCfg := cfg.(*Config)
 	oCfg.logger = set.Logger
-	if f.defaultDataPointFunctionsOverridden || f.defaultMetricFunctionsOverridden {
+	if f.defaultDataPointFunctionsOverridden || f.defaultExemplarFunctionsOverridden || f.defaultMetricFunctionsOverridden {
 		set.Logger.Debug("non-default OTTL metric functions have been registered in the \"transform\" processor",
 			zap.Bool("datapoint", f.defaultDataPointFunctionsOverridden),
+			zap.Bool("exemplar", f.defaultExemplarFunctionsOverridden),
 			zap.Bool("metric", f.defaultMetricFunctionsOverridden),
 		)
 	}

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
@@ -39,6 +40,9 @@ func assertConfigContainsDefaultFunctions(t *testing.T, config Config) {
 	}
 	for _, f := range DefaultDataPointFunctionsNew() {
 		assert.Contains(t, config.dataPointFunctions, f.Name(), "missing data point function %v", f.Name())
+	}
+	for _, f := range DefaultExemplarFunctionsNew() {
+		assert.Contains(t, config.exemplarFunctions, f.Name(), "missing exemplar function %v", f.Name())
 	}
 	for _, f := range DefaultMetricFunctionsNew() {
 		assert.Contains(t, config.metricFunctions, f.Name(), "missing metric function %v", f.Name())
@@ -1234,6 +1238,57 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			wantErrorWith: `undefined function "set"`,
 			factoryOptions: []FactoryOption{
 				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
+			},
+		},
+		{
+			name: "with exemplar functions : statement with added exemplar func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("exemplar"),
+					Statements: []string{`set(cache["attr"], TestExemplarFunc())`},
+				},
+			},
+			factoryOptions: []FactoryOption{
+				WithExemplarFunctionsNew(DefaultExemplarFunctionsNew()),
+				WithExemplarFunctionsNew([]ottl.Factory[*ottlexemplar.TransformContext]{createTestFuncFactory[*ottlexemplar.TransformContext]("TestExemplarFunc")}),
+			},
+		},
+		{
+			name: "with exemplar functions : statement with missing exemplar func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("exemplar"),
+					Statements: []string{`set(cache["attr"], TestExemplarFunc())`},
+				},
+			},
+			wantErrorWith: `undefined function "TestExemplarFunc"`,
+			factoryOptions: []FactoryOption{
+				WithExemplarFunctionsNew(DefaultExemplarFunctionsNew()),
+			},
+		},
+		{
+			name: "with exemplar functions : only custom functions",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("exemplar"),
+					Statements: []string{`testExemplarFunc()`},
+				},
+			},
+			factoryOptions: []FactoryOption{
+				WithExemplarFunctionsNew([]ottl.Factory[*ottlexemplar.TransformContext]{createTestFuncFactory[*ottlexemplar.TransformContext]("testExemplarFunc")}),
+			},
+		},
+		{
+			name: "with exemplar functions : missing default functions",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("exemplar"),
+					Statements: []string{`set(filtered_attributes["test"], "TestExemplarFunc()")`},
+				},
+			},
+			wantErrorWith: `undefined function "set"`,
+			factoryOptions: []FactoryOption{
+				WithExemplarFunctionsNew([]ottl.Factory[*ottlexemplar.TransformContext]{createTestFuncFactory[*ottlexemplar.TransformContext]("TestExemplarFunc")}),
 			},
 		},
 	}

--- a/processor/transformprocessor/functions.go
+++ b/processor/transformprocessor/functions.go
@@ -49,6 +49,10 @@ func DefaultDataPointFunctionsNew() []ottl.Factory[*ottldatapoint.TransformConte
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
+func DefaultExemplarFunctionsNew() []ottl.Factory[*ottlexemplar.TransformContext] {
+	return slices.Collect(maps.Values(defaultExemplarFunctionsMap()))
+}
+
 // Deprecated: [v0.142.0] use DefaultSpanFunctionsNew.
 func DefaultSpanFunctions() []ottl.Factory[ottlspan.TransformContext] {
 	functions := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()

--- a/processor/transformprocessor/functions.go
+++ b/processor/transformprocessor/functions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
@@ -94,6 +95,10 @@ func defaultMetricFunctionsMap() map[string]ottl.Factory[*ottlmetric.TransformCo
 
 func defaultDataPointFunctionsMap() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
 	return metrics.DataPointFunctions()
+}
+
+func defaultExemplarFunctionsMap() map[string]ottl.Factory[*ottlexemplar.TransformContext] {
+	return metrics.ExemplarFunctions()
 }
 
 func defaultSpanFunctionsMap() map[string]ottl.Factory[*ottlspan.TransformContext] {

--- a/processor/transformprocessor/internal/common/config.go
+++ b/processor/transformprocessor/internal/common/config.go
@@ -21,6 +21,7 @@ const (
 	SpanEvent ContextID = "spanevent"
 	Metric    ContextID = "metric"
 	DataPoint ContextID = "datapoint"
+	Exemplar  ContextID = "exemplar"
 	Log       ContextID = "log"
 	Profile   ContextID = "profile"
 )
@@ -28,7 +29,7 @@ const (
 func (c *ContextID) UnmarshalText(text []byte) error {
 	str := ContextID(strings.ToLower(string(text)))
 	switch str {
-	case Resource, Scope, Span, SpanEvent, Metric, DataPoint, Log, Profile:
+	case Resource, Scope, Span, SpanEvent, Metric, DataPoint, Exemplar, Log, Profile:
 		*c = str
 		return nil
 	default:

--- a/processor/transformprocessor/internal/common/metrics.go
+++ b/processor/transformprocessor/internal/common/metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 )
 
@@ -177,6 +178,102 @@ func (d dataPointStatements) handleSummaryDataPoints(ctx context.Context, resour
 	return nil
 }
 
+type exemplarStatements struct {
+	ottl.StatementSequence[*ottlexemplar.TransformContext]
+	expr.BoolExpr[*ottlexemplar.TransformContext]
+}
+
+func (exemplarStatements) Context() ContextID {
+	return Exemplar
+}
+
+func (e exemplarStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rmetrics := md.ResourceMetrics().At(i)
+		for j := 0; j < rmetrics.ScopeMetrics().Len(); j++ {
+			smetrics := rmetrics.ScopeMetrics().At(j)
+			metrics := smetrics.Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				metric := metrics.At(k)
+				var err error
+				//exhaustive:enforce
+				switch metric.Type() {
+				case pmetric.MetricTypeSum:
+					err = e.handleNumberDataPointExemplars(ctx, rmetrics, smetrics, metric, metric.Sum().DataPoints())
+				case pmetric.MetricTypeGauge:
+					err = e.handleNumberDataPointExemplars(ctx, rmetrics, smetrics, metric, metric.Gauge().DataPoints())
+				case pmetric.MetricTypeHistogram:
+					err = e.handleHistogramDataPointExemplars(ctx, rmetrics, smetrics, metric, metric.Histogram().DataPoints())
+				case pmetric.MetricTypeExponentialHistogram:
+					err = e.handleExponentialHistogramDataPointExemplars(ctx, rmetrics, smetrics, metric, metric.ExponentialHistogram().DataPoints())
+				case pmetric.MetricTypeSummary:
+					// Summary datapoints do not have exemplars.
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (e exemplarStatements) handleNumberDataPointExemplars(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.NumberDataPointSlice) error {
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		for j := 0; j < dp.Exemplars().Len(); j++ {
+			tCtx := ottlexemplar.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dp, dp.Exemplars().At(j))
+			if err := e.executeExemplar(ctx, tCtx); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e exemplarStatements) handleHistogramDataPointExemplars(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.HistogramDataPointSlice) error {
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		for j := 0; j < dp.Exemplars().Len(); j++ {
+			tCtx := ottlexemplar.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dp, dp.Exemplars().At(j))
+			if err := e.executeExemplar(ctx, tCtx); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e exemplarStatements) handleExponentialHistogramDataPointExemplars(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.ExponentialHistogramDataPointSlice) error {
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		for j := 0; j < dp.Exemplars().Len(); j++ {
+			tCtx := ottlexemplar.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dp, dp.Exemplars().At(j))
+			if err := e.executeExemplar(ctx, tCtx); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e exemplarStatements) executeExemplar(ctx context.Context, tCtx *ottlexemplar.TransformContext) error {
+	condition, err := e.Eval(ctx, tCtx)
+	if err != nil {
+		tCtx.Close()
+		return err
+	}
+	if condition {
+		err = e.Execute(ctx, tCtx)
+		if err != nil {
+			tCtx.Close()
+			return err
+		}
+	}
+	tCtx.Close()
+	return nil
+}
+
 type MetricParserCollection ottl.ParserCollection[MetricsConsumer]
 
 type MetricParserCollectionOption ottl.ParserCollectionOption[MetricsConsumer]
@@ -188,6 +285,16 @@ func WithMetricParser(functions map[string]ottl.Factory[*ottlmetric.TransformCon
 			return err
 		}
 		return ottl.WithParserCollectionContext(ottlmetric.ContextName, &metricParser, ottl.WithStatementConverter(convertMetricStatements))(pc)
+	}
+}
+
+func WithExemplarParser(functions map[string]ottl.Factory[*ottlexemplar.TransformContext]) MetricParserCollectionOption {
+	return func(pc *ottl.ParserCollection[MetricsConsumer]) error {
+		exemplarParser, err := ottlexemplar.NewParser(functions, pc.Settings, ottlexemplar.EnablePathContextNames())
+		if err != nil {
+			return err
+		}
+		return ottl.WithParserCollectionContext(ottlexemplar.ContextName, &exemplarParser, ottl.WithStatementConverter(convertExemplarStatements))(pc)
 	}
 }
 
@@ -264,6 +371,27 @@ func convertDataPointStatements(pc *ottl.ParserCollection[MetricsConsumer], stat
 	}
 	dpStatements := ottldatapoint.NewStatementSequence(parsedStatements, pc.Settings, ottldatapoint.WithStatementSequenceErrorMode(errorMode))
 	return dataPointStatements{dpStatements, globalExpr}, nil
+}
+
+func convertExemplarStatements(pc *ottl.ParserCollection[MetricsConsumer], statements ottl.StatementsGetter, parsedStatements []*ottl.Statement[*ottlexemplar.TransformContext]) (MetricsConsumer, error) {
+	contextStatements, err := toContextStatements(statements)
+	if err != nil {
+		return nil, err
+	}
+	errorMode := pc.ErrorMode
+	if contextStatements.ErrorMode != "" {
+		errorMode = contextStatements.ErrorMode
+	}
+	var parserOptions []ottl.Option[*ottlexemplar.TransformContext]
+	if contextStatements.Context == "" {
+		parserOptions = append(parserOptions, ottlexemplar.EnablePathContextNames())
+	}
+	globalExpr, errGlobalBoolExpr := parseGlobalExpr(filterottl.NewBoolExprForExemplarWithOptions, contextStatements.Conditions, errorMode, pc.Settings, filterottl.StandardExemplarFuncs(), parserOptions)
+	if errGlobalBoolExpr != nil {
+		return nil, errGlobalBoolExpr
+	}
+	eStatements := ottlexemplar.NewStatementSequence(parsedStatements, pc.Settings, ottlexemplar.WithStatementSequenceErrorMode(errorMode))
+	return exemplarStatements{eStatements, globalExpr}, nil
 }
 
 func (mpc *MetricParserCollection) ParseContextStatements(contextStatements ContextStatements) (MetricsConsumer, error) {

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
@@ -33,6 +34,10 @@ func DataPointFunctions() map[string]ottl.Factory[*ottldatapoint.TransformContex
 	maps.Copy(functions, datapointFunctions)
 
 	return functions
+}
+
+func ExemplarFunctions() map[string]ottl.Factory[*ottlexemplar.TransformContext] {
+	return ottlfuncs.StandardFuncs[*ottlexemplar.TransformContext]()
 }
 
 func MetricFunctions() map[string]ottl.Factory[*ottlmetric.TransformContext] {

--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlexemplar"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
@@ -22,8 +23,8 @@ type Processor struct {
 	logger   *zap.Logger
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, metricFunctions map[string]ottl.Factory[*ottlmetric.TransformContext], dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]) (*Processor, error) {
-	pc, err := common.NewMetricParserCollection(settings, common.WithMetricParser(metricFunctions), common.WithDataPointParser(dataPointFunctions), common.WithMetricErrorMode(errorMode))
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, metricFunctions map[string]ottl.Factory[*ottlmetric.TransformContext], dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext], exemplarFunctions map[string]ottl.Factory[*ottlexemplar.TransformContext]) (*Processor, error) {
+	pc, err := common.NewMetricParserCollection(settings, common.WithMetricParser(metricFunctions), common.WithDataPointParser(dataPointFunctions), common.WithExemplarParser(exemplarFunctions), common.WithMetricErrorMode(errorMode))
 	if err != nil {
 		return nil, err
 	}

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -29,6 +29,7 @@ var (
 
 	DefaultMetricFunctions    = MetricFunctions()
 	DefaultDataPointFunctions = DataPointFunctions()
+	DefaultExemplarFunctions  = ExemplarFunctions()
 )
 
 func Test_ProcessMetrics_ResourceContext(t *testing.T) {
@@ -58,7 +59,7 @@ func Test_ProcessMetrics_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -99,7 +100,7 @@ func Test_ProcessMetrics_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -140,7 +141,7 @@ func Test_ProcessMetrics_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -181,7 +182,7 @@ func Test_ProcessMetrics_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -385,7 +386,7 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -565,7 +566,7 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 			}
 
 			td := constructMetrics()
-			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -1008,7 +1009,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -1456,7 +1457,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 				contextStatements = append(contextStatements, common.ContextStatements{Context: "", Statements: []string{statement}})
 			}
 
-			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -1594,7 +1595,7 @@ func Test_ProcessMetrics_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -1634,7 +1635,7 @@ func Test_ProcessMetrics_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -1737,7 +1738,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 			_, err = processor.ProcessMetrics(t.Context(), td)
 			if tt.wantErrorWith != "" {
@@ -1900,7 +1901,7 @@ func Test_ProcessMetrics_CacheAccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -1957,7 +1958,7 @@ func Test_ProcessMetrics_InferredContextFromConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
@@ -2027,7 +2028,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
@@ -2124,7 +2125,7 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), tt.metricFunctions, tt.dataPointFunctions)
+			_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), tt.metricFunctions, tt.dataPointFunctions, DefaultExemplarFunctions)
 			if tt.wantErrorWith != "" {
 				if err == nil {
 					t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -2266,3 +2266,119 @@ func fillMetricFive(m pmetric.Metric) {
 	dataPoint1.SetDoubleValue(3.7)
 	dataPoint1.Attributes().PutStr("attr1", "test2")
 }
+
+func constructMetricsWithExemplars() pmetric.Metrics {
+	td := pmetric.NewMetrics()
+	rm := td.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("host.name", "myhost")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("scope")
+
+	// Gauge with exemplar
+	gauge := sm.Metrics().AppendEmpty()
+	gauge.SetName("gauge.with.exemplar")
+	gaugeDp := gauge.SetEmptyGauge().DataPoints().AppendEmpty()
+	gaugeDp.SetTimestamp(StartTimestamp)
+	gaugeDp.SetDoubleValue(1.0)
+	exemplar0 := gaugeDp.Exemplars().AppendEmpty()
+	exemplar0.SetTimestamp(StartTimestamp)
+	exemplar0.SetDoubleValue(1.0)
+	exemplar0.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	exemplar0.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	exemplar0.FilteredAttributes().PutStr("exemplar.attr", "value1")
+
+	// Sum with exemplar
+	sum := sm.Metrics().AppendEmpty()
+	sum.SetName("sum.with.exemplar")
+	sumDp := sum.SetEmptySum().DataPoints().AppendEmpty()
+	sumDp.SetTimestamp(StartTimestamp)
+	sumDp.SetDoubleValue(2.0)
+	exemplar1 := sumDp.Exemplars().AppendEmpty()
+	exemplar1.SetTimestamp(StartTimestamp)
+	exemplar1.SetDoubleValue(2.0)
+	exemplar1.FilteredAttributes().PutStr("exemplar.attr", "value2")
+
+	// Histogram with exemplar
+	hist := sm.Metrics().AppendEmpty()
+	hist.SetName("hist.with.exemplar")
+	histDp := hist.SetEmptyHistogram().DataPoints().AppendEmpty()
+	histDp.SetTimestamp(StartTimestamp)
+	exemplar2 := histDp.Exemplars().AppendEmpty()
+	exemplar2.SetTimestamp(StartTimestamp)
+	exemplar2.SetDoubleValue(3.0)
+	exemplar2.FilteredAttributes().PutStr("exemplar.attr", "value3")
+
+	// ExponentialHistogram with exemplar
+	expHist := sm.Metrics().AppendEmpty()
+	expHist.SetName("exphist.with.exemplar")
+	expHistDp := expHist.SetEmptyExponentialHistogram().DataPoints().AppendEmpty()
+	expHistDp.SetTimestamp(StartTimestamp)
+	exemplar3 := expHistDp.Exemplars().AppendEmpty()
+	exemplar3.SetTimestamp(StartTimestamp)
+	exemplar3.SetDoubleValue(4.0)
+	exemplar3.FilteredAttributes().PutStr("exemplar.attr", "value4")
+
+	return td
+}
+
+func Test_ProcessMetrics_ExemplarContext(t *testing.T) {
+	newTimestamp := pcommon.NewTimestampFromTime(TestTime)
+
+	tests := []struct {
+		statements []string
+		want       func(pmetric.Metrics)
+	}{
+		{
+			statements: []string{fmt.Sprintf(`set(time_unix_nano, %d)`, newTimestamp.AsTime().UnixNano())},
+			want: func(td pmetric.Metrics) {
+				sm := td.ResourceMetrics().At(0).ScopeMetrics().At(0)
+				sm.Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).SetTimestamp(newTimestamp)
+				sm.Metrics().At(1).Sum().DataPoints().At(0).Exemplars().At(0).SetTimestamp(newTimestamp)
+				sm.Metrics().At(2).Histogram().DataPoints().At(0).Exemplars().At(0).SetTimestamp(newTimestamp)
+				sm.Metrics().At(3).ExponentialHistogram().DataPoints().At(0).Exemplars().At(0).SetTimestamp(newTimestamp)
+			},
+		},
+		{
+			statements: []string{`set(filtered_attributes["exemplar.attr"], "updated") where metric.name == "gauge.with.exemplar"`},
+			want: func(td pmetric.Metrics) {
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).FilteredAttributes().PutStr("exemplar.attr", "updated")
+			},
+		},
+		{
+			statements: []string{`set(filtered_attributes["new.key"], "added") where resource.attributes["host.name"] == "myhost"`},
+			want: func(td pmetric.Metrics) {
+				sm := td.ResourceMetrics().At(0).ScopeMetrics().At(0)
+				sm.Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).FilteredAttributes().PutStr("new.key", "added")
+				sm.Metrics().At(1).Sum().DataPoints().At(0).Exemplars().At(0).FilteredAttributes().PutStr("new.key", "added")
+				sm.Metrics().At(2).Histogram().DataPoints().At(0).Exemplars().At(0).FilteredAttributes().PutStr("new.key", "added")
+				sm.Metrics().At(3).ExponentialHistogram().DataPoints().At(0).Exemplars().At(0).FilteredAttributes().PutStr("new.key", "added")
+			},
+		},
+		{
+			statements: []string{`set(trace_id, TraceID(0x00000000000000000000000000000000))`},
+			want: func(td pmetric.Metrics) {
+				sm := td.ResourceMetrics().At(0).ScopeMetrics().At(0)
+				sm.Metrics().At(0).Gauge().DataPoints().At(0).Exemplars().At(0).SetTraceID(pcommon.NewTraceIDEmpty())
+				sm.Metrics().At(1).Sum().DataPoints().At(0).Exemplars().At(0).SetTraceID(pcommon.NewTraceIDEmpty())
+				sm.Metrics().At(2).Histogram().DataPoints().At(0).Exemplars().At(0).SetTraceID(pcommon.NewTraceIDEmpty())
+				sm.Metrics().At(3).ExponentialHistogram().DataPoints().At(0).Exemplars().At(0).SetTraceID(pcommon.NewTraceIDEmpty())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statements[0], func(t *testing.T) {
+			td := constructMetricsWithExemplars()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "exemplar", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions, DefaultExemplarFunctions)
+			require.NoError(t, err)
+
+			_, err = processor.ProcessMetrics(t.Context(), td)
+			require.NoError(t, err)
+
+			exTd := constructMetricsWithExemplars()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}


### PR DESCRIPTION
Description :
This PR adds exemplar support to OTTL-backed metric transforms by introducing a new ottlexemplar context and wiring it into transformprocessor. That makes exemplar fields such as timestamp, value, trace/span IDs, and filtered attributes available for read/write operations in metric_statements, including conditions that reference parent resource, scope, metric, and datapoint paths.

This closes the upstream gap where exemplar timestamps could not be transformed through transformprocessor, and does so using the existing OTTL model rather than a processor-specific workaround.

The PR also completes the public extension surface for this new context by adding:

    WithExemplarFunctionsNew(...)
    DefaultExemplarFunctionsNew()

Link to tracking issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47322

Fixes

    Adds a new public ottlexemplar OTTL context.
    Wires exemplar parsing and execution into metric transforms in transformprocessor.
    Enables exemplar conditions through filterottl.
    Exposes the missing public factory APIs for custom exemplar functions.
    Updates metric processor debug logging to include non-default exemplar functions.

Testing

    Added unit tests for internal exemplar path accessors.
    Added public parser/context tests for ottlexemplar.
    Added transform processor integration tests covering exemplar updates for gauge, sum, histogram, and exponential histogram metrics.
    Added factory tests for default exemplar functions, custom exemplar functions, missing custom functions, and missing default functions.
    Ran go test ./... in processor/transformprocessor.

Documentation

    Added ottlexemplar context documentation.
    Updated transformprocessor docs to list exemplar as a supported metric context.
    Updated OTTL context index docs to include exemplar support.
    Refreshed the general OTTL contexts overview to mention exemplars.

