### PR TITLE
[exporter/splunkhec] Fix HEC routing partitioning broken when batcher is enabled

### DIFF
--- a/.chloggen/splunkhec-batcher-partitioning.yaml
+++ b/.chloggen/splunkhec-batcher-partitioning.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: exporter/splunkhec
+note: Fix HEC routing partitioning broken when batcher is enabled
+issues: [47695]
+change_logs: [user]

--- a/exporter/splunkhecexporter/context_injector.go
+++ b/exporter/splunkhecexporter/context_injector.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
+
+import (
+	"context"
+
+	collclient "go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
+)
+
+// logsHECMetadataInjector sits between batchperresourceattr and the
+// exporterhelper-wrapped exporter. After batchperresourceattr has split the
+// batch into uniform-token/index subsets, this wrapper reads those values from
+// the first resource and injects them as client.Metadata so the batcher's
+// MetadataKeys partitioner keeps them in separate partitions.
+type logsHECMetadataInjector struct {
+	next consumer.Logs
+}
+
+func (l *logsHECMetadataInjector) Capabilities() consumer.Capabilities {
+	return l.next.Capabilities()
+}
+
+func (l *logsHECMetadataInjector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	if ld.ResourceLogs().Len() > 0 {
+		ctx = injectHECMetadata(ctx, ld.ResourceLogs().At(0).Resource().Attributes())
+	}
+	return l.next.ConsumeLogs(ctx, ld)
+}
+
+type metricsHECMetadataInjector struct {
+	next consumer.Metrics
+}
+
+func (m *metricsHECMetadataInjector) Capabilities() consumer.Capabilities {
+	return m.next.Capabilities()
+}
+
+func (m *metricsHECMetadataInjector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if md.ResourceMetrics().Len() > 0 {
+		ctx = injectHECMetadata(ctx, md.ResourceMetrics().At(0).Resource().Attributes())
+	}
+	return m.next.ConsumeMetrics(ctx, md)
+}
+
+type tracesHECMetadataInjector struct {
+	next consumer.Traces
+}
+
+func (t *tracesHECMetadataInjector) Capabilities() consumer.Capabilities {
+	return t.next.Capabilities()
+}
+
+func (t *tracesHECMetadataInjector) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	if td.ResourceSpans().Len() > 0 {
+		ctx = injectHECMetadata(ctx, td.ResourceSpans().At(0).Resource().Attributes())
+	}
+	return t.next.ConsumeTraces(ctx, td)
+}
+
+// injectHECMetadata reads HecTokenLabel and DefaultIndexLabel from attrs and
+// injects them as client.Metadata into ctx. Returns ctx unchanged if neither
+// key is present.
+func injectHECMetadata(ctx context.Context, attrs pcommon.Map) context.Context {
+	meta := map[string][]string{}
+	if v, ok := attrs.Get(splunk.HecTokenLabel); ok {
+		meta[splunk.HecTokenLabel] = []string{v.Str()}
+	}
+	if v, ok := attrs.Get(splunk.DefaultIndexLabel); ok {
+		meta[splunk.DefaultIndexLabel] = []string{v.Str()}
+	}
+	if len(meta) == 0 {
+		return ctx
+	}
+	return collclient.NewContext(ctx, collclient.Info{Metadata: collclient.NewMetadata(meta)})
+}

--- a/exporter/splunkhecexporter/context_injector_test.go
+++ b/exporter/splunkhecexporter/context_injector_test.go
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package splunkhecexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	collclient "go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
+)
+
+// ctxCaptureLogs captures the context passed to ConsumeLogs.
+type ctxCaptureLogs struct{ ctx context.Context }
+
+func (_ *ctxCaptureLogs) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (c *ctxCaptureLogs) ConsumeLogs(ctx context.Context, _ plog.Logs) error {
+	c.ctx = ctx
+	return nil
+}
+
+// ctxCaptureMetrics captures the context passed to ConsumeMetrics.
+type ctxCaptureMetrics struct{ ctx context.Context }
+
+func (_ *ctxCaptureMetrics) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (c *ctxCaptureMetrics) ConsumeMetrics(ctx context.Context, _ pmetric.Metrics) error {
+	c.ctx = ctx
+	return nil
+}
+
+// ctxCaptureTraces captures the context passed to ConsumeTraces.
+type ctxCaptureTraces struct{ ctx context.Context }
+
+func (_ *ctxCaptureTraces) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (c *ctxCaptureTraces) ConsumeTraces(ctx context.Context, _ ptrace.Traces) error {
+	c.ctx = ctx
+	return nil
+}
+
+func TestInjectHECMetadata(t *testing.T) {
+	t.Run("both keys present", func(t *testing.T) {
+		attrs := plog.NewLogs().ResourceLogs().AppendEmpty().Resource().Attributes()
+		attrs.PutStr(splunk.HecTokenLabel, "my-token")
+		attrs.PutStr(splunk.DefaultIndexLabel, "my-index")
+
+		ctx := injectHECMetadata(t.Context(), attrs)
+
+		meta := collclient.FromContext(ctx).Metadata
+		assert.Equal(t, []string{"my-token"}, meta.Get(splunk.HecTokenLabel))
+		assert.Equal(t, []string{"my-index"}, meta.Get(splunk.DefaultIndexLabel))
+	})
+
+	t.Run("token only", func(t *testing.T) {
+		attrs := plog.NewLogs().ResourceLogs().AppendEmpty().Resource().Attributes()
+		attrs.PutStr(splunk.HecTokenLabel, "tok")
+
+		ctx := injectHECMetadata(t.Context(), attrs)
+
+		meta := collclient.FromContext(ctx).Metadata
+		assert.Equal(t, []string{"tok"}, meta.Get(splunk.HecTokenLabel))
+		assert.Empty(t, meta.Get(splunk.DefaultIndexLabel))
+	})
+
+	t.Run("no keys returns original context", func(t *testing.T) {
+		attrs := plog.NewLogs().ResourceLogs().AppendEmpty().Resource().Attributes()
+		parent := t.Context()
+		got := injectHECMetadata(parent, attrs)
+		assert.Equal(t, parent, got)
+	})
+}
+
+func TestLogsHECMetadataInjector(t *testing.T) {
+	capture := &ctxCaptureLogs{}
+	inj := &logsHECMetadataInjector{next: capture}
+
+	ld := plog.NewLogs()
+	ld.ResourceLogs().AppendEmpty().Resource().Attributes().PutStr(splunk.HecTokenLabel, "injected-token")
+
+	require.NoError(t, inj.ConsumeLogs(t.Context(), ld))
+	meta := collclient.FromContext(capture.ctx).Metadata
+	assert.Equal(t, []string{"injected-token"}, meta.Get(splunk.HecTokenLabel))
+}
+
+func TestMetricsHECMetadataInjector(t *testing.T) {
+	capture := &ctxCaptureMetrics{}
+	inj := &metricsHECMetadataInjector{next: capture}
+
+	md := pmetric.NewMetrics()
+	md.ResourceMetrics().AppendEmpty().Resource().Attributes().PutStr(splunk.DefaultIndexLabel, "idx")
+
+	require.NoError(t, inj.ConsumeMetrics(t.Context(), md))
+	meta := collclient.FromContext(capture.ctx).Metadata
+	assert.Equal(t, []string{"idx"}, meta.Get(splunk.DefaultIndexLabel))
+}
+
+func TestTracesHECMetadataInjector(t *testing.T) {
+	capture := &ctxCaptureTraces{}
+	inj := &tracesHECMetadataInjector{next: capture}
+
+	td := ptrace.NewTraces()
+	td.ResourceSpans().AppendEmpty().Resource().Attributes().PutStr(splunk.HecTokenLabel, "trace-token")
+
+	require.NoError(t, inj.ConsumeTraces(t.Context(), td))
+	meta := collclient.FromContext(capture.ctx).Metadata
+	assert.Equal(t, []string{"trace-token"}, meta.Get(splunk.HecTokenLabel))
+}
+
+func TestLogsHECMetadataInjector_EmptyLogs(t *testing.T) {
+	capture := &ctxCaptureLogs{}
+	inj := &logsHECMetadataInjector{next: capture}
+
+	require.NoError(t, inj.ConsumeLogs(t.Context(), plog.NewLogs()))
+	// context should be unchanged — no resource means no metadata injected
+	assert.Empty(t, collclient.FromContext(capture.ctx).Metadata.Get(splunk.HecTokenLabel))
+}

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -5,6 +5,7 @@ package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -113,7 +114,7 @@ func createTracesExporter(
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
-		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithQueue(hecQueueSettings(cfg.QueueSettings)),
 		exporterhelper.WithStart(c.start),
 		exporterhelper.WithShutdown(c.stop),
 	)
@@ -123,7 +124,10 @@ func createTracesExporter(
 
 	wrapped := &baseTracesExporter{
 		Component: e,
-		Traces:    batchperresourceattr.NewMultiBatchPerResourceTraces([]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel}, e),
+		Traces: batchperresourceattr.NewMultiBatchPerResourceTraces(
+			[]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel},
+			&tracesHECMetadataInjector{next: e},
+		),
 	}
 
 	return wrapped, nil
@@ -146,7 +150,7 @@ func createMetricsExporter(
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
-		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithQueue(hecQueueSettings(cfg.QueueSettings)),
 		exporterhelper.WithStart(c.start),
 		exporterhelper.WithShutdown(c.stop),
 	)
@@ -156,7 +160,10 @@ func createMetricsExporter(
 
 	wrapped := &baseMetricsExporter{
 		Component: e,
-		Metrics:   batchperresourceattr.NewMultiBatchPerResourceMetrics([]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel}, e),
+		Metrics: batchperresourceattr.NewMultiBatchPerResourceMetrics(
+			[]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel},
+			&metricsHECMetadataInjector{next: e},
+		),
 	}
 
 	return wrapped, nil
@@ -179,7 +186,7 @@ func createLogsExporter(
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
-		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithQueue(hecQueueSettings(cfg.QueueSettings)),
 		exporterhelper.WithStart(c.start),
 		exporterhelper.WithShutdown(c.stop),
 	)
@@ -189,15 +196,46 @@ func createLogsExporter(
 
 	wrapped := &baseLogsExporter{
 		Component: logsExporter,
-		Logs: batchperresourceattr.NewMultiBatchPerResourceLogs([]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel}, &perScopeBatcher{
-			logsEnabled:      cfg.LogDataEnabled,
-			profilingEnabled: cfg.ProfilingDataEnabled,
-			logger:           set.Logger,
-			next:             logsExporter,
-		}),
+		Logs: batchperresourceattr.NewMultiBatchPerResourceLogs(
+			[]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel},
+			&perScopeBatcher{
+				logsEnabled:      cfg.LogDataEnabled,
+				profilingEnabled: cfg.ProfilingDataEnabled,
+				logger:           set.Logger,
+				next:             &logsHECMetadataInjector{next: logsExporter},
+			},
+		),
 	}
 
 	return wrapped, nil
+}
+
+// hecRequiredMetadataKeys are always appended to Batch.Partition.MetadataKeys
+// so the batcher never merges requests that belong to different HEC routing
+// partitions (different tokens or indices).
+var hecRequiredMetadataKeys = []string{splunk.HecTokenLabel, splunk.DefaultIndexLabel}
+
+// hecQueueSettings returns a copy of qs with hecRequiredMetadataKeys guaranteed
+// to be present in Batch.Partition.MetadataKeys. Any keys already set by the
+// user are preserved; the required keys are appended only when absent.
+func hecQueueSettings(qs configoptional.Optional[exporterhelper.QueueBatchConfig]) configoptional.Optional[exporterhelper.QueueBatchConfig] {
+	if !qs.HasValue() || !qs.Get().Batch.HasValue() {
+		return qs
+	}
+	qCopy := *qs.Get()
+	bCopy := *qCopy.Batch.Get()
+
+	existing := make(map[string]bool, len(bCopy.Partition.MetadataKeys))
+	for _, k := range bCopy.Partition.MetadataKeys {
+		existing[strings.ToLower(k)] = true
+	}
+	for _, k := range hecRequiredMetadataKeys {
+		if !existing[strings.ToLower(k)] {
+			bCopy.Partition.MetadataKeys = append(bCopy.Partition.MetadataKeys, k)
+		}
+	}
+	qCopy.Batch = configoptional.Some(bCopy)
+	return configoptional.Some(qCopy)
 }
 
 func showDeprecationWarnings(cfg *Config, logger *zap.Logger) {

--- a/exporter/splunkhecexporter/factory_test.go
+++ b/exporter/splunkhecexporter/factory_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -128,4 +129,72 @@ func TestFactory_EnabledBatchingMakesExporterMutable(t *testing.T) {
 	le, err = createLogsExporter(t.Context(), exportertest.NewNopSettings(metadata.Type), config)
 	require.NoError(t, err)
 	assert.True(t, le.Capabilities().MutatesData)
+}
+
+func TestHecQueueSettings(t *testing.T) {
+	t.Run("no queue settings", func(t *testing.T) {
+		out := hecQueueSettings(configoptional.None[exporterhelper.QueueBatchConfig]())
+		assert.False(t, out.HasValue())
+	})
+
+	t.Run("queue without batch", func(t *testing.T) {
+		qs := configoptional.Some(exporterhelper.QueueBatchConfig{NumConsumers: 2, QueueSize: 100})
+		out := hecQueueSettings(qs)
+		require.True(t, out.HasValue())
+		assert.False(t, out.Get().Batch.HasValue())
+	})
+
+	someBatch := func(keys []string) exporterhelper.QueueBatchConfig {
+		cfg := exporterhelper.NewDefaultQueueConfig()
+		batch := exporterhelper.BatchConfig{
+			FlushTimeout: 200 * time.Millisecond,
+			Sizer:        exporterhelper.RequestSizerTypeItems,
+			MinSize:      8192,
+		}
+		batch.Partition.MetadataKeys = keys
+		cfg.Batch = configoptional.Some(batch)
+		return cfg
+	}
+
+	t.Run("required keys added when missing", func(t *testing.T) {
+		out := hecQueueSettings(configoptional.Some(someBatch(nil)))
+		require.True(t, out.Get().Batch.HasValue())
+		keys := out.Get().Batch.Get().Partition.MetadataKeys
+		assert.Contains(t, keys, splunk.HecTokenLabel)
+		assert.Contains(t, keys, splunk.DefaultIndexLabel)
+	})
+
+	t.Run("user keys preserved and required keys appended", func(t *testing.T) {
+		out := hecQueueSettings(configoptional.Some(someBatch([]string{"custom_key"})))
+		keys := out.Get().Batch.Get().Partition.MetadataKeys
+		assert.Contains(t, keys, "custom_key")
+		assert.Contains(t, keys, splunk.HecTokenLabel)
+		assert.Contains(t, keys, splunk.DefaultIndexLabel)
+	})
+
+	t.Run("no duplicates when required keys already present", func(t *testing.T) {
+		out := hecQueueSettings(configoptional.Some(someBatch([]string{splunk.HecTokenLabel, splunk.DefaultIndexLabel})))
+		keys := out.Get().Batch.Get().Partition.MetadataKeys
+		count := 0
+		for _, k := range keys {
+			if k == splunk.HecTokenLabel || k == splunk.DefaultIndexLabel {
+				count++
+			}
+		}
+		assert.Equal(t, 2, count, "required keys should appear exactly once each")
+	})
+
+	t.Run("case-insensitive deduplication", func(t *testing.T) {
+		out := hecQueueSettings(configoptional.Some(someBatch([]string{"Com.Splunk.Hec.Access_Token", "COM.SPLUNK.INDEX"})))
+		// should not add the required keys again since case-insensitive match found
+		keys := out.Get().Batch.Get().Partition.MetadataKeys
+		assert.Len(t, keys, 2)
+	})
+
+	t.Run("original config is not mutated", func(t *testing.T) {
+		orig := someBatch(nil)
+		origKeys := orig.Batch.Get().Partition.MetadataKeys
+		_ = hecQueueSettings(configoptional.Some(orig))
+		assert.Equal(t, origKeys, orig.Batch.Get().Partition.MetadataKeys)
+	})
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47695

Inject HEC token and index into client.Metadata context between `batchperresourceattr` and the exporterhelper exporter so the batcher's MetadataKeysPartitioner keeps different routing partitions separate.
