### PR TITLE
[receiver/prometheus] remove stable feature gate RemoveLegacyResourceAttributes

### DIFF
--- a/.chloggen/codeboten_prom-flag.yaml
+++ b/.chloggen/codeboten_prom-flag.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes the feature gate `receiver.prometheusreceiver.RemoveLegacyResourceAttributes` which has been stable for some time.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47598]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -187,9 +187,6 @@ linters:
         path: receiver/jaegerreceiver/
       - linters:
           - forbidigo
-        path: receiver/prometheusreceiver/
-      - linters:
-          - forbidigo
         path: receiver/vcenterreceiver/
 
     # Log a warning if an exclusion rule is unused.

--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -8,18 +8,8 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
-)
-
-var _ = featuregate.GlobalRegistry().MustRegister(
-	"receiver.prometheusreceiver.RemoveLegacyResourceAttributes",
-	featuregate.StageStable,
-	featuregate.WithRegisterFromVersion("v0.101.0"),
-	featuregate.WithRegisterDescription("When enabled, the net.host.name, net.host.port, and http.scheme resource attributes are no longer added to metrics. Use server.address, server.port, and url.scheme instead."),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32814"),
-	featuregate.WithRegisterToVersion("v0.130.0"),
 )
 
 // isDiscernibleHost checks if a host can be used as a value for the 'host.name' key.


### PR DESCRIPTION
Removes the feature gate `receiver.prometheusreceiver.RemoveLegacyResourceAttributes` which has been stable for some time.
