### PR TITLE
[chore] Add linter rule to forbid direct usage of `net/http.Server`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -364,7 +364,7 @@ linters:
           msg: >-
             Define feature gates in metadata.yaml instead of registering them manually.
             See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46116.
-        - pattern: ^http\.(Server|ListenAndServe|ListenAndServeTLS|Serve|ServeTLS)$
+        - pattern: ^http\.(ListenAndServe|ListenAndServeTLS|Serve|ServeTLS)$
           msg: >-
             Use confighttp.ServerConfig to create HTTP servers instead of net/http directly.
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,6 +222,42 @@ linters:
           - forbidigo
         path: receiver/vcenterreceiver/
 
+      # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47586
+      - linters:
+          - forbidigo
+        path: receiver/cloudflarereceiver/
+        text: confighttp
+      - linters:
+          - forbidigo
+        path: receiver/mongodbatlasreceiver/
+        text: confighttp
+      - linters:
+          - forbidigo
+        path: internal/aws/proxy/
+        text: confighttp
+      - linters:
+          - forbidigo
+        path: extension/datadogextension/
+        text: confighttp
+      - linters:
+          - forbidigo
+        path: testbed/
+        text: confighttp
+
+      # Exclude tests and examples from the confighttp rule.
+      - linters:
+          - forbidigo
+        path: _test\.go
+        text: confighttp
+      - linters:
+          - forbidigo
+        path: examples/
+        text: confighttp
+      - linters:
+          - forbidigo
+        path: testdata/
+        text: confighttp
+
     # Log a warning if an exclusion rule is unused.
     warn-unused: true
 
@@ -328,6 +364,9 @@ linters:
           msg: >-
             Define feature gates in metadata.yaml instead of registering them manually.
             See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46116.
+        - pattern: ^http\.(Server|ListenAndServe|ListenAndServeTLS|Serve|ServeTLS)$
+          msg: >-
+            Use confighttp.ServerConfig to create HTTP servers instead of net/http directly.
 
     exhaustive:
       # Presence of "default" case in switch statements satisfies exhaustiveness,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Forbid direct usage of `net/http` to create servers, nudging to use `confighttp` instead.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Updates #47586