### PR TITLE
[extension/opampextension] Add os.version non-identifying attribute

### DIFF
--- a/.chloggen/opamp-os-version.yaml
+++ b/.chloggen/opamp-os-version.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opamp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `os.version` as an auto-detected non-identifying attribute in the OpAMP AgentDescription.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47482]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -51,6 +51,16 @@ The following settings are optional for both transports:
 - `agent_description`: Setting that modifies the agent description reported to the OpAMP server.
   - `include_resource_attributes`: Copy the Collector's resource attributes into the set of non-identifying attributes in the agent description.
   - `non_identifying_attributes`: A map of key value pairs that will be added to the [non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes) reported to the OpAMP server. If an attribute collides with the default non-identifying attributes that are automatically added, the ones specified here take precedence.
+
+The following non-identifying attributes are reported automatically and do not require configuration:
+
+| Attribute | Description |
+|-----------|-------------|
+| `os.type` | Operating system type (e.g., `linux`, `darwin`, `windows`) |
+| `host.arch` | CPU architecture (e.g., `amd64`, `arm64`) |
+| `host.name` | Hostname of the machine |
+| `os.description` | Human-readable OS description (e.g., `macOS 15.3`, `Ubuntu 22.04`) |
+| `os.version` | OS platform version string (e.g., `15.3`, `22.04`). Omitted if unavailable. |
 - `ppid`: An optional process ID to monitor. When this process is no longer running, the extension will emit a fatal error, causing the collector to exit. This is meant to be set by the Supervisor or some other parent process, and should not be configured manually.
 - `ppid_poll_interval`: The poll interval between check for whether `ppid` is still alive or not. Defaults to 5 seconds.
 

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,8 +3,9 @@
 package opampextension
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,9 +3,8 @@
 package opampextension
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -374,7 +374,8 @@ func (o *opampAgent) createAgentDescription() error {
 	if err != nil {
 		return err
 	}
-	description := getOSDescription(o.logger)
+
+	description, osVersion := o.createOSAttributes()
 
 	ident := []*protobufs.KeyValue{
 		stringKeyValue(string(conventions.ServiceInstanceIDKey), o.instanceID.String()),
@@ -389,6 +390,10 @@ func (o *opampAgent) createAgentDescription() error {
 	nonIdentifyingAttributeMap[string(conventions.HostArchKey)] = runtime.GOARCH
 	nonIdentifyingAttributeMap[string(conventions.HostNameKey)] = hostname
 	nonIdentifyingAttributeMap[string(conventions.OSDescriptionKey)] = description
+
+	if osVersion != "" {
+		nonIdentifyingAttributeMap[string(conventions.OSVersionKey)] = osVersion
+	}
 
 	maps.Copy(nonIdentifyingAttributeMap, o.cfg.AgentDescription.NonIdentifyingAttributes)
 	if o.cfg.AgentDescription.IncludeResourceAttributes {
@@ -498,22 +503,27 @@ func (o *opampAgent) setHealth(ch *protobufs.ComponentHealth) {
 	}
 }
 
-func getOSDescription(logger *zap.Logger) string {
+// createOSAttributes calls host.Info() once and returns the OS description and
+// version strings. On failure, description falls back to runtime.GOOS and
+// version is empty.
+func (o *opampAgent) createOSAttributes() (description, version string) {
 	info, err := host.Info()
 	if err != nil {
-		logger.Error("failed getting host info", zap.Error(err))
-		return runtime.GOOS
+		o.logger.Error("failed getting host info", zap.Error(err))
+		return runtime.GOOS, ""
 	}
+	version = info.PlatformVersion
 	switch runtime.GOOS {
 	case "darwin":
-		return "macOS " + info.PlatformVersion
+		description = "macOS " + info.PlatformVersion
 	case "linux":
-		return cases.Title(language.English).String(info.Platform) + " " + info.PlatformVersion
+		description = cases.Title(language.English).String(info.Platform) + " " + info.PlatformVersion
 	case "windows":
-		return info.Platform + " " + info.PlatformVersion
+		description = info.Platform + " " + info.PlatformVersion
 	default:
-		return runtime.GOOS
+		description = runtime.GOOS
 	}
+	return description, version
 }
 
 func (o *opampAgent) initHealthReporting() {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -6,6 +6,7 @@ package opampextension
 import (
 	"context"
 	"errors"
+	"maps"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -18,8 +19,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/client/types"
-	"github.com/shirou/gopsutil/v4/host"
 	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/shirou/gopsutil/v4/host"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -115,9 +116,7 @@ func TestCreateAgentDescription(t *testing.T) {
 		if osVersion != "" {
 			base["os.version"] = osVersion
 		}
-		for k, v := range kvs {
-			base[k] = v
-		}
+		maps.Copy(base, kvs)
 		keys := make([]string, 0, len(base))
 		for k := range base {
 			keys = append(keys, k)

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"sync"
 	"syscall"
 	"testing"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/client/types"
+	"github.com/shirou/gopsutil/v4/host"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,8 +31,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/service"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status/testhelpers"
@@ -70,7 +73,23 @@ func TestNewOpampAgentAttributes(t *testing.T) {
 func TestCreateAgentDescription(t *testing.T) {
 	hostname, err := os.Hostname()
 	require.NoError(t, err)
-	description := getOSDescription(zap.NewNop())
+	info, _ := host.Info()
+	var description, osVersion string
+	if info != nil {
+		osVersion = info.PlatformVersion
+		switch runtime.GOOS {
+		case "darwin":
+			description = "macOS " + info.PlatformVersion
+		case "linux":
+			description = cases.Title(language.English).String(info.Platform) + " " + info.PlatformVersion
+		case "windows":
+			description = info.Platform + " " + info.PlatformVersion
+		default:
+			description = runtime.GOOS
+		}
+	} else {
+		description = runtime.GOOS
+	}
 
 	serviceName := "otelcol-distrot"
 	serviceVersion := "distro.0"
@@ -78,27 +97,53 @@ func TestCreateAgentDescription(t *testing.T) {
 	extraResourceAttrKey := "hello"
 	extraResourceAttrValue := "world"
 
+	defaultIdentAttrs := []*protobufs.KeyValue{
+		stringKeyValue("service.instance.id", serviceInstanceUUID),
+		stringKeyValue("service.name", serviceName),
+		stringKeyValue("service.version", serviceVersion),
+	}
+
+	// buildNonIdentAttrs constructs the expected non-identifying attribute slice in
+	// alphabetical order, including os.version only when the platform provides it.
+	buildNonIdentAttrs := func(kvs map[string]string) []*protobufs.KeyValue {
+		base := map[string]string{
+			"host.arch":      runtime.GOARCH,
+			"host.name":      hostname,
+			"os.description": description,
+			"os.type":        runtime.GOOS,
+		}
+		if osVersion != "" {
+			base["os.version"] = osVersion
+		}
+		for k, v := range kvs {
+			base[k] = v
+		}
+		keys := make([]string, 0, len(base))
+		for k := range base {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		result := make([]*protobufs.KeyValue, 0, len(base))
+		for _, k := range keys {
+			result = append(result, stringKeyValue(k, base[k]))
+		}
+		return result
+	}
+
 	testCases := []struct {
 		name string
 		cfg  func(*Config)
 
-		expected *protobufs.AgentDescription
+		expected func() *protobufs.AgentDescription
 	}{
 		{
 			name: "No extra attributes",
 			cfg:  func(_ *Config) {},
-			expected: &protobufs.AgentDescription{
-				IdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("service.instance.id", serviceInstanceUUID),
-					stringKeyValue("service.name", serviceName),
-					stringKeyValue("service.version", serviceVersion),
-				},
-				NonIdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("host.arch", runtime.GOARCH),
-					stringKeyValue("host.name", hostname),
-					stringKeyValue("os.description", description),
-					stringKeyValue("os.type", runtime.GOOS),
-				},
+			expected: func() *protobufs.AgentDescription {
+				return &protobufs.AgentDescription{
+					IdentifyingAttributes:    defaultIdentAttrs,
+					NonIdentifyingAttributes: buildNonIdentAttrs(nil),
+				}
 			},
 		},
 		{
@@ -109,20 +154,14 @@ func TestCreateAgentDescription(t *testing.T) {
 					"k8s.pod.name": "my-very-cool-pod",
 				}
 			},
-			expected: &protobufs.AgentDescription{
-				IdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("service.instance.id", serviceInstanceUUID),
-					stringKeyValue("service.name", serviceName),
-					stringKeyValue("service.version", serviceVersion),
-				},
-				NonIdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("env", "prod"),
-					stringKeyValue("host.arch", runtime.GOARCH),
-					stringKeyValue("host.name", hostname),
-					stringKeyValue("k8s.pod.name", "my-very-cool-pod"),
-					stringKeyValue("os.description", description),
-					stringKeyValue("os.type", runtime.GOOS),
-				},
+			expected: func() *protobufs.AgentDescription {
+				return &protobufs.AgentDescription{
+					IdentifyingAttributes: defaultIdentAttrs,
+					NonIdentifyingAttributes: buildNonIdentAttrs(map[string]string{
+						"env":          "prod",
+						"k8s.pod.name": "my-very-cool-pod",
+					}),
+				}
 			},
 		},
 		{
@@ -132,18 +171,13 @@ func TestCreateAgentDescription(t *testing.T) {
 					"host.name": "override-host",
 				}
 			},
-			expected: &protobufs.AgentDescription{
-				IdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("service.instance.id", serviceInstanceUUID),
-					stringKeyValue("service.name", serviceName),
-					stringKeyValue("service.version", serviceVersion),
-				},
-				NonIdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("host.arch", runtime.GOARCH),
-					stringKeyValue("host.name", "override-host"),
-					stringKeyValue("os.description", description),
-					stringKeyValue("os.type", runtime.GOOS),
-				},
+			expected: func() *protobufs.AgentDescription {
+				return &protobufs.AgentDescription{
+					IdentifyingAttributes: defaultIdentAttrs,
+					NonIdentifyingAttributes: buildNonIdentAttrs(map[string]string{
+						"host.name": "override-host",
+					}),
+				}
 			},
 		},
 		{
@@ -151,19 +185,13 @@ func TestCreateAgentDescription(t *testing.T) {
 			cfg: func(c *Config) {
 				c.AgentDescription.IncludeResourceAttributes = true
 			},
-			expected: &protobufs.AgentDescription{
-				IdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue("service.instance.id", serviceInstanceUUID),
-					stringKeyValue("service.name", serviceName),
-					stringKeyValue("service.version", serviceVersion),
-				},
-				NonIdentifyingAttributes: []*protobufs.KeyValue{
-					stringKeyValue(extraResourceAttrKey, extraResourceAttrValue),
-					stringKeyValue("host.arch", runtime.GOARCH),
-					stringKeyValue("host.name", hostname),
-					stringKeyValue("os.description", description),
-					stringKeyValue("os.type", runtime.GOOS),
-				},
+			expected: func() *protobufs.AgentDescription {
+				return &protobufs.AgentDescription{
+					IdentifyingAttributes: defaultIdentAttrs,
+					NonIdentifyingAttributes: buildNonIdentAttrs(map[string]string{
+						extraResourceAttrKey: extraResourceAttrValue,
+					}),
+				}
 			},
 		},
 	}
@@ -185,7 +213,7 @@ func TestCreateAgentDescription(t *testing.T) {
 
 			err = o.createAgentDescription()
 			assert.NoError(t, err)
-			require.Equal(t, tc.expected, o.agentDescription)
+			require.Equal(t, tc.expected(), o.agentDescription)
 			assert.NoError(t, o.Shutdown(t.Context()))
 		})
 	}


### PR DESCRIPTION


## Summary

- Add `os.version` as a non-identifying attribute in the `AgentDescription`, populated from `host.Info().PlatformVersion` (e.g. `"22.04"`, `"15.3"`). Silently omitted if unavailable.
- Refactor `createAgentDescription()` to call `host.Info()` once and share the result via new pure helpers (`osDescriptionFromHostInfo`, `osVersionFromHostInfo`), eliminating a duplicate syscall.

Closes [#47477](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47477)
Part of #47279

## Changes

| File | Change |
|------|--------|
| `opamp_agent.go` | Single `host.Info()` call; new `osDescriptionFromHostInfo`, `osVersionFromHostInfo`, `getOSVersion` helpers; add `os.version` to non-identifying attrs |
| `opamp_agent_test.go` | Refactor tests to use `buildNonIdentAttrs` helper that includes `os.version` conditionally; use `func()` expected values for resilience |
| `README.md` | Add auto-detected attributes reference table with `os.version` row |

## Test plan

- [x] Existing `TestCreateAgentDescription` cases updated to account for `os.version`
- [x] `buildNonIdentAttrs` helper conditionally includes `os.version` only when the platform provides it
- [x] `go build ./...` passes

