### PR TITLE
[extension/azure_encoding] add encoding.format scope attribute for metrics

### DIFF
--- a/.chloggen/feat_add_encoding_format_metrics.yaml
+++ b/.chloggen/feat_add_encoding_format_metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/encoding/azureencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add encoding.format scope attribute for metrics based on Azure resource provider
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/feat_add_encoding_format_metrics.yaml
+++ b/.chloggen/feat_add_encoding_format_metrics.yaml
@@ -4,13 +4,13 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/encoding/azureencodingextension
+component: extension/azure_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add encoding.format scope attribute for metrics based on Azure resource provider
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47537]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/extension/encoding/azureencodingextension/internal/constants/format.go
+++ b/extension/encoding/azureencodingextension/internal/constants/format.go
@@ -3,6 +3,8 @@
 
 package constants // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension/internal/constants"
 
+import "strings"
+
 // Format is the encoding format for Azure logs.
 type Format string
 
@@ -53,4 +55,30 @@ func FormatForCategory(category string) Format {
 	default:
 		return FormatGeneric
 	}
+}
+
+// ProviderFromResourceID extracts the Azure resource provider from a resource ID
+// and returns an encoding format string. For Microsoft providers, the "microsoft."
+// prefix is stripped (e.g., "Microsoft.Web" becomes "azure.web"). For non-Microsoft
+// providers, the full lowercased name is used (e.g., "Sendgrid.Email" becomes
+// "azure.sendgrid.email"). Returns "azure.generic" if the resource ID is empty
+// or the provider cannot be extracted.
+func ProviderFromResourceID(resourceID string) string {
+	if resourceID == "" {
+		return string(FormatGeneric)
+	}
+
+	parts := strings.Split(resourceID, "/")
+	for i, part := range parts {
+		if strings.EqualFold(part, "providers") && i+1 < len(parts) {
+			provider := strings.ToLower(parts[i+1])
+			if provider == "" {
+				return string(FormatGeneric)
+			}
+			provider = strings.TrimPrefix(provider, "microsoft.")
+			return "azure." + provider
+		}
+	}
+
+	return string(FormatGeneric)
 }

--- a/extension/encoding/azureencodingextension/internal/constants/format_test.go
+++ b/extension/encoding/azureencodingextension/internal/constants/format_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderFromResourceID(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		want       string
+	}{
+		{
+			name:       "Microsoft.Web uppercase",
+			resourceID: "/SUBSCRIPTIONS/AAAA0A0A-BB1B-CC2C-DD3D-EEEEEE4E4E4E/RESOURCEGROUPS/RG-001/PROVIDERS/MICROSOFT.WEB/SITES/SCALEABLEWEBAPP1",
+			want:       "azure.web",
+		},
+		{
+			name:       "Microsoft.Compute uppercase",
+			resourceID: "/SUBSCRIPTIONS/AAAA0A0A-BB1B-CC2C-DD3D-EEEEEE4E4E4E/RESOURCEGROUPS/RG-001/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINES/VM1",
+			want:       "azure.compute",
+		},
+		{
+			name:       "microsoft.keyvault lowercase",
+			resourceID: "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/rg-dcrs/providers/microsoft.keyvault/vaults/dcr-vault",
+			want:       "azure.keyvault",
+		},
+		{
+			name:       "Microsoft.Storage mixed case",
+			resourceID: "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Storage/storageAccounts/sa1",
+			want:       "azure.storage",
+		},
+		{
+			name:       "Microsoft.Network",
+			resourceID: "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/applicationGateways/gw1",
+			want:       "azure.network",
+		},
+		{
+			name:       "non-Microsoft provider",
+			resourceID: "/subscriptions/sub-1/resourceGroups/rg-1/providers/Sendgrid.Email/accounts/sg1",
+			want:       "azure.sendgrid.email",
+		},
+		{
+			name:       "empty string",
+			resourceID: "",
+			want:       "azure.generic",
+		},
+		{
+			name:       "no providers segment",
+			resourceID: "/subscriptions/sub-1/resourceGroups/rg-1",
+			want:       "azure.generic",
+		},
+		{
+			name:       "providers at end with no value after",
+			resourceID: "/subscriptions/sub-1/resourceGroups/rg-1/providers",
+			want:       "azure.generic",
+		},
+		{
+			name:       "providers followed by trailing slash only",
+			resourceID: "/subscriptions/sub-1/resourceGroups/rg-1/providers/",
+			want:       "azure.generic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ProviderFromResourceID(tt.resourceID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/testdata/metrics-array_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/testdata/metrics-array_expected.yaml
@@ -40,6 +40,10 @@ resourceMetrics:
                   timeUnixNano: "1681808640000000000"
             name: cputime5m_average
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.web
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version
   - resource:
@@ -123,5 +127,9 @@ resourceMetrics:
             name: serviceapihit_average
             unit: Count
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.keyvault
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/testdata/metrics-ndjson_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/testdata/metrics-ndjson_expected.yaml
@@ -40,6 +40,10 @@ resourceMetrics:
                   timeUnixNano: "1681808580000000000"
             name: cputime_average
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.web
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version
   - resource:
@@ -83,5 +87,9 @@ resourceMetrics:
                   timeUnixNano: "1681808640000000000"
             name: cputime5m_average
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.web
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/testdata/metrics-records_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/testdata/metrics-records_expected.yaml
@@ -70,6 +70,10 @@ resourceMetrics:
                   timeUnixNano: "1681808580000000000"
             name: requests_average
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.web
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version
   - resource:
@@ -113,6 +117,10 @@ resourceMetrics:
                   timeUnixNano: "1681808640000000000"
             name: cputime5m_average
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.web
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version
   - resource:
@@ -196,5 +204,9 @@ resourceMetrics:
             name: serviceapihit_average
             unit: Count
         scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.keyvault
           name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
           version: test-version

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
@@ -18,6 +18,7 @@ import (
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension/internal/constants"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension/internal/unmarshaler"
 )
@@ -152,6 +153,7 @@ func (r ResourceMetricsUnmarshaler) unmarshalRecord(allResourceScopeMetrics map[
 		scopeMetrics = pmetric.NewScopeMetrics()
 		scopeMetrics.Scope().SetName(metadata.ScopeName)
 		scopeMetrics.Scope().SetVersion(r.buildInfo.Version)
+		scopeMetrics.Scope().Attributes().PutStr(constants.FormatIdentificationTag, constants.ProviderFromResourceID(azureMetric.ResourceID))
 		allResourceScopeMetrics[azureMetric.ResourceID] = scopeMetrics
 	}
 


### PR DESCRIPTION
## Summary

- Add `encoding.format` scope attribute to the Azure encoding extension's metrics unmarshaler, mirroring the existing logs support from #46412
- Dynamically extract the Azure resource provider from the metric's `resourceId` field (e.g., `Microsoft.Web` → `azure.web`, `Microsoft.KeyVault` → `azure.keyvault`)
- Falls back to `azure.generic` when the resource ID is empty or unparseable

This enables the downstream components like exporters (and any other consumer that reads `encoding.format`) to route metrics to provider-specific, which is useful for isolating high-volume metric producers.

### Design choice: provider-level vs. resource-type-level granularity

We chose **provider-level** granularity (e.g., `azure.compute` for all `Microsoft.Compute/*` resources) over resource-type-level (e.g., `azure.compute.virtual_machines` for `Microsoft.Compute/virtualMachines` specifically).

Provider-level is simpler and covers the common use case of isolating high-volume metric producers. Resource-type-level would allow finer routing (e.g., separate data streams for VMs vs. disks) but adds complexity. The provider-level approach can be extended to resource-type-level later if needed without breaking changes — it would just produce more specific format values.

## Test Plan

- [x] Unit tests for `ProviderFromResourceID` — 10 test cases covering standard providers, case insensitivity, non-Microsoft providers, empty/malformed inputs
- [x] Golden test updates — all 3 metrics expected YAML files updated with `encoding.format` scope attribute
- [x] Full azure encoding extension test suite passes (`go test ./...`)
- [x] `go vet` passes

Assisted-by: Claude Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)