### PR TITLE
[chore] faster casting on values

### DIFF
--- a/pkg/translator/splunk/logs_to_splunk.go
+++ b/pkg/translator/splunk/logs_to_splunk.go
@@ -57,7 +57,7 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 		case splunk.HecTokenLabel:
 			// ignore
 		default:
-			mergeValue(fields, k, v.AsRaw())
+			mergeValue(fields, k, v)
 		}
 	}
 	for k, v := range lr.Attributes().All() {
@@ -73,7 +73,7 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 		case splunk.HecTokenLabel:
 			// ignore
 		default:
-			mergeValue(fields, k, v.AsRaw())
+			mergeValue(fields, k, v)
 		}
 	}
 
@@ -93,48 +93,67 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 	}
 }
 
-func mergeValue(dst map[string]any, k string, v any) {
-	switch element := v.(type) {
-	case []any:
-		if isArrayFlat(element) {
-			dst[k] = v
+func mergeValue(dst map[string]any, k string, v pcommon.Value) {
+	switch v.Type() {
+	case pcommon.ValueTypeEmpty:
+		dst[k] = nil
+	case pcommon.ValueTypeStr:
+		dst[k] = v.Str()
+	case pcommon.ValueTypeBool:
+		dst[k] = v.Bool()
+	case pcommon.ValueTypeDouble:
+		dst[k] = v.Double()
+	case pcommon.ValueTypeInt:
+		dst[k] = v.Int()
+	case pcommon.ValueTypeBytes:
+		dst[k] = v.Bytes().AsRaw()
+	case pcommon.ValueTypeMap:
+		flattenAndMergeMap(v.Map(), dst, k)
+	case pcommon.ValueTypeSlice:
+		if isArrayFlat(v.Slice()) {
+			dst[k] = v.Slice().AsRaw()
 		} else {
-			b, _ := json.Marshal(element)
+			b, _ := json.Marshal(v.Slice().AsRaw())
 			dst[k] = string(b)
 		}
-	case map[string]any:
-		flattenAndMergeMap(element, dst, k)
-	default:
-		dst[k] = v
 	}
 }
 
-func isArrayFlat(array []any) bool {
-	for _, v := range array {
-		switch v.(type) {
-		case []any, map[string]any:
+func isArrayFlat(array pcommon.Slice) bool {
+	for _, v := range array.All() {
+		switch v.Type() {
+		case pcommon.ValueTypeSlice, pcommon.ValueTypeMap:
 			return false
 		}
 	}
 	return true
 }
 
-func flattenAndMergeMap(src, dst map[string]any, key string) {
-	for k, v := range src {
+func flattenAndMergeMap(src pcommon.Map, dst map[string]any, key string) {
+	for k, v := range src.All() {
 		current := fmt.Sprintf("%s.%s", key, k)
-		switch element := v.(type) {
-		case map[string]any:
-			flattenAndMergeMap(element, dst, current)
-		case []any:
-			if isArrayFlat(element) {
-				dst[current] = element
+		switch v.Type() {
+		case pcommon.ValueTypeMap:
+			flattenAndMergeMap(v.Map(), dst, current)
+		case pcommon.ValueTypeSlice:
+			if isArrayFlat(v.Slice()) {
+				dst[current] = v.Slice().AsRaw()
 			} else {
-				b, _ := json.Marshal(element)
+				b, _ := json.Marshal(v.Slice().AsRaw())
 				dst[current] = string(b)
 			}
-
-		default:
-			dst[current] = element
+		case pcommon.ValueTypeEmpty:
+			dst[current] = nil
+		case pcommon.ValueTypeStr:
+			dst[current] = v.Str()
+		case pcommon.ValueTypeBool:
+			dst[current] = v.Bool()
+		case pcommon.ValueTypeDouble:
+			dst[current] = v.Double()
+		case pcommon.ValueTypeInt:
+			dst[current] = v.Int()
+		case pcommon.ValueTypeBytes:
+			dst[current] = v.Bytes().AsRaw()
 		}
 	}
 }

--- a/pkg/translator/splunk/logs_to_splunk_test.go
+++ b/pkg/translator/splunk/logs_to_splunk_test.go
@@ -464,56 +464,84 @@ func Test_mergeValue(t *testing.T) {
 	tests := []struct {
 		name     string
 		key      string
-		val      any
+		val      pcommon.Value
 		expected map[string]any
 	}{
 		{
 			name:     "int",
 			key:      "intKey",
-			val:      0,
-			expected: map[string]any{"intKey": 0},
+			val:      pcommon.NewValueInt(0),
+			expected: map[string]any{"intKey": int64(0)},
 		},
 		{
-			name:     "flat_array",
-			key:      "arrayKey",
-			val:      []any{0, 1, 2, 3},
-			expected: map[string]any{"arrayKey": []any{0, 1, 2, 3}},
+			name: "flat_array",
+			key:  "arrayKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueSlice()
+				_ = v.FromRaw([]any{0, 1, 2, 3})
+				return v
+			}(),
+			expected: map[string]any{"arrayKey": []any{int64(0), int64(1), int64(2), int64(3)}},
 		},
 		{
-			name:     "nested_array",
-			key:      "arrayKey",
-			val:      []any{0, 1, []any{2, 3}},
+			name: "nested_array",
+			key:  "arrayKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueSlice()
+				_ = v.FromRaw([]any{0, 1, []any{2, 3}})
+				return v
+			}(),
 			expected: map[string]any{"arrayKey": "[0,1,[2,3]]"},
 		},
 		{
-			name:     "array_of_map",
-			key:      "arrayKey",
-			val:      []any{0, 1, map[string]any{"3": 3}},
+			name: "array_of_map",
+			key:  "arrayKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueSlice()
+				_ = v.FromRaw([]any{0, 1, map[string]any{"3": 3}})
+				return v
+			}(),
 			expected: map[string]any{"arrayKey": "[0,1,{\"3\":3}]"},
 		},
 		{
-			name:     "flat_map",
-			key:      "mapKey",
-			val:      map[string]any{"1": 1, "2": 2},
-			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2},
+			name: "flat_map",
+			key:  "mapKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueMap()
+				_ = v.FromRaw(map[string]any{"1": 1, "2": 2})
+				return v
+			}(),
+			expected: map[string]any{"mapKey.1": int64(1), "mapKey.2": int64(2)},
 		},
 		{
-			name:     "nested_map",
-			key:      "mapKey",
-			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "4": 4}},
-			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.4": 4},
+			name: "nested_map",
+			key:  "mapKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueMap()
+				_ = v.FromRaw(map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "4": 4}})
+				return v
+			}(),
+			expected: map[string]any{"mapKey.1": int64(1), "mapKey.2": int64(2), "mapKey.nested.3": int64(3), "mapKey.nested.4": int64(4)},
 		},
 		{
-			name:     "flat_array_in_nested_map",
-			key:      "mapKey",
-			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "flat_array": []any{4}}},
-			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.flat_array": []any{4}},
+			name: "flat_array_in_nested_map",
+			key:  "mapKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueMap()
+				_ = v.FromRaw(map[string]any{"1": int64(1), "2": int64(2), "nested": map[string]any{"3": int64(3), "flat_array": []any{int64(4)}}})
+				return v
+			}(),
+			expected: map[string]any{"mapKey.1": int64(1), "mapKey.2": int64(2), "mapKey.nested.3": int64(3), "mapKey.nested.flat_array": []any{int64(4)}},
 		},
 		{
-			name:     "nested_array_in_nested_map",
-			key:      "mapKey",
-			val:      map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "nested_array": []any{4, []any{5}}}},
-			expected: map[string]any{"mapKey.1": 1, "mapKey.2": 2, "mapKey.nested.3": 3, "mapKey.nested.nested_array": "[4,[5]]"},
+			name: "nested_array_in_nested_map",
+			key:  "mapKey",
+			val: func() pcommon.Value {
+				v := pcommon.NewValueMap()
+				_ = v.FromRaw(map[string]any{"1": 1, "2": 2, "nested": map[string]any{"3": 3, "nested_array": []any{4, []any{5}}}})
+				return v
+			}(),
+			expected: map[string]any{"mapKey.1": int64(1), "mapKey.2": int64(2), "mapKey.nested.3": int64(3), "mapKey.nested.nested_array": "[4,[5]]"},
 		},
 	}
 


### PR DESCRIPTION
Make exporting logs to HEC events faster by only serializing the values to go native objects at the last minute.

Before:
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   17335	     74243 ns/op	   86155 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   20803	     59168 ns/op	   75112 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   19272	     69521 ns/op	   74443 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	     844	   1450500 ns/op	 1512177 B/op	   16020 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      92	  12529954 ns/op	15113401 B/op	  160039 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	      87	  12541103 ns/op	15187117 B/op	  160026 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    1510	   1037920 ns/op	 3378515 B/op	     911 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	    5313	    263834 ns/op	   76635 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   10278	    111720 ns/op	   76737 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     488	   2338692 ns/op	 1507837 B/op	   16022 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      49	  23616483 ns/op	15067027 B/op	  160043 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      44	  23246753 ns/op	15068667 B/op	  160041 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    112802 ns/op	   93131 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	    6944	    144011 ns/op	  100430 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    3235	    324814 ns/op	 2192950 B/op	    1520 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     492	   2929750 ns/op	 3938584 B/op	   30026 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      44	  30500624 ns/op	22614603 B/op	  300057 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      40	  29292578 ns/op	28916003 B/op	  300058 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    5371	    200170 ns/op	   95371 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6349	    225109 ns/op	  103237 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3044	    404600 ns/op	 2195277 B/op	    1521 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     333	   3821134 ns/op	 3933083 B/op	   30027 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      32	  34545564 ns/op	20465457 B/op	  300052 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      31	  33849896 ns/op	23607452 B/op	  300032 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5248	    219404 ns/op	  170385 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5473	    222394 ns/op	  170308 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5494	    275767 ns/op	  170410 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     255	   4762914 ns/op	 3464834 B/op	   40081 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      26	  43733527 ns/op	34951553 B/op	  400230 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      24	  44159260 ns/op	34965678 B/op	  400233 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4125	    288644 ns/op	  171300 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    3716	    307309 ns/op	  172285 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    3014	    352203 ns/op	  171630 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     206	   6447532 ns/op	 3470035 B/op	   40084 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      19	  61253215 ns/op	34861528 B/op	  400234 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      19	  57987537 ns/op	34858824 B/op	  400224 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    1754	    771480 ns/op	  756408 B/op	    8030 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	45.311s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.346s

Process finished with the exit code 0

```

After
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   19548	     60966 ns/op	   86141 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   21614	     54269 ns/op	   75100 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   22844	     52837 ns/op	   74406 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	    1002	   1177702 ns/op	 1509119 B/op	   16021 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      96	  10532616 ns/op	15111242 B/op	  160042 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	     114	  10568851 ns/op	15153288 B/op	  160028 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    2328	    489083 ns/op	 3369675 B/op	     912 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	   12548	     95721 ns/op	   75852 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   12528	     95892 ns/op	   76250 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     541	   2214121 ns/op	 1507639 B/op	   16022 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      50	  21949671 ns/op	15065876 B/op	  160040 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      52	  22165813 ns/op	15065592 B/op	  160043 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    107725 ns/op	   93086 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	   10000	    111334 ns/op	  100390 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    4987	    244127 ns/op	 2192924 B/op	    1520 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     499	   2401649 ns/op	 3942843 B/op	   30027 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      50	  22123976 ns/op	22687390 B/op	  300058 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      50	  22312913 ns/op	28894365 B/op	  300055 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    6636	    176239 ns/op	   95058 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6457	    176365 ns/op	  102154 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3890	    327798 ns/op	 2195636 B/op	    1521 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     328	   3577158 ns/op	 3930575 B/op	   30027 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      32	  32976751 ns/op	20465653 B/op	  300053 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      34	  34318268 ns/op	23644680 B/op	  300039 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5178	    215851 ns/op	  170368 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5456	    211302 ns/op	  170342 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5076	    214931 ns/op	  170306 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     265	   4434621 ns/op	 3456660 B/op	   40082 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      27	  42698772 ns/op	35256971 B/op	  400233 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      24	  43656243 ns/op	34962740 B/op	  400221 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4303	    289023 ns/op	  171214 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    4284	    275964 ns/op	  171439 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    4287	    278021 ns/op	  171456 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     226	   5238773 ns/op	 3461230 B/op	   40085 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      20	  50987388 ns/op	34858566 B/op	  400236 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      21	  51218391 ns/op	34856362 B/op	  400239 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    2024	    588298 ns/op	  756819 B/op	    8031 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	43.105s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.419s

Process finished with the exit code 0
```

Benchstat:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
                                                     │ before_buffer.txt │        after_buffer_reuse.txt         │
                                                     │      sec/op       │    sec/op     vs base                 │
_pushLogData_10_10_1024-12                                  74.24µ ± ∞ ¹   60.97µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                    59.17µ ± ∞ ¹   54.27µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                    69.52µ ± ∞ ¹   52.84µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                   1.451m ± ∞ ¹   1.178m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                  12.53m ± ∞ ¹   10.53m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                  12.54m ± ∞ ¹   10.57m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                      1037.9µ ± ∞ ¹   489.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                        263.83µ ± ∞ ¹   95.72µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                        111.72µ ± ∞ ¹   95.89µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                        2.339m ± ∞ ¹   2.214m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                       23.62m ± ∞ ¹   21.95m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                       23.25m ± ∞ ¹   22.17m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                               112.8µ ± ∞ ¹   107.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                 144.0µ ± ∞ ¹   111.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                 324.8µ ± ∞ ¹   244.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                2.930m ± ∞ ¹   2.402m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                               30.50m ± ∞ ¹   22.12m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                               29.29m ± ∞ ¹   22.31m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                    200.2µ ± ∞ ¹   176.2µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                      225.1µ ± ∞ ¹   176.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                      404.6µ ± ∞ ¹   327.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                     3.821m ± ∞ ¹   3.577m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                    34.55m ± ∞ ¹   32.98m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                    33.85m ± ∞ ¹   34.32m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                   219.4µ ± ∞ ¹   215.9µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                     222.4µ ± ∞ ¹   211.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                     275.8µ ± ∞ ¹   214.9µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                    4.763m ± ∞ ¹   4.435m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                   43.73m ± ∞ ¹   42.70m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                   44.16m ± ∞ ¹   43.66m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12        288.6µ ± ∞ ¹   289.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12          307.3µ ± ∞ ¹   276.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12          352.2µ ± ∞ ¹   278.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12         6.448m ± ∞ ¹   5.239m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12        61.25m ± ∞ ¹   50.99m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12        57.99m ± ∞ ¹   51.22m ± ∞ ¹        ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                      771.5µ ± ∞ ¹   588.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                     1.679m         1.396m        -16.83%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ before_buffer.txt │        after_buffer_reuse.txt         │
                                                     │       B/op        │     B/op       vs base                │
_pushLogData_10_10_1024-12                                 84.14Ki ± ∞ ¹   84.12Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                   73.35Ki ± ∞ ¹   73.34Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                   72.70Ki ± ∞ ¹   72.66Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                  1.442Mi ± ∞ ¹   1.439Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                 14.41Mi ± ∞ ¹   14.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                 14.48Mi ± ∞ ¹   14.45Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                      3.222Mi ± ∞ ¹   3.214Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                        74.84Ki ± ∞ ¹   74.07Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                        74.94Ki ± ∞ ¹   74.46Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                       1.438Mi ± ∞ ¹   1.438Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                      14.37Mi ± ∞ ¹   14.37Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                      14.37Mi ± ∞ ¹   14.37Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                              90.95Ki ± ∞ ¹   90.90Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                98.08Ki ± ∞ ¹   98.04Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                2.091Mi ± ∞ ¹   2.091Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                               3.756Mi ± ∞ ¹   3.760Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                              21.57Mi ± ∞ ¹   21.64Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                              27.58Mi ± ∞ ¹   27.56Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                   93.14Ki ± ∞ ¹   92.83Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                    100.82Ki ± ∞ ¹   99.76Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                     2.094Mi ± ∞ ¹   2.094Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                    3.751Mi ± ∞ ¹   3.748Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                   19.52Mi ± ∞ ¹   19.52Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                   22.51Mi ± ∞ ¹   22.55Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                  166.4Ki ± ∞ ¹   166.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                    166.3Ki ± ∞ ¹   166.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                    166.4Ki ± ∞ ¹   166.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                   3.304Mi ± ∞ ¹   3.297Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                  33.33Mi ± ∞ ¹   33.62Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                  33.35Mi ± ∞ ¹   33.34Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12       167.3Ki ± ∞ ¹   167.2Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12         168.2Ki ± ∞ ¹   167.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12         167.6Ki ± ∞ ¹   167.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12        3.309Mi ± ∞ ¹   3.301Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12       33.25Mi ± ∞ ¹   33.24Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12       33.24Mi ± ∞ ¹   33.24Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                     738.7Ki ± ∞ ¹   739.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                    1.379Mi         1.377Mi        -0.10%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ before_buffer.txt │        after_buffer_reuse.txt        │
                                                     │     allocs/op     │  allocs/op    vs base                │
_pushLogData_10_10_1024-12                                   938.0 ± ∞ ¹    938.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                     818.0 ± ∞ ¹    818.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                     810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                   16.02k ± ∞ ¹   16.02k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-12                                  160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_5M-12                                  160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_1024-12                        911.0 ± ∞ ¹    912.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_8K-12                          810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                          810.0 ± ∞ ¹    810.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                        16.02k ± ∞ ¹   16.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                       160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_5M-12                       160.0k ± ∞ ¹   160.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024-12                               1.511k ± ∞ ¹   1.511k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                 1.511k ± ∞ ¹   1.511k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                 1.520k ± ∞ ¹   1.520k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                30.03k ± ∞ ¹   30.03k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M-12                               300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M-12                               300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024-12                    1.512k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                      1.512k ± ∞ ¹   1.512k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                      1.521k ± ∞ ¹   1.521k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                     30.03k ± ∞ ¹   30.03k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                    300.1k ± ∞ ¹   300.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M-12                    300.0k ± ∞ ¹   300.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024_MultiMetric-12                   2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                     2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                     2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                    40.08k ± ∞ ¹   40.08k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-12                   400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-12                   400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-12        2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12          2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12          2.037k ± ∞ ¹   2.037k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12         40.08k ± ∞ ¹   40.09k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M_MultiMetric-12        400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M_MultiMetric-12        400.2k ± ∞ ¹   400.2k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-12                                      8.030k ± ∞ ¹   8.031k ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                     12.92k         12.92k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```