### PR TITLE
enhancement(logdedup): add timestamp_mode config and first/last timestamp attributes

### DIFF
--- a/.chloggen/enhancement_logdedup-timestamp-mode.yaml
+++ b/.chloggen/enhancement_logdedup-timestamp-mode.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/logdedup
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `timestamp_mode` configuration option (`observed` (default) or `preserved`) and new attributes `first_event_timestamp` and `last_event_timestamp` to the logdedup processor."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43647]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - `observed` sets the emitted log's timestamp to export time (default behavior).
+  - `preserved` retains the timestamp from the first log received in the aggregation window.
+  - `first_event_timestamp` and `last_event_timestamp` attributes are always added, recording the earliest and latest source log timestamps seen in the window.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/logdedupprocessor/README.md
+++ b/processor/logdedupprocessor/README.md
@@ -27,8 +27,17 @@ emitting a single log with the count of logs that were deduplicated.
     - `log_count`: The count of logs that were deduplicated over the interval. The name of the attribute is configurable via the `log_count_attribute` parameter.
     - `first_observed_timestamp`: The timestamp of the first log that was observed during the aggregation interval.
     - `last_observed_timestamp`: The timestamp of the last log that was observed during the aggregation interval.
+    - `first_event_timestamp`: The timestamp of the first log received during the aggregation interval.
+    - `last_event_timestamp`: The timestamp of the last log received during the aggregation interval.
 
-**Note**: The `ObservedTimestamp` and `Timestamp` of the emitted log will be the time that the aggregated log was emitted and will not be the same as the `ObservedTimestamp` and `Timestamp` of the original logs.
+**Note**: The `Timestamp` of the emitted log depends on the configured `timestamp_mode`:
+
+| `timestamp_mode` | `Timestamp` of the emitted log |
+| --- | --- |
+| `observed` (default) | Set to when the aggregated log was emitted. |
+| `preserved` | Preserved from the first log received in the aggregation window. |
+
+Using `preserved` is recommended when accurate time-based analysis and alerting are required, as it maintains the original event timestamp rather than the aggregation time. It also improves interoperability with downstream systems that rely on correct temporal ordering. See [Tradeoffs and Considerations](https://opentelemetry.io/blog/2026/log-deduplication-processor/#tradeoffs-and-considerations) for guidance on when to avoid deduplication entirely, such as for compliance-critical or audit logs.
 
 ## Configuration
 | Field               | Type     | Default     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -38,6 +47,7 @@ emitting a single log with the count of logs that were deduplicated.
 | log_count_attribute | string   | `log_count` | The name of the count attribute of deduplicated logs that will be added to the emitted aggregated log.                                                                                                                                                                                                                                                                                                                                                  |
 | include_fields                | []string | `[]`        | Fields to include in duplication matching. Fields can be from the log `body` or `attributes`.  Nested fields must be `.` delimited. If a field contains a `.` it can be escaped by using a `\`.  This option is **mutually exclusive** with `exclude_fields`. See [example config](#example-config-with-deduplication-key).
 | timezone            | string   | `UTC`       | The timezone of the `first_observed_timestamp` and `last_observed_timestamp` timestamps on the emitted aggregated log. The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`.                                                                                                                               |
+| timestamp_mode      | string   | `observed`  | Controls how the `Timestamp` field of the emitted log is set. `observed`: set to when the aggregated log was emitted. `preserved`: preserved from the first log received in the aggregation window. In all modes, `first_event_timestamp` and `last_event_timestamp` attributes capture the original event timestamps. |
 | exclude_fields      | []string | `[]`        | Fields to exclude from duplication matching. Fields can be excluded from the log `body` or `attributes`. These fields will not be present in the emitted aggregated log. Nested fields must be `.` delimited. This option is `mutually exclusive` with `include_fields`. If a field contains a `.` it can be escaped by using a `\` see [example config](#example-config-with-excluded-fields).<br><br>**Note**: The entire `body` cannot be excluded. If the body is a map then fields within it can be excluded. |
 
 [OTTL]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.109.0/pkg/ottl#readme

--- a/processor/logdedupprocessor/config.go
+++ b/processor/logdedupprocessor/config.go
@@ -13,6 +13,16 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
+// TimestampMode defines how the timestamp of the emitted log record is set.
+type TimestampMode string
+
+const (
+	// TimestampModeObserved sets the log record timestamp to when the aggregated log was emitted.
+	TimestampModeObserved TimestampMode = "observed"
+	// TimestampModePreserved preserves the log record timestamp from the first log received in the aggregation window.
+	TimestampModePreserved TimestampMode = "preserved"
+)
+
 // Config defaults
 const (
 	// defaultInterval is the default export interval.
@@ -23,6 +33,9 @@ const (
 
 	// defaultTimezone is the default timezone
 	defaultTimezone = "UTC"
+
+	// defaultTimestampMode is the default timestamp mode
+	defaultTimestampMode = TimestampModeObserved
 
 	// bodyField is the name of the body field
 	bodyField = "body"
@@ -37,6 +50,7 @@ var (
 	errInvalidInterval          = errors.New("interval must be greater than 0")
 	errCannotExcludeBody        = errors.New("cannot exclude the entire body")
 	errCannotIncludeBody        = errors.New("cannot include the entire body")
+	errInvalidTimestampMode     = errors.New("timestamp_mode must be one of 'observed' or 'preserved'")
 )
 
 // Config is the config of the processor.
@@ -47,6 +61,7 @@ type Config struct {
 	ExcludeFields     []string      `mapstructure:"exclude_fields"`
 	IncludeFields     []string      `mapstructure:"include_fields"`
 	Conditions        []string      `mapstructure:"conditions"`
+	TimestampMode     TimestampMode `mapstructure:"timestamp_mode"`
 }
 
 // createDefaultConfig returns the default config for the processor.
@@ -55,6 +70,7 @@ func createDefaultConfig() component.Config {
 		LogCountAttribute: defaultLogCountAttribute,
 		Interval:          defaultInterval,
 		Timezone:          defaultTimezone,
+		TimestampMode:     defaultTimestampMode,
 		ExcludeFields:     []string{},
 		IncludeFields:     []string{},
 		Conditions:        []string{},
@@ -88,6 +104,12 @@ func (c Config) Validate() error {
 	err = c.validateIncludeFields()
 	if err != nil {
 		return err
+	}
+
+	switch c.TimestampMode {
+	case TimestampModeObserved, TimestampModePreserved, "":
+	default:
+		return errInvalidTimestampMode
 	}
 
 	return nil

--- a/processor/logdedupprocessor/config.schema.yaml
+++ b/processor/logdedupprocessor/config.schema.yaml
@@ -1,3 +1,7 @@
+$defs:
+  timestamp_mode:
+    description: TimestampMode defines how the timestamp of the emitted log record is set.
+    type: string
 description: Config is the config of the processor.
 type: object
 properties:
@@ -18,5 +22,7 @@ properties:
     format: duration
   log_count_attribute:
     type: string
+  timestamp_mode:
+    $ref: timestamp_mode
   timezone:
     type: string

--- a/processor/logdedupprocessor/config_test.go
+++ b/processor/logdedupprocessor/config_test.go
@@ -15,6 +15,7 @@ func TestCreateDefaultProcessorConfig(t *testing.T) {
 	require.Equal(t, defaultInterval, cfg.Interval)
 	require.Equal(t, defaultLogCountAttribute, cfg.LogCountAttribute)
 	require.Equal(t, defaultTimezone, cfg.Timezone)
+	require.Equal(t, defaultTimestampMode, cfg.TimestampMode)
 	require.Equal(t, []string{}, cfg.ExcludeFields)
 }
 
@@ -115,11 +116,42 @@ func TestValidateConfig(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			desc: "invalid timestamp_mode",
+			cfg: &Config{
+				LogCountAttribute: defaultLogCountAttribute,
+				Interval:          defaultInterval,
+				Timezone:          defaultTimezone,
+				TimestampMode:     "invalid",
+			},
+			expectedErr: errInvalidTimestampMode,
+		},
+		{
+			desc: "valid timestamp_mode observed",
+			cfg: &Config{
+				LogCountAttribute: defaultLogCountAttribute,
+				Interval:          defaultInterval,
+				Timezone:          defaultTimezone,
+				TimestampMode:     TimestampModeObserved,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "valid timestamp_mode preserved",
+			cfg: &Config{
+				LogCountAttribute: defaultLogCountAttribute,
+				Interval:          defaultInterval,
+				Timezone:          defaultTimezone,
+				TimestampMode:     TimestampModePreserved,
+			},
+			expectedErr: nil,
+		},
+		{
 			desc: "valid config",
 			cfg: &Config{
 				LogCountAttribute: defaultLogCountAttribute,
 				Interval:          defaultInterval,
 				Timezone:          defaultTimezone,
+				TimestampMode:     defaultTimestampMode,
 				Conditions:        []string{},
 				ExcludeFields:     []string{"body.thing", "attributes.otherthing"},
 			},

--- a/processor/logdedupprocessor/counter.go
+++ b/processor/logdedupprocessor/counter.go
@@ -14,10 +14,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor/internal/metadata"
 )
 
-// Attributes names for first and last observed timestamps
+// Attribute names added to each emitted log record.
 const (
-	firstObservedTSAttr = "first_observed_timestamp"
-	lastObservedTSAttr  = "last_observed_timestamp"
+	firstObservedTSAttr     = "first_observed_timestamp"
+	lastObservedTSAttr      = "last_observed_timestamp"
+	firstEventTimestampAttr = "first_event_timestamp"
+	lastEventTimestampAttr  = "last_event_timestamp"
+
+	// numAddedAttributes is the number of attributes added to each emitted log record,
+	// used to pre-allocate capacity. Must be updated if attributes are added or removed.
+	numAddedAttributes = 5 // log_count, first_observed_timestamp, last_observed_timestamp, first_event_timestamp, last_event_timestamp
 )
 
 // timeNow can be reassigned for testing
@@ -30,16 +36,18 @@ type logAggregator struct {
 	timezone          *time.Location
 	telemetryBuilder  *metadata.TelemetryBuilder
 	dedupFields       []string
+	timestampMode     TimestampMode
 }
 
 // newLogAggregator creates a new LogCounter.
-func newLogAggregator(logCountAttribute string, timezone *time.Location, telemetryBuilder *metadata.TelemetryBuilder, dedupFields []string) *logAggregator {
+func newLogAggregator(logCountAttribute string, timezone *time.Location, telemetryBuilder *metadata.TelemetryBuilder, dedupFields []string, timestampMode TimestampMode) *logAggregator {
 	return &logAggregator{
 		resources:         make(map[uint64]*resourceAggregator),
 		logCountAttribute: logCountAttribute,
 		timezone:          timezone,
 		telemetryBuilder:  telemetryBuilder,
 		dedupFields:       dedupFields,
+		timestampMode:     timestampMode,
 	}
 }
 
@@ -62,17 +70,28 @@ func (l *logAggregator) Export(ctx context.Context) plog.Logs {
 				lr := sl.LogRecords().AppendEmpty()
 				logAggregator.logRecord.CopyTo(lr)
 
-				// Set log record timestamps
-				lr.SetTimestamp(pcommon.NewTimestampFromTime(timeNow()))
+				// Set observed timestamp to when the record was first seen
 				lr.SetObservedTimestamp(pcommon.NewTimestampFromTime(logAggregator.firstObservedTimestamp))
 
-				// Add attributes for log count and first/last observed timestamps
-				lr.Attributes().EnsureCapacity(lr.Attributes().Len() + 3)
+				// Capture the first event timestamp before any timestamp mode-based overwrite.
+				firstEventTimestamp := lr.Timestamp()
+
+				// Observed mode sets the timestamp to when the aggregated log was emitted.
+				if l.timestampMode == TimestampModeObserved {
+					lr.SetTimestamp(pcommon.NewTimestampFromTime(timeNow()))
+				}
+
+				// Add attributes for log count, first/last observed timestamps, and first/last event timestamps
+				lr.Attributes().EnsureCapacity(lr.Attributes().Len() + numAddedAttributes)
 				lr.Attributes().PutInt(l.logCountAttribute, logAggregator.count)
-				firstTimestampStr := logAggregator.firstObservedTimestamp.In(l.timezone).Format(time.RFC3339)
-				lr.Attributes().PutStr(firstObservedTSAttr, firstTimestampStr)
-				lastTimestampStr := logAggregator.lastObservedTimestamp.In(l.timezone).Format(time.RFC3339)
-				lr.Attributes().PutStr(lastObservedTSAttr, lastTimestampStr)
+				firstObservedTimestampStr := logAggregator.firstObservedTimestamp.In(l.timezone).Format(time.RFC3339)
+				lr.Attributes().PutStr(firstObservedTSAttr, firstObservedTimestampStr)
+				lastObservedTimestampStr := logAggregator.lastObservedTimestamp.In(l.timezone).Format(time.RFC3339)
+				lr.Attributes().PutStr(lastObservedTSAttr, lastObservedTimestampStr)
+				firstEventTimestampStr := firstEventTimestamp.AsTime().In(l.timezone).Format(time.RFC3339)
+				lr.Attributes().PutStr(firstEventTimestampAttr, firstEventTimestampStr)
+				lastEventTimestampStr := logAggregator.lastEventTimestamp.AsTime().In(l.timezone).Format(time.RFC3339)
+				lr.Attributes().PutStr(lastEventTimestampAttr, lastEventTimestampStr)
 			}
 		}
 	}
@@ -150,6 +169,8 @@ func (s *scopeAggregator) Add(logRecord plog.LogRecord) {
 	if !ok {
 		lc = newLogCounter(logRecord)
 		s.logCounters[key] = lc
+	} else {
+		lc.lastEventTimestamp = logRecord.Timestamp()
 	}
 	lc.Increment()
 }
@@ -159,6 +180,7 @@ type logCounter struct {
 	logRecord              plog.LogRecord
 	firstObservedTimestamp time.Time
 	lastObservedTimestamp  time.Time
+	lastEventTimestamp     pcommon.Timestamp
 	count                  int64
 }
 
@@ -172,6 +194,7 @@ func newLogCounter(logRecord plog.LogRecord) *logCounter {
 		count:                  0,
 		firstObservedTimestamp: timeNow().UTC(),
 		lastObservedTimestamp:  timeNow().UTC(),
+		lastEventTimestamp:     movedLogRecord.Timestamp(),
 	}
 }
 

--- a/processor/logdedupprocessor/counter_test.go
+++ b/processor/logdedupprocessor/counter_test.go
@@ -21,7 +21,7 @@ func Test_newLogAggregator(t *testing.T) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
-	aggregator := newLogAggregator(cfg.LogCountAttribute, time.UTC, telemetryBuilder, cfg.IncludeFields)
+	aggregator := newLogAggregator(cfg.LogCountAttribute, time.UTC, telemetryBuilder, cfg.IncludeFields, cfg.TimestampMode)
 	require.Equal(t, cfg.LogCountAttribute, aggregator.logCountAttribute)
 	require.Equal(t, time.UTC, aggregator.timezone)
 	require.NotNil(t, aggregator.resources)
@@ -43,7 +43,7 @@ func Test_logAggregatorAdd(t *testing.T) {
 	require.NoError(t, err)
 
 	// Setup aggregator
-	aggregator := newLogAggregator("log_count", time.UTC, telemetryBuilder, nil)
+	aggregator := newLogAggregator("log_count", time.UTC, telemetryBuilder, nil, defaultTimestampMode)
 	logRecord := plog.NewLogRecord()
 
 	resource := pcommon.NewResource()
@@ -93,7 +93,7 @@ func Test_logAggregatorReset(t *testing.T) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
-	aggregator := newLogAggregator("log_count", time.UTC, telemetryBuilder, nil)
+	aggregator := newLogAggregator("log_count", time.UTC, telemetryBuilder, nil, defaultTimestampMode)
 	for i := range 2 {
 		resource := pcommon.NewResource()
 		resource.Attributes().PutInt("i", int64(i))
@@ -128,7 +128,7 @@ func Test_logAggregatorExport(t *testing.T) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
-	aggregator := newLogAggregator(defaultLogCountAttribute, location, telemetryBuilder, nil)
+	aggregator := newLogAggregator(defaultLogCountAttribute, location, telemetryBuilder, nil, TimestampModePreserved)
 	resource := pcommon.NewResource()
 	resource.Attributes().PutStr("one", "two")
 	expectedHash := pdatautil.MapHash(resource.Attributes())
@@ -136,7 +136,9 @@ func Test_logAggregatorExport(t *testing.T) {
 	scope := pcommon.NewInstrumentationScope()
 
 	// Add logRecord
-	aggregator.Add(resource, scope, generateTestLogRecord(t, "body string"))
+	originalLogRecord := generateTestLogRecord(t, "body string")
+	originalTimestamp := originalLogRecord.Timestamp()
+	aggregator.Add(resource, scope, originalLogRecord)
 
 	exportedLogs := aggregator.Export(t.Context())
 	require.Equal(t, 1, exportedLogs.LogRecordCount())
@@ -161,7 +163,7 @@ func Test_logAggregatorExport(t *testing.T) {
 	require.Equal(t, expectedLogRecord.SeverityNumber(), actualLogRecord.SeverityNumber())
 	require.Equal(t, expectedLogRecord.SeverityText(), actualLogRecord.SeverityText())
 	require.Equal(t, expectedTimestamp.UnixMilli(), actualLogRecord.ObservedTimestamp().AsTime().UnixMilli())
-	require.Equal(t, expectedTimestamp.UnixMilli(), actualLogRecord.Timestamp().AsTime().UnixMilli())
+	require.Equal(t, originalTimestamp, actualLogRecord.Timestamp())
 
 	actualRawAttrs := actualLogRecord.Attributes().AsRaw()
 	for key, val := range expectedLogRecord.Attributes().AsRaw() {
@@ -182,6 +184,78 @@ func Test_logAggregatorExport(t *testing.T) {
 	actualLastObserved, ok := actualRawAttrs[lastObservedTSAttr]
 	require.True(t, ok)
 	require.Equal(t, expectedTimestampStr, actualLastObserved)
+
+	// first_event_timestamp and last_event_timestamp are always stored as RFC3339 strings
+	expectedEventTS := originalTimestamp.AsTime().In(location).Format(time.RFC3339)
+	actualFirstEventTS, ok := actualRawAttrs[firstEventTimestampAttr]
+	require.True(t, ok)
+	require.Equal(t, expectedEventTS, actualFirstEventTS)
+
+	actualLastEventTS, ok := actualRawAttrs[lastEventTimestampAttr]
+	require.True(t, ok)
+	require.Equal(t, expectedEventTS, actualLastEventTS)
+}
+
+func Test_logAggregatorExportTimestampModes(t *testing.T) {
+	oldTimeNow := timeNow
+	defer func() {
+		timeNow = oldTimeNow
+	}()
+
+	location, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	exportTimestamp := time.Now().UTC()
+	timeNow = func() time.Time {
+		return exportTimestamp
+	}
+
+	telemetryBuilder, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+
+	resource := pcommon.NewResource()
+	scope := pcommon.NewInstrumentationScope()
+
+	testCases := []struct {
+		desc           string
+		mode           TimestampMode
+		checkTimestamp func(t *testing.T, lr plog.LogRecord, originalTS pcommon.Timestamp)
+	}{
+		{
+			desc: "observed mode sets timestamp to emitted observed time",
+			mode: TimestampModeObserved,
+			checkTimestamp: func(t *testing.T, lr plog.LogRecord, originalTS pcommon.Timestamp) {
+				require.Equal(t, exportTimestamp.UnixMilli(), lr.Timestamp().AsTime().UnixMilli())
+				val, ok := lr.Attributes().Get(firstEventTimestampAttr)
+				require.True(t, ok)
+				require.Equal(t, originalTS.AsTime().In(location).Format(time.RFC3339), val.Str())
+			},
+		},
+		{
+			desc: "preserved mode keeps original timestamp",
+			mode: TimestampModePreserved,
+			checkTimestamp: func(t *testing.T, lr plog.LogRecord, originalTS pcommon.Timestamp) {
+				require.Equal(t, originalTS, lr.Timestamp())
+				val, ok := lr.Attributes().Get(firstEventTimestampAttr)
+				require.True(t, ok)
+				require.Equal(t, originalTS.AsTime().In(location).Format(time.RFC3339), val.Str())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			aggregator := newLogAggregator(defaultLogCountAttribute, location, telemetryBuilder, nil, tc.mode)
+			original := generateTestLogRecord(t, "body")
+			originalTS := original.Timestamp()
+			aggregator.Add(resource, scope, original)
+
+			exported := aggregator.Export(t.Context())
+			require.Equal(t, 1, exported.LogRecordCount())
+			lr := exported.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+			tc.checkTimestamp(t, lr, originalTS)
+		})
+	}
 }
 
 func Test_newResourceAggregator(t *testing.T) {
@@ -232,10 +306,13 @@ func Test_logCounterIncrement(t *testing.T) {
 
 	last := time.Now().UTC()
 	timeNow = func() time.Time { return last }
+	eventTS := pcommon.NewTimestampFromTime(last)
+	lc.lastEventTimestamp = eventTS
 	lc.Increment()
 	require.Equal(t, int64(1), lc.count)
 	require.Equal(t, first, lc.firstObservedTimestamp)
 	require.Equal(t, last, lc.lastObservedTimestamp)
+	require.Equal(t, eventTS, lc.lastEventTimestamp)
 }
 
 func Test_getLogKey(t *testing.T) {

--- a/processor/logdedupprocessor/processor.go
+++ b/processor/logdedupprocessor/processor.go
@@ -48,7 +48,7 @@ func newProcessor(cfg *Config, nextConsumer consumer.Logs, settings processor.Se
 
 	return &logDedupProcessor{
 		emitInterval: cfg.Interval,
-		aggregator:   newLogAggregator(cfg.LogCountAttribute, timezone, telemetryBuilder, cfg.IncludeFields),
+		aggregator:   newLogAggregator(cfg.LogCountAttribute, timezone, telemetryBuilder, cfg.IncludeFields, cfg.TimestampMode),
 		remover:      newFieldRemover(cfg.ExcludeFields),
 		nextConsumer: nextConsumer,
 		logger:       settings.Logger,

--- a/processor/logdedupprocessor/processor_test.go
+++ b/processor/logdedupprocessor/processor_test.go
@@ -169,7 +169,7 @@ func TestProcessorConsume(t *testing.T) {
 	allSinkLogs := logsSink.AllLogs()
 	require.Len(t, allSinkLogs, 1)
 
-	require.NoError(t, plogtest.CompareLogs(expectedLogs, allSinkLogs[0], plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp")))
+	require.NoError(t, plogtest.CompareLogs(expectedLogs, allSinkLogs[0], plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp")))
 
 	// Cleanup
 	err = p.Shutdown(t.Context())
@@ -252,8 +252,8 @@ func TestProcessorConsumeCondition(t *testing.T) {
 	consumedLogs := allSinkLogs[0]
 	dedupedLogs := allSinkLogs[1]
 
-	require.NoError(t, plogtest.CompareLogs(expectedConsumedLogs, consumedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordsOrder()))
-	require.NoError(t, plogtest.CompareLogs(expectedDedupedLogs, dedupedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordsOrder()))
+	require.NoError(t, plogtest.CompareLogs(expectedConsumedLogs, consumedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp"), plogtest.IgnoreLogRecordsOrder()))
+	require.NoError(t, plogtest.CompareLogs(expectedDedupedLogs, dedupedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp"), plogtest.IgnoreLogRecordsOrder()))
 
 	// Cleanup
 	err = p.Shutdown(t.Context())
@@ -302,8 +302,8 @@ func TestProcessorConsumeMultipleConditions(t *testing.T) {
 	expectedDedupedLogs, err := golden.ReadLogs(filepath.Join("testdata", "expected", "multipleConditionsDedupedLogs.yaml"))
 	require.NoError(t, err)
 
-	require.NoError(t, plogtest.CompareLogs(expectedConsumedLogs, consumedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordsOrder()))
-	require.NoError(t, plogtest.CompareLogs(expectedDedupedLogs, dedupedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordsOrder()))
+	require.NoError(t, plogtest.CompareLogs(expectedConsumedLogs, consumedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp"), plogtest.IgnoreLogRecordsOrder()))
+	require.NoError(t, plogtest.CompareLogs(expectedDedupedLogs, dedupedLogs, plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp"), plogtest.IgnoreLogRecordsOrder()))
 
 	// Cleanup
 	err = p.Shutdown(t.Context())
@@ -381,13 +381,107 @@ func TestProcessorIncludeFields(t *testing.T) {
 			allSinkLogs := logsSink.AllLogs()
 			require.Len(t, allSinkLogs, 1)
 
-			require.NoError(t, plogtest.CompareLogs(expectedLogs, allSinkLogs[0], plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp")))
+			require.NoError(t, plogtest.CompareLogs(expectedLogs, allSinkLogs[0], plogtest.IgnoreObservedTimestamp(), plogtest.IgnoreTimestamp(), plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"), plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"), plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp")))
 
 			// Cleanup
 			err = p.Shutdown(t.Context())
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestProcessorTimestampModeObserved(t *testing.T) {
+	logsSink := &consumertest.LogsSink{}
+	cfg := &Config{
+		LogCountAttribute: defaultLogCountAttribute,
+		Interval:          1 * time.Second,
+		Timezone:          defaultTimezone,
+		Conditions:        []string{},
+		TimestampMode:     TimestampModeObserved,
+	}
+
+	p, err := createLogsProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, logsSink)
+	require.NoError(t, err)
+	err = p.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	logs, err := golden.ReadLogs(filepath.Join("testdata", "input", "timestampModeLogs.yaml"))
+	require.NoError(t, err)
+
+	err = p.ConsumeLogs(t.Context(), logs)
+	require.NoError(t, err)
+
+	beforeExport := time.Now()
+	require.Eventually(t, func() bool {
+		return logsSink.LogRecordCount() > 0
+	}, 3*time.Second, 200*time.Millisecond)
+	afterExport := time.Now()
+
+	allSinkLogs := logsSink.AllLogs()
+	require.Len(t, allSinkLogs, 1)
+
+	expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "expected", "timestampModeObservedLogs.yaml"))
+	require.NoError(t, err)
+
+	// Timestamp is ignored in the golden file comparison since it is non-deterministic (set to export time).
+	// It is validated separately below against the export window.
+	require.NoError(t, plogtest.CompareLogs(expectedLogs, allSinkLogs[0],
+		plogtest.IgnoreObservedTimestamp(),
+		plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"),
+		plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"),
+		plogtest.IgnoreLogRecordAttributeValue("first_event_timestamp"),
+		plogtest.IgnoreLogRecordAttributeValue("last_event_timestamp"),
+		plogtest.IgnoreTimestamp(),
+	))
+
+	emitted := allSinkLogs[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	emittedTS := emitted.Timestamp().AsTime()
+	// Timestamp must fall within the export window, not equal the original event timestamps.
+	require.False(t, emittedTS.Before(beforeExport), "timestamp should not be before export")
+	require.False(t, emittedTS.After(afterExport), "timestamp should not be after export")
+
+	require.NoError(t, p.Shutdown(t.Context()))
+}
+
+func TestProcessorTimestampModePreserved(t *testing.T) {
+	logsSink := &consumertest.LogsSink{}
+	cfg := &Config{
+		LogCountAttribute: defaultLogCountAttribute,
+		Interval:          1 * time.Second,
+		Timezone:          defaultTimezone,
+		Conditions:        []string{},
+		TimestampMode:     TimestampModePreserved,
+	}
+
+	p, err := createLogsProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, logsSink)
+	require.NoError(t, err)
+	err = p.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	logs, err := golden.ReadLogs(filepath.Join("testdata", "input", "timestampModeLogs.yaml"))
+	require.NoError(t, err)
+
+	err = p.ConsumeLogs(t.Context(), logs)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return logsSink.LogRecordCount() > 0
+	}, 3*time.Second, 200*time.Millisecond)
+
+	allSinkLogs := logsSink.AllLogs()
+	require.Len(t, allSinkLogs, 1)
+
+	expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "expected", "timestampModePreservedLogs.yaml"))
+	require.NoError(t, err)
+
+	// Timestamp is intentionally not ignored — preserved mode must keep the original.
+	require.NoError(t, plogtest.CompareLogs(expectedLogs, allSinkLogs[0],
+		plogtest.IgnoreObservedTimestamp(),
+		plogtest.IgnoreLogRecordAttributeValue("first_observed_timestamp"),
+		plogtest.IgnoreLogRecordAttributeValue("last_observed_timestamp"),
+	))
+
+	require.NoError(t, p.Shutdown(t.Context()))
 }
 
 func TestProcessorConfigValidate(t *testing.T) {

--- a/processor/logdedupprocessor/testdata/expected/basicLogs.yaml
+++ b/processor/logdedupprocessor/testdata/expected/basicLogs.yaml
@@ -22,6 +22,12 @@ resourceLogs:
               - key: last_observed_timestamp
                 value:
                   stringValue: "2024-10-04T19:21:47Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:14:26Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:14:26Z"
             body:
               stringValue: Body of the log
             observedTimeUnixNano: "1728069707998122000"

--- a/processor/logdedupprocessor/testdata/expected/conditionDedupedLogs.yaml
+++ b/processor/logdedupprocessor/testdata/expected/conditionDedupedLogs.yaml
@@ -21,6 +21,12 @@ resourceLogs:
               - key: last_observed_timestamp
                 value:
                   stringValue: "2024-10-04T19:40:31Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:16:25Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:25Z"
             body:
               stringValue: Body of the log1
             observedTimeUnixNano: "1728070831326144000"

--- a/processor/logdedupprocessor/testdata/expected/includeFieldsLogs.yaml
+++ b/processor/logdedupprocessor/testdata/expected/includeFieldsLogs.yaml
@@ -25,6 +25,12 @@ resourceLogs:
               - key: last_observed_timestamp
                 value:
                   stringValue: "2024-10-04T19:21:47Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:13:26Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:14:26Z"
             body:
               kvlistValue:
                 values:

--- a/processor/logdedupprocessor/testdata/expected/multipleConditionsDedupedLogs.yaml
+++ b/processor/logdedupprocessor/testdata/expected/multipleConditionsDedupedLogs.yaml
@@ -21,6 +21,12 @@ resourceLogs:
               - key: last_observed_timestamp
                 value:
                   stringValue: "2024-10-04T19:46:39Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:16:25Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:17:25Z"
             body:
               stringValue: Body of the log1
             observedTimeUnixNano: "1728071199778796000"
@@ -47,6 +53,12 @@ resourceLogs:
               - key: last_observed_timestamp
                 value:
                   stringValue: "2024-10-04T19:46:39Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:20:25Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:25Z"
             body:
               stringValue: Body of the log3
             observedTimeUnixNano: "1728071199778800000"

--- a/processor/logdedupprocessor/testdata/expected/timestampModeObservedLogs.yaml
+++ b/processor/logdedupprocessor/testdata/expected/timestampModeObservedLogs.yaml
@@ -1,0 +1,25 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: log_count
+                value:
+                  intValue: "2"
+              - key: first_observed_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:48Z"
+              - key: last_observed_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:53Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:47Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:52Z"
+            body:
+              stringValue: dedup me
+            spanId: ""
+            traceId: ""
+        scope: {}

--- a/processor/logdedupprocessor/testdata/expected/timestampModePreservedLogs.yaml
+++ b/processor/logdedupprocessor/testdata/expected/timestampModePreservedLogs.yaml
@@ -1,0 +1,26 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: log_count
+                value:
+                  intValue: "2"
+              - key: first_observed_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:48Z"
+              - key: last_observed_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:53Z"
+              - key: first_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:47Z"
+              - key: last_event_timestamp
+                value:
+                  stringValue: "2024-10-04T19:21:52Z"
+            body:
+              stringValue: dedup me
+            spanId: ""
+            timeUnixNano: "1728069707000000000"
+            traceId: ""
+        scope: {}

--- a/processor/logdedupprocessor/testdata/input/timestampModeLogs.yaml
+++ b/processor/logdedupprocessor/testdata/input/timestampModeLogs.yaml
@@ -1,0 +1,15 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              stringValue: dedup me
+            spanId: ""
+            timeUnixNano: "1728069707000000000"
+            traceId: ""
+          - body:
+              stringValue: dedup me
+            spanId: ""
+            timeUnixNano: "1728069712000000000"
+            traceId: ""
+        scope: {}


### PR DESCRIPTION
#### Description

1. Add a `timestamp_mode` configuration option to the `logdedupprocessor` with two values:                                  
    - `observed` (default): sets the emitted log timestamp to export time, preserving existing behavior
    - `preserved` (opt-in): retains the timestamp from the first log received in the aggregation window, recommended for time-based analysis and alerting
2. Add `first_event_timestamp` and `last_event_timestamp` attributes (RFC3339) to every emitted log, recording the earliest and latest source log event timestamps seen within the aggregation window.

#### Link to tracking issue
Fixes #43647

#### Testing

1. Added dedicated integration tests for each `timestamp_mode` using golden file fixtures                                  
    - `testdata/input/timestampModeLogs.yaml`
    - `testdata/expected/timestampModeObservedLogs.yaml`
    - `testdata/expected/timestampModePreservedLogs.yaml`
2. Updated existing golden files and unit tests to reflect the new `first_event_timestamp` and `last_event_timestamp` attributes.

#### Documentation

Updated `README.md` with a `timestamp_mode` configuration table explaining the behaviors and the tradeoffs between `observed` and `preserved`, and a reference to further guidance on log deduplication considerations.