### PR TITLE
fix(extension/google_cloud_logentry_encoding): Add googlecloudlogentry_encoding as deprecated alias

### DIFF
--- a/.chloggen/googlecloudlogentryencodingextension_deprecated_alias.yaml
+++ b/.chloggen/googlecloudlogentryencodingextension_deprecated_alias.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/encoding/googlecloudlogentryencoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the deprecated name of the googlecloudlogentryencoding extension as a deprecated option to the factory.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47663]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This was one of several components renamed in v0.148.0. 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/googlecloudlogentryencodingextension_deprecated_alias.yaml
+++ b/.chloggen/googlecloudlogentryencodingextension_deprecated_alias.yaml
@@ -4,7 +4,7 @@
 change_type: 'bug_fix'
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/encoding/googlecloudlogentryencoding
+component: extension/google_cloud_logentry_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add the deprecated name of the googlecloudlogentryencoding extension as a deprecated option to the factory.

--- a/extension/encoding/googlecloudlogentryencodingextension/factory.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/factory.go
@@ -8,16 +8,18 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/xextension"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension/internal/metadata"
 )
 
 func NewFactory() extension.Factory {
-	return extension.NewFactory(
+	return xextension.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
 		createExtension,
 		metadata.ExtensionStability,
+		xextension.WithDeprecatedTypeAlias(metadata.DeprecatedType),
 	)
 }
 

--- a/extension/encoding/googlecloudlogentryencodingextension/go.mod
+++ b/extension/encoding/googlecloudlogentryencodingextension/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/collector/confmap/xconfmap v0.150.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/extension v1.56.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/extension/extensiontest v0.150.1-0.20260415114935-307e3abdbae9
+	go.opentelemetry.io/collector/extension/xextension v0.150.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/pdata v1.56.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/otel v1.43.0
 	go.uber.org/goleak v1.3.0

--- a/extension/encoding/googlecloudlogentryencodingextension/go.sum
+++ b/extension/encoding/googlecloudlogentryencodingextension/go.sum
@@ -73,6 +73,8 @@ go.opentelemetry.io/collector/extension v1.56.1-0.20260415114935-307e3abdbae9 h1
 go.opentelemetry.io/collector/extension v1.56.1-0.20260415114935-307e3abdbae9/go.mod h1:GMuwYa2Sgy8rGTvPWMi0muzAcs6oBs7TRV41b5TA+Q4=
 go.opentelemetry.io/collector/extension/extensiontest v0.150.1-0.20260415114935-307e3abdbae9 h1:VOy/JsYZn96/OgyltgOkvZX5e6zn0CPDHAiuAHgbOxM=
 go.opentelemetry.io/collector/extension/extensiontest v0.150.1-0.20260415114935-307e3abdbae9/go.mod h1:XkwVtWA6tQPbm7Yhu3MZNg83k1qDMVd8YZFaEDQSf1o=
+go.opentelemetry.io/collector/extension/xextension v0.150.1-0.20260415114935-307e3abdbae9 h1:JTur3vZzxrsqI++SYHylGFsIY45G/akZp+bMO6X0ISA=
+go.opentelemetry.io/collector/extension/xextension v0.150.1-0.20260415114935-307e3abdbae9/go.mod h1:4j63nieN77xkax46IhQ+HVyRbJ8RJ7D1Sv4GJwoDHwc=
 go.opentelemetry.io/collector/featuregate v1.56.1-0.20260415114935-307e3abdbae9 h1:JMMYu48DiKErKQFBNEqRbatDkz6wNF8K7w2EjXg41fw=
 go.opentelemetry.io/collector/featuregate v1.56.1-0.20260415114935-307e3abdbae9/go.mod h1:4ga1QBMPEejXXmpyJS8lmaRpknJ3Lb9Bvk6e420bUFU=
 go.opentelemetry.io/collector/internal/componentalias v0.150.1-0.20260415114935-307e3abdbae9 h1:Iv7v2/gqpW0cDjosBE3G3imDBnk+KOl+Sv2pQoA1IXg=


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46778 renamed the Google Cloud Log Entry Encoding extension from googlecloudlogentry_encoding to google_cloud_logentry_encoding. However, it did not add the old name as a deprecated alias. This PR fixes that.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47663

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Started the collector successfully with a config with this extension:
```
extensions:
    googlecloudlogentry_encoding/test:
        handle_json_payload_as: json
        handle_proto_payload_as: json
```
