### PR TITLE
[extension/datadog] add gateway_service and gateway_destination config fields for gateway topology

### DIFF
--- a/.chloggen/datadogextension-gateway-topology.yaml
+++ b/.chloggen/datadogextension-gateway-topology.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: extension/datadog
+
+note: Add `gateway_service` and `gateway_destination` config fields to support gateway topology view in Fleet Automation.
+
+issues: [OTAGENT-956]
+
+subtext: |
+  Gateway collectors set `gateway_service` to the k8s Service fronting them.
+  Agent/daemonset collectors set `gateway_destination` to the k8s Service they forward telemetry to.
+  Both fields are optional and omitted from the metadata payload when empty.
+
+change_logs: [user]

--- a/.chloggen/datadogextension-gateway-topology.yaml
+++ b/.chloggen/datadogextension-gateway-topology.yaml
@@ -4,7 +4,7 @@ component: extension/datadog
 
 note: Add `gateway_service` and `gateway_destination` config fields to support gateway topology view in Fleet Automation.
 
-issues: [OTAGENT-956]
+issues: [47471]
 
 subtext: |
   Gateway collectors set `gateway_service` to the k8s Service fronting them.

--- a/extension/datadogextension/config.go
+++ b/extension/datadogextension/config.go
@@ -36,6 +36,14 @@ type Config struct {
 	// Valid values: "", "kubernetes", "bare-metal", "docker", "ecs-fargate", "eks-fargate".
 	// Defaults to "" (unset) if not configured.
 	InstallationMethod string `mapstructure:"installation_method"`
+	// GatewayService is the k8s Service fronting the gateway collector pods.
+	// Set by gateway collectors. Format: "service" or "namespace/service".
+	// Together with cluster_name, it forms the join key for fleet topology queries.
+	GatewayService string `mapstructure:"gateway_service"`
+	// GatewayDestination is the k8s Service that this collector forwards telemetry to.
+	// Set by agent/daemonset collectors. Format: "service" or "namespace/service".
+	// Must match gateway_service on the receiving gateway collector.
+	GatewayDestination string `mapstructure:"gateway_destination"`
 }
 
 // Validate ensures that the configuration is valid.

--- a/extension/datadogextension/config.schema.yaml
+++ b/extension/datadogextension/config.schema.yaml
@@ -7,6 +7,12 @@ properties:
   deployment_type:
     description: DeploymentType indicates the type of deployment (gateway, daemonset, or unknown). Defaults to "unknown" if not set.
     type: string
+  gateway_destination:
+    description: 'GatewayDestination is the k8s Service that this collector forwards telemetry to. Set by agent/daemonset collectors. Format: "service" or "namespace/service". Must match gateway_service on the receiving gateway collector.'
+    type: string
+  gateway_service:
+    description: 'GatewayService is the k8s Service fronting the gateway collector pods. Set by gateway collectors. Format: "service" or "namespace/service". Together with cluster_name, it forms the join key for fleet topology queries.'
+    type: string
   hostname:
     description: If Hostname is empty extension will use available system APIs and cloud provider endpoints.
     type: string

--- a/extension/datadogextension/config_test.go
+++ b/extension/datadogextension/config_test.go
@@ -418,3 +418,60 @@ func TestConfig_DeploymentTypeValidValues(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_GatewayTopologyFields(t *testing.T) {
+	baseConfig := func() Config {
+		return Config{
+			API: datadogconfig.APIConfig{
+				Site: datadogconfig.DefaultSite,
+				Key:  "1234567890abcdef1234567890abcdef",
+			},
+			HTTPConfig: &httpserver.Config{
+				ServerConfig: confighttp.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Transport: confignet.TransportTypeTCP,
+						Endpoint:  "localhost:8080",
+					},
+				},
+				Path: "/metadata",
+			},
+		}
+	}
+
+	t.Run("empty gateway fields are valid", func(t *testing.T) {
+		cfg := baseConfig()
+		assert.NoError(t, cfg.Validate())
+		assert.Empty(t, cfg.GatewayService)
+		assert.Empty(t, cfg.GatewayDestination)
+	})
+
+	t.Run("gateway_service set by gateway collector", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.GatewayService = "monitoring/otelcol-gateway"
+		assert.NoError(t, cfg.Validate())
+		assert.Equal(t, "monitoring/otelcol-gateway", cfg.GatewayService)
+	})
+
+	t.Run("gateway_destination set by daemonset collector", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.GatewayDestination = "monitoring/otelcol-gateway"
+		assert.NoError(t, cfg.Validate())
+		assert.Equal(t, "monitoring/otelcol-gateway", cfg.GatewayDestination)
+	})
+
+	t.Run("both fields set for intermediate gateway", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.GatewayService = "monitoring/otelcol-gateway-l2"
+		cfg.GatewayDestination = "monitoring/otelcol-gateway-l1"
+		assert.NoError(t, cfg.Validate())
+		assert.Equal(t, "monitoring/otelcol-gateway-l2", cfg.GatewayService)
+		assert.Equal(t, "monitoring/otelcol-gateway-l1", cfg.GatewayDestination)
+	})
+
+	t.Run("simple service name without namespace", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.GatewayService = "otelcol-gateway"
+		cfg.GatewayDestination = "otelcol-gateway"
+		assert.NoError(t, cfg.Validate())
+	})
+}

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -132,6 +132,8 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		e.configs.extension.InstallationMethod,
 		buildInfo,
 		int64(payloadTTL),
+		e.configs.extension.GatewayService,
+		e.configs.extension.GatewayDestination,
 	)
 
 	// Populate resource attributes collected from TelemetrySettings.Resource

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -364,6 +364,8 @@ func createTestOtelCollectorPayload() *payload.OtelCollectorPayload {
 		"",
 		buildInfo,
 		int64(payloadTTL),
+		"",
+		"",
 	)
 
 	// Populate with realistic component data
@@ -573,6 +575,8 @@ func TestHTTPServerIntegration(t *testing.T) {
 		"",
 		buildInfo,
 		int64(payloadTTL),
+		"",
+		"",
 	)
 	if activeComponents != nil {
 		otelMetadata.ActiveComponents = *activeComponents
@@ -737,6 +741,8 @@ func TestHTTPServerConfigIntegration(t *testing.T) {
 		"",
 		buildInfo,
 		int64(payloadTTL),
+		"",
+		"",
 	)
 
 	// Test different server configurations
@@ -834,6 +840,8 @@ func TestHTTPServerConcurrentAccess(t *testing.T) {
 		"",
 		buildInfo,
 		int64(payloadTTL),
+		"",
+		"",
 	)
 
 	// Create server

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -38,7 +38,12 @@ type OtelCollector struct {
 	CollectorResourceAttributes map[string]string  `json:"collector_resource_attributes"`
 	CollectorDeploymentType     string             `json:"collector_deployment_type"`     // deployment type: gateway, daemonset, or unknown
 	CollectorInstallationMethod string             `json:"collector_installation_method"` // installation method: kubernetes, bare-metal, docker, ecs-fargate, eks-fargate, or ""
-	TTL                         int64              `json:"ttl"`
+	// Gateway topology fields (RFC: Gateway Topology View in Fleet Automation)
+	// GatewayService is set by gateway collectors: the k8s Service fronting the gateway pods.
+	GatewayService string `json:"gateway_service,omitempty"`
+	// GatewayDestination is set by agent/daemonset collectors: the k8s Service they forward telemetry to.
+	GatewayDestination string `json:"gateway_destination,omitempty"`
+	TTL                int64  `json:"ttl"`
 }
 
 type CollectorModule struct {
@@ -95,6 +100,8 @@ func PrepareOtelCollectorMetadata(
 	installationMethod string,
 	buildInfo CustomBuildInfo,
 	ttl int64,
+	gatewayService string,
+	gatewayDestination string,
 ) OtelCollector {
 	return OtelCollector{
 		HostKey:                     "",
@@ -108,6 +115,8 @@ func PrepareOtelCollectorMetadata(
 		FullConfiguration:           fullConfig,
 		CollectorDeploymentType:     deploymentType,
 		CollectorInstallationMethod: installationMethod,
+		GatewayService:              gatewayService,
+		GatewayDestination:          gatewayDestination,
 		TTL:                         ttl,
 	}
 }

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -170,6 +170,8 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 		"",
 		buildInfo,
 		int64(5*time.Minute*3),
+		"",
+		"",
 	)
 
 	// Add full components (what would come from module info)
@@ -439,6 +441,8 @@ func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 				"",
 				buildInfo,
 				int64(5*time.Minute*3),
+				"",
+				"",
 			)
 
 			assert.Equal(t, tt.deploymentType, metadata.CollectorDeploymentType)
@@ -465,6 +469,77 @@ func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 	}
 }
 
+func TestPrepareOtelCollectorMetadata_GatewayTopology(t *testing.T) {
+	tests := []struct {
+		name               string
+		gatewayService     string
+		gatewayDestination string
+		expectInJSON       bool
+	}{
+		{
+			name:               "both empty - omitted from JSON",
+			gatewayService:     "",
+			gatewayDestination: "",
+			expectInJSON:       false,
+		},
+		{
+			name:               "gateway_service set by gateway collector",
+			gatewayService:     "monitoring/otelcol-gateway",
+			gatewayDestination: "",
+			expectInJSON:       true,
+		},
+		{
+			name:               "gateway_destination set by daemonset collector",
+			gatewayService:     "",
+			gatewayDestination: "monitoring/otelcol-gateway",
+			expectInJSON:       true,
+		},
+		{
+			name:               "both set for intermediate gateway",
+			gatewayService:     "monitoring/otelcol-gateway-l2",
+			gatewayDestination: "monitoring/otelcol-gateway-l1",
+			expectInJSON:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildInfo := CustomBuildInfo{Command: "otelcol", Description: "Test Collector", Version: "1.0.0"}
+			metadata := PrepareOtelCollectorMetadata(
+				"test-host", "config", "test-uuid", "1.0.0", "datadoghq.com", "{}",
+				"unknown", "", buildInfo, int64(5*time.Minute*3),
+				tt.gatewayService, tt.gatewayDestination,
+			)
+
+			assert.Equal(t, tt.gatewayService, metadata.GatewayService)
+			assert.Equal(t, tt.gatewayDestination, metadata.GatewayDestination)
+
+			p := &OtelCollectorPayload{Hostname: "test-host", Timestamp: time.Now().UnixNano(), UUID: "test-uuid", Metadata: metadata}
+			jsonData, err := json.Marshal(p)
+			require.NoError(t, err)
+
+			var jsonMap map[string]any
+			err = json.Unmarshal(jsonData, &jsonMap)
+			require.NoError(t, err)
+
+			metadataMap, ok := jsonMap["otel_collector"].(map[string]any)
+			require.True(t, ok)
+
+			if tt.expectInJSON {
+				if tt.gatewayService != "" {
+					assert.Equal(t, tt.gatewayService, metadataMap["gateway_service"])
+				}
+				if tt.gatewayDestination != "" {
+					assert.Equal(t, tt.gatewayDestination, metadataMap["gateway_destination"])
+				}
+			} else {
+				assert.NotContains(t, metadataMap, "gateway_service")
+				assert.NotContains(t, metadataMap, "gateway_destination")
+			}
+		})
+	}
+}
+
 func TestPrepareOtelCollectorMetadata_InstallationMethod(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -484,6 +559,7 @@ func TestPrepareOtelCollectorMetadata_InstallationMethod(t *testing.T) {
 			metadata := PrepareOtelCollectorMetadata(
 				"test-host", "config", "test-uuid", "1.0.0", "datadoghq.com", "{}",
 				"unknown", tt.installationMethod, buildInfo, int64(5*time.Minute*3),
+				"", "",
 			)
 
 			assert.Equal(t, tt.installationMethod, metadata.CollectorInstallationMethod)


### PR DESCRIPTION
## Summary

- Adds two new optional config fields to the Datadog extension:
  - `gateway_service`: set by gateway collectors — the k8s Service fronting the gateway pods (format: `service` or `namespace/service`)
  - `gateway_destination`: set by agent/daemonset collectors — the k8s Service they forward telemetry to
- Both fields are propagated into the `otel_collector` metadata payload sent to `/api/v1/metadata` and are omitted from JSON when empty (`omitempty`)
- An intermediate gateway collector in a multi-layer setup may set both fields

## Test plan

- [x] `TestConfig_GatewayTopologyFields` — validates new config fields accept any string and are optional
- [x] `TestPrepareOtelCollectorMetadata_GatewayTopology` — verifies all combinations (empty, gateway-only, daemonset-only, intermediate) serialize correctly and empty fields are omitted from JSON
- [x] All existing tests pass with updated `PrepareOtelCollectorMetadata` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)