### PR TITLE
[exporter/awsxray] declare MutatesData capability

### DIFF
--- a/.chloggen/awsxray-mutates-data.yaml
+++ b/.chloggen/awsxray-mutates-data.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: exporter/awsxray
+note: "Declare `MutatesData: true` capability so the collector clones trace data before fanout, preventing `panic: invalid access to shared data` when the exporter is used alongside other exporters in the same pipeline."
+issues: [46889]
+change_logs: [user]

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	"github.com/aws/smithy-go"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -73,6 +74,11 @@ func newTracesExporter(ctx context.Context, cfg *Config, set exporter.Settings, 
 			}
 			return err
 		},
+		// The translator removes the aws.xray.inprogress attribute from spans
+		// (segment.go:makeEndTimeAndInProgress). Declare MutatesData so the
+		// collector clones the data before passing it to this exporter and
+		// fanout pipelines are not affected.
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithStart(func(context.Context, component.Host) error {
 			sender.Start(ctx)
 			return nil


### PR DESCRIPTION
Fixes #46889. The translator removes the  attribute from spans, so the exporter mutates shared pdata. Adding  tells the collector to clone the data before fanout, preventing the  crash.