### PR TITLE
[extension/sigv4authextension] Add configurable credential refresh window and session duration for AssumeRole

### DIFF
--- a/.chloggen/47473-sigv4auth-assume-role-expiry.yaml
+++ b/.chloggen/47473-sigv4auth-assume-role-expiry.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/sigv4authextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add configurable `expiry_window` and `session_duration` options to the `assume_role` block so long-running exporters can avoid dropped requests caused by STS credentials expiring mid-flight.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47473]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -28,6 +28,7 @@ type AssumeRole struct {
 	WebIdentityTokenFile string `mapstructure:"web_identity_token_file,omitempty"`
 	ExternalID           string `mapstructure:"external_id,omitempty"`
 	ExpiryWindow 		 time.Duration `mapstructure:"expiry_window"`
+	SessionDuration  time.Duration `mapstructure:"session_duration"`
 }
 
 // compile time check that the Config struct satisfies the component.Config interface

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -6,7 +6,8 @@ package sigv4authextension // import "github.com/open-telemetry/opentelemetry-co
 import (
 	"errors"
 	"fmt"
-
+	"time"
+	
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/component"
 )
@@ -26,6 +27,7 @@ type AssumeRole struct {
 	STSRegion            string `mapstructure:"sts_region,omitempty"`
 	WebIdentityTokenFile string `mapstructure:"web_identity_token_file,omitempty"`
 	ExternalID           string `mapstructure:"external_id,omitempty"`
+	ExpiryWindow 		 time.Duration `mapstructure:"expiry_window"`
 }
 
 // compile time check that the Config struct satisfies the component.Config interface

--- a/extension/sigv4authextension/config.schema.yaml
+++ b/extension/sigv4authextension/config.schema.yaml
@@ -7,6 +7,8 @@ $defs:
         type: string
       external_id:
         type: string
+      expiry_window:
+        type: string
       session_name:
         type: string
       sts_region:

--- a/extension/sigv4authextension/config.schema.yaml
+++ b/extension/sigv4authextension/config.schema.yaml
@@ -9,6 +9,8 @@ $defs:
         type: string
       expiry_window:
         type: string
+      session_duration:
+        type: string
       session_name:
         type: string
       sts_region:

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -78,7 +78,13 @@ func getCredsProviderFromConfig(cfg *Config) (*aws.CredentialsProvider, error) {
 		stsSvc := sts.NewFromConfig(awscfg)
 
 		provider := stscreds.NewAssumeRoleProvider(stsSvc, cfg.AssumeRole.ARN, assumeRoleOptions(cfg))
-		awscfg.Credentials = aws.NewCredentialsCache(provider)
+		if cfg.AssumeRole.ExpiryWindow > 0 {
+			awscfg.Credentials = aws.NewCredentialsCache(provider, func(o *aws.CredentialsCacheOptions) {
+				o.ExpiryWindow = cfg.AssumeRole.ExpiryWindow
+			})
+		} else {
+			awscfg.Credentials = aws.NewCredentialsCache(provider)	
+		}
 	}
 
 	_, err = awscfg.Credentials.Retrieve(context.Background())

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -129,5 +129,8 @@ func assumeRoleOptions(cfg *Config) func(*stscreds.AssumeRoleOptions) {
 		if cfg.AssumeRole.ExternalID != "" {
 			o.ExternalID = &cfg.AssumeRole.ExternalID
 		}
+		if cfg.AssumeRole.SessionDuration > 0 {
+			o.Duration = cfg.AssumeRole.SessionDuration
+		}
 	}
 }


### PR DESCRIPTION
## Problem

When using `sigv4auth` with `assume_role` in long-running collectors (e.g., DaemonSets exporting to OpenSearch), STS credentials can expire mid-flight during slow bulk requests. The AWS SDK's default `ExpiryWindow` (~5-10 min before expiry) is too tight — if a request is in-flight when credentials expire, the 403 is classified as non-retryable and data is permanently dropped.

Additionally, the default AssumeRole session duration (1 hour) means credentials rotate frequently, increasing the chance of hitting this window. Users currently have no way to control either setting without forking the extension.

## Proposed Changes

Expose two new config options on the `assume_role` block:

- **`expiry_window`** — controls how far before expiry the AWS SDK refreshes credentials (default: ~5-10 min)
- **`session_duration`** — controls the AssumeRole STS session lifetime (default: 1h, max depends on IAM role's `MaxSessionDuration`)

### Configuration Example

```yaml
sigv4auth:
  region: eu-west-1
  service: es
  assume_role:
    arn: arn:aws:iam::123456789:role/my-role
    sts_region: eu-west-1
    session_duration: 4h  # longer session, fewer rotations
    expiry_window: 20m    # refresh 20 min before expiry
```

### Code Changes

**`config.go`** — added `ExpiryWindow` and `SessionDuration` fields to `AssumeRole` struct

**`extension.go`** — pass `ExpiryWindow` to `aws.NewCredentialsCache` options and `SessionDuration` to `stscreds.AssumeRoleOptions.Duration`

**`config.schema.yaml`** — added both new properties to the schema

## Why This Matters

- Default 1h STS session with ~5 min refresh window means credentials can expire during slow requests (network latency, target-side GC pauses, large bulk payloads)
- HTTP 403 "security token expired" is treated as a permanent error → data dropped, no retry
- Users currently have no way to control this without forking the extension
- Zero breaking changes — default behavior is preserved when options are unset