### PR TITLE
[receiver/filestats] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46355-filestats-enable-reaggregation.yaml
+++ b/.chloggen/46355-filestats-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/filestats
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable re-aggregation and set requirement levels for attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46355]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/filestatsreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/filestatsreceiver/internal/metadata/config.schema.yaml
@@ -25,6 +25,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "file.permissions"
+            default:
+              - "file.permissions"
       file.mtime:
         description: "FileMtimeMetricConfig provides config for the file.mtime metric."
         type: object

--- a/receiver/filestatsreceiver/internal/metadata/generated_config.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,127 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// FileAtimeMetricConfig provides config for the file.atime metric.
+type FileAtimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *FileAtimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FileCountMetricConfig provides config for the file.count metric.
+type FileCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FileCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FileCtimeMetricAttributeKey specifies the key of an attribute for the file.ctime metric.
+type FileCtimeMetricAttributeKey string
+
+const (
+	FileCtimeMetricAttributeKeyFilePermissions FileCtimeMetricAttributeKey = "file.permissions"
+)
+
+// FileCtimeMetricConfig provides config for the file.ctime metric.
+type FileCtimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []FileCtimeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *FileCtimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *FileCtimeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case FileCtimeMetricAttributeKeyFilePermissions:
+		default:
+			return fmt.Errorf("metric file.ctime doesn't have an attribute %v, valid attributes: [file.permissions]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// FileMtimeMetricConfig provides config for the file.mtime metric.
+type FileMtimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FileMtimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// FileSizeMetricConfig provides config for the file.size metric.
+type FileSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *FileSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,28 +139,30 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for filestats metrics.
 type MetricsConfig struct {
-	FileAtime MetricConfig `mapstructure:"file.atime"`
-	FileCount MetricConfig `mapstructure:"file.count"`
-	FileCtime MetricConfig `mapstructure:"file.ctime"`
-	FileMtime MetricConfig `mapstructure:"file.mtime"`
-	FileSize  MetricConfig `mapstructure:"file.size"`
+	FileAtime FileAtimeMetricConfig `mapstructure:"file.atime"`
+	FileCount FileCountMetricConfig `mapstructure:"file.count"`
+	FileCtime FileCtimeMetricConfig `mapstructure:"file.ctime"`
+	FileMtime FileMtimeMetricConfig `mapstructure:"file.mtime"`
+	FileSize  FileSizeMetricConfig  `mapstructure:"file.size"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		FileAtime: MetricConfig{
+		FileAtime: FileAtimeMetricConfig{
 			Enabled: false,
 		},
-		FileCount: MetricConfig{
+		FileCount: FileCountMetricConfig{
 			Enabled: false,
 		},
-		FileCtime: MetricConfig{
-			Enabled: false,
+		FileCtime: FileCtimeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []FileCtimeMetricAttributeKey{FileCtimeMetricAttributeKeyFilePermissions},
 		},
-		FileMtime: MetricConfig{
+		FileMtime: FileMtimeMetricConfig{
 			Enabled: true,
 		},
-		FileSize: MetricConfig{
+		FileSize: FileSizeMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/filestatsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_config_test.go
@@ -26,19 +26,21 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					FileAtime: MetricConfig{
+					FileAtime: FileAtimeMetricConfig{
 						Enabled: true,
 					},
-					FileCount: MetricConfig{
+					FileCount: FileCountMetricConfig{
 						Enabled: true,
 					},
-					FileCtime: MetricConfig{
+					FileCtime: FileCtimeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []FileCtimeMetricAttributeKey{FileCtimeMetricAttributeKeyFilePermissions},
+					},
+					FileMtime: FileMtimeMetricConfig{
 						Enabled: true,
 					},
-					FileMtime: MetricConfig{
-						Enabled: true,
-					},
-					FileSize: MetricConfig{
+					FileSize: FileSizeMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -52,19 +54,21 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					FileAtime: MetricConfig{
+					FileAtime: FileAtimeMetricConfig{
 						Enabled: false,
 					},
-					FileCount: MetricConfig{
+					FileCount: FileCountMetricConfig{
 						Enabled: false,
 					},
-					FileCtime: MetricConfig{
+					FileCtime: FileCtimeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []FileCtimeMetricAttributeKey{FileCtimeMetricAttributeKeyFilePermissions},
+					},
+					FileMtime: FileMtimeMetricConfig{
 						Enabled: false,
 					},
-					FileMtime: MetricConfig{
-						Enabled: false,
-					},
-					FileSize: MetricConfig{
+					FileSize: FileSizeMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -78,7 +82,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(FileAtimeMetricConfig{}, FileCountMetricConfig{}, FileCtimeMetricConfig{}, FileMtimeMetricConfig{}, FileSizeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -43,9 +51,9 @@ type metricInfo struct {
 }
 
 type metricFileAtime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric        // data buffer for generated metric.
+	config   FileAtimeMetricConfig // metric config provided by user.
+	capacity int                   // max observed number of data points added to the metric.
 }
 
 // init fills file.atime metric with initial data.
@@ -84,7 +92,7 @@ func (m *metricFileAtime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFileAtime(cfg MetricConfig) metricFileAtime {
+func newMetricFileAtime(cfg FileAtimeMetricConfig) metricFileAtime {
 	m := metricFileAtime{config: cfg}
 
 	if cfg.Enabled {
@@ -95,9 +103,9 @@ func newMetricFileAtime(cfg MetricConfig) metricFileAtime {
 }
 
 type metricFileCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric        // data buffer for generated metric.
+	config   FileCountMetricConfig // metric config provided by user.
+	capacity int                   // max observed number of data points added to the metric.
 }
 
 // init fills file.count metric with initial data.
@@ -134,7 +142,7 @@ func (m *metricFileCount) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFileCount(cfg MetricConfig) metricFileCount {
+func newMetricFileCount(cfg FileCountMetricConfig) metricFileCount {
 	m := metricFileCount{config: cfg}
 
 	if cfg.Enabled {
@@ -145,9 +153,10 @@ func newMetricFileCount(cfg MetricConfig) metricFileCount {
 }
 
 type metricFileCtime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric        // data buffer for generated metric.
+	config        FileCtimeMetricConfig // metric config provided by user.
+	capacity      int                   // max observed number of data points added to the metric.
+	aggDataPoints []int64               // slice containing number of aggregated datapoints at each index
 }
 
 // init fills file.ctime metric with initial data.
@@ -159,17 +168,48 @@ func (m *metricFileCtime) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFileCtime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, filePermissionsAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, FileCtimeMetricAttributeKeyFilePermissions) {
+		dp.Attributes().PutStr("file.permissions", filePermissionsAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("file.permissions", filePermissionsAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -182,13 +222,18 @@ func (m *metricFileCtime) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFileCtime) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFileCtime(cfg MetricConfig) metricFileCtime {
+func newMetricFileCtime(cfg FileCtimeMetricConfig) metricFileCtime {
 	m := metricFileCtime{config: cfg}
 
 	if cfg.Enabled {
@@ -199,9 +244,9 @@ func newMetricFileCtime(cfg MetricConfig) metricFileCtime {
 }
 
 type metricFileMtime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric        // data buffer for generated metric.
+	config   FileMtimeMetricConfig // metric config provided by user.
+	capacity int                   // max observed number of data points added to the metric.
 }
 
 // init fills file.mtime metric with initial data.
@@ -240,7 +285,7 @@ func (m *metricFileMtime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFileMtime(cfg MetricConfig) metricFileMtime {
+func newMetricFileMtime(cfg FileMtimeMetricConfig) metricFileMtime {
 	m := metricFileMtime{config: cfg}
 
 	if cfg.Enabled {
@@ -251,9 +296,9 @@ func newMetricFileMtime(cfg MetricConfig) metricFileMtime {
 }
 
 type metricFileSize struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric       // data buffer for generated metric.
+	config   FileSizeMetricConfig // metric config provided by user.
+	capacity int                  // max observed number of data points added to the metric.
 }
 
 // init fills file.size metric with initial data.
@@ -290,7 +335,7 @@ func (m *metricFileSize) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricFileSize(cfg MetricConfig) metricFileSize {
+func newMetricFileSize(cfg FileSizeMetricConfig) metricFileSize {
 	m := metricFileSize{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/filestatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["FileCtime"] = mb.metricFileCtime.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -75,6 +85,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordFileCtimeDataPoint(ts, 1, "file.permissions-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFileCtimeDataPoint(ts, 3, "file.permissions-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -89,6 +102,9 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetFilePath("file.path-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricFileCtime.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -142,22 +158,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "file.ctime":
-					assert.False(t, validatedMetrics["file.ctime"], "Found a duplicate in the metrics slice: file.ctime")
-					validatedMetrics["file.ctime"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					filePermissionsAttrVal, ok := dp.Attributes().Get("file.permissions")
-					assert.True(t, ok)
-					assert.Equal(t, "file.permissions-val", filePermissionsAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["file.ctime"], "Found a duplicate in the metrics slice: file.ctime")
+						validatedMetrics["file.ctime"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						filePermissionsAttrVal, ok := dp.Attributes().Get("file.permissions")
+						assert.True(t, ok)
+						assert.Equal(t, "file.permissions-val", filePermissionsAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["file.ctime"], "Found a duplicate in the metrics slice: file.ctime")
+						validatedMetrics["file.ctime"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["file.ctime"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("file.permissions")
+						assert.False(t, ok)
+					}
 				case "file.mtime":
 					assert.False(t, validatedMetrics["file.mtime"], "Found a duplicate in the metrics slice: file.mtime")
 					validatedMetrics["file.mtime"] = true

--- a/receiver/filestatsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/filestatsreceiver/internal/metadata/testdata/config.yaml
@@ -7,6 +7,25 @@ all_set:
       enabled: true
     file.ctime:
       enabled: true
+      attributes: ["file.permissions"]
+    file.mtime:
+      enabled: true
+    file.size:
+      enabled: true
+  resource_attributes:
+    file.name:
+      enabled: true
+    file.path:
+      enabled: true
+reaggregate_set:
+  metrics:
+    file.atime:
+      enabled: true
+    file.count:
+      enabled: true
+    file.ctime:
+      enabled: true
+      attributes: []
     file.mtime:
       enabled: true
     file.size:
@@ -24,6 +43,7 @@ none_set:
       enabled: false
     file.ctime:
       enabled: false
+      attributes: ["file.permissions"]
     file.mtime:
       enabled: false
     file.size:

--- a/receiver/filestatsreceiver/metadata.yaml
+++ b/receiver/filestatsreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: File Stats Receiver
 type: filestats
+reaggregation_enabled: true
 
 description: The File Stats receiver collects metrics from files specified with a glob pattern.
 
@@ -26,6 +27,7 @@ resource_attributes:
 attributes:
   file.permissions:
     description: the permissions associated with the file, using an octal format.
+    requirement_level: recommended
     type: string
 
 metrics:


### PR DESCRIPTION
Fixes #46355
Part of #45396

## Summary

- Set `reaggregation_enabled: true` in `metadata.yaml`
- Added `requirement_level: recommended` to the `file.permissions` attribute
- Ran `go generate ./...`, `make fmt`, `make gci`, and `schemagen` to regenerate all derived files

## Test plan

- [x] `make test` in `receiver/filestatsreceiver/` - all 29 tests pass
- [x] `make lint` in `receiver/filestatsreceiver/` - clean
- [x] `make chlog-validate` - valid
- [x] `make gci` - no diffs
- [x] `schemagen` - schema up to date