### PR TITLE
[receiver/tcpcheck] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46382-tcpcheck-enable-reaggregation.yaml
+++ b/.chloggen/46382-tcpcheck-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/tcpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the TCP Check receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46382]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/tcpcheckreceiver/documentation.md
+++ b/receiver/tcpcheckreceiver/documentation.md
@@ -24,7 +24,7 @@ Measures the duration of TCP connection.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| tcpcheck.endpoint | TCP endpoint | Any Str | Recommended | - |
+| tcpcheck.endpoint | TCP endpoint | Any Str | Required | - |
 
 ### tcpcheck.error
 
@@ -38,7 +38,7 @@ Records errors occurring during TCP check.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| tcpcheck.endpoint | TCP endpoint | Any Str | Recommended | - |
+| tcpcheck.endpoint | TCP endpoint | Any Str | Required | - |
 | error.code | Error code recorded during check | Str: ``connection_refused``, ``connection_timeout``, ``invalid_endpoint``, ``network_unreachable``, ``unknown_error`` | Recommended | - |
 
 ### tcpcheck.status
@@ -53,4 +53,4 @@ Records errors occurring during TCP check.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| tcpcheck.endpoint | TCP endpoint | Any Str | Recommended | - |
+| tcpcheck.endpoint | TCP endpoint | Any Str | Required | - |

--- a/receiver/tcpcheckreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/tcpcheckreceiver/internal/metadata/config.schema.yaml
@@ -18,6 +18,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "tcpcheck.endpoint"
+                - "error.code"
+            default:
+              - "tcpcheck.endpoint"
+              - "error.code"
       tcpcheck.status:
         description: "TcpcheckStatusMetricConfig provides config for the tcpcheck.status metric."
         type: object

--- a/receiver/tcpcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/tcpcheckreceiver/internal/metadata/generated_config.go
@@ -3,16 +3,91 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// TcpcheckDurationMetricConfig provides config for the tcpcheck.duration metric.
+type TcpcheckDurationMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *TcpcheckDurationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// TcpcheckErrorMetricAttributeKey specifies the key of an attribute for the tcpcheck.error metric.
+type TcpcheckErrorMetricAttributeKey string
+
+const (
+	TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint TcpcheckErrorMetricAttributeKey = "tcpcheck.endpoint"
+	TcpcheckErrorMetricAttributeKeyErrorCode        TcpcheckErrorMetricAttributeKey = "error.code"
+)
+
+// TcpcheckErrorMetricConfig provides config for the tcpcheck.error metric.
+type TcpcheckErrorMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []TcpcheckErrorMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *TcpcheckErrorMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *TcpcheckErrorMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint, TcpcheckErrorMetricAttributeKeyErrorCode:
+		default:
+			return fmt.Errorf("metric tcpcheck.error doesn't have an attribute %v, valid attributes: [tcpcheck.endpoint, error.code]", val)
+		}
+	}
+	if !slices.Contains(ms.EnabledAttributes, TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint) {
+		return fmt.Errorf("tcpcheck.endpoint is a required attribute for tcpcheck.error metric and must be included")
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// TcpcheckStatusMetricConfig provides config for the tcpcheck.status metric.
+type TcpcheckStatusMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *TcpcheckStatusMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -28,20 +103,22 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for tcpcheck metrics.
 type MetricsConfig struct {
-	TcpcheckDuration MetricConfig `mapstructure:"tcpcheck.duration"`
-	TcpcheckError    MetricConfig `mapstructure:"tcpcheck.error"`
-	TcpcheckStatus   MetricConfig `mapstructure:"tcpcheck.status"`
+	TcpcheckDuration TcpcheckDurationMetricConfig `mapstructure:"tcpcheck.duration"`
+	TcpcheckError    TcpcheckErrorMetricConfig    `mapstructure:"tcpcheck.error"`
+	TcpcheckStatus   TcpcheckStatusMetricConfig   `mapstructure:"tcpcheck.status"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		TcpcheckDuration: MetricConfig{
+		TcpcheckDuration: TcpcheckDurationMetricConfig{
 			Enabled: true,
 		},
-		TcpcheckError: MetricConfig{
-			Enabled: true,
+		TcpcheckError: TcpcheckErrorMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []TcpcheckErrorMetricAttributeKey{TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint, TcpcheckErrorMetricAttributeKeyErrorCode},
 		},
-		TcpcheckStatus: MetricConfig{
+		TcpcheckStatus: TcpcheckStatusMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/tcpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/tcpcheckreceiver/internal/metadata/generated_config_test.go
@@ -26,13 +26,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					TcpcheckDuration: MetricConfig{
+					TcpcheckDuration: TcpcheckDurationMetricConfig{
 						Enabled: true,
 					},
-					TcpcheckError: MetricConfig{
-						Enabled: true,
+					TcpcheckError: TcpcheckErrorMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []TcpcheckErrorMetricAttributeKey{TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint, TcpcheckErrorMetricAttributeKeyErrorCode},
 					},
-					TcpcheckStatus: MetricConfig{
+					TcpcheckStatus: TcpcheckStatusMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -42,13 +44,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					TcpcheckDuration: MetricConfig{
+					TcpcheckDuration: TcpcheckDurationMetricConfig{
 						Enabled: false,
 					},
-					TcpcheckError: MetricConfig{
-						Enabled: false,
+					TcpcheckError: TcpcheckErrorMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []TcpcheckErrorMetricAttributeKey{TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint, TcpcheckErrorMetricAttributeKeyErrorCode},
 					},
-					TcpcheckStatus: MetricConfig{
+					TcpcheckStatus: TcpcheckStatusMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -58,7 +62,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(TcpcheckDurationMetricConfig{}, TcpcheckErrorMetricConfig{}, TcpcheckStatusMetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/tcpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/tcpcheckreceiver/internal/metadata/generated_metrics.go
@@ -3,12 +3,20 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeErrorCode specifies the value error.code attribute.
@@ -72,9 +80,9 @@ type metricInfo struct {
 }
 
 type metricTcpcheckDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   TcpcheckDurationMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills tcpcheck.duration metric with initial data.
@@ -113,7 +121,7 @@ func (m *metricTcpcheckDuration) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricTcpcheckDuration(cfg MetricConfig) metricTcpcheckDuration {
+func newMetricTcpcheckDuration(cfg TcpcheckDurationMetricConfig) metricTcpcheckDuration {
 	m := metricTcpcheckDuration{config: cfg}
 
 	if cfg.Enabled {
@@ -124,9 +132,10 @@ func newMetricTcpcheckDuration(cfg MetricConfig) metricTcpcheckDuration {
 }
 
 type metricTcpcheckError struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric            // data buffer for generated metric.
+	config        TcpcheckErrorMetricConfig // metric config provided by user.
+	capacity      int                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                   // slice containing number of aggregated datapoints at each index
 }
 
 // init fills tcpcheck.error metric with initial data.
@@ -138,18 +147,51 @@ func (m *metricTcpcheckError) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTcpcheckError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tcpcheckEndpointAttributeValue string, errorCodeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, TcpcheckErrorMetricAttributeKeyTcpcheckEndpoint) {
+		dp.Attributes().PutStr("tcpcheck.endpoint", tcpcheckEndpointAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, TcpcheckErrorMetricAttributeKeyErrorCode) {
+		dp.Attributes().PutStr("error.code", errorCodeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("tcpcheck.endpoint", tcpcheckEndpointAttributeValue)
-	dp.Attributes().PutStr("error.code", errorCodeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -162,13 +204,18 @@ func (m *metricTcpcheckError) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTcpcheckError) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricTcpcheckError(cfg MetricConfig) metricTcpcheckError {
+func newMetricTcpcheckError(cfg TcpcheckErrorMetricConfig) metricTcpcheckError {
 	m := metricTcpcheckError{config: cfg}
 
 	if cfg.Enabled {
@@ -179,9 +226,9 @@ func newMetricTcpcheckError(cfg MetricConfig) metricTcpcheckError {
 }
 
 type metricTcpcheckStatus struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   TcpcheckStatusMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills tcpcheck.status metric with initial data.
@@ -220,7 +267,7 @@ func (m *metricTcpcheckStatus) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricTcpcheckStatus(cfg MetricConfig) metricTcpcheckStatus {
+func newMetricTcpcheckStatus(cfg TcpcheckStatusMetricConfig) metricTcpcheckStatus {
 	m := metricTcpcheckStatus{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/tcpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/tcpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -37,6 +38,11 @@ func TestMetricsBuilder(t *testing.T) {
 			resAttrsSet: testDataSetAll,
 		},
 		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
+		},
+		{
 			name:        "none_set",
 			metricsSet:  testDataSetNone,
 			resAttrsSet: testDataSetNone,
@@ -51,9 +57,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["TcpcheckError"] = mb.metricTcpcheckError.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -65,6 +75,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTcpcheckErrorDataPoint(ts, 1, "tcpcheck.endpoint-val", AttributeErrorCodeConnectionRefused)
+			if tt.name == "reaggregate_set" {
+				mb.RecordTcpcheckErrorDataPoint(ts, 3, "tcpcheck.endpoint-val", AttributeErrorCodeConnectionTimeout)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -72,6 +85,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricTcpcheckError.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -114,25 +130,54 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.True(t, ok)
 					assert.Equal(t, "tcpcheck.endpoint-val", tcpcheckEndpointAttrVal.Str())
 				case "tcpcheck.error":
-					assert.False(t, validatedMetrics["tcpcheck.error"], "Found a duplicate in the metrics slice: tcpcheck.error")
-					validatedMetrics["tcpcheck.error"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Records errors occurring during TCP check.", mi.Description())
-					assert.Equal(t, "{errors}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					tcpcheckEndpointAttrVal, ok := dp.Attributes().Get("tcpcheck.endpoint")
-					assert.True(t, ok)
-					assert.Equal(t, "tcpcheck.endpoint-val", tcpcheckEndpointAttrVal.Str())
-					errorCodeAttrVal, ok := dp.Attributes().Get("error.code")
-					assert.True(t, ok)
-					assert.Equal(t, "connection_refused", errorCodeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["tcpcheck.error"], "Found a duplicate in the metrics slice: tcpcheck.error")
+						validatedMetrics["tcpcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during TCP check.", mi.Description())
+						assert.Equal(t, "{errors}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						tcpcheckEndpointAttrVal, ok := dp.Attributes().Get("tcpcheck.endpoint")
+						assert.True(t, ok)
+						assert.Equal(t, "tcpcheck.endpoint-val", tcpcheckEndpointAttrVal.Str())
+						errorCodeAttrVal, ok := dp.Attributes().Get("error.code")
+						assert.True(t, ok)
+						assert.Equal(t, "connection_refused", errorCodeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["tcpcheck.error"], "Found a duplicate in the metrics slice: tcpcheck.error")
+						validatedMetrics["tcpcheck.error"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Records errors occurring during TCP check.", mi.Description())
+						assert.Equal(t, "{errors}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["tcpcheck.error"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("tcpcheck.endpoint")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("error.code")
+						assert.False(t, ok)
+					}
 				case "tcpcheck.status":
 					assert.False(t, validatedMetrics["tcpcheck.status"], "Found a duplicate in the metrics slice: tcpcheck.status")
 					validatedMetrics["tcpcheck.status"] = true

--- a/receiver/tcpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/tcpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -5,6 +5,16 @@ all_set:
       enabled: true
     tcpcheck.error:
       enabled: true
+      attributes: ["tcpcheck.endpoint","error.code"]
+    tcpcheck.status:
+      enabled: true
+reaggregate_set:
+  metrics:
+    tcpcheck.duration:
+      enabled: true
+    tcpcheck.error:
+      enabled: true
+      attributes: ["tcpcheck.endpoint"]
     tcpcheck.status:
       enabled: true
 none_set:
@@ -13,5 +23,6 @@ none_set:
       enabled: false
     tcpcheck.error:
       enabled: false
+      attributes: ["tcpcheck.endpoint","error.code"]
     tcpcheck.status:
       enabled: false

--- a/receiver/tcpcheckreceiver/metadata.yaml
+++ b/receiver/tcpcheckreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: TCP Check Receiver
 type: tcpcheck
+reaggregation_enabled: true
 
 description: This receiver creates stats by connecting to a TCP server.
 
@@ -16,10 +17,12 @@ resource_attributes:
 attributes:
   error.code:
     description: Error code recorded during check
+    requirement_level: recommended
     type: string
     enum: [connection_refused, connection_timeout, invalid_endpoint, network_unreachable, unknown_error]
   tcpcheck.endpoint:
     description: TCP endpoint
+    requirement_level: required
     type: string
 
 metrics:


### PR DESCRIPTION
Fixes #46382
Part of #45396

## Summary

- Set `reaggregation_enabled: true` in `metadata.yaml`
- Added `requirement_level: required` to the `tcpcheck.endpoint` attribute
- Added `requirement_level: recommended` to the `error.code` attribute
- Ran `go generate ./...`, `make gci`, and `schemagen` to regenerate all derived files

## Test plan

- [x] `go test ./...` in `receiver/tcpcheckreceiver/` - all tests pass
- [x] `make chlog-validate` - valid
- [x] `make gci` - no diffs
- [x] `schemagen` - schema up to date