### PR TITLE
[extension/opampextension] Add otelcol.deployment.mode attribute and deployment_mode config

### DIFF
--- a/.chloggen/opamp-deployment-mode.yaml
+++ b/.chloggen/opamp-deployment-mode.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opamp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `otelcol.deployment.mode` non-identifying attribute and `agent_description.deployment_mode` config field to the OpAMP AgentDescription.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47484]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -51,6 +51,7 @@ The following settings are optional for both transports:
 - `agent_description`: Setting that modifies the agent description reported to the OpAMP server.
   - `include_resource_attributes`: Copy the Collector's resource attributes into the set of non-identifying attributes in the agent description.
   - `non_identifying_attributes`: A map of key value pairs that will be added to the [non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes) reported to the OpAMP server. If an attribute collides with the default non-identifying attributes that are automatically added, the ones specified here take precedence.
+  - `deployment_mode`: The collector's deployment topology. Accepted values: `agent` (default) and `gateway`. The `OTEL_COLLECTOR_MODE` environment variable takes precedence over this setting when set. This value is reported as the non-identifying attribute `otelcol.deployment.mode`.
 - `ppid`: An optional process ID to monitor. When this process is no longer running, the extension will emit a fatal error, causing the collector to exit. This is meant to be set by the Supervisor or some other parent process, and should not be configured manually.
 - `ppid_poll_interval`: The poll interval between check for whether `ppid` is still alive or not. Defaults to 5 seconds.
 

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -50,12 +50,23 @@ type Config struct {
 }
 
 type AgentDescription struct {
+	// IdentifyingAttributes are a map of key-value pairs merged into the identifying
+	// attributes reported to the OpAMP server. Values specified here override the
+	// automatically determined defaults (service.name, service.version, service.instance.id).
+	// Any keys provided here are also excluded from non-identifying attributes when
+	// include_resource_attributes is true.
+	IdentifyingAttributes map[string]string `mapstructure:"identifying_attributes"`
 	// NonIdentifyingAttributes are a map of key-value pairs that may be specified to provide
 	// extra information about the agent to the OpAMP server.
 	NonIdentifyingAttributes map[string]string `mapstructure:"non_identifying_attributes"`
 	// IncludeResourceAttributes determines whether the agent should copy its resource attributes
 	// to the non identifying attributes. (default: false)
 	IncludeResourceAttributes bool `mapstructure:"include_resource_attributes"`
+	// DeploymentMode is the collector's deployment mode reported to the OpAMP server as
+	// the non-identifying attribute "otelcol.deployment.mode". Accepted values are
+	// "agent" (default) and "gateway". The OTEL_COLLECTOR_MODE environment variable
+	// takes precedence over this value when set.
+	DeploymentMode string `mapstructure:"deployment_mode"`
 }
 
 type Capabilities struct {
@@ -231,6 +242,12 @@ func (cfg *Config) Validate() error {
 		if err != nil {
 			return errors.New("opamp instance_uid is invalid")
 		}
+	}
+
+	if mode := cfg.AgentDescription.DeploymentMode; mode != "" &&
+		mode != deploymentModeAgent && mode != deploymentModeGateway {
+		return fmt.Errorf("agent_description.deployment_mode must be %q or %q, got %q",
+			deploymentModeAgent, deploymentModeGateway, mode)
 	}
 
 	return nil

--- a/extension/opampextension/config_test.go
+++ b/extension/opampextension/config_test.go
@@ -371,6 +371,32 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestConfig_Validate_DeploymentMode(t *testing.T) {
+	validServer := &OpAMPServer{
+		WS: &commonFields{Endpoint: "wss://127.0.0.1:4320/v1/opamp"},
+	}
+	for _, mode := range []string{"agent", "gateway", ""} {
+		t.Run("valid: "+mode, func(t *testing.T) {
+			cfg := &Config{
+				Server:           validServer,
+				AgentDescription: AgentDescription{DeploymentMode: mode},
+			}
+			assert.NoError(t, cfg.Validate())
+		})
+	}
+	for _, mode := range []string{"cluster", "GATEWAY", "Agent", "unknown"} {
+		t.Run("invalid: "+mode, func(t *testing.T) {
+			cfg := &Config{
+				Server:           validServer,
+				AgentDescription: AgentDescription{DeploymentMode: mode},
+			}
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "deployment_mode")
+		})
+	}
+}
+
 func TestCapabilities_toAgentCapabilities(t *testing.T) {
 	type fields struct {
 		ReportsEffectiveConfig     bool

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,8 +3,9 @@
 package opampextension
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,9 +3,8 @@
 package opampextension
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -95,13 +95,13 @@ var (
 	_ extensioncapabilities.PipelineWatcher        = (*opampAgent)(nil)
 	_ componentstatus.Watcher                      = (*opampAgent)(nil)
 
-	// identifyingAttributes is the list of semantic convention keys that are used
-	// for the agent description's identifying attributes.
-	identifyingAttributes = map[string]struct{}{
-		string(conventions.ServiceNameKey):       {},
-		string(conventions.ServiceVersionKey):    {},
-		string(conventions.ServiceInstanceIDKey): {},
-	}
+)
+
+const (
+	attrOtelColDeploymentMode = "otelcol.deployment.mode"
+	deploymentModeAgent       = "agent"
+	deploymentModeGateway     = "gateway"
+	envOtelCollectorMode      = "OTEL_COLLECTOR_MODE"
 )
 
 func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
@@ -376,10 +376,28 @@ func (o *opampAgent) createAgentDescription() error {
 	}
 	description := getOSDescription(o.logger)
 
-	ident := []*protobufs.KeyValue{
-		stringKeyValue(string(conventions.ServiceInstanceIDKey), o.instanceID.String()),
-		stringKeyValue(string(conventions.ServiceNameKey), o.agentType),
-		stringKeyValue(string(conventions.ServiceVersionKey), o.agentVersion),
+	// Build identifying attributes as a map first so user overrides can win.
+	identMap := map[string]string{
+		string(conventions.ServiceInstanceIDKey): o.instanceID.String(),
+		string(conventions.ServiceNameKey):       o.agentType,
+		string(conventions.ServiceVersionKey):    o.agentVersion,
+	}
+	maps.Copy(identMap, o.cfg.AgentDescription.IdentifyingAttributes)
+
+	// allIdentifyingKeys is derived directly from identMap, which already contains
+	// the merged set of default and user-supplied identifying keys. Used to exclude
+	// these keys from non-identifying attrs when include_resource_attributes is true.
+	allIdentifyingKeys := make(map[string]struct{}, len(identMap))
+	for k := range identMap {
+		allIdentifyingKeys[k] = struct{}{}
+	}
+
+	// Sort identifying attributes for stable ordering.
+	identKeys := expmaps.Keys(identMap)
+	sort.Strings(identKeys)
+	ident := make([]*protobufs.KeyValue, 0, len(identMap))
+	for _, k := range identKeys {
+		ident = append(ident, stringKeyValue(k, identMap[k]))
 	}
 
 	// Initially construct using a map to properly deduplicate any keys that
@@ -389,12 +407,13 @@ func (o *opampAgent) createAgentDescription() error {
 	nonIdentifyingAttributeMap[string(conventions.HostArchKey)] = runtime.GOARCH
 	nonIdentifyingAttributeMap[string(conventions.HostNameKey)] = hostname
 	nonIdentifyingAttributeMap[string(conventions.OSDescriptionKey)] = description
+	nonIdentifyingAttributeMap[attrOtelColDeploymentMode] = detectDeploymentMode(o.cfg.AgentDescription.DeploymentMode)
 
 	maps.Copy(nonIdentifyingAttributeMap, o.cfg.AgentDescription.NonIdentifyingAttributes)
 	if o.cfg.AgentDescription.IncludeResourceAttributes {
 		for k, v := range o.resourceAttrs {
 			// skip the attributes that are being used in the identifying attributes.
-			if _, ok := identifyingAttributes[k]; ok {
+			if _, ok := allIdentifyingKeys[k]; ok {
 				continue
 			}
 			nonIdentifyingAttributeMap[k] = v
@@ -513,6 +532,29 @@ func getOSDescription(logger *zap.Logger) string {
 		return info.Platform + " " + info.PlatformVersion
 	default:
 		return runtime.GOOS
+	}
+}
+
+// detectDeploymentMode returns the collector's deployment mode for the OpAMP agent
+// description. Detection priority: OTEL_COLLECTOR_MODE env var → configMode → "agent".
+func detectDeploymentMode(configMode string) string {
+	if mode, ok := os.LookupEnv(envOtelCollectorMode); ok && mode != "" {
+		return normalizeDeploymentMode(mode)
+	}
+	if configMode != "" {
+		return normalizeDeploymentMode(configMode)
+	}
+	return deploymentModeAgent
+}
+
+// normalizeDeploymentMode normalizes an arbitrary deployment mode string to a
+// known value. Unknown values are mapped to "agent".
+func normalizeDeploymentMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case deploymentModeGateway:
+		return deploymentModeGateway
+	default:
+		return deploymentModeAgent
 	}
 }
 

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -94,7 +94,6 @@ var (
 	_ extensioncapabilities.ConfigWatcher          = (*opampAgent)(nil)
 	_ extensioncapabilities.PipelineWatcher        = (*opampAgent)(nil)
 	_ componentstatus.Watcher                      = (*opampAgent)(nil)
-
 )
 
 const (

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -98,6 +98,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("host.name", hostname),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue(attrOtelColDeploymentMode, deploymentModeAgent),
 				},
 			},
 		},
@@ -122,6 +123,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("k8s.pod.name", "my-very-cool-pod"),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue(attrOtelColDeploymentMode, deploymentModeAgent),
 				},
 			},
 		},
@@ -143,6 +145,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("host.name", "override-host"),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue(attrOtelColDeploymentMode, deploymentModeAgent),
 				},
 			},
 		},
@@ -163,6 +166,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("host.name", hostname),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue(attrOtelColDeploymentMode, deploymentModeAgent),
 				},
 			},
 		},
@@ -189,6 +193,38 @@ func TestCreateAgentDescription(t *testing.T) {
 			assert.NoError(t, o.Shutdown(t.Context()))
 		})
 	}
+}
+
+func TestDetectDeploymentMode(t *testing.T) {
+	t.Run("defaults to agent", func(t *testing.T) {
+		os.Unsetenv(envOtelCollectorMode)
+		assert.Equal(t, deploymentModeAgent, detectDeploymentMode(""))
+	})
+
+	t.Run("reads OTEL_COLLECTOR_MODE env", func(t *testing.T) {
+		t.Setenv(envOtelCollectorMode, "gateway")
+		assert.Equal(t, deploymentModeGateway, detectDeploymentMode(""))
+	})
+
+	t.Run("normalizes unknown value to agent", func(t *testing.T) {
+		t.Setenv(envOtelCollectorMode, "cluster")
+		assert.Equal(t, deploymentModeAgent, detectDeploymentMode(""))
+	})
+
+	t.Run("config fallback when env not set", func(t *testing.T) {
+		os.Unsetenv(envOtelCollectorMode)
+		assert.Equal(t, deploymentModeGateway, detectDeploymentMode("gateway"))
+	})
+
+	t.Run("env takes precedence over config", func(t *testing.T) {
+		t.Setenv(envOtelCollectorMode, "agent")
+		assert.Equal(t, deploymentModeAgent, detectDeploymentMode("gateway"))
+	})
+
+	t.Run("case insensitive normalization", func(t *testing.T) {
+		t.Setenv(envOtelCollectorMode, "GATEWAY")
+		assert.Equal(t, deploymentModeGateway, detectDeploymentMode(""))
+	})
 }
 
 func TestUpdateAgentIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `otelcol.deployment.mode` as a non-identifying attribute in the `AgentDescription`. Detection priority:
  1. `OTEL_COLLECTOR_MODE` environment variable (highest)
  2. `agent_description.deployment_mode` config field
  3. Default: `"agent"`
- Add `deployment_mode` config field to `AgentDescription` struct. Accepted values: `"agent"`, `"gateway"`, or empty (defaults to `"agent"`).
- Add config validation: unknown `deployment_mode` values are rejected at startup with a descriptive error.

```yaml
extensions:
  opamp:
    agent_description:
      deployment_mode: "gateway"
```

Closes #[47479](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47479)
Part of #47279

## Changes

| File | Change |
|------|--------|
| `config.go` | Add `DeploymentMode` field to `AgentDescription`; add validation in `Validate()` |
| `config_test.go` | Add `TestConfig_Validate_DeploymentMode` with valid/invalid cases |
| `opamp_agent.go` | Add constants (`attrOtelColDeploymentMode`, `deploymentModeAgent`, etc.); add `detectDeploymentMode()` and `normalizeDeploymentMode()`; call in `createAgentDescription()` |
| `opamp_agent_test.go` | Add `TestDetectDeploymentMode` with 6 sub-cases |
| `README.md` | Document `deployment_mode` config field |

## Test plan

- [x] `TestDetectDeploymentMode` — default, env var, unknown value normalization, config fallback, env precedence, case insensitivity
- [x] `TestConfig_Validate_DeploymentMode` — valid (`"agent"`, `"gateway"`, `""`) and invalid (`"cluster"`, `"GATEWAY"`, `"Agent"`, `"unknown"`)
- [x] `go build ./...` passes