### PR TITLE
[pkg/translator/prometheus] remove stable feature gate

### DIFF
--- a/.chloggen/codeboten_prom-norm-fg.yaml
+++ b/.chloggen/codeboten_prom-norm-fg.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes `pkg.translator.prometheus.NormalizeName` feature gate which has been stable for some time.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47597]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/prometheus/normalize_name.go
+++ b/pkg/translator/prometheus/normalize_name.go
@@ -8,16 +8,7 @@ import (
 	"strings"
 	"unicode"
 
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-)
-
-var _ = featuregate.GlobalRegistry().MustRegister(
-	"pkg.translator.prometheus.NormalizeName",
-	featuregate.StageStable,
-	featuregate.WithRegisterDescription("Controls whether metrics names are automatically normalized to follow Prometheus naming convention"),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950"),
-	featuregate.WithRegisterToVersion("v0.130.0"),
 )
 
 // BuildCompliantName builds a Prometheus-compliant metric name for the specified metric


### PR DESCRIPTION
Removes `pkg.translator.prometheus.NormalizeName` feature gate that has been stabilized for some time.
