### PR TITLE
fix(exporter/awsxray): use local service name for Consumer local root segments

### DIFF
--- a/.chloggen/47568.yaml
+++ b/.chloggen/47568.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: exporter/awsxray
+
+note: Use local service name for Consumer local root segment names, falling back to resource service name when aws.local.service is absent.
+
+issues: [43432]
+
+subtext: |
+  Consumer spans promoted to X-Ray Segments after #42633 were named
+  using the span (operation) name instead of the local service name.
+  The fix mirrors the existing Server span naming behavior.
+
+change_logs: [user]

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -186,9 +186,11 @@ func MakeServiceSegmentForLocalRootDependencySpan(span ptrace.Span, resource pco
 		return nil, err
 	}
 
-	// Set the name
+	// Set the name: prefer aws.local.service, fall back to resource service name (mirrors Server span behavior).
 	if myAwsLocalService, ok := span.Attributes().Get(awsLocalService); ok {
 		serviceSegment.Name = awsxray.String(myAwsLocalService.Str())
+	} else if resourceServiceName, ok := resource.Attributes().Get(string(conventionsv112.ServiceNameKey)); ok {
+		serviceSegment.Name = awsxray.String(resourceServiceName.Str())
 	}
 
 	// Remove the HTTP field
@@ -358,7 +360,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 	// X-Ray segment names are service names, unlike span names which are methods. Try to find a service name.
 
 	// support x-ray specific service name attributes as segment name if it exists
-	if span.Kind() == ptrace.SpanKindServer || (span.Kind() == ptrace.SpanKindConsumer && isLocalRoot(span)) {
+	if span.Kind() == ptrace.SpanKindServer {
 		if localServiceName, ok := attributes.Get(awsLocalService); ok {
 			name = localServiceName.Str()
 		}
@@ -422,8 +424,8 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		}
 	}
 
-	if name == "" && (span.Kind() == ptrace.SpanKindServer || (span.Kind() == ptrace.SpanKindConsumer && isLocalRoot(span))) {
-		// For server spans and local root consumer spans, fall back to the resource service name.
+	if name == "" && span.Kind() == ptrace.SpanKindServer {
+		// Only for a server span, we can use the resource.
 		if service, ok := resource.Attributes().Get(string(conventionsv112.ServiceNameKey)); ok {
 			name = service.Str()
 		}

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -358,7 +358,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 	// X-Ray segment names are service names, unlike span names which are methods. Try to find a service name.
 
 	// support x-ray specific service name attributes as segment name if it exists
-	if span.Kind() == ptrace.SpanKindServer {
+	if span.Kind() == ptrace.SpanKindServer || (span.Kind() == ptrace.SpanKindConsumer && isLocalRoot(span)) {
 		if localServiceName, ok := attributes.Get(awsLocalService); ok {
 			name = localServiceName.Str()
 		}
@@ -422,8 +422,8 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		}
 	}
 
-	if name == "" && span.Kind() == ptrace.SpanKindServer {
-		// Only for a server span, we can use the resource.
+	if name == "" && (span.Kind() == ptrace.SpanKindServer || (span.Kind() == ptrace.SpanKindConsumer && isLocalRoot(span))) {
+		// For server spans and local root consumer spans, fall back to the resource service name.
 		if service, ok := resource.Attributes().Get(string(conventionsv112.ServiceNameKey)); ok {
 			name = service.Str()
 		}

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1450,6 +1450,35 @@ func TestLocalRootConsumer(t *testing.T) {
 	assert.Equal(t, expectedEndTime, *segments[1].EndTime)
 }
 
+// TestLocalRootConsumerUsesResourceServiceName verifies that when a local root
+// Consumer span does not carry the aws.local.service attribute, the X-Ray
+// service segment falls back to resource.service.name rather than using the
+// span (operation) name.
+func TestLocalRootConsumerUsesResourceServiceName(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	assert.NoError(t, err)
+
+	spanName := "destination operation"
+	resource := getBasicResource() // has service.name = "signup_aggregator"
+	parentSpanID := newSegmentID()
+
+	attributes := getBasicAttributes()
+	delete(attributes, awsLocalService) // remove aws.local.service to trigger fallback
+
+	span := constructConsumerSpan(parentSpanID, spanName, 200, "OK", attributes)
+
+	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
+
+	assert.NotNil(t, segments)
+	assert.Len(t, segments, 2)
+	assert.NoError(t, err)
+
+	serviceSegment := segments[1]
+	// Service segment must use the resource service name, not the span (operation) name.
+	assert.Equal(t, "signup_aggregator", *serviceSegment.Name)
+	assert.Nil(t, serviceSegment.Type)
+}
+
 func TestNonLocalRootConsumerProcess(t *testing.T) {
 	spanName := "destination operation"
 	resource := getBasicResource()


### PR DESCRIPTION
## Description

Fixes #43432.

After PR #42633, Consumer spans that are local roots are promoted to X-Ray **Segments** (rather than just subsegments). However, the segment naming logic in `MakeSegment` still treated Consumer spans like dependency spans (using `aws.remote.service` / operation name), while Server segments already used `aws.local.service` / `resource.service.name`.

### Root cause

Two gaps in `MakeSegment` (both in `segment.go`):

1. **`aws.local.service` check (line 361)** — only guarded by `SpanKindServer`, so Consumer local root spans never used this attribute for naming.
2. **`resource.service.name` fallback (line 425)** — also only for `SpanKindServer`, so Consumer local root spans fell through to the span (operation) name.

### Fix

Extend both checks to also cover `SpanKindConsumer && isLocalRoot(span)`:

```go
// Before
if span.Kind() == ptrace.SpanKindServer {

// After  
if span.Kind() == ptrace.SpanKindServer || (span.Kind() == ptrace.SpanKindConsumer && isLocalRoot(span)) {
```

The dependency **subsegment** produced alongside the service segment is unaffected: `MakeDependencySubsegmentForLocalRootDependencySpan` explicitly overrides the name to `aws.remote.service` after calling `MakeSegment`, so the subsegment name remains correct.

### Tests

- Existing `TestLocalRootConsumer` and `TestLocalRootConsumerAWSNamespace` continue to pass.
- New `TestLocalRootConsumerUsesResourceServiceName`: Consumer local root span **without** `aws.local.service` attribute — service segment name must be `resource.service.name` (`"signup_aggregator"`), not the operation name (`"destination operation"`).

## Checklist

- [x] Tests added
- [x] Existing tests pass
- [x] `Fixes #43432` linked