### PR TITLE
Fix memory leak in k8sattributes processor caused by map bucket reten…

### DIFF
--- a/.chloggen/47337.yaml
+++ b/.chloggen/47337.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix steady memory growth caused by map bucket retention in high-churn clusters."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47337]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Compacts the pods map incrementally to avoid memory leaks.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/47337.yaml
+++ b/.chloggen/47337.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: k8sattributesprocessor
+component: processor/k8s_attributes
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fix steady memory growth caused by map bucket retention in high-churn clusters."

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -749,6 +749,7 @@ func (c *WatchClient) deleteLoopProcessing(gracePeriod time.Duration) {
 	c.deleteMut.Unlock()
 
 	c.m.Lock()
+	deleted := false
 	for i := range toDelete {
 		d := toDelete[i]
 		if p, ok := c.Pods[d.id]; ok {
@@ -756,9 +757,15 @@ func (c *WatchClient) deleteLoopProcessing(gracePeriod time.Duration) {
 			// and the underlying state (ip<>pod mapping) has not changed.
 			if p.PodUID == d.podUID {
 				delete(c.Pods, d.id)
+				deleted = true
 			}
 		}
 	}
+
+	if deleted {
+		c.compactPodMap()
+	}
+
 	podTableSize := len(c.Pods)
 	if !metadata.ProcessorK8sattributesTelemetryDisableOldFormatMetricsFeatureGate.IsEnabled() {
 		c.telemetryBuilder.OtelsvcK8sPodTableSize.Record(context.Background(), int64(podTableSize))
@@ -767,6 +774,14 @@ func (c *WatchClient) deleteLoopProcessing(gracePeriod time.Duration) {
 		c.telemetryBuilder.K8sWatcherPodCacheSize.Record(context.Background(), int64(podTableSize))
 	}
 	c.m.Unlock()
+}
+
+func (c *WatchClient) compactPodMap() {
+	newMap := make(map[PodIdentifier]*Pod, len(c.Pods))
+	for k, v := range c.Pods {
+		newMap[k] = v
+	}
+	c.Pods = newMap
 }
 
 // GetPod takes an IP address or Pod UID and returns the pod the identifier is associated with.

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -778,9 +778,7 @@ func (c *WatchClient) deleteLoopProcessing(gracePeriod time.Duration) {
 
 func (c *WatchClient) compactPodMap() {
 	newMap := make(map[PodIdentifier]*Pod, len(c.Pods))
-	for k, v := range c.Pods {
-		newMap[k] = v
-	}
+	maps.Copy(newMap, c.Pods)
 	c.Pods = newMap
 }
 

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -4720,5 +4720,5 @@ func TestCompactPodMap(t *testing.T) {
 	assert.Contains(t, c.Pods, podB)
 	assert.Contains(t, c.Pods, podC)
 	assert.NotContains(t, c.Pods, podA)
-	assert.Equal(t, 2, len(c.Pods))
+	assert.Len(t, c.Pods, 2)
 }

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -4699,3 +4699,26 @@ func TestMetadataNewForConfigFailure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "metadata.NewForConfig failed")
 }
+
+func TestCompactPodMap(t *testing.T) {
+	podA := PodIdentifier{{Value: "pod-a"}}
+	podB := PodIdentifier{{Value: "pod-b"}}
+	podC := PodIdentifier{{Value: "pod-c"}}
+
+	c := WatchClient{
+		Pods: map[PodIdentifier]*Pod{
+			podA: {},
+			podB: {},
+		},
+	}
+
+	c.Pods[podC] = &Pod{}
+	delete(c.Pods, podA)
+
+	c.compactPodMap()
+
+	assert.Contains(t, c.Pods, podB)
+	assert.Contains(t, c.Pods, podC)
+	assert.NotContains(t, c.Pods, podA)
+	assert.Equal(t, 2, len(c.Pods))
+}


### PR DESCRIPTION
#### Description

Fixes steady memory growth in `k8sattributes` caused by Go's map bucket retention in environments with high pod churn. Adds a `compactPodMap` method to copy active pods to a newly allocated map when `deleteLoopProcessing` purges pods, dropping cache references and allowing garbage collection of overgrown slice arrays.

#### Link to tracking issue
Fixes #47337

#### Testing

- Added `TestCompactPodMap` unit test to explicitly verify items are correctly compacted into the new list but deleted keys are removed.
- Validated logic with `make test` inside `processor/k8sattributesprocessor` where all passed.

#### Documentation

- Added `.chloggen/47337.yaml` containing the unreleased changelog entry for this bug fix.
