### PR TITLE
[chore] Reuse buffer when marshaling to JSON

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -678,7 +678,7 @@ func buildHTTPHeaders(config *Config, buildInfo component.BuildInfo) map[string]
 }
 
 var jsonBufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -677,14 +677,27 @@ func buildHTTPHeaders(config *Config, buildInfo component.BuildInfo) map[string]
 	}
 }
 
+var jsonBufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
 // marshalEvent marshals an event to JSON
 func marshalEvent(event *translator.Event, sizeLimit uint) ([]byte, error) {
-	b, err := json.Marshal(event)
-	if err != nil {
+	buf := jsonBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer jsonBufferPool.Put(buf)
+
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(event); err != nil {
 		return nil, err
 	}
-	if uint(len(b)) > sizeLimit {
-		return nil, fmt.Errorf("event size %d exceeds limit %d", len(b), sizeLimit)
+	if uint(buf.Len()) > sizeLimit {
+		return nil, fmt.Errorf("event size %d exceeds limit %d", buf.Len(), sizeLimit)
 	}
+
+	b := make([]byte, buf.Len())
+	copy(b, buf.Bytes())
 	return b, nil
 }


### PR DESCRIPTION
Reuse the buffer when marshaling to JSON to reduce allocations.

Before:
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   17335	     74243 ns/op	   86155 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   20803	     59168 ns/op	   75112 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   19272	     69521 ns/op	   74443 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	     844	   1450500 ns/op	 1512177 B/op	   16020 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      92	  12529954 ns/op	15113401 B/op	  160039 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	      87	  12541103 ns/op	15187117 B/op	  160026 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    1510	   1037920 ns/op	 3378515 B/op	     911 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	    5313	    263834 ns/op	   76635 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   10278	    111720 ns/op	   76737 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     488	   2338692 ns/op	 1507837 B/op	   16022 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      49	  23616483 ns/op	15067027 B/op	  160043 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      44	  23246753 ns/op	15068667 B/op	  160041 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    112802 ns/op	   93131 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	    6944	    144011 ns/op	  100430 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    3235	    324814 ns/op	 2192950 B/op	    1520 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     492	   2929750 ns/op	 3938584 B/op	   30026 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      44	  30500624 ns/op	22614603 B/op	  300057 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      40	  29292578 ns/op	28916003 B/op	  300058 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    5371	    200170 ns/op	   95371 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6349	    225109 ns/op	  103237 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3044	    404600 ns/op	 2195277 B/op	    1521 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     333	   3821134 ns/op	 3933083 B/op	   30027 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      32	  34545564 ns/op	20465457 B/op	  300052 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      31	  33849896 ns/op	23607452 B/op	  300032 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5248	    219404 ns/op	  170385 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5473	    222394 ns/op	  170308 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5494	    275767 ns/op	  170410 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     255	   4762914 ns/op	 3464834 B/op	   40081 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      26	  43733527 ns/op	34951553 B/op	  400230 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      24	  44159260 ns/op	34965678 B/op	  400233 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4125	    288644 ns/op	  171300 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    3716	    307309 ns/op	  172285 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    3014	    352203 ns/op	  171630 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     206	   6447532 ns/op	 3470035 B/op	   40084 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      19	  61253215 ns/op	34861528 B/op	  400234 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      19	  57987537 ns/op	34858824 B/op	  400224 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    1754	    771480 ns/op	  756408 B/op	    8030 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	45.311s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.346s

Process finished with the exit code 0
```

After:
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   17598	     70290 ns/op	   87887 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   19902	     58638 ns/op	   76626 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   19508	     58576 ns/op	   75945 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	     944	   1214229 ns/op	 1515291 B/op	   16023 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      97	  10981348 ns/op	15115759 B/op	  160044 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	     110	  10804868 ns/op	15162031 B/op	  160029 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    2442	    479023 ns/op	 3372710 B/op	     914 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	   10000	    101537 ns/op	   78327 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   12098	     99394 ns/op	   77567 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     511	   2278630 ns/op	 1515229 B/op	   16025 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      50	  22696956 ns/op	15074601 B/op	  160046 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      51	  22681757 ns/op	15074894 B/op	  160050 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    112062 ns/op	   93283 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	   10000	    109747 ns/op	  100428 B/op	    1512 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    5066	    252906 ns/op	 2193808 B/op	    1521 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     500	   2380650 ns/op	 3939893 B/op	   30027 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      46	  22381769 ns/op	22743817 B/op	  300064 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      51	  22453444 ns/op	29189910 B/op	  300060 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    6421	    179604 ns/op	   94429 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6226	    181455 ns/op	  102356 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3866	    383664 ns/op	 2195656 B/op	    1523 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     337	   3474300 ns/op	 3931620 B/op	   30028 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      33	  33156054 ns/op	20594989 B/op	  300049 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      34	  32393384 ns/op	23817326 B/op	  300048 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5553	    208027 ns/op	  170421 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5528	    206707 ns/op	  170461 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5713	    208509 ns/op	  170444 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     278	   4329534 ns/op	 3466330 B/op	   40085 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      25	  42675587 ns/op	35089976 B/op	  400232 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      24	  43477189 ns/op	35097326 B/op	  400235 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4227	    285497 ns/op	  171638 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    4214	    286569 ns/op	  171654 B/op	    2038 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    4046	    279513 ns/op	  170908 B/op	    2038 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     217	   5446249 ns/op	 3459267 B/op	   40087 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      20	  53928202 ns/op	34991184 B/op	  400240 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      20	  53152856 ns/op	34991047 B/op	  400240 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    1743	    639512 ns/op	  758751 B/op	    8031 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	43.126s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.365s

Process finished with the exit code 0
```

Benchstat:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
                                                     │ before_buffer.txt │        after_buffer_reuse.txt         │
                                                     │      sec/op       │    sec/op     vs base                 │
_pushLogData_10_10_1024-12                                  74.24µ ± ∞ ¹   70.29µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                    59.17µ ± ∞ ¹   58.64µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                    69.52µ ± ∞ ¹   58.58µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                   1.451m ± ∞ ¹   1.214m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                  12.53m ± ∞ ¹   10.98m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                  12.54m ± ∞ ¹   10.80m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                      1037.9µ ± ∞ ¹   479.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                         263.8µ ± ∞ ¹   101.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                        111.72µ ± ∞ ¹   99.39µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                        2.339m ± ∞ ¹   2.279m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                       23.62m ± ∞ ¹   22.70m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                       23.25m ± ∞ ¹   22.68m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                               112.8µ ± ∞ ¹   112.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                 144.0µ ± ∞ ¹   109.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                 324.8µ ± ∞ ¹   252.9µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                2.930m ± ∞ ¹   2.381m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                               30.50m ± ∞ ¹   22.38m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                               29.29m ± ∞ ¹   22.45m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                    200.2µ ± ∞ ¹   179.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                      225.1µ ± ∞ ¹   181.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                      404.6µ ± ∞ ¹   383.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                     3.821m ± ∞ ¹   3.474m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                    34.55m ± ∞ ¹   33.16m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                    33.85m ± ∞ ¹   32.39m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                   219.4µ ± ∞ ¹   208.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                     222.4µ ± ∞ ¹   206.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                     275.8µ ± ∞ ¹   208.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                    4.763m ± ∞ ¹   4.330m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                   43.73m ± ∞ ¹   42.68m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                   44.16m ± ∞ ¹   43.48m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12        288.6µ ± ∞ ¹   285.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12          307.3µ ± ∞ ¹   286.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12          352.2µ ± ∞ ¹   279.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12         6.448m ± ∞ ¹   5.446m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12        61.25m ± ∞ ¹   53.93m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12        57.99m ± ∞ ¹   53.15m ± ∞ ¹        ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                      771.5µ ± ∞ ¹   639.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                     1.679m         1.430m        -14.79%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ before_buffer.txt │        after_buffer_reuse.txt         │
                                                     │       B/op        │     B/op       vs base                │
_pushLogData_10_10_1024-12                                 84.14Ki ± ∞ ¹   85.83Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                   73.35Ki ± ∞ ¹   74.83Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                   72.70Ki ± ∞ ¹   74.17Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                  1.442Mi ± ∞ ¹   1.445Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                 14.41Mi ± ∞ ¹   14.42Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                 14.48Mi ± ∞ ¹   14.46Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                      3.222Mi ± ∞ ¹   3.216Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                        74.84Ki ± ∞ ¹   76.49Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                        74.94Ki ± ∞ ¹   75.75Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                       1.438Mi ± ∞ ¹   1.445Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                      14.37Mi ± ∞ ¹   14.38Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                      14.37Mi ± ∞ ¹   14.38Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                              90.95Ki ± ∞ ¹   91.10Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                98.08Ki ± ∞ ¹   98.07Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                2.091Mi ± ∞ ¹   2.092Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                               3.756Mi ± ∞ ¹   3.757Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                              21.57Mi ± ∞ ¹   21.69Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                              27.58Mi ± ∞ ¹   27.84Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                   93.14Ki ± ∞ ¹   92.22Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                    100.82Ki ± ∞ ¹   99.96Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                     2.094Mi ± ∞ ¹   2.094Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                    3.751Mi ± ∞ ¹   3.749Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                   19.52Mi ± ∞ ¹   19.64Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                   22.51Mi ± ∞ ¹   22.71Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                  166.4Ki ± ∞ ¹   166.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                    166.3Ki ± ∞ ¹   166.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                    166.4Ki ± ∞ ¹   166.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                   3.304Mi ± ∞ ¹   3.306Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                  33.33Mi ± ∞ ¹   33.46Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                  33.35Mi ± ∞ ¹   33.47Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12       167.3Ki ± ∞ ¹   167.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12         168.2Ki ± ∞ ¹   167.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12         167.6Ki ± ∞ ¹   166.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12        3.309Mi ± ∞ ¹   3.299Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12       33.25Mi ± ∞ ¹   33.37Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12       33.24Mi ± ∞ ¹   33.37Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                     738.7Ki ± ∞ ¹   741.0Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                    1.379Mi         1.383Mi        +0.33%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ before_buffer.txt │        after_buffer_reuse.txt        │
                                                     │     allocs/op     │  allocs/op    vs base                │
_pushLogData_10_10_1024-12                                   938.0 ± ∞ ¹    938.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                     818.0 ± ∞ ¹    818.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                     810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                   16.02k ± ∞ ¹   16.02k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-12                                  160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_5M-12                                  160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_1024-12                        911.0 ± ∞ ¹    914.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_8K-12                          810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                          810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                        16.02k ± ∞ ¹   16.02k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_2M-12                       160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_5M-12                       160.0k ± ∞ ¹   160.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024-12                               1.511k ± ∞ ¹   1.511k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                 1.511k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_2M-12                                 1.520k ± ∞ ¹   1.521k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_200_2M-12                                30.03k ± ∞ ¹   30.03k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M-12                               300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M-12                               300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024-12                    1.512k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                      1.512k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                      1.521k ± ∞ ¹   1.523k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_200_2M-12                     30.03k ± ∞ ¹   30.03k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M-12                    300.1k ± ∞ ¹   300.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M-12                    300.0k ± ∞ ¹   300.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024_MultiMetric-12                   2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                     2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                     2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                    40.08k ± ∞ ¹   40.09k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-12                   400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-12                   400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-12        2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12          2.037k ± ∞ ¹   2.038k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_2M_MultiMetric-12          2.037k ± ∞ ¹   2.038k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_200_2M_MultiMetric-12         40.08k ± ∞ ¹   40.09k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M_MultiMetric-12        400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M_MultiMetric-12        400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-12                                      8.030k ± ∞ ¹   8.031k ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                     12.92k         12.92k        +0.02%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```