### PR TITLE
[extension/opampextension] Auto-detect Kubernetes attributes from Downward API env vars

### DIFF
--- a/.chloggen/opamp-k8s-attributes.yaml
+++ b/.chloggen/opamp-k8s-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opamp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Auto-detect Kubernetes attributes from Downward API environment variables and include them as non-identifying attributes in the OpAMP AgentDescription.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47483]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -51,6 +51,18 @@ The following settings are optional for both transports:
 - `agent_description`: Setting that modifies the agent description reported to the OpAMP server.
   - `include_resource_attributes`: Copy the Collector's resource attributes into the set of non-identifying attributes in the agent description.
   - `non_identifying_attributes`: A map of key value pairs that will be added to the [non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes) reported to the OpAMP server. If an attribute collides with the default non-identifying attributes that are automatically added, the ones specified here take precedence.
+
+When running inside Kubernetes (when `KUBERNETES_SERVICE_HOST` is set), the extension also adds these non-identifying attributes from Downward API environment variables:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `k8s.node.name` | Kubernetes node name. Auto-detected from the `K8S_NODE_NAME` env var when running in Kubernetes (identified by the presence of `KUBERNETES_SERVICE_HOST`). |
+| `k8s.pod.name` | Kubernetes pod name. Auto-detected from the `K8S_POD_NAME` env var. |
+| `k8s.namespace.name` | Kubernetes namespace. Auto-detected from the `K8S_NAMESPACE` env var. |
+| `k8s.pod.uid` | Kubernetes pod UID. Auto-detected from the `K8S_POD_UID` env var. |
+| `k8s.cluster.name` | Kubernetes cluster name. Auto-detected from the `OTEL_K8S_CLUSTER_NAME` env var. |
+| `k8s.daemonset.name` | Kubernetes DaemonSet name. Auto-detected from the `K8S_DAEMONSET_NAME` env var. |
+| `k8s.deployment.name` | Kubernetes Deployment name. Auto-detected from the `K8S_DEPLOYMENT_NAME` env var. |
 - `ppid`: An optional process ID to monitor. When this process is no longer running, the extension will emit a fatal error, causing the collector to exit. This is meant to be set by the Supervisor or some other parent process, and should not be configured manually.
 - `ppid_poll_interval`: The poll interval between check for whether `ppid` is still alive or not. Defaults to 5 seconds.
 

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,8 +3,9 @@
 package opampextension
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,9 +3,8 @@
 package opampextension
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -102,6 +102,21 @@ var (
 		string(conventions.ServiceVersionKey):    {},
 		string(conventions.ServiceInstanceIDKey): {},
 	}
+
+	// k8sEnvMapping maps Kubernetes Downward API environment variable names to
+	// their corresponding OTel semantic convention attribute keys.
+	k8sEnvMapping = []struct {
+		envVar  string
+		attrKey string
+	}{
+		{"K8S_NODE_NAME", "k8s.node.name"},
+		{"K8S_POD_NAME", "k8s.pod.name"},
+		{"K8S_NAMESPACE", "k8s.namespace.name"},
+		{"K8S_POD_UID", "k8s.pod.uid"},
+		{"OTEL_K8S_CLUSTER_NAME", "k8s.cluster.name"},
+		{"K8S_DAEMONSET_NAME", "k8s.daemonset.name"},
+		{"K8S_DEPLOYMENT_NAME", "k8s.deployment.name"},
+	}
 )
 
 func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
@@ -390,6 +405,11 @@ func (o *opampAgent) createAgentDescription() error {
 	nonIdentifyingAttributeMap[string(conventions.HostNameKey)] = hostname
 	nonIdentifyingAttributeMap[string(conventions.OSDescriptionKey)] = description
 
+	// Auto-detect Kubernetes attributes when running inside a K8s cluster.
+	if k8sAttrs := detectK8sAttributes(); len(k8sAttrs) > 0 {
+		maps.Copy(nonIdentifyingAttributeMap, k8sAttrs)
+	}
+
 	maps.Copy(nonIdentifyingAttributeMap, o.cfg.AgentDescription.NonIdentifyingAttributes)
 	if o.cfg.AgentDescription.IncludeResourceAttributes {
 		for k, v := range o.resourceAttrs {
@@ -514,6 +534,23 @@ func getOSDescription(logger *zap.Logger) string {
 	default:
 		return runtime.GOOS
 	}
+}
+
+// detectK8sAttributes returns Kubernetes-specific non-identifying attributes by reading
+// Downward API environment variables. Returns nil if not running inside Kubernetes
+// (detected by the absence of the KUBERNETES_SERVICE_HOST environment variable).
+func detectK8sAttributes() map[string]string {
+	if _, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST"); !ok {
+		return nil
+	}
+
+	attrs := make(map[string]string)
+	for _, m := range k8sEnvMapping {
+		if val, ok := os.LookupEnv(m.envVar); ok && val != "" {
+			attrs[m.attrKey] = val
+		}
+	}
+	return attrs
 }
 
 func (o *opampAgent) initHealthReporting() {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -191,6 +191,47 @@ func TestCreateAgentDescription(t *testing.T) {
 	}
 }
 
+func TestDetectK8sAttributes(t *testing.T) {
+	t.Run("not in K8s", func(t *testing.T) {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
+		os.Unsetenv("KUBERNETES_SERVICE_HOST")
+		result := detectK8sAttributes()
+		assert.Nil(t, result)
+	})
+
+	t.Run("in K8s with all env vars", func(t *testing.T) {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+		t.Setenv("K8S_NODE_NAME", "my-node")
+		t.Setenv("K8S_POD_NAME", "my-pod")
+		t.Setenv("K8S_NAMESPACE", "my-namespace")
+		t.Setenv("K8S_POD_UID", "abc-123")
+		t.Setenv("OTEL_K8S_CLUSTER_NAME", "my-cluster")
+		t.Setenv("K8S_DAEMONSET_NAME", "my-daemonset")
+		t.Setenv("K8S_DEPLOYMENT_NAME", "my-deployment")
+
+		result := detectK8sAttributes()
+		require.NotNil(t, result)
+		assert.Equal(t, "my-node", result["k8s.node.name"])
+		assert.Equal(t, "my-pod", result["k8s.pod.name"])
+		assert.Equal(t, "my-namespace", result["k8s.namespace.name"])
+		assert.Equal(t, "abc-123", result["k8s.pod.uid"])
+		assert.Equal(t, "my-cluster", result["k8s.cluster.name"])
+		assert.Equal(t, "my-daemonset", result["k8s.daemonset.name"])
+		assert.Equal(t, "my-deployment", result["k8s.deployment.name"])
+	})
+
+	t.Run("in K8s with partial env vars", func(t *testing.T) {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+		t.Setenv("K8S_NODE_NAME", "my-node")
+
+		result := detectK8sAttributes()
+		require.NotNil(t, result)
+		assert.Equal(t, "my-node", result["k8s.node.name"])
+		assert.NotContains(t, result, "k8s.pod.name")
+		assert.NotContains(t, result, "k8s.namespace.name")
+	})
+}
+
 func TestUpdateAgentIdentity(t *testing.T) {
 	cfg := createDefaultConfig()
 	set := extensiontest.NewNopSettings(extensiontest.NopType)


### PR DESCRIPTION
## Summary

- When running inside a Kubernetes cluster (detected via `KUBERNETES_SERVICE_HOST` env var), automatically map seven Downward API environment variables to OTel semantic convention keys and include them as non-identifying attributes in the `AgentDescription`.

| Env Var | Attribute Key |
|---------|---------------|
| `K8S_NODE_NAME` | `k8s.node.name` |
| `K8S_POD_NAME` | `k8s.pod.name` |
| `K8S_NAMESPACE` | `k8s.namespace.name` |
| `K8S_POD_UID` | `k8s.pod.uid` |
| `OTEL_K8S_CLUSTER_NAME` | `k8s.cluster.name` |
| `K8S_DAEMONSET_NAME` | `k8s.daemonset.name` |
| `K8S_DEPLOYMENT_NAME` | `k8s.deployment.name` |

Only env vars that are set and non-empty are included. No new configuration fields required.

Closes [#47478](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47478)
Part of #47279

## Changes

| File | Change |
|------|--------|
| `opamp_agent.go` | Add `k8sEnvMapping` var; add `detectK8sAttributes()` function; call it in `createAgentDescription()` |
| `opamp_agent_test.go` | Add `TestDetectK8sAttributes` with 3 sub-cases (not in K8s, all vars, partial vars) |
| `README.md` | Add K8s attribute rows to auto-detected attributes table |

## Test plan

- [x] `TestDetectK8sAttributes` — not in K8s (nil result), all env vars set, partial env vars
- [x] `go build ./...` passes

