### PR TITLE
[chore][pkg/stanza] Reuse entry.Entry objects with a sync.Pool

### DIFF
--- a/pkg/stanza/adapter/frompdataconverter.go
+++ b/pkg/stanza/adapter/frompdataconverter.go
@@ -153,12 +153,13 @@ func convertFromLogs(workerItem fromConverterWorkerItem) []*entry.Entry {
 	result := make([]*entry.Entry, 0, workerItem.LogRecordSlice.Len())
 	for i := 0; i < workerItem.LogRecordSlice.Len(); i++ {
 		record := workerItem.LogRecordSlice.At(i)
-		entry := entry.Entry{}
+		e := entry.New()
+		e.ObservedTimestamp = time.Time{}
 
-		entry.ScopeName = workerItem.Scope.Scope().Name()
-		entry.Resource = workerItem.Resource.Attributes().AsRaw()
-		convertFrom(record, &entry)
-		result = append(result, &entry)
+		e.ScopeName = workerItem.Scope.Scope().Name()
+		e.Resource = workerItem.Resource.Attributes().AsRaw()
+		convertFrom(record, e)
+		result = append(result, e)
 	}
 	return result
 }

--- a/pkg/stanza/adapter/receiver.go
+++ b/pkg/stanza/adapter/receiver.go
@@ -54,6 +54,9 @@ func (r *receiver) Start(ctx context.Context, host component.Host) error {
 func (r *receiver) consumeEntries(ctx context.Context, entries []*entry.Entry) {
 	obsrecvCtx := r.obsrecv.StartLogsOp(ctx)
 	pLogs := ConvertEntries(entries)
+	for _, e := range entries {
+		entry.Put(e)
+	}
 	logRecordCount := pLogs.LogRecordCount()
 
 	cErr := r.consumer.ConsumeLogs(ctx, pLogs)

--- a/pkg/stanza/entry/entry.go
+++ b/pkg/stanza/entry/entry.go
@@ -35,13 +35,14 @@ var entriesPool = sync.Pool{
 // New will create a new log entry with current timestamp and an empty body.
 func New() *Entry {
 	e := entriesPool.Get().(*Entry)
+	*e = *zeroE
 	e.ObservedTimestamp = timeNow()
 	return e
 }
 
+var zeroE = &Entry{}
 // Put releases the entry back to the pool
 func Put(e *Entry) {
-	*e = Entry{}
 	entriesPool.Put(e)
 }
 

--- a/pkg/stanza/entry/entry.go
+++ b/pkg/stanza/entry/entry.go
@@ -28,15 +28,15 @@ type Entry struct {
 
 var entriesPool = sync.Pool{
 	New: func() any {
-		return &Entry{
-			ObservedTimestamp: timeNow(),
-		}
+		return &Entry{}
 	},
 }
 
 // New will create a new log entry with current timestamp and an empty body.
 func New() *Entry {
-	return entriesPool.Get().(*Entry)
+	e := entriesPool.Get().(*Entry)
+	e.ObservedTimestamp = timeNow()
+	return e
 }
 
 // Put releases the entry back to the pool
@@ -177,17 +177,18 @@ func (entry *Entry) readToStringMap(field FieldInterface, dest *map[string]strin
 
 // Copy will return a deep copy of the entry.
 func (entry *Entry) Copy() *Entry {
-	return &Entry{
-		ObservedTimestamp: entry.ObservedTimestamp,
-		Timestamp:         entry.Timestamp,
-		Severity:          entry.Severity,
-		SeverityText:      entry.SeverityText,
-		Attributes:        copyInterfaceMap(entry.Attributes),
-		Resource:          copyInterfaceMap(entry.Resource),
-		Body:              copyValue(entry.Body),
-		TraceID:           copyByteArray(entry.TraceID),
-		SpanID:            copyByteArray(entry.SpanID),
-		TraceFlags:        copyByteArray(entry.TraceFlags),
-		ScopeName:         entry.ScopeName,
-	}
+	e := New()
+	e.ObservedTimestamp = entry.ObservedTimestamp
+	e.Timestamp = entry.Timestamp
+	e.Severity = entry.Severity
+	e.SeverityText = entry.SeverityText
+	e.Attributes = copyInterfaceMap(entry.Attributes)
+	e.Resource = copyInterfaceMap(entry.Resource)
+	e.Body = copyValue(entry.Body)
+	e.TraceID = copyByteArray(entry.TraceID)
+	e.SpanID = copyByteArray(entry.SpanID)
+	e.TraceFlags = copyByteArray(entry.TraceFlags)
+	e.ScopeName = entry.ScopeName
+
+	return e
 }

--- a/pkg/stanza/entry/entry.go
+++ b/pkg/stanza/entry/entry.go
@@ -32,6 +32,8 @@ var entriesPool = sync.Pool{
 	},
 }
 
+var zeroE = &Entry{}
+
 // New will create a new log entry with current timestamp and an empty body.
 func New() *Entry {
 	e := entriesPool.Get().(*Entry)
@@ -40,7 +42,6 @@ func New() *Entry {
 	return e
 }
 
-var zeroE = &Entry{}
 // Put releases the entry back to the pool
 func Put(e *Entry) {
 	entriesPool.Put(e)

--- a/pkg/stanza/entry/entry.go
+++ b/pkg/stanza/entry/entry.go
@@ -5,6 +5,7 @@ package entry // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -25,11 +26,23 @@ type Entry struct {
 	ScopeName         string         `json:"scope_name"              yaml:"scope_name"`
 }
 
+var entriesPool = sync.Pool{
+	New: func() any {
+		return &Entry{
+			ObservedTimestamp: timeNow(),
+		}
+	},
+}
+
 // New will create a new log entry with current timestamp and an empty body.
 func New() *Entry {
-	return &Entry{
-		ObservedTimestamp: timeNow(),
-	}
+	return entriesPool.Get().(*Entry)
+}
+
+// Put releases the entry back to the pool
+func Put(e *Entry) {
+	*e = Entry{}
+	entriesPool.Put(e)
 }
 
 // AddAttribute will add a key/value pair to the entry's attributes.

--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -30,6 +30,7 @@ func BenchmarkReadExistingLogs(b *testing.B) {
 }
 
 func benchmarkReadExistingLogs(b *testing.B, lines int) {
+	b.ReportAllocs()
 	logFilePath := generateLogFile(b, lines)
 	b.ReportAllocs()
 
@@ -125,12 +126,13 @@ func (*benchmarkOutput) Stop() error {
 // Type implements operator.Operator.
 func (*benchmarkOutput) Type() string { return "benchmark_output" }
 
-func (o *benchmarkOutput) Process(_ context.Context, _ *entry.Entry) error {
+func (o *benchmarkOutput) Process(_ context.Context, e *entry.Entry) error {
 	o.logsReceived++
 	if o.logsReceived == o.totalLogs {
 		o.doneChan <- struct{}{}
 		o.logsReceived = 0
 	}
+	entry.Put(e)
 	return nil
 }
 
@@ -139,6 +141,9 @@ func (o *benchmarkOutput) ProcessBatch(_ context.Context, entries []*entry.Entry
 	if o.logsReceived >= o.totalLogs {
 		o.doneChan <- struct{}{}
 		o.logsReceived = 0
+	}
+	for _, e := range entries {
+		entry.Put(e)
 	}
 	return nil
 }

--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -32,7 +32,6 @@ func BenchmarkReadExistingLogs(b *testing.B) {
 func benchmarkReadExistingLogs(b *testing.B, lines int) {
 	b.ReportAllocs()
 	logFilePath := generateLogFile(b, lines)
-	b.ReportAllocs()
 
 	config := NewConfig()
 	config.Include = []string{

--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -31,6 +31,7 @@ func BenchmarkReadExistingLogs(b *testing.B) {
 
 func benchmarkReadExistingLogs(b *testing.B, lines int) {
 	logFilePath := generateLogFile(b, lines)
+	b.ReportAllocs()
 
 	config := NewConfig()
 	config.Include = []string{

--- a/pkg/stanza/operator/output/drop/output.go
+++ b/pkg/stanza/operator/output/drop/output.go
@@ -20,6 +20,7 @@ func (*Output) ProcessBatch(context.Context, []*entry.Entry) error {
 }
 
 // Process will drop the incoming entry.
-func (*Output) Process(context.Context, *entry.Entry) error {
+func (*Output) Process(_ context.Context, e *entry.Entry) error {
+	entry.Put(e)
 	return nil
 }

--- a/pkg/stanza/operator/output/file/output.go
+++ b/pkg/stanza/operator/output/file/output.go
@@ -62,17 +62,18 @@ func (o *Output) ProcessBatch(ctx context.Context, entries []*entry.Entry) error
 }
 
 // Process will write an entry to the output file.
-func (o *Output) Process(_ context.Context, entry *entry.Entry) error {
+func (o *Output) Process(_ context.Context, e *entry.Entry) error {
 	o.mux.Lock()
 	defer o.mux.Unlock()
+	defer entry.Put(e)
 
 	if o.tmpl != nil {
-		err := o.tmpl.Execute(o.file, entry)
+		err := o.tmpl.Execute(o.file, e)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := o.encoder.Encode(entry)
+		err := o.encoder.Encode(e)
 		if err != nil {
 			return err
 		}

--- a/pkg/stanza/operator/output/stdout/output.go
+++ b/pkg/stanza/operator/output/stdout/output.go
@@ -31,14 +31,16 @@ func (o *Output) ProcessBatch(ctx context.Context, entries []*entry.Entry) error
 }
 
 // Process will log entries received.
-func (o *Output) Process(_ context.Context, entry *entry.Entry) error {
+func (o *Output) Process(_ context.Context, e *entry.Entry) error {
 	o.mux.Lock()
-	err := o.encoder.Encode(entry)
+	defer entry.Put(e)
+	err := o.encoder.Encode(e)
 	if err != nil {
 		o.mux.Unlock()
 		o.Logger().Error("Failed to process entry", zap.Error(err))
 		return err
 	}
+
 	o.mux.Unlock()
 	return nil
 }

--- a/pkg/stanza/operator/output/stdout/output.go
+++ b/pkg/stanza/operator/output/stdout/output.go
@@ -40,7 +40,6 @@ func (o *Output) Process(_ context.Context, e *entry.Entry) error {
 		o.Logger().Error("Failed to process entry", zap.Error(err))
 		return err
 	}
-
 	o.mux.Unlock()
 	return nil
 }

--- a/pkg/stanza/operator/parser/regex/benchmark_test.go
+++ b/pkg/stanza/operator/parser/regex/benchmark_test.go
@@ -16,6 +16,7 @@ import (
 
 func BenchmarkProcessBatch(b *testing.B) {
 	b.Run("SeverityMapping", func(b *testing.B) {
+		b.ReportAllocs()
 		config := NewConfig()
 		config.OnError = helper.SendOnError
 		config.Regex = `(?P<remote_host>[^\s]+) - (?P<remote_user>[^\s]+) \[(?P<timestamp>[^\]]+)\] "(?P<http_method>[A-Z]+) (?P<path>[^\s]+) [^"]+" (?P<http_status>\d+) (?P<bytes_sent>[^\s]+)`
@@ -38,7 +39,7 @@ func BenchmarkProcessBatch(b *testing.B) {
 		require.NoError(b, err)
 
 		entries := make([]*entry.Entry, 1000000)
-		for i := range 1000 {
+		for i := range len(entries) {
 			entries[i] = entry.New()
 			entries[i].Body = fmt.Sprintf("10.33.121.119 - - [11/Aug/2020:00:00:00 -0400] \"GET /index.html HTTP/1.1\" 404 %d\n", i%1000)
 		}


### PR DESCRIPTION
Performance improvement by reusing entry.Entry objects, pooled with a sync.Pool:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter
cpu: Apple M4 Pro
                                                                 │  stanza.txt  │           stanza_pool.txt            │
                                                                 │    sec/op    │    sec/op     vs base                │
EndToEnd/maxBatchSize=1,flushInterval=10ms-12                      405.7m ± ∞ ¹   340.1m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1,flushInterval=100ms-12                     333.6m ± ∞ ¹   314.4m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10,flushInterval=10ms-12                     334.5m ± ∞ ¹   273.1m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10,flushInterval=100ms-12                    315.5m ± ∞ ¹   268.4m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=100,flushInterval=10ms-12                    265.9m ± ∞ ¹   238.9m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=100,flushInterval=100ms-12                   255.1m ± ∞ ¹   237.8m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1000,flushInterval=10ms-12                   258.8m ± ∞ ¹   236.8m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1000,flushInterval=100ms-12                  249.5m ± ∞ ¹   257.6m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10000,flushInterval=10ms-12                  251.5m ± ∞ ¹   234.6m ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10000,flushInterval=100ms-12                 236.8m ± ∞ ¹   233.1m ± ∞ ¹       ~ (p=1.000 n=1) ²
ConvertSimple-12                                                   54.05n ± ∞ ¹   44.94n ± ∞ ¹       ~ (p=1.000 n=1) ²
ConvertComplex-12                                                  1.051µ ± ∞ ¹   1.078µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=1-12                                         2.008 ± ∞ ¹    1.667 ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=2-12                                         3.019 ± ∞ ¹    1.583 ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=4-12                                         2.753 ± ∞ ¹    1.789 ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=6-12                                         2.308 ± ∞ ¹    1.681 ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=8-12                                         2.471 ± ∞ ¹    1.581 ± ∞ ¹       ~ (p=1.000 n=1) ²
GetResourceID-12                                                   565.3n ± ∞ ¹   550.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
GetResourceIDEmptyResource-12                                      1.829n ± ∞ ¹   1.806n ± ∞ ¹       ~ (p=1.000 n=1) ²
GetResourceIDSingleResource-12                                     55.38n ± ∞ ¹   55.07n ± ∞ ¹       ~ (p=1.000 n=1) ²
GetResourceIDComplexResource-12                                    334.4n ± ∞ ¹   328.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
FromPdataConverter/worker_count=1-12                                7.694 ± ∞ ¹    6.453 ± ∞ ¹       ~ (p=1.000 n=1) ²
FromPdataConverter/worker_count=2-12                                6.502 ± ∞ ¹    6.994 ± ∞ ¹       ~ (p=1.000 n=1) ²
FromPdataConverter/worker_count=4-12                                6.829 ± ∞ ¹    7.902 ± ∞ ¹       ~ (p=1.000 n=1) ²
FromPdataConverter/worker_count=6-12                                6.601 ± ∞ ¹    6.265 ± ∞ ¹       ~ (p=1.000 n=1) ²
FromPdataConverter/worker_count=8-12                                6.614 ± ∞ ¹    6.864 ± ∞ ¹       ~ (p=1.000 n=1) ²
EmitterToConsumer-12                                                1.681 ± ∞ ¹    3.055 ± ∞ ¹       ~ (p=1.000 n=1) ²
EmitterToConsumerScopeGroupping-12                                  1.800 ± ∞ ¹    3.061 ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithBatchingLogEmitter/1_logs-12                           100.0m ± ∞ ¹   100.1m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithBatchingLogEmitter/10_logs-12                          100.1m ± ∞ ¹   100.0m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithBatchingLogEmitter/100_logs-12                         199.4µ ± ∞ ¹   189.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithBatchingLogEmitter/1000_logs-12                        1.986m ± ∞ ¹   1.882m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithBatchingLogEmitter/10000_logs-12                       19.01m ± ∞ ¹   18.57m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithBatchingLogEmitter/100000_logs-12                      182.4m ± ∞ ¹   184.3m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitter/1_logs-12                        3.722µ ± ∞ ¹   3.654µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitter/10_logs-12                       28.38µ ± ∞ ¹   30.02µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitter/100_logs-12                      260.3µ ± ∞ ¹   256.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitter/1000_logs-12                     2.598m ± ∞ ¹   2.557m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitter/10000_logs-12                    26.08m ± ∞ ¹   25.90m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitter/100000_logs-12                   261.2m ± ∞ ¹   252.1m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitterAndBatchingInput/1_logs-12        173.5µ ± ∞ ¹   171.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitterAndBatchingInput/10_logs-12       174.4µ ± ∞ ¹   172.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitterAndBatchingInput/100_logs-12      173.1µ ± ∞ ¹   170.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitterAndBatchingInput/1000_logs-12     1.716m ± ∞ ¹   1.679m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitterAndBatchingInput/10000_logs-12    17.18m ± ∞ ¹   16.81m ± ∞ ¹       ~ (p=1.000 n=1) ²
ReceiverWithSynchronousLogEmitterAndBatchingInput/100000_logs-12   171.0m ± ∞ ¹   168.4m ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                            13.16m         12.53m        -4.81%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                   │  stanza.txt   │            stanza_pool.txt            │
                                                   │     B/op      │     B/op       vs base                │
EndToEnd/maxBatchSize=1,flushInterval=10ms-12        475.8Mi ± ∞ ¹   468.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1,flushInterval=100ms-12       475.8Mi ± ∞ ¹   464.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10,flushInterval=10ms-12       385.0Mi ± ∞ ¹   371.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10,flushInterval=100ms-12      385.0Mi ± ∞ ¹   371.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=100,flushInterval=10ms-12      346.8Mi ± ∞ ¹   332.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=100,flushInterval=100ms-12     346.8Mi ± ∞ ¹   334.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1000,flushInterval=10ms-12     342.7Mi ± ∞ ¹   327.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1000,flushInterval=100ms-12    342.7Mi ± ∞ ¹   329.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10000,flushInterval=10ms-12    343.7Mi ± ∞ ¹   329.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10000,flushInterval=100ms-12   343.7Mi ± ∞ ¹   329.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
ConvertSimple-12                                       136.0 ± ∞ ¹     136.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
ConvertComplex-12                                    1.333Ki ± ∞ ¹   1.333Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
Converter/worker_count=1-12                          1.504Gi ± ∞ ¹   1.504Gi ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=2-12                          1.504Gi ± ∞ ¹   1.504Gi ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=4-12                          1.504Gi ± ∞ ¹   1.504Gi ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=6-12                          1.504Gi ± ∞ ¹   1.504Gi ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=8-12                          1.504Gi ± ∞ ¹   1.504Gi ± ∞ ¹       ~ (p=1.000 n=1) ²
GetResourceID-12                                       96.00 ± ∞ ¹     96.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
GetResourceIDEmptyResource-12                          0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
GetResourceIDSingleResource-12                         0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
GetResourceIDComplexResource-12                        168.0 ± ∞ ¹     168.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                          ⁴                  -1.69%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
⁴ summaries must be >0 to compute geomean

                                                   │  stanza.txt  │           stanza_pool.txt            │
                                                   │  allocs/op   │  allocs/op    vs base                │
EndToEnd/maxBatchSize=1,flushInterval=10ms-12        8.900M ± ∞ ¹   8.849M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1,flushInterval=100ms-12       8.900M ± ∞ ¹   8.824M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10,flushInterval=10ms-12       7.030M ± ∞ ¹   6.944M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10,flushInterval=100ms-12      7.030M ± ∞ ¹   6.946M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=100,flushInterval=10ms-12      6.207M ± ∞ ¹   6.119M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=100,flushInterval=100ms-12     6.207M ± ∞ ¹   6.131M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1000,flushInterval=10ms-12     6.112M ± ∞ ¹   6.017M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=1000,flushInterval=100ms-12    6.112M ± ∞ ¹   6.031M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10000,flushInterval=10ms-12    6.102M ± ∞ ¹   6.013M ± ∞ ¹       ~ (p=1.000 n=1) ²
EndToEnd/maxBatchSize=10000,flushInterval=100ms-12   6.102M ± ∞ ¹   6.011M ± ∞ ¹       ~ (p=1.000 n=1) ²
ConvertSimple-12                                      2.000 ± ∞ ¹    2.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
ConvertComplex-12                                     34.00 ± ∞ ¹    34.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
Converter/worker_count=1-12                          42.53M ± ∞ ¹   42.53M ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=2-12                          42.53M ± ∞ ¹   42.53M ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=4-12                          42.53M ± ∞ ¹   42.53M ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=6-12                          42.53M ± ∞ ¹   42.53M ± ∞ ¹       ~ (p=1.000 n=1) ²
Converter/worker_count=8-12                          42.53M ± ∞ ¹   42.53M ± ∞ ¹       ~ (p=1.000 n=1) ²
GetResourceID-12                                      4.000 ± ∞ ¹    4.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
GetResourceIDEmptyResource-12                         0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
GetResourceIDSingleResource-12                        0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
GetResourceIDComplexResource-12                       6.000 ± ∞ ¹    6.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                         ⁴                 -0.59%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
⁴ summaries must be >0 to compute geomean

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer
                                    │  stanza.txt  │           stanza_pool.txt            │
                                    │    sec/op    │    sec/op     vs base                │
FileInput/Single-12                   11.01µ ± ∞ ¹   10.52µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/Glob-12                     22.34µ ± ∞ ¹   20.58µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/MultiGlob-12                23.26µ ± ∞ ¹   22.81µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/MaxConcurrent-12            60.35µ ± ∞ ¹   62.42µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/FngrPrntLarge-12            13.77µ ± ∞ ¹   15.16µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/FngrPrntSmall-12            13.44µ ± ∞ ¹   11.20µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/NoFlush-12                  11.05µ ± ∞ ¹   10.64µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/Many-12                     2.261m ± ∞ ¹   4.929m ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeFiles/Single-12                9.006µ ± ∞ ¹   9.440µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeFiles/Multiple-12              304.4µ ± ∞ ¹   282.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_10-12      26.80n ± ∞ ¹   26.54n ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_100-12     201.0n ± ∞ ¹   192.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_1000-12    1.740µ ± ∞ ¹   1.739µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_10000-12   23.64µ ± ∞ ¹   23.19µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_10-12               64.70n ± ∞ ¹   69.78n ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_100-12              518.8n ± ∞ ¹   504.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_1000-12             5.172µ ± ∞ ¹   5.081µ ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_10000-12            45.13µ ± ∞ ¹   44.93µ ± ∞ ¹       ~ (p=1.000 n=1) ²
StartLatency/Files_1000-12            6.270µ ± ∞ ¹   6.006µ ± ∞ ¹       ~ (p=1.000 n=1) ²
StartLatency/Files_10000-12           4.789µ ± ∞ ¹   4.670µ ± ∞ ¹       ~ (p=1.000 n=1) ²
RealisticPolling/Files_100-12         1.843m ± ∞ ¹   1.815m ± ∞ ¹       ~ (p=1.000 n=1) ²
RealisticPolling/Files_500-12         9.773m ± ∞ ¹   9.708m ± ∞ ¹       ~ (p=1.000 n=1) ²
RealisticPolling/Files_1000-12        30.22m ± ∞ ¹   29.61m ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                               18.41µ         18.69µ        +1.55%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                    │   stanza.txt   │            stanza_pool.txt             │
                                    │      B/op      │      B/op       vs base                │
FileInput/Single-12                    10.00Ki ± ∞ ¹    10.00Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/Glob-12                      40.01Ki ± ∞ ¹    40.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FileInput/MultiGlob-12                 40.01Ki ± ∞ ¹    40.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FileInput/MaxConcurrent-12             40.01Ki ± ∞ ¹    40.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FileInput/FngrPrntLarge-12             10.00Ki ± ∞ ¹    10.00Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FileInput/FngrPrntSmall-12             10.00Ki ± ∞ ¹    10.00Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FileInput/NoFlush-12                   10.00Ki ± ∞ ¹    10.00Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FileInput/Many-12                     1008.5Ki ± ∞ ¹   1034.7Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeFiles/Single-12                 10.01Ki ± ∞ ¹    10.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeFiles/Multiple-12              1019.8Ki ± ∞ ¹   1018.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
FingerprintComparison/Size_10-12         0.000 ± ∞ ¹      0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_100-12        0.000 ± ∞ ¹      0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_1000-12       0.000 ± ∞ ¹      0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_10000-12      0.000 ± ∞ ¹      0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_10-12                  80.00 ± ∞ ¹      80.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_100-12                 896.0 ± ∞ ¹      896.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_1000-12              8.000Ki ± ∞ ¹    8.000Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_10000-12             80.00Ki ± ∞ ¹    80.00Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
StartLatency/Files_1000-12             26.52Ki ± ∞ ¹    26.52Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
StartLatency/Files_10000-12            26.51Ki ± ∞ ¹    26.51Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
RealisticPolling/Files_100-12          856.2Ki ± ∞ ¹    853.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
RealisticPolling/Files_500-12          3.956Mi ± ∞ ¹    3.973Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
RealisticPolling/Files_1000-12         11.81Mi ± ∞ ¹    11.82Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                            ⁴                   +0.11%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
⁴ summaries must be >0 to compute geomean

                                    │  stanza.txt  │           stanza_pool.txt            │
                                    │  allocs/op   │  allocs/op    vs base                │
FileInput/Single-12                    10.00 ± ∞ ¹    10.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/Glob-12                      40.00 ± ∞ ¹    40.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/MultiGlob-12                 40.00 ± ∞ ¹    40.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/MaxConcurrent-12             40.00 ± ∞ ¹    40.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/FngrPrntLarge-12             10.00 ± ∞ ¹    10.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/FngrPrntSmall-12             10.00 ± ∞ ¹    10.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/NoFlush-12                   10.00 ± ∞ ¹    10.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
FileInput/Many-12                     1.013k ± ∞ ¹   1.075k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeFiles/Single-12                 10.00 ± ∞ ¹    10.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeFiles/Multiple-12              1.001k ± ∞ ¹   1.001k ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_10-12       0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_100-12      0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_1000-12     0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintComparison/Size_10000-12    0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_10-12                1.000 ± ∞ ¹    1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_100-12               1.000 ± ∞ ¹    1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_1000-12              1.000 ± ∞ ¹    1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
FilesetMatch/Size_10000-12             1.000 ± ∞ ¹    1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
StartLatency/Files_1000-12             47.00 ± ∞ ¹    47.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
StartLatency/Files_10000-12            47.00 ± ∞ ¹    47.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
RealisticPolling/Files_100-12         3.990k ± ∞ ¹   3.991k ± ∞ ¹       ~ (p=1.000 n=1) ³
RealisticPolling/Files_500-12         19.62k ± ∞ ¹   19.62k ± ∞ ¹       ~ (p=1.000 n=1) ³
RealisticPolling/Files_1000-12        47.20k ± ∞ ¹   47.20k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                          ⁴                 +0.26%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
⁴ summaries must be >0 to compute geomean

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/checkpoint
                                        │  stanza.txt   │           stanza_pool.txt            │
                                        │    sec/op     │    sec/op     vs base                │
CheckpointEncoding/1_file-12               1.135µ ± ∞ ¹   1.111µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/10_files-12            10.111µ ± ∞ ¹   9.875µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/100_files-12           100.41µ ± ∞ ¹   98.56µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/1000_files-12           963.1µ ± ∞ ¹   943.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/1_file-12               1.680µ ± ∞ ¹   1.639µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/10_files-12             16.98µ ± ∞ ¹   15.71µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/100_files-12            161.5µ ± ∞ ¹   162.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/1000_files-12           1.646m ± ∞ ¹   1.572m ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/1_file-12              3.251µ ± ∞ ¹   2.929µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/10_files-12            28.00µ ± ∞ ¹   26.82µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/100_files-12           287.5µ ± ∞ ¹   266.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/1000_files-12          2.896m ± ∞ ¹   2.483m ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintConversion/json_roundtrip-12    9.723µ ± ∞ ¹   9.237µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                    47.46µ         45.13µ        -4.92%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                        │  stanza.txt   │            stanza_pool.txt            │
                                        │     B/op      │     B/op       vs base                │
CheckpointEncoding/1_file-12              3.189Ki ± ∞ ¹   3.189Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/10_files-12            30.34Ki ± ∞ ¹   30.34Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
CheckpointEncoding/100_files-12           302.5Ki ± ∞ ¹   302.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/1000_files-12          2.920Mi ± ∞ ¹   2.920Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
CheckpointDecoding/1_file-12              2.484Ki ± ∞ ¹   2.484Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/10_files-12            24.34Ki ± ∞ ¹   24.34Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/100_files-12           242.5Ki ± ∞ ¹   242.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/1000_files-12          2.363Mi ± ∞ ¹   2.363Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
CheckpointRoundTrip/1_file-12             6.090Ki ± ∞ ¹   6.090Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/10_files-12           55.11Ki ± ∞ ¹   55.11Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/100_files-12          545.6Ki ± ∞ ¹   545.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
CheckpointRoundTrip/1000_files-12         5.284Mi ± ∞ ¹   5.284Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
FingerprintConversion/json_roundtrip-12   4.385Ki ± ∞ ¹   4.384Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                   85.72Ki         85.72Ki        -0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05

                                        │  stanza.txt  │           stanza_pool.txt            │
                                        │  allocs/op   │  allocs/op    vs base                │
CheckpointEncoding/1_file-12               22.00 ± ∞ ¹    22.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/10_files-12             175.0 ± ∞ ¹    175.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/100_files-12           1.705k ± ∞ ¹   1.705k ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointEncoding/1000_files-12          17.01k ± ∞ ¹   17.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/1_file-12               38.00 ± ∞ ¹    38.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/10_files-12             348.0 ± ∞ ¹    348.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/100_files-12           3.411k ± ∞ ¹   3.411k ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointDecoding/1000_files-12          34.01k ± ∞ ¹   34.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/1_file-12              63.00 ± ∞ ¹    63.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/10_files-12            526.0 ± ∞ ¹    526.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/100_files-12          5.120k ± ∞ ¹   5.120k ± ∞ ¹       ~ (p=1.000 n=1) ²
CheckpointRoundTrip/1000_files-12         51.03k ± ∞ ¹   51.03k ± ∞ ¹       ~ (p=1.000 n=1) ²
FingerprintConversion/json_roundtrip-12    12.00 ± ∞ ¹    12.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                    733.5          733.5        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader
            │  stanza.txt  │         stanza_pool.txt         │
            │    sec/op    │    sec/op     vs base           │
FileRead-12   111.6µ ± ∞ ¹   116.4µ ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

            │  stanza.txt   │         stanza_pool.txt          │
            │     B/op      │     B/op       vs base           │
FileRead-12   106.9Ki ± ∞ ¹   106.9Ki ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

            │ stanza.txt  │        stanza_pool.txt         │
            │  allocs/op  │  allocs/op   vs base           │
FileRead-12   131.0 ± ∞ ¹   131.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher/internal/finder
                │  stanza.txt  │         stanza_pool.txt          │
                │    sec/op    │    sec/op      vs base           │
Find10kFiles-12   9.184m ± ∞ ¹   10.030m ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file
                                 │  stanza.txt   │            stanza_pool.txt            │
                                 │    sec/op     │    sec/op     vs base                 │
ReadExistingLogs/1-lines-12        219.44µ ± ∞ ¹   88.78µ ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/10-lines-12        263.2µ ± ∞ ¹   101.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/100-lines-12       445.8µ ± ∞ ¹   244.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/1000-lines-12      2.144m ± ∞ ¹   1.353m ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/10000-lines-12     15.15m ± ∞ ¹   14.44m ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/100000-lines-12    123.9m ± ∞ ¹   113.1m ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                             2.167m         1.301m        -39.98%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                 │   stanza.txt   │            stanza_pool.txt             │
                                 │      B/op      │     B/op       vs base                 │
ReadExistingLogs/1-lines-12         95.43Ki ± ∞ ¹   75.71Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/10-lines-12       112.57Ki ± ∞ ¹   90.57Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/100-lines-12       266.2Ki ± ∞ ¹   221.7Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/1000-lines-12      1.659Mi ± ∞ ¹   1.460Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/10000-lines-12     15.61Mi ± ∞ ¹   13.82Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/100000-lines-12    155.1Mi ± ∞ ¹   137.1Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                             1.484Mi         1.255Mi        -15.42%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                 │  stanza.txt  │            stanza_pool.txt            │
                                 │  allocs/op   │  allocs/op    vs base                 │
ReadExistingLogs/1-lines-12         248.0 ± ∞ ¹    187.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/10-lines-12        318.0 ± ∞ ¹    248.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/100-lines-12       976.0 ± ∞ ¹    797.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/1000-lines-12     7.284k ± ∞ ¹   6.223k ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/10000-lines-12    70.36k ± ∞ ¹   60.45k ± ∞ ¹        ~ (p=1.000 n=1) ²
ReadExistingLogs/100000-lines-12   701.2k ± ∞ ¹   601.9k ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                            5.499k         4.506k        -18.07%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp
            │  stanza.txt  │         stanza_pool.txt         │
            │    sec/op    │    sec/op     vs base           │
TCPInput-12   17.75µ ± ∞ ¹   18.35µ ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp
            │  stanza.txt  │         stanza_pool.txt         │
            │    sec/op    │    sec/op     vs base           │
UDPInput-12   12.64µ ± ∞ ¹   12.17µ ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows
                                    │  stanza.txt  │            stanza_pool.txt            │
                                    │    sec/op    │    sec/op     vs base                 │
Unmarshal/simple/full-12              15.66µ ± ∞ ¹   14.11µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Unmarshal/simple/raw-12               12.47µ ± ∞ ¹   11.70µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Unmarshal/withRenderingInfo/full-12   63.15µ ± ∞ ¹   59.53µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Unmarshal/withRenderingInfo/raw-12    57.47µ ± ∞ ¹   49.38µ ± ∞ ¹        ~ (p=1.000 n=1) ²
XMLUnmarshal_Baseline-12              16.27µ ± ∞ ¹   14.51µ ± ∞ ¹        ~ (p=1.000 n=1) ²
UnmarshalEventXML_CleanInput-12       31.69µ ± ∞ ¹   14.58µ ± ∞ ¹        ~ (p=1.000 n=1) ²
UnmarshalEventXML_DirtyInput-12       17.27µ ± ∞ ¹   16.00µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SanitizeXMLBytes_CleanInput-12        562.9n ± ∞ ¹   565.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
SanitizeXMLBytes_DirtyInput-12        2.305µ ± ∞ ¹   2.240µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                               12.63µ         10.85µ        -14.12%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                    │  stanza.txt   │            stanza_pool.txt            │
                                    │     B/op      │     B/op       vs base                │
Unmarshal/simple/full-12              9.891Ki ± ∞ ¹   9.891Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Unmarshal/simple/raw-12               8.781Ki ± ∞ ¹   8.781Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Unmarshal/withRenderingInfo/full-12   42.44Ki ± ∞ ¹   42.44Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Unmarshal/withRenderingInfo/raw-12    31.25Ki ± ∞ ¹   31.25Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                               18.42Ki         18.42Ki        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                    │ stanza.txt  │           stanza_pool.txt           │
                                    │  allocs/op  │  allocs/op   vs base                │
Unmarshal/simple/full-12              236.0 ± ∞ ¹   236.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
Unmarshal/simple/raw-12               200.0 ± ∞ ¹   200.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
Unmarshal/withRenderingInfo/full-12   754.0 ± ∞ ¹   754.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
Unmarshal/withRenderingInfo/raw-12    578.0 ± ∞ ¹   578.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                               378.7         378.7        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/json
                    │  stanza.txt  │           stanza_pool.txt            │
                    │    sec/op    │    sec/op     vs base                │
Process-12            8.305µ ± ∞ ¹   7.854µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ProcessParseInts-12   9.596µ ± ∞ ¹   9.071µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean               8.927µ         8.441µ        -5.45%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                    │  stanza.txt   │            stanza_pool.txt            │
                    │     B/op      │     B/op       vs base                │
Process-12            9.556Ki ± ∞ ¹   9.556Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
ProcessParseInts-12   16.22Ki ± ∞ ¹   16.22Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean               12.45Ki         12.45Ki        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                    │ stanza.txt  │           stanza_pool.txt           │
                    │  allocs/op  │  allocs/op   vs base                │
Process-12            117.0 ± ∞ ¹   117.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
ProcessParseInts-12   159.0 ± ∞ ¹   159.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean               136.4         136.4        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/jsonparser
                    │  stanza.txt  │           stanza_pool.txt            │
                    │    sec/op    │    sec/op     vs base                │
Process-12            8.050µ ± ∞ ¹   7.798µ ± ∞ ¹       ~ (p=1.000 n=1) ²
ProcessParseInts-12   9.579µ ± ∞ ¹   9.555µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean               8.781µ         8.632µ        -1.70%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                    │  stanza.txt   │            stanza_pool.txt            │
                    │     B/op      │     B/op       vs base                │
Process-12            9.556Ki ± ∞ ¹   9.556Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
ProcessParseInts-12   16.22Ki ± ∞ ¹   16.22Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean               12.45Ki         12.45Ki        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                    │ stanza.txt  │           stanza_pool.txt           │
                    │  allocs/op  │  allocs/op   vs base                │
Process-12            117.0 ± ∞ ¹   117.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
ProcessParseInts-12   159.0 ± ∞ ¹   159.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean               136.4         136.4        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex
                                  │  stanza.txt   │           stanza_pool.txt            │
                                  │    sec/op     │    sec/op     vs base                │
ProcessBatch/SeverityMapping-12       1.345 ± ∞ ¹    1.263 ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/NoCache-12                     96.73µ ± ∞ ¹   95.56µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCache-12             26.63µ ± ∞ ¹   27.22µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCacheFullByOne-12    29.46µ ± ∞ ¹   28.78µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCacheFullBy10-12     37.99µ ± ∞ ¹   37.15µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCacheFullBy50-12     65.44µ ± ∞ ¹   64.21µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCacheFullBy90-12     94.36µ ± ∞ ¹   90.85µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCacheFullBy99-12    112.26µ ± ∞ ¹   95.97µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/NoCacheOneFile-12              1.785µ ± ∞ ¹   1.736µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Parse/WithMemoryCacheOneFile-12      13.46n ± ∞ ¹   13.52n ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                              47.98µ         46.39µ        -3.31%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                │  stanza.txt   │         stanza_pool.txt          │
                                │     B/op      │     B/op       vs base           │
ProcessBatch/SeverityMapping-12   999.6Mi ± ∞ ¹   999.7Mi ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                │  stanza.txt  │         stanza_pool.txt         │
                                │  allocs/op   │  allocs/op    vs base           │
ProcessBatch/SeverityMapping-12   13.00M ± ∞ ¹   13.00M ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/uri
               │  stanza.txt  │         stanza_pool.txt         │
               │    sec/op    │    sec/op     vs base           │
ParserParse-12   1.110µ ± ∞ ¹   1.155µ ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine
                         │  stanza.txt  │           stanza_pool.txt            │
                         │    sec/op    │    sec/op     vs base                │
Recombine-12               3.950m ± ∞ ¹   3.726m ± ∞ ¹       ~ (p=1.000 n=1) ²
RecombineLimitTrigger-12   2.434µ ± ∞ ¹   2.433µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                    98.05µ         95.21µ        -2.90%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

             │  stanza.txt   │         stanza_pool.txt          │
             │     B/op      │     B/op       vs base           │
Recombine-12   90.66Mi ± ∞ ¹   81.24Mi ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

             │ stanza.txt  │        stanza_pool.txt         │
             │  allocs/op  │  allocs/op   vs base           │
Recombine-12   824.0 ± ∞ ¹   824.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split
                                           │  stanza.txt  │           stanza_pool.txt            │
                                           │    sec/op    │    sec/op     vs base                │
LineStartSplitFunc_UTF8-12                   47.09µ ± ∞ ¹   51.39µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF16LE-12                267.1µ ± ∞ ¹   283.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF8_LargeRecords-12      26.89µ ± ∞ ¹   28.85µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF16LE_LargeRecords-12   228.5µ ± ∞ ¹   260.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF8-12                     12.96µ ± ∞ ¹   16.40µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF16LE-12                  263.8µ ± ∞ ¹   291.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF8_LargeRecords-12        9.023µ ± ∞ ¹   9.358µ ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF16LE_LargeRecords-12     262.9µ ± ∞ ¹   291.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
NewlineSplitFunc_UTF8-12                     1.829µ ± ∞ ¹   1.910µ ± ∞ ¹       ~ (p=1.000 n=1) ²
NewlineSplitFunc_UTF16LE-12                  2.516µ ± ∞ ¹   2.557µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                      35.16µ         38.40µ        +9.22%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                           │  stanza.txt   │            stanza_pool.txt            │
                                           │     B/op      │     B/op       vs base                │
LineStartSplitFunc_UTF8-12                   40.03Ki ± ∞ ¹   40.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF16LE-12                284.7Ki ± ∞ ¹   284.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF8_LargeRecords-12      26.83Ki ± ∞ ¹   26.83Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF16LE_LargeRecords-12   193.8Ki ± ∞ ¹   194.2Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF8-12                     12.21Ki ± ∞ ¹   12.23Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF16LE-12                  278.7Ki ± ∞ ¹   278.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF8_LargeRecords-12        10.45Ki ± ∞ ¹   10.46Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF16LE_LargeRecords-12     183.8Ki ± ∞ ¹   183.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
NewlineSplitFunc_UTF8-12                     4.188Ki ± ∞ ¹   4.188Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
NewlineSplitFunc_UTF16LE-12                  4.188Ki ± ∞ ¹   4.188Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                      38.30Ki         38.33Ki        +0.07%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal

                                           │ stanza.txt  │           stanza_pool.txt           │
                                           │  allocs/op  │  allocs/op   vs base                │
LineStartSplitFunc_UTF8-12                   513.0 ± ∞ ¹   513.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF16LE-12                964.0 ± ∞ ¹   964.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF8_LargeRecords-12      279.0 ± ∞ ¹   279.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineStartSplitFunc_UTF16LE_LargeRecords-12   604.0 ± ∞ ¹   604.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF8-12                     209.0 ± ∞ ¹   209.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF16LE-12                  733.0 ± ∞ ¹   733.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF8_LargeRecords-12        117.0 ± ∞ ¹   117.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
LineEndSplitFunc_UTF16LE_LargeRecords-12     428.0 ± ∞ ¹   428.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
NewlineSplitFunc_UTF8-12                     9.000 ± ∞ ¹   9.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
NewlineSplitFunc_UTF16LE-12                  11.00 ± ∞ ¹   11.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                      190.6         190.6        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim
                                    │  stanza.txt  │           stanza_pool.txt            │
                                    │    sec/op    │    sec/op     vs base                │
TrimFuncs/leading/small_clean-12      1.817n ± ∞ ¹   1.847n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/small_dirty-12      3.358n ± ∞ ¹   3.385n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/all_space-12        4.060n ± ∞ ¹   4.106n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/large_dirty-12      2.734n ± ∞ ¹   2.937n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/small_clean-12     1.813n ± ∞ ¹   1.883n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/small_dirty-12     2.745n ± ∞ ¹   2.779n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/all_space-12       3.729n ± ∞ ¹   3.673n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/large_dirty-12     2.078n ± ∞ ¹   2.109n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/small_clean-12   1.807n ± ∞ ¹   1.902n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/small_dirty-12   5.669n ± ∞ ¹   6.206n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/all_space-12     3.689n ± ∞ ¹   3.851n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/large_dirty-12   4.091n ± ∞ ¹   4.320n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/small_clean-12          1.823n ± ∞ ¹   1.858n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/small_dirty-12          1.817n ± ∞ ¹   1.853n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/all_space-12            1.814n ± ∞ ¹   1.861n ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/large_dirty-12          1.835n ± ∞ ¹   1.897n ± ∞ ¹       ~ (p=1.000 n=1) ²
WithFunc/baseline_scanlines-12        2.438n ± ∞ ¹   2.595n ± ∞ ¹       ~ (p=1.000 n=1) ²
WithFunc/with_whitespace-12           4.315n ± ∞ ¹   4.442n ± ∞ ¹       ~ (p=1.000 n=1) ²
ToLength/under_limit-12               3.869n ± ∞ ¹   4.255n ± ∞ ¹       ~ (p=1.000 n=1) ²
ToLength/over_limit-12                7.837n ± ∞ ¹   8.951n ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                               2.868n         2.987n        +4.15%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                    │ stanza.txt  │           stanza_pool.txt           │
                                    │    B/op     │    B/op      vs base                │
TrimFuncs/leading/small_clean-12      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/small_dirty-12      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/all_space-12        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/large_dirty-12      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/small_clean-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/small_dirty-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/all_space-12       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/large_dirty-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/small_clean-12   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/small_dirty-12   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/all_space-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/large_dirty-12   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/small_clean-12          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/small_dirty-12          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/all_space-12            0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/large_dirty-12          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
WithFunc/baseline_scanlines-12        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
WithFunc/with_whitespace-12           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ToLength/under_limit-12               0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ToLength/over_limit-12                0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                         ³                +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

                                    │ stanza.txt  │           stanza_pool.txt           │
                                    │  allocs/op  │  allocs/op   vs base                │
TrimFuncs/leading/small_clean-12      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/small_dirty-12      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/all_space-12        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/leading/large_dirty-12      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/small_clean-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/small_dirty-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/all_space-12       0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/trailing/large_dirty-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/small_clean-12   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/small_dirty-12   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/all_space-12     0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/whitespace/large_dirty-12   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/small_clean-12          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/small_dirty-12          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/all_space-12            0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
TrimFuncs/nop/large_dirty-12          0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
WithFunc/baseline_scanlines-12        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
WithFunc/with_whitespace-12           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ToLength/under_limit-12               0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
ToLength/over_limit-12                0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                         ³                +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

```
