### PR TITLE
[receiver/googlecloudpubsubreceiver] Fix flaky TestReceiver

### DIFF
--- a/receiver/googlecloudpubsubreceiver/receiver_test.go
+++ b/receiver/googlecloudpubsubreceiver/receiver_test.go
@@ -179,8 +179,6 @@ func TestReceiver(t *testing.T) {
 	// no locks should be kept though
 	assert.NoError(t, receiver.Start(ctx, fakeHost{}))
 
-	time.Sleep(1 * time.Second)
-
 	// Test an OTLP trace message
 	traceSink.Reset()
 	srv.Publish("projects/my-project/topics/otlp", createTraceExport(), map[string]string{
@@ -189,7 +187,7 @@ func TestReceiver(t *testing.T) {
 	})
 	assert.Eventually(t, func() bool {
 		return len(traceSink.AllTraces()) == 1
-	}, 100*time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
 	// Test an OTLP metric message
 	metricSink.Reset()
@@ -199,7 +197,7 @@ func TestReceiver(t *testing.T) {
 	})
 	assert.Eventually(t, func() bool {
 		return len(metricSink.AllMetrics()) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
 	// Test an OTLP log message
 	logSink.Reset()
@@ -209,7 +207,7 @@ func TestReceiver(t *testing.T) {
 	})
 	assert.Eventually(t, func() bool {
 		return len(logSink.AllLogs()) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, receiver.Shutdown(ctx))
 	assert.NoError(t, receiver.Shutdown(ctx))
@@ -407,5 +405,5 @@ func TestEncodingWithCompressionConfig(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return len(traceSink.AllTraces()) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
Stabilize TestReceiver by replacing an unreliable 1s fixed sleep with proper assert. Eventually polling. 
The test was flaking in CI when async stream startup took longer than 1s, causing published messages to be missed.

The change also:
normalizes all Eventually timeouts in the file to 10s for consistency across signal types.
Fixes #47541