### PR TITLE
[chore] Bump load test memory limits

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -160,13 +160,13 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 		{
 			Name:                "NoMemoryLimit",
 			Processor:           noLimitProcessors,
-			ExpectedMaxRAM:      100,
+			ExpectedMaxRAM:      110,
 			ExpectedMinFinalRAM: 80,
 		},
 		{
 			Name:                "MemoryLimit",
 			Processor:           limitProcessors,
-			ExpectedMaxRAM:      100,
+			ExpectedMaxRAM:      110,
 			ExpectedMinFinalRAM: 50,
 		},
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The `TestTraceNoBackend10kSPS` test have been failing intermittently.
Bumping the memory up to help tests pass more consistently.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47561
