### PR TITLE
[receiver/googlecloudpubsub] Add flow control configuration (#40736)

### DIFF
--- a/.chloggen/googlepubsub_receiver_flow_control_config.yaml
+++ b/.chloggen/googlepubsub_receiver_flow_control_config.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add flow control configuration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44804]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Add flow control configuration, giving advanced users more control over the parameters of the streaming 
+  pull control loop.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudpubsubreceiver/README.md
+++ b/receiver/googlecloudpubsubreceiver/README.md
@@ -35,6 +35,8 @@ The following configuration options are supported:
 * `ignore_encoding_error` (Optional): Ignore errors when the configured encoder fails to decoding a PubSub messages.
   It's advised to set this to `true` when using a custom encoder, and use `receiver.googlecloudpubsub.encoding_error`
   metric to monitor the number of errors. Ignoring the error will cause the receiver to drop the message.
+* `flow_control` (Optional): Allows to fine tune the flow control settings for the subscription stream. See
+  [Flow control](#flow-control) for more details.
 
 ```yaml
 receivers:
@@ -98,6 +100,34 @@ it expects the subscription to be created upfront. Security wise it's best to gi
 service account and give the subscription `Pub/Sub Subscriber` permission.
 
 The subscription should also be of delivery type `Pull`.
+
+### Flow control
+
+The flow control allows to fine tune the flow control settings for the subscription stream.
+
+* `trigger_ack_batch_duration` (Optional): Part of the control loop, the time between each message
+  acknowledge batch.
+* `stream_ack_deadline` (Optional): The ack deadline to use for the stream. The minimum deadline you can specify
+  is 10 seconds. The maximum deadline you can specify is 600 seconds (10 minutes).
+* `max_outstanding_messages` (Optional): Flow control settings for the maximum number of outstanding messages. When
+  there are max_outstanding_messages currently sent to the streaming pull client that have not yet been acked or 
+  nacked, the server stops sending more messages. The sending of messages resumes once the number of outstanding
+  messages is less than this value. If the value is <= 0, there is no limit to the number of outstanding messages.
+* `max_outstanding_bytes` (Optional): Flow control settings for the maximum number of outstanding bytes. When there
+  are max_outstanding_bytes or more worth of messages currently sent to the streaming pull client that have not yet
+  been acked or nacked, the server will stop sending more messages. The sending of messages resumes once the number
+  of outstanding bytes is less than this value. If the value is <= 0, there is no limit to the number of outstanding
+  bytes.
+
+```yaml
+flow_control:
+  trigger_ack_batch_duration: 1s
+  stream_ack_deadline: 60s
+  max_outstanding_messages: 1000000
+  max_outstanding_bytes: 1000000
+```
+
+More details can be found at [Pub/Sub gRPC StreamingPullRequest](https://docs.cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#streamingpullrequest)
 
 ### Filtering
 

--- a/receiver/googlecloudpubsubreceiver/config.schema.yaml
+++ b/receiver/googlecloudpubsubreceiver/config.schema.yaml
@@ -1,3 +1,24 @@
+$defs:
+  flow_control_config:
+    description: FlowControlConfig defines the flow control configuration for the receiver. This is used to tune the internal flow control implementation, along with the Pub/Sub flow control settings documented at https://cloud.google.com/pubsub/docs/flow-control and https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#streamingpullrequest
+    type: object
+    properties:
+      max_outstanding_bytes:
+        description: Pub/Sub flow control settings for the maximum number of outstanding bytes.
+        type: integer
+        x-customType: int64
+      max_outstanding_messages:
+        description: Pub/Sub flow control settings for the maximum number of outstanding messages.
+        type: integer
+        x-customType: int64
+      stream_ack_deadline:
+        description: The ack deadline to use for the Pub/Sub stream.
+        type: string
+        format: duration
+      trigger_ack_batch_duration:
+        description: The maximum duration the acknowledgement loop waits before sending the acknowledgements.
+        type: string
+        format: duration
 type: object
 properties:
   client_id:
@@ -12,6 +33,8 @@ properties:
   endpoint:
     description: Override of the Pubsub Endpoint, leave empty for the default endpoint
     type: string
+  flow_control:
+    $ref: flow_control_config
   ignore_encoding_error:
     description: Ignore errors when the configured encoder fails to decoding a PubSub messages
     type: boolean

--- a/receiver/googlecloudpubsubreceiver/config_test.go
+++ b/receiver/googlecloudpubsubreceiver/config_test.go
@@ -30,8 +30,13 @@ func TestLoadConfig(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			id:       component.NewIDWithName(metadata.Type, ""),
-			expected: &Config{},
+			id: component.NewIDWithName(metadata.Type, ""),
+			expected: &Config{
+				FlowControlConfig: FlowControlConfig{
+					TriggerAckBatchDuration: 10 * time.Second,
+					StreamAckDeadline:       60 * time.Second,
+				},
+			},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "customname"),
@@ -42,6 +47,10 @@ func TestLoadConfig(t *testing.T) {
 					Timeout: 20 * time.Second,
 				},
 				Subscription: "projects/my-project/subscriptions/otlp-subscription",
+				FlowControlConfig: FlowControlConfig{
+					TriggerAckBatchDuration: 10 * time.Second,
+					StreamAckDeadline:       60 * time.Second,
+				},
 			},
 		},
 	}

--- a/receiver/googlecloudpubsubreceiver/factory.go
+++ b/receiver/googlecloudpubsubreceiver/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver/internal/metadata"
 )
 
@@ -38,7 +39,15 @@ type pubsubReceiverFactory struct {
 }
 
 func (*pubsubReceiverFactory) CreateDefaultConfig() component.Config {
-	return &Config{}
+	fcc := internal.NewDefaultFlowControlConfig()
+	return &Config{
+		FlowControlConfig: FlowControlConfig{
+			TriggerAckBatchDuration: fcc.TriggerAckBatchDuration,
+			StreamAckDeadline:       fcc.StreamAckDeadline,
+			MaxOutstandingMessages:  fcc.MaxOutstandingMessages,
+			MaxOutstandingBytes:     fcc.MaxOutstandingBytes,
+		},
+	}
 }
 
 func (factory *pubsubReceiverFactory) ensureReceiver(settings receiver.Settings, config component.Config) (*pubsubReceiver, error) {

--- a/receiver/googlecloudpubsubreceiver/internal/flow_control_config.go
+++ b/receiver/googlecloudpubsubreceiver/internal/flow_control_config.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver/internal"
+
+import "time"
+
+type FlowControlConfig struct {
+	// The maximum duration the acknowledgement loop waits before sending the acknowledgements.
+	TriggerAckBatchDuration time.Duration
+	// The ack deadline to use for the Pub/Sub stream.
+	StreamAckDeadline time.Duration
+	// Pub/Sub flow control settings for the maximum number of outstanding messages.
+	MaxOutstandingMessages int64
+	// Pub/Sub flow control settings for the maximum number of outstanding bytes.
+	MaxOutstandingBytes int64
+}
+
+func NewDefaultFlowControlConfig() *FlowControlConfig {
+	return &FlowControlConfig{
+		TriggerAckBatchDuration: 10 * time.Second,
+		StreamAckDeadline:       60 * time.Second,
+		MaxOutstandingMessages:  0,
+		MaxOutstandingBytes:     0,
+	}
+}

--- a/receiver/googlecloudpubsubreceiver/receiver.go
+++ b/receiver/googlecloudpubsubreceiver/receiver.go
@@ -355,6 +355,7 @@ func (receiver *pubsubReceiver) createMultiplexingReceiverHandler(ctx context.Co
 		receiver.client,
 		receiver.config.ClientID,
 		receiver.config.Subscription,
+		receiver.config.FlowControlConfig.getInternalConfig(),
 		func(ctx context.Context, message *pubsubpb.ReceivedMessage) error {
 			payload := message.Message.Data
 			encoding, compression := receiver.detectEncoding(message.Message.Attributes)
@@ -417,6 +418,7 @@ func (receiver *pubsubReceiver) createReceiverHandler(ctx context.Context) error
 		receiver.client,
 		receiver.config.ClientID,
 		receiver.config.Subscription,
+		receiver.config.FlowControlConfig.getInternalConfig(),
 		handlerFn)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Description
Add flow control configuration, giving advanced users more control over the parameters of the streaming pull control loop.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44804

#### Testing
Added tests for the config

#### Documentation
Added documentation in the README.md