### PR TITLE
PRW 2: respect the incoming zero threshold when set

### DIFF
--- a/.chloggen/prw2-zerothreshold.yaml
+++ b/.chloggen/prw2-zerothreshold.yaml
@@ -10,7 +10,7 @@ component: exporter/prometheusremotewrite
 note: Respect the zero threshold of exponential histograms when set for PRW v2
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [47681]
+issues: [33661]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/prw2-zerothreshold.yaml
+++ b/.chloggen/prw2-zerothreshold.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Respect the zero threshold of exponential histograms when set for PRW v2
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/prw2-zerothreshold.yaml
+++ b/.chloggen/prw2-zerothreshold.yaml
@@ -10,7 +10,7 @@ component: exporter/prometheusremotewrite
 note: Respect the zero threshold of exponential histograms when set for PRW v2
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47681]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/translator/prometheusremotewrite/histograms_v2.go
+++ b/pkg/translator/prometheusremotewrite/histograms_v2.go
@@ -62,6 +62,11 @@ func exponentialToNativeHistogramV2(p pmetric.ExponentialHistogramDataPoint) (wr
 	pSpans, pDeltas := convertBucketsLayoutV2(p.Positive(), scaleDown)
 	nSpans, nDeltas := convertBucketsLayoutV2(p.Negative(), scaleDown)
 
+	zeroThreshold := p.ZeroThreshold()
+	if zeroThreshold == 0 {
+		zeroThreshold = defaultZeroThreshold
+	}
+
 	h := writev2.Histogram{
 		// The counter reset detection must be compatible with Prometheus to
 		// safely set ResetHint to NO. This is not ensured currently.
@@ -75,10 +80,8 @@ func exponentialToNativeHistogramV2(p pmetric.ExponentialHistogramDataPoint) (wr
 		ResetHint: writev2.Histogram_RESET_HINT_UNSPECIFIED,
 		Schema:    scale,
 
-		ZeroCount: &writev2.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
-		// TODO use zero_threshold, if set, see
-		// https://github.com/open-telemetry/opentelemetry-proto/pull/441
-		ZeroThreshold: defaultZeroThreshold,
+		ZeroCount:     &writev2.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
+		ZeroThreshold: zeroThreshold,
 
 		PositiveSpans:  pSpans,
 		PositiveDeltas: pDeltas,

--- a/pkg/translator/prometheusremotewrite/histograms_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/histograms_v2_test.go
@@ -550,6 +550,38 @@ func TestExponentialToNativeHistogramV2(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "convert exp. to native histogram with non-zero zero threshold",
+			exponentialHist: func() pmetric.ExponentialHistogramDataPoint {
+				pt := pmetric.NewExponentialHistogramDataPoint()
+				pt.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(500)))
+				pt.SetCount(4)
+				pt.SetScale(1)
+				pt.SetZeroCount(1)
+				pt.SetZeroThreshold(0.5)
+
+				pt.Positive().BucketCounts().FromRaw([]uint64{1, 1})
+				pt.Positive().SetOffset(1)
+
+				pt.Negative().BucketCounts().FromRaw([]uint64{1, 1})
+				pt.Negative().SetOffset(1)
+
+				return pt
+			},
+			wantNativeHist: func() writev2.Histogram {
+				return writev2.Histogram{
+					Count:          &writev2.Histogram_CountInt{CountInt: 4},
+					Schema:         1,
+					ZeroThreshold:  0.5,
+					ZeroCount:      &writev2.Histogram_ZeroCountInt{ZeroCountInt: 1},
+					NegativeSpans:  []writev2.BucketSpan{{Offset: 2, Length: 2}},
+					NegativeDeltas: []int64{1, 0},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 2, Length: 2}},
+					PositiveDeltas: []int64{1, 0},
+					Timestamp:      500,
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### Description

Fix PRW 2.0 zero threshold.  This is the same fix as https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46183, but for PRW v2.