### PR TITLE
[chore] [receiver/jaeger] fix go vet error

### DIFF
--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -359,7 +359,7 @@ func (jr *jReceiver) startCollector(ctx context.Context, host component.Host) er
 
 		ln, err := grpcConfig.NetAddr.Listen(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to bind to gRPC address %q: %w", grpcConfig.NetAddr, err)
+			return fmt.Errorf("failed to bind to gRPC address %q: %w", grpcConfig.NetAddr.Endpoint, err)
 		}
 
 		api_v2.RegisterCollectorServiceServer(jr.grpc, jr)


### PR DESCRIPTION
#### Description

Print the endpoint, not the whole NetAddr struct.

#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector/actions/runs/23881801994/job/69636971970?pr=14058

#### Testing

N/A

#### Documentation

N/A