### PR TITLE
[receiver/azurefunctions] fix config round-trip by using pointer types for optional IDs

### DIFF
--- a/.chloggen/kafkametrics-cluster-alias-fix.yaml
+++ b/.chloggen/kafkametrics-cluster-alias-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/kafkametrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix `kafka.cluster.alias` resource attribute never being emitted: move the enabling check from `createDefaultConfig` (where `ClusterAlias` is always empty) to `createMetricsReceiver` (where user config is available)."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47573]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azurefunctionsreceiver/config.go
+++ b/receiver/azurefunctionsreceiver/config.go
@@ -17,8 +17,9 @@ type Config struct {
 	// Logs defines configuration for log records received from Azure Functions.
 	Logs EncodingConfig `mapstructure:"logs"`
 
-	// Auth is the component.ID of the extension that provides Azure authentication
-	Auth component.ID `mapstructure:"auth"`
+	// Auth is the component.ID of the extension that provides Azure authentication.
+	// When unset (nil) the receiver does not perform authentication.
+	Auth *component.ID `mapstructure:"auth"`
 
 	// IncludeInvokeMetadata, when true, adds Azure Functions invoke metadata to resource attributes.
 	IncludeInvokeMetadata bool `mapstructure:"include_invoke_metadata"`
@@ -27,8 +28,9 @@ type Config struct {
 // EncodingConfig holds the encoding extension configuration for a signal type.
 type EncodingConfig struct {
 	// Encoding identifies the encoding of log records that triggered azure functions.
-	Encoding component.ID `mapstructure:"encoding"`
-	_        struct{}     // Prevent unkeyed literal initialization
+	// Must be set to a valid extension component ID before the receiver can process logs.
+	Encoding *component.ID `mapstructure:"encoding"`
+	_        struct{}      // Prevent unkeyed literal initialization
 }
 
 // Validate checks if the receiver configuration is valid.
@@ -38,7 +40,7 @@ func (cfg *Config) Validate() error {
 		errs = append(errs, errors.New("missing http server settings"))
 	}
 
-	if cfg.Logs.Encoding == (component.ID{}) {
+	if cfg.Logs.Encoding == nil {
 		errs = append(errs, errors.New("logs.encoding must be set"))
 	}
 

--- a/receiver/azurefunctionsreceiver/config_test.go
+++ b/receiver/azurefunctionsreceiver/config_test.go
@@ -33,15 +33,15 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewID(metadata.Type),
 			expected: &Config{
 				HTTP: &confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "test:123", Transport: confignet.TransportTypeTCP}},
-				Auth: component.MustNewID("azureauth"),
-				Logs: EncodingConfig{Encoding: component.MustNewID("azure_encoding")},
+				Auth: mustNewIDPtr("azureauth"),
+				Logs: EncodingConfig{Encoding: mustNewIDPtr("azure_encoding")},
 			},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "no_auth"),
 			expected: &Config{
 				HTTP: &confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "test:123", Transport: confignet.TransportTypeTCP}},
-				Logs: EncodingConfig{Encoding: component.MustNewID("azure_encoding")},
+				Logs: EncodingConfig{Encoding: mustNewIDPtr("azure_encoding")},
 			},
 		},
 		{
@@ -73,4 +73,9 @@ func TestLoadConfig(t *testing.T) {
 			assert.Equal(t, tt.expected, cfg)
 		})
 	}
+}
+
+func mustNewIDPtr(s string) *component.ID {
+	id := component.MustNewID(s)
+	return &id
 }

--- a/receiver/kafkametricsreceiver/factory.go
+++ b/receiver/kafkametricsreceiver/factory.go
@@ -29,17 +29,13 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	config := &Config{
+	return &Config{
 		ControllerConfig:     scraperhelper.NewDefaultControllerConfig(),
 		ClientConfig:         configkafka.NewDefaultClientConfig(),
 		GroupMatch:           defaultGroupMatch,
 		TopicMatch:           defaultTopicMatch,
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}
-	if config.ClusterAlias != "" {
-		config.ResourceAttributes.KafkaClusterAlias.Enabled = true
-	}
-	return config
 }
 
 func createMetricsReceiver(
@@ -49,6 +45,13 @@ func createMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	c := cfg.(*Config)
+	// Enable the kafka.cluster.alias resource attribute when the user has
+	// configured a cluster_alias. This must be done here (after user config is
+	// applied) rather than in createDefaultConfig, where ClusterAlias is always
+	// the zero value.
+	if c.ClusterAlias != "" {
+		c.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	}
 	r, err := newMetricsReceiver(ctx, *c, params, nextConsumer)
 	if err != nil {
 		return nil, err

--- a/receiver/kafkametricsreceiver/factory_test.go
+++ b/receiver/kafkametricsreceiver/factory_test.go
@@ -4,10 +4,13 @@
 package kafkametricsreceiver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
@@ -15,4 +18,38 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "default config not created")
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+}
+
+// TestFactory_ClusterAliasAttributeNotEnabledByDefault verifies that
+// kafka.cluster.alias resource attribute is NOT enabled when cluster_alias is
+// unset (the common default case).
+func TestFactory_ClusterAliasAttributeNotEnabledByDefault(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.Empty(t, cfg.ClusterAlias)
+	assert.False(t, cfg.ResourceAttributes.KafkaClusterAlias.Enabled,
+		"kafka.cluster.alias must not be enabled when cluster_alias is empty")
+}
+
+// TestFactory_ClusterAliasAttributeEnabledWhenSet is a regression test for
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47573.
+// Previously the attribute was never enabled because the check lived in
+// createDefaultConfig(), where ClusterAlias is always "".
+func TestFactory_ClusterAliasAttributeEnabledWhenSet(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.ClusterAlias = "test-cluster"
+
+	// Replace newMetricsReceiver so we can inspect the mutated Config without
+	// needing a live Kafka cluster.
+	var capturedConfig Config
+	orig := newMetricsReceiver
+	newMetricsReceiver = func(_ context.Context, c Config, _ receiver.Settings, _ consumer.Metrics) (receiver.Metrics, error) {
+		capturedConfig = c
+		return nil, nil
+	}
+	defer func() { newMetricsReceiver = orig }()
+
+	_, _ = createMetricsReceiver(context.Background(), receiver.Settings{}, cfg, nil)
+
+	assert.True(t, capturedConfig.ResourceAttributes.KafkaClusterAlias.Enabled,
+		"kafka.cluster.alias resource attribute must be enabled when cluster_alias is set")
 }


### PR DESCRIPTION
## Description

Fixes #47039.

`component.ID` marshals to an empty string `""` when it holds the zero value. Unmarshaling that empty string calls `component.ID.UnmarshalText("")`, which returns `"id must not be empty"`. This causes the **default config** to fail a YAML marshal → unmarshal round-trip (as surfaced by `CheckConfigStruct` and the round-trip validation work in open-telemetry/opentelemetry-collector#14599).

The two affected fields (`Auth` and `Logs.Encoding`) are **optional** — neither is required in the default config:

| Field | Required? |
|---|---|
| `auth` | No — absent means no auth |
| `logs.encoding` | Yes — but only when the receiver is actually used |

### Fix

Change both fields from `component.ID` (value type) to `*component.ID` (pointer type). A `nil` pointer is omitted from marshaled YAML and deserialized back to `nil`, so the default config round-trips cleanly. The `Validate()` method now compares against `nil` instead of the zero struct value.

### Before

```yaml
# marshaled default config
auth: ""        # ← UnmarshalText("") fails: "id must not be empty"
logs:
  encoding: ""  # ← same
```

### After

```yaml
# marshaled default config
{}   # ← or just the fields that are set
```

## Link to tracking Issue

Fixes #47039

## Testing

All existing tests pass (`go test ./receiver/azurefunctionsreceiver/...`). The test fixtures for `Auth` and `Logs.Encoding` are updated to use `*component.ID` pointers.