### PR TITLE
[extension/azure_encoding] Fix parsing of stringified JSON properties in App Service logs

### DIFF
--- a/.chloggen/fix-azureencodingextension-string-properties.yaml
+++ b/.chloggen/fix-azureencodingextension-string-properties.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: extension/azure_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix parsing of AppServiceHTTPLogs when properties field is a stringified JSON string instead of an object.
+note: Fix parsing of all App Service and Function App log categories when properties field is a stringified JSON string instead of an object.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [47539]
@@ -17,7 +17,9 @@ issues: [47539]
 # Use pipe (|) for multiline entries.
 subtext: |
   Some Azure Event Hub sources emit the properties field as a JSON string rather than an object.
-  This caused AppServiceHTTPLogs to fall back to raw log storage, losing all semantic attributes.
+  This caused App Service log categories (AppLogs, AuditLogs, AuthenticationLogs, ConsoleLogs,
+  HTTPLogs, IPSecAuditLogs, PlatformLogs, FileAuditLogs) to fall back to raw log storage,
+  losing all semantic attributes.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/fix-azureencodingextension-string-properties.yaml
+++ b/.chloggen/fix-azureencodingextension-string-properties.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/azure_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix parsing of AppServiceHTTPLogs when properties field is a stringified JSON string instead of an object.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47539]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Some Azure Event Hub sources emit the properties field as a JSON string rather than an object.
+  This caused AppServiceHTTPLogs to fall back to raw log storage, losing all semantic attributes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_appservice.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_appservice.go
@@ -64,24 +64,36 @@ const (
 	attributeHTTPHeaderReferer = "http.request.header.referer"
 )
 
+type appServiceAppLogProperties struct {
+	ContainerID       string `json:"containerId"`
+	CustomLevel       string `json:"customLevel"`
+	ExceptionClass    string `json:"exceptionClass"`
+	Host              string `json:"host"`
+	Logger            string `json:"logger"`
+	Message           string `json:"message"`
+	Method            string `json:"method"`
+	Source            string `json:"source"`
+	StackTrace        string `json:"stackTrace"`
+	WebSiteInstanceID string `json:"webSiteInstanceId"`
+}
+
+func (p *appServiceAppLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServiceAppLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceAppLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appserviceapplogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServiceAppLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		ContainerID       string `json:"containerId"`
-		CustomLevel       string `json:"customLevel"`
-		ExceptionClass    string `json:"exceptionClass"`
-		Host              string `json:"host"`
-		Logger            string `json:"logger"`
-		Message           string `json:"message"`
-		Method            string `json:"method"`
-		Source            string `json:"source"`
-		StackTrace        string `json:"stackTrace"`
-		WebSiteInstanceID string `json:"webSiteInstanceId"`
-	} `json:"properties"`
+	Properties appServiceAppLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceAppLog) PutProperties(attrs pcommon.Map, body pcommon.Value) error {
@@ -100,16 +112,28 @@ func (r *azureAppServiceAppLog) PutProperties(attrs pcommon.Map, body pcommon.Va
 	return nil
 }
 
+type appServiceAuditLogProperties struct {
+	User            string `json:"user"`
+	UserDisplayName string `json:"userDisplayName"`
+	UserAddress     string `json:"userAddress"`
+	Protocol        string `json:"protocol"`
+}
+
+func (p *appServiceAuditLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServiceAuditLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceAuditLogProperties(temp)
+	return nil
+}
+
 // See https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/app-service/configure-basic-auth-disable.md#monitor-for-basic-authentication-attempts
 type azureAppServiceAuditLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		User            string `json:"user"`
-		UserDisplayName string `json:"userDisplayName"`
-		UserAddress     string `json:"userAddress"`
-		Protocol        string `json:"protocol"`
-	} `json:"properties"`
+	Properties appServiceAuditLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceAuditLog) PutProperties(attrs pcommon.Map, _ pcommon.Value) error {
@@ -121,22 +145,34 @@ func (r *azureAppServiceAuditLog) PutProperties(attrs pcommon.Map, _ pcommon.Val
 	return nil
 }
 
+type appServiceAuthenticationLogProperties struct {
+	Details              string      `json:"details"`
+	Host                 string      `json:"hostName"`
+	Message              string      `json:"message"`
+	ModuleRuntimeVersion string      `json:"moduleRuntimeVersion"`
+	SiteName             string      `json:"siteName"`
+	StatusCode           json.Number `json:"statusCode"`    // int
+	SubStatusCode        json.Number `json:"subStatusCode"` // int
+	TaskName             string      `json:"taskName"`
+}
+
+func (p *appServiceAuthenticationLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServiceAuthenticationLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceAuthenticationLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appserviceauthenticationlogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServiceAuthenticationLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		Details              string      `json:"details"`
-		Host                 string      `json:"hostName"`
-		Message              string      `json:"message"`
-		ModuleRuntimeVersion string      `json:"moduleRuntimeVersion"`
-		SiteName             string      `json:"siteName"`
-		StatusCode           json.Number `json:"statusCode"`    // int
-		SubStatusCode        json.Number `json:"subStatusCode"` // int
-		TaskName             string      `json:"taskName"`
-	} `json:"properties"`
+	Properties appServiceAuthenticationLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceAuthenticationLog) PutProperties(attrs pcommon.Map, body pcommon.Value) error {
@@ -152,16 +188,28 @@ func (r *azureAppServiceAuthenticationLog) PutProperties(attrs pcommon.Map, body
 	return nil
 }
 
+type appServiceConsoleLogProperties struct {
+	ContainerID string `json:"containerId"`
+	Host        string `json:"host"`
+}
+
+func (p *appServiceConsoleLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServiceConsoleLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceConsoleLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appserviceconsolelogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServiceConsoleLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		ContainerID string `json:"containerId"`
-		Host        string `json:"host"`
-	} `json:"properties"`
+	Properties appServiceConsoleLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceConsoleLog) PutProperties(attrs pcommon.Map, _ pcommon.Value) error {
@@ -240,23 +288,35 @@ func (r *azureAppServiceHTTPLog) PutProperties(attrs pcommon.Map, body pcommon.V
 	return nil
 }
 
+type appServiceIPSecAuditLogProperties struct {
+	ClientIP          string `json:"CIp"`
+	HostHeader        string `json:"CsHost"`
+	Details           string `json:"details"`
+	Result            string `json:"Result"`
+	IsServiceEndpoint string `json:"ServiceEndpoint"`
+	XAzureFDID        string `json:"XAzureFDID"`     // X-Azure-FDID header
+	XFDHealthProbe    string `json:"XFDHealthProbe"` // X-FD-HealthProbe header
+	XForwardedFor     string `json:"XForwardedFor"`  // X-Forwarded-For header
+	XForwardedHost    string `json:"XForwardedHost"` // X-Forwarded-Host header
+}
+
+func (p *appServiceIPSecAuditLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServiceIPSecAuditLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceIPSecAuditLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appserviceipsecauditlogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServiceIPSecAuditLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		ClientIP          string `json:"CIp"`
-		HostHeader        string `json:"CsHost"`
-		Details           string `json:"details"`
-		Result            string `json:"Result"`
-		IsServiceEndpoint string `json:"ServiceEndpoint"`
-		XAzureFDID        string `json:"XAzureFDID"`     // X-Azure-FDID header
-		XFDHealthProbe    string `json:"XFDHealthProbe"` // X-FD-HealthProbe header
-		XForwardedFor     string `json:"XForwardedFor"`  // X-Forwarded-For header
-		XForwardedHost    string `json:"XForwardedHost"` // X-Forwarded-Host header
-	} `json:"properties"`
+	Properties appServiceIPSecAuditLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceIPSecAuditLog) PutProperties(attrs pcommon.Map, body pcommon.Value) error {
@@ -274,20 +334,32 @@ func (r *azureAppServiceIPSecAuditLog) PutProperties(attrs pcommon.Map, body pco
 	return nil
 }
 
+type appServicePlatformLogProperties struct {
+	ContainerID  string `json:"containerId"`
+	DeploymentID string `json:"deploymentId"`
+	Exception    string `json:"Exception"`
+	Host         string `json:"host"`
+	Message      string `json:"message"`
+	StackTrace   string `json:"stackTrace"`
+}
+
+func (p *appServicePlatformLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServicePlatformLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServicePlatformLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appserviceplatformlogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServicePlatformLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		ContainerID  string `json:"containerId"`
-		DeploymentID string `json:"deploymentId"`
-		Exception    string `json:"Exception"`
-		Host         string `json:"host"`
-		Message      string `json:"message"`
-		StackTrace   string `json:"stackTrace"`
-	} `json:"properties"`
+	Properties appServicePlatformLogProperties `json:"properties"`
 }
 
 func (r *azureAppServicePlatformLog) PutProperties(attrs pcommon.Map, body pcommon.Value) error {
@@ -302,16 +374,28 @@ func (r *azureAppServicePlatformLog) PutProperties(attrs pcommon.Map, body pcomm
 	return nil
 }
 
+type appServiceFileAuditLogProperties struct {
+	Path    string `json:"path"`
+	Process string `json:"process"`
+}
+
+func (p *appServiceFileAuditLogProperties) UnmarshalJSON(data []byte) error {
+	type alias appServiceFileAuditLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceFileAuditLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appservicefileauditlogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServiceFileAuditLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		Path    string `json:"path"`
-		Process string `json:"process"`
-	} `json:"properties"`
+	Properties appServiceFileAuditLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceFileAuditLog) PutProperties(attrs pcommon.Map, _ pcommon.Value) error {

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_appservice.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_appservice.go
@@ -171,31 +171,47 @@ func (r *azureAppServiceConsoleLog) PutProperties(attrs pcommon.Map, _ pcommon.V
 	return nil
 }
 
+// appServiceHTTPLogProperties represents the properties field of AppServiceHTTPLogs.
+// Azure can emit this field as either a JSON object or a stringified JSON string
+// (common when logs are routed via Azure Event Hub).
+type appServiceHTTPLogProperties struct {
+	ClientIP       string      `json:"CIp"`
+	Host           string      `json:"ComputerName"`
+	Cookie         string      `json:"Cookie"`
+	RequestBytes   json.Number `json:"CsBytes"` // int
+	HostHeader     string      `json:"CsHost"`
+	RequestMethod  string      `json:"CsMethod"`
+	URIQuery       string      `json:"CsUriQuery"`
+	RequestPath    string      `json:"CsUriStem"`
+	UserName       string      `json:"CsUsername"`
+	Referer        string      `json:"Referer"`
+	Result         string      `json:"Result"`
+	ResponseBytes  json.Number `json:"ScBytes"`  // int
+	HTTPStatusCode json.Number `json:"ScStatus"` // int
+	HTTPSubStatus  string      `json:"ScSubStatus"`
+	ServerPort     json.Number `json:"SPort"`     // int
+	TimeTaken      json.Number `json:"TimeTaken"` // int
+	UserAgent      string      `json:"UserAgent"`
+}
+
+func (p *appServiceHTTPLogProperties) UnmarshalJSON(data []byte) error {
+	// Define an alias type to avoid infinite recursion
+	type alias appServiceHTTPLogProperties
+	var temp alias
+	if err := unmarshalStringOrObjectJSON(data, &temp); err != nil {
+		return err
+	}
+	*p = appServiceHTTPLogProperties(temp)
+	return nil
+}
+
 // See https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appservicehttplogs
 // There is no documentation about the structure of the logs, so we will
 // implement this based on the fields from Azure Monitor table excluding generic fields
 type azureAppServiceHTTPLog struct {
 	azureLogRecordBase
 
-	Properties struct {
-		ClientIP       string      `json:"CIp"`
-		Host           string      `json:"ComputerName"`
-		Cookie         string      `json:"Cookie"`
-		RequestBytes   json.Number `json:"CsBytes"` // int
-		HostHeader     string      `json:"CsHost"`
-		RequestMethod  string      `json:"CsMethod"`
-		URIQuery       string      `json:"CsUriQuery"`
-		RequestPath    string      `json:"CsUriStem"`
-		UserName       string      `json:"CsUsername"`
-		Referer        string      `json:"Referer"`
-		Result         string      `json:"Result"`
-		ResponseBytes  json.Number `json:"ScBytes"`  // int
-		HTTPStatusCode json.Number `json:"ScStatus"` // int
-		HTTPSubStatus  string      `json:"ScSubStatus"`
-		ServerPort     json.Number `json:"SPort"`     // int
-		TimeTaken      json.Number `json:"TimeTaken"` // int
-		UserAgent      string      `json:"UserAgent"`
-	} `json:"properties"`
+	Properties appServiceHTTPLogProperties `json:"properties"`
 }
 
 func (r *azureAppServiceHTTPLog) PutProperties(attrs pcommon.Map, body pcommon.Value) error {

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/helpers.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/helpers.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -223,4 +224,19 @@ func parseUnixTimestamp(s string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return time.Unix(ts, 0).UTC(), nil
+}
+
+// unmarshalStringOrObjectJSON handles Azure properties fields that can be either
+// a JSON object or a stringified JSON string (where Azure wraps the object in quotes).
+// Some Azure Event Hub sources emit `"properties": "{\"key\":\"value\"}"` instead of
+// `"properties": {"key":"value"}`.
+func unmarshalStringOrObjectJSON(data []byte, v any) error {
+	if len(data) > 1 && data[0] == '"' {
+		var s string
+		if err := jsoniter.ConfigFastest.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		data = []byte(s)
+	}
+	return jsoniter.ConfigFastest.Unmarshal(data, v)
 }

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/helpers_test.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/helpers_test.go
@@ -326,6 +326,68 @@ func TestConvertInvalidSingleQuotedJSON(t *testing.T) {
 	}
 }
 
+func TestUnmarshalStringOrObjectJSON(t *testing.T) {
+	t.Parallel()
+
+	type simple struct {
+		Key   string `json:"key"`
+		Count int    `json:"count"`
+	}
+
+	tests := []struct {
+		name        string
+		input       []byte
+		expected    simple
+		expectError bool
+	}{
+		{
+			name:     "JSON object",
+			input:    []byte(`{"key":"value","count":42}`),
+			expected: simple{Key: "value", Count: 42},
+		},
+		{
+			name:     "stringified JSON object",
+			input:    []byte(`"{\"key\":\"value\",\"count\":42}"`),
+			expected: simple{Key: "value", Count: 42},
+		},
+		{
+			name:        "non-JSON string payload",
+			input:       []byte(`"not-json"`),
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			input:       []byte(`""`),
+			expectError: true,
+		},
+		{
+			name:        "invalid JSON",
+			input:       []byte(`{invalid`),
+			expectError: true,
+		},
+		{
+			name:     "null value",
+			input:    []byte(`null`),
+			expected: simple{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got simple
+			err := unmarshalStringOrObjectJSON(tt.input, &got)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}
+
 func Test_stringToNumber(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/appservice/http-log-string-properties.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/appservice/http-log-string-properties.json
@@ -1,0 +1,16 @@
+{
+  "records": [
+    {
+      "time": "2026-04-07T16:06:21.6250810Z",
+      "EventTime": "2026-04-07T16:06:21.6250810Z",
+      "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/AZURE-RESOURCE-GROUP-NAME/PROVIDERS/MICROSOFT.WEB/SITES/AZURE-APP-SERVICE-NAME1",
+      "properties": "{\"CsHost\":\"host.domain.com\",\"CIp\":\"000.00.00.000\",\"SPort\":\"80\",\"CsUriStem\":\"\\/connect\\/token\",\"CsUriQuery\":\"\",\"CsMethod\":\"POST\",\"TimeTaken\":5,\"ScStatus\":\"200\",\"Result\":\"Success\",\"CsBytes\":\"1839\",\"ScBytes\":\"1330\",\"UserAgent\":\"\",\"Cookie\":\"<REDACTED>\",\"CsUsername\":\"\",\"Referer\":\"\",\"ComputerName\":\"hostname\",\"Protocol\":\"HTTP\\/1.1\"}",
+      "category": "AppServiceHTTPLogs",
+      "EventStampType": "Stamp",
+      "EventPrimaryStampName": "waws-prod-bn0-000",
+      "EventStampName": "waws-prod-bn0-000",
+      "Host": "hostname",
+      "EventIpAddress": "00.00.00.000"
+    }
+  ]
+}

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/appservice/http-log-string-properties_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/appservice/http-log-string-properties_expected.yaml
@@ -1,0 +1,58 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: azure
+        - key: cloudevents.event_source
+          value:
+            stringValue: azure.resource.log
+        - key: cloud.resource_id
+          value:
+            stringValue: /SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/AZURE-RESOURCE-GROUP-NAME/PROVIDERS/MICROSOFT.WEB/SITES/AZURE-APP-SERVICE-NAME1
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: azure.category
+                value:
+                  stringValue: AppServiceHTTPLogs
+              - key: client.address
+                value:
+                  stringValue: 000.00.00.000
+              - key: server.address
+                value:
+                  stringValue: hostname
+              - key: server.port
+                value:
+                  intValue: "80"
+              - key: http.request.size
+                value:
+                  intValue: "1839"
+              - key: http.request.header.host
+                value:
+                  stringValue: host.domain.com
+              - key: http.request.method
+                value:
+                  stringValue: POST
+              - key: url.path
+                value:
+                  stringValue: /connect/token
+              - key: http.response.size
+                value:
+                  intValue: "1330"
+              - key: http.response.status_code
+                value:
+                  intValue: "200"
+              - key: azure.request.duration
+                value:
+                  doubleValue: 5
+            body:
+              stringValue: Success
+            timeUnixNano: "1775577981625081000"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.appservice
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
+          version: test-version

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/functionapp/function-app-log-string-properties.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/functionapp/function-app-log-string-properties.json
@@ -1,0 +1,18 @@
+{
+  "records": [
+    {
+      "category": "FunctionAppLogs",
+      "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/AZURE-RESOURCE-GROUP-NAME/PROVIDERS/MICROSOFT.WEB/SITES/AZURE-FUNCTION-APP-NAME1",
+      "level": "Informational",
+      "operationName": "Microsoft.Web/sites/functions/log",
+      "properties": "{'appName':'AZURE-FUNCTION-APP-NAME1','roleInstance':'d00e000e00c000c0000000000b0c00000000000cca00d0dc0d0a0fb00cba00f','message':'conversation_twilio_queue-00000000-0000-0000-0000-000000000000-Receiver:ReceiveBatchAsyncstart.MessageCount=1','category':'Azure.Messaging.ServiceBus','hostVersion':'4.1047.100.3','hostInstanceId':'00000000-0000-0000-0000-000000000000','level':'Information','levelId':2,'processId':9,'eventId':7,'eventName':'ReceiveMessageStart'}",
+      "location": "eastus2",
+      "time": "2026-04-07T16:06:56Z",
+      "EventStampType": "Stamp",
+      "EventPrimaryStampName": "waws-prod-bn0-000",
+      "EventStampName": "waws-prod-bn0-000",
+      "Host": "hostname",
+      "EventIpAddress": "00.00.0.000"
+    }
+  ]
+}

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/functionapp/function-app-log-string-properties_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/functionapp/function-app-log-string-properties_expected.yaml
@@ -1,0 +1,63 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: azure
+        - key: cloudevents.event_source
+          value:
+            stringValue: azure.resource.log
+        - key: cloud.resource_id
+          value:
+            stringValue: /SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/AZURE-RESOURCE-GROUP-NAME/PROVIDERS/MICROSOFT.WEB/SITES/AZURE-FUNCTION-APP-NAME1
+        - key: cloud.region
+          value:
+            stringValue: eastus2
+        - key: service.name
+          value:
+            stringValue: AZURE-FUNCTION-APP-NAME1
+        - key: service.instance.id
+          value:
+            stringValue: d00e000e00c000c0000000000b0c00000000000cca00d0dc0d0a0fb00cba00f
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: azure.category
+                value:
+                  stringValue: FunctionAppLogs
+              - key: azure.operation.name
+                value:
+                  stringValue: Microsoft.Web/sites/functions/log
+              - key: faas.invoked_provider
+                value:
+                  stringValue: azure
+              - key: azure.event.name
+                value:
+                  stringValue: ReceiveMessageStart
+              - key: azure.event.id
+                value:
+                  intValue: "7"
+              - key: faas.name
+                value:
+                  stringValue: AZURE-FUNCTION-APP-NAME1/
+              - key: host.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000000
+              - key: host.image.version
+                value:
+                  stringValue: 4.1047.100.3
+              - key: process.pid
+                value:
+                  intValue: "9"
+            body:
+              stringValue: conversation_twilio_queue-00000000-0000-0000-0000-000000000000-Receiver:ReceiveBatchAsyncstart.MessageCount=1
+            severityNumber: 9
+            severityText: Informational
+            timeUnixNano: "1775578016000000000"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.function_app
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
+          version: test-version


### PR DESCRIPTION
## Summary

- Fix `AppServiceHTTPLogs` parsing failure when `properties` is a JSON string instead of a JSON object (common when logs are routed via Azure Event Hub)
- Add reusable `unmarshalStringOrObjectJSON` helper for detecting and unquoting string-wrapped JSON before unmarshaling
- Add golden test fixtures for both `AppServiceHTTPLogs` and `FunctionAppLogs` with string-encoded properties from real Event Hub samples

## Context

Some Azure Event Hub sources emit the `properties` field as a stringified JSON string (`"properties": "{\"key\":\"value\"}"`) instead of a JSON object (`"properties": {"key":"value"}`). This caused the `AppServiceHTTPLogs` unmarshaler to fail with `readObjectStart: expect { or n, but found "`, falling back to raw log storage and losing all semantic attributes.

`FunctionAppLogs` already handled this case via its existing custom `UnmarshalJSON` with `convertInvalidSingleQuotedJSON`, so only a test fixture was added for that category.

## Test plan

- [x] Existing golden tests pass (no regressions across all 30+ Azure log categories)
- [x] New `appservice/http-log-string-properties` golden test passes
- [x] New `functionapp/function-app-log-string-properties` golden test passes
- [x] Full extension test suite passes (`go test ./...`)