### PR TITLE
[receiver/azurefunctions] fix config round-trip by using pointer types for optional IDs

### DIFF
--- a/receiver/azurefunctionsreceiver/config.go
+++ b/receiver/azurefunctionsreceiver/config.go
@@ -17,8 +17,9 @@ type Config struct {
 	// Logs defines configuration for log records received from Azure Functions.
 	Logs EncodingConfig `mapstructure:"logs"`
 
-	// Auth is the component.ID of the extension that provides Azure authentication
-	Auth component.ID `mapstructure:"auth"`
+	// Auth is the component.ID of the extension that provides Azure authentication.
+	// When unset (nil) the receiver does not perform authentication.
+	Auth *component.ID `mapstructure:"auth"`
 
 	// IncludeInvokeMetadata, when true, adds Azure Functions invoke metadata to resource attributes.
 	IncludeInvokeMetadata bool `mapstructure:"include_invoke_metadata"`
@@ -27,8 +28,9 @@ type Config struct {
 // EncodingConfig holds the encoding extension configuration for a signal type.
 type EncodingConfig struct {
 	// Encoding identifies the encoding of log records that triggered azure functions.
-	Encoding component.ID `mapstructure:"encoding"`
-	_        struct{}     // Prevent unkeyed literal initialization
+	// Must be set to a valid extension component ID before the receiver can process logs.
+	Encoding *component.ID `mapstructure:"encoding"`
+	_        struct{}      // Prevent unkeyed literal initialization
 }
 
 // Validate checks if the receiver configuration is valid.
@@ -38,7 +40,7 @@ func (cfg *Config) Validate() error {
 		errs = append(errs, errors.New("missing http server settings"))
 	}
 
-	if cfg.Logs.Encoding == (component.ID{}) {
+	if cfg.Logs.Encoding == nil {
 		errs = append(errs, errors.New("logs.encoding must be set"))
 	}
 

--- a/receiver/azurefunctionsreceiver/config_test.go
+++ b/receiver/azurefunctionsreceiver/config_test.go
@@ -33,15 +33,15 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewID(metadata.Type),
 			expected: &Config{
 				HTTP: &confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "test:123", Transport: confignet.TransportTypeTCP}},
-				Auth: component.MustNewID("azureauth"),
-				Logs: EncodingConfig{Encoding: component.MustNewID("azure_encoding")},
+				Auth: mustNewIDPtr("azureauth"),
+				Logs: EncodingConfig{Encoding: mustNewIDPtr("azure_encoding")},
 			},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "no_auth"),
 			expected: &Config{
 				HTTP: &confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "test:123", Transport: confignet.TransportTypeTCP}},
-				Logs: EncodingConfig{Encoding: component.MustNewID("azure_encoding")},
+				Logs: EncodingConfig{Encoding: mustNewIDPtr("azure_encoding")},
 			},
 		},
 		{
@@ -73,4 +73,9 @@ func TestLoadConfig(t *testing.T) {
 			assert.Equal(t, tt.expected, cfg)
 		})
 	}
+}
+
+func mustNewIDPtr(s string) *component.ID {
+	id := component.MustNewID(s)
+	return &id
 }


### PR DESCRIPTION
## Description

Fixes #47039.

`component.ID` marshals to an empty string `""` when it holds the zero value. Unmarshaling that empty string calls `component.ID.UnmarshalText("")`, which returns `"id must not be empty"`. This causes the **default config** to fail a YAML marshal → unmarshal round-trip.

The two affected fields (`Auth` and `Logs.Encoding`) are **optional** — neither is required in the default config. Change both from `component.ID` (value type) to `*component.ID` (pointer type). A `nil` pointer is omitted from marshaled YAML and deserialized back to `nil`, so the default config round-trips cleanly. The `Validate()` method now compares against `nil` instead of the zero struct value.

### Before

```yaml
# marshaled default config
auth: ""        # ← UnmarshalText("") fails: "id must not be empty"
logs:
  encoding: ""  # ← same
```

### After

```yaml
# marshaled default config — absent fields serialise as nothing
{}
```

## Link to tracking Issue

Fixes #47039

## Testing

All existing tests pass. Test fixtures updated to use `*component.ID` pointers.