### PR TITLE
[receiver/nginx] Enable attribute reaggregation

### DIFF
--- a/.chloggen/46368-nginx-enable-reaggregation.yaml
+++ b/.chloggen/46368-nginx-enable-reaggregation.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: receiver/nginx
+note: Enable the re-aggregation feature for the nginx receiver
+issues: [46368]
+subtext:
+change_logs: [user]

--- a/receiver/nginxreceiver/generated_package_test.go
+++ b/receiver/nginxreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package nginxreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/nginxreceiver/generated_package_test.go
+++ b/receiver/nginxreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package nginxreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/nginxreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/nginxreceiver/internal/metadata/config.schema.yaml
@@ -18,6 +18,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "state"
+            default:
+              - "state"
       nginx.connections_handled:
         description: "NginxConnectionsHandledMetricConfig provides config for the nginx.connections_handled metric."
         type: object

--- a/receiver/nginxreceiver/internal/metadata/generated_config.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_config.go
@@ -3,16 +3,106 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// NginxConnectionsAcceptedMetricConfig provides config for the nginx.connections_accepted metric.
+type NginxConnectionsAcceptedMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *NginxConnectionsAcceptedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// NginxConnectionsCurrentMetricAttributeKey specifies the key of an attribute for the nginx.connections_current metric.
+type NginxConnectionsCurrentMetricAttributeKey string
+
+const (
+	NginxConnectionsCurrentMetricAttributeKeyState NginxConnectionsCurrentMetricAttributeKey = "state"
+)
+
+// NginxConnectionsCurrentMetricConfig provides config for the nginx.connections_current metric.
+type NginxConnectionsCurrentMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []NginxConnectionsCurrentMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *NginxConnectionsCurrentMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *NginxConnectionsCurrentMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case NginxConnectionsCurrentMetricAttributeKeyState:
+		default:
+			return fmt.Errorf("metric nginx.connections_current doesn't have an attribute %v, valid attributes: [state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// NginxConnectionsHandledMetricConfig provides config for the nginx.connections_handled metric.
+type NginxConnectionsHandledMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *NginxConnectionsHandledMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// NginxRequestsMetricConfig provides config for the nginx.requests metric.
+type NginxRequestsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *NginxRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -28,24 +118,26 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for nginx metrics.
 type MetricsConfig struct {
-	NginxConnectionsAccepted MetricConfig `mapstructure:"nginx.connections_accepted"`
-	NginxConnectionsCurrent  MetricConfig `mapstructure:"nginx.connections_current"`
-	NginxConnectionsHandled  MetricConfig `mapstructure:"nginx.connections_handled"`
-	NginxRequests            MetricConfig `mapstructure:"nginx.requests"`
+	NginxConnectionsAccepted NginxConnectionsAcceptedMetricConfig `mapstructure:"nginx.connections_accepted"`
+	NginxConnectionsCurrent  NginxConnectionsCurrentMetricConfig  `mapstructure:"nginx.connections_current"`
+	NginxConnectionsHandled  NginxConnectionsHandledMetricConfig  `mapstructure:"nginx.connections_handled"`
+	NginxRequests            NginxRequestsMetricConfig            `mapstructure:"nginx.requests"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		NginxConnectionsAccepted: MetricConfig{
+		NginxConnectionsAccepted: NginxConnectionsAcceptedMetricConfig{
 			Enabled: true,
 		},
-		NginxConnectionsCurrent: MetricConfig{
+		NginxConnectionsCurrent: NginxConnectionsCurrentMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []NginxConnectionsCurrentMetricAttributeKey{NginxConnectionsCurrentMetricAttributeKeyState},
+		},
+		NginxConnectionsHandled: NginxConnectionsHandledMetricConfig{
 			Enabled: true,
 		},
-		NginxConnectionsHandled: MetricConfig{
-			Enabled: true,
-		},
-		NginxRequests: MetricConfig{
+		NginxRequests: NginxRequestsMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/nginxreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/nginxreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,16 +27,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NginxConnectionsAccepted: MetricConfig{
+					NginxConnectionsAccepted: NginxConnectionsAcceptedMetricConfig{
 						Enabled: true,
 					},
-					NginxConnectionsCurrent: MetricConfig{
+					NginxConnectionsCurrent: NginxConnectionsCurrentMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NginxConnectionsCurrentMetricAttributeKey{NginxConnectionsCurrentMetricAttributeKeyState},
+					},
+					NginxConnectionsHandled: NginxConnectionsHandledMetricConfig{
 						Enabled: true,
 					},
-					NginxConnectionsHandled: MetricConfig{
-						Enabled: true,
-					},
-					NginxRequests: MetricConfig{
+					NginxRequests: NginxRequestsMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -45,16 +48,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NginxConnectionsAccepted: MetricConfig{
+					NginxConnectionsAccepted: NginxConnectionsAcceptedMetricConfig{
 						Enabled: false,
 					},
-					NginxConnectionsCurrent: MetricConfig{
+					NginxConnectionsCurrent: NginxConnectionsCurrentMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NginxConnectionsCurrentMetricAttributeKey{NginxConnectionsCurrentMetricAttributeKeyState},
+					},
+					NginxConnectionsHandled: NginxConnectionsHandledMetricConfig{
 						Enabled: false,
 					},
-					NginxConnectionsHandled: MetricConfig{
-						Enabled: false,
-					},
-					NginxRequests: MetricConfig{
+					NginxRequests: NginxRequestsMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -64,7 +69,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(NginxConnectionsAcceptedMetricConfig{}, NginxConnectionsCurrentMetricConfig{}, NginxConnectionsHandledMetricConfig{}, NginxRequestsMetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics.go
@@ -3,12 +3,20 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeState specifies the value state attribute.
@@ -72,9 +80,9 @@ type metricInfo struct {
 }
 
 type metricNginxConnectionsAccepted struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   NginxConnectionsAcceptedMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills nginx.connections_accepted metric with initial data.
@@ -113,7 +121,7 @@ func (m *metricNginxConnectionsAccepted) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricNginxConnectionsAccepted(cfg MetricConfig) metricNginxConnectionsAccepted {
+func newMetricNginxConnectionsAccepted(cfg NginxConnectionsAcceptedMetricConfig) metricNginxConnectionsAccepted {
 	m := metricNginxConnectionsAccepted{config: cfg}
 
 	if cfg.Enabled {
@@ -124,9 +132,10 @@ func newMetricNginxConnectionsAccepted(cfg MetricConfig) metricNginxConnectionsA
 }
 
 type metricNginxConnectionsCurrent struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        NginxConnectionsCurrentMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
 }
 
 // init fills nginx.connections_current metric with initial data.
@@ -138,17 +147,48 @@ func (m *metricNginxConnectionsCurrent) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricNginxConnectionsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, NginxConnectionsCurrentMetricAttributeKeyState) {
+		dp.Attributes().PutStr("state", stateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("state", stateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -161,13 +201,18 @@ func (m *metricNginxConnectionsCurrent) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricNginxConnectionsCurrent) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricNginxConnectionsCurrent(cfg MetricConfig) metricNginxConnectionsCurrent {
+func newMetricNginxConnectionsCurrent(cfg NginxConnectionsCurrentMetricConfig) metricNginxConnectionsCurrent {
 	m := metricNginxConnectionsCurrent{config: cfg}
 
 	if cfg.Enabled {
@@ -178,9 +223,9 @@ func newMetricNginxConnectionsCurrent(cfg MetricConfig) metricNginxConnectionsCu
 }
 
 type metricNginxConnectionsHandled struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   NginxConnectionsHandledMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
 }
 
 // init fills nginx.connections_handled metric with initial data.
@@ -219,7 +264,7 @@ func (m *metricNginxConnectionsHandled) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricNginxConnectionsHandled(cfg MetricConfig) metricNginxConnectionsHandled {
+func newMetricNginxConnectionsHandled(cfg NginxConnectionsHandledMetricConfig) metricNginxConnectionsHandled {
 	m := metricNginxConnectionsHandled{config: cfg}
 
 	if cfg.Enabled {
@@ -230,9 +275,9 @@ func newMetricNginxConnectionsHandled(cfg MetricConfig) metricNginxConnectionsHa
 }
 
 type metricNginxRequests struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   NginxRequestsMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills nginx.requests metric with initial data.
@@ -271,7 +316,7 @@ func (m *metricNginxRequests) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricNginxRequests(cfg MetricConfig) metricNginxRequests {
+func newMetricNginxRequests(cfg NginxRequestsMetricConfig) metricNginxRequests {
 	m := metricNginxRequests{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -37,6 +38,11 @@ func TestMetricsBuilder(t *testing.T) {
 			resAttrsSet: testDataSetAll,
 		},
 		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
+		},
+		{
 			name:        "none_set",
 			metricsSet:  testDataSetNone,
 			resAttrsSet: testDataSetNone,
@@ -51,9 +57,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["NginxConnectionsCurrent"] = mb.metricNginxConnectionsCurrent.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -65,6 +75,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordNginxConnectionsCurrentDataPoint(ts, 1, AttributeStateActive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordNginxConnectionsCurrentDataPoint(ts, 3, AttributeStateReading)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -76,6 +89,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricNginxConnectionsCurrent.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -117,22 +133,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "nginx.connections_current":
-					assert.False(t, validatedMetrics["nginx.connections_current"], "Found a duplicate in the metrics slice: nginx.connections_current")
-					validatedMetrics["nginx.connections_current"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The current number of nginx connections by state", mi.Description())
-					assert.Equal(t, "connections", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					stateAttrVal, ok := dp.Attributes().Get("state")
-					assert.True(t, ok)
-					assert.Equal(t, "active", stateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["nginx.connections_current"], "Found a duplicate in the metrics slice: nginx.connections_current")
+						validatedMetrics["nginx.connections_current"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The current number of nginx connections by state", mi.Description())
+						assert.Equal(t, "connections", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						stateAttrVal, ok := dp.Attributes().Get("state")
+						assert.True(t, ok)
+						assert.Equal(t, "active", stateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["nginx.connections_current"], "Found a duplicate in the metrics slice: nginx.connections_current")
+						validatedMetrics["nginx.connections_current"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The current number of nginx connections by state", mi.Description())
+						assert.Equal(t, "connections", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["nginx.connections_current"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("state")
+						assert.False(t, ok)
+					}
 				case "nginx.connections_handled":
 					assert.False(t, validatedMetrics["nginx.connections_handled"], "Found a duplicate in the metrics slice: nginx.connections_handled")
 					validatedMetrics["nginx.connections_handled"] = true

--- a/receiver/nginxreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/nginxreceiver/internal/metadata/testdata/config.yaml
@@ -5,6 +5,18 @@ all_set:
       enabled: true
     nginx.connections_current:
       enabled: true
+      attributes: ["state"]
+    nginx.connections_handled:
+      enabled: true
+    nginx.requests:
+      enabled: true
+reaggregate_set:
+  metrics:
+    nginx.connections_accepted:
+      enabled: true
+    nginx.connections_current:
+      enabled: true
+      attributes: []
     nginx.connections_handled:
       enabled: true
     nginx.requests:
@@ -15,6 +27,7 @@ none_set:
       enabled: false
     nginx.connections_current:
       enabled: false
+      attributes: ["state"]
     nginx.connections_handled:
       enabled: false
     nginx.requests:

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -5,6 +5,8 @@ description: |
   This receiver can fetch stats from a NGINX instance using the `ngx_http_stub_status_module` module's `status`
   endpoint.
 
+reaggregation_enabled: true
+
 status:
   class: receiver
   stability:
@@ -18,6 +20,7 @@ attributes:
   state:
     description: The state of a connection
     type: string
+    requirement_level: recommended
     enum:
       - active
       - reading


### PR DESCRIPTION
This PR enables the re-aggregation feature for the `nginx` receiver by:

1. Setting `reaggregation_enabled: true` in `metadata.yaml`
2. Marking the `state` attribute as `recommended` so it can be disabled by users for reaggregation

The `state` attribute (active/reading/writing/waiting) is used only by `nginx.connections_current`. Marking it `recommended` means it is enabled by default (preserving current behavior) but can be disabled via config to aggregate across all states.

Generated files under `internal/metadata/` were regenerated with `go generate ./...` followed by `goimports -w` (as `make generate` does at the root).

Fixes #46368
Part of #45396