### PR TITLE
[pkg/ottl]: Improve performance for decode function

### DIFF
--- a/.chloggen/improve-decode.yaml
+++ b/.chloggen/improve-decode.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improve performance for decode function and fix ValueBytes decoding
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47685]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -28,6 +28,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
+	golang.org/x/text v0.36.0
 	google.golang.org/grpc v1.80.0
 )
 
@@ -55,7 +56,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/pkg/ottl/ottlfuncs/func_decode.go
+++ b/pkg/ottl/ottlfuncs/func_decode.go
@@ -10,10 +10,57 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"golang.org/x/text/encoding"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
+
+type decoder interface {
+	Decode(src []byte) (any, error)
+	DecodeString(src string) (any, error)
+}
+
+type textDecoder struct {
+	enc encoding.Encoding
+}
+
+func (td textDecoder) Decode(src []byte) (any, error) {
+	ret, err := td.enc.NewDecoder().Bytes(src)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode: %w", err)
+	}
+	return string(ret), nil
+}
+
+func (td textDecoder) DecodeString(src string) (any, error) {
+	decodedString, err := td.enc.NewDecoder().String(src)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode: %w", err)
+	}
+	return decodedString, nil
+}
+
+type base64Decoder struct {
+	enc *base64.Encoding
+}
+
+func (bd base64Decoder) Decode(src []byte) (any, error) {
+	dbuf := make([]byte, bd.enc.DecodedLen(len(src)))
+	n, err := bd.enc.Decode(dbuf, src)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode: %w", err)
+	}
+	return string(dbuf[:n]), nil
+}
+
+func (bd base64Decoder) DecodeString(src string) (any, error) {
+	buf, err := bd.enc.DecodeString(src)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode: %w", err)
+	}
+	return string(buf), nil
+}
 
 type DecodeArguments[K any] struct {
 	Target   ottl.Getter[K]
@@ -30,70 +77,94 @@ func createDecodeFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (
 		return nil, errors.New("DecodeFactory args must be of type *DecodeArguments[K]")
 	}
 
-	return Decode(args.Target, args.Encoding), nil
+	return decode(args.Target, args.Encoding)
 }
 
-func Decode[K any](target ottl.Getter[K], encoding ottl.StringGetter[K]) ottl.ExprFunc[K] {
+func decode[K any](target ottl.Getter[K], encoding ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
+	decGet, err := newDecoderGetter(encoding)
+	if err != nil {
+		return nil, err
+	}
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		encodingVal, err := encoding.Get(ctx, tCtx)
+		dec, err := decGet.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		var stringValue string
 
 		switch v := val.(type) {
 		case []byte:
-			stringValue = string(v)
+			return dec.Decode(v)
 		case *string:
-			stringValue = *v
+			return dec.DecodeString(*v)
 		case string:
-			stringValue = v
+			return dec.DecodeString(v)
 		case pcommon.ByteSlice:
-			stringValue = string(v.AsRaw())
+			return dec.Decode(v.AsRaw())
 		case *pcommon.ByteSlice:
-			stringValue = string(v.AsRaw())
+			return dec.Decode(v.AsRaw())
 		case pcommon.Value:
-			stringValue = v.AsString()
+			if v.Type() == pcommon.ValueTypeBytes {
+				return dec.Decode(v.Bytes().AsRaw())
+			}
+			return dec.DecodeString(v.AsString())
 		case *pcommon.Value:
-			stringValue = v.AsString()
+			if v.Type() == pcommon.ValueTypeBytes {
+				return dec.Decode(v.Bytes().AsRaw())
+			}
+			return dec.DecodeString(v.AsString())
 		default:
 			return nil, fmt.Errorf("unsupported type provided to Decode function: %T", v)
 		}
-
-		switch encodingVal {
-		// base64 is not in IANA index, so we have to deal with this encoding separately
-		case "base64":
-			return decodeBase64(base64.StdEncoding, stringValue)
-		case "base64-raw":
-			return decodeBase64(base64.RawStdEncoding, stringValue)
-		case "base64-url":
-			return decodeBase64(base64.URLEncoding, stringValue)
-		case "base64-raw-url":
-			return decodeBase64(base64.RawURLEncoding, stringValue)
-		default:
-			e, err := textutils.LookupEncoding(encodingVal)
-			if err != nil {
-				return nil, err
-			}
-
-			decodedString, err := e.NewDecoder().String(stringValue)
-			if err != nil {
-				return nil, fmt.Errorf("could not decode: %w", err)
-			}
-
-			return decodedString, nil
-		}
-	}
+	}, nil
 }
 
-func decodeBase64(encoding *base64.Encoding, stringValue string) (any, error) {
-	decodedBytes, err := encoding.DecodeString(stringValue)
-	if err != nil {
-		return nil, fmt.Errorf("could not decode: %w", err)
+type decoderGetter[K any] struct {
+	decoder decoder
+	getter  ottl.StringGetter[K]
+}
+
+func newDecoderGetter[K any](getter ottl.StringGetter[K]) (*decoderGetter[K], error) {
+	if enc, isLiteral := ottl.GetLiteralValue(getter); isLiteral {
+		dec, err := asDecoder(enc)
+		if err != nil {
+			return nil, err
+		}
+		return &decoderGetter[K]{decoder: dec}, nil
 	}
-	return string(decodedBytes), nil
+	return &decoderGetter[K]{getter: getter}, nil
+}
+
+func (d *decoderGetter[K]) Get(ctx context.Context, tCtx K) (decoder, error) {
+	if d.decoder != nil {
+		return d.decoder, nil
+	}
+	enc, err := d.getter.Get(ctx, tCtx)
+	if err != nil {
+		return nil, err
+	}
+	return asDecoder(enc)
+}
+
+func asDecoder(encodingVal string) (decoder, error) {
+	switch encodingVal {
+	// base64 is not in IANA index, so we have to deal with this encoding separately
+	case "base64":
+		return base64Decoder{enc: base64.StdEncoding}, nil
+	case "base64-raw":
+		return base64Decoder{enc: base64.RawStdEncoding}, nil
+	case "base64-url":
+		return base64Decoder{enc: base64.URLEncoding}, nil
+	case "base64-raw-url":
+		return base64Decoder{enc: base64.RawURLEncoding}, nil
+	default:
+		e, err := textutils.LookupEncoding(encodingVal)
+		if err != nil {
+			return nil, err
+		}
+		return textDecoder{enc: e}, nil
+	}
 }

--- a/pkg/ottl/ottlfuncs/func_decode_test.go
+++ b/pkg/ottl/ottlfuncs/func_decode_test.go
@@ -19,10 +19,11 @@ func TestDecode(t *testing.T) {
 	testByteSliceB64 := pcommon.NewByteSlice()
 	testByteSliceB64.FromRaw([]byte("aGVsbG8gd29ybGQ="))
 
-	testValue := pcommon.NewValueEmpty()
-	_ = testValue.FromRaw("test string")
-	testValueB64 := pcommon.NewValueEmpty()
-	_ = testValueB64.FromRaw("aGVsbG8gd29ybGQ=")
+	testValue := pcommon.NewValueStr("test string")
+	testValueB64 := pcommon.NewValueStr("aGVsbG8gd29ybGQ=")
+
+	testValueBytes := pcommon.NewValueBytes()
+	testValueBytes.Bytes().FromRaw([]byte{116, 0, 101, 0, 115, 0, 116, 0, 32, 0, 115, 0, 116, 0, 114, 0, 105, 0, 110, 0, 103, 0})
 
 	type testCase struct {
 		name          string
@@ -141,6 +142,12 @@ func TestDecode(t *testing.T) {
 			want:     "test string",
 		},
 		{
+			name:     "decode UTF-16 encoded value bytes",
+			value:    testValueBytes,
+			encoding: "UTF16",
+			want:     "test string",
+		},
+		{
 			name:          "decode GB2312 encoded string; no decoder available",
 			value:         "test string",
 			encoding:      "GB2312",
@@ -210,7 +217,6 @@ func TestDecode(t *testing.T) {
 					},
 				},
 			})
-
 			require.NoError(t, err)
 
 			result, err := expressionFunc(nil, nil)
@@ -222,5 +228,63 @@ func TestDecode(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.want, result)
 		})
+	}
+}
+
+func BenchmarkDecodeBytes(b *testing.B) {
+	val := pcommon.NewValueBytes()
+	val.Bytes().FromRaw([]byte(benchData))
+
+	encGetter, err := ottl.NewTestingLiteralGetter[any, string](true, &ottl.StandardStringGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "utf-8", nil
+		},
+	})
+	require.NoError(b, err)
+
+	dec, err := decode(ottl.StandardGetSetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return val, nil
+		},
+	}, encGetter)
+	require.NoError(b, err)
+
+	ctx := b.Context()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, err = dec(ctx, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkDecodeString(b *testing.B) {
+	val := pcommon.NewValueStr(benchData)
+	encGetter, err := ottl.NewTestingLiteralGetter[any, string](true, &ottl.StandardStringGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "utf-8", nil
+		},
+	})
+	require.NoError(b, err)
+
+	dec, err := decode(ottl.StandardGetSetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return val, nil
+		},
+	}, encGetter)
+	require.NoError(b, err)
+
+	ctx := b.Context()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, err = dec(ctx, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
Changes in this PR:
* If encoding is literal, then avoid re-checking the encoding value.
* For bytes avoid conversion to string to improve performance.
* Fix bug, where for pcommon.Value of type Bytes it was used `AsString` which does a base64 encoding of the bytes.

**Before:**
```
BenchmarkDecodeBytes-12    	  116629	      8875 ns/op	   12600 B/op	       6 allocs/op
BenchmarkDecodeString-12    	  250376	      4206 ns/op	     312 B/op	       4 allocs/op
```

**After:**
```
BenchmarkDecodeBytes-12    	  232830	      5109 ns/op	   12344 B/op	       6 allocs/op
BenchmarkDecodeString-12    	  275353	      4177 ns/op	     312 B/op	       4 allocs/op```
```
