### PR TITLE
Fix PRW 1.0 maps non-monotonic sums to counter instead of gauge

### DIFF
--- a/.chloggen/prw-nonmonotonic.yaml
+++ b/.chloggen/prw-nonmonotonic.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where non-monotonic sums are mapped to OTel sums instead of gauges.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33661]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/prw-nonmonotonic.yaml
+++ b/.chloggen/prw-nonmonotonic.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: exporter/prometheusremotewrite
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix bug where non-monotonic sums are mapped to OTel sums instead of gauges.
+note: Fix bug where non-monotonic sums are mapped to Prometheus counters instead of gauges.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [33661]

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -197,10 +197,7 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, scope p
 		})
 	}
 
-	for i := 0; i < len(extras); i += 2 {
-		if i+1 >= len(extras) {
-			break
-		}
+	for i := 0; i+1 < len(extras); i += 2 {
 		_, found := l[extras[i]]
 		if found && logOnOverwrite {
 			log.Println("label " + extras[i] + " is overwritten. Check if Prometheus reserved labels are used.")
@@ -487,9 +484,7 @@ func createLabels(name string, baseLabels []prompb.Label, extras ...string) []pr
 	labels := make([]prompb.Label, len(baseLabels), len(baseLabels)+extraLabelCount+1) // +1 for name
 	copy(labels, baseLabels)
 
-	n := len(extras)
-	n -= n % 2
-	for extrasIdx := 0; extrasIdx < n; extrasIdx += 2 {
+	for extrasIdx := 0; extrasIdx+1 < len(extras); extrasIdx += 2 {
 		labels = append(labels, prompb.Label{Name: extras[extrasIdx], Value: extras[extrasIdx+1]})
 	}
 

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -108,7 +108,11 @@ func (c *prometheusConverter) fromMetrics(md pmetric.Metrics, settings Settings)
 						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
 						break
 					}
-					errs = multierr.Append(errs, c.addSumNumberDataPoints(dataPoints, resource, scope, metric, settings, promName))
+					if metric.Sum().IsMonotonic() {
+						errs = multierr.Append(errs, c.addSumNumberDataPoints(dataPoints, resource, scope, metric, settings, promName))
+					} else {
+						errs = multierr.Append(errs, c.addGaugeNumberDataPoints(dataPoints, resource, scope, settings, promName))
+					}
 				case pmetric.MetricTypeHistogram:
 					dataPoints := metric.Histogram().DataPoints()
 					if dataPoints.Len() == 0 {

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -203,4 +204,57 @@ func TestIsSameMetric(t *testing.T) {
 			assert.Equal(t, tt.same, same)
 		})
 	}
+}
+
+func TestFromMetrics_NonMonotonicSum(t *testing.T) {
+	// Create a non-monotonic sum metric
+	metricNonMonotonic := pmetric.NewMetric()
+	metricNonMonotonic.SetName("test_non_monotonic_sum")
+	metricNonMonotonic.SetEmptySum().SetIsMonotonic(false)
+	metricNonMonotonic.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	pt1 := metricNonMonotonic.Sum().DataPoints().AppendEmpty()
+	pt1.SetTimestamp(pcommon.Timestamp(1000000000))
+	pt1.SetDoubleValue(1.23)
+	pt1.Exemplars().AppendEmpty().SetDoubleValue(4.56)
+
+	// Create a monotonic sum metric
+	metricMonotonic := pmetric.NewMetric()
+	metricMonotonic.SetName("test_monotonic_sum")
+	metricMonotonic.SetEmptySum().SetIsMonotonic(true)
+	metricMonotonic.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	pt2 := metricMonotonic.Sum().DataPoints().AppendEmpty()
+	pt2.SetTimestamp(pcommon.Timestamp(1000000000))
+	pt2.SetDoubleValue(7.89)
+	pt2.Exemplars().AppendEmpty().SetDoubleValue(0.12)
+
+	md := pmetric.NewMetrics()
+	metrics := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
+	metricNonMonotonic.CopyTo(metrics.AppendEmpty())
+	metricMonotonic.CopyTo(metrics.AppendEmpty())
+
+	tsMap, err := FromMetrics(md, Settings{})
+	require.NoError(t, err)
+	require.Len(t, tsMap, 2)
+
+	var tsNonMonotonic, tsMonotonic *prompb.TimeSeries
+	for _, ts := range tsMap {
+		for _, l := range ts.Labels {
+			if l.Name == model.MetricNameLabel {
+				if l.Value == "test_non_monotonic_sum" {
+					tsNonMonotonic = ts
+				} else if l.Value == "test_monotonic_sum" {
+					tsMonotonic = ts
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, tsNonMonotonic, "non-monotonic sum series not found")
+	require.NotNil(t, tsMonotonic, "monotonic sum series not found")
+
+	// Non-monotonic sum should NOT have exemplars (intentional)
+	assert.Empty(t, tsNonMonotonic.Exemplars)
+
+	// Monotonic sum SHOULD have exemplars
+	assert.Len(t, tsMonotonic.Exemplars, 1)
 }

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
@@ -240,9 +240,10 @@ func TestFromMetrics_NonMonotonicSum(t *testing.T) {
 	for _, ts := range tsMap {
 		for _, l := range ts.Labels {
 			if l.Name == model.MetricNameLabel {
-				if l.Value == "test_non_monotonic_sum" {
+				switch l.Value {
+				case "test_non_monotonic_sum":
 					tsNonMonotonic = ts
-				} else if l.Value == "test_monotonic_sum_total" {
+				case "test_monotonic_sum_total":
 					tsMonotonic = ts
 				}
 			}

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
@@ -232,7 +232,7 @@ func TestFromMetrics_NonMonotonicSum(t *testing.T) {
 	metricNonMonotonic.CopyTo(metrics.AppendEmpty())
 	metricMonotonic.CopyTo(metrics.AppendEmpty())
 
-	tsMap, err := FromMetrics(md, Settings{})
+	tsMap, err := FromMetrics(md, Settings{AddMetricSuffixes: true})
 	require.NoError(t, err)
 	require.Len(t, tsMap, 2)
 
@@ -242,7 +242,7 @@ func TestFromMetrics_NonMonotonicSum(t *testing.T) {
 			if l.Name == model.MetricNameLabel {
 				if l.Value == "test_non_monotonic_sum" {
 					tsNonMonotonic = ts
-				} else if l.Value == "test_monotonic_sum" {
+				} else if l.Value == "test_monotonic_sum_total" {
 					tsMonotonic = ts
 				}
 			}

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -141,7 +141,7 @@ func getPromLabels(lbs ...string) []prompb.Label {
 	pbLbs := prompb.Labels{
 		Labels: []prompb.Label{},
 	}
-	for i := 0; i < len(lbs); i += 2 {
+	for i := 0; i+1 < len(lbs); i += 2 {
 		pbLbs.Labels = append(pbLbs.Labels, getLabel(lbs[i], lbs[i+1]))
 	}
 	return pbLbs.Labels


### PR DESCRIPTION
#### Description

The [compatibility Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#sums) requires mapping non-monotonic sums to gauges:

> If the aggregation temporality is cumulative and the sum is non-monotonic, it MUST be converted to a Prometheus Gauge.

#### Link to tracking issue
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33661

This is already fixed for PRW 2.0, but there was a note in the issue above to fix this for PRW v1.

#### Testing

Added a unit test.  It couldn't be integrated into the existing table-based tests because those tests use addSumNumberDataPoints and addGaugeNumberDataPoints directly.

Gemini helped write the test.
