### PR TITLE
[receiver/kafkametrics] fix kafka.cluster.alias attribute never emitted

### DIFF
--- a/.chloggen/kafkametrics-cluster-alias-fix.yaml
+++ b/.chloggen/kafkametrics-cluster-alias-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/kafkametrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix `kafka.cluster.alias` resource attribute never being emitted: move the enabling check from `createDefaultConfig` (where `ClusterAlias` is always empty) to `createMetricsReceiver` (where user config is available)."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47573]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkametricsreceiver/factory.go
+++ b/receiver/kafkametricsreceiver/factory.go
@@ -29,17 +29,13 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	config := &Config{
+	return &Config{
 		ControllerConfig:     scraperhelper.NewDefaultControllerConfig(),
 		ClientConfig:         configkafka.NewDefaultClientConfig(),
 		GroupMatch:           defaultGroupMatch,
 		TopicMatch:           defaultTopicMatch,
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}
-	if config.ClusterAlias != "" {
-		config.ResourceAttributes.KafkaClusterAlias.Enabled = true
-	}
-	return config
 }
 
 func createMetricsReceiver(
@@ -49,6 +45,13 @@ func createMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	c := cfg.(*Config)
+	// Enable the kafka.cluster.alias resource attribute when the user has
+	// configured a cluster_alias. This must be done here (after user config is
+	// applied) rather than in createDefaultConfig, where ClusterAlias is always
+	// the zero value.
+	if c.ClusterAlias != "" {
+		c.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	}
 	r, err := newMetricsReceiver(ctx, *c, params, nextConsumer)
 	if err != nil {
 		return nil, err

--- a/receiver/kafkametricsreceiver/factory_test.go
+++ b/receiver/kafkametricsreceiver/factory_test.go
@@ -4,10 +4,13 @@
 package kafkametricsreceiver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
@@ -15,4 +18,38 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "default config not created")
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+}
+
+// TestFactory_ClusterAliasAttributeNotEnabledByDefault verifies that
+// kafka.cluster.alias resource attribute is NOT enabled when cluster_alias is
+// unset (the common default case).
+func TestFactory_ClusterAliasAttributeNotEnabledByDefault(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.Empty(t, cfg.ClusterAlias)
+	assert.False(t, cfg.ResourceAttributes.KafkaClusterAlias.Enabled,
+		"kafka.cluster.alias must not be enabled when cluster_alias is empty")
+}
+
+// TestFactory_ClusterAliasAttributeEnabledWhenSet is a regression test for
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47573.
+// Previously the attribute was never enabled because the check lived in
+// createDefaultConfig(), where ClusterAlias is always "".
+func TestFactory_ClusterAliasAttributeEnabledWhenSet(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.ClusterAlias = "test-cluster"
+
+	// Replace newMetricsReceiver so we can inspect the mutated Config without
+	// needing a live Kafka cluster.
+	var capturedConfig Config
+	orig := newMetricsReceiver
+	newMetricsReceiver = func(_ context.Context, c Config, _ receiver.Settings, _ consumer.Metrics) (receiver.Metrics, error) {
+		capturedConfig = c
+		return nil, nil
+	}
+	defer func() { newMetricsReceiver = orig }()
+
+	_, _ = createMetricsReceiver(context.Background(), receiver.Settings{}, cfg, nil)
+
+	assert.True(t, capturedConfig.ResourceAttributes.KafkaClusterAlias.Enabled,
+		"kafka.cluster.alias resource attribute must be enabled when cluster_alias is set")
 }


### PR DESCRIPTION
## Description

Fixes #47573.

The `kafka.cluster.alias` resource attribute was never emitted even when `cluster_alias` was configured, because the check to enable it lived in `createDefaultConfig()`:

```go
// createDefaultConfig — runs BEFORE user config is applied:
if config.ClusterAlias != "" {   // always false — ClusterAlias is "" here
    config.ResourceAttributes.KafkaClusterAlias.Enabled = true
}
```

Since `createDefaultConfig()` runs before the user's YAML is unmarshalled into the config, `ClusterAlias` is always `""` at that point, and the attribute is never enabled.

**Fix:** Move the check to `createMetricsReceiver()`, where the user-supplied config is already populated.

### Before

```yaml
receivers:
  kafkametrics:
    cluster_alias: my-cluster  # → kafka.cluster.alias never set on metrics
```

### After

```yaml
receivers:
  kafkametrics:
    cluster_alias: my-cluster  # → kafka.cluster.alias: my-cluster ✓
```

## Link to tracking Issue

Fixes #47573

## Testing

Added two unit tests in `factory_test.go`:
- `TestFactory_ClusterAliasAttributeNotEnabledByDefault` — sanity check that the attribute is off when `cluster_alias` is not set
- `TestFactory_ClusterAliasAttributeEnabledWhenSet` — regression test using a mock `newMetricsReceiver` to confirm the attribute is enabled when `cluster_alias` is set

All three `TestFactory*` tests pass (`go test -run TestFactory ./receiver/kafkametricsreceiver/`).