### PR TITLE
exporter/elasticsearch: Fix malformed JSON creation for numbers in exponential notation

### DIFF
--- a/.chloggen/exponent-logic-bug.yaml
+++ b/.chloggen/exponent-logic-bug.yaml
@@ -10,7 +10,7 @@ component: 'exporter/elasticsearch'
 note: Fix malformed JSON creation for numbers in exponential notation.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47363]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/exponent-logic-bug.yaml
+++ b/.chloggen/exponent-logic-bug.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: 'exporter/elasticsearch'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix malformed JSON creation for numbers in exponential notation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When rendering numbers in exponential notation the exporter JSON implementation always added a radix point (e.g. 1.0 not 1).
+  The implementation had a buffer corruption bug where it was overriding part of the buffer leading to malformed and invalid JSON numbers being created.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter.go
@@ -100,7 +100,7 @@ func (w *jsonWriter) float64Val(val float64) {
 		// Insert ".0" before exponent.
 		// Copy tail for reuse below. Any write to buf would overwrite the
 		// remaining b content, leading to a corruption in the tail part.
-		// tail length is based on IEEE 754 max exponent of 308 padded
+		// tail length is based on IEEE 754 max exponent of +308 or min exponent of -324, padded
 		// for alignment.
 		var tail [8]byte
 		n := copy(tail[:], b[expIdx:])

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter.go
@@ -97,10 +97,16 @@ func (w *jsonWriter) float64Val(val float64) {
 		}
 	}
 	if needDot {
-		// Insert ".0" before exponent
+		// Insert ".0" before exponent.
+		// Copy tail for reuse below. Any write to buf would overwrite the
+		// remaining b content, leading to a corruption in the tail part.
+		// tail length is based on IEEE 754 max exponent of 308 padded
+		// for alignment.
+		var tail [8]byte
+		n := copy(tail[:], b[expIdx:])
 		w.buf.Write(b[:expIdx])
 		w.buf.WriteString(".0")
-		w.buf.Write(b[expIdx:])
+		w.buf.Write(tail[:n])
 	} else {
 		w.buf.Write(b)
 	}

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter_test.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelserializer
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFloat64Val verifies the behavior of JSONWriter.float64Val.
+// It verifies usual behavior and in addition verifies that a
+// buffer corruption vulnerability happening when values requires
+// the addition of ".0".
+func TestFloat64Val(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected string
+	}{
+		// Values with exponents that need ".0" insertion — these triggered the
+		// AvailableBuffer corruption bug when the buffer has prior content.
+		{name: "large exponent", input: 1e+20, expected: "1.0e+20"},
+		{name: "very large exponent", input: 1e+100, expected: "1.0e+100"},
+		{name: "negative value large exponent", input: -1e+20, expected: "-1.0e+20"},
+		{name: "5e+18", input: 5e+18, expected: "5.0e+18"},
+
+		// Values that already have a decimal point
+		{name: "decimal value", input: 1.5, expected: "1.5"},
+		{name: "small exponent with decimal", input: 1e-20, expected: "1.0e-20"},
+		{name: "trailing zero", input: 42.0, expected: "42.0"},
+		{name: "negative decimal", input: -3.14, expected: "-3.14"},
+
+		// Integer-like values (no decimal, no exponent)
+		{name: "zero", input: 0.0, expected: "0.0"},
+		{name: "one", input: 1.0, expected: "1.0"},
+		{name: "negative one", input: -1.0, expected: "-1.0"},
+
+		// Special values
+		{name: "positive infinity", input: math.Inf(1), expected: "null"},
+		{name: "negative infinity", input: math.Inf(-1), expected: "null"},
+		{name: "NaN", input: math.NaN(), expected: "null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Pre-grow and write prior content so AvailableBuffer returns a
+			// slice that shares the buffer's internal backing array. Without
+			// this, the corruption does not manifest because the append in
+			// strconv.AppendFloat allocates a fresh slice.
+			var buf bytes.Buffer
+			buf.Grow(64)
+			buf.WriteString(`{"v":`)
+
+			w := newJSONWriter(&buf)
+			w.float64Val(tt.input)
+			buf.WriteByte('}')
+
+			raw := buf.String()
+			// Verify the resulting buffer is valid JSON.
+			require.True(t, json.Valid(buf.Bytes()), "invalid JSON produced: %s", raw)
+
+			// Strip wrapping JSON to match the expected format.
+			got := raw[5 : len(raw)-1]
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter_test.go
@@ -71,3 +71,31 @@ func TestFloat64Val(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkFloat64Val(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		input float64
+	}{
+		{name: "integer", input: 42},
+		{name: "integer with exponent", input: 1e+20},
+		{name: "decimal", input: 3.14},
+		{name: "decimal with exponent", input: 3.14e+20},
+	}
+
+	for _, bb := range benchmarks {
+		b.Run(bb.name, func(b *testing.B) {
+			var buf bytes.Buffer
+			buf.Grow(64)
+			w := newJSONWriter(&buf)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				buf.Reset()
+				w.float64Val(bb.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In the `elasticsearchexporter` the `JSONWriter` component has a buffer corruption in the `float64Val` function, related to the addition of the number radix when exponential notation is used.
On adding the radix the code was writing to the buffer while reading from the same buffer due to an append and a reslice).
This lead the code to override two characters in the remaining buffer with `.0`. An input like `1e+20`, for which we were expecting an output like `1.0e+20`, was instead changed to `1.020`, creating a malformed JSON number.

The bug was discovered by @lahsivjar, I'm proposing a fix after reviewing his findings.

To confirm the bug I added a regression test and I pushed it to this PR without the actual fix, to observe the failure. A following commit fixes it and we can observe the test passing.

To ensure the fix does not impact performances I added a benchmark, the result shows still 0 allocations and less than 1% performance impact:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/serializer/otelserializer
cpu: Apple M4 Pro
                                    │ before.txt  │             after.txt              │
                                    │   sec/op    │   sec/op     vs base               │
Float64Val/integer-14                 26.70n ± 5%   27.11n ± 5%       ~ (p=0.363 n=10)
Float64Val/integer_with_exponent-14   25.59n ± 3%   25.91n ± 4%       ~ (p=0.392 n=10)
Float64Val/decimal-14                 24.05n ± 3%   23.69n ± 2%       ~ (p=0.159 n=10)
Float64Val/decimal_with_exponent-14   23.89n ± 3%   24.04n ± 1%       ~ (p=0.796 n=10)
geomean                               25.03n        25.15n       +0.46%

                                    │  before.txt  │              after.txt              │
                                    │     B/op     │    B/op     vs base                 │
Float64Val/integer-14                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Float64Val/integer_with_exponent-14   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Float64Val/decimal-14                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Float64Val/decimal_with_exponent-14   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                    │  before.txt  │              after.txt              │
                                    │  allocs/op   │ allocs/op   vs base                 │
Float64Val/integer-14                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Float64Val/integer_with_exponent-14   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Float64Val/decimal-14                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Float64Val/decimal_with_exponent-14   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

No issue exists.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Automated testing with the added `TestFloat64Val` in `exporter/elasticsearchexporter/internal/serializer/otelserializer/jsonwriter_test.go`.
