### PR TITLE
[receiver/sshcheck] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46380-sshcheck-enable-reaggregation.yaml
+++ b/.chloggen/46380-sshcheck-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/sshcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the SSH Check receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46380]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/.chloggen/46380-sshcheck-enable-reaggregation.yaml
+++ b/.chloggen/46380-sshcheck-enable-reaggregation.yaml
@@ -4,7 +4,7 @@
 change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/sshcheck
+component: receiver/ssh_check
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Enables dynamic metric reaggregation in the SSH Check receiver. This does not break existing configuration files.

--- a/receiver/sshcheckreceiver/generated_package_test.go
+++ b/receiver/sshcheckreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package sshcheckreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/sshcheckreceiver/generated_package_test.go
+++ b/receiver/sshcheckreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package sshcheckreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/sshcheckreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/sshcheckreceiver/internal/metadata/config.schema.yaml
@@ -18,6 +18,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "error.message"
+            default:
+              - "error.message"
       sshcheck.sftp_duration:
         description: "SshcheckSftpDurationMetricConfig provides config for the sshcheck.sftp_duration metric."
         type: object
@@ -32,6 +48,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "error.message"
+            default:
+              - "error.message"
       sshcheck.sftp_status:
         description: "SshcheckSftpStatusMetricConfig provides config for the sshcheck.sftp_status metric."
         type: object

--- a/receiver/sshcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_config.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"fmt"
-	"slices"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"

--- a/receiver/sshcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,176 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// SshcheckDurationMetricConfig provides config for the sshcheck.duration metric.
+type SshcheckDurationMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *SshcheckDurationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SshcheckErrorMetricAttributeKey specifies the key of an attribute for the sshcheck.error metric.
+type SshcheckErrorMetricAttributeKey string
+
+const (
+	SshcheckErrorMetricAttributeKeyErrorMessage SshcheckErrorMetricAttributeKey = "error.message"
+)
+
+// SshcheckErrorMetricConfig provides config for the sshcheck.error metric.
+type SshcheckErrorMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SshcheckErrorMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SshcheckErrorMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SshcheckErrorMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SshcheckErrorMetricAttributeKeyErrorMessage:
+		default:
+			return fmt.Errorf("metric sshcheck.error doesn't have an attribute %v, valid attributes: [error.message]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SshcheckSftpDurationMetricConfig provides config for the sshcheck.sftp_duration metric.
+type SshcheckSftpDurationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SshcheckSftpDurationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SshcheckSftpErrorMetricAttributeKey specifies the key of an attribute for the sshcheck.sftp_error metric.
+type SshcheckSftpErrorMetricAttributeKey string
+
+const (
+	SshcheckSftpErrorMetricAttributeKeyErrorMessage SshcheckSftpErrorMetricAttributeKey = "error.message"
+)
+
+// SshcheckSftpErrorMetricConfig provides config for the sshcheck.sftp_error metric.
+type SshcheckSftpErrorMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SshcheckSftpErrorMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SshcheckSftpErrorMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SshcheckSftpErrorMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SshcheckSftpErrorMetricAttributeKeyErrorMessage:
+		default:
+			return fmt.Errorf("metric sshcheck.sftp_error doesn't have an attribute %v, valid attributes: [error.message]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SshcheckSftpStatusMetricConfig provides config for the sshcheck.sftp_status metric.
+type SshcheckSftpStatusMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SshcheckSftpStatusMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SshcheckStatusMetricConfig provides config for the sshcheck.status metric.
+type SshcheckStatusMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SshcheckStatusMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,32 +188,36 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for ssh_check metrics.
 type MetricsConfig struct {
-	SshcheckDuration     MetricConfig `mapstructure:"sshcheck.duration"`
-	SshcheckError        MetricConfig `mapstructure:"sshcheck.error"`
-	SshcheckSftpDuration MetricConfig `mapstructure:"sshcheck.sftp_duration"`
-	SshcheckSftpError    MetricConfig `mapstructure:"sshcheck.sftp_error"`
-	SshcheckSftpStatus   MetricConfig `mapstructure:"sshcheck.sftp_status"`
-	SshcheckStatus       MetricConfig `mapstructure:"sshcheck.status"`
+	SshcheckDuration     SshcheckDurationMetricConfig     `mapstructure:"sshcheck.duration"`
+	SshcheckError        SshcheckErrorMetricConfig        `mapstructure:"sshcheck.error"`
+	SshcheckSftpDuration SshcheckSftpDurationMetricConfig `mapstructure:"sshcheck.sftp_duration"`
+	SshcheckSftpError    SshcheckSftpErrorMetricConfig    `mapstructure:"sshcheck.sftp_error"`
+	SshcheckSftpStatus   SshcheckSftpStatusMetricConfig   `mapstructure:"sshcheck.sftp_status"`
+	SshcheckStatus       SshcheckStatusMetricConfig       `mapstructure:"sshcheck.status"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		SshcheckDuration: MetricConfig{
+		SshcheckDuration: SshcheckDurationMetricConfig{
 			Enabled: true,
 		},
-		SshcheckError: MetricConfig{
-			Enabled: true,
+		SshcheckError: SshcheckErrorMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SshcheckErrorMetricAttributeKey{SshcheckErrorMetricAttributeKeyErrorMessage},
 		},
-		SshcheckSftpDuration: MetricConfig{
+		SshcheckSftpDuration: SshcheckSftpDurationMetricConfig{
 			Enabled: false,
 		},
-		SshcheckSftpError: MetricConfig{
+		SshcheckSftpError: SshcheckSftpErrorMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SshcheckSftpErrorMetricAttributeKey{SshcheckSftpErrorMetricAttributeKeyErrorMessage},
+		},
+		SshcheckSftpStatus: SshcheckSftpStatusMetricConfig{
 			Enabled: false,
 		},
-		SshcheckSftpStatus: MetricConfig{
-			Enabled: false,
-		},
-		SshcheckStatus: MetricConfig{
+		SshcheckStatus: SshcheckStatusMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/sshcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,176 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// SshcheckDurationMetricConfig provides config for the sshcheck.duration metric.
+type SshcheckDurationMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *SshcheckDurationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SshcheckErrorMetricAttributeKey specifies the key of an attribute for the sshcheck.error metric.
+type SshcheckErrorMetricAttributeKey string
+
+const (
+	SshcheckErrorMetricAttributeKeyErrorMessage SshcheckErrorMetricAttributeKey = "error.message"
+)
+
+// SshcheckErrorMetricConfig provides config for the sshcheck.error metric.
+type SshcheckErrorMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SshcheckErrorMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SshcheckErrorMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SshcheckErrorMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SshcheckErrorMetricAttributeKeyErrorMessage:
+		default:
+			return fmt.Errorf("metric sshcheck.error doesn't have an attribute %v, valid attributes: [error.message]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SshcheckSftpDurationMetricConfig provides config for the sshcheck.sftp_duration metric.
+type SshcheckSftpDurationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SshcheckSftpDurationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SshcheckSftpErrorMetricAttributeKey specifies the key of an attribute for the sshcheck.sftp_error metric.
+type SshcheckSftpErrorMetricAttributeKey string
+
+const (
+	SshcheckSftpErrorMetricAttributeKeyErrorMessage SshcheckSftpErrorMetricAttributeKey = "error.message"
+)
+
+// SshcheckSftpErrorMetricConfig provides config for the sshcheck.sftp_error metric.
+type SshcheckSftpErrorMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SshcheckSftpErrorMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SshcheckSftpErrorMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SshcheckSftpErrorMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SshcheckSftpErrorMetricAttributeKeyErrorMessage:
+		default:
+			return fmt.Errorf("metric sshcheck.sftp_error doesn't have an attribute %v, valid attributes: [error.message]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SshcheckSftpStatusMetricConfig provides config for the sshcheck.sftp_status metric.
+type SshcheckSftpStatusMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SshcheckSftpStatusMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SshcheckStatusMetricConfig provides config for the sshcheck.status metric.
+type SshcheckStatusMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SshcheckStatusMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,32 +188,36 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for sshcheck metrics.
 type MetricsConfig struct {
-	SshcheckDuration     MetricConfig `mapstructure:"sshcheck.duration"`
-	SshcheckError        MetricConfig `mapstructure:"sshcheck.error"`
-	SshcheckSftpDuration MetricConfig `mapstructure:"sshcheck.sftp_duration"`
-	SshcheckSftpError    MetricConfig `mapstructure:"sshcheck.sftp_error"`
-	SshcheckSftpStatus   MetricConfig `mapstructure:"sshcheck.sftp_status"`
-	SshcheckStatus       MetricConfig `mapstructure:"sshcheck.status"`
+	SshcheckDuration     SshcheckDurationMetricConfig     `mapstructure:"sshcheck.duration"`
+	SshcheckError        SshcheckErrorMetricConfig        `mapstructure:"sshcheck.error"`
+	SshcheckSftpDuration SshcheckSftpDurationMetricConfig `mapstructure:"sshcheck.sftp_duration"`
+	SshcheckSftpError    SshcheckSftpErrorMetricConfig    `mapstructure:"sshcheck.sftp_error"`
+	SshcheckSftpStatus   SshcheckSftpStatusMetricConfig   `mapstructure:"sshcheck.sftp_status"`
+	SshcheckStatus       SshcheckStatusMetricConfig       `mapstructure:"sshcheck.status"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		SshcheckDuration: MetricConfig{
+		SshcheckDuration: SshcheckDurationMetricConfig{
 			Enabled: true,
 		},
-		SshcheckError: MetricConfig{
-			Enabled: true,
+		SshcheckError: SshcheckErrorMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SshcheckErrorMetricAttributeKey{SshcheckErrorMetricAttributeKeyErrorMessage},
 		},
-		SshcheckSftpDuration: MetricConfig{
+		SshcheckSftpDuration: SshcheckSftpDurationMetricConfig{
 			Enabled: false,
 		},
-		SshcheckSftpError: MetricConfig{
+		SshcheckSftpError: SshcheckSftpErrorMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SshcheckSftpErrorMetricAttributeKey{SshcheckSftpErrorMetricAttributeKeyErrorMessage},
+		},
+		SshcheckSftpStatus: SshcheckSftpStatusMetricConfig{
 			Enabled: false,
 		},
-		SshcheckSftpStatus: MetricConfig{
-			Enabled: false,
-		},
-		SshcheckStatus: MetricConfig{
+		SshcheckStatus: SshcheckStatusMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/sshcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/sshcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,22 +27,26 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SshcheckDuration: MetricConfig{
+					SshcheckDuration: SshcheckDurationMetricConfig{
 						Enabled: true,
 					},
-					SshcheckError: MetricConfig{
+					SshcheckError: SshcheckErrorMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SshcheckErrorMetricAttributeKey{SshcheckErrorMetricAttributeKeyErrorMessage},
+					},
+					SshcheckSftpDuration: SshcheckSftpDurationMetricConfig{
 						Enabled: true,
 					},
-					SshcheckSftpDuration: MetricConfig{
+					SshcheckSftpError: SshcheckSftpErrorMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SshcheckSftpErrorMetricAttributeKey{SshcheckSftpErrorMetricAttributeKeyErrorMessage},
+					},
+					SshcheckSftpStatus: SshcheckSftpStatusMetricConfig{
 						Enabled: true,
 					},
-					SshcheckSftpError: MetricConfig{
-						Enabled: true,
-					},
-					SshcheckSftpStatus: MetricConfig{
-						Enabled: true,
-					},
-					SshcheckStatus: MetricConfig{
+					SshcheckStatus: SshcheckStatusMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -54,22 +59,26 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SshcheckDuration: MetricConfig{
+					SshcheckDuration: SshcheckDurationMetricConfig{
 						Enabled: false,
 					},
-					SshcheckError: MetricConfig{
+					SshcheckError: SshcheckErrorMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SshcheckErrorMetricAttributeKey{SshcheckErrorMetricAttributeKeyErrorMessage},
+					},
+					SshcheckSftpDuration: SshcheckSftpDurationMetricConfig{
 						Enabled: false,
 					},
-					SshcheckSftpDuration: MetricConfig{
+					SshcheckSftpError: SshcheckSftpErrorMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SshcheckSftpErrorMetricAttributeKey{SshcheckSftpErrorMetricAttributeKeyErrorMessage},
+					},
+					SshcheckSftpStatus: SshcheckSftpStatusMetricConfig{
 						Enabled: false,
 					},
-					SshcheckSftpError: MetricConfig{
-						Enabled: false,
-					},
-					SshcheckSftpStatus: MetricConfig{
-						Enabled: false,
-					},
-					SshcheckStatus: MetricConfig{
+					SshcheckStatus: SshcheckStatusMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -82,7 +91,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SshcheckDurationMetricConfig{}, SshcheckErrorMetricConfig{}, SshcheckSftpDurationMetricConfig{}, SshcheckSftpErrorMetricConfig{}, SshcheckSftpStatusMetricConfig{}, SshcheckStatusMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/sshcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -47,9 +55,9 @@ type metricInfo struct {
 }
 
 type metricSshcheckDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   SshcheckDurationMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills sshcheck.duration metric with initial data.
@@ -86,7 +94,7 @@ func (m *metricSshcheckDuration) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSshcheckDuration(cfg MetricConfig) metricSshcheckDuration {
+func newMetricSshcheckDuration(cfg SshcheckDurationMetricConfig) metricSshcheckDuration {
 	m := metricSshcheckDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -97,9 +105,10 @@ func newMetricSshcheckDuration(cfg MetricConfig) metricSshcheckDuration {
 }
 
 type metricSshcheckError struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric            // data buffer for generated metric.
+	config        SshcheckErrorMetricConfig // metric config provided by user.
+	capacity      int                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                   // slice containing number of aggregated datapoints at each index
 }
 
 // init fills sshcheck.error metric with initial data.
@@ -111,17 +120,48 @@ func (m *metricSshcheckError) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSshcheckError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, errorMessageAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SshcheckErrorMetricAttributeKeyErrorMessage) {
+		dp.Attributes().PutStr("error.message", errorMessageAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("error.message", errorMessageAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -134,13 +174,18 @@ func (m *metricSshcheckError) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckError) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckError(cfg MetricConfig) metricSshcheckError {
+func newMetricSshcheckError(cfg SshcheckErrorMetricConfig) metricSshcheckError {
 	m := metricSshcheckError{config: cfg}
 
 	if cfg.Enabled {
@@ -151,9 +196,9 @@ func newMetricSshcheckError(cfg MetricConfig) metricSshcheckError {
 }
 
 type metricSshcheckSftpDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   SshcheckSftpDurationMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills sshcheck.sftp_duration metric with initial data.
@@ -190,7 +235,7 @@ func (m *metricSshcheckSftpDuration) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSshcheckSftpDuration(cfg MetricConfig) metricSshcheckSftpDuration {
+func newMetricSshcheckSftpDuration(cfg SshcheckSftpDurationMetricConfig) metricSshcheckSftpDuration {
 	m := metricSshcheckSftpDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -201,9 +246,10 @@ func newMetricSshcheckSftpDuration(cfg MetricConfig) metricSshcheckSftpDuration 
 }
 
 type metricSshcheckSftpError struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        SshcheckSftpErrorMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills sshcheck.sftp_error metric with initial data.
@@ -215,17 +261,48 @@ func (m *metricSshcheckSftpError) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSshcheckSftpError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, errorMessageAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SshcheckSftpErrorMetricAttributeKeyErrorMessage) {
+		dp.Attributes().PutStr("error.message", errorMessageAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("error.message", errorMessageAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -238,13 +315,18 @@ func (m *metricSshcheckSftpError) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckSftpError) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckSftpError(cfg MetricConfig) metricSshcheckSftpError {
+func newMetricSshcheckSftpError(cfg SshcheckSftpErrorMetricConfig) metricSshcheckSftpError {
 	m := metricSshcheckSftpError{config: cfg}
 
 	if cfg.Enabled {
@@ -255,9 +337,9 @@ func newMetricSshcheckSftpError(cfg MetricConfig) metricSshcheckSftpError {
 }
 
 type metricSshcheckSftpStatus struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   SshcheckSftpStatusMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills sshcheck.sftp_status metric with initial data.
@@ -296,7 +378,7 @@ func (m *metricSshcheckSftpStatus) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSshcheckSftpStatus(cfg MetricConfig) metricSshcheckSftpStatus {
+func newMetricSshcheckSftpStatus(cfg SshcheckSftpStatusMetricConfig) metricSshcheckSftpStatus {
 	m := metricSshcheckSftpStatus{config: cfg}
 
 	if cfg.Enabled {
@@ -307,9 +389,9 @@ func newMetricSshcheckSftpStatus(cfg MetricConfig) metricSshcheckSftpStatus {
 }
 
 type metricSshcheckStatus struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   SshcheckStatusMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills sshcheck.status metric with initial data.
@@ -348,7 +430,7 @@ func (m *metricSshcheckStatus) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricSshcheckStatus(cfg MetricConfig) metricSshcheckStatus {
+func newMetricSshcheckStatus(cfg SshcheckStatusMetricConfig) metricSshcheckStatus {
 	m := metricSshcheckStatus{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/sshcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,14 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["SshcheckError"] = mb.metricSshcheckError.config.AggregationStrategy
+			aggMap["SshcheckSftpError"] = mb.metricSshcheckSftpError.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -74,12 +85,18 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSshcheckErrorDataPoint(ts, 1, "error.message-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSshcheckErrorDataPoint(ts, 3, "error.message-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordSshcheckSftpDurationDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSshcheckSftpErrorDataPoint(ts, 1, "error.message-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSshcheckSftpErrorDataPoint(ts, 3, "error.message-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordSshcheckSftpStatusDataPoint(ts, 1)
@@ -92,6 +109,10 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetSSHEndpoint("ssh.endpoint-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricSshcheckError.aggDataPoints)
+				assert.Empty(t, mb.metricSshcheckSftpError.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -131,22 +152,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "sshcheck.error":
-					assert.False(t, validatedMetrics["sshcheck.error"], "Found a duplicate in the metrics slice: sshcheck.error")
-					validatedMetrics["sshcheck.error"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Records errors occurring during SSH check.", mi.Description())
-					assert.Equal(t, "{error}", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					errorMessageAttrVal, ok := dp.Attributes().Get("error.message")
-					assert.True(t, ok)
-					assert.Equal(t, "error.message-val", errorMessageAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sshcheck.error"], "Found a duplicate in the metrics slice: sshcheck.error")
+						validatedMetrics["sshcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during SSH check.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						errorMessageAttrVal, ok := dp.Attributes().Get("error.message")
+						assert.True(t, ok)
+						assert.Equal(t, "error.message-val", errorMessageAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sshcheck.error"], "Found a duplicate in the metrics slice: sshcheck.error")
+						validatedMetrics["sshcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during SSH check.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sshcheck.error"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("error.message")
+						assert.False(t, ok)
+					}
 				case "sshcheck.sftp_duration":
 					assert.False(t, validatedMetrics["sshcheck.sftp_duration"], "Found a duplicate in the metrics slice: sshcheck.sftp_duration")
 					validatedMetrics["sshcheck.sftp_duration"] = true
@@ -160,22 +208,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "sshcheck.sftp_error":
-					assert.False(t, validatedMetrics["sshcheck.sftp_error"], "Found a duplicate in the metrics slice: sshcheck.sftp_error")
-					validatedMetrics["sshcheck.sftp_error"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Records errors occurring during SFTP check.", mi.Description())
-					assert.Equal(t, "{error}", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					errorMessageAttrVal, ok := dp.Attributes().Get("error.message")
-					assert.True(t, ok)
-					assert.Equal(t, "error.message-val", errorMessageAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sshcheck.sftp_error"], "Found a duplicate in the metrics slice: sshcheck.sftp_error")
+						validatedMetrics["sshcheck.sftp_error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during SFTP check.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						errorMessageAttrVal, ok := dp.Attributes().Get("error.message")
+						assert.True(t, ok)
+						assert.Equal(t, "error.message-val", errorMessageAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sshcheck.sftp_error"], "Found a duplicate in the metrics slice: sshcheck.sftp_error")
+						validatedMetrics["sshcheck.sftp_error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during SFTP check.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sshcheck.sftp_error"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("error.message")
+						assert.False(t, ok)
+					}
 				case "sshcheck.sftp_status":
 					assert.False(t, validatedMetrics["sshcheck.sftp_status"], "Found a duplicate in the metrics slice: sshcheck.sftp_status")
 					validatedMetrics["sshcheck.sftp_status"] = true

--- a/receiver/sshcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sshcheckreceiver/internal/metadata/testdata/config.yaml
@@ -5,10 +5,31 @@ all_set:
       enabled: true
     sshcheck.error:
       enabled: true
+      attributes: ["error.message"]
     sshcheck.sftp_duration:
       enabled: true
     sshcheck.sftp_error:
       enabled: true
+      attributes: ["error.message"]
+    sshcheck.sftp_status:
+      enabled: true
+    sshcheck.status:
+      enabled: true
+  resource_attributes:
+    ssh.endpoint:
+      enabled: true
+reaggregate_set:
+  metrics:
+    sshcheck.duration:
+      enabled: true
+    sshcheck.error:
+      enabled: true
+      attributes: []
+    sshcheck.sftp_duration:
+      enabled: true
+    sshcheck.sftp_error:
+      enabled: true
+      attributes: []
     sshcheck.sftp_status:
       enabled: true
     sshcheck.status:
@@ -22,10 +43,12 @@ none_set:
       enabled: false
     sshcheck.error:
       enabled: false
+      attributes: ["error.message"]
     sshcheck.sftp_duration:
       enabled: false
     sshcheck.sftp_error:
       enabled: false
+      attributes: ["error.message"]
     sshcheck.sftp_status:
       enabled: false
     sshcheck.status:

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -1,6 +1,7 @@
 display_name: SSH Check Receiver
 type: ssh_check
 deprecated_type: sshcheck
+reaggregation_enabled: true
 
 description: This receiver creates stats by connecting to an SSH server which may be an SFTP server.
 
@@ -22,6 +23,7 @@ resource_attributes:
 attributes:
   error.message:
     description: Error message recorded during check
+    requirement_level: recommended
     type: string
 
 metrics:

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: SSH Check Receiver
 type: sshcheck
+reaggregation_enabled: true
 
 description: This receiver creates stats by connecting to an SSH server which may be an SFTP server.
 
@@ -21,6 +22,7 @@ resource_attributes:
 attributes:
   error.message:
     description: Error message recorded during check
+    requirement_level: recommended
     type: string
 
 metrics:


### PR DESCRIPTION
Closes #46380
Part of #45396

## Changes

- Added `reaggregation_enabled: true` to `metadata.yaml`
- Set `requirement_level: recommended` on the `error.message` attribute
- Regenerated all files under `internal/metadata/` via `go generate`

Follows the same pattern as other receivers in #45396 (e.g. chrony #47533, nginx #47489).

## Testing

All existing tests pass:
```
ok  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
ok  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver/internal/configssh
ok  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver/internal/metadata
```