### PR TITLE
fix(receiver/cisco_os): Add ciscoos as deprecated alias

### DIFF
--- a/.chloggen/ciscoosreceiver_deprecated_alias.yaml
+++ b/.chloggen/ciscoosreceiver_deprecated_alias.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/cisco_os
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the deprecated name of the ciscoos extension as a deprecated option to the factory.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47666]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This was one of several components renamed in v0.148.0. 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/ciscoosreceiver/factory.go
+++ b/receiver/ciscoosreceiver/factory.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
 	"go.opentelemetry.io/collector/scraper"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 	"go.uber.org/multierr"
@@ -27,10 +28,11 @@ var scraperFactories = map[component.Type]scraper.Factory{
 }
 
 func NewFactory() receiver.Factory {
-	return receiver.NewFactory(
+	return xreceiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		receiver.WithMetrics(createMetricsReceiver, component.StabilityLevelDevelopment),
+		xreceiver.WithMetrics(createMetricsReceiver, component.StabilityLevelDevelopment),
+		xreceiver.WithDeprecatedTypeAlias(metadata.DeprecatedType),
 	)
 }
 

--- a/receiver/ciscoosreceiver/go.mod
+++ b/receiver/ciscoosreceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.56.0
 	go.opentelemetry.io/collector/receiver v1.56.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.150.0
+	go.opentelemetry.io/collector/receiver/xreceiver v0.150.0
 	go.opentelemetry.io/collector/scraper v0.150.0
 	go.opentelemetry.io/collector/scraper/scraperhelper v0.150.0
 	go.opentelemetry.io/collector/scraper/scrapertest v0.150.0
@@ -52,7 +53,6 @@ require (
 	go.opentelemetry.io/collector/pipeline v1.56.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.150.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.150.0 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.150.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46948 renamed the Cisco OS receiver from ciscoos to cisco_os. However, it did not add the old name as a deprecated alias. This PR fixes that.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47666 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Started the collector successfully with a config using the old name.
