### PR TITLE
[receiver/mysql] strip leading SQL comments in isQueryExplainable

### DIFF
--- a/.chloggen/mysql-explain-comment-prefix.yaml
+++ b/.chloggen/mysql-explain-comment-prefix.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: receiver/mysql
+note: "Fix EXPLAIN failing for SQL statements prefixed with block comments (/* ... */) or line comments (-- ...); isQueryExplainable now strips leading comments before checking for DML keywords."
+issues: [46587]
+change_logs: [user]

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -834,6 +834,29 @@ func isQueryExplainable(query string) bool {
 	}
 
 	trimmedQuery := strings.TrimSpace(query)
+
+	// Strip leading SQL comments so that queries prefixed by client-tool
+	// comments (e.g. /* ApplicationName=DBeaver */ SELECT ...) are still
+	// recognised as explainable. We handle both block comments (/* ... */)
+	// and line comments (-- ...).
+	for {
+		if strings.HasPrefix(trimmedQuery, "/*") {
+			end := strings.Index(trimmedQuery, "*/")
+			if end == -1 {
+				break
+			}
+			trimmedQuery = strings.TrimSpace(trimmedQuery[end+2:])
+		} else if strings.HasPrefix(trimmedQuery, "--") {
+			end := strings.IndexByte(trimmedQuery, '\n')
+			if end == -1 {
+				break
+			}
+			trimmedQuery = strings.TrimSpace(trimmedQuery[end+1:])
+		} else {
+			break
+		}
+	}
+
 	lowerQuery := strings.ToLower(trimmedQuery)
 
 	for _, keyword := range sqlStartingKeywords {


### PR DESCRIPTION
Fixes #46587. Queries prefixed with DBMS tool comments (e.g. `/* ApplicationName=DBeaver */ SELECT ...`) were not being EXPLAIN'd because `isQueryExplainable` saw the comment prefix rather than the DML keyword. Strip block and line comments before the keyword check.