### PR TITLE
[chore] allocate the initial map length to avoid resizing maps

### DIFF
--- a/pkg/translator/splunk/logs_to_splunk.go
+++ b/pkg/translator/splunk/logs_to_splunk.go
@@ -30,7 +30,7 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 	}
 
 	host := unknownHostName
-	fields := map[string]any{}
+	fields := make(map[string]any, lr.Attributes().Len() + res.Attributes().Len() + 2)
 	if spanID := lr.SpanID(); !spanID.IsEmpty() {
 		fields[spanIDFieldKey] = hex.EncodeToString(spanID[:])
 	}

--- a/pkg/translator/splunk/logs_to_splunk.go
+++ b/pkg/translator/splunk/logs_to_splunk.go
@@ -30,7 +30,7 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 	}
 
 	host := unknownHostName
-	fields := make(map[string]any, lr.Attributes().Len() + res.Attributes().Len()+2)
+	fields := make(map[string]any, lr.Attributes().Len()+res.Attributes().Len()+2)
 	if spanID := lr.SpanID(); !spanID.IsEmpty() {
 		fields[spanIDFieldKey] = hex.EncodeToString(spanID[:])
 	}

--- a/pkg/translator/splunk/logs_to_splunk.go
+++ b/pkg/translator/splunk/logs_to_splunk.go
@@ -30,7 +30,7 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 	}
 
 	host := unknownHostName
-	fields := make(map[string]any, lr.Attributes().Len() + res.Attributes().Len() + 2)
+	fields := make(map[string]any, lr.Attributes().Len() + res.Attributes().Len()+2)
 	if spanID := lr.SpanID(); !spanID.IsEmpty() {
 		fields[spanIDFieldKey] = hex.EncodeToString(spanID[:])
 	}

--- a/pkg/translator/splunk/metrics_to_splunk.go
+++ b/pkg/translator/splunk/metrics_to_splunk.go
@@ -54,7 +54,7 @@ func sanitizeFloat(value float64) any {
 
 func MetricToSplunkEvent(res pcommon.Resource, m pmetric.Metric, logger *zap.Logger, mapping HecToOtelAttrs, source, sourceType, index string) []*Event {
 	host := unknownHostName
-	commonFields := map[string]any{}
+	commonFields := make(map[string]any, res.Attributes().Len())
 
 	for k, v := range res.Attributes().All() {
 		switch k {

--- a/pkg/translator/splunk/traces_to_splunk.go
+++ b/pkg/translator/splunk/traces_to_splunk.go
@@ -49,7 +49,7 @@ type hecSpan struct {
 
 func SpanToSplunkEvent(resource pcommon.Resource, span ptrace.Span, mapping HecToOtelAttrs, source, sourceType, index string) *Event {
 	host := unknownHostName
-	commonFields := map[string]any{}
+	commonFields := make(map[string]any, span.Attributes().Len() + resource.Attributes().Len())
 	for k, v := range resource.Attributes().All() {
 		switch k {
 		case mapping.Host:

--- a/pkg/translator/splunk/traces_to_splunk.go
+++ b/pkg/translator/splunk/traces_to_splunk.go
@@ -49,7 +49,7 @@ type hecSpan struct {
 
 func SpanToSplunkEvent(resource pcommon.Resource, span ptrace.Span, mapping HecToOtelAttrs, source, sourceType, index string) *Event {
 	host := unknownHostName
-	commonFields := make(map[string]any, span.Attributes().Len() + resource.Attributes().Len())
+	commonFields := make(map[string]any, span.Attributes().Len()+resource.Attributes().Len())
 	for k, v := range resource.Attributes().All() {
 		switch k {
 		case mapping.Host:


### PR DESCRIPTION
A simple trick to avoid allocs and memory consumption if we have to resize maps.

Before:
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   17335	     74243 ns/op	   86155 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   20803	     59168 ns/op	   75112 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   19272	     69521 ns/op	   74443 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	     844	   1450500 ns/op	 1512177 B/op	   16020 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      92	  12529954 ns/op	15113401 B/op	  160039 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	      87	  12541103 ns/op	15187117 B/op	  160026 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    1510	   1037920 ns/op	 3378515 B/op	     911 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	    5313	    263834 ns/op	   76635 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   10278	    111720 ns/op	   76737 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     488	   2338692 ns/op	 1507837 B/op	   16022 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      49	  23616483 ns/op	15067027 B/op	  160043 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      44	  23246753 ns/op	15068667 B/op	  160041 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    112802 ns/op	   93131 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	    6944	    144011 ns/op	  100430 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    3235	    324814 ns/op	 2192950 B/op	    1520 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     492	   2929750 ns/op	 3938584 B/op	   30026 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      44	  30500624 ns/op	22614603 B/op	  300057 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      40	  29292578 ns/op	28916003 B/op	  300058 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    5371	    200170 ns/op	   95371 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6349	    225109 ns/op	  103237 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3044	    404600 ns/op	 2195277 B/op	    1521 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     333	   3821134 ns/op	 3933083 B/op	   30027 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      32	  34545564 ns/op	20465457 B/op	  300052 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      31	  33849896 ns/op	23607452 B/op	  300032 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5248	    219404 ns/op	  170385 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5473	    222394 ns/op	  170308 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5494	    275767 ns/op	  170410 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     255	   4762914 ns/op	 3464834 B/op	   40081 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      26	  43733527 ns/op	34951553 B/op	  400230 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      24	  44159260 ns/op	34965678 B/op	  400233 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4125	    288644 ns/op	  171300 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    3716	    307309 ns/op	  172285 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    3014	    352203 ns/op	  171630 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     206	   6447532 ns/op	 3470035 B/op	   40084 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      19	  61253215 ns/op	34861528 B/op	  400234 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      19	  57987537 ns/op	34858824 B/op	  400224 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    1754	    771480 ns/op	  756408 B/op	    8030 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	45.311s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.346s

Process finished with the exit code 0
```

After:
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   17989	     74398 ns/op	   87893 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   18931	     61815 ns/op	   76669 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   14859	     72950 ns/op	   75998 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	     822	   1305173 ns/op	 1519889 B/op	   16024 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      94	  11645090 ns/op	15117839 B/op	  160044 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	     103	  11491240 ns/op	15292178 B/op	  160030 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    2017	    569822 ns/op	 3380929 B/op	     915 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	   10000	    103723 ns/op	   78507 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   10000	    102665 ns/op	   78668 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     517	   2298639 ns/op	 1513335 B/op	   16023 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      50	  23253532 ns/op	15074673 B/op	  160047 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      51	  22449801 ns/op	15074378 B/op	  160047 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    111805 ns/op	   93234 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	   10000	    113803 ns/op	  100413 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    4534	    269209 ns/op	 2193975 B/op	    1521 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     490	   2421106 ns/op	 3944751 B/op	   30029 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      50	  22572909 ns/op	22904269 B/op	  300066 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      48	  22665145 ns/op	29117734 B/op	  300059 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    6547	    177755 ns/op	   94668 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6444	    175494 ns/op	  101761 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3829	    339613 ns/op	 2194609 B/op	    1523 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     349	   3404076 ns/op	 3931486 B/op	   30027 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      33	  33336913 ns/op	20638399 B/op	  300063 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      33	  33281420 ns/op	23902153 B/op	  300052 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5419	    208649 ns/op	  170409 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5600	    209972 ns/op	  170425 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    4585	    254285 ns/op	  170488 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     219	   4874048 ns/op	 3459455 B/op	   40084 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      24	  47596384 ns/op	35097985 B/op	  400237 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      26	  43020915 ns/op	35245103 B/op	  400235 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4240	    289085 ns/op	  171821 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    4137	    285763 ns/op	  171666 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    4173	    281840 ns/op	  172843 B/op	    2038 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     217	   5439154 ns/op	 3463485 B/op	   40088 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      19	  52782947 ns/op	34993746 B/op	  400237 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      21	  52222444 ns/op	34987499 B/op	  400239 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    1873	    651468 ns/op	  761844 B/op	    8032 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	42.830s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.263s

Process finished with the exit code 0
```

Benchstat:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
                                                     │ before_buffer.txt │        after_buffer_reuse.txt         │
                                                     │      sec/op       │    sec/op     vs base                 │
_pushLogData_10_10_1024-12                                  74.24µ ± ∞ ¹   74.40µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                    59.17µ ± ∞ ¹   61.82µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                    69.52µ ± ∞ ¹   72.95µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                   1.451m ± ∞ ¹   1.305m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                  12.53m ± ∞ ¹   11.65m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                  12.54m ± ∞ ¹   11.49m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                      1037.9µ ± ∞ ¹   569.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                         263.8µ ± ∞ ¹   103.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                         111.7µ ± ∞ ¹   102.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                        2.339m ± ∞ ¹   2.299m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                       23.62m ± ∞ ¹   23.25m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                       23.25m ± ∞ ¹   22.45m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                               112.8µ ± ∞ ¹   111.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                 144.0µ ± ∞ ¹   113.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                 324.8µ ± ∞ ¹   269.2µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                2.930m ± ∞ ¹   2.421m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                               30.50m ± ∞ ¹   22.57m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                               29.29m ± ∞ ¹   22.67m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                    200.2µ ± ∞ ¹   177.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                      225.1µ ± ∞ ¹   175.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                      404.6µ ± ∞ ¹   339.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                     3.821m ± ∞ ¹   3.404m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                    34.55m ± ∞ ¹   33.34m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                    33.85m ± ∞ ¹   33.28m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                   219.4µ ± ∞ ¹   208.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                     222.4µ ± ∞ ¹   210.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                     275.8µ ± ∞ ¹   254.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                    4.763m ± ∞ ¹   4.874m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                   43.73m ± ∞ ¹   47.60m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                   44.16m ± ∞ ¹   43.02m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12        288.6µ ± ∞ ¹   289.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12          307.3µ ± ∞ ¹   285.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12          352.2µ ± ∞ ¹   281.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12         6.448m ± ∞ ¹   5.439m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12        61.25m ± ∞ ¹   52.78m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12        57.99m ± ∞ ¹   52.22m ± ∞ ¹        ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                      771.5µ ± ∞ ¹   651.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                     1.679m         1.477m        -12.03%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ before_buffer.txt │        after_buffer_reuse.txt         │
                                                     │       B/op        │     B/op       vs base                │
_pushLogData_10_10_1024-12                                 84.14Ki ± ∞ ¹   85.83Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                   73.35Ki ± ∞ ¹   74.87Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                   72.70Ki ± ∞ ¹   74.22Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                  1.442Mi ± ∞ ¹   1.449Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                 14.41Mi ± ∞ ¹   14.42Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                 14.48Mi ± ∞ ¹   14.58Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                      3.222Mi ± ∞ ¹   3.224Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                        74.84Ki ± ∞ ¹   76.67Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                        74.94Ki ± ∞ ¹   76.82Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                       1.438Mi ± ∞ ¹   1.443Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                      14.37Mi ± ∞ ¹   14.38Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                      14.37Mi ± ∞ ¹   14.38Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                              90.95Ki ± ∞ ¹   91.05Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                98.08Ki ± ∞ ¹   98.06Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                2.091Mi ± ∞ ¹   2.092Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                               3.756Mi ± ∞ ¹   3.762Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                              21.57Mi ± ∞ ¹   21.84Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                              27.58Mi ± ∞ ¹   27.77Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                   93.14Ki ± ∞ ¹   92.45Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                    100.82Ki ± ∞ ¹   99.38Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                     2.094Mi ± ∞ ¹   2.093Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                    3.751Mi ± ∞ ¹   3.749Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                   19.52Mi ± ∞ ¹   19.68Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                   22.51Mi ± ∞ ¹   22.79Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                  166.4Ki ± ∞ ¹   166.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                    166.3Ki ± ∞ ¹   166.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                    166.4Ki ± ∞ ¹   166.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                   3.304Mi ± ∞ ¹   3.299Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                  33.33Mi ± ∞ ¹   33.47Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                  33.35Mi ± ∞ ¹   33.61Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12       167.3Ki ± ∞ ¹   167.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12         168.2Ki ± ∞ ¹   167.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12         167.6Ki ± ∞ ¹   168.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12        3.309Mi ± ∞ ¹   3.303Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12       33.25Mi ± ∞ ¹   33.37Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12       33.24Mi ± ∞ ¹   33.37Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                     738.7Ki ± ∞ ¹   744.0Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                    1.379Mi         1.385Mi        +0.49%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ before_buffer.txt │        after_buffer_reuse.txt        │
                                                     │     allocs/op     │  allocs/op    vs base                │
_pushLogData_10_10_1024-12                                   938.0 ± ∞ ¹    938.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                     818.0 ± ∞ ¹    818.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                     810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                   16.02k ± ∞ ¹   16.02k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-12                                  160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_5M-12                                  160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_1024-12                        911.0 ± ∞ ¹    915.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_8K-12                          810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                          810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                        16.02k ± ∞ ¹   16.02k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_2M-12                       160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_5M-12                       160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024-12                               1.511k ± ∞ ¹   1.511k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                 1.511k ± ∞ ¹   1.511k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                 1.520k ± ∞ ¹   1.521k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_200_2M-12                                30.03k ± ∞ ¹   30.03k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M-12                               300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M-12                               300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024-12                    1.512k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                      1.512k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                      1.521k ± ∞ ¹   1.523k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_200_2M-12                     30.03k ± ∞ ¹   30.03k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                    300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M-12                    300.0k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024_MultiMetric-12                   2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                     2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                     2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                    40.08k ± ∞ ¹   40.08k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-12                   400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-12                   400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-12        2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12          2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12          2.037k ± ∞ ¹   2.038k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_200_2M_MultiMetric-12         40.08k ± ∞ ¹   40.09k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M_MultiMetric-12        400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M_MultiMetric-12        400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-12                                      8.030k ± ∞ ¹   8.032k ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                     12.92k         12.92k        +0.02%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```