### PR TITLE
[chore]: (processor/transformprocessor) finish migrating feature gate to metadata.yaml and remove linting rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -205,9 +205,6 @@ linters:
         path: processor/tailsamplingprocessor/
       - linters:
           - forbidigo
-        path: processor/transformprocessor/
-      - linters:
-          - forbidigo
         path: receiver/awscontainerinsightreceiver/
       - linters:
           - forbidigo

--- a/processor/transformprocessor/documentation.md
+++ b/processor/transformprocessor/documentation.md
@@ -8,6 +8,7 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
+| `processor.transform.defaultErrorModeIgnore` | alpha | Changes the default error_mode of the transform processor from propagate to ignore | v0.150.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231) |
 | `transform.flatten.logs` | alpha | Flatten log data prior to transformation so every record has a unique copy of the resource and scope. Regroups logs based on resource and scope after transformations. | v0.103.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32080#issuecomment-2120764953) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/xconsumer"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper"
@@ -33,16 +32,6 @@ import (
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
-
-const defaultErrorModeIgnoreGateID = "processor.transform.defaultErrorModeIgnore"
-
-var defaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	defaultErrorModeIgnoreGateID,
-	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("Changes the default error_mode of the transform processor from propagate to ignore"),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231"),
-	featuregate.WithRegisterFromVersion("v0.150.0"),
-)
 
 type transformProcessorFactory struct {
 	dataPointFunctions                  map[string]ottl.Factory[*ottldatapoint.TransformContext]
@@ -218,7 +207,7 @@ func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 
 func (f *transformProcessorFactory) createDefaultConfig() component.Config {
 	defaultErrorMode := ottl.PropagateError
-	if defaultErrorModeIgnoreFeatureGate.IsEnabled() {
+	if metadata.ProcessorTransformDefaultErrorModeIgnoreFeatureGate.IsEnabled() {
 		defaultErrorMode = ottl.IgnoreError
 	}
 	return &Config{

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -62,7 +62,7 @@ func TestFactory_Type(t *testing.T) {
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
 	t.Cleanup(func() {
-		_ = featuregate.GlobalRegistry().Set(defaultErrorModeIgnoreGateID, false)
+		_ = featuregate.GlobalRegistry().Set(metadata.ProcessorTransformDefaultErrorModeIgnoreFeatureGate.ID(), false)
 	})
 
 	factory := NewFactory()
@@ -77,7 +77,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
 	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 
-	err := featuregate.GlobalRegistry().Set(defaultErrorModeIgnoreGateID, true)
+	err := featuregate.GlobalRegistry().Set(metadata.ProcessorTransformDefaultErrorModeIgnoreFeatureGate.ID(), true)
 	require.NoError(t, err)
 
 	cfg = factory.CreateDefaultConfig()

--- a/processor/transformprocessor/generated_package_test.go
+++ b/processor/transformprocessor/generated_package_test.go
@@ -3,8 +3,9 @@
 package transformprocessor
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/transformprocessor/generated_package_test.go
+++ b/processor/transformprocessor/generated_package_test.go
@@ -3,9 +3,8 @@
 package transformprocessor
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/transformprocessor/internal/metadata/generated_feature_gates.go
+++ b/processor/transformprocessor/internal/metadata/generated_feature_gates.go
@@ -6,6 +6,14 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 )
 
+var ProcessorTransformDefaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"processor.transform.defaultErrorModeIgnore",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Changes the default error_mode of the transform processor from propagate to ignore"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231"),
+	featuregate.WithRegisterFromVersion("v0.150.0"),
+)
+
 var TransformFlattenLogsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"transform.flatten.logs",
 	featuregate.StageAlpha,

--- a/processor/transformprocessor/metadata.yaml
+++ b/processor/transformprocessor/metadata.yaml
@@ -14,11 +14,17 @@ status:
     seeking_new: true
 
 feature_gates:
+  - id: "processor.transform.defaultErrorModeIgnore"
+    description: Changes the default error_mode of the transform processor from propagate to ignore
+    stage: alpha
+    from_version: v0.150.0
+    reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231
+
   - id: "transform.flatten.logs"
     description: Flatten log data prior to transformation so every record has a unique copy of the resource and scope. Regroups logs based on resource and scope after transformations.
     stage: alpha
     from_version: v0.103.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32080#issuecomment-2120764953
-
+    
 tests:
   config:


### PR DESCRIPTION
#### Description
* Migrates last feature gate (``) for `processor/transformprocessor` to metadata.yaml
* Updates factory test to use new metadata feature gate ID
* Enables forbidigo linting rule for `processor/transformprocessor` (rule forbids manual creation of feature gates)

#### Link to tracking issue
Part of #46116 
Follow-up for #47371 and #47506

#### Testing
`make lint` and `make test` pass.