### PR TITLE
[receiver/icmpcheckreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46359-icmpcheck-enable-reaggregation.yaml
+++ b/.chloggen/46359-icmpcheck-enable-reaggregation.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user, api]
+change_logs: [user]

--- a/.chloggen/46359-icmpcheck-enable-reaggregation.yaml
+++ b/.chloggen/46359-icmpcheck-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/icmpcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the ICMP Check receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46359]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/icmpcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/icmpcheckreceiver/internal/metadata/generated_config.go
@@ -7,13 +7,93 @@ import (
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// PingLossRatioMetricConfig provides config for the ping.loss.ratio metric.
+type PingLossRatioMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *PingLossRatioMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PingRttAvgMetricConfig provides config for the ping.rtt.avg metric.
+type PingRttAvgMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PingRttAvgMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PingRttMaxMetricConfig provides config for the ping.rtt.max metric.
+type PingRttMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PingRttMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PingRttMinMetricConfig provides config for the ping.rtt.min metric.
+type PingRttMinMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PingRttMinMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PingRttStddevMetricConfig provides config for the ping.rtt.stddev metric.
+type PingRttStddevMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PingRttStddevMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,28 +109,28 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for icmpcheckreceiver metrics.
 type MetricsConfig struct {
-	PingLossRatio MetricConfig `mapstructure:"ping.loss.ratio"`
-	PingRttAvg    MetricConfig `mapstructure:"ping.rtt.avg"`
-	PingRttMax    MetricConfig `mapstructure:"ping.rtt.max"`
-	PingRttMin    MetricConfig `mapstructure:"ping.rtt.min"`
-	PingRttStddev MetricConfig `mapstructure:"ping.rtt.stddev"`
+	PingLossRatio PingLossRatioMetricConfig `mapstructure:"ping.loss.ratio"`
+	PingRttAvg    PingRttAvgMetricConfig    `mapstructure:"ping.rtt.avg"`
+	PingRttMax    PingRttMaxMetricConfig    `mapstructure:"ping.rtt.max"`
+	PingRttMin    PingRttMinMetricConfig    `mapstructure:"ping.rtt.min"`
+	PingRttStddev PingRttStddevMetricConfig `mapstructure:"ping.rtt.stddev"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		PingLossRatio: MetricConfig{
+		PingLossRatio: PingLossRatioMetricConfig{
 			Enabled: true,
 		},
-		PingRttAvg: MetricConfig{
+		PingRttAvg: PingRttAvgMetricConfig{
 			Enabled: true,
 		},
-		PingRttMax: MetricConfig{
+		PingRttMax: PingRttMaxMetricConfig{
 			Enabled: true,
 		},
-		PingRttMin: MetricConfig{
+		PingRttMin: PingRttMinMetricConfig{
 			Enabled: true,
 		},
-		PingRttStddev: MetricConfig{
+		PingRttStddev: PingRttStddevMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/icmpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/icmpcheckreceiver/internal/metadata/generated_config_test.go
@@ -26,19 +26,19 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					PingLossRatio: MetricConfig{
+					PingLossRatio: PingLossRatioMetricConfig{
 						Enabled: true,
 					},
-					PingRttAvg: MetricConfig{
+					PingRttAvg: PingRttAvgMetricConfig{
 						Enabled: true,
 					},
-					PingRttMax: MetricConfig{
+					PingRttMax: PingRttMaxMetricConfig{
 						Enabled: true,
 					},
-					PingRttMin: MetricConfig{
+					PingRttMin: PingRttMinMetricConfig{
 						Enabled: true,
 					},
-					PingRttStddev: MetricConfig{
+					PingRttStddev: PingRttStddevMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -52,19 +52,19 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					PingLossRatio: MetricConfig{
+					PingLossRatio: PingLossRatioMetricConfig{
 						Enabled: false,
 					},
-					PingRttAvg: MetricConfig{
+					PingRttAvg: PingRttAvgMetricConfig{
 						Enabled: false,
 					},
-					PingRttMax: MetricConfig{
+					PingRttMax: PingRttMaxMetricConfig{
 						Enabled: false,
 					},
-					PingRttMin: MetricConfig{
+					PingRttMin: PingRttMinMetricConfig{
 						Enabled: false,
 					},
-					PingRttStddev: MetricConfig{
+					PingRttStddev: PingRttStddevMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -78,7 +78,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(PingLossRatioMetricConfig{}, PingRttAvgMetricConfig{}, PingRttMaxMetricConfig{}, PingRttMinMetricConfig{}, PingRttStddevMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/icmpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/icmpcheckreceiver/internal/metadata/generated_metrics.go
@@ -12,6 +12,13 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
+)
+
 var MetricsInfo = metricsInfo{
 	PingLossRatio: metricInfo{
 		Name: "ping.loss.ratio",
@@ -43,9 +50,9 @@ type metricInfo struct {
 }
 
 type metricPingLossRatio struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   PingLossRatioMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills ping.loss.ratio metric with initial data.
@@ -82,7 +89,7 @@ func (m *metricPingLossRatio) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricPingLossRatio(cfg MetricConfig) metricPingLossRatio {
+func newMetricPingLossRatio(cfg PingLossRatioMetricConfig) metricPingLossRatio {
 	m := metricPingLossRatio{config: cfg}
 
 	if cfg.Enabled {
@@ -93,9 +100,9 @@ func newMetricPingLossRatio(cfg MetricConfig) metricPingLossRatio {
 }
 
 type metricPingRttAvg struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric         // data buffer for generated metric.
+	config   PingRttAvgMetricConfig // metric config provided by user.
+	capacity int                    // max observed number of data points added to the metric.
 }
 
 // init fills ping.rtt.avg metric with initial data.
@@ -132,7 +139,7 @@ func (m *metricPingRttAvg) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricPingRttAvg(cfg MetricConfig) metricPingRttAvg {
+func newMetricPingRttAvg(cfg PingRttAvgMetricConfig) metricPingRttAvg {
 	m := metricPingRttAvg{config: cfg}
 
 	if cfg.Enabled {
@@ -143,9 +150,9 @@ func newMetricPingRttAvg(cfg MetricConfig) metricPingRttAvg {
 }
 
 type metricPingRttMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric         // data buffer for generated metric.
+	config   PingRttMaxMetricConfig // metric config provided by user.
+	capacity int                    // max observed number of data points added to the metric.
 }
 
 // init fills ping.rtt.max metric with initial data.
@@ -182,7 +189,7 @@ func (m *metricPingRttMax) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricPingRttMax(cfg MetricConfig) metricPingRttMax {
+func newMetricPingRttMax(cfg PingRttMaxMetricConfig) metricPingRttMax {
 	m := metricPingRttMax{config: cfg}
 
 	if cfg.Enabled {
@@ -193,9 +200,9 @@ func newMetricPingRttMax(cfg MetricConfig) metricPingRttMax {
 }
 
 type metricPingRttMin struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric         // data buffer for generated metric.
+	config   PingRttMinMetricConfig // metric config provided by user.
+	capacity int                    // max observed number of data points added to the metric.
 }
 
 // init fills ping.rtt.min metric with initial data.
@@ -232,7 +239,7 @@ func (m *metricPingRttMin) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricPingRttMin(cfg MetricConfig) metricPingRttMin {
+func newMetricPingRttMin(cfg PingRttMinMetricConfig) metricPingRttMin {
 	m := metricPingRttMin{config: cfg}
 
 	if cfg.Enabled {
@@ -243,9 +250,9 @@ func newMetricPingRttMin(cfg MetricConfig) metricPingRttMin {
 }
 
 type metricPingRttStddev struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   PingRttStddevMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills ping.rtt.stddev metric with initial data.
@@ -282,7 +289,7 @@ func (m *metricPingRttStddev) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricPingRttStddev(cfg MetricConfig) metricPingRttStddev {
+func newMetricPingRttStddev(cfg PingRttStddevMetricConfig) metricPingRttStddev {
 	m := metricPingRttStddev{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/icmpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/icmpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -62,7 +68,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -92,6 +100,8 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetNetPeerName("net.peer.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())

--- a/receiver/icmpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/icmpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -16,6 +16,23 @@ all_set:
       enabled: true
     net.peer.name:
       enabled: true
+reaggregate_set:
+  metrics:
+    ping.loss.ratio:
+      enabled: true
+    ping.rtt.avg:
+      enabled: true
+    ping.rtt.max:
+      enabled: true
+    ping.rtt.min:
+      enabled: true
+    ping.rtt.stddev:
+      enabled: true
+  resource_attributes:
+    net.peer.ip:
+      enabled: true
+    net.peer.name:
+      enabled: true
 none_set:
   metrics:
     ping.loss.ratio:

--- a/receiver/icmpcheckreceiver/metadata.yaml
+++ b/receiver/icmpcheckreceiver/metadata.yaml
@@ -14,6 +14,8 @@ status:
   codeowners:
     active: [atoulme, jkoronaAtCisco]
 
+reaggregation_enabled: true
+
 resource_attributes:
   net.peer.ip:
     enabled: true


### PR DESCRIPTION
#### Description

Enables dynamic metric re-aggregation in the ICMP Check receiver.

- Set `reaggregation_enabled: true` in `metadata.yaml`
- Regenerated code via `go generate`

This receiver currently has no metric-level attributes, so there is no behavioral change. The flag enables the re-aggregation infrastructure so that if attributes are added in the future, they can be configured for aggregation.

This does not break existing configuration files.

#### Link to tracking issue

Fixes #46359
Part of #45396

#### Testing

- `go test -race ./...` — all tests pass
- `go vet ./...` — clean
- `make generate` — generated files are up to date (includes `fmt` and `gci`)

#### Documentation

No documentation changes needed.