### PR TITLE
[exporter/splunk_hec] Direct write

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -191,7 +192,6 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, headers
 
 // fillLogsBuffer fills the buffer with Splunk events until the buffer is full or all logs are processed.
 func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterState, []error) {
-	var b []byte
 	var permanentErrors []error
 
 	for i := is.resource; i < logs.ResourceLogs().Len(); i++ {
@@ -203,8 +203,10 @@ func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterS
 				is.record = 0 // Reset record index for next library.
 				logRecord := sl.LogRecords().At(k)
 
+				var err error
 				if c.config.ExportRaw {
-					b = []byte(logRecord.Body().AsString() + "\n")
+					b := []byte(logRecord.Body().AsString() + "\n")
+					_, err = buf.Write(b)
 				} else {
 					// Parsing log record to Splunk event.
 					event := translator.LogToSplunkEvent(rl.Resource(), logRecord, c.config.OtelAttrsToHec, c.config.HecFields, c.config.Source, c.config.SourceType, c.config.Index)
@@ -214,16 +216,15 @@ func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterS
 					}
 
 					// JSON encoding event and writing to buffer.
-					var err error
-					b, err = marshalEvent(event, c.config.MaxEventSize)
-					if err != nil {
-						permanentErrors = append(permanentErrors, consumererror.NewPermanent(err))
+					var jsonErr error
+					jsonErr, err = marshalEvent(event, c.config.MaxEventSize, buf)
+					if jsonErr != nil {
+						permanentErrors = append(permanentErrors, consumererror.NewPermanent(jsonErr))
 						continue
 					}
 				}
 
 				// Continue adding events to buffer up to capacity.
-				_, err := buf.Write(b)
 				if err == nil {
 					continue
 				}
@@ -233,7 +234,7 @@ func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterS
 					}
 					permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 						fmt.Errorf("dropped log event: error: event size %d bytes larger than configured max"+
-							" content length %d bytes", len(b), c.config.MaxContentLengthLogs)))
+							" content length %d bytes", buf.Len(), c.config.MaxContentLengthLogs)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
 				permanentErrors = append(permanentErrors,
@@ -248,7 +249,6 @@ func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterS
 func (c *client) fillMetricsBuffer(metrics pmetric.Metrics, buf buffer, is iterState) (iterState, []error) {
 	var permanentErrors []error
 
-	tempBuf := bytes.NewBuffer(make([]byte, 0, c.config.MaxContentLengthMetrics))
 	for i := is.resource; i < metrics.ResourceMetrics().Len(); i++ {
 		rm := metrics.ResourceMetrics().At(i)
 		for j := is.library; j < rm.ScopeMetrics().Len(); j++ {
@@ -260,20 +260,18 @@ func (c *client) fillMetricsBuffer(metrics pmetric.Metrics, buf buffer, is iterS
 
 				// Parsing metric record to Splunk event.
 				events := translator.MetricToSplunkEvent(rm.Resource(), metric, c.logger, c.config.OtelAttrsToHec, c.config.Source, c.config.SourceType, c.config.Index)
-				tempBuf.Reset()
+				var err error
 				for _, event := range events {
 					// JSON encoding event and writing to buffer.
-					b, err := marshalEvent(event, c.config.MaxEventSize)
-					if err != nil {
-						permanentErrors = append(permanentErrors, consumererror.NewPermanent(err))
+					var jsonErr error
+					jsonErr, err = marshalEvent(event, c.config.MaxEventSize, buf)
+					if jsonErr != nil {
+						permanentErrors = append(permanentErrors, consumererror.NewPermanent(jsonErr))
 						continue
 					}
-					tempBuf.Write(b)
 				}
 
 				// Continue adding events to buffer up to capacity.
-				b := tempBuf.Bytes()
-				_, err := buf.Write(b)
 				if err == nil {
 					continue
 				}
@@ -283,7 +281,7 @@ func (c *client) fillMetricsBuffer(metrics pmetric.Metrics, buf buffer, is iterS
 					}
 					permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 						fmt.Errorf("dropped metric event: error: event size %d bytes larger than configured max"+
-							" content length %d bytes", len(b), c.config.MaxContentLengthMetrics)))
+							" content length %d bytes", buf.Len(), c.config.MaxContentLengthMetrics)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
 				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(
@@ -301,12 +299,11 @@ func (c *client) fillMetricsBufferMultiMetrics(events []*translator.Event, buf b
 	for i := is.record; i < len(events); i++ {
 		event := events[i]
 		// JSON encoding event and writing to buffer.
-		b, jsonErr := marshalEvent(event, c.config.MaxEventSize)
+		jsonErr, err := marshalEvent(event, c.config.MaxEventSize, buf)
 		if jsonErr != nil {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(jsonErr))
 			continue
 		}
-		_, err := buf.Write(b)
 		if errors.Is(err, errOverCapacity) {
 			if !buf.Empty() {
 				return iterState{
@@ -316,7 +313,7 @@ func (c *client) fillMetricsBufferMultiMetrics(events []*translator.Event, buf b
 			}
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 				fmt.Errorf("dropped metric event: error: event size %d bytes larger than configured max"+
-					" content length %d bytes", len(b), c.config.MaxContentLengthMetrics)))
+					" content length %d bytes", buf.Len(), c.config.MaxContentLengthMetrics)))
 			return iterState{
 				record: i + 1,
 				done:   i+1 != len(events),
@@ -346,14 +343,13 @@ func (c *client) fillTracesBuffer(traces ptrace.Traces, buf buffer, is iterState
 				event := translator.SpanToSplunkEvent(rs.Resource(), span, c.config.OtelAttrsToHec, c.config.Source, c.config.SourceType, c.config.Index)
 
 				// JSON encoding event and writing to buffer.
-				b, err := marshalEvent(event, c.config.MaxEventSize)
-				if err != nil {
-					permanentErrors = append(permanentErrors, consumererror.NewPermanent(err))
+				jsonErr, err := marshalEvent(event, c.config.MaxEventSize, buf)
+				if jsonErr != nil {
+					permanentErrors = append(permanentErrors, consumererror.NewPermanent(jsonErr))
 					continue
 				}
 
 				// Continue adding events to buffer up to capacity.
-				_, err = buf.Write(b)
 				if err == nil {
 					continue
 				}
@@ -363,7 +359,7 @@ func (c *client) fillTracesBuffer(traces ptrace.Traces, buf buffer, is iterState
 					}
 					permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 						fmt.Errorf("dropped span event: error: event size %d bytes larger than configured max"+
-							" content length %d bytes", len(b), c.config.MaxContentLengthTraces)))
+							" content length %d bytes", buf.Len(), c.config.MaxContentLengthTraces)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
 				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(
@@ -684,7 +680,7 @@ var jsonBufferPool = sync.Pool{
 }
 
 // marshalEvent marshals an event to JSON
-func marshalEvent(event *translator.Event, sizeLimit uint) ([]byte, error) {
+func marshalEvent(event *translator.Event, sizeLimit uint, writer io.Writer) (error, error) {
 	buf := jsonBufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer jsonBufferPool.Put(buf)
@@ -694,10 +690,9 @@ func marshalEvent(event *translator.Event, sizeLimit uint) ([]byte, error) {
 		return nil, err
 	}
 	if uint(buf.Len()) > sizeLimit {
-		return nil, fmt.Errorf("event size %d exceeds limit %d", buf.Len(), sizeLimit)
+		return fmt.Errorf("event size %d exceeds limit %d", buf.Len(), sizeLimit), nil
 	}
 
-	b := make([]byte, buf.Len())
-	copy(b, buf.Bytes())
-	return b, nil
+	_, err := writer.Write(buf.Bytes())
+	return nil, err
 }


### PR DESCRIPTION
Avoid copying bytes around, send to writer straight up.
Before (with #47375 )
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   19548	     60966 ns/op	   86141 B/op	     938 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   21614	     54269 ns/op	   75100 B/op	     818 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   22844	     52837 ns/op	   74406 B/op	     810 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	    1002	   1177702 ns/op	 1509119 B/op	   16021 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      96	  10532616 ns/op	15111242 B/op	  160042 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	     114	  10568851 ns/op	15153288 B/op	  160028 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    2328	    489083 ns/op	 3369675 B/op	     912 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	   12548	     95721 ns/op	   75852 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   12528	     95892 ns/op	   76250 B/op	     810 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     541	   2214121 ns/op	 1507639 B/op	   16022 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      50	  21949671 ns/op	15065876 B/op	  160040 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      52	  22165813 ns/op	15065592 B/op	  160043 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    107725 ns/op	   93086 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	   10000	    111334 ns/op	  100390 B/op	    1511 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	    4987	    244127 ns/op	 2192924 B/op	    1520 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     499	   2401649 ns/op	 3942843 B/op	   30027 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      50	  22123976 ns/op	22687390 B/op	  300058 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      50	  22312913 ns/op	28894365 B/op	  300055 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    6636	    176239 ns/op	   95058 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6457	    176365 ns/op	  102154 B/op	    1512 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    3890	    327798 ns/op	 2195636 B/op	    1521 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     328	   3577158 ns/op	 3930575 B/op	   30027 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      32	  32976751 ns/op	20465653 B/op	  300053 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      34	  34318268 ns/op	23644680 B/op	  300039 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5178	    215851 ns/op	  170368 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5456	    211302 ns/op	  170342 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5076	    214931 ns/op	  170306 B/op	    2037 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     265	   4434621 ns/op	 3456660 B/op	   40082 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      27	  42698772 ns/op	35256971 B/op	  400233 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      24	  43656243 ns/op	34962740 B/op	  400221 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4303	    289023 ns/op	  171214 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    4284	    275964 ns/op	  171439 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    4287	    278021 ns/op	  171456 B/op	    2037 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     226	   5238773 ns/op	 3461230 B/op	   40085 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      20	  50987388 ns/op	34858566 B/op	  400236 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      21	  51218391 ns/op	34856362 B/op	  400239 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    2024	    588298 ns/op	  756819 B/op	    8031 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	43.105s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.419s

Process finished with the exit code 0
```

After:
```
GOROOT=/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 #gosetup
GOPATH=/Users/atoulme/go #gosetup
GOPROXY=proxy.golang.org #gosetup
/Users/atoulme/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/bin/go test -v ./... -bench . -run ^$ #gosetup
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-12                              	   20107	     59800 ns/op	   67585 B/op	     822 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-12                                	   22370	     53607 ns/op	   58929 B/op	     717 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-12                                	   23510	     51086 ns/op	   58377 B/op	     710 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-12                               	     950	   1153921 ns/op	 1159379 B/op	   14019 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-12                              	      99	  10293288 ns/op	11593332 B/op	  140038 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-12                              	     118	  10008486 ns/op	11633749 B/op	  140025 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-12                   	    2359	    484244 ns/op	 3353534 B/op	     812 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-12                     	   12704	     94365 ns/op	   60401 B/op	     710 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-12                     	   12624	     96081 ns/op	   60362 B/op	     710 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-12                    	     514	   2270366 ns/op	 1163168 B/op	   14020 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-12                   	      51	  22158322 ns/op	11552143 B/op	  140035 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-12                   	      52	  22173889 ns/op	11551954 B/op	  140036 allocs/op
Benchmark_pushMetricData_10_10_1024
Benchmark_pushMetricData_10_10_1024-12                           	   10000	    106520 ns/op	   71260 B/op	    1410 allocs/op
Benchmark_pushMetricData_10_10_8K
Benchmark_pushMetricData_10_10_8K-12                             	   10000	    106886 ns/op	   71323 B/op	    1410 allocs/op
Benchmark_pushMetricData_10_10_2M
Benchmark_pushMetricData_10_10_2M-12                             	   10000	    106696 ns/op	   71323 B/op	    1410 allocs/op
Benchmark_pushMetricData_10_200_2M
Benchmark_pushMetricData_10_200_2M-12                            	     532	   2231953 ns/op	 1427955 B/op	   28023 allocs/op
Benchmark_pushMetricData_100_200_2M
Benchmark_pushMetricData_100_200_2M-12                           	      49	  21170442 ns/op	14178458 B/op	  280053 allocs/op
Benchmark_pushMetricData_100_200_5M
Benchmark_pushMetricData_100_200_5M-12                           	      55	  21794717 ns/op	14320204 B/op	  280047 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024
Benchmark_pushMetricData_compressed_10_10_1024-12                	    6765	    174449 ns/op	   73326 B/op	    1411 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K
Benchmark_pushMetricData_compressed_10_10_8K-12                  	    6799	    175945 ns/op	   72837 B/op	    1411 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M
Benchmark_pushMetricData_compressed_10_10_2M-12                  	    6291	    180034 ns/op	   73215 B/op	    1411 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M
Benchmark_pushMetricData_compressed_10_200_2M-12                 	     337	   3459981 ns/op	 1421876 B/op	   28023 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M
Benchmark_pushMetricData_compressed_100_200_2M-12                	      34	  31848675 ns/op	14132084 B/op	  280040 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M
Benchmark_pushMetricData_compressed_100_200_5M-12                	      34	  31624004 ns/op	14132858 B/op	  280043 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric
Benchmark_pushMetricData_10_10_1024_MultiMetric-12               	    5636	    206352 ns/op	  149565 B/op	    1937 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric
Benchmark_pushMetricData_10_10_8K_MultiMetric-12                 	    5463	    207050 ns/op	  149564 B/op	    1937 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric
Benchmark_pushMetricData_10_10_2M_MultiMetric-12                 	    5552	    207739 ns/op	  149637 B/op	    1937 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric
Benchmark_pushMetricData_10_200_2M_MultiMetric-12                	     283	   4199441 ns/op	 3056473 B/op	   38082 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric
Benchmark_pushMetricData_100_200_2M_MultiMetric-12               	      26	  40238399 ns/op	30882223 B/op	  380232 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric
Benchmark_pushMetricData_100_200_5M_MultiMetric-12               	      26	  40284082 ns/op	30720501 B/op	  380229 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-12    	    4366	    269598 ns/op	  150333 B/op	    1937 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-12      	    4279	    274660 ns/op	  150949 B/op	    1937 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-12      	    4364	    262483 ns/op	  150117 B/op	    1937 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-12     	     234	   5079699 ns/op	 3041935 B/op	   38084 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-12    	      22	  49639241 ns/op	30620753 B/op	  380233 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-12    	      22	  50401011 ns/op	30620383 B/op	  380231 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-12                                  	    2108	    573605 ns/op	  584421 B/op	    7030 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	42.809s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/integrationtestutils	[no test files]
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata	0.347s

Process finished with the exit code 0
```

Benchstat:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
cpu: Apple M4 Pro
                                                     │ after_buffer_reuse.txt │        after_direct_write.txt        │
                                                     │         sec/op         │    sec/op     vs base                │
_pushLogData_10_10_1024-12                                       60.97µ ± ∞ ¹   59.80µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                         54.27µ ± ∞ ¹   53.61µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                         52.84µ ± ∞ ¹   51.09µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                        1.178m ± ∞ ¹   1.154m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                       10.53m ± ∞ ¹   10.29m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                       10.57m ± ∞ ¹   10.01m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                            489.1µ ± ∞ ¹   484.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                              95.72µ ± ∞ ¹   94.37µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                              95.89µ ± ∞ ¹   96.08µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                             2.214m ± ∞ ¹   2.270m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                            21.95m ± ∞ ¹   22.16m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                            22.17m ± ∞ ¹   22.17m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                                    107.7µ ± ∞ ¹   106.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                      111.3µ ± ∞ ¹   106.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                      244.1µ ± ∞ ¹   106.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                     2.402m ± ∞ ¹   2.232m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                                    22.12m ± ∞ ¹   21.17m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                                    22.31m ± ∞ ¹   21.79m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                         176.2µ ± ∞ ¹   174.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                           176.4µ ± ∞ ¹   175.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                           327.8µ ± ∞ ¹   180.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                          3.577m ± ∞ ¹   3.460m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                         32.98m ± ∞ ¹   31.85m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                         34.32m ± ∞ ¹   31.62m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                        215.9µ ± ∞ ¹   206.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                          211.3µ ± ∞ ¹   207.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                          214.9µ ± ∞ ¹   207.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                         4.435m ± ∞ ¹   4.199m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                        42.70m ± ∞ ¹   40.24m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                        43.66m ± ∞ ¹   40.28m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12             289.0µ ± ∞ ¹   269.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12               276.0µ ± ∞ ¹   274.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12               278.0µ ± ∞ ¹   262.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12              5.239m ± ∞ ¹   5.080m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12             50.99m ± ∞ ¹   49.64m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12             51.22m ± ∞ ¹   50.40m ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                           588.3µ ± ∞ ¹   573.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                          1.396m         1.306m        -6.43%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ after_buffer_reuse.txt │         after_direct_write.txt         │
                                                     │          B/op          │     B/op       vs base                 │
_pushLogData_10_10_1024-12                                      84.12Ki ± ∞ ¹   66.00Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                        73.34Ki ± ∞ ¹   57.55Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                        72.66Ki ± ∞ ¹   57.01Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                       1.439Mi ± ∞ ¹   1.106Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                      14.41Mi ± ∞ ¹   11.06Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                      14.45Mi ± ∞ ¹   11.09Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                           3.214Mi ± ∞ ¹   3.198Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                             74.07Ki ± ∞ ¹   58.99Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                             74.46Ki ± ∞ ¹   58.95Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                            1.438Mi ± ∞ ¹   1.109Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                           14.37Mi ± ∞ ¹   11.02Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                           14.37Mi ± ∞ ¹   11.02Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                                   90.90Ki ± ∞ ¹   69.59Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                     98.04Ki ± ∞ ¹   69.65Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                   2141.53Ki ± ∞ ¹   69.65Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                    3.760Mi ± ∞ ¹   1.362Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                                   21.64Mi ± ∞ ¹   13.52Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                                   27.56Mi ± ∞ ¹   13.66Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                        92.83Ki ± ∞ ¹   71.61Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                          99.76Ki ± ∞ ¹   71.13Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                        2144.18Ki ± ∞ ¹   71.50Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                         3.748Mi ± ∞ ¹   1.356Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                        19.52Mi ± ∞ ¹   13.48Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                        22.55Mi ± ∞ ¹   13.48Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                       166.4Ki ± ∞ ¹   146.1Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                         166.3Ki ± ∞ ¹   146.1Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                         166.3Ki ± ∞ ¹   146.1Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                        3.297Mi ± ∞ ¹   2.915Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                       33.62Mi ± ∞ ¹   29.45Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                       33.34Mi ± ∞ ¹   29.30Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12            167.2Ki ± ∞ ¹   146.8Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12              167.4Ki ± ∞ ¹   147.4Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12              167.4Ki ± ∞ ¹   146.6Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12             3.301Mi ± ∞ ¹   2.901Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12            33.24Mi ± ∞ ¹   29.20Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12            33.24Mi ± ∞ ¹   29.20Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                          739.1Ki ± ∞ ¹   570.7Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                         1.377Mi         897.7Ki        -36.34%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │ after_buffer_reuse.txt │        after_direct_write.txt        │
                                                     │       allocs/op        │  allocs/op    vs base                │
_pushLogData_10_10_1024-12                                        938.0 ± ∞ ¹    822.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-12                                          818.0 ± ∞ ¹    717.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-12                                          810.0 ± ∞ ¹    710.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-12                                        16.02k ± ∞ ¹   14.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-12                                       160.0k ± ∞ ¹   140.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-12                                       160.0k ± ∞ ¹   140.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-12                             912.0 ± ∞ ¹    812.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-12                               810.0 ± ∞ ¹    710.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-12                               810.0 ± ∞ ¹    710.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-12                             16.02k ± ∞ ¹   14.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-12                            160.0k ± ∞ ¹   140.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-12                            160.0k ± ∞ ¹   140.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-12                                    1.511k ± ∞ ¹   1.410k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-12                                      1.511k ± ∞ ¹   1.410k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-12                                      1.520k ± ∞ ¹   1.410k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-12                                     30.03k ± ∞ ¹   28.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-12                                    300.1k ± ∞ ¹   280.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-12                                    300.1k ± ∞ ¹   280.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-12                         1.512k ± ∞ ¹   1.411k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-12                           1.512k ± ∞ ¹   1.411k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-12                           1.521k ± ∞ ¹   1.411k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-12                          30.03k ± ∞ ¹   28.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-12                         300.1k ± ∞ ¹   280.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-12                         300.0k ± ∞ ¹   280.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-12                        2.037k ± ∞ ¹   1.937k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-12                          2.037k ± ∞ ¹   1.937k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-12                          2.037k ± ∞ ¹   1.937k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-12                         40.08k ± ∞ ¹   38.08k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-12                        400.2k ± ∞ ¹   380.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-12                        400.2k ± ∞ ¹   380.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-12             2.037k ± ∞ ¹   1.937k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-12               2.037k ± ∞ ¹   1.937k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-12               2.037k ± ∞ ¹   1.937k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-12              40.09k ± ∞ ¹   38.08k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-12             400.2k ± ∞ ¹   380.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-12             400.2k ± ∞ ¹   380.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-12                                           8.031k ± ∞ ¹   7.030k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                          12.92k         11.86k        -8.19%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```