### PR TITLE
[extension/opampextension] Add process.executable.path non-identifying attribute

### DIFF
--- a/.chloggen/opamp-executable-path.yaml
+++ b/.chloggen/opamp-executable-path.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opamp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `process.executable.path` as an auto-detected non-identifying attribute in the OpAMP AgentDescription.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47485]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -51,6 +51,7 @@ The following settings are optional for both transports:
 - `agent_description`: Setting that modifies the agent description reported to the OpAMP server.
   - `include_resource_attributes`: Copy the Collector's resource attributes into the set of non-identifying attributes in the agent description.
   - `non_identifying_attributes`: A map of key value pairs that will be added to the [non-identifying attributes](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionnon_identifying_attributes) reported to the OpAMP server. If an attribute collides with the default non-identifying attributes that are automatically added, the ones specified here take precedence.
+  - The `process.executable.path` attribute is automatically reported when the binary path can be determined.
 - `ppid`: An optional process ID to monitor. When this process is no longer running, the extension will emit a fatal error, causing the collector to exit. This is meant to be set by the Supervisor or some other parent process, and should not be configured manually.
 - `ppid_poll_interval`: The poll interval between check for whether `ppid` is still alive or not. Defaults to 5 seconds.
 

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,8 +3,9 @@
 package opampextension
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/generated_package_test.go
+++ b/extension/opampextension/generated_package_test.go
@@ -3,9 +3,8 @@
 package opampextension
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -389,6 +389,9 @@ func (o *opampAgent) createAgentDescription() error {
 	nonIdentifyingAttributeMap[string(conventions.HostArchKey)] = runtime.GOARCH
 	nonIdentifyingAttributeMap[string(conventions.HostNameKey)] = hostname
 	nonIdentifyingAttributeMap[string(conventions.OSDescriptionKey)] = description
+	if exePath := getExecutablePath(o.logger); exePath != "" {
+		nonIdentifyingAttributeMap[string(conventions.ProcessExecutablePathKey)] = exePath
+	}
 
 	maps.Copy(nonIdentifyingAttributeMap, o.cfg.AgentDescription.NonIdentifyingAttributes)
 	if o.cfg.AgentDescription.IncludeResourceAttributes {
@@ -514,6 +517,17 @@ func getOSDescription(logger *zap.Logger) string {
 	default:
 		return runtime.GOOS
 	}
+}
+
+// getExecutablePath returns the full path to the running collector binary.
+// Returns an empty string if the path cannot be determined.
+func getExecutablePath(logger *zap.Logger) string {
+	path, err := os.Executable()
+	if err != nil {
+		logger.Error("failed getting executable path", zap.Error(err))
+		return ""
+	}
+	return path
 }
 
 func (o *opampAgent) initHealthReporting() {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -71,6 +71,8 @@ func TestCreateAgentDescription(t *testing.T) {
 	hostname, err := os.Hostname()
 	require.NoError(t, err)
 	description := getOSDescription(zap.NewNop())
+	exePath, err := os.Executable()
+	require.NoError(t, err)
 
 	serviceName := "otelcol-distrot"
 	serviceVersion := "distro.0"
@@ -98,6 +100,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("host.name", hostname),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue("process.executable.path", exePath),
 				},
 			},
 		},
@@ -122,6 +125,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("k8s.pod.name", "my-very-cool-pod"),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue("process.executable.path", exePath),
 				},
 			},
 		},
@@ -143,6 +147,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("host.name", "override-host"),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue("process.executable.path", exePath),
 				},
 			},
 		},
@@ -163,6 +168,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue("host.name", hostname),
 					stringKeyValue("os.description", description),
 					stringKeyValue("os.type", runtime.GOOS),
+					stringKeyValue("process.executable.path", exePath),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Add `process.executable.path` as a non-identifying attribute in the `AgentDescription`, populated via `os.Executable()`. Uses the OTel semantic convention key. Silently omitted if detection fails.

Useful for distinguishing collector binaries in mixed-version or multi-binary deployments (e.g. side-by-side upgrades, canary rollouts).

Closes #[47480](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47480)
Part of #47279

## Changes

| File | Change |
|------|--------|
| `opamp_agent.go` | Add `getExecutablePath()` helper; call in `createAgentDescription()` |
| `README.md` | Document auto-detected `process.executable.path` attribute |

## Test plan

- [x] `go build ./...` passes
- [x] Manual verification: `process.executable.path` appears in agent description with correct binary path