### PR TITLE
[pkg/datadog][exporter/datadog][extension/datadog] Detect missing sta…

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -392,6 +392,7 @@ func (f *factory) createTracesExporter(
 
 	var (
 		pusher consumer.ConsumeTracesFunc
+		start  component.StartFunc
 		stop   component.ShutdownFunc
 		wg     sync.WaitGroup // waits for agent to exit
 	)
@@ -456,6 +457,7 @@ func (f *factory) createTracesExporter(
 			return nil, err2
 		}
 		pusher = tracex.consumeTraces
+		start = tracex.start
 		stop = func(context.Context) error {
 			cancel() // first cancel context
 			f.StopReporter()
@@ -463,17 +465,23 @@ func (f *factory) createTracesExporter(
 		}
 	}
 
-	return exporterhelper.NewTraces(
-		ctx,
-		set,
-		cfg,
-		pusher,
+	opts := []exporterhelper.Option{
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0 * time.Second}),
 		// We don't do retries on traces because of deduping concerns on APM Events.
 		exporterhelper.WithRetry(configretry.BackOffConfig{Enabled: false}),
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithShutdown(stop),
+	}
+	if start != nil {
+		opts = append(opts, exporterhelper.WithStart(start))
+	}
+	return exporterhelper.NewTraces(
+		ctx,
+		set,
+		cfg,
+		pusher,
+		opts...,
 	)
 }
 

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -131,6 +131,13 @@ func (exp *traceExporter) consumeTraces(
 	td ptrace.Traces,
 ) (err error) {
 	defer func() { err = exp.scrubber.Scrub(err) }()
+	// If we need to enrich resource attributes, copy the traces data first
+	// since the pipeline shares it read-only across exporters.
+	if exp.extensionFoundNoStatsConnector {
+		cp := ptrace.NewTraces()
+		td.CopyTo(cp)
+		td = cp
+	}
 	if exp.cfg.HostMetadata.Enabled {
 		// start host metadata with resource attributes from
 		// the first payload.

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -22,12 +22,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
+	datadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog/clientutil"
@@ -43,14 +45,15 @@ type traceExporter struct {
 	cfg    *datadogconfig.Config
 	ctx    context.Context // ctx triggers shutdown upon cancellation
 
-	metricsAPI       *datadogV2.MetricsApi    // client sends running metrics to backend
-	scrubber         scrub.Scrubber           // scrubber scrubs sensitive information from error messages
-	onceMetadata     *sync.Once               // onceMetadata ensures that metadata is sent only once across all exporters
-	agent            *agent.Agent             // agent processes incoming traces
-	sourceProvider   source.Provider          // is able to source the origin of a trace (hostname, container, etc)
-	metadataReporter *inframetadata.Reporter  // reports host metadata from resource attributes and metrics
-	retrier          *clientutil.Retrier      // retrier handles retries on requests
-	gatewayUsage     *attributes.GatewayUsage // gatewayUsage stores the gateway usage metrics
+	metricsAPI        *datadogV2.MetricsApi    // client sends running metrics to backend
+	scrubber          scrub.Scrubber           // scrubber scrubs sensitive information from error messages
+	onceMetadata      *sync.Once               // onceMetadata ensures that metadata is sent only once across all exporters
+	agent             *agent.Agent             // agent processes incoming traces
+	sourceProvider    source.Provider          // is able to source the origin of a trace (hostname, container, etc)
+	metadataReporter  *inframetadata.Reporter  // reports host metadata from resource attributes and metrics
+	retrier           *clientutil.Retrier      // retrier handles retries on requests
+	gatewayUsage      *attributes.GatewayUsage // gatewayUsage stores the gateway usage metrics
+	extensionFoundNoStatsConnector bool // true if datadogextension is present but no stats connector is configured
 }
 
 func newTracesExporter(
@@ -94,6 +97,31 @@ func newTracesExporter(
 
 var _ consumer.ConsumeTracesFunc = (*traceExporter)(nil).consumeTraces
 
+var (
+	datadogConnectorType    = component.MustNewType("datadog")
+	spanmetricsConnectorType = component.MustNewType("spanmetrics")
+)
+
+// start checks for stats connectors in the pipeline via the datadogextension.
+// If the extension is present but no stats connector is configured, the exporter
+// will stamp traces with _dd.pipeline_has_no_stats_connector.
+func (exp *traceExporter) start(_ context.Context, host component.Host) error {
+	for _, ext := range host.GetExtensions() {
+		checker, ok := ext.(datadog.ConnectorChecker)
+		if !ok {
+			continue
+		}
+		// Extension found — check if any stats connector is configured
+		if !checker.HasConnector(datadogConnectorType) && !checker.HasConnector(spanmetricsConnectorType) {
+			exp.extensionFoundNoStatsConnector = true
+			exp.params.Logger.Warn("No stats connector (datadog or spanmetrics) detected in pipeline",
+				zap.Bool("extensionFoundNoStatsConnector", true))
+		}
+		break
+	}
+	return nil
+}
+
 // headerComputedStats specifies the HTTP header which indicates whether APM stats
 // have already been computed for a payload.
 const headerComputedStats = "Datadog-Client-Computed-Stats"
@@ -129,6 +157,9 @@ func (exp *traceExporter) consumeTraces(
 	}
 	for i := 0; i < rspans.Len(); i++ {
 		rspan := rspans.At(i)
+		if exp.extensionFoundNoStatsConnector {
+			rspan.Resource().Attributes().PutBool("_dd.extension_found_no_stats_connector", true)
+		}
 		var src source.Source
 		src, err = exp.agent.OTLPReceiver.ReceiveResourceSpans(ctx, rspan, header, exp.gatewayUsage)
 		if err != nil {

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -25,8 +25,11 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -542,6 +545,222 @@ func TestResRelatedAttributesInSpanAttributes_ReceiveResourceSpansV2Enabled(t *t
 	assert.Empty(t, tracerPayload.Env)
 	assert.Equal(t, "otlpresourcenoservicename", span.Service)
 	assert.Empty(t, span.Meta["version"])
+}
+
+// mockConnectorCheckerExtension implements both extension.Extension and datadog.ConnectorChecker.
+type mockConnectorCheckerExtension struct {
+	extension.Extension
+	connectors map[component.Type]struct{}
+}
+
+func (m *mockConnectorCheckerExtension) HasConnector(connectorType component.Type) bool {
+	_, ok := m.connectors[connectorType]
+	return ok
+}
+
+// mockHostWithExtensions implements component.Host with configurable extensions.
+type mockHostWithExtensions struct {
+	component.Host
+	extensions map[component.ID]component.Component
+}
+
+func (m *mockHostWithExtensions) GetExtensions() map[component.ID]component.Component {
+	return m.extensions
+}
+
+func (m *mockHostWithExtensions) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+	return nil
+}
+
+func TestStartDetectsStatsConnector(t *testing.T) {
+	t.Run("false when datadog connector is present", func(t *testing.T) {
+		exp := &traceExporter{params: exportertest.NewNopSettings(metadata.Type)}
+		host := &mockHostWithExtensions{
+			extensions: map[component.ID]component.Component{
+				component.MustNewID("datadog"): &mockConnectorCheckerExtension{
+					connectors: map[component.Type]struct{}{
+						component.MustNewType("datadog"): {},
+					},
+				},
+			},
+		}
+		err := exp.start(t.Context(), host)
+		require.NoError(t, err)
+		assert.False(t, exp.extensionFoundNoStatsConnector)
+	})
+
+	t.Run("false when spanmetrics connector is present", func(t *testing.T) {
+		exp := &traceExporter{params: exportertest.NewNopSettings(metadata.Type)}
+		host := &mockHostWithExtensions{
+			extensions: map[component.ID]component.Component{
+				component.MustNewID("datadog"): &mockConnectorCheckerExtension{
+					connectors: map[component.Type]struct{}{
+						component.MustNewType("spanmetrics"): {},
+					},
+				},
+			},
+		}
+		err := exp.start(t.Context(), host)
+		require.NoError(t, err)
+		assert.False(t, exp.extensionFoundNoStatsConnector)
+	})
+
+	t.Run("true when extension present but no stats connector configured", func(t *testing.T) {
+		exp := &traceExporter{params: exportertest.NewNopSettings(metadata.Type)}
+		host := &mockHostWithExtensions{
+			extensions: map[component.ID]component.Component{
+				component.MustNewID("datadog"): &mockConnectorCheckerExtension{
+					connectors: map[component.Type]struct{}{},
+				},
+			},
+		}
+		err := exp.start(t.Context(), host)
+		require.NoError(t, err)
+		assert.True(t, exp.extensionFoundNoStatsConnector)
+	})
+
+	t.Run("false when no ConnectorChecker extension present", func(t *testing.T) {
+		exp := &traceExporter{params: exportertest.NewNopSettings(metadata.Type)}
+		host := componenttest.NewNopHost()
+		err := exp.start(t.Context(), host)
+		require.NoError(t, err)
+		assert.False(t, exp.extensionFoundNoStatsConnector)
+	})
+}
+
+func TestConsumeTracesEnrichesResourceAttrs(t *testing.T) {
+	t.Run("adds attribute when extension present but no stats connector", func(t *testing.T) {
+		server := testutil.DatadogServerMock()
+		defer server.Close()
+		cfg := &datadogconfig.Config{
+			API: datadogconfig.APIConfig{
+				Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			TagsConfig: datadogconfig.TagsConfig{
+				Hostname: "test-host",
+			},
+			Metrics: datadogconfig.MetricsConfig{
+				TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			},
+			Traces: datadogconfig.TracesExporterConfig{
+				TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			},
+		}
+
+		params := exportertest.NewNopSettings(metadata.Type)
+		f := NewFactory()
+		exp, err := f.CreateTraces(t.Context(), params, cfg)
+		require.NoError(t, err)
+
+		// Start with extension present but no connectors configured
+		host := &mockHostWithExtensions{
+			extensions: map[component.ID]component.Component{
+				component.MustNewID("datadog"): &mockConnectorCheckerExtension{
+					connectors: map[component.Type]struct{}{},
+				},
+			},
+		}
+		err = exp.Start(t.Context(), host)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, exp.Shutdown(t.Context())) }()
+
+		td := simpleTraces(map[string]any{"service.name": "test-svc"}, nil, ptrace.SpanKindClient)
+		err = exp.ConsumeTraces(t.Context(), td)
+		require.NoError(t, err)
+
+		// Verify the resource attribute was added
+		rspans := td.ResourceSpans()
+		require.Equal(t, 1, rspans.Len())
+		val, ok := rspans.At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
+		assert.True(t, ok, "expected _dd.extension_found_no_stats_connector attribute")
+		assert.True(t, val.Bool())
+	})
+
+	t.Run("does not add attribute when stats connector is present", func(t *testing.T) {
+		server := testutil.DatadogServerMock()
+		defer server.Close()
+		cfg := &datadogconfig.Config{
+			API: datadogconfig.APIConfig{
+				Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			TagsConfig: datadogconfig.TagsConfig{
+				Hostname: "test-host",
+			},
+			Metrics: datadogconfig.MetricsConfig{
+				TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			},
+			Traces: datadogconfig.TracesExporterConfig{
+				TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			},
+		}
+
+		params := exportertest.NewNopSettings(metadata.Type)
+		f := NewFactory()
+		exp, err := f.CreateTraces(t.Context(), params, cfg)
+		require.NoError(t, err)
+
+		// Start with extension present AND datadog connector configured
+		host := &mockHostWithExtensions{
+			extensions: map[component.ID]component.Component{
+				component.MustNewID("datadog"): &mockConnectorCheckerExtension{
+					connectors: map[component.Type]struct{}{
+						component.MustNewType("datadog"): {},
+					},
+				},
+			},
+		}
+		err = exp.Start(t.Context(), host)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, exp.Shutdown(t.Context())) }()
+
+		td := simpleTraces(map[string]any{"service.name": "test-svc"}, nil, ptrace.SpanKindClient)
+		err = exp.ConsumeTraces(t.Context(), td)
+		require.NoError(t, err)
+
+		// Verify no attribute was added
+		rspans := td.ResourceSpans()
+		require.Equal(t, 1, rspans.Len())
+		_, ok := rspans.At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
+		assert.False(t, ok, "expected no _dd.extension_found_no_stats_connector attribute")
+	})
+
+	t.Run("does not add attribute when no extension present", func(t *testing.T) {
+		server := testutil.DatadogServerMock()
+		defer server.Close()
+		cfg := &datadogconfig.Config{
+			API: datadogconfig.APIConfig{
+				Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			TagsConfig: datadogconfig.TagsConfig{
+				Hostname: "test-host",
+			},
+			Metrics: datadogconfig.MetricsConfig{
+				TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			},
+			Traces: datadogconfig.TracesExporterConfig{
+				TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			},
+		}
+
+		params := exportertest.NewNopSettings(metadata.Type)
+		f := NewFactory()
+		exp, err := f.CreateTraces(t.Context(), params, cfg)
+		require.NoError(t, err)
+
+		err = exp.Start(t.Context(), componenttest.NewNopHost())
+		require.NoError(t, err)
+		defer func() { require.NoError(t, exp.Shutdown(t.Context())) }()
+
+		td := simpleTraces(map[string]any{"service.name": "test-svc"}, nil, ptrace.SpanKindClient)
+		err = exp.ConsumeTraces(t.Context(), td)
+		require.NoError(t, err)
+
+		// Verify no attribute was added
+		rspans := td.ResourceSpans()
+		require.Equal(t, 1, rspans.Len())
+		_, ok := rspans.At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
+		assert.False(t, ok, "expected no _dd.extension_found_no_stats_connector attribute")
+	})
 }
 
 func simpleTraces(rattrs, sattrs map[string]any, kind ptrace.SpanKind) ptrace.Traces {

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -628,8 +628,8 @@ func TestStartDetectsStatsConnector(t *testing.T) {
 	})
 }
 
-func TestConsumeTracesEnrichesResourceAttrs(t *testing.T) {
-	t.Run("adds attribute when extension present but no stats connector", func(t *testing.T) {
+func TestConsumeTracesWithStatsConnectorDetection(t *testing.T) {
+	t.Run("succeeds when extension present but no stats connector", func(t *testing.T) {
 		server := testutil.DatadogServerMock()
 		defer server.Close()
 		cfg := &datadogconfig.Config{
@@ -664,19 +664,18 @@ func TestConsumeTracesEnrichesResourceAttrs(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, exp.Shutdown(t.Context())) }()
 
+		// Traces are shared/read-only in the pipeline, so the exporter copies
+		// before mutating. Verify it does not panic and consumes successfully.
 		td := simpleTraces(map[string]any{"service.name": "test-svc"}, nil, ptrace.SpanKindClient)
 		err = exp.ConsumeTraces(t.Context(), td)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
-		// Verify the resource attribute was added
-		rspans := td.ResourceSpans()
-		require.Equal(t, 1, rspans.Len())
-		val, ok := rspans.At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
-		assert.True(t, ok, "expected _dd.extension_found_no_stats_connector attribute")
-		assert.True(t, val.Bool())
+		// Original traces should be unmodified (exporter works on a copy)
+		_, ok := td.ResourceSpans().At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
+		assert.False(t, ok, "original traces should not be mutated")
 	})
 
-	t.Run("does not add attribute when stats connector is present", func(t *testing.T) {
+	t.Run("succeeds when stats connector is present", func(t *testing.T) {
 		server := testutil.DatadogServerMock()
 		defer server.Close()
 		cfg := &datadogconfig.Config{
@@ -699,7 +698,6 @@ func TestConsumeTracesEnrichesResourceAttrs(t *testing.T) {
 		exp, err := f.CreateTraces(t.Context(), params, cfg)
 		require.NoError(t, err)
 
-		// Start with extension present AND datadog connector configured
 		host := &mockHostWithExtensions{
 			extensions: map[component.ID]component.Component{
 				component.MustNewID("datadog"): &mockConnectorCheckerExtension{
@@ -715,16 +713,10 @@ func TestConsumeTracesEnrichesResourceAttrs(t *testing.T) {
 
 		td := simpleTraces(map[string]any{"service.name": "test-svc"}, nil, ptrace.SpanKindClient)
 		err = exp.ConsumeTraces(t.Context(), td)
-		require.NoError(t, err)
-
-		// Verify no attribute was added
-		rspans := td.ResourceSpans()
-		require.Equal(t, 1, rspans.Len())
-		_, ok := rspans.At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
-		assert.False(t, ok, "expected no _dd.extension_found_no_stats_connector attribute")
+		assert.NoError(t, err)
 	})
 
-	t.Run("does not add attribute when no extension present", func(t *testing.T) {
+	t.Run("succeeds when no extension present", func(t *testing.T) {
 		server := testutil.DatadogServerMock()
 		defer server.Close()
 		cfg := &datadogconfig.Config{
@@ -753,13 +745,7 @@ func TestConsumeTracesEnrichesResourceAttrs(t *testing.T) {
 
 		td := simpleTraces(map[string]any{"service.name": "test-svc"}, nil, ptrace.SpanKindClient)
 		err = exp.ConsumeTraces(t.Context(), td)
-		require.NoError(t, err)
-
-		// Verify no attribute was added
-		rspans := td.ResourceSpans()
-		require.Equal(t, 1, rspans.Len())
-		_, ok := rspans.At(0).Resource().Attributes().Get("_dd.extension_found_no_stats_connector")
-		assert.False(t, ok, "expected no _dd.extension_found_no_stats_connector attribute")
+		assert.NoError(t, err)
 	})
 }
 

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/service"
@@ -30,6 +31,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
+	datadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/agentcomponents"
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 )
@@ -53,9 +55,10 @@ func (*realUUIDProvider) NewString() string {
 }
 
 type configs struct {
-	collector *confmap.Conf
-	extension *Config
-	mutex     sync.RWMutex
+	collector  *confmap.Conf
+	extension  *Config
+	connectors map[component.ID]component.Config // parsed from collector config
+	mutex      sync.RWMutex
 }
 
 type info struct {
@@ -99,6 +102,7 @@ var (
 	_ extensioncapabilities.ConfigWatcher   = (*datadogExtension)(nil)
 	_ extensioncapabilities.PipelineWatcher = (*datadogExtension)(nil)
 	_ componentstatus.Watcher               = (*datadogExtension)(nil)
+	_ datadog.ConnectorChecker              = (*datadogExtension)(nil)
 )
 
 // NotifyConfig implements the extensioncapabilities.ConfigWatcher interface, which allows
@@ -109,6 +113,14 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 	defer e.configs.mutex.Unlock()
 
 	e.configs.collector = conf
+
+	// Parse and cache connector configuration for HasConnector queries
+	oc := otelcol.Config{}
+	if err := conf.Unmarshal(&oc); err != nil {
+		e.logger.Warn("Failed to unmarshal collector config for connector checking", zap.Error(err))
+	} else {
+		e.configs.connectors = oc.Connectors
+	}
 
 	// Create the build info struct for the payload
 	buildInfo := payload.CustomBuildInfo{
@@ -346,6 +358,19 @@ func (e *datadogExtension) stopPeriodicPayloadSending() {
 // with the same proxy configuration.
 func (e *datadogExtension) GetSerializer() agentcomponents.SerializerWithForwarder {
 	return e.serializer
+}
+
+// HasConnector implements datadog.ConnectorChecker. It reports whether at least
+// one connector of the given type is configured in the collector pipeline.
+func (e *datadogExtension) HasConnector(connectorType component.Type) bool {
+	e.configs.mutex.RLock()
+	defer e.configs.mutex.RUnlock()
+	for id := range e.configs.connectors {
+		if id.Type() == connectorType {
+			return true
+		}
+	}
+	return false
 }
 
 func newExtension(

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -1172,3 +1172,85 @@ func TestExtensionLivenessMetric(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestHasConnector(t *testing.T) {
+	set := extension.Settings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+		BuildInfo:         component.BuildInfo{Version: "1.0.0"},
+	}
+	hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
+	uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
+	cfg := &Config{
+		API: datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Site: "datadoghq.com"},
+		HTTPConfig: &httpserver.Config{
+			ServerConfig: confighttp.ServerConfig{
+				NetAddr: confignet.AddrConfig{
+					Transport: confignet.TransportTypeTCP,
+					Endpoint:  "localhost:0",
+				},
+			},
+			Path: "/test-path",
+		},
+	}
+
+	ext, err := newExtension(t.Context(), cfg, set, hostProvider, uuidProvider)
+	require.NoError(t, err)
+	ext.serializer = &mockSerializer{}
+	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
+
+	t.Run("returns false before NotifyConfig", func(t *testing.T) {
+		assert.False(t, ext.HasConnector(component.MustNewType("spanmetrics")))
+	})
+
+	t.Run("returns true when connector is configured", func(t *testing.T) {
+		conf := confmap.NewFromStringMap(map[string]any{
+			"connectors": map[string]any{
+				"spanmetrics": map[string]any{},
+			},
+			"receivers": map[string]any{
+				"otlp": map[string]any{},
+			},
+			"exporters": map[string]any{
+				"debug": map[string]any{},
+			},
+			"service": map[string]any{
+				"pipelines": map[string]any{
+					"traces": map[string]any{
+						"receivers": []any{"otlp"},
+						"exporters": []any{"spanmetrics"},
+					},
+					"metrics": map[string]any{
+						"receivers": []any{"spanmetrics"},
+						"exporters": []any{"debug"},
+					},
+				},
+			},
+		})
+		err := ext.NotifyConfig(t.Context(), conf)
+		require.NoError(t, err)
+
+		assert.True(t, ext.HasConnector(component.MustNewType("spanmetrics")))
+		assert.False(t, ext.HasConnector(component.MustNewType("routing")))
+	})
+
+	t.Run("returns false when no connectors configured", func(t *testing.T) {
+		conf := confmap.NewFromStringMap(map[string]any{
+			"receivers": map[string]any{"otlp": map[string]any{}},
+			"exporters": map[string]any{"debug": map[string]any{}},
+			"service": map[string]any{
+				"pipelines": map[string]any{
+					"traces": map[string]any{
+						"receivers": []any{"otlp"},
+						"exporters": []any{"debug"},
+					},
+				},
+			},
+		})
+		err := ext.NotifyConfig(t.Context(), conf)
+		require.NoError(t, err)
+
+		assert.False(t, ext.HasConnector(component.MustNewType("spanmetrics")))
+	})
+
+	require.NoError(t, ext.Shutdown(t.Context()))
+}

--- a/pkg/datadog/connector_checker.go
+++ b/pkg/datadog/connector_checker.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
+
+import "go.opentelemetry.io/collector/component"
+
+// ConnectorChecker is an interface that can be implemented by extensions to
+// allow other components (e.g., exporters) to query whether a specific
+// connector type is configured in the collector pipeline.
+//
+// Components can retrieve this interface at startup via host.GetExtensions()
+// and type-assert to ConnectorChecker.
+type ConnectorChecker interface {
+	// HasConnector reports whether at least one connector of the given type
+	// is configured in the collector pipeline.
+	HasConnector(connectorType component.Type) bool
+}


### PR DESCRIPTION
…ts connectors via extension

Add ConnectorChecker interface to pkg/datadog so the datadogextension can expose which connectors are configured in the collector pipeline.

The datadog exporter queries this interface at startup. When the datadogextension is present but neither a datadog nor spanmetrics connector is configured, the exporter stamps every resource span with `_dd.extension_found_no_stats_connector: true`.

Assisted-by: Claude Opus 4.6

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
