### PR TITLE
[chore] [extension/datadog] Refactor to use confighttp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -195,10 +195,6 @@ linters:
         text: confighttp
       - linters:
           - forbidigo
-        path: extension/datadogextension/
-        text: confighttp
-      - linters:
-          - forbidigo
         path: testbed/
         text: confighttp
 

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -82,11 +82,15 @@ type datadogExtension struct {
 	configs *configs
 
 	// components to assist in payload sending/logging
-	logger     *zap.Logger
-	serializer agentcomponents.SerializerWithForwarder
+	logger            *zap.Logger
+	serializer        agentcomponents.SerializerWithForwarder
+	telemetrySettings component.TelemetrySettings
 
 	// struct to store extension info
 	info *info
+
+	// host stores the component host for use when creating the HTTP server
+	host component.Host
 
 	otelCollectorMetadata *payload.OtelCollector
 	httpServer            *httpserver.Server
@@ -172,8 +176,12 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		e.info.host.Identifier,
 		e.info.uuid,
 		otelCollectorPayload,
+		e.telemetrySettings,
 	)
-	e.httpServer.Start()
+	startErr := e.httpServer.Start(context.Background(), e.host)
+	if startErr != nil {
+		return startErr
+	}
 	_, err = e.httpServer.SendPayload()
 	if err != nil {
 		return err
@@ -204,6 +212,9 @@ func (*datadogExtension) ComponentStatusChanged(
 
 // Start starts the extension via the component interface.
 func (e *datadogExtension) Start(_ context.Context, host component.Host) error {
+	// Store host for later use when creating the HTTP server
+	e.host = host
+
 	// Retrieve module information from the host
 	if mi, ok := host.(hostcapabilities.ModuleInfo); ok {
 		e.info.modules = mi.GetModuleInfos()
@@ -408,9 +419,10 @@ func newExtension(
 	channel := make(chan struct{}, 1)
 
 	e := &datadogExtension{
-		configs:    &configs{extension: cfg},
-		logger:     set.Logger,
-		serializer: serializer,
+		configs:           &configs{extension: cfg},
+		logger:            set.Logger,
+		serializer:        serializer,
+		telemetrySettings: set.TelemetrySettings,
 		info: &info{
 			host:               host,
 			hostnameSource:     hostnameSource,

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/confmap"
@@ -631,6 +632,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 		testHostname,
 		testUUID,
 		otelMetadata,
+		telemetrySettings,
 	)
 	require.NotNil(t, server)
 
@@ -640,7 +642,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 	defer serializer.Stop()
 
 	// Start the HTTP server
-	server.Start()
+	require.NoError(t, server.Start(t.Context(), componenttest.NewNopHost()))
 	defer func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
@@ -786,11 +788,12 @@ func TestHTTPServerConfigIntegration(t *testing.T) {
 				"test-host-"+tc.name,
 				"test-uuid-"+tc.name,
 				otelMetadata,
+				telemetrySettings,
 			)
 			require.NotNil(t, server)
 
 			// Test server creation doesn't panic and can be started/stopped
-			server.Start()
+			require.NoError(t, server.Start(t.Context(), componenttest.NewNopHost()))
 			time.Sleep(50 * time.Millisecond) // Brief pause to allow server startup
 
 			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
@@ -862,6 +865,7 @@ func TestHTTPServerConcurrentAccess(t *testing.T) {
 		"concurrent-test-host",
 		"concurrent-test-uuid",
 		otelMetadata,
+		telemetrySettings,
 	)
 
 	// Start serializer

--- a/extension/datadogextension/internal/httpserver/httpserver.go
+++ b/extension/datadogextension/internal/httpserver/httpserver.go
@@ -8,13 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
@@ -26,10 +27,16 @@ var nowFunc = time.Now
 // Server provides local metadata server functionality (display the otel_collector payload locally) as well as
 // functions to serialize and export this metadata to Datadog backend.
 type Server struct {
-	// server is used to respond to local metadata requests
-	server *http.Server
+	// serverConfig is used to create the HTTP server via confighttp
+	serverConfig *confighttp.ServerConfig
+	// handler is the HTTP handler for the server
+	handler http.Handler
+	// listenClose is used to shut down the server
+	listenClose func(ctx context.Context) error
 	// logger is passed from the extension to allow logging
 	logger *zap.Logger
+	// telemetrySettings holds the telemetry settings for the server
+	telemetrySettings component.TelemetrySettings
 	// serializer is a datadog-agent component used to forward payloads to Datadog backend
 	serializer agentcomponents.SerializerWithForwarder
 	// config contains the httpserver configuration values
@@ -53,6 +60,7 @@ func NewServer(
 	hostname string,
 	uuid string,
 	p payload.OtelCollector,
+	telemetrySettings component.TelemetrySettings,
 ) *Server {
 	// Create payload but don't add timestamp, that will happen in SendPayload
 	oc := &payload.OtelCollectorPayload{
@@ -62,50 +70,58 @@ func NewServer(
 	}
 
 	srv := &Server{
-		logger:     logger,
-		serializer: s,
-		config:     config,
-		payload:    oc, // store as interface
-		server: &http.Server{
-			Addr:         config.NetAddr.Endpoint,
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 10 * time.Second,
-			BaseContext:  func(net.Listener) context.Context { return context.Background() },
-		},
+		logger:            logger,
+		telemetrySettings: telemetrySettings,
+		serializer:        s,
+		config:            config,
+		serverConfig:      &config.ServerConfig,
+		payload:           oc, // store as interface
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(config.Path, srv.HandleMetadata)
-	srv.server.Handler = mux
+	srv.handler = mux
 
 	return srv
 }
 
 // Start starts the HTTP server and begins sending payloads periodically.
-func (s *Server) Start() {
+func (s *Server) Start(ctx context.Context, host component.Host) error {
+	server, err := s.serverConfig.ToServer(
+		ctx,
+		host.GetExtensions(),
+		s.telemetrySettings,
+		s.handler,
+	)
+	if err != nil {
+		return err
+	}
+
+	listener, err := s.serverConfig.ToListener(ctx)
+	if err != nil {
+		return err
+	}
+	s.listenClose = server.Shutdown
+
 	// Start HTTP server
 	go func() {
-		lis, err := s.config.ToListener(context.Background())
-		if err != nil {
-			s.logger.Error("HTTP server error", zap.Error(err))
-			return
-		}
-		if err := s.server.Serve(lis); err != nil && err != http.ErrServerClosed {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			s.logger.Error("HTTP server error", zap.Error(err))
 		}
 	}()
 
 	s.logger.Info("HTTP Server started at " + s.config.NetAddr.Endpoint + s.config.Path)
+	return nil
 }
 
 // Stop shuts down the HTTP server, pass a context to allow for cancellation.
 func (s *Server) Stop(ctx context.Context) {
-	if s.server != nil {
+	if s.listenClose != nil {
 		shutdownDone := make(chan struct{})
 
 		go func() {
 			defer close(shutdownDone) // Ensure channel is always closed
-			if err := s.server.Shutdown(ctx); err != nil {
+			if err := s.listenClose(ctx); err != nil {
 				s.logger.Error("Failed to shutdown HTTP server", zap.Error(err))
 			}
 		}()

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.uber.org/zap"
@@ -57,6 +57,7 @@ func TestServerStart(t *testing.T) {
 					"test-hostname",
 					"test-uuid",
 					payload.OtelCollector{},
+					componenttest.NewNopTelemetrySettings(),
 				)
 				return s, logs
 			},
@@ -67,7 +68,7 @@ func TestServerStart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, logs := tt.setupServer()
-			s.Start()
+			require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
 
 			// Verify the logs
 			for _, expectedLog := range tt.expectedLogs {
@@ -182,6 +183,7 @@ func TestPrepareAndSendFleetAutomationPayloads(t *testing.T) {
 				"test-hostname",
 				"test-uuid",
 				payload.OtelCollector{},
+				componenttest.NewNopTelemetrySettings(),
 			)
 			ocPayload, err := s.SendPayload()
 			if tt.expectedError != "" {
@@ -421,13 +423,13 @@ func TestServerStop(t *testing.T) {
 		simulateSlowStop bool
 	}{
 		{
-			name: "Stop with nil server - should be no-op",
+			name: "Stop with nil listenClose - should be no-op",
 			setupServer: func() (*Server, *observer.ObservedLogs) {
 				core, logs := observer.New(zapcore.InfoLevel)
 				logger := zap.New(core)
 				return &Server{
-					logger: logger,
-					server: nil, // nil server
+					logger:      logger,
+					listenClose: nil, // nil listenClose
 				}, logs
 			},
 			contextSetup: func() (context.Context, context.CancelFunc) {
@@ -448,14 +450,13 @@ func TestServerStop(t *testing.T) {
 					w.WriteHeader(http.StatusOK)
 				})
 				server := &http.Server{
-					Addr:              "127.0.0.1:0", // Use any available port
 					Handler:           mux,
 					ReadHeaderTimeout: 10 * time.Millisecond,
 				}
 
 				return &Server{
-					logger: logger,
-					server: server,
+					logger:      logger,
+					listenClose: server.Shutdown,
 				}, logs
 			},
 			contextSetup: func() (context.Context, context.CancelFunc) {
@@ -472,22 +473,8 @@ func TestServerStop(t *testing.T) {
 			ctx, cancel := tt.contextSetup()
 			defer cancel()
 
-			if srv.server != nil && srv.server.Addr != "" {
-				listener, err := net.Listen("tcp", srv.server.Addr)
-				require.NoError(t, err)
-				go func() {
-					if err := srv.server.Serve(listener); err != nil && err != http.ErrServerClosed {
-						t.Logf("Unexpected server error: %v", err)
-					}
-				}()
-
-				if tt.simulateSlowStop {
-					cancel()
-					resp, err := http.Get("http://" + srv.server.Addr + "/block")
-					if err == nil {
-						_ = resp.Body.Close()
-					}
-				}
+			if tt.simulateSlowStop {
+				cancel()
 			}
 
 			start := time.Now()
@@ -536,13 +523,13 @@ func TestServerStopChannelBehavior(t *testing.T) {
 	}
 
 	srv := &Server{
-		logger: logger,
-		server: server,
+		logger:      logger,
+		listenClose: server.Shutdown,
 	}
 
 	// Start the server
 	go func() {
-		if err := srv.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			t.Errorf("Unexpected server error: %v", err)
 		}
 	}()
@@ -594,13 +581,13 @@ func TestServerStopConcurrency(t *testing.T) {
 	}
 
 	srv := &Server{
-		logger: logger,
-		server: server,
+		logger:      logger,
+		listenClose: server.Shutdown,
 	}
 
 	// Start the server
 	go func() {
-		if err := srv.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			t.Logf("Unexpected server error: %v", err)
 		}
 	}()
@@ -668,7 +655,7 @@ func TestServer_SendPayload(t *testing.T) {
 		return nil
 	}
 
-	server := NewServer(logger, serializer, config, "host", "uuid", pl)
+	server := NewServer(logger, serializer, config, "host", "uuid", pl, componenttest.NewNopTelemetrySettings())
 
 	result, err := server.SendPayload()
 	assert.NoError(t, err)
@@ -694,7 +681,7 @@ func TestServer_SendPayload_ForwarderNotStarted(t *testing.T) {
 	pl := payload.OtelCollector{}
 	serializer := &mockSerializer{state: 0} // 0 != defaultforwarder.Started
 
-	server := NewServer(logger, serializer, config, "host", "uuid", pl)
+	server := NewServer(logger, serializer, config, "host", "uuid", pl, componenttest.NewNopTelemetrySettings())
 
 	result, err := server.SendPayload()
 	assert.Error(t, err)
@@ -761,6 +748,7 @@ func TestNewServerErrorPaths(t *testing.T) {
 			"test-hostname",
 			"test-uuid",
 			payload.OtelCollector{},
+			componenttest.NewNopTelemetrySettings(),
 		)
 
 		// Stop should not panic even if server was never started
@@ -769,17 +757,17 @@ func TestNewServerErrorPaths(t *testing.T) {
 		})
 	})
 
-	t.Run("Stop server with nil server", func(t *testing.T) {
+	t.Run("Stop server with nil listenClose", func(t *testing.T) {
 		core, _ := observer.New(zapcore.InfoLevel)
 		logger := zap.New(core)
 
-		// Create a server instance with nil server field
+		// Create a server instance with nil listenClose field
 		s := &Server{
-			logger: logger,
-			server: nil,
+			logger:      logger,
+			listenClose: nil,
 		}
 
-		// Stop should not panic with nil server
+		// Stop should not panic with nil listenClose
 		assert.NotPanics(t, func() {
 			s.Stop(t.Context())
 		})


### PR DESCRIPTION
#### Description
- Refactor to use `confighttp` instead of `net/http`
- Remove the lint exclusion for this component

#### Link to tracking issue
Related to #47586

#### Assisted-by
Claude-Opus 4.6