### PR TITLE
[processor/transform] Change default `error_mode` to `ignore`

### DIFF
--- a/.chloggen/fix_47231.yaml
+++ b/.chloggen/fix_47231.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: processor/transform
+note: Add feature gate `processor.transform.defaultErrorModeIgnore` to change default error_mode to ignore
+issues: [47231]
+subtext:
+change_logs: []

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	// Valid values are `ignore` and `propagate`.
 	// `ignore` means the processor ignores errors returned by statements and continues on to the next statement. This is the recommended mode.
 	// `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector.
-	// The default value is `propagate`.
+	// The current default value is `propagate`, which will change to `ignore` when the `processor.transform.defaultErrorModeIgnore` feature gate is stable.
 	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
 
 	TraceStatements   []common.ContextStatements `mapstructure:"trace_statements"`

--- a/processor/transformprocessor/config.schema.yaml
+++ b/processor/transformprocessor/config.schema.yaml
@@ -2,7 +2,7 @@ description: Config defines the configuration for the processor.
 type: object
 properties:
   error_mode:
-    description: ErrorMode determines how the processor reacts to errors that occur while processing a statement. Valid values are `ignore` and `propagate`. `ignore` means the processor ignores errors returned by statements and continues on to the next statement. This is the recommended mode. `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector. The default value is `propagate`.
+    description: ErrorMode determines how the processor reacts to errors that occur while processing a statement. Valid values are `ignore` and `propagate`. `ignore` means the processor ignores errors returned by statements and continues on to the next statement. This is the recommended mode. `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector. The current default value is `propagate`, which will change to `ignore` when the `processor.transform.defaultErrorModeIgnore` feature gate is stable.
     $ref: /pkg/ottl.error_mode
   flatten_data:
     type: boolean

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/xconsumer"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper"
@@ -32,6 +33,16 @@ import (
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
+
+const defaultErrorModeIgnoreGateID = "processor.transform.defaultErrorModeIgnore"
+
+var defaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	defaultErrorModeIgnoreGateID,
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Changes the default error_mode of the transform processor from propagate to ignore"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231"),
+	featuregate.WithRegisterFromVersion("v0.150.0"),
+)
 
 type transformProcessorFactory struct {
 	dataPointFunctions                  map[string]ottl.Factory[*ottldatapoint.TransformContext]
@@ -206,8 +217,12 @@ func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 }
 
 func (f *transformProcessorFactory) createDefaultConfig() component.Config {
+	defaultErrorMode := ottl.PropagateError
+	if defaultErrorModeIgnoreFeatureGate.IsEnabled() {
+		defaultErrorMode = ottl.IgnoreError
+	}
 	return &Config{
-		ErrorMode:          ottl.PropagateError,
+		ErrorMode:          defaultErrorMode,
 		TraceStatements:    []common.ContextStatements{},
 		MetricStatements:   []common.ContextStatements{},
 		LogStatements:      []common.ContextStatements{},

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -60,6 +61,10 @@ func TestFactory_Type(t *testing.T) {
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
+	t.Cleanup(func() {
+		_ = featuregate.GlobalRegistry().Set(defaultErrorModeIgnoreGateID, false)
+	})
+
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.EqualExportedValues(t, &Config{
@@ -71,6 +76,12 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	}, cfg)
 	assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
 	require.NoError(t, componenttest.CheckConfigStruct(cfg))
+
+	err := featuregate.GlobalRegistry().Set(defaultErrorModeIgnoreGateID, true)
+	require.NoError(t, err)
+
+	cfg = factory.CreateDefaultConfig()
+	assert.Equal(t, ottl.IgnoreError, cfg.(*Config).ErrorMode)
 }
 
 func TestFactoryCreateProcessor_Empty(t *testing.T) {


### PR DESCRIPTION
fixes #47231

This PR introduces a feature gate `processor.transform.defaultErrorModeIgnore` (starting at `alpha`) that changes the default `error_mode` to `ignore`. In `ignore` mode, errors are logged for visibility but processing continues with the next statement, preserving valid data.