### PR TITLE
Support malformed days in RFC 3164 syslogs

### DIFF
--- a/.chloggen/syslog-with-lenient.yaml
+++ b/.chloggen/syslog-with-lenient.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/syslog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support malformed dates in RFC3164 syslogs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/syslog-with-lenient.yaml
+++ b/.chloggen/syslog-with-lenient.yaml
@@ -7,10 +7,10 @@ change_type: bug_fix
 component: receiver/syslog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Support malformed dates in RFC3164 syslogs
+note: Support days with leading zeros in RFC 3164 syslogs
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0]
+issues: [47665]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/stanza/operator/parser/syslog/parser.go
+++ b/pkg/stanza/operator/parser/syslog/parser.go
@@ -157,7 +157,7 @@ func (p *Parser) buildParseFunc() (parseFunc, error) {
 			if p.allowSkipPriHeader && !priRegex.Match(input) {
 				input = append([]byte("<0>"), input...)
 			}
-			return rfc3164.NewMachine(rfc3164.WithLocaleTimezone(p.location)).Parse(input)
+			return rfc3164.NewMachine(rfc3164.WithLocaleTimezone(p.location), rfc3164.WithLenientDay()).Parse(input)
 		}, nil
 	case RFC5424:
 		switch {

--- a/pkg/stanza/operator/parser/syslog/parser_test.go
+++ b/pkg/stanza/operator/parser/syslog/parser_test.go
@@ -55,6 +55,34 @@ func TestParser(t *testing.T) {
 	}
 }
 
+func TestSyslogParseRFC3164_MalformedDay(t *testing.T) {
+	cfg := basicConfig()
+	cfg.Protocol = syslog.RFC3164
+
+	body := `<13>Feb 05 17:32:18 10.0.0.99 Test message`
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	fake := testutil.NewFakeOutput(t)
+	err = op.SetOutputs([]operator.Operator{fake})
+	require.NoError(t, err)
+
+	newEntry := entry.New()
+	newEntry.Body = body
+	err = op.Process(t.Context(), newEntry)
+	require.NoError(t, err)
+
+	select {
+	case e := <-fake.Received:
+		require.Equal(t, body, e.Body)
+		require.Equal(t, time.Date(2026, time.February, 5, 17, 32, 18, 0, time.UTC), e.Timestamp)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be processed")
+	}
+}
+
 func TestSyslogParseRFC5424_SDNameTooLong(t *testing.T) {
 	cfg := basicConfig()
 	cfg.Protocol = syslog.RFC5424


### PR DESCRIPTION
#### Description
By default, go-sylog's parsing for RFC 3164 timestamps requires the day of the month to be formatted with a leading space (`Jan  2`) rather than with a zero (e.g. `Jan 02`). This is correct, and matches the RFC. However, I have observed some producers of syslogs (e.g. some embedded devices) do not produce correctly formatted timestamps, instead producing messages like `<20>Jan 02 17:32:18 10.0.0.99 An example message!`

This PR enables go-syslog's new lenient parsing of days (see https://github.com/leodido/go-syslog/pull/46) for RFC 3164.

I don't think there's any risk of regression from this change ([rsyslog also does this](https://github.com/rsyslog/rsyslog/blob/02c575b9df3168df460ca04cd09391b693b9eaa7/runtime/datetime.c#L629-L637)), but I'm happy to gate this behind a config option if preferred.

#### Testing
Have run a collector with the syslog receiver and debug exporter, and confirmed it can receive logs from non-compliant producers.

