### PR TITLE
fix(prometheusexporter): prevent panic on histogram with empty BucketCounts

### DIFF
--- a/.chloggen/fix-prometheus-collector-panic.yaml
+++ b/.chloggen/fix-prometheus-collector-panic.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: prevent panic on histogram with empty BucketCounts.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47351]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Guard BucketCounts access with a length check in convertDoubleHistogram to avoid index-out-of-range panic when a histogram has explicit bounds but no corresponding bucket counts.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -486,7 +486,7 @@ func (c *collector) convertDoubleHistogram(metric pmetric.Metric, resourceAttrs 
 	for _, bucket := range buckets {
 		index := indicesMap[bucket]
 		var countPerBucket uint64
-		if ip.ExplicitBounds().Len() > 0 && index < ip.ExplicitBounds().Len() {
+		if ip.ExplicitBounds().Len() > 0 && index < ip.ExplicitBounds().Len() && index < ip.BucketCounts().Len() {
 			countPerBucket = ip.BucketCounts().At(index)
 		}
 		cumCount += countPerBucket

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -253,6 +253,28 @@ func TestConvertDoubleHistogramExemplar(t *testing.T) {
 	exemplarsEqual(t, promExporterExemplars, buckets[0].GetExemplar())
 }
 
+func TestConvertDoubleHistogramEmptyBucketCounts(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("test_metric")
+	metric.SetDescription("this is test metric")
+	metric.SetUnit("T")
+
+	histogramDataPoint := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+	histogramDataPoint.ExplicitBounds().FromRaw([]float64{5, 25, 90})
+
+	pMap := pcommon.NewMap()
+
+	c := newCollector(&Config{}, zap.NewNop())
+	c.accumulator = &mockAccumulator{
+		metrics:            []pmetric.Metric{metric},
+		resourceAttributes: pMap,
+	}
+
+	// Should not panic
+	_, err := c.convertDoubleHistogram(metric, pMap, "test", "1.0.0", "http://test.com", pcommon.NewMap())
+	require.NoError(t, err)
+}
+
 func TestConvertMonotonicSumExemplar(t *testing.T) {
 	// initialize empty metric
 	metric := pmetric.NewMetric()


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Guard BucketCounts access with a length check in convertDoubleHistogram to avoid index-out-of-range panic when a histogram has explicit bounds but no corresponding bucket counts.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [47351](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47351)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit test.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
