### PR TITLE
[receiver/awsxrayreceiver]: support for fileystem sql urls

### DIFF
--- a/.chloggen/awsxray-fs-sql-urls.yaml
+++ b/.chloggen/awsxray-fs-sql-urls.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awsxray
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support for fileystem sql urls
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47361]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Support for parsing sql urls without a hostname.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awsxrayreceiver/internal/translator/sql.go
+++ b/receiver/awsxrayreceiver/internal/translator/sql.go
@@ -6,6 +6,7 @@ package translator // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventionsv125 "go.opentelemetry.io/otel/semconv/v1.25.0"
@@ -36,8 +37,8 @@ func addSQLToSpan(sql *awsxray.SQLData, attrs pcommon.Map) error {
 	return nil
 }
 
-// SQL URL is of the format: protocol+transport://host:port/dbName?queryParam
-var re = regexp.MustCompile(`^(.+//.+)/([^\?]+)\??.*$`)
+// SQL URL is of the format: protocol+transport://host:port/dbName?queryParam or protocol+transport:dbName?queryParam
+var re = regexp.MustCompile(`^([^/]+:(?://[^/]+/)?)([^\?]+)\??.*$`)
 
 const (
 	dbURLI  = 1
@@ -52,5 +53,5 @@ func splitSQLURL(rawURL string) (string, string, error) {
 			rawURL,
 		)
 	}
-	return m[dbURLI], m[dbNameI], nil
+	return strings.TrimRight(m[dbURLI], "/"), m[dbNameI], nil
 }

--- a/receiver/awsxrayreceiver/internal/translator/sql_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/sql_test.go
@@ -34,3 +34,16 @@ func TestSQLURLQueryParameter(t *testing.T) {
 		"ebdb",
 		dbName, "expected db name to be the same")
 }
+
+func TestFsURL(t *testing.T) {
+	raw := "jdbc:sqlite:/tmp/ebdb.sqlite"
+	url, dbName, err := splitSQLURL(raw)
+	assert.NoError(t, err, "should succeed")
+	assert.Equal(t,
+		"jdbc:sqlite:",
+		url, "expected url to be the same")
+
+	assert.Equal(t,
+		"/tmp/ebdb.sqlite",
+		dbName, "expected db name to be the same")
+}


### PR DESCRIPTION
Support for database url's which do not contain a hostname like jdbc:sqlite:/tmp/ebdb.sqlite.

#### Description

When the awsxrayreceiver receives an Xray segment containing a database url not containing a hostname it today fails with:

```
warn        awsxrayreceiver@v0.143.0/receiver.go:112    X-Ray segment to OT traces conversion failed        {"resource": {"service.instance.id": "85f59f80-f4ab-4626-979b-f79a6f2e539a", "service.name": "aws-otel-collector", "service.version": "v0.47.0"}, "otelcol.component.id": "awsxray", "otelcol.component.kind": "receiver", "otelcol.signal": "traces", "error": "failed to parse out the database name in the \"sql.url\" field, rawUrl: jdbc:sqlite:/tmp/ebdb.sqlite"}
```

With this fix we update the parse to support database urls like this.

#### Testing

Extra unit tests added supporting this format.

#### Documentation

No need for documentation update.
