### PR TITLE
[extension/googlecloudlogentryencoding] fix protocol parsing for ALPN identifiers

### DIFF
--- a/.chloggen/45214-allow-h2-protocol.yaml
+++ b/.chloggen/45214-allow-h2-protocol.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/google_cloud_logentry_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow the googlecloudlogentry_encoding Extension to parse h2 and h3 as valid protocol identifiers.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45214]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This will allow the googlecloudlogentry_encoding Extension to correctly parse HTTP logs coming from Google Cloud Load Balancers.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/googlecloudlogentryencodingextension/log_entry.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/log_entry.go
@@ -67,6 +67,19 @@ const (
 	gcpAppHubWorkloadCriticalityTypeField = "workload.criticality_type"
 )
 
+type protocolID struct {
+	name    string
+	version string
+}
+
+// alpnProtocols maps ALPN protocol identifiers (RFC 7301) to their
+// corresponding protocol name and version. GCP load balancers may use
+// these identifiers instead of the "name/version" format.
+var alpnProtocols = map[string]protocolID{
+	"h2": {name: "http", version: "2"},
+	"h3": {name: "http", version: "3"},
+}
+
 // getEncodingFormat maps GCP log types to encoding format values
 func getEncodingFormat(logType string) string {
 	switch logType {
@@ -231,7 +244,10 @@ func handleHTTPRequestField(attributes pcommon.Map, req *httpRequest) error {
 		shared.PutStr(string(conventions.URLDomainKey), u.Host, attributes)
 	}
 
-	if req.Protocol != "" {
+	if alpn, ok := alpnProtocols[req.Protocol]; ok {
+		attributes.PutStr(string(conventions.NetworkProtocolNameKey), alpn.name)
+		attributes.PutStr(string(conventions.NetworkProtocolVersionKey), alpn.version)
+	} else if req.Protocol != "" {
 		if strings.Count(req.Protocol, "/") != 1 {
 			return fmt.Errorf(
 				`invalid protocol %q: expected exactly one "/" (format "<name>/<version>", e.g. "HTTP/1.1")`,
@@ -241,7 +257,7 @@ func handleHTTPRequestField(attributes pcommon.Map, req *httpRequest) error {
 		name, version, found := strings.Cut(req.Protocol, "/")
 		if !found || name == "" || version == "" {
 			return fmt.Errorf(
-				`invalid protocol %q: name or version is missing (expected format "<name>/<version>", e.g. "HTTP/1.1")`,
+				`invalid protocol %q: expected format "<name>/<version>" (e.g. "HTTP/1.1") or a known ALPN identifier (e.g. "h2")`,
 				req.Protocol,
 			)
 		}

--- a/extension/encoding/googlecloudlogentryencodingextension/log_entry_test.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/log_entry_test.go
@@ -112,18 +112,38 @@ func TestHandleHTTPRequestField(t *testing.T) {
 			expectsErr: "failed to parse request url",
 		},
 		{
-			name: "invalid protocol",
+			name: "ALPN protocol h2",
+			request: &httpRequest{
+				Protocol: "h2",
+			},
+			expectsAttributes: map[string]any{
+				"network.protocol.name":    "http",
+				"network.protocol.version": "2",
+			},
+		},
+		{
+			name: "ALPN protocol h3",
+			request: &httpRequest{
+				Protocol: "h3",
+			},
+			expectsAttributes: map[string]any{
+				"network.protocol.name":    "http",
+				"network.protocol.version": "3",
+			},
+		},
+		{
+			name: "invalid protocol no slash",
 			request: &httpRequest{
 				Protocol: "invalid",
 			},
 			expectsErr: `expected exactly one "/"`,
 		},
 		{
-			name: "invalid protocol 2",
+			name: "invalid protocol empty version",
 			request: &httpRequest{
-				Protocol: "invalid/",
+				Protocol: "HTTP/",
 			},
-			expectsErr: "name or version is missing",
+			expectsErr: "known ALPN identifier",
 		},
 		{
 			name: "latency without suffix",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Before: The googlecloudlogentryencoding extension cannot parse HTTP logs from Google Cloud load balancers because they provide ALPN identifiers for protocol (like `h2`), while the extension expects the `HTTP/2` format.

After: The extension is able to parse these logs and identify the `h2` and `h3` ALPN identifiers as valid protocols.

Assisted-by: Claude Opus 4.6

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45214

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests are added for the `h2` and `h3` cases.
