### PR TITLE
feat: add Proxy Protocol v2 support to tcplog, udplog, and syslog rec…

### DIFF
--- a/pkg/stanza/operator/input/syslog/config_test.go
+++ b/pkg/stanza/operator/input/syslog/config_test.go
@@ -67,6 +67,32 @@ func TestUnmarshal(t *testing.T) {
 					return cfg
 				}(),
 			},
+			{
+				Name:               "tcp_with_proxy_protocol",
+				ExpectUnmarshalErr: false,
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Protocol = "rfc5424"
+					cfg.TCP = &tcp.BaseConfig{
+						ListenAddress: "10.0.0.1:9000",
+						ProxyProtocol: true,
+					}
+					return cfg
+				}(),
+			},
+			{
+				Name:               "udp_with_proxy_protocol",
+				ExpectUnmarshalErr: false,
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Protocol = "rfc5424"
+					cfg.UDP = &udp.BaseConfig{
+						ListenAddress: "10.0.0.1:9000",
+						ProxyProtocol: true,
+					}
+					return cfg
+				}(),
+			},
 		},
 	}.Run(t)
 }

--- a/pkg/stanza/operator/input/syslog/testdata/config.yaml
+++ b/pkg/stanza/operator/input/syslog/testdata/config.yaml
@@ -29,3 +29,15 @@ udp:
     multiline:
       line_start_pattern: ABC
       line_end_pattern: ""
+tcp_with_proxy_protocol:
+  type: syslog_input
+  protocol: rfc5424
+  tcp:
+    listen_address: 10.0.0.1:9000
+    proxy_protocol: true
+udp_with_proxy_protocol:
+  type: syslog_input
+  protocol: rfc5424
+  udp:
+    listen_address: 10.0.0.1:9000
+    proxy_protocol: true

--- a/pkg/stanza/operator/input/tcp/config.go
+++ b/pkg/stanza/operator/input/tcp/config.go
@@ -63,15 +63,19 @@ type Config struct {
 
 // BaseConfig is the detailed configuration of a tcp input operator.
 type BaseConfig struct {
-	MaxLogSize       helper.ByteSize         `mapstructure:"max_log_size,omitempty"`
-	ListenAddress    string                  `mapstructure:"listen_address,omitempty"`
-	TLS              *configtls.ServerConfig `mapstructure:"tls,omitempty"`
-	AddAttributes    bool                    `mapstructure:"add_attributes,omitempty"`
-	OneLogPerPacket  bool                    `mapstructure:"one_log_per_packet,omitempty"`
-	Encoding         string                  `mapstructure:"encoding,omitempty"`
-	SplitConfig      split.Config            `mapstructure:"multiline,omitempty"`
-	TrimConfig       trim.Config             `mapstructure:",squash"`
-	SplitFuncBuilder SplitFuncBuilder        `mapstructure:"-"`
+	MaxLogSize      helper.ByteSize         `mapstructure:"max_log_size,omitempty"`
+	ListenAddress   string                  `mapstructure:"listen_address,omitempty"`
+	TLS             *configtls.ServerConfig `mapstructure:"tls,omitempty"`
+	AddAttributes   bool                    `mapstructure:"add_attributes,omitempty"`
+	OneLogPerPacket bool                    `mapstructure:"one_log_per_packet,omitempty"`
+	Encoding        string                  `mapstructure:"encoding,omitempty"`
+	SplitConfig     split.Config            `mapstructure:"multiline,omitempty"`
+	TrimConfig      trim.Config             `mapstructure:",squash"`
+	// ProxyProtocol enables Proxy Protocol version 2 support. When true, the
+	// receiver expects each incoming connection to begin with a PPv2 header and
+	// uses the source address it carries instead of the raw TCP remote address.
+	ProxyProtocol    bool             `mapstructure:"proxy_protocol,omitempty"`
+	SplitFuncBuilder SplitFuncBuilder `mapstructure:"-"`
 }
 
 type SplitFuncBuilder func(enc encoding.Encoding) (bufio.SplitFunc, error)
@@ -132,6 +136,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		MaxLogSize:      int(c.MaxLogSize),
 		addAttributes:   c.AddAttributes,
 		OneLogPerPacket: c.OneLogPerPacket,
+		proxyProtocol:   c.ProxyProtocol,
 		encoding:        enc,
 		splitFunc:       splitFunc,
 		backoff: backoff.Backoff{

--- a/pkg/stanza/operator/input/tcp/config.schema.yaml
+++ b/pkg/stanza/operator/input/tcp/config.schema.yaml
@@ -15,6 +15,12 @@ $defs:
         $ref: /pkg/stanza/split.config
       one_log_per_packet:
         type: boolean
+      proxy_protocol:
+        description: >-
+          When true, each incoming TCP connection is expected to begin with a
+          Proxy Protocol v2 header. The receiver uses the source address carried
+          in that header instead of the raw TCP remote address.
+        type: boolean
       tls:
         x-pointer: true
         $ref: go.opentelemetry.io/collector/config/configtls.server_config

--- a/pkg/stanza/operator/input/tcp/config_test.go
+++ b/pkg/stanza/operator/input/tcp/config_test.go
@@ -43,6 +43,16 @@ func TestUnmarshal(t *testing.T) {
 					return cfg
 				}(),
 			},
+			{
+				Name:               "proxy_protocol",
+				ExpectUnmarshalErr: false,
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.ListenAddress = "10.0.0.1:9000"
+					cfg.ProxyProtocol = true
+					return cfg
+				}(),
+			},
 		},
-	}.Run(t)
+}.Run(t)
 }

--- a/pkg/stanza/operator/input/tcp/input.go
+++ b/pkg/stanza/operator/input/tcp/input.go
@@ -32,6 +32,7 @@ type Input struct {
 	MaxLogSize      int
 	addAttributes   bool
 	OneLogPerPacket bool
+	proxyProtocol   bool
 
 	listener net.Listener
 	cancel   context.CancelFunc
@@ -119,6 +120,21 @@ func (i *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 	i.wg.Go(func() {
 		defer cancel()
 
+		// remoteAddr is the address we attribute log entries to. When proxy
+		// protocol v2 is enabled, we replace it with the address from the header.
+		remoteAddr := conn.RemoteAddr()
+
+		if i.proxyProtocol {
+			addr, err := parseProxyProtocolV2Header(conn)
+			if err != nil {
+				i.Logger().Error("Failed to parse proxy protocol v2 header", zap.Error(err))
+				return
+			}
+			if addr != nil {
+				remoteAddr = addr
+			}
+		}
+
 		dec := i.encoding.NewDecoder()
 		if i.OneLogPerPacket {
 			var buf bytes.Buffer
@@ -127,7 +143,7 @@ func (i *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 				i.Logger().Error("IO copy net connection buffer error", zap.Error(err))
 			}
 			log := truncateMaxLog(buf.Bytes(), i.MaxLogSize)
-			i.handleMessage(ctx, conn, dec, log)
+			i.handleMessage(ctx, conn, remoteAddr, dec, log)
 			return
 		}
 
@@ -139,7 +155,7 @@ func (i *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 		scanner.Split(i.splitFunc)
 
 		for scanner.Scan() {
-			i.handleMessage(ctx, conn, dec, scanner.Bytes())
+			i.handleMessage(ctx, conn, remoteAddr, dec, scanner.Bytes())
 		}
 
 		if err := scanner.Err(); err != nil {
@@ -148,7 +164,7 @@ func (i *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 	})
 }
 
-func (i *Input) handleMessage(ctx context.Context, conn net.Conn, dec *encoding.Decoder, log []byte) {
+func (i *Input) handleMessage(ctx context.Context, conn net.Conn, remoteAddr net.Addr, dec *encoding.Decoder, log []byte) {
 	decoded, err := textutils.DecodeAsString(dec, log)
 	if err != nil {
 		i.Logger().Error("Failed to decode data", zap.Error(err))
@@ -163,7 +179,7 @@ func (i *Input) handleMessage(ctx context.Context, conn net.Conn, dec *encoding.
 
 	if i.addAttributes {
 		entry.AddAttribute("net.transport", "IP.TCP")
-		if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		if addr, ok := remoteAddr.(*net.TCPAddr); ok {
 			ip := addr.IP.String()
 			entry.AddAttribute("net.peer.ip", ip)
 			entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))

--- a/pkg/stanza/operator/input/tcp/input_test.go
+++ b/pkg/stanza/operator/input/tcp/input_test.go
@@ -375,6 +375,113 @@ func TestTLSTCPInput(t *testing.T) {
 	t.Run("CarriageReturn", tlsInputTest([]byte("message\r\n"), []string{"message"}))
 }
 
+func TestProxyProtocolV2Input(t *testing.T) {
+	t.Run("IPv4", proxyProtocolInputTest(false))
+	t.Run("IPv4WithAttributes", proxyProtocolInputTest(true))
+}
+
+// proxyProtocolInputTest sends a PPv2 header (with a spoofed source IPv4 address)
+// followed by a log line and verifies that the entry uses the proxied address.
+func proxyProtocolInputTest(addAttributes bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewConfigWithID("test_id")
+		cfg.ListenAddress = ":0"
+		cfg.ProxyProtocol = true
+		cfg.AddAttributes = addAttributes
+
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		mockOutput := testutil.Operator{}
+		tcpInput := op.(*Input)
+		tcpInput.OutputOperators = []operator.Operator{&mockOutput}
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, tcpInput.Stop(), "expected to stop tcp input operator without error")
+		}()
+
+		conn, err := net.Dial("tcp", tcpInput.listener.Addr().String())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Build a PPv2 header claiming the connection comes from 1.2.3.4:5678.
+		proxiedSrcIP := net.ParseIP("1.2.3.4").To4()
+		proxiedDstIP := net.ParseIP("127.0.0.1").To4()
+		addrBlock := buildIPv4AddrBlock(proxiedSrcIP, proxiedDstIP, 5678, 9000)
+		header := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, addrBlock)
+
+		_, err = conn.Write(header)
+		require.NoError(t, err)
+		_, err = conn.Write([]byte("proxied message\n"))
+		require.NoError(t, err)
+
+		select {
+		case e := <-entryChan:
+			require.Equal(t, "proxied message", e.Body)
+			if addAttributes {
+				// The peer address must reflect the proxied source, not the raw TCP client.
+				require.Equal(t, "1.2.3.4", e.Attributes["net.peer.ip"])
+				require.Equal(t, "5678", e.Attributes["net.peer.port"])
+			}
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "Timed out waiting for proxied message")
+		}
+	}
+}
+
+func TestProxyProtocolV2LocalCommand(t *testing.T) {
+	// LOCAL command (health-check): the connection should fall back to the
+	// actual TCP remote address and the log body should still be received.
+	cfg := NewConfigWithID("test_id")
+	cfg.ListenAddress = ":0"
+	cfg.ProxyProtocol = true
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	mockOutput := testutil.Operator{}
+	tcpInput := op.(*Input)
+	tcpInput.OutputOperators = []operator.Operator{&mockOutput}
+
+	entryChan := make(chan *entry.Entry, 1)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		entryChan <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tcpInput.Stop())
+	}()
+
+	conn, err := net.Dial("tcp", tcpInput.listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// LOCAL command with UNSPEC family and empty address block.
+	header := buildPPv2Header(ppV2CmdLocal, ppV2FamilyUnspec, nil)
+	_, err = conn.Write(header)
+	require.NoError(t, err)
+	_, err = conn.Write([]byte("local message\n"))
+	require.NoError(t, err)
+
+	select {
+	case e := <-entryChan:
+		require.Equal(t, "local message", e.Body)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Timed out waiting for local-command message")
+	}
+}
+
 func TestFailToBind(t *testing.T) {
 	ip := "localhost"
 	port := 0

--- a/pkg/stanza/operator/input/tcp/proxy_protocol.go
+++ b/pkg/stanza/operator/input/tcp/proxy_protocol.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tcp // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+)
+
+// proxyProtocolV2Signature is the fixed 12-byte signature that every PPv2 header starts with.
+var proxyProtocolV2Signature = []byte{
+	0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
+}
+
+const (
+	proxyProtocolV2HeaderLen = 16
+
+	ppV2CmdLocal = 0x00
+	ppV2CmdProxy = 0x01
+
+	ppV2FamilyUnspec = 0x00
+	ppV2FamilyIPv4   = 0x10
+	ppV2FamilyIPv6   = 0x20
+	ppV2FamilyUnix   = 0x30
+
+	ppV2AddrLenIPv4 = 12
+	ppV2AddrLenIPv6 = 36
+)
+
+// parseProxyProtocolV2Header reads and parses a Proxy Protocol v2 header from r.
+// It returns the source address reported by the proxy, or nil when the command is
+// LOCAL or the address family is UNSPEC/UNIX (callers should fall back to the
+// actual connection remote address in those cases).
+//
+// Spec: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt §2.2
+func parseProxyProtocolV2Header(r io.Reader) (net.Addr, error) {
+	header := make([]byte, proxyProtocolV2HeaderLen)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, fmt.Errorf("reading proxy protocol v2 header: %w", err)
+	}
+
+	// Validate the 12-byte signature.
+	for i, b := range proxyProtocolV2Signature {
+		if header[i] != b {
+			return nil, fmt.Errorf("invalid proxy protocol v2 signature at byte %d: got 0x%02X, want 0x%02X", i, header[i], b)
+		}
+	}
+
+	// Byte 12: high nibble = version, low nibble = command.
+	verCmd := header[12]
+	if verCmd>>4 != 0x2 {
+		return nil, fmt.Errorf("unsupported proxy protocol version %d, only version 2 is supported", verCmd>>4)
+	}
+	cmd := verCmd & 0x0F
+
+	// Byte 13: high nibble = address family, low nibble = transport protocol.
+	family := header[13] & 0xF0
+
+	// Bytes 14-15: length (big-endian) of the address block that follows.
+	addrLen := binary.BigEndian.Uint16(header[14:16])
+
+	// Consume the address block regardless of whether we use it, so the reader
+	// is positioned at the start of the actual payload.
+	addrBlock := make([]byte, addrLen)
+	if addrLen > 0 {
+		if _, err := io.ReadFull(r, addrBlock); err != nil {
+			return nil, fmt.Errorf("reading proxy protocol v2 address block: %w", err)
+		}
+	}
+
+	// LOCAL command is used for health checks — no proxied address.
+	if cmd == ppV2CmdLocal {
+		return nil, nil
+	}
+
+	if cmd != ppV2CmdProxy {
+		return nil, fmt.Errorf("unsupported proxy protocol v2 command: 0x%02X", cmd)
+	}
+
+	switch family {
+	case ppV2FamilyIPv4:
+		if int(addrLen) < ppV2AddrLenIPv4 {
+			return nil, fmt.Errorf("proxy protocol v2 IPv4 address block too short: got %d bytes, need %d", addrLen, ppV2AddrLenIPv4)
+		}
+		srcIP := make(net.IP, 4)
+		copy(srcIP, addrBlock[0:4])
+		srcPort := binary.BigEndian.Uint16(addrBlock[8:10])
+		return &net.TCPAddr{IP: srcIP, Port: int(srcPort)}, nil
+
+	case ppV2FamilyIPv6:
+		if int(addrLen) < ppV2AddrLenIPv6 {
+			return nil, fmt.Errorf("proxy protocol v2 IPv6 address block too short: got %d bytes, need %d", addrLen, ppV2AddrLenIPv6)
+		}
+		srcIP := make(net.IP, 16)
+		copy(srcIP, addrBlock[0:16])
+		srcPort := binary.BigEndian.Uint16(addrBlock[32:34])
+		return &net.TCPAddr{IP: srcIP, Port: int(srcPort)}, nil
+
+	default:
+		// UNSPEC and UNIX families carry no usable IP address — fall back to
+		// the actual connection remote address.
+		return nil, nil
+	}
+}

--- a/pkg/stanza/operator/input/tcp/proxy_protocol_test.go
+++ b/pkg/stanza/operator/input/tcp/proxy_protocol_test.go
@@ -1,0 +1,165 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tcp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildPPv2Header builds a minimal Proxy Protocol v2 binary header.
+// family: e.g. ppV2FamilyIPv4 (0x10), ppV2FamilyIPv6 (0x20), ppV2FamilyUnspec (0x00)
+// cmd:    ppV2CmdProxy (0x01) or ppV2CmdLocal (0x00)
+// addr:   the address block bytes (may be nil)
+func buildPPv2Header(cmd, family byte, addr []byte) []byte {
+	var buf bytes.Buffer
+	buf.Write(proxyProtocolV2Signature)
+	buf.WriteByte(0x20 | cmd)    // version 2, command
+	buf.WriteByte(family | 0x01) // family, STREAM transport
+	addrLen := uint16(len(addr))
+	_ = binary.Write(&buf, binary.BigEndian, addrLen)
+	buf.Write(addr)
+	return buf.Bytes()
+}
+
+func buildIPv4AddrBlock(srcIP net.IP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	block := make([]byte, ppV2AddrLenIPv4)
+	copy(block[0:4], srcIP.To4())
+	copy(block[4:8], dstIP.To4())
+	binary.BigEndian.PutUint16(block[8:10], srcPort)
+	binary.BigEndian.PutUint16(block[10:12], dstPort)
+	return block
+}
+
+func buildIPv6AddrBlock(srcIP net.IP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	block := make([]byte, ppV2AddrLenIPv6)
+	copy(block[0:16], srcIP.To16())
+	copy(block[16:32], dstIP.To16())
+	binary.BigEndian.PutUint16(block[32:34], srcPort)
+	binary.BigEndian.PutUint16(block[34:36], dstPort)
+	return block
+}
+
+func TestParseProxyProtocolV2_IPv4(t *testing.T) {
+	srcIP := net.ParseIP("192.168.1.10").To4()
+	dstIP := net.ParseIP("10.0.0.1").To4()
+	addrBlock := buildIPv4AddrBlock(srcIP, dstIP, 12345, 9000)
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, addrBlock)
+	// Append a fake payload so the reader position is correct after parsing.
+	raw = append(raw, []byte("hello\n")...)
+
+	r := bytes.NewReader(raw)
+	addr, err := parseProxyProtocolV2Header(r)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	require.True(t, ok)
+	assert.Equal(t, "192.168.1.10", tcpAddr.IP.String())
+	assert.Equal(t, 12345, tcpAddr.Port)
+
+	// Verify that the remaining bytes are the payload (reader is positioned correctly).
+	remaining := make([]byte, 6)
+	n, _ := r.Read(remaining)
+	assert.Equal(t, "hello\n", string(remaining[:n]))
+}
+
+func TestParseProxyProtocolV2_IPv6(t *testing.T) {
+	srcIP := net.ParseIP("2001:db8::1")
+	dstIP := net.ParseIP("2001:db8::2")
+	addrBlock := buildIPv6AddrBlock(srcIP, dstIP, 54321, 9000)
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv6, addrBlock)
+
+	r := bytes.NewReader(raw)
+	addr, err := parseProxyProtocolV2Header(r)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
+
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	require.True(t, ok)
+	assert.Equal(t, "2001:db8::1", tcpAddr.IP.String())
+	assert.Equal(t, 54321, tcpAddr.Port)
+}
+
+func TestParseProxyProtocolV2_LocalCommand(t *testing.T) {
+	// LOCAL command — no address is proxied; addr should be nil.
+	raw := buildPPv2Header(ppV2CmdLocal, ppV2FamilyUnspec, nil)
+
+	r := bytes.NewReader(raw)
+	addr, err := parseProxyProtocolV2Header(r)
+	require.NoError(t, err)
+	assert.Nil(t, addr)
+}
+
+func TestParseProxyProtocolV2_UnspecFamily(t *testing.T) {
+	// PROXY command with UNSPEC family — addr should be nil.
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyUnspec, nil)
+
+	r := bytes.NewReader(raw)
+	addr, err := parseProxyProtocolV2Header(r)
+	require.NoError(t, err)
+	assert.Nil(t, addr)
+}
+
+func TestParseProxyProtocolV2_UnixFamily(t *testing.T) {
+	// PROXY command with UNIX family — addr should be nil (no IP address available).
+	unixBlock := make([]byte, 216)
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyUnix, unixBlock)
+
+	r := bytes.NewReader(raw)
+	addr, err := parseProxyProtocolV2Header(r)
+	require.NoError(t, err)
+	assert.Nil(t, addr)
+}
+
+func TestParseProxyProtocolV2_InvalidSignature(t *testing.T) {
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, make([]byte, ppV2AddrLenIPv4))
+	raw[5] = 0xFF // corrupt a signature byte
+
+	r := bytes.NewReader(raw)
+	_, err := parseProxyProtocolV2Header(r)
+	require.ErrorContains(t, err, "invalid proxy protocol v2 signature")
+}
+
+func TestParseProxyProtocolV2_WrongVersion(t *testing.T) {
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, make([]byte, ppV2AddrLenIPv4))
+	// Override byte 12: set version to 1 instead of 2.
+	raw[12] = 0x11
+
+	r := bytes.NewReader(raw)
+	_, err := parseProxyProtocolV2Header(r)
+	require.ErrorContains(t, err, "unsupported proxy protocol version")
+}
+
+func TestParseProxyProtocolV2_TruncatedHeader(t *testing.T) {
+	// Only 8 bytes — not enough for a full 16-byte header.
+	r := bytes.NewReader(proxyProtocolV2Signature[:8])
+	_, err := parseProxyProtocolV2Header(r)
+	require.Error(t, err)
+}
+
+func TestParseProxyProtocolV2_TruncatedAddressBlock(t *testing.T) {
+	// Header claims 12-byte IPv4 address block but provides only 4 bytes.
+	var buf bytes.Buffer
+	buf.Write(proxyProtocolV2Signature)
+	buf.WriteByte(0x21)                                           // version 2, PROXY command
+	buf.WriteByte(ppV2FamilyIPv4 | 0x01)                          // IPv4, STREAM
+	binary.Write(&buf, binary.BigEndian, uint16(ppV2AddrLenIPv4)) //nolint:errcheck
+	buf.Write(make([]byte, 4))                                    // only 4 bytes instead of 12
+
+	_, err := parseProxyProtocolV2Header(bytes.NewReader(buf.Bytes()))
+	require.ErrorContains(t, err, "reading proxy protocol v2 address block")
+}
+
+func TestParseProxyProtocolV2_UnsupportedCommand(t *testing.T) {
+	raw := buildPPv2Header(0x0F, ppV2FamilyIPv4, make([]byte, ppV2AddrLenIPv4))
+	r := bytes.NewReader(raw)
+	_, err := parseProxyProtocolV2Header(r)
+	require.ErrorContains(t, err, "unsupported proxy protocol v2 command")
+}

--- a/pkg/stanza/operator/input/tcp/testdata/config.yaml
+++ b/pkg/stanza/operator/input/tcp/testdata/config.yaml
@@ -13,3 +13,7 @@ all:
     key_file: foo2
     ca_file: foo3
     client_ca_file: foo4
+proxy_protocol:
+  type: tcp_input
+  listen_address: 10.0.0.1:9000
+  proxy_protocol: true

--- a/pkg/stanza/operator/input/udp/config.go
+++ b/pkg/stanza/operator/input/udp/config.go
@@ -73,6 +73,10 @@ type BaseConfig struct {
 	SplitConfig     split.Config `mapstructure:"multiline,omitempty"`
 	TrimConfig      trim.Config  `mapstructure:",squash"`
 	AsyncConfig     *AsyncConfig `mapstructure:"async,omitempty"`
+	// ProxyProtocol enables Proxy Protocol version 2 support. When true, each
+	// incoming UDP datagram is expected to begin with a PPv2 header whose source
+	// address is used instead of the raw UDP sender address.
+	ProxyProtocol bool `mapstructure:"proxy_protocol,omitempty"`
 }
 
 // Build will build a udp input operator.
@@ -130,6 +134,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		resolver:        resolver,
 		OneLogPerPacket: c.OneLogPerPacket,
 		AsyncConfig:     c.AsyncConfig,
+		proxyProtocol:   c.ProxyProtocol,
 	}
 
 	if c.AsyncConfig != nil {

--- a/pkg/stanza/operator/input/udp/config.schema.yaml
+++ b/pkg/stanza/operator/input/udp/config.schema.yaml
@@ -25,6 +25,12 @@ $defs:
         $ref: /pkg/stanza/split.config
       one_log_per_packet:
         type: boolean
+      proxy_protocol:
+        description: >-
+          When true, each incoming UDP datagram is expected to begin with a
+          Proxy Protocol v2 header. The source address carried in that header
+          is used instead of the raw UDP sender address.
+        type: boolean
     allOf:
       - $ref: /pkg/stanza/trim.config
   config:

--- a/pkg/stanza/operator/input/udp/config_test.go
+++ b/pkg/stanza/operator/input/udp/config_test.go
@@ -51,6 +51,16 @@ func TestUnmarshal(t *testing.T) {
 					return cfg
 				}(),
 			},
+			{
+				Name:               "proxy_protocol",
+				ExpectUnmarshalErr: false,
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.ListenAddress = "10.0.0.1:9000"
+					cfg.ProxyProtocol = true
+					return cfg
+				}(),
+			},
 		},
 	}.Run(t)
 }

--- a/pkg/stanza/operator/input/udp/input.go
+++ b/pkg/stanza/operator/input/udp/input.go
@@ -28,6 +28,7 @@ type Input struct {
 	addAttributes   bool
 	OneLogPerPacket bool
 	AsyncConfig     *AsyncConfig
+	proxyProtocol   bool
 
 	connection net.PacketConn
 	cancel     context.CancelFunc
@@ -103,6 +104,14 @@ func (i *Input) readAndProcessMessages(ctx context.Context) {
 			break
 		}
 
+		if i.proxyProtocol {
+			message, remoteAddr, err = applyProxyProtocolV2(message, remoteAddr)
+			if err != nil {
+				i.Logger().Error("Failed to parse proxy protocol v2 header", zap.Error(err))
+				continue
+			}
+		}
+
 		i.processMessage(ctx, message, remoteAddr, dec, scannerBuffer)
 	}
 }
@@ -169,7 +178,19 @@ func (i *Input) processMessagesAsync(ctx context.Context) {
 		}
 
 		trimmedMessage := i.removeTrailingCharactersAndNULsFromBuffer(*messageAndAddr.Message, messageAndAddr.MessageLength)
-		i.processMessage(ctx, trimmedMessage, messageAndAddr.RemoteAddr, dec, scannerBuffer)
+		remoteAddr := messageAndAddr.RemoteAddr
+
+		if i.proxyProtocol {
+			var err error
+			trimmedMessage, remoteAddr, err = applyProxyProtocolV2(trimmedMessage, remoteAddr)
+			if err != nil {
+				i.Logger().Error("Failed to parse proxy protocol v2 header", zap.Error(err))
+				i.readBufferPool.Put(messageAndAddr.Message)
+				continue
+			}
+		}
+
+		i.processMessage(ctx, trimmedMessage, remoteAddr, dec, scannerBuffer)
 		i.readBufferPool.Put(messageAndAddr.Message)
 	}
 }

--- a/pkg/stanza/operator/input/udp/input_test.go
+++ b/pkg/stanza/operator/input/udp/input_test.go
@@ -213,6 +213,106 @@ func TestFailToBind(t *testing.T) {
 	require.Error(t, err, "expected second udp operator to fail to start")
 }
 
+func TestProxyProtocolV2Input(t *testing.T) {
+	t.Run("IPv4", proxyProtocolUDPTest(false))
+	t.Run("IPv4WithAttributes", proxyProtocolUDPTest(true))
+}
+
+func proxyProtocolUDPTest(addAttributes bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewConfigWithID("test_id")
+		cfg.ListenAddress = ":0"
+		cfg.ProxyProtocol = true
+		cfg.AddAttributes = addAttributes
+
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		mockOutput := testutil.Operator{}
+		udpInput := op.(*Input)
+		udpInput.OutputOperators = []operator.Operator{&mockOutput}
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = udpInput.Start(testutil.NewUnscopedMockPersister())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, udpInput.Stop())
+		}()
+
+		conn, err := net.Dial("udp", udpInput.connection.LocalAddr().String())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Build a PPv2 datagram claiming source 1.2.3.4:5678.
+		proxiedSrcIP := net.ParseIP("1.2.3.4").To4()
+		proxiedDstIP := net.ParseIP("127.0.0.1").To4()
+		addrBlock := buildIPv4AddrBlock(proxiedSrcIP, proxiedDstIP, 5678, 9000)
+		header := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, addrBlock)
+		datagram := append(header, []byte("proxied udp message\n")...)
+
+		_, err = conn.Write(datagram)
+		require.NoError(t, err)
+
+		select {
+		case e := <-entryChan:
+			require.Equal(t, "proxied udp message", e.Body)
+			if addAttributes {
+				assert.Equal(t, "1.2.3.4", e.Attributes["net.peer.ip"])
+				assert.Equal(t, "5678", e.Attributes["net.peer.port"])
+			}
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "Timed out waiting for proxied UDP message")
+		}
+	}
+}
+
+func TestProxyProtocolV2LocalCommandUDP(t *testing.T) {
+	cfg := NewConfigWithID("test_id")
+	cfg.ListenAddress = ":0"
+	cfg.ProxyProtocol = true
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	mockOutput := testutil.Operator{}
+	udpInput := op.(*Input)
+	udpInput.OutputOperators = []operator.Operator{&mockOutput}
+
+	entryChan := make(chan *entry.Entry, 1)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		entryChan <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = udpInput.Start(testutil.NewUnscopedMockPersister())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, udpInput.Stop())
+	}()
+
+	conn, err := net.Dial("udp", udpInput.connection.LocalAddr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// LOCAL command — fallback to actual remote address, payload still processed.
+	header := buildPPv2Header(ppV2CmdLocal, ppV2FamilyUnspec, nil)
+	datagram := append(header, []byte("local udp message\n")...)
+	_, err = conn.Write(datagram)
+	require.NoError(t, err)
+
+	select {
+	case e := <-entryChan:
+		require.Equal(t, "local udp message", e.Body)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Timed out waiting for local-command UDP message")
+	}
+}
+
 func BenchmarkUDPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"

--- a/pkg/stanza/operator/input/udp/proxy_protocol.go
+++ b/pkg/stanza/operator/input/udp/proxy_protocol.go
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package udp // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp"
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+)
+
+// proxyProtocolV2Signature is the fixed 12-byte signature every PPv2 header starts with.
+var proxyProtocolV2Signature = []byte{
+	0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
+}
+
+const (
+	proxyProtocolV2HeaderLen = 16
+
+	ppV2CmdLocal = 0x00
+	ppV2CmdProxy = 0x01
+
+	ppV2FamilyUnspec = 0x00
+	ppV2FamilyIPv4   = 0x10
+	ppV2FamilyIPv6   = 0x20
+	ppV2FamilyUnix   = 0x30
+
+	ppV2AddrLenIPv4 = 12
+	ppV2AddrLenIPv6 = 36
+)
+
+// parseProxyProtocolV2Header reads and parses a Proxy Protocol v2 header from r.
+// It returns the source address reported by the proxy, or nil when the command
+// is LOCAL or the address family is UNSPEC/UNIX.
+//
+// Spec: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt §2.2
+func parseProxyProtocolV2Header(r io.Reader) (net.Addr, error) {
+	header := make([]byte, proxyProtocolV2HeaderLen)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, fmt.Errorf("reading proxy protocol v2 header: %w", err)
+	}
+
+	for i, b := range proxyProtocolV2Signature {
+		if header[i] != b {
+			return nil, fmt.Errorf("invalid proxy protocol v2 signature at byte %d: got 0x%02X, want 0x%02X", i, header[i], b)
+		}
+	}
+
+	verCmd := header[12]
+	if verCmd>>4 != 0x2 {
+		return nil, fmt.Errorf("unsupported proxy protocol version %d, only version 2 is supported", verCmd>>4)
+	}
+	cmd := verCmd & 0x0F
+
+	family := header[13] & 0xF0
+	addrLen := binary.BigEndian.Uint16(header[14:16])
+
+	addrBlock := make([]byte, addrLen)
+	if addrLen > 0 {
+		if _, err := io.ReadFull(r, addrBlock); err != nil {
+			return nil, fmt.Errorf("reading proxy protocol v2 address block: %w", err)
+		}
+	}
+
+	if cmd == ppV2CmdLocal {
+		return nil, nil
+	}
+	if cmd != ppV2CmdProxy {
+		return nil, fmt.Errorf("unsupported proxy protocol v2 command: 0x%02X", cmd)
+	}
+
+	switch family {
+	case ppV2FamilyIPv4:
+		if int(addrLen) < ppV2AddrLenIPv4 {
+			return nil, fmt.Errorf("proxy protocol v2 IPv4 address block too short: got %d bytes, need %d", addrLen, ppV2AddrLenIPv4)
+		}
+		srcIP := make(net.IP, 4)
+		copy(srcIP, addrBlock[0:4])
+		srcPort := binary.BigEndian.Uint16(addrBlock[8:10])
+		return &net.UDPAddr{IP: srcIP, Port: int(srcPort)}, nil
+
+	case ppV2FamilyIPv6:
+		if int(addrLen) < ppV2AddrLenIPv6 {
+			return nil, fmt.Errorf("proxy protocol v2 IPv6 address block too short: got %d bytes, need %d", addrLen, ppV2AddrLenIPv6)
+		}
+		srcIP := make(net.IP, 16)
+		copy(srcIP, addrBlock[0:16])
+		srcPort := binary.BigEndian.Uint16(addrBlock[32:34])
+		return &net.UDPAddr{IP: srcIP, Port: int(srcPort)}, nil
+
+	default:
+		// UNSPEC and UNIX carry no usable IP address — fall back to the actual
+		// connection remote address.
+		return nil, nil
+	}
+}
+
+// applyProxyProtocolV2 parses a PPv2 header from the start of datagram and
+// returns the payload bytes (everything after the header) together with the
+// proxied source address. When the command is LOCAL or the family is
+// UNSPEC/UNIX, fallbackAddr is returned unchanged.
+func applyProxyProtocolV2(datagram []byte, fallbackAddr net.Addr) ([]byte, net.Addr, error) {
+	reader := bytes.NewReader(datagram)
+	proxyAddr, err := parseProxyProtocolV2Header(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	headerLen := len(datagram) - reader.Len()
+	payload := datagram[headerLen:]
+	if proxyAddr != nil {
+		return payload, proxyAddr, nil
+	}
+	return payload, fallbackAddr, nil
+}

--- a/pkg/stanza/operator/input/udp/proxy_protocol_test.go
+++ b/pkg/stanza/operator/input/udp/proxy_protocol_test.go
@@ -1,0 +1,127 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package udp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildPPv2Header builds a Proxy Protocol v2 binary header for testing.
+func buildPPv2Header(cmd, family byte, addr []byte) []byte {
+	var buf bytes.Buffer
+	buf.Write(proxyProtocolV2Signature)
+	buf.WriteByte(0x20 | cmd)    // version 2, command
+	buf.WriteByte(family | 0x02) // family, DGRAM transport
+	addrLen := uint16(len(addr))
+	_ = binary.Write(&buf, binary.BigEndian, addrLen)
+	buf.Write(addr)
+	return buf.Bytes()
+}
+
+func buildIPv4AddrBlock(srcIP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	block := make([]byte, ppV2AddrLenIPv4)
+	copy(block[0:4], srcIP.To4())
+	copy(block[4:8], dstIP.To4())
+	binary.BigEndian.PutUint16(block[8:10], srcPort)
+	binary.BigEndian.PutUint16(block[10:12], dstPort)
+	return block
+}
+
+func buildIPv6AddrBlock(srcIP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	block := make([]byte, ppV2AddrLenIPv6)
+	copy(block[0:16], srcIP.To16())
+	copy(block[16:32], dstIP.To16())
+	binary.BigEndian.PutUint16(block[32:34], srcPort)
+	binary.BigEndian.PutUint16(block[34:36], dstPort)
+	return block
+}
+
+func TestParseProxyProtocolV2_IPv4(t *testing.T) {
+	srcIP := net.ParseIP("192.168.1.10").To4()
+	dstIP := net.ParseIP("10.0.0.1").To4()
+	addrBlock := buildIPv4AddrBlock(srcIP, dstIP, 12345, 9000)
+	payload := []byte("hello udp\n")
+	raw := append(buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, addrBlock), payload...)
+
+	gotPayload, gotAddr, err := applyProxyProtocolV2(raw, nil)
+	require.NoError(t, err)
+	require.NotNil(t, gotAddr)
+
+	udpAddr, ok := gotAddr.(*net.UDPAddr)
+	require.True(t, ok)
+	assert.Equal(t, "192.168.1.10", udpAddr.IP.String())
+	assert.Equal(t, 12345, udpAddr.Port)
+	assert.Equal(t, payload, gotPayload)
+}
+
+func TestParseProxyProtocolV2_IPv6(t *testing.T) {
+	srcIP := net.ParseIP("2001:db8::1")
+	dstIP := net.ParseIP("2001:db8::2")
+	addrBlock := buildIPv6AddrBlock(srcIP, dstIP, 54321, 9000)
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv6, addrBlock)
+
+	gotPayload, gotAddr, err := applyProxyProtocolV2(raw, nil)
+	require.NoError(t, err)
+	require.NotNil(t, gotAddr)
+
+	udpAddr, ok := gotAddr.(*net.UDPAddr)
+	require.True(t, ok)
+	assert.Equal(t, "2001:db8::1", udpAddr.IP.String())
+	assert.Equal(t, 54321, udpAddr.Port)
+	assert.Empty(t, gotPayload)
+}
+
+func TestParseProxyProtocolV2_LocalCommandFallback(t *testing.T) {
+	raw := buildPPv2Header(ppV2CmdLocal, ppV2FamilyUnspec, nil)
+	raw = append(raw, []byte("payload")...)
+
+	fallback := &net.UDPAddr{IP: net.ParseIP("9.9.9.9"), Port: 1234}
+	gotPayload, gotAddr, err := applyProxyProtocolV2(raw, fallback)
+	require.NoError(t, err)
+	// LOCAL command: fallback address must be preserved
+	assert.Equal(t, fallback, gotAddr)
+	assert.Equal(t, []byte("payload"), gotPayload)
+}
+
+func TestParseProxyProtocolV2_UnspecFamilyFallback(t *testing.T) {
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyUnspec, nil)
+	fallback := &net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 999}
+
+	_, gotAddr, err := applyProxyProtocolV2(raw, fallback)
+	require.NoError(t, err)
+	assert.Equal(t, fallback, gotAddr)
+}
+
+func TestParseProxyProtocolV2_InvalidSignature(t *testing.T) {
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, make([]byte, ppV2AddrLenIPv4))
+	raw[5] = 0xFF
+
+	_, _, err := applyProxyProtocolV2(raw, nil)
+	require.ErrorContains(t, err, "invalid proxy protocol v2 signature")
+}
+
+func TestParseProxyProtocolV2_WrongVersion(t *testing.T) {
+	raw := buildPPv2Header(ppV2CmdProxy, ppV2FamilyIPv4, make([]byte, ppV2AddrLenIPv4))
+	raw[12] = 0x11 // version 1
+
+	_, _, err := applyProxyProtocolV2(raw, nil)
+	require.ErrorContains(t, err, "unsupported proxy protocol version")
+}
+
+func TestParseProxyProtocolV2_TruncatedHeader(t *testing.T) {
+	_, _, err := applyProxyProtocolV2(proxyProtocolV2Signature[:8], nil)
+	require.Error(t, err)
+}
+
+func TestParseProxyProtocolV2_UnsupportedCommand(t *testing.T) {
+	raw := buildPPv2Header(0x0F, ppV2FamilyIPv4, make([]byte, ppV2AddrLenIPv4))
+	_, _, err := applyProxyProtocolV2(raw, nil)
+	require.ErrorContains(t, err, "unsupported proxy protocol v2 command")
+}

--- a/pkg/stanza/operator/input/udp/testdata/config.yaml
+++ b/pkg/stanza/operator/input/udp/testdata/config.yaml
@@ -20,3 +20,7 @@ all_with_async:
     readers: 2
     processors: 2
     max_queue_length: 100
+proxy_protocol:
+  type: udp_input
+  listen_address: 10.0.0.1:9000
+  proxy_protocol: true

--- a/receiver/syslogreceiver/README.md
+++ b/receiver/syslogreceiver/README.md
@@ -58,6 +58,7 @@ Each operator performs a simple responsibility, such as parsing a timestamp or J
 | `preserve_trailing_whitespaces` | false    | Whether to preserve trailing whitespaces.                                                                                         |
 | `encoding`                      | `utf-8`  | The encoding of the file being read. See the list of supported encodings below for available options.                             |
 | `async`                         | nil      | An `async` configuration block. See below for details.                                                                            |
+| `proxy_protocol`                | false    | When `true`, each incoming UDP datagram must begin with a [Proxy Protocol v2](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) header. The source address from the header is used instead of the raw UDP sender address for `net.*` attributes. |
 
 ### TCP Configuration
 
@@ -72,6 +73,7 @@ Each operator performs a simple responsibility, such as parsing a timestamp or J
 | `preserve_leading_whitespaces`  | false    | Whether to preserve leading whitespaces.                                                                                          |
 | `preserve_trailing_whitespaces` | false    | Whether to preserve trailing whitespaces.                                                                                         |
 | `encoding`                      | `utf-8`  | The encoding of the file being read. See the list of supported encodings below for available options.                             |
+| `proxy_protocol`                | false    | When `true`, each incoming TCP connection must begin with a [Proxy Protocol v2](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) header. The source address from the header is used instead of the raw TCP remote address for `net.*` attributes. |
 
 #### TLS Configuration
 

--- a/receiver/tcplogreceiver/README.md
+++ b/receiver/tcplogreceiver/README.md
@@ -27,6 +27,7 @@ The TCP Log Receiver receives logs over TCP.
 | `one_log_per_packet`      | false                | Skip log tokenization, set to true if logs contains one log per record and multiline is not used.  This will improve performance.                                                 |
 | `resource`                | {}                   | A map of `key: value` pairs to add to the entry's resource                                                         |
 | `add_attributes`          | false                | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/network.md#network-attributes] |
+| `proxy_protocol`          | false                | When `true`, each incoming TCP connection must begin with a [Proxy Protocol v2](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) header. The source IP/port extracted from that header is used instead of the raw TCP remote address when populating `net.*` attributes. |
 | `multiline`               |                      | A `multiline` configuration block. See below for details                                                           |
 | `encoding`                | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `operators`               | []                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -25,6 +25,7 @@ The UDP Log Receiver receives logs over UDP.
 | `one_log_per_packet`      | false                | Skip log tokenization, set to true if logs contains one log per record and multiline is not used.  This will improve performance.                                                 |
 | `resource`                | {}                   | A map of `key: value` pairs to add to the entry's resource                                                         |
 | `add_attributes`          | false                | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/semantic-conventions/blob/cee22ec91448808ebcfa53df689c800c7171c9e1/docs/general/attributes.md#other-network-attributes] |
+| `proxy_protocol`          | false                | When `true`, each incoming UDP datagram must begin with a [Proxy Protocol v2](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) header. The source address carried in that header is used instead of the raw UDP sender address when populating `net.*` attributes. |
 | `multiline`               |                      | A `multiline` configuration block. See below for details                                                           |
 | `encoding`                | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `operators`               | []                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |

--- a/receiver/udplogreceiver/udp_test.go
+++ b/receiver/udplogreceiver/udp_test.go
@@ -4,6 +4,8 @@
 package udplogreceiver
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -130,4 +132,59 @@ func expectNLogs(sink *consumertest.LogsSink, expected int) func() bool {
 	return func() bool {
 		return sink.LogRecordCount() == expected
 	}
+}
+
+// ppv2Signature is the 12-byte fixed signature of a Proxy Protocol v2 header.
+var ppv2Signature = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+
+// buildPPv2Datagram prepends a PPv2 header (IPv4 PROXY DGRAM) to payload.
+func buildPPv2Datagram(srcIP net.IP, srcPort uint16, dstIP net.IP, dstPort uint16, payload []byte) []byte {
+	var buf bytes.Buffer
+	buf.Write(ppv2Signature)
+	buf.WriteByte(0x21)                              // version 2 | PROXY command
+	buf.WriteByte(0x12)                              // IPv4 family | DGRAM transport
+	binary.Write(&buf, binary.BigEndian, uint16(12)) //nolint:errcheck // writing to a bytes.Buffer never fails
+	buf.Write(srcIP.To4())
+	buf.Write(dstIP.To4())
+	binary.Write(&buf, binary.BigEndian, srcPort) //nolint:errcheck
+	binary.Write(&buf, binary.BigEndian, dstPort) //nolint:errcheck
+	buf.Write(payload)
+	return buf.Bytes()
+}
+
+func TestProxyProtocolV2(t *testing.T) {
+	listenAddress := "127.0.0.1:29020"
+
+	cfg := testdataConfigYaml(listenAddress)
+	cfg.InputConfig.ProxyProtocol = true
+	cfg.InputConfig.AddAttributes = true
+
+	f := NewFactory()
+	sink := new(consumertest.LogsSink)
+	rcvr, err := f.CreateLogs(t.Context(), receivertest.NewNopSettings(metadata.Type), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, rcvr.Shutdown(t.Context()))
+	}()
+
+	conn, err := net.Dial("udp", listenAddress)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	proxiedSrcIP := net.ParseIP("1.2.3.4").To4()
+	dstIP := net.ParseIP("127.0.0.1").To4()
+	msg := []byte("<86>1 2021-02-28T00:00:02.003Z test proxied msg\n")
+	datagram := buildPPv2Datagram(proxiedSrcIP, 5678, dstIP, 29020, msg)
+
+	_, err = conn.Write(datagram)
+	require.NoError(t, err)
+
+	require.Eventually(t, expectNLogs(sink, 1), 2*time.Second, time.Millisecond)
+
+	logRecord := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.Equal(t, "<86>1 2021-02-28T00:00:02.003Z test proxied msg", logRecord.Body().Str())
+	// The peer address should reflect the proxied source, not the raw UDP sender.
+	assert.Equal(t, "1.2.3.4", logRecord.Attributes().AsRaw()["net.peer.ip"])
+	assert.Equal(t, "5678", logRecord.Attributes().AsRaw()["net.peer.port"])
 }


### PR DESCRIPTION
…eivers

#### Description

Adds a new boolean config field `proxy_protocol` (default false) to the TCP and UDP input operators. When enabled, each incoming connection or datagram is expected to begin with a Proxy Protocol v2 binary header (https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt §2.2). The source address extracted from the header is used instead of the raw network remote address when populating `net.*` log attributes.

Supported address families: IPv4, IPv6.
For the LOCAL command and UNSPEC/UNIX families the receiver falls back to the actual connection/sender address.

Affected components:
  - receiver/tcplogreceiver   (TCP)
  - receiver/udplogreceiver   (UDP)
  - receiver/syslogreceiver   (TCP + UDP via their respective operators)

New files:
  pkg/stanza/operator/input/tcp/proxy_protocol.go
  pkg/stanza/operator/input/tcp/proxy_protocol_test.go
  pkg/stanza/operator/input/udp/proxy_protocol.go
  pkg/stanza/operator/input/udp/proxy_protocol_test.go

Modified files:
  pkg/stanza/operator/input/tcp/config.go
  pkg/stanza/operator/input/tcp/config_test.go
  pkg/stanza/operator/input/tcp/config.schema.yaml
  pkg/stanza/operator/input/tcp/input.go
  pkg/stanza/operator/input/tcp/testdata/config.yaml
  pkg/stanza/operator/input/udp/config.go
  pkg/stanza/operator/input/udp/config_test.go
  pkg/stanza/operator/input/udp/config.schema.yaml
  pkg/stanza/operator/input/udp/input.go
  pkg/stanza/operator/input/udp/testdata/config.yaml
  pkg/stanza/operator/input/syslog/config_test.go
  pkg/stanza/operator/input/syslog/testdata/config.yaml
  receiver/tcplogreceiver/README.md
  receiver/udplogreceiver/README.md
  receiver/udplogreceiver/udp_test.go
  receiver/syslogreceiver/README.md

Assisted-by: Claude Sonnet 4.6
