### PR TITLE
feat(receiver/mongodbatlas): enable dynamic metric reaggregation

### DIFF
--- a/.chloggen/46365-mongodbatlas-enable-reaggregation.yaml
+++ b/.chloggen/46365-mongodbatlas-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mongodbatlas
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the MongoDB Atlas receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46365]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/mongodbatlasreceiver/generated_package_test.go
+++ b/receiver/mongodbatlasreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package mongodbatlasreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/mongodbatlasreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/mongodbatlasreceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "object_type"
+            default:
+              - "object_type"
       mongodbatlas.db.size:
         description: "MongodbatlasDbSizeMetricConfig provides config for the mongodbatlas.db.size metric."
         type: object
@@ -18,6 +34,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "object_type"
+            default:
+              - "object_type"
       mongodbatlas.disk.partition.iops.average:
         description: "MongodbatlasDiskPartitionIopsAverageMetricConfig provides config for the mongodbatlas.disk.partition.iops.average metric."
         type: object
@@ -25,6 +57,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_direction"
+            default:
+              - "disk_direction"
       mongodbatlas.disk.partition.iops.max:
         description: "MongodbatlasDiskPartitionIopsMaxMetricConfig provides config for the mongodbatlas.disk.partition.iops.max metric."
         type: object
@@ -32,6 +80,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_direction"
+            default:
+              - "disk_direction"
       mongodbatlas.disk.partition.latency.average:
         description: "MongodbatlasDiskPartitionLatencyAverageMetricConfig provides config for the mongodbatlas.disk.partition.latency.average metric."
         type: object
@@ -39,6 +103,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_direction"
+            default:
+              - "disk_direction"
       mongodbatlas.disk.partition.latency.max:
         description: "MongodbatlasDiskPartitionLatencyMaxMetricConfig provides config for the mongodbatlas.disk.partition.latency.max metric."
         type: object
@@ -46,6 +126,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_direction"
+            default:
+              - "disk_direction"
       mongodbatlas.disk.partition.queue.depth:
         description: "MongodbatlasDiskPartitionQueueDepthMetricConfig provides config for the mongodbatlas.disk.partition.queue.depth metric."
         type: object
@@ -60,6 +156,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_status"
+            default:
+              - "disk_status"
       mongodbatlas.disk.partition.space.max:
         description: "MongodbatlasDiskPartitionSpaceMaxMetricConfig provides config for the mongodbatlas.disk.partition.space.max metric."
         type: object
@@ -67,6 +179,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_status"
+            default:
+              - "disk_status"
       mongodbatlas.disk.partition.throughput:
         description: "MongodbatlasDiskPartitionThroughputMetricConfig provides config for the mongodbatlas.disk.partition.throughput metric."
         type: object
@@ -74,6 +202,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_direction"
+            default:
+              - "disk_direction"
       mongodbatlas.disk.partition.usage.average:
         description: "MongodbatlasDiskPartitionUsageAverageMetricConfig provides config for the mongodbatlas.disk.partition.usage.average metric."
         type: object
@@ -81,6 +225,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_status"
+            default:
+              - "disk_status"
       mongodbatlas.disk.partition.usage.max:
         description: "MongodbatlasDiskPartitionUsageMaxMetricConfig provides config for the mongodbatlas.disk.partition.usage.max metric."
         type: object
@@ -88,6 +248,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "disk_status"
+            default:
+              - "disk_status"
       mongodbatlas.disk.partition.utilization.average:
         description: "MongodbatlasDiskPartitionUtilizationAverageMetricConfig provides config for the mongodbatlas.disk.partition.utilization.average metric."
         type: object
@@ -109,6 +285,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "assert_type"
+            default:
+              - "assert_type"
       mongodbatlas.process.background_flush:
         description: "MongodbatlasProcessBackgroundFlushMetricConfig provides config for the mongodbatlas.process.background_flush metric."
         type: object
@@ -123,6 +315,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cache_direction"
+            default:
+              - "cache_direction"
       mongodbatlas.process.cache.ratio:
         description: "MongodbatlasProcessCacheRatioMetricConfig provides config for the mongodbatlas.process.cache.ratio metric."
         type: object
@@ -130,6 +338,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cache_ratio_type"
+            default:
+              - "cache_ratio_type"
       mongodbatlas.process.cache.size:
         description: "MongodbatlasProcessCacheSizeMetricConfig provides config for the mongodbatlas.process.cache.size metric."
         type: object
@@ -137,6 +361,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cache_status"
+            default:
+              - "cache_status"
       mongodbatlas.process.connections:
         description: "MongodbatlasProcessConnectionsMetricConfig provides config for the mongodbatlas.process.connections metric."
         type: object
@@ -151,6 +391,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.children.normalized.usage.max:
         description: "MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.children.normalized.usage.max metric."
         type: object
@@ -158,6 +414,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.children.usage.average:
         description: "MongodbatlasProcessCPUChildrenUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.children.usage.average metric."
         type: object
@@ -165,6 +437,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.children.usage.max:
         description: "MongodbatlasProcessCPUChildrenUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.children.usage.max metric."
         type: object
@@ -172,6 +460,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.normalized.usage.average:
         description: "MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.normalized.usage.average metric."
         type: object
@@ -179,6 +483,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.normalized.usage.max:
         description: "MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.normalized.usage.max metric."
         type: object
@@ -186,6 +506,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.usage.average:
         description: "MongodbatlasProcessCPUUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.usage.average metric."
         type: object
@@ -193,6 +529,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cpu.usage.max:
         description: "MongodbatlasProcessCPUUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.usage.max metric."
         type: object
@@ -200,6 +552,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.process.cursors:
         description: "MongodbatlasProcessCursorsMetricConfig provides config for the mongodbatlas.process.cursors metric."
         type: object
@@ -207,6 +575,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cursor_state"
+            default:
+              - "cursor_state"
       mongodbatlas.process.db.document.rate:
         description: "MongodbatlasProcessDbDocumentRateMetricConfig provides config for the mongodbatlas.process.db.document.rate metric."
         type: object
@@ -214,6 +598,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "document_status"
+            default:
+              - "document_status"
       mongodbatlas.process.db.operations.rate:
         description: "MongodbatlasProcessDbOperationsRateMetricConfig provides config for the mongodbatlas.process.db.operations.rate metric."
         type: object
@@ -221,6 +621,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "operation"
+                - "cluster_role"
+            default:
+              - "operation"
+              - "cluster_role"
       mongodbatlas.process.db.operations.time:
         description: "MongodbatlasProcessDbOperationsTimeMetricConfig provides config for the mongodbatlas.process.db.operations.time metric."
         type: object
@@ -228,6 +646,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "execution_type"
+            default:
+              - "execution_type"
       mongodbatlas.process.db.query_executor.scanned:
         description: "MongodbatlasProcessDbQueryExecutorScannedMetricConfig provides config for the mongodbatlas.process.db.query_executor.scanned metric."
         type: object
@@ -235,6 +669,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "scanned_type"
+            default:
+              - "scanned_type"
       mongodbatlas.process.db.query_targeting.scanned_per_returned:
         description: "MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig provides config for the mongodbatlas.process.db.query_targeting.scanned_per_returned metric."
         type: object
@@ -242,6 +692,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "scanned_type"
+            default:
+              - "scanned_type"
       mongodbatlas.process.db.storage:
         description: "MongodbatlasProcessDbStorageMetricConfig provides config for the mongodbatlas.process.db.storage metric."
         type: object
@@ -249,6 +715,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "storage_status"
+            default:
+              - "storage_status"
       mongodbatlas.process.global_lock:
         description: "MongodbatlasProcessGlobalLockMetricConfig provides config for the mongodbatlas.process.global_lock metric."
         type: object
@@ -256,6 +738,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "global_lock_state"
+            default:
+              - "global_lock_state"
       mongodbatlas.process.index.btree_miss_ratio:
         description: "MongodbatlasProcessIndexBtreeMissRatioMetricConfig provides config for the mongodbatlas.process.index.btree_miss_ratio metric."
         type: object
@@ -270,6 +768,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "btree_counter_type"
+            default:
+              - "btree_counter_type"
       mongodbatlas.process.journaling.commits:
         description: "MongodbatlasProcessJournalingCommitsMetricConfig provides config for the mongodbatlas.process.journaling.commits metric."
         type: object
@@ -298,6 +812,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_state"
+            default:
+              - "memory_state"
       mongodbatlas.process.network.io:
         description: "MongodbatlasProcessNetworkIoMetricConfig provides config for the mongodbatlas.process.network.io metric."
         type: object
@@ -305,6 +835,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       mongodbatlas.process.network.requests:
         description: "MongodbatlasProcessNetworkRequestsMetricConfig provides config for the mongodbatlas.process.network.requests metric."
         type: object
@@ -326,6 +872,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "oplog_type"
+            default:
+              - "oplog_type"
       mongodbatlas.process.page_faults:
         description: "MongodbatlasProcessPageFaultsMetricConfig provides config for the mongodbatlas.process.page_faults metric."
         type: object
@@ -333,6 +895,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_issue_type"
+            default:
+              - "memory_issue_type"
       mongodbatlas.process.restarts:
         description: "MongodbatlasProcessRestartsMetricConfig provides config for the mongodbatlas.process.restarts metric."
         type: object
@@ -347,6 +925,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "ticket_type"
+            default:
+              - "ticket_type"
       mongodbatlas.system.cpu.normalized.usage.average:
         description: "MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig provides config for the mongodbatlas.system.cpu.normalized.usage.average metric."
         type: object
@@ -354,6 +948,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.system.cpu.normalized.usage.max:
         description: "MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig provides config for the mongodbatlas.system.cpu.normalized.usage.max metric."
         type: object
@@ -361,6 +971,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.system.cpu.usage.average:
         description: "MongodbatlasSystemCPUUsageAverageMetricConfig provides config for the mongodbatlas.system.cpu.usage.average metric."
         type: object
@@ -368,6 +994,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.system.cpu.usage.max:
         description: "MongodbatlasSystemCPUUsageMaxMetricConfig provides config for the mongodbatlas.system.cpu.usage.max metric."
         type: object
@@ -375,6 +1017,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.system.fts.cpu.normalized.usage:
         description: "MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig provides config for the mongodbatlas.system.fts.cpu.normalized.usage metric."
         type: object
@@ -382,6 +1040,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.system.fts.cpu.usage:
         description: "MongodbatlasSystemFtsCPUUsageMetricConfig provides config for the mongodbatlas.system.fts.cpu.usage metric."
         type: object
@@ -389,6 +1063,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "cpu_state"
+            default:
+              - "cpu_state"
       mongodbatlas.system.fts.disk.used:
         description: "MongodbatlasSystemFtsDiskUsedMetricConfig provides config for the mongodbatlas.system.fts.disk.used metric."
         type: object
@@ -403,6 +1093,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_state"
+            default:
+              - "memory_state"
       mongodbatlas.system.memory.usage.average:
         description: "MongodbatlasSystemMemoryUsageAverageMetricConfig provides config for the mongodbatlas.system.memory.usage.average metric."
         type: object
@@ -410,6 +1116,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_status"
+            default:
+              - "memory_status"
       mongodbatlas.system.memory.usage.max:
         description: "MongodbatlasSystemMemoryUsageMaxMetricConfig provides config for the mongodbatlas.system.memory.usage.max metric."
         type: object
@@ -417,6 +1139,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_status"
+            default:
+              - "memory_status"
       mongodbatlas.system.network.io.average:
         description: "MongodbatlasSystemNetworkIoAverageMetricConfig provides config for the mongodbatlas.system.network.io.average metric."
         type: object
@@ -424,6 +1162,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       mongodbatlas.system.network.io.max:
         description: "MongodbatlasSystemNetworkIoMaxMetricConfig provides config for the mongodbatlas.system.network.io.max metric."
         type: object
@@ -431,6 +1185,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       mongodbatlas.system.paging.io.average:
         description: "MongodbatlasSystemPagingIoAverageMetricConfig provides config for the mongodbatlas.system.paging.io.average metric."
         type: object
@@ -438,6 +1208,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       mongodbatlas.system.paging.io.max:
         description: "MongodbatlasSystemPagingIoMaxMetricConfig provides config for the mongodbatlas.system.paging.io.max metric."
         type: object
@@ -445,6 +1231,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       mongodbatlas.system.paging.usage.average:
         description: "MongodbatlasSystemPagingUsageAverageMetricConfig provides config for the mongodbatlas.system.paging.usage.average metric."
         type: object
@@ -452,6 +1254,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_state"
+            default:
+              - "memory_state"
       mongodbatlas.system.paging.usage.max:
         description: "MongodbatlasSystemPagingUsageMaxMetricConfig provides config for the mongodbatlas.system.paging.usage.max metric."
         type: object
@@ -459,6 +1277,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "memory_state"
+            default:
+              - "memory_state"
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for mongodb_atlas resource attributes.
     type: object

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,29 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// MongodbatlasDbCountsMetricAttributeKey specifies the key of an attribute for the mongodbatlas.db.counts metric.
+type MongodbatlasDbCountsMetricAttributeKey string
+
+const (
+	MongodbatlasDbCountsMetricAttributeKeyObjectType MongodbatlasDbCountsMetricAttributeKey = "object_type"
+)
+
+// MongodbatlasDbCountsMetricConfig provides config for the mongodbatlas.db.counts metric.
+type MongodbatlasDbCountsMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDbCountsMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *MongodbatlasDbCountsMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -27,271 +39,3102 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+func (ms *MongodbatlasDbCountsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDbCountsMetricAttributeKeyObjectType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.db.counts doesn't have an attribute %v, valid attributes: [object_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDbSizeMetricAttributeKey specifies the key of an attribute for the mongodbatlas.db.size metric.
+type MongodbatlasDbSizeMetricAttributeKey string
+
+const (
+	MongodbatlasDbSizeMetricAttributeKeyObjectType MongodbatlasDbSizeMetricAttributeKey = "object_type"
+)
+
+// MongodbatlasDbSizeMetricConfig provides config for the mongodbatlas.db.size metric.
+type MongodbatlasDbSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDbSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDbSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDbSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDbSizeMetricAttributeKeyObjectType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.db.size doesn't have an attribute %v, valid attributes: [object_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionIopsAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.iops.average metric.
+type MongodbatlasDiskPartitionIopsAverageMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionIopsAverageMetricAttributeKeyDiskDirection MongodbatlasDiskPartitionIopsAverageMetricAttributeKey = "disk_direction"
+)
+
+// MongodbatlasDiskPartitionIopsAverageMetricConfig provides config for the mongodbatlas.disk.partition.iops.average metric.
+type MongodbatlasDiskPartitionIopsAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionIopsAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionIopsAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionIopsAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionIopsAverageMetricAttributeKeyDiskDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.iops.average doesn't have an attribute %v, valid attributes: [disk_direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionIopsMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.iops.max metric.
+type MongodbatlasDiskPartitionIopsMaxMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionIopsMaxMetricAttributeKeyDiskDirection MongodbatlasDiskPartitionIopsMaxMetricAttributeKey = "disk_direction"
+)
+
+// MongodbatlasDiskPartitionIopsMaxMetricConfig provides config for the mongodbatlas.disk.partition.iops.max metric.
+type MongodbatlasDiskPartitionIopsMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionIopsMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionIopsMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionIopsMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionIopsMaxMetricAttributeKeyDiskDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.iops.max doesn't have an attribute %v, valid attributes: [disk_direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.latency.average metric.
+type MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionLatencyAverageMetricAttributeKeyDiskDirection MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey = "disk_direction"
+)
+
+// MongodbatlasDiskPartitionLatencyAverageMetricConfig provides config for the mongodbatlas.disk.partition.latency.average metric.
+type MongodbatlasDiskPartitionLatencyAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionLatencyAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionLatencyAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionLatencyAverageMetricAttributeKeyDiskDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.latency.average doesn't have an attribute %v, valid attributes: [disk_direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.latency.max metric.
+type MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionLatencyMaxMetricAttributeKeyDiskDirection MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey = "disk_direction"
+)
+
+// MongodbatlasDiskPartitionLatencyMaxMetricConfig provides config for the mongodbatlas.disk.partition.latency.max metric.
+type MongodbatlasDiskPartitionLatencyMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionLatencyMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionLatencyMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionLatencyMaxMetricAttributeKeyDiskDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.latency.max doesn't have an attribute %v, valid attributes: [disk_direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionQueueDepthMetricConfig provides config for the mongodbatlas.disk.partition.queue.depth metric.
+type MongodbatlasDiskPartitionQueueDepthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasDiskPartitionQueueDepthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.space.average metric.
+type MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionSpaceAverageMetricAttributeKeyDiskStatus MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey = "disk_status"
+)
+
+// MongodbatlasDiskPartitionSpaceAverageMetricConfig provides config for the mongodbatlas.disk.partition.space.average metric.
+type MongodbatlasDiskPartitionSpaceAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionSpaceAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionSpaceAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionSpaceAverageMetricAttributeKeyDiskStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.space.average doesn't have an attribute %v, valid attributes: [disk_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.space.max metric.
+type MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionSpaceMaxMetricAttributeKeyDiskStatus MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey = "disk_status"
+)
+
+// MongodbatlasDiskPartitionSpaceMaxMetricConfig provides config for the mongodbatlas.disk.partition.space.max metric.
+type MongodbatlasDiskPartitionSpaceMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionSpaceMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionSpaceMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionSpaceMaxMetricAttributeKeyDiskStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.space.max doesn't have an attribute %v, valid attributes: [disk_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionThroughputMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.throughput metric.
+type MongodbatlasDiskPartitionThroughputMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionThroughputMetricAttributeKeyDiskDirection MongodbatlasDiskPartitionThroughputMetricAttributeKey = "disk_direction"
+)
+
+// MongodbatlasDiskPartitionThroughputMetricConfig provides config for the mongodbatlas.disk.partition.throughput metric.
+type MongodbatlasDiskPartitionThroughputMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionThroughputMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionThroughputMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionThroughputMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionThroughputMetricAttributeKeyDiskDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.throughput doesn't have an attribute %v, valid attributes: [disk_direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.usage.average metric.
+type MongodbatlasDiskPartitionUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionUsageAverageMetricAttributeKeyDiskStatus MongodbatlasDiskPartitionUsageAverageMetricAttributeKey = "disk_status"
+)
+
+// MongodbatlasDiskPartitionUsageAverageMetricConfig provides config for the mongodbatlas.disk.partition.usage.average metric.
+type MongodbatlasDiskPartitionUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionUsageAverageMetricAttributeKeyDiskStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.usage.average doesn't have an attribute %v, valid attributes: [disk_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.disk.partition.usage.max metric.
+type MongodbatlasDiskPartitionUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasDiskPartitionUsageMaxMetricAttributeKeyDiskStatus MongodbatlasDiskPartitionUsageMaxMetricAttributeKey = "disk_status"
+)
+
+// MongodbatlasDiskPartitionUsageMaxMetricConfig provides config for the mongodbatlas.disk.partition.usage.max metric.
+type MongodbatlasDiskPartitionUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasDiskPartitionUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasDiskPartitionUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasDiskPartitionUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasDiskPartitionUsageMaxMetricAttributeKeyDiskStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.disk.partition.usage.max doesn't have an attribute %v, valid attributes: [disk_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasDiskPartitionUtilizationAverageMetricConfig provides config for the mongodbatlas.disk.partition.utilization.average metric.
+type MongodbatlasDiskPartitionUtilizationAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasDiskPartitionUtilizationAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasDiskPartitionUtilizationMaxMetricConfig provides config for the mongodbatlas.disk.partition.utilization.max metric.
+type MongodbatlasDiskPartitionUtilizationMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasDiskPartitionUtilizationMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessAssertsMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.asserts metric.
+type MongodbatlasProcessAssertsMetricAttributeKey string
+
+const (
+	MongodbatlasProcessAssertsMetricAttributeKeyAssertType MongodbatlasProcessAssertsMetricAttributeKey = "assert_type"
+)
+
+// MongodbatlasProcessAssertsMetricConfig provides config for the mongodbatlas.process.asserts metric.
+type MongodbatlasProcessAssertsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessAssertsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessAssertsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessAssertsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessAssertsMetricAttributeKeyAssertType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.asserts doesn't have an attribute %v, valid attributes: [assert_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessBackgroundFlushMetricConfig provides config for the mongodbatlas.process.background_flush metric.
+type MongodbatlasProcessBackgroundFlushMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessBackgroundFlushMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessCacheIoMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cache.io metric.
+type MongodbatlasProcessCacheIoMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCacheIoMetricAttributeKeyCacheDirection MongodbatlasProcessCacheIoMetricAttributeKey = "cache_direction"
+)
+
+// MongodbatlasProcessCacheIoMetricConfig provides config for the mongodbatlas.process.cache.io metric.
+type MongodbatlasProcessCacheIoMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCacheIoMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCacheIoMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCacheIoMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCacheIoMetricAttributeKeyCacheDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cache.io doesn't have an attribute %v, valid attributes: [cache_direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCacheRatioMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cache.ratio metric.
+type MongodbatlasProcessCacheRatioMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCacheRatioMetricAttributeKeyCacheRatioType MongodbatlasProcessCacheRatioMetricAttributeKey = "cache_ratio_type"
+)
+
+// MongodbatlasProcessCacheRatioMetricConfig provides config for the mongodbatlas.process.cache.ratio metric.
+type MongodbatlasProcessCacheRatioMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCacheRatioMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCacheRatioMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCacheRatioMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCacheRatioMetricAttributeKeyCacheRatioType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cache.ratio doesn't have an attribute %v, valid attributes: [cache_ratio_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCacheSizeMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cache.size metric.
+type MongodbatlasProcessCacheSizeMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCacheSizeMetricAttributeKeyCacheStatus MongodbatlasProcessCacheSizeMetricAttributeKey = "cache_status"
+)
+
+// MongodbatlasProcessCacheSizeMetricConfig provides config for the mongodbatlas.process.cache.size metric.
+type MongodbatlasProcessCacheSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCacheSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCacheSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCacheSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCacheSizeMetricAttributeKeyCacheStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cache.size doesn't have an attribute %v, valid attributes: [cache_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessConnectionsMetricConfig provides config for the mongodbatlas.process.connections metric.
+type MongodbatlasProcessConnectionsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessConnectionsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.children.normalized.usage.average metric.
+type MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKeyCPUState MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.children.normalized.usage.average metric.
+type MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.children.normalized.usage.average doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.children.normalized.usage.max metric.
+type MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKeyCPUState MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.children.normalized.usage.max metric.
+type MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.children.normalized.usage.max doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.children.usage.average metric.
+type MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKeyCPUState MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUChildrenUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.children.usage.average metric.
+type MongodbatlasProcessCPUChildrenUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUChildrenUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUChildrenUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.children.usage.average doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.children.usage.max metric.
+type MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKeyCPUState MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUChildrenUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.children.usage.max metric.
+type MongodbatlasProcessCPUChildrenUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUChildrenUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUChildrenUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.children.usage.max doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.normalized.usage.average metric.
+type MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKeyCPUState MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.normalized.usage.average metric.
+type MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.normalized.usage.average doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.normalized.usage.max metric.
+type MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKeyCPUState MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.normalized.usage.max metric.
+type MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.normalized.usage.max doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.usage.average metric.
+type MongodbatlasProcessCPUUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUUsageAverageMetricAttributeKeyCPUState MongodbatlasProcessCPUUsageAverageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUUsageAverageMetricConfig provides config for the mongodbatlas.process.cpu.usage.average metric.
+type MongodbatlasProcessCPUUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUUsageAverageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.usage.average doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCPUUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cpu.usage.max metric.
+type MongodbatlasProcessCPUUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCPUUsageMaxMetricAttributeKeyCPUState MongodbatlasProcessCPUUsageMaxMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasProcessCPUUsageMaxMetricConfig provides config for the mongodbatlas.process.cpu.usage.max metric.
+type MongodbatlasProcessCPUUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCPUUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCPUUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCPUUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCPUUsageMaxMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cpu.usage.max doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessCursorsMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.cursors metric.
+type MongodbatlasProcessCursorsMetricAttributeKey string
+
+const (
+	MongodbatlasProcessCursorsMetricAttributeKeyCursorState MongodbatlasProcessCursorsMetricAttributeKey = "cursor_state"
+)
+
+// MongodbatlasProcessCursorsMetricConfig provides config for the mongodbatlas.process.cursors metric.
+type MongodbatlasProcessCursorsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessCursorsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessCursorsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessCursorsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessCursorsMetricAttributeKeyCursorState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.cursors doesn't have an attribute %v, valid attributes: [cursor_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessDbDocumentRateMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.db.document.rate metric.
+type MongodbatlasProcessDbDocumentRateMetricAttributeKey string
+
+const (
+	MongodbatlasProcessDbDocumentRateMetricAttributeKeyDocumentStatus MongodbatlasProcessDbDocumentRateMetricAttributeKey = "document_status"
+)
+
+// MongodbatlasProcessDbDocumentRateMetricConfig provides config for the mongodbatlas.process.db.document.rate metric.
+type MongodbatlasProcessDbDocumentRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessDbDocumentRateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessDbDocumentRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessDbDocumentRateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessDbDocumentRateMetricAttributeKeyDocumentStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.db.document.rate doesn't have an attribute %v, valid attributes: [document_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessDbOperationsRateMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.db.operations.rate metric.
+type MongodbatlasProcessDbOperationsRateMetricAttributeKey string
+
+const (
+	MongodbatlasProcessDbOperationsRateMetricAttributeKeyOperation   MongodbatlasProcessDbOperationsRateMetricAttributeKey = "operation"
+	MongodbatlasProcessDbOperationsRateMetricAttributeKeyClusterRole MongodbatlasProcessDbOperationsRateMetricAttributeKey = "cluster_role"
+)
+
+// MongodbatlasProcessDbOperationsRateMetricConfig provides config for the mongodbatlas.process.db.operations.rate metric.
+type MongodbatlasProcessDbOperationsRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessDbOperationsRateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessDbOperationsRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessDbOperationsRateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessDbOperationsRateMetricAttributeKeyOperation, MongodbatlasProcessDbOperationsRateMetricAttributeKeyClusterRole:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.db.operations.rate doesn't have an attribute %v, valid attributes: [operation, cluster_role]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessDbOperationsTimeMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.db.operations.time metric.
+type MongodbatlasProcessDbOperationsTimeMetricAttributeKey string
+
+const (
+	MongodbatlasProcessDbOperationsTimeMetricAttributeKeyExecutionType MongodbatlasProcessDbOperationsTimeMetricAttributeKey = "execution_type"
+)
+
+// MongodbatlasProcessDbOperationsTimeMetricConfig provides config for the mongodbatlas.process.db.operations.time metric.
+type MongodbatlasProcessDbOperationsTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessDbOperationsTimeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessDbOperationsTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessDbOperationsTimeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessDbOperationsTimeMetricAttributeKeyExecutionType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.db.operations.time doesn't have an attribute %v, valid attributes: [execution_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.db.query_executor.scanned metric.
+type MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey string
+
+const (
+	MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKeyScannedType MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey = "scanned_type"
+)
+
+// MongodbatlasProcessDbQueryExecutorScannedMetricConfig provides config for the mongodbatlas.process.db.query_executor.scanned metric.
+type MongodbatlasProcessDbQueryExecutorScannedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessDbQueryExecutorScannedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessDbQueryExecutorScannedMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKeyScannedType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.db.query_executor.scanned doesn't have an attribute %v, valid attributes: [scanned_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.db.query_targeting.scanned_per_returned metric.
+type MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey string
+
+const (
+	MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKeyScannedType MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey = "scanned_type"
+)
+
+// MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig provides config for the mongodbatlas.process.db.query_targeting.scanned_per_returned metric.
+type MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKeyScannedType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.db.query_targeting.scanned_per_returned doesn't have an attribute %v, valid attributes: [scanned_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessDbStorageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.db.storage metric.
+type MongodbatlasProcessDbStorageMetricAttributeKey string
+
+const (
+	MongodbatlasProcessDbStorageMetricAttributeKeyStorageStatus MongodbatlasProcessDbStorageMetricAttributeKey = "storage_status"
+)
+
+// MongodbatlasProcessDbStorageMetricConfig provides config for the mongodbatlas.process.db.storage metric.
+type MongodbatlasProcessDbStorageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessDbStorageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessDbStorageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessDbStorageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessDbStorageMetricAttributeKeyStorageStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.db.storage doesn't have an attribute %v, valid attributes: [storage_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessGlobalLockMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.global_lock metric.
+type MongodbatlasProcessGlobalLockMetricAttributeKey string
+
+const (
+	MongodbatlasProcessGlobalLockMetricAttributeKeyGlobalLockState MongodbatlasProcessGlobalLockMetricAttributeKey = "global_lock_state"
+)
+
+// MongodbatlasProcessGlobalLockMetricConfig provides config for the mongodbatlas.process.global_lock metric.
+type MongodbatlasProcessGlobalLockMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessGlobalLockMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessGlobalLockMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessGlobalLockMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessGlobalLockMetricAttributeKeyGlobalLockState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.global_lock doesn't have an attribute %v, valid attributes: [global_lock_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessIndexBtreeMissRatioMetricConfig provides config for the mongodbatlas.process.index.btree_miss_ratio metric.
+type MongodbatlasProcessIndexBtreeMissRatioMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessIndexBtreeMissRatioMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessIndexCountersMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.index.counters metric.
+type MongodbatlasProcessIndexCountersMetricAttributeKey string
+
+const (
+	MongodbatlasProcessIndexCountersMetricAttributeKeyBtreeCounterType MongodbatlasProcessIndexCountersMetricAttributeKey = "btree_counter_type"
+)
+
+// MongodbatlasProcessIndexCountersMetricConfig provides config for the mongodbatlas.process.index.counters metric.
+type MongodbatlasProcessIndexCountersMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessIndexCountersMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessIndexCountersMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessIndexCountersMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessIndexCountersMetricAttributeKeyBtreeCounterType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.index.counters doesn't have an attribute %v, valid attributes: [btree_counter_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessJournalingCommitsMetricConfig provides config for the mongodbatlas.process.journaling.commits metric.
+type MongodbatlasProcessJournalingCommitsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessJournalingCommitsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessJournalingDataFilesMetricConfig provides config for the mongodbatlas.process.journaling.data_files metric.
+type MongodbatlasProcessJournalingDataFilesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessJournalingDataFilesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessJournalingWrittenMetricConfig provides config for the mongodbatlas.process.journaling.written metric.
+type MongodbatlasProcessJournalingWrittenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessJournalingWrittenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessMemoryUsageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.memory.usage metric.
+type MongodbatlasProcessMemoryUsageMetricAttributeKey string
+
+const (
+	MongodbatlasProcessMemoryUsageMetricAttributeKeyMemoryState MongodbatlasProcessMemoryUsageMetricAttributeKey = "memory_state"
+)
+
+// MongodbatlasProcessMemoryUsageMetricConfig provides config for the mongodbatlas.process.memory.usage metric.
+type MongodbatlasProcessMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessMemoryUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessMemoryUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessMemoryUsageMetricAttributeKeyMemoryState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.memory.usage doesn't have an attribute %v, valid attributes: [memory_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessNetworkIoMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.network.io metric.
+type MongodbatlasProcessNetworkIoMetricAttributeKey string
+
+const (
+	MongodbatlasProcessNetworkIoMetricAttributeKeyDirection MongodbatlasProcessNetworkIoMetricAttributeKey = "direction"
+)
+
+// MongodbatlasProcessNetworkIoMetricConfig provides config for the mongodbatlas.process.network.io metric.
+type MongodbatlasProcessNetworkIoMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessNetworkIoMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessNetworkIoMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessNetworkIoMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessNetworkIoMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.network.io doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessNetworkRequestsMetricConfig provides config for the mongodbatlas.process.network.requests metric.
+type MongodbatlasProcessNetworkRequestsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessNetworkRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessOplogRateMetricConfig provides config for the mongodbatlas.process.oplog.rate metric.
+type MongodbatlasProcessOplogRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessOplogRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessOplogTimeMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.oplog.time metric.
+type MongodbatlasProcessOplogTimeMetricAttributeKey string
+
+const (
+	MongodbatlasProcessOplogTimeMetricAttributeKeyOplogType MongodbatlasProcessOplogTimeMetricAttributeKey = "oplog_type"
+)
+
+// MongodbatlasProcessOplogTimeMetricConfig provides config for the mongodbatlas.process.oplog.time metric.
+type MongodbatlasProcessOplogTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessOplogTimeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessOplogTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessOplogTimeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessOplogTimeMetricAttributeKeyOplogType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.oplog.time doesn't have an attribute %v, valid attributes: [oplog_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessPageFaultsMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.page_faults metric.
+type MongodbatlasProcessPageFaultsMetricAttributeKey string
+
+const (
+	MongodbatlasProcessPageFaultsMetricAttributeKeyMemoryIssueType MongodbatlasProcessPageFaultsMetricAttributeKey = "memory_issue_type"
+)
+
+// MongodbatlasProcessPageFaultsMetricConfig provides config for the mongodbatlas.process.page_faults metric.
+type MongodbatlasProcessPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessPageFaultsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessPageFaultsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessPageFaultsMetricAttributeKeyMemoryIssueType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.page_faults doesn't have an attribute %v, valid attributes: [memory_issue_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasProcessRestartsMetricConfig provides config for the mongodbatlas.process.restarts metric.
+type MongodbatlasProcessRestartsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasProcessRestartsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasProcessTicketsMetricAttributeKey specifies the key of an attribute for the mongodbatlas.process.tickets metric.
+type MongodbatlasProcessTicketsMetricAttributeKey string
+
+const (
+	MongodbatlasProcessTicketsMetricAttributeKeyTicketType MongodbatlasProcessTicketsMetricAttributeKey = "ticket_type"
+)
+
+// MongodbatlasProcessTicketsMetricConfig provides config for the mongodbatlas.process.tickets metric.
+type MongodbatlasProcessTicketsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasProcessTicketsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasProcessTicketsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasProcessTicketsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasProcessTicketsMetricAttributeKeyTicketType:
+		default:
+			return fmt.Errorf("metric mongodbatlas.process.tickets doesn't have an attribute %v, valid attributes: [ticket_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.cpu.normalized.usage.average metric.
+type MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKeyCPUState MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig provides config for the mongodbatlas.system.cpu.normalized.usage.average metric.
+type MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                          `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.cpu.normalized.usage.average doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.cpu.normalized.usage.max metric.
+type MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKeyCPUState MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig provides config for the mongodbatlas.system.cpu.normalized.usage.max metric.
+type MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.cpu.normalized.usage.max doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemCPUUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.cpu.usage.average metric.
+type MongodbatlasSystemCPUUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemCPUUsageAverageMetricAttributeKeyCPUState MongodbatlasSystemCPUUsageAverageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasSystemCPUUsageAverageMetricConfig provides config for the mongodbatlas.system.cpu.usage.average metric.
+type MongodbatlasSystemCPUUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemCPUUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemCPUUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemCPUUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemCPUUsageAverageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.cpu.usage.average doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemCPUUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.cpu.usage.max metric.
+type MongodbatlasSystemCPUUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasSystemCPUUsageMaxMetricAttributeKeyCPUState MongodbatlasSystemCPUUsageMaxMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasSystemCPUUsageMaxMetricConfig provides config for the mongodbatlas.system.cpu.usage.max metric.
+type MongodbatlasSystemCPUUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemCPUUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemCPUUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemCPUUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemCPUUsageMaxMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.cpu.usage.max doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.fts.cpu.normalized.usage metric.
+type MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKeyCPUState MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig provides config for the mongodbatlas.system.fts.cpu.normalized.usage metric.
+type MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.fts.cpu.normalized.usage doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemFtsCPUUsageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.fts.cpu.usage metric.
+type MongodbatlasSystemFtsCPUUsageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemFtsCPUUsageMetricAttributeKeyCPUState MongodbatlasSystemFtsCPUUsageMetricAttributeKey = "cpu_state"
+)
+
+// MongodbatlasSystemFtsCPUUsageMetricConfig provides config for the mongodbatlas.system.fts.cpu.usage metric.
+type MongodbatlasSystemFtsCPUUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemFtsCPUUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemFtsCPUUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemFtsCPUUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemFtsCPUUsageMetricAttributeKeyCPUState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.fts.cpu.usage doesn't have an attribute %v, valid attributes: [cpu_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemFtsDiskUsedMetricConfig provides config for the mongodbatlas.system.fts.disk.used metric.
+type MongodbatlasSystemFtsDiskUsedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbatlasSystemFtsDiskUsedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbatlasSystemFtsMemoryUsageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.fts.memory.usage metric.
+type MongodbatlasSystemFtsMemoryUsageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemFtsMemoryUsageMetricAttributeKeyMemoryState MongodbatlasSystemFtsMemoryUsageMetricAttributeKey = "memory_state"
+)
+
+// MongodbatlasSystemFtsMemoryUsageMetricConfig provides config for the mongodbatlas.system.fts.memory.usage metric.
+type MongodbatlasSystemFtsMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemFtsMemoryUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemFtsMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemFtsMemoryUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemFtsMemoryUsageMetricAttributeKeyMemoryState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.fts.memory.usage doesn't have an attribute %v, valid attributes: [memory_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemMemoryUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.memory.usage.average metric.
+type MongodbatlasSystemMemoryUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemMemoryUsageAverageMetricAttributeKeyMemoryStatus MongodbatlasSystemMemoryUsageAverageMetricAttributeKey = "memory_status"
+)
+
+// MongodbatlasSystemMemoryUsageAverageMetricConfig provides config for the mongodbatlas.system.memory.usage.average metric.
+type MongodbatlasSystemMemoryUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemMemoryUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemMemoryUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemMemoryUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemMemoryUsageAverageMetricAttributeKeyMemoryStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.memory.usage.average doesn't have an attribute %v, valid attributes: [memory_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemMemoryUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.memory.usage.max metric.
+type MongodbatlasSystemMemoryUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasSystemMemoryUsageMaxMetricAttributeKeyMemoryStatus MongodbatlasSystemMemoryUsageMaxMetricAttributeKey = "memory_status"
+)
+
+// MongodbatlasSystemMemoryUsageMaxMetricConfig provides config for the mongodbatlas.system.memory.usage.max metric.
+type MongodbatlasSystemMemoryUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemMemoryUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemMemoryUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemMemoryUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemMemoryUsageMaxMetricAttributeKeyMemoryStatus:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.memory.usage.max doesn't have an attribute %v, valid attributes: [memory_status]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemNetworkIoAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.network.io.average metric.
+type MongodbatlasSystemNetworkIoAverageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemNetworkIoAverageMetricAttributeKeyDirection MongodbatlasSystemNetworkIoAverageMetricAttributeKey = "direction"
+)
+
+// MongodbatlasSystemNetworkIoAverageMetricConfig provides config for the mongodbatlas.system.network.io.average metric.
+type MongodbatlasSystemNetworkIoAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemNetworkIoAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemNetworkIoAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemNetworkIoAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemNetworkIoAverageMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.network.io.average doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemNetworkIoMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.network.io.max metric.
+type MongodbatlasSystemNetworkIoMaxMetricAttributeKey string
+
+const (
+	MongodbatlasSystemNetworkIoMaxMetricAttributeKeyDirection MongodbatlasSystemNetworkIoMaxMetricAttributeKey = "direction"
+)
+
+// MongodbatlasSystemNetworkIoMaxMetricConfig provides config for the mongodbatlas.system.network.io.max metric.
+type MongodbatlasSystemNetworkIoMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemNetworkIoMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemNetworkIoMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemNetworkIoMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemNetworkIoMaxMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.network.io.max doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemPagingIoAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.paging.io.average metric.
+type MongodbatlasSystemPagingIoAverageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemPagingIoAverageMetricAttributeKeyDirection MongodbatlasSystemPagingIoAverageMetricAttributeKey = "direction"
+)
+
+// MongodbatlasSystemPagingIoAverageMetricConfig provides config for the mongodbatlas.system.paging.io.average metric.
+type MongodbatlasSystemPagingIoAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemPagingIoAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemPagingIoAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemPagingIoAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemPagingIoAverageMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.paging.io.average doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemPagingIoMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.paging.io.max metric.
+type MongodbatlasSystemPagingIoMaxMetricAttributeKey string
+
+const (
+	MongodbatlasSystemPagingIoMaxMetricAttributeKeyDirection MongodbatlasSystemPagingIoMaxMetricAttributeKey = "direction"
+)
+
+// MongodbatlasSystemPagingIoMaxMetricConfig provides config for the mongodbatlas.system.paging.io.max metric.
+type MongodbatlasSystemPagingIoMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemPagingIoMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemPagingIoMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemPagingIoMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemPagingIoMaxMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.paging.io.max doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemPagingUsageAverageMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.paging.usage.average metric.
+type MongodbatlasSystemPagingUsageAverageMetricAttributeKey string
+
+const (
+	MongodbatlasSystemPagingUsageAverageMetricAttributeKeyMemoryState MongodbatlasSystemPagingUsageAverageMetricAttributeKey = "memory_state"
+)
+
+// MongodbatlasSystemPagingUsageAverageMetricConfig provides config for the mongodbatlas.system.paging.usage.average metric.
+type MongodbatlasSystemPagingUsageAverageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemPagingUsageAverageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemPagingUsageAverageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemPagingUsageAverageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemPagingUsageAverageMetricAttributeKeyMemoryState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.paging.usage.average doesn't have an attribute %v, valid attributes: [memory_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbatlasSystemPagingUsageMaxMetricAttributeKey specifies the key of an attribute for the mongodbatlas.system.paging.usage.max metric.
+type MongodbatlasSystemPagingUsageMaxMetricAttributeKey string
+
+const (
+	MongodbatlasSystemPagingUsageMaxMetricAttributeKeyMemoryState MongodbatlasSystemPagingUsageMaxMetricAttributeKey = "memory_state"
+)
+
+// MongodbatlasSystemPagingUsageMaxMetricConfig provides config for the mongodbatlas.system.paging.usage.max metric.
+type MongodbatlasSystemPagingUsageMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbatlasSystemPagingUsageMaxMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbatlasSystemPagingUsageMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbatlasSystemPagingUsageMaxMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbatlasSystemPagingUsageMaxMetricAttributeKeyMemoryState:
+		default:
+			return fmt.Errorf("metric mongodbatlas.system.paging.usage.max doesn't have an attribute %v, valid attributes: [memory_state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MetricsConfig provides config for mongodb_atlas metrics.
 type MetricsConfig struct {
-	MongodbatlasDbCounts                                  MetricConfig `mapstructure:"mongodbatlas.db.counts"`
-	MongodbatlasDbSize                                    MetricConfig `mapstructure:"mongodbatlas.db.size"`
-	MongodbatlasDiskPartitionIopsAverage                  MetricConfig `mapstructure:"mongodbatlas.disk.partition.iops.average"`
-	MongodbatlasDiskPartitionIopsMax                      MetricConfig `mapstructure:"mongodbatlas.disk.partition.iops.max"`
-	MongodbatlasDiskPartitionLatencyAverage               MetricConfig `mapstructure:"mongodbatlas.disk.partition.latency.average"`
-	MongodbatlasDiskPartitionLatencyMax                   MetricConfig `mapstructure:"mongodbatlas.disk.partition.latency.max"`
-	MongodbatlasDiskPartitionQueueDepth                   MetricConfig `mapstructure:"mongodbatlas.disk.partition.queue.depth"`
-	MongodbatlasDiskPartitionSpaceAverage                 MetricConfig `mapstructure:"mongodbatlas.disk.partition.space.average"`
-	MongodbatlasDiskPartitionSpaceMax                     MetricConfig `mapstructure:"mongodbatlas.disk.partition.space.max"`
-	MongodbatlasDiskPartitionThroughput                   MetricConfig `mapstructure:"mongodbatlas.disk.partition.throughput"`
-	MongodbatlasDiskPartitionUsageAverage                 MetricConfig `mapstructure:"mongodbatlas.disk.partition.usage.average"`
-	MongodbatlasDiskPartitionUsageMax                     MetricConfig `mapstructure:"mongodbatlas.disk.partition.usage.max"`
-	MongodbatlasDiskPartitionUtilizationAverage           MetricConfig `mapstructure:"mongodbatlas.disk.partition.utilization.average"`
-	MongodbatlasDiskPartitionUtilizationMax               MetricConfig `mapstructure:"mongodbatlas.disk.partition.utilization.max"`
-	MongodbatlasProcessAsserts                            MetricConfig `mapstructure:"mongodbatlas.process.asserts"`
-	MongodbatlasProcessBackgroundFlush                    MetricConfig `mapstructure:"mongodbatlas.process.background_flush"`
-	MongodbatlasProcessCacheIo                            MetricConfig `mapstructure:"mongodbatlas.process.cache.io"`
-	MongodbatlasProcessCacheRatio                         MetricConfig `mapstructure:"mongodbatlas.process.cache.ratio"`
-	MongodbatlasProcessCacheSize                          MetricConfig `mapstructure:"mongodbatlas.process.cache.size"`
-	MongodbatlasProcessConnections                        MetricConfig `mapstructure:"mongodbatlas.process.connections"`
-	MongodbatlasProcessCPUChildrenNormalizedUsageAverage  MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.average"`
-	MongodbatlasProcessCPUChildrenNormalizedUsageMax      MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.max"`
-	MongodbatlasProcessCPUChildrenUsageAverage            MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.usage.average"`
-	MongodbatlasProcessCPUChildrenUsageMax                MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.usage.max"`
-	MongodbatlasProcessCPUNormalizedUsageAverage          MetricConfig `mapstructure:"mongodbatlas.process.cpu.normalized.usage.average"`
-	MongodbatlasProcessCPUNormalizedUsageMax              MetricConfig `mapstructure:"mongodbatlas.process.cpu.normalized.usage.max"`
-	MongodbatlasProcessCPUUsageAverage                    MetricConfig `mapstructure:"mongodbatlas.process.cpu.usage.average"`
-	MongodbatlasProcessCPUUsageMax                        MetricConfig `mapstructure:"mongodbatlas.process.cpu.usage.max"`
-	MongodbatlasProcessCursors                            MetricConfig `mapstructure:"mongodbatlas.process.cursors"`
-	MongodbatlasProcessDbDocumentRate                     MetricConfig `mapstructure:"mongodbatlas.process.db.document.rate"`
-	MongodbatlasProcessDbOperationsRate                   MetricConfig `mapstructure:"mongodbatlas.process.db.operations.rate"`
-	MongodbatlasProcessDbOperationsTime                   MetricConfig `mapstructure:"mongodbatlas.process.db.operations.time"`
-	MongodbatlasProcessDbQueryExecutorScanned             MetricConfig `mapstructure:"mongodbatlas.process.db.query_executor.scanned"`
-	MongodbatlasProcessDbQueryTargetingScannedPerReturned MetricConfig `mapstructure:"mongodbatlas.process.db.query_targeting.scanned_per_returned"`
-	MongodbatlasProcessDbStorage                          MetricConfig `mapstructure:"mongodbatlas.process.db.storage"`
-	MongodbatlasProcessGlobalLock                         MetricConfig `mapstructure:"mongodbatlas.process.global_lock"`
-	MongodbatlasProcessIndexBtreeMissRatio                MetricConfig `mapstructure:"mongodbatlas.process.index.btree_miss_ratio"`
-	MongodbatlasProcessIndexCounters                      MetricConfig `mapstructure:"mongodbatlas.process.index.counters"`
-	MongodbatlasProcessJournalingCommits                  MetricConfig `mapstructure:"mongodbatlas.process.journaling.commits"`
-	MongodbatlasProcessJournalingDataFiles                MetricConfig `mapstructure:"mongodbatlas.process.journaling.data_files"`
-	MongodbatlasProcessJournalingWritten                  MetricConfig `mapstructure:"mongodbatlas.process.journaling.written"`
-	MongodbatlasProcessMemoryUsage                        MetricConfig `mapstructure:"mongodbatlas.process.memory.usage"`
-	MongodbatlasProcessNetworkIo                          MetricConfig `mapstructure:"mongodbatlas.process.network.io"`
-	MongodbatlasProcessNetworkRequests                    MetricConfig `mapstructure:"mongodbatlas.process.network.requests"`
-	MongodbatlasProcessOplogRate                          MetricConfig `mapstructure:"mongodbatlas.process.oplog.rate"`
-	MongodbatlasProcessOplogTime                          MetricConfig `mapstructure:"mongodbatlas.process.oplog.time"`
-	MongodbatlasProcessPageFaults                         MetricConfig `mapstructure:"mongodbatlas.process.page_faults"`
-	MongodbatlasProcessRestarts                           MetricConfig `mapstructure:"mongodbatlas.process.restarts"`
-	MongodbatlasProcessTickets                            MetricConfig `mapstructure:"mongodbatlas.process.tickets"`
-	MongodbatlasSystemCPUNormalizedUsageAverage           MetricConfig `mapstructure:"mongodbatlas.system.cpu.normalized.usage.average"`
-	MongodbatlasSystemCPUNormalizedUsageMax               MetricConfig `mapstructure:"mongodbatlas.system.cpu.normalized.usage.max"`
-	MongodbatlasSystemCPUUsageAverage                     MetricConfig `mapstructure:"mongodbatlas.system.cpu.usage.average"`
-	MongodbatlasSystemCPUUsageMax                         MetricConfig `mapstructure:"mongodbatlas.system.cpu.usage.max"`
-	MongodbatlasSystemFtsCPUNormalizedUsage               MetricConfig `mapstructure:"mongodbatlas.system.fts.cpu.normalized.usage"`
-	MongodbatlasSystemFtsCPUUsage                         MetricConfig `mapstructure:"mongodbatlas.system.fts.cpu.usage"`
-	MongodbatlasSystemFtsDiskUsed                         MetricConfig `mapstructure:"mongodbatlas.system.fts.disk.used"`
-	MongodbatlasSystemFtsMemoryUsage                      MetricConfig `mapstructure:"mongodbatlas.system.fts.memory.usage"`
-	MongodbatlasSystemMemoryUsageAverage                  MetricConfig `mapstructure:"mongodbatlas.system.memory.usage.average"`
-	MongodbatlasSystemMemoryUsageMax                      MetricConfig `mapstructure:"mongodbatlas.system.memory.usage.max"`
-	MongodbatlasSystemNetworkIoAverage                    MetricConfig `mapstructure:"mongodbatlas.system.network.io.average"`
-	MongodbatlasSystemNetworkIoMax                        MetricConfig `mapstructure:"mongodbatlas.system.network.io.max"`
-	MongodbatlasSystemPagingIoAverage                     MetricConfig `mapstructure:"mongodbatlas.system.paging.io.average"`
-	MongodbatlasSystemPagingIoMax                         MetricConfig `mapstructure:"mongodbatlas.system.paging.io.max"`
-	MongodbatlasSystemPagingUsageAverage                  MetricConfig `mapstructure:"mongodbatlas.system.paging.usage.average"`
-	MongodbatlasSystemPagingUsageMax                      MetricConfig `mapstructure:"mongodbatlas.system.paging.usage.max"`
+	MongodbatlasDbCounts                                  MongodbatlasDbCountsMetricConfig                                  `mapstructure:"mongodbatlas.db.counts"`
+	MongodbatlasDbSize                                    MongodbatlasDbSizeMetricConfig                                    `mapstructure:"mongodbatlas.db.size"`
+	MongodbatlasDiskPartitionIopsAverage                  MongodbatlasDiskPartitionIopsAverageMetricConfig                  `mapstructure:"mongodbatlas.disk.partition.iops.average"`
+	MongodbatlasDiskPartitionIopsMax                      MongodbatlasDiskPartitionIopsMaxMetricConfig                      `mapstructure:"mongodbatlas.disk.partition.iops.max"`
+	MongodbatlasDiskPartitionLatencyAverage               MongodbatlasDiskPartitionLatencyAverageMetricConfig               `mapstructure:"mongodbatlas.disk.partition.latency.average"`
+	MongodbatlasDiskPartitionLatencyMax                   MongodbatlasDiskPartitionLatencyMaxMetricConfig                   `mapstructure:"mongodbatlas.disk.partition.latency.max"`
+	MongodbatlasDiskPartitionQueueDepth                   MongodbatlasDiskPartitionQueueDepthMetricConfig                   `mapstructure:"mongodbatlas.disk.partition.queue.depth"`
+	MongodbatlasDiskPartitionSpaceAverage                 MongodbatlasDiskPartitionSpaceAverageMetricConfig                 `mapstructure:"mongodbatlas.disk.partition.space.average"`
+	MongodbatlasDiskPartitionSpaceMax                     MongodbatlasDiskPartitionSpaceMaxMetricConfig                     `mapstructure:"mongodbatlas.disk.partition.space.max"`
+	MongodbatlasDiskPartitionThroughput                   MongodbatlasDiskPartitionThroughputMetricConfig                   `mapstructure:"mongodbatlas.disk.partition.throughput"`
+	MongodbatlasDiskPartitionUsageAverage                 MongodbatlasDiskPartitionUsageAverageMetricConfig                 `mapstructure:"mongodbatlas.disk.partition.usage.average"`
+	MongodbatlasDiskPartitionUsageMax                     MongodbatlasDiskPartitionUsageMaxMetricConfig                     `mapstructure:"mongodbatlas.disk.partition.usage.max"`
+	MongodbatlasDiskPartitionUtilizationAverage           MongodbatlasDiskPartitionUtilizationAverageMetricConfig           `mapstructure:"mongodbatlas.disk.partition.utilization.average"`
+	MongodbatlasDiskPartitionUtilizationMax               MongodbatlasDiskPartitionUtilizationMaxMetricConfig               `mapstructure:"mongodbatlas.disk.partition.utilization.max"`
+	MongodbatlasProcessAsserts                            MongodbatlasProcessAssertsMetricConfig                            `mapstructure:"mongodbatlas.process.asserts"`
+	MongodbatlasProcessBackgroundFlush                    MongodbatlasProcessBackgroundFlushMetricConfig                    `mapstructure:"mongodbatlas.process.background_flush"`
+	MongodbatlasProcessCacheIo                            MongodbatlasProcessCacheIoMetricConfig                            `mapstructure:"mongodbatlas.process.cache.io"`
+	MongodbatlasProcessCacheRatio                         MongodbatlasProcessCacheRatioMetricConfig                         `mapstructure:"mongodbatlas.process.cache.ratio"`
+	MongodbatlasProcessCacheSize                          MongodbatlasProcessCacheSizeMetricConfig                          `mapstructure:"mongodbatlas.process.cache.size"`
+	MongodbatlasProcessConnections                        MongodbatlasProcessConnectionsMetricConfig                        `mapstructure:"mongodbatlas.process.connections"`
+	MongodbatlasProcessCPUChildrenNormalizedUsageAverage  MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig  `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.average"`
+	MongodbatlasProcessCPUChildrenNormalizedUsageMax      MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig      `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.max"`
+	MongodbatlasProcessCPUChildrenUsageAverage            MongodbatlasProcessCPUChildrenUsageAverageMetricConfig            `mapstructure:"mongodbatlas.process.cpu.children.usage.average"`
+	MongodbatlasProcessCPUChildrenUsageMax                MongodbatlasProcessCPUChildrenUsageMaxMetricConfig                `mapstructure:"mongodbatlas.process.cpu.children.usage.max"`
+	MongodbatlasProcessCPUNormalizedUsageAverage          MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig          `mapstructure:"mongodbatlas.process.cpu.normalized.usage.average"`
+	MongodbatlasProcessCPUNormalizedUsageMax              MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig              `mapstructure:"mongodbatlas.process.cpu.normalized.usage.max"`
+	MongodbatlasProcessCPUUsageAverage                    MongodbatlasProcessCPUUsageAverageMetricConfig                    `mapstructure:"mongodbatlas.process.cpu.usage.average"`
+	MongodbatlasProcessCPUUsageMax                        MongodbatlasProcessCPUUsageMaxMetricConfig                        `mapstructure:"mongodbatlas.process.cpu.usage.max"`
+	MongodbatlasProcessCursors                            MongodbatlasProcessCursorsMetricConfig                            `mapstructure:"mongodbatlas.process.cursors"`
+	MongodbatlasProcessDbDocumentRate                     MongodbatlasProcessDbDocumentRateMetricConfig                     `mapstructure:"mongodbatlas.process.db.document.rate"`
+	MongodbatlasProcessDbOperationsRate                   MongodbatlasProcessDbOperationsRateMetricConfig                   `mapstructure:"mongodbatlas.process.db.operations.rate"`
+	MongodbatlasProcessDbOperationsTime                   MongodbatlasProcessDbOperationsTimeMetricConfig                   `mapstructure:"mongodbatlas.process.db.operations.time"`
+	MongodbatlasProcessDbQueryExecutorScanned             MongodbatlasProcessDbQueryExecutorScannedMetricConfig             `mapstructure:"mongodbatlas.process.db.query_executor.scanned"`
+	MongodbatlasProcessDbQueryTargetingScannedPerReturned MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig `mapstructure:"mongodbatlas.process.db.query_targeting.scanned_per_returned"`
+	MongodbatlasProcessDbStorage                          MongodbatlasProcessDbStorageMetricConfig                          `mapstructure:"mongodbatlas.process.db.storage"`
+	MongodbatlasProcessGlobalLock                         MongodbatlasProcessGlobalLockMetricConfig                         `mapstructure:"mongodbatlas.process.global_lock"`
+	MongodbatlasProcessIndexBtreeMissRatio                MongodbatlasProcessIndexBtreeMissRatioMetricConfig                `mapstructure:"mongodbatlas.process.index.btree_miss_ratio"`
+	MongodbatlasProcessIndexCounters                      MongodbatlasProcessIndexCountersMetricConfig                      `mapstructure:"mongodbatlas.process.index.counters"`
+	MongodbatlasProcessJournalingCommits                  MongodbatlasProcessJournalingCommitsMetricConfig                  `mapstructure:"mongodbatlas.process.journaling.commits"`
+	MongodbatlasProcessJournalingDataFiles                MongodbatlasProcessJournalingDataFilesMetricConfig                `mapstructure:"mongodbatlas.process.journaling.data_files"`
+	MongodbatlasProcessJournalingWritten                  MongodbatlasProcessJournalingWrittenMetricConfig                  `mapstructure:"mongodbatlas.process.journaling.written"`
+	MongodbatlasProcessMemoryUsage                        MongodbatlasProcessMemoryUsageMetricConfig                        `mapstructure:"mongodbatlas.process.memory.usage"`
+	MongodbatlasProcessNetworkIo                          MongodbatlasProcessNetworkIoMetricConfig                          `mapstructure:"mongodbatlas.process.network.io"`
+	MongodbatlasProcessNetworkRequests                    MongodbatlasProcessNetworkRequestsMetricConfig                    `mapstructure:"mongodbatlas.process.network.requests"`
+	MongodbatlasProcessOplogRate                          MongodbatlasProcessOplogRateMetricConfig                          `mapstructure:"mongodbatlas.process.oplog.rate"`
+	MongodbatlasProcessOplogTime                          MongodbatlasProcessOplogTimeMetricConfig                          `mapstructure:"mongodbatlas.process.oplog.time"`
+	MongodbatlasProcessPageFaults                         MongodbatlasProcessPageFaultsMetricConfig                         `mapstructure:"mongodbatlas.process.page_faults"`
+	MongodbatlasProcessRestarts                           MongodbatlasProcessRestartsMetricConfig                           `mapstructure:"mongodbatlas.process.restarts"`
+	MongodbatlasProcessTickets                            MongodbatlasProcessTicketsMetricConfig                            `mapstructure:"mongodbatlas.process.tickets"`
+	MongodbatlasSystemCPUNormalizedUsageAverage           MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig           `mapstructure:"mongodbatlas.system.cpu.normalized.usage.average"`
+	MongodbatlasSystemCPUNormalizedUsageMax               MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig               `mapstructure:"mongodbatlas.system.cpu.normalized.usage.max"`
+	MongodbatlasSystemCPUUsageAverage                     MongodbatlasSystemCPUUsageAverageMetricConfig                     `mapstructure:"mongodbatlas.system.cpu.usage.average"`
+	MongodbatlasSystemCPUUsageMax                         MongodbatlasSystemCPUUsageMaxMetricConfig                         `mapstructure:"mongodbatlas.system.cpu.usage.max"`
+	MongodbatlasSystemFtsCPUNormalizedUsage               MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig               `mapstructure:"mongodbatlas.system.fts.cpu.normalized.usage"`
+	MongodbatlasSystemFtsCPUUsage                         MongodbatlasSystemFtsCPUUsageMetricConfig                         `mapstructure:"mongodbatlas.system.fts.cpu.usage"`
+	MongodbatlasSystemFtsDiskUsed                         MongodbatlasSystemFtsDiskUsedMetricConfig                         `mapstructure:"mongodbatlas.system.fts.disk.used"`
+	MongodbatlasSystemFtsMemoryUsage                      MongodbatlasSystemFtsMemoryUsageMetricConfig                      `mapstructure:"mongodbatlas.system.fts.memory.usage"`
+	MongodbatlasSystemMemoryUsageAverage                  MongodbatlasSystemMemoryUsageAverageMetricConfig                  `mapstructure:"mongodbatlas.system.memory.usage.average"`
+	MongodbatlasSystemMemoryUsageMax                      MongodbatlasSystemMemoryUsageMaxMetricConfig                      `mapstructure:"mongodbatlas.system.memory.usage.max"`
+	MongodbatlasSystemNetworkIoAverage                    MongodbatlasSystemNetworkIoAverageMetricConfig                    `mapstructure:"mongodbatlas.system.network.io.average"`
+	MongodbatlasSystemNetworkIoMax                        MongodbatlasSystemNetworkIoMaxMetricConfig                        `mapstructure:"mongodbatlas.system.network.io.max"`
+	MongodbatlasSystemPagingIoAverage                     MongodbatlasSystemPagingIoAverageMetricConfig                     `mapstructure:"mongodbatlas.system.paging.io.average"`
+	MongodbatlasSystemPagingIoMax                         MongodbatlasSystemPagingIoMaxMetricConfig                         `mapstructure:"mongodbatlas.system.paging.io.max"`
+	MongodbatlasSystemPagingUsageAverage                  MongodbatlasSystemPagingUsageAverageMetricConfig                  `mapstructure:"mongodbatlas.system.paging.usage.average"`
+	MongodbatlasSystemPagingUsageMax                      MongodbatlasSystemPagingUsageMaxMetricConfig                      `mapstructure:"mongodbatlas.system.paging.usage.max"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		MongodbatlasDbCounts: MetricConfig{
-			Enabled: true,
+		MongodbatlasDbCounts: MongodbatlasDbCountsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDbCountsMetricAttributeKey{MongodbatlasDbCountsMetricAttributeKeyObjectType},
 		},
-		MongodbatlasDbSize: MetricConfig{
-			Enabled: true,
+		MongodbatlasDbSize: MongodbatlasDbSizeMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDbSizeMetricAttributeKey{MongodbatlasDbSizeMetricAttributeKeyObjectType},
 		},
-		MongodbatlasDiskPartitionIopsAverage: MetricConfig{
-			Enabled: true,
+		MongodbatlasDiskPartitionIopsAverage: MongodbatlasDiskPartitionIopsAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionIopsAverageMetricAttributeKey{MongodbatlasDiskPartitionIopsAverageMetricAttributeKeyDiskDirection},
 		},
-		MongodbatlasDiskPartitionIopsMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasDiskPartitionIopsMax: MongodbatlasDiskPartitionIopsMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionIopsMaxMetricAttributeKey{MongodbatlasDiskPartitionIopsMaxMetricAttributeKeyDiskDirection},
 		},
-		MongodbatlasDiskPartitionLatencyAverage: MetricConfig{
-			Enabled: true,
+		MongodbatlasDiskPartitionLatencyAverage: MongodbatlasDiskPartitionLatencyAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey{MongodbatlasDiskPartitionLatencyAverageMetricAttributeKeyDiskDirection},
 		},
-		MongodbatlasDiskPartitionLatencyMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasDiskPartitionLatencyMax: MongodbatlasDiskPartitionLatencyMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey{MongodbatlasDiskPartitionLatencyMaxMetricAttributeKeyDiskDirection},
 		},
-		MongodbatlasDiskPartitionQueueDepth: MetricConfig{
+		MongodbatlasDiskPartitionQueueDepth: MongodbatlasDiskPartitionQueueDepthMetricConfig{
 			Enabled: false,
 		},
-		MongodbatlasDiskPartitionSpaceAverage: MetricConfig{
+		MongodbatlasDiskPartitionSpaceAverage: MongodbatlasDiskPartitionSpaceAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey{MongodbatlasDiskPartitionSpaceAverageMetricAttributeKeyDiskStatus},
+		},
+		MongodbatlasDiskPartitionSpaceMax: MongodbatlasDiskPartitionSpaceMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey{MongodbatlasDiskPartitionSpaceMaxMetricAttributeKeyDiskStatus},
+		},
+		MongodbatlasDiskPartitionThroughput: MongodbatlasDiskPartitionThroughputMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionThroughputMetricAttributeKey{MongodbatlasDiskPartitionThroughputMetricAttributeKeyDiskDirection},
+		},
+		MongodbatlasDiskPartitionUsageAverage: MongodbatlasDiskPartitionUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionUsageAverageMetricAttributeKey{MongodbatlasDiskPartitionUsageAverageMetricAttributeKeyDiskStatus},
+		},
+		MongodbatlasDiskPartitionUsageMax: MongodbatlasDiskPartitionUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasDiskPartitionUsageMaxMetricAttributeKey{MongodbatlasDiskPartitionUsageMaxMetricAttributeKeyDiskStatus},
+		},
+		MongodbatlasDiskPartitionUtilizationAverage: MongodbatlasDiskPartitionUtilizationAverageMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionSpaceMax: MetricConfig{
+		MongodbatlasDiskPartitionUtilizationMax: MongodbatlasDiskPartitionUtilizationMaxMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionThroughput: MetricConfig{
-			Enabled: false,
+		MongodbatlasProcessAsserts: MongodbatlasProcessAssertsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessAssertsMetricAttributeKey{MongodbatlasProcessAssertsMetricAttributeKeyAssertType},
 		},
-		MongodbatlasDiskPartitionUsageAverage: MetricConfig{
+		MongodbatlasProcessBackgroundFlush: MongodbatlasProcessBackgroundFlushMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUsageMax: MetricConfig{
+		MongodbatlasProcessCacheIo: MongodbatlasProcessCacheIoMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCacheIoMetricAttributeKey{MongodbatlasProcessCacheIoMetricAttributeKeyCacheDirection},
+		},
+		MongodbatlasProcessCacheRatio: MongodbatlasProcessCacheRatioMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCacheRatioMetricAttributeKey{MongodbatlasProcessCacheRatioMetricAttributeKeyCacheRatioType},
+		},
+		MongodbatlasProcessCacheSize: MongodbatlasProcessCacheSizeMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MongodbatlasProcessCacheSizeMetricAttributeKey{MongodbatlasProcessCacheSizeMetricAttributeKeyCacheStatus},
+		},
+		MongodbatlasProcessConnections: MongodbatlasProcessConnectionsMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUtilizationAverage: MetricConfig{
+		MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey{MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUChildrenNormalizedUsageMax: MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey{MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUChildrenUsageAverage: MongodbatlasProcessCPUChildrenUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey{MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUChildrenUsageMax: MongodbatlasProcessCPUChildrenUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey{MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUNormalizedUsageAverage: MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey{MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUNormalizedUsageMax: MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey{MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUUsageAverage: MongodbatlasProcessCPUUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUUsageAverageMetricAttributeKey{MongodbatlasProcessCPUUsageAverageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCPUUsageMax: MongodbatlasProcessCPUUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCPUUsageMaxMetricAttributeKey{MongodbatlasProcessCPUUsageMaxMetricAttributeKeyCPUState},
+		},
+		MongodbatlasProcessCursors: MongodbatlasProcessCursorsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessCursorsMetricAttributeKey{MongodbatlasProcessCursorsMetricAttributeKeyCursorState},
+		},
+		MongodbatlasProcessDbDocumentRate: MongodbatlasProcessDbDocumentRateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessDbDocumentRateMetricAttributeKey{MongodbatlasProcessDbDocumentRateMetricAttributeKeyDocumentStatus},
+		},
+		MongodbatlasProcessDbOperationsRate: MongodbatlasProcessDbOperationsRateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessDbOperationsRateMetricAttributeKey{MongodbatlasProcessDbOperationsRateMetricAttributeKeyOperation, MongodbatlasProcessDbOperationsRateMetricAttributeKeyClusterRole},
+		},
+		MongodbatlasProcessDbOperationsTime: MongodbatlasProcessDbOperationsTimeMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MongodbatlasProcessDbOperationsTimeMetricAttributeKey{MongodbatlasProcessDbOperationsTimeMetricAttributeKeyExecutionType},
+		},
+		MongodbatlasProcessDbQueryExecutorScanned: MongodbatlasProcessDbQueryExecutorScannedMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey{MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKeyScannedType},
+		},
+		MongodbatlasProcessDbQueryTargetingScannedPerReturned: MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey{MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKeyScannedType},
+		},
+		MongodbatlasProcessDbStorage: MongodbatlasProcessDbStorageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessDbStorageMetricAttributeKey{MongodbatlasProcessDbStorageMetricAttributeKeyStorageStatus},
+		},
+		MongodbatlasProcessGlobalLock: MongodbatlasProcessGlobalLockMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessGlobalLockMetricAttributeKey{MongodbatlasProcessGlobalLockMetricAttributeKeyGlobalLockState},
+		},
+		MongodbatlasProcessIndexBtreeMissRatio: MongodbatlasProcessIndexBtreeMissRatioMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUtilizationMax: MetricConfig{
+		MongodbatlasProcessIndexCounters: MongodbatlasProcessIndexCountersMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessIndexCountersMetricAttributeKey{MongodbatlasProcessIndexCountersMetricAttributeKeyBtreeCounterType},
+		},
+		MongodbatlasProcessJournalingCommits: MongodbatlasProcessJournalingCommitsMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessAsserts: MetricConfig{
+		MongodbatlasProcessJournalingDataFiles: MongodbatlasProcessJournalingDataFilesMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessBackgroundFlush: MetricConfig{
+		MongodbatlasProcessJournalingWritten: MongodbatlasProcessJournalingWrittenMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCacheIo: MetricConfig{
+		MongodbatlasProcessMemoryUsage: MongodbatlasProcessMemoryUsageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessMemoryUsageMetricAttributeKey{MongodbatlasProcessMemoryUsageMetricAttributeKeyMemoryState},
+		},
+		MongodbatlasProcessNetworkIo: MongodbatlasProcessNetworkIoMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessNetworkIoMetricAttributeKey{MongodbatlasProcessNetworkIoMetricAttributeKeyDirection},
+		},
+		MongodbatlasProcessNetworkRequests: MongodbatlasProcessNetworkRequestsMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCacheRatio: MetricConfig{
-			Enabled: false,
-		},
-		MongodbatlasProcessCacheSize: MetricConfig{
+		MongodbatlasProcessOplogRate: MongodbatlasProcessOplogRateMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessConnections: MetricConfig{
+		MongodbatlasProcessOplogTime: MongodbatlasProcessOplogTimeMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessOplogTimeMetricAttributeKey{MongodbatlasProcessOplogTimeMetricAttributeKeyOplogType},
+		},
+		MongodbatlasProcessPageFaults: MongodbatlasProcessPageFaultsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessPageFaultsMetricAttributeKey{MongodbatlasProcessPageFaultsMetricAttributeKeyMemoryIssueType},
+		},
+		MongodbatlasProcessRestarts: MongodbatlasProcessRestartsMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MetricConfig{
+		MongodbatlasProcessTickets: MongodbatlasProcessTicketsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasProcessTicketsMetricAttributeKey{MongodbatlasProcessTicketsMetricAttributeKeyTicketType},
+		},
+		MongodbatlasSystemCPUNormalizedUsageAverage: MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey{MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasSystemCPUNormalizedUsageMax: MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey{MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKeyCPUState},
+		},
+		MongodbatlasSystemCPUUsageAverage: MongodbatlasSystemCPUUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemCPUUsageAverageMetricAttributeKey{MongodbatlasSystemCPUUsageAverageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasSystemCPUUsageMax: MongodbatlasSystemCPUUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemCPUUsageMaxMetricAttributeKey{MongodbatlasSystemCPUUsageMaxMetricAttributeKeyCPUState},
+		},
+		MongodbatlasSystemFtsCPUNormalizedUsage: MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey{MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasSystemFtsCPUUsage: MongodbatlasSystemFtsCPUUsageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemFtsCPUUsageMetricAttributeKey{MongodbatlasSystemFtsCPUUsageMetricAttributeKeyCPUState},
+		},
+		MongodbatlasSystemFtsDiskUsed: MongodbatlasSystemFtsDiskUsedMetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUChildrenNormalizedUsageMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemFtsMemoryUsage: MongodbatlasSystemFtsMemoryUsageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MongodbatlasSystemFtsMemoryUsageMetricAttributeKey{MongodbatlasSystemFtsMemoryUsageMetricAttributeKeyMemoryState},
 		},
-		MongodbatlasProcessCPUChildrenUsageAverage: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemMemoryUsageAverage: MongodbatlasSystemMemoryUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemMemoryUsageAverageMetricAttributeKey{MongodbatlasSystemMemoryUsageAverageMetricAttributeKeyMemoryStatus},
 		},
-		MongodbatlasProcessCPUChildrenUsageMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemMemoryUsageMax: MongodbatlasSystemMemoryUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemMemoryUsageMaxMetricAttributeKey{MongodbatlasSystemMemoryUsageMaxMetricAttributeKeyMemoryStatus},
 		},
-		MongodbatlasProcessCPUNormalizedUsageAverage: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemNetworkIoAverage: MongodbatlasSystemNetworkIoAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemNetworkIoAverageMetricAttributeKey{MongodbatlasSystemNetworkIoAverageMetricAttributeKeyDirection},
 		},
-		MongodbatlasProcessCPUNormalizedUsageMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemNetworkIoMax: MongodbatlasSystemNetworkIoMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemNetworkIoMaxMetricAttributeKey{MongodbatlasSystemNetworkIoMaxMetricAttributeKeyDirection},
 		},
-		MongodbatlasProcessCPUUsageAverage: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemPagingIoAverage: MongodbatlasSystemPagingIoAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemPagingIoAverageMetricAttributeKey{MongodbatlasSystemPagingIoAverageMetricAttributeKeyDirection},
 		},
-		MongodbatlasProcessCPUUsageMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemPagingIoMax: MongodbatlasSystemPagingIoMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemPagingIoMaxMetricAttributeKey{MongodbatlasSystemPagingIoMaxMetricAttributeKeyDirection},
 		},
-		MongodbatlasProcessCursors: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemPagingUsageAverage: MongodbatlasSystemPagingUsageAverageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemPagingUsageAverageMetricAttributeKey{MongodbatlasSystemPagingUsageAverageMetricAttributeKeyMemoryState},
 		},
-		MongodbatlasProcessDbDocumentRate: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessDbOperationsRate: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessDbOperationsTime: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessDbQueryExecutorScanned: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessDbQueryTargetingScannedPerReturned: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessDbStorage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessGlobalLock: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessIndexBtreeMissRatio: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessIndexCounters: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessJournalingCommits: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessJournalingDataFiles: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessJournalingWritten: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessMemoryUsage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessNetworkIo: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessNetworkRequests: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessOplogRate: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessOplogTime: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessPageFaults: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessRestarts: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasProcessTickets: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemCPUNormalizedUsageAverage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemCPUNormalizedUsageMax: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemCPUUsageAverage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemCPUUsageMax: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemFtsCPUNormalizedUsage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemFtsCPUUsage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemFtsDiskUsed: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemFtsMemoryUsage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemMemoryUsageAverage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemMemoryUsageMax: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemNetworkIoAverage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemNetworkIoMax: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemPagingIoAverage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemPagingIoMax: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemPagingUsageAverage: MetricConfig{
-			Enabled: true,
-		},
-		MongodbatlasSystemPagingUsageMax: MetricConfig{
-			Enabled: true,
+		MongodbatlasSystemPagingUsageMax: MongodbatlasSystemPagingUsageMaxMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbatlasSystemPagingUsageMaxMetricAttributeKey{MongodbatlasSystemPagingUsageMaxMetricAttributeKeyMemoryState},
 		},
 	}
 }

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,200 +27,304 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					MongodbatlasDbCounts: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDbSize: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionIopsAverage: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionIopsMax: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionLatencyAverage: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionLatencyMax: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionQueueDepth: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionSpaceAverage: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionSpaceMax: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionThroughput: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionUsageAverage: MetricConfig{
-						Enabled: true,
-					},
-					MongodbatlasDiskPartitionUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasDbCounts: MongodbatlasDbCountsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDbCountsMetricAttributeKey{MongodbatlasDbCountsMetricAttributeKeyObjectType},
 					},
-					MongodbatlasDiskPartitionUtilizationAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasDbSize: MongodbatlasDbSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDbSizeMetricAttributeKey{MongodbatlasDbSizeMetricAttributeKeyObjectType},
 					},
-					MongodbatlasDiskPartitionUtilizationMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasDiskPartitionIopsAverage: MongodbatlasDiskPartitionIopsAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionIopsAverageMetricAttributeKey{MongodbatlasDiskPartitionIopsAverageMetricAttributeKeyDiskDirection},
 					},
-					MongodbatlasProcessAsserts: MetricConfig{
-						Enabled: true,
+					MongodbatlasDiskPartitionIopsMax: MongodbatlasDiskPartitionIopsMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionIopsMaxMetricAttributeKey{MongodbatlasDiskPartitionIopsMaxMetricAttributeKeyDiskDirection},
 					},
-					MongodbatlasProcessBackgroundFlush: MetricConfig{
-						Enabled: true,
+					MongodbatlasDiskPartitionLatencyAverage: MongodbatlasDiskPartitionLatencyAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey{MongodbatlasDiskPartitionLatencyAverageMetricAttributeKeyDiskDirection},
 					},
-					MongodbatlasProcessCacheIo: MetricConfig{
+					MongodbatlasDiskPartitionLatencyMax: MongodbatlasDiskPartitionLatencyMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey{MongodbatlasDiskPartitionLatencyMaxMetricAttributeKeyDiskDirection},
+					},
+					MongodbatlasDiskPartitionQueueDepth: MongodbatlasDiskPartitionQueueDepthMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessCacheRatio: MetricConfig{
-						Enabled: true,
+					MongodbatlasDiskPartitionSpaceAverage: MongodbatlasDiskPartitionSpaceAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey{MongodbatlasDiskPartitionSpaceAverageMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionSpaceMax: MongodbatlasDiskPartitionSpaceMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey{MongodbatlasDiskPartitionSpaceMaxMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionThroughput: MongodbatlasDiskPartitionThroughputMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionThroughputMetricAttributeKey{MongodbatlasDiskPartitionThroughputMetricAttributeKeyDiskDirection},
+					},
+					MongodbatlasDiskPartitionUsageAverage: MongodbatlasDiskPartitionUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionUsageAverageMetricAttributeKey{MongodbatlasDiskPartitionUsageAverageMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionUsageMax: MongodbatlasDiskPartitionUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionUsageMaxMetricAttributeKey{MongodbatlasDiskPartitionUsageMaxMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionUtilizationAverage: MongodbatlasDiskPartitionUtilizationAverageMetricConfig{
+						Enabled: true,
+					},
+					MongodbatlasDiskPartitionUtilizationMax: MongodbatlasDiskPartitionUtilizationMaxMetricConfig{
+						Enabled: true,
+					},
+					MongodbatlasProcessAsserts: MongodbatlasProcessAssertsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessAssertsMetricAttributeKey{MongodbatlasProcessAssertsMetricAttributeKeyAssertType},
+					},
+					MongodbatlasProcessBackgroundFlush: MongodbatlasProcessBackgroundFlushMetricConfig{
+						Enabled: true,
+					},
+					MongodbatlasProcessCacheIo: MongodbatlasProcessCacheIoMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCacheIoMetricAttributeKey{MongodbatlasProcessCacheIoMetricAttributeKeyCacheDirection},
+					},
+					MongodbatlasProcessCacheRatio: MongodbatlasProcessCacheRatioMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCacheRatioMetricAttributeKey{MongodbatlasProcessCacheRatioMetricAttributeKeyCacheRatioType},
 					},
-					MongodbatlasProcessCacheSize: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCacheSize: MongodbatlasProcessCacheSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbatlasProcessCacheSizeMetricAttributeKey{MongodbatlasProcessCacheSizeMetricAttributeKeyCacheStatus},
 					},
-					MongodbatlasProcessConnections: MetricConfig{
+					MongodbatlasProcessConnections: MongodbatlasProcessConnectionsMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey{MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUChildrenNormalizedUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUChildrenNormalizedUsageMax: MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey{MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUChildrenUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUChildrenUsageAverage: MongodbatlasProcessCPUChildrenUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey{MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUChildrenUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUChildrenUsageMax: MongodbatlasProcessCPUChildrenUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey{MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUNormalizedUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUNormalizedUsageAverage: MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey{MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUNormalizedUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUNormalizedUsageMax: MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey{MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUUsageAverage: MongodbatlasProcessCPUUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUUsageAverageMetricAttributeKey{MongodbatlasProcessCPUUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCPUUsageMax: MongodbatlasProcessCPUUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUUsageMaxMetricAttributeKey{MongodbatlasProcessCPUUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCursors: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessCursors: MongodbatlasProcessCursorsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCursorsMetricAttributeKey{MongodbatlasProcessCursorsMetricAttributeKeyCursorState},
 					},
-					MongodbatlasProcessDbDocumentRate: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessDbDocumentRate: MongodbatlasProcessDbDocumentRateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbDocumentRateMetricAttributeKey{MongodbatlasProcessDbDocumentRateMetricAttributeKeyDocumentStatus},
 					},
-					MongodbatlasProcessDbOperationsRate: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessDbOperationsRate: MongodbatlasProcessDbOperationsRateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbOperationsRateMetricAttributeKey{MongodbatlasProcessDbOperationsRateMetricAttributeKeyOperation, MongodbatlasProcessDbOperationsRateMetricAttributeKeyClusterRole},
 					},
-					MongodbatlasProcessDbOperationsTime: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessDbOperationsTime: MongodbatlasProcessDbOperationsTimeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbatlasProcessDbOperationsTimeMetricAttributeKey{MongodbatlasProcessDbOperationsTimeMetricAttributeKeyExecutionType},
 					},
-					MongodbatlasProcessDbQueryExecutorScanned: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessDbQueryExecutorScanned: MongodbatlasProcessDbQueryExecutorScannedMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey{MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKeyScannedType},
 					},
-					MongodbatlasProcessDbQueryTargetingScannedPerReturned: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessDbQueryTargetingScannedPerReturned: MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey{MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKeyScannedType},
 					},
-					MongodbatlasProcessDbStorage: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessDbStorage: MongodbatlasProcessDbStorageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbStorageMetricAttributeKey{MongodbatlasProcessDbStorageMetricAttributeKeyStorageStatus},
 					},
-					MongodbatlasProcessGlobalLock: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessGlobalLock: MongodbatlasProcessGlobalLockMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessGlobalLockMetricAttributeKey{MongodbatlasProcessGlobalLockMetricAttributeKeyGlobalLockState},
 					},
-					MongodbatlasProcessIndexBtreeMissRatio: MetricConfig{
+					MongodbatlasProcessIndexBtreeMissRatio: MongodbatlasProcessIndexBtreeMissRatioMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessIndexCounters: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessIndexCounters: MongodbatlasProcessIndexCountersMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessIndexCountersMetricAttributeKey{MongodbatlasProcessIndexCountersMetricAttributeKeyBtreeCounterType},
 					},
-					MongodbatlasProcessJournalingCommits: MetricConfig{
+					MongodbatlasProcessJournalingCommits: MongodbatlasProcessJournalingCommitsMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessJournalingDataFiles: MetricConfig{
+					MongodbatlasProcessJournalingDataFiles: MongodbatlasProcessJournalingDataFilesMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessJournalingWritten: MetricConfig{
+					MongodbatlasProcessJournalingWritten: MongodbatlasProcessJournalingWrittenMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessMemoryUsage: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessMemoryUsage: MongodbatlasProcessMemoryUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessMemoryUsageMetricAttributeKey{MongodbatlasProcessMemoryUsageMetricAttributeKeyMemoryState},
 					},
-					MongodbatlasProcessNetworkIo: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessNetworkIo: MongodbatlasProcessNetworkIoMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessNetworkIoMetricAttributeKey{MongodbatlasProcessNetworkIoMetricAttributeKeyDirection},
 					},
-					MongodbatlasProcessNetworkRequests: MetricConfig{
+					MongodbatlasProcessNetworkRequests: MongodbatlasProcessNetworkRequestsMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessOplogRate: MetricConfig{
+					MongodbatlasProcessOplogRate: MongodbatlasProcessOplogRateMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessOplogTime: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessOplogTime: MongodbatlasProcessOplogTimeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessOplogTimeMetricAttributeKey{MongodbatlasProcessOplogTimeMetricAttributeKeyOplogType},
 					},
-					MongodbatlasProcessPageFaults: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessPageFaults: MongodbatlasProcessPageFaultsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessPageFaultsMetricAttributeKey{MongodbatlasProcessPageFaultsMetricAttributeKeyMemoryIssueType},
 					},
-					MongodbatlasProcessRestarts: MetricConfig{
+					MongodbatlasProcessRestarts: MongodbatlasProcessRestartsMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasProcessTickets: MetricConfig{
-						Enabled: true,
+					MongodbatlasProcessTickets: MongodbatlasProcessTicketsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessTicketsMetricAttributeKey{MongodbatlasProcessTicketsMetricAttributeKeyTicketType},
 					},
-					MongodbatlasSystemCPUNormalizedUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemCPUNormalizedUsageAverage: MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey{MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemCPUNormalizedUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemCPUNormalizedUsageMax: MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey{MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemCPUUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemCPUUsageAverage: MongodbatlasSystemCPUUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUUsageAverageMetricAttributeKey{MongodbatlasSystemCPUUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemCPUUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemCPUUsageMax: MongodbatlasSystemCPUUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUUsageMaxMetricAttributeKey{MongodbatlasSystemCPUUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemFtsCPUNormalizedUsage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemFtsCPUNormalizedUsage: MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey{MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemFtsCPUUsage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemFtsCPUUsage: MongodbatlasSystemFtsCPUUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemFtsCPUUsageMetricAttributeKey{MongodbatlasSystemFtsCPUUsageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemFtsDiskUsed: MetricConfig{
+					MongodbatlasSystemFtsDiskUsed: MongodbatlasSystemFtsDiskUsedMetricConfig{
 						Enabled: true,
 					},
-					MongodbatlasSystemFtsMemoryUsage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemFtsMemoryUsage: MongodbatlasSystemFtsMemoryUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbatlasSystemFtsMemoryUsageMetricAttributeKey{MongodbatlasSystemFtsMemoryUsageMetricAttributeKeyMemoryState},
 					},
-					MongodbatlasSystemMemoryUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemMemoryUsageAverage: MongodbatlasSystemMemoryUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemMemoryUsageAverageMetricAttributeKey{MongodbatlasSystemMemoryUsageAverageMetricAttributeKeyMemoryStatus},
 					},
-					MongodbatlasSystemMemoryUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemMemoryUsageMax: MongodbatlasSystemMemoryUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemMemoryUsageMaxMetricAttributeKey{MongodbatlasSystemMemoryUsageMaxMetricAttributeKeyMemoryStatus},
 					},
-					MongodbatlasSystemNetworkIoAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemNetworkIoAverage: MongodbatlasSystemNetworkIoAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemNetworkIoAverageMetricAttributeKey{MongodbatlasSystemNetworkIoAverageMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemNetworkIoMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemNetworkIoMax: MongodbatlasSystemNetworkIoMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemNetworkIoMaxMetricAttributeKey{MongodbatlasSystemNetworkIoMaxMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemPagingIoAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemPagingIoAverage: MongodbatlasSystemPagingIoAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingIoAverageMetricAttributeKey{MongodbatlasSystemPagingIoAverageMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemPagingIoMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemPagingIoMax: MongodbatlasSystemPagingIoMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingIoMaxMetricAttributeKey{MongodbatlasSystemPagingIoMaxMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemPagingUsageAverage: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemPagingUsageAverage: MongodbatlasSystemPagingUsageAverageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingUsageAverageMetricAttributeKey{MongodbatlasSystemPagingUsageAverageMetricAttributeKeyMemoryState},
 					},
-					MongodbatlasSystemPagingUsageMax: MetricConfig{
-						Enabled: true,
+					MongodbatlasSystemPagingUsageMax: MongodbatlasSystemPagingUsageMaxMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingUsageMaxMetricAttributeKey{MongodbatlasSystemPagingUsageMaxMetricAttributeKeyMemoryState},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -243,200 +348,304 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					MongodbatlasDbCounts: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDbSize: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionIopsAverage: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionIopsMax: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionLatencyAverage: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionLatencyMax: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionQueueDepth: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionSpaceAverage: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionSpaceMax: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionThroughput: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionUsageAverage: MetricConfig{
-						Enabled: false,
-					},
-					MongodbatlasDiskPartitionUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasDbCounts: MongodbatlasDbCountsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDbCountsMetricAttributeKey{MongodbatlasDbCountsMetricAttributeKeyObjectType},
 					},
-					MongodbatlasDiskPartitionUtilizationAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasDbSize: MongodbatlasDbSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDbSizeMetricAttributeKey{MongodbatlasDbSizeMetricAttributeKeyObjectType},
 					},
-					MongodbatlasDiskPartitionUtilizationMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasDiskPartitionIopsAverage: MongodbatlasDiskPartitionIopsAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionIopsAverageMetricAttributeKey{MongodbatlasDiskPartitionIopsAverageMetricAttributeKeyDiskDirection},
 					},
-					MongodbatlasProcessAsserts: MetricConfig{
-						Enabled: false,
+					MongodbatlasDiskPartitionIopsMax: MongodbatlasDiskPartitionIopsMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionIopsMaxMetricAttributeKey{MongodbatlasDiskPartitionIopsMaxMetricAttributeKeyDiskDirection},
 					},
-					MongodbatlasProcessBackgroundFlush: MetricConfig{
-						Enabled: false,
+					MongodbatlasDiskPartitionLatencyAverage: MongodbatlasDiskPartitionLatencyAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionLatencyAverageMetricAttributeKey{MongodbatlasDiskPartitionLatencyAverageMetricAttributeKeyDiskDirection},
 					},
-					MongodbatlasProcessCacheIo: MetricConfig{
+					MongodbatlasDiskPartitionLatencyMax: MongodbatlasDiskPartitionLatencyMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionLatencyMaxMetricAttributeKey{MongodbatlasDiskPartitionLatencyMaxMetricAttributeKeyDiskDirection},
+					},
+					MongodbatlasDiskPartitionQueueDepth: MongodbatlasDiskPartitionQueueDepthMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessCacheRatio: MetricConfig{
-						Enabled: false,
+					MongodbatlasDiskPartitionSpaceAverage: MongodbatlasDiskPartitionSpaceAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionSpaceAverageMetricAttributeKey{MongodbatlasDiskPartitionSpaceAverageMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionSpaceMax: MongodbatlasDiskPartitionSpaceMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionSpaceMaxMetricAttributeKey{MongodbatlasDiskPartitionSpaceMaxMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionThroughput: MongodbatlasDiskPartitionThroughputMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionThroughputMetricAttributeKey{MongodbatlasDiskPartitionThroughputMetricAttributeKeyDiskDirection},
+					},
+					MongodbatlasDiskPartitionUsageAverage: MongodbatlasDiskPartitionUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionUsageAverageMetricAttributeKey{MongodbatlasDiskPartitionUsageAverageMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionUsageMax: MongodbatlasDiskPartitionUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasDiskPartitionUsageMaxMetricAttributeKey{MongodbatlasDiskPartitionUsageMaxMetricAttributeKeyDiskStatus},
+					},
+					MongodbatlasDiskPartitionUtilizationAverage: MongodbatlasDiskPartitionUtilizationAverageMetricConfig{
+						Enabled: false,
+					},
+					MongodbatlasDiskPartitionUtilizationMax: MongodbatlasDiskPartitionUtilizationMaxMetricConfig{
+						Enabled: false,
+					},
+					MongodbatlasProcessAsserts: MongodbatlasProcessAssertsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessAssertsMetricAttributeKey{MongodbatlasProcessAssertsMetricAttributeKeyAssertType},
+					},
+					MongodbatlasProcessBackgroundFlush: MongodbatlasProcessBackgroundFlushMetricConfig{
+						Enabled: false,
+					},
+					MongodbatlasProcessCacheIo: MongodbatlasProcessCacheIoMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCacheIoMetricAttributeKey{MongodbatlasProcessCacheIoMetricAttributeKeyCacheDirection},
+					},
+					MongodbatlasProcessCacheRatio: MongodbatlasProcessCacheRatioMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCacheRatioMetricAttributeKey{MongodbatlasProcessCacheRatioMetricAttributeKeyCacheRatioType},
 					},
-					MongodbatlasProcessCacheSize: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCacheSize: MongodbatlasProcessCacheSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbatlasProcessCacheSizeMetricAttributeKey{MongodbatlasProcessCacheSizeMetricAttributeKeyCacheStatus},
 					},
-					MongodbatlasProcessConnections: MetricConfig{
+					MongodbatlasProcessConnections: MongodbatlasProcessConnectionsMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKey{MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUChildrenNormalizedUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUChildrenNormalizedUsageMax: MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKey{MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUChildrenUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUChildrenUsageAverage: MongodbatlasProcessCPUChildrenUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKey{MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUChildrenUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUChildrenUsageMax: MongodbatlasProcessCPUChildrenUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKey{MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUNormalizedUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUNormalizedUsageAverage: MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKey{MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUNormalizedUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUNormalizedUsageMax: MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKey{MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUUsageAverage: MongodbatlasProcessCPUUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUUsageAverageMetricAttributeKey{MongodbatlasProcessCPUUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCPUUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCPUUsageMax: MongodbatlasProcessCPUUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCPUUsageMaxMetricAttributeKey{MongodbatlasProcessCPUUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasProcessCursors: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessCursors: MongodbatlasProcessCursorsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessCursorsMetricAttributeKey{MongodbatlasProcessCursorsMetricAttributeKeyCursorState},
 					},
-					MongodbatlasProcessDbDocumentRate: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessDbDocumentRate: MongodbatlasProcessDbDocumentRateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbDocumentRateMetricAttributeKey{MongodbatlasProcessDbDocumentRateMetricAttributeKeyDocumentStatus},
 					},
-					MongodbatlasProcessDbOperationsRate: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessDbOperationsRate: MongodbatlasProcessDbOperationsRateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbOperationsRateMetricAttributeKey{MongodbatlasProcessDbOperationsRateMetricAttributeKeyOperation, MongodbatlasProcessDbOperationsRateMetricAttributeKeyClusterRole},
 					},
-					MongodbatlasProcessDbOperationsTime: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessDbOperationsTime: MongodbatlasProcessDbOperationsTimeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbatlasProcessDbOperationsTimeMetricAttributeKey{MongodbatlasProcessDbOperationsTimeMetricAttributeKeyExecutionType},
 					},
-					MongodbatlasProcessDbQueryExecutorScanned: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessDbQueryExecutorScanned: MongodbatlasProcessDbQueryExecutorScannedMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKey{MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKeyScannedType},
 					},
-					MongodbatlasProcessDbQueryTargetingScannedPerReturned: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessDbQueryTargetingScannedPerReturned: MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKey{MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKeyScannedType},
 					},
-					MongodbatlasProcessDbStorage: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessDbStorage: MongodbatlasProcessDbStorageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessDbStorageMetricAttributeKey{MongodbatlasProcessDbStorageMetricAttributeKeyStorageStatus},
 					},
-					MongodbatlasProcessGlobalLock: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessGlobalLock: MongodbatlasProcessGlobalLockMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessGlobalLockMetricAttributeKey{MongodbatlasProcessGlobalLockMetricAttributeKeyGlobalLockState},
 					},
-					MongodbatlasProcessIndexBtreeMissRatio: MetricConfig{
+					MongodbatlasProcessIndexBtreeMissRatio: MongodbatlasProcessIndexBtreeMissRatioMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessIndexCounters: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessIndexCounters: MongodbatlasProcessIndexCountersMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessIndexCountersMetricAttributeKey{MongodbatlasProcessIndexCountersMetricAttributeKeyBtreeCounterType},
 					},
-					MongodbatlasProcessJournalingCommits: MetricConfig{
+					MongodbatlasProcessJournalingCommits: MongodbatlasProcessJournalingCommitsMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessJournalingDataFiles: MetricConfig{
+					MongodbatlasProcessJournalingDataFiles: MongodbatlasProcessJournalingDataFilesMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessJournalingWritten: MetricConfig{
+					MongodbatlasProcessJournalingWritten: MongodbatlasProcessJournalingWrittenMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessMemoryUsage: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessMemoryUsage: MongodbatlasProcessMemoryUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessMemoryUsageMetricAttributeKey{MongodbatlasProcessMemoryUsageMetricAttributeKeyMemoryState},
 					},
-					MongodbatlasProcessNetworkIo: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessNetworkIo: MongodbatlasProcessNetworkIoMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessNetworkIoMetricAttributeKey{MongodbatlasProcessNetworkIoMetricAttributeKeyDirection},
 					},
-					MongodbatlasProcessNetworkRequests: MetricConfig{
+					MongodbatlasProcessNetworkRequests: MongodbatlasProcessNetworkRequestsMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessOplogRate: MetricConfig{
+					MongodbatlasProcessOplogRate: MongodbatlasProcessOplogRateMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessOplogTime: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessOplogTime: MongodbatlasProcessOplogTimeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessOplogTimeMetricAttributeKey{MongodbatlasProcessOplogTimeMetricAttributeKeyOplogType},
 					},
-					MongodbatlasProcessPageFaults: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessPageFaults: MongodbatlasProcessPageFaultsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessPageFaultsMetricAttributeKey{MongodbatlasProcessPageFaultsMetricAttributeKeyMemoryIssueType},
 					},
-					MongodbatlasProcessRestarts: MetricConfig{
+					MongodbatlasProcessRestarts: MongodbatlasProcessRestartsMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasProcessTickets: MetricConfig{
-						Enabled: false,
+					MongodbatlasProcessTickets: MongodbatlasProcessTicketsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasProcessTicketsMetricAttributeKey{MongodbatlasProcessTicketsMetricAttributeKeyTicketType},
 					},
-					MongodbatlasSystemCPUNormalizedUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemCPUNormalizedUsageAverage: MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKey{MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemCPUNormalizedUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemCPUNormalizedUsageMax: MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKey{MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemCPUUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemCPUUsageAverage: MongodbatlasSystemCPUUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUUsageAverageMetricAttributeKey{MongodbatlasSystemCPUUsageAverageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemCPUUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemCPUUsageMax: MongodbatlasSystemCPUUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemCPUUsageMaxMetricAttributeKey{MongodbatlasSystemCPUUsageMaxMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemFtsCPUNormalizedUsage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemFtsCPUNormalizedUsage: MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKey{MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemFtsCPUUsage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemFtsCPUUsage: MongodbatlasSystemFtsCPUUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemFtsCPUUsageMetricAttributeKey{MongodbatlasSystemFtsCPUUsageMetricAttributeKeyCPUState},
 					},
-					MongodbatlasSystemFtsDiskUsed: MetricConfig{
+					MongodbatlasSystemFtsDiskUsed: MongodbatlasSystemFtsDiskUsedMetricConfig{
 						Enabled: false,
 					},
-					MongodbatlasSystemFtsMemoryUsage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemFtsMemoryUsage: MongodbatlasSystemFtsMemoryUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbatlasSystemFtsMemoryUsageMetricAttributeKey{MongodbatlasSystemFtsMemoryUsageMetricAttributeKeyMemoryState},
 					},
-					MongodbatlasSystemMemoryUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemMemoryUsageAverage: MongodbatlasSystemMemoryUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemMemoryUsageAverageMetricAttributeKey{MongodbatlasSystemMemoryUsageAverageMetricAttributeKeyMemoryStatus},
 					},
-					MongodbatlasSystemMemoryUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemMemoryUsageMax: MongodbatlasSystemMemoryUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemMemoryUsageMaxMetricAttributeKey{MongodbatlasSystemMemoryUsageMaxMetricAttributeKeyMemoryStatus},
 					},
-					MongodbatlasSystemNetworkIoAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemNetworkIoAverage: MongodbatlasSystemNetworkIoAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemNetworkIoAverageMetricAttributeKey{MongodbatlasSystemNetworkIoAverageMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemNetworkIoMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemNetworkIoMax: MongodbatlasSystemNetworkIoMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemNetworkIoMaxMetricAttributeKey{MongodbatlasSystemNetworkIoMaxMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemPagingIoAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemPagingIoAverage: MongodbatlasSystemPagingIoAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingIoAverageMetricAttributeKey{MongodbatlasSystemPagingIoAverageMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemPagingIoMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemPagingIoMax: MongodbatlasSystemPagingIoMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingIoMaxMetricAttributeKey{MongodbatlasSystemPagingIoMaxMetricAttributeKeyDirection},
 					},
-					MongodbatlasSystemPagingUsageAverage: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemPagingUsageAverage: MongodbatlasSystemPagingUsageAverageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingUsageAverageMetricAttributeKey{MongodbatlasSystemPagingUsageAverageMetricAttributeKeyMemoryState},
 					},
-					MongodbatlasSystemPagingUsageMax: MetricConfig{
-						Enabled: false,
+					MongodbatlasSystemPagingUsageMax: MongodbatlasSystemPagingUsageMaxMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbatlasSystemPagingUsageMaxMetricAttributeKey{MongodbatlasSystemPagingUsageMaxMetricAttributeKeyMemoryState},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -460,7 +669,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbatlasDbCountsMetricConfig{}, MongodbatlasDbSizeMetricConfig{}, MongodbatlasDiskPartitionIopsAverageMetricConfig{}, MongodbatlasDiskPartitionIopsMaxMetricConfig{}, MongodbatlasDiskPartitionLatencyAverageMetricConfig{}, MongodbatlasDiskPartitionLatencyMaxMetricConfig{}, MongodbatlasDiskPartitionQueueDepthMetricConfig{}, MongodbatlasDiskPartitionSpaceAverageMetricConfig{}, MongodbatlasDiskPartitionSpaceMaxMetricConfig{}, MongodbatlasDiskPartitionThroughputMetricConfig{}, MongodbatlasDiskPartitionUsageAverageMetricConfig{}, MongodbatlasDiskPartitionUsageMaxMetricConfig{}, MongodbatlasDiskPartitionUtilizationAverageMetricConfig{}, MongodbatlasDiskPartitionUtilizationMaxMetricConfig{}, MongodbatlasProcessAssertsMetricConfig{}, MongodbatlasProcessBackgroundFlushMetricConfig{}, MongodbatlasProcessCacheIoMetricConfig{}, MongodbatlasProcessCacheRatioMetricConfig{}, MongodbatlasProcessCacheSizeMetricConfig{}, MongodbatlasProcessConnectionsMetricConfig{}, MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig{}, MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig{}, MongodbatlasProcessCPUChildrenUsageAverageMetricConfig{}, MongodbatlasProcessCPUChildrenUsageMaxMetricConfig{}, MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig{}, MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig{}, MongodbatlasProcessCPUUsageAverageMetricConfig{}, MongodbatlasProcessCPUUsageMaxMetricConfig{}, MongodbatlasProcessCursorsMetricConfig{}, MongodbatlasProcessDbDocumentRateMetricConfig{}, MongodbatlasProcessDbOperationsRateMetricConfig{}, MongodbatlasProcessDbOperationsTimeMetricConfig{}, MongodbatlasProcessDbQueryExecutorScannedMetricConfig{}, MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig{}, MongodbatlasProcessDbStorageMetricConfig{}, MongodbatlasProcessGlobalLockMetricConfig{}, MongodbatlasProcessIndexBtreeMissRatioMetricConfig{}, MongodbatlasProcessIndexCountersMetricConfig{}, MongodbatlasProcessJournalingCommitsMetricConfig{}, MongodbatlasProcessJournalingDataFilesMetricConfig{}, MongodbatlasProcessJournalingWrittenMetricConfig{}, MongodbatlasProcessMemoryUsageMetricConfig{}, MongodbatlasProcessNetworkIoMetricConfig{}, MongodbatlasProcessNetworkRequestsMetricConfig{}, MongodbatlasProcessOplogRateMetricConfig{}, MongodbatlasProcessOplogTimeMetricConfig{}, MongodbatlasProcessPageFaultsMetricConfig{}, MongodbatlasProcessRestartsMetricConfig{}, MongodbatlasProcessTicketsMetricConfig{}, MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig{}, MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig{}, MongodbatlasSystemCPUUsageAverageMetricConfig{}, MongodbatlasSystemCPUUsageMaxMetricConfig{}, MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig{}, MongodbatlasSystemFtsCPUUsageMetricConfig{}, MongodbatlasSystemFtsDiskUsedMetricConfig{}, MongodbatlasSystemFtsMemoryUsageMetricConfig{}, MongodbatlasSystemMemoryUsageAverageMetricConfig{}, MongodbatlasSystemMemoryUsageMaxMetricConfig{}, MongodbatlasSystemNetworkIoAverageMetricConfig{}, MongodbatlasSystemNetworkIoMaxMetricConfig{}, MongodbatlasSystemPagingIoAverageMetricConfig{}, MongodbatlasSystemPagingIoMaxMetricConfig{}, MongodbatlasSystemPagingUsageAverageMetricConfig{}, MongodbatlasSystemPagingUsageMaxMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_logs_test.go
@@ -3,15 +3,14 @@
 package metadata
 
 import (
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"testing"
+	"time"
 )
 
 func TestLogsBuilderAppendLogRecord(t *testing.T) {

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeAssertType specifies the value assert_type attribute.
@@ -1033,9 +1041,10 @@ type metricInfo struct {
 }
 
 type metricMongodbatlasDbCounts struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        MongodbatlasDbCountsMetricConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []float64                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.db.counts metric with initial data.
@@ -1045,17 +1054,48 @@ func (m *metricMongodbatlasDbCounts) init() {
 	m.data.SetUnit("{objects}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDbCounts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, objectTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDbCountsMetricAttributeKeyObjectType) {
+		dp.Attributes().PutStr("object_type", objectTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("object_type", objectTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1068,13 +1108,18 @@ func (m *metricMongodbatlasDbCounts) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDbCounts) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDbCounts(cfg MetricConfig) metricMongodbatlasDbCounts {
+func newMetricMongodbatlasDbCounts(cfg MongodbatlasDbCountsMetricConfig) metricMongodbatlasDbCounts {
 	m := metricMongodbatlasDbCounts{config: cfg}
 
 	if cfg.Enabled {
@@ -1085,9 +1130,10 @@ func newMetricMongodbatlasDbCounts(cfg MetricConfig) metricMongodbatlasDbCounts 
 }
 
 type metricMongodbatlasDbSize struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        MongodbatlasDbSizeMetricConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []float64                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.db.size metric with initial data.
@@ -1097,17 +1143,48 @@ func (m *metricMongodbatlasDbSize) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDbSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, objectTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDbSizeMetricAttributeKeyObjectType) {
+		dp.Attributes().PutStr("object_type", objectTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("object_type", objectTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1120,13 +1197,18 @@ func (m *metricMongodbatlasDbSize) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDbSize) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDbSize(cfg MetricConfig) metricMongodbatlasDbSize {
+func newMetricMongodbatlasDbSize(cfg MongodbatlasDbSizeMetricConfig) metricMongodbatlasDbSize {
 	m := metricMongodbatlasDbSize{config: cfg}
 
 	if cfg.Enabled {
@@ -1137,9 +1219,10 @@ func newMetricMongodbatlasDbSize(cfg MetricConfig) metricMongodbatlasDbSize {
 }
 
 type metricMongodbatlasDiskPartitionIopsAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                   // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionIopsAverageMetricConfig // metric config provided by user.
+	capacity      int                                              // max observed number of data points added to the metric.
+	aggDataPoints []float64                                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.iops.average metric with initial data.
@@ -1149,17 +1232,48 @@ func (m *metricMongodbatlasDiskPartitionIopsAverage) init() {
 	m.data.SetUnit("{ops}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionIopsAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionIopsAverageMetricAttributeKeyDiskDirection) {
+		dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1172,13 +1286,18 @@ func (m *metricMongodbatlasDiskPartitionIopsAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionIopsAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionIopsAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionIopsAverage {
+func newMetricMongodbatlasDiskPartitionIopsAverage(cfg MongodbatlasDiskPartitionIopsAverageMetricConfig) metricMongodbatlasDiskPartitionIopsAverage {
 	m := metricMongodbatlasDiskPartitionIopsAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -1189,9 +1308,10 @@ func newMetricMongodbatlasDiskPartitionIopsAverage(cfg MetricConfig) metricMongo
 }
 
 type metricMongodbatlasDiskPartitionIopsMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionIopsMaxMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.iops.max metric with initial data.
@@ -1201,17 +1321,48 @@ func (m *metricMongodbatlasDiskPartitionIopsMax) init() {
 	m.data.SetUnit("{ops}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionIopsMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionIopsMaxMetricAttributeKeyDiskDirection) {
+		dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1224,13 +1375,18 @@ func (m *metricMongodbatlasDiskPartitionIopsMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionIopsMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionIopsMax(cfg MetricConfig) metricMongodbatlasDiskPartitionIopsMax {
+func newMetricMongodbatlasDiskPartitionIopsMax(cfg MongodbatlasDiskPartitionIopsMaxMetricConfig) metricMongodbatlasDiskPartitionIopsMax {
 	m := metricMongodbatlasDiskPartitionIopsMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1241,9 +1397,10 @@ func newMetricMongodbatlasDiskPartitionIopsMax(cfg MetricConfig) metricMongodbat
 }
 
 type metricMongodbatlasDiskPartitionLatencyAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                      // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionLatencyAverageMetricConfig // metric config provided by user.
+	capacity      int                                                 // max observed number of data points added to the metric.
+	aggDataPoints []float64                                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.latency.average metric with initial data.
@@ -1253,17 +1410,48 @@ func (m *metricMongodbatlasDiskPartitionLatencyAverage) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionLatencyAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionLatencyAverageMetricAttributeKeyDiskDirection) {
+		dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1276,13 +1464,18 @@ func (m *metricMongodbatlasDiskPartitionLatencyAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionLatencyAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionLatencyAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionLatencyAverage {
+func newMetricMongodbatlasDiskPartitionLatencyAverage(cfg MongodbatlasDiskPartitionLatencyAverageMetricConfig) metricMongodbatlasDiskPartitionLatencyAverage {
 	m := metricMongodbatlasDiskPartitionLatencyAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -1293,9 +1486,10 @@ func newMetricMongodbatlasDiskPartitionLatencyAverage(cfg MetricConfig) metricMo
 }
 
 type metricMongodbatlasDiskPartitionLatencyMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionLatencyMaxMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []float64                                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.latency.max metric with initial data.
@@ -1305,17 +1499,48 @@ func (m *metricMongodbatlasDiskPartitionLatencyMax) init() {
 	m.data.SetUnit("ms")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionLatencyMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionLatencyMaxMetricAttributeKeyDiskDirection) {
+		dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1328,13 +1553,18 @@ func (m *metricMongodbatlasDiskPartitionLatencyMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionLatencyMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionLatencyMax(cfg MetricConfig) metricMongodbatlasDiskPartitionLatencyMax {
+func newMetricMongodbatlasDiskPartitionLatencyMax(cfg MongodbatlasDiskPartitionLatencyMaxMetricConfig) metricMongodbatlasDiskPartitionLatencyMax {
 	m := metricMongodbatlasDiskPartitionLatencyMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1345,9 +1575,9 @@ func newMetricMongodbatlasDiskPartitionLatencyMax(cfg MetricConfig) metricMongod
 }
 
 type metricMongodbatlasDiskPartitionQueueDepth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                  // data buffer for generated metric.
+	config   MongodbatlasDiskPartitionQueueDepthMetricConfig // metric config provided by user.
+	capacity int                                             // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.disk.partition.queue.depth metric with initial data.
@@ -1384,7 +1614,7 @@ func (m *metricMongodbatlasDiskPartitionQueueDepth) emit(metrics pmetric.MetricS
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionQueueDepth(cfg MetricConfig) metricMongodbatlasDiskPartitionQueueDepth {
+func newMetricMongodbatlasDiskPartitionQueueDepth(cfg MongodbatlasDiskPartitionQueueDepthMetricConfig) metricMongodbatlasDiskPartitionQueueDepth {
 	m := metricMongodbatlasDiskPartitionQueueDepth{config: cfg}
 
 	if cfg.Enabled {
@@ -1395,9 +1625,10 @@ func newMetricMongodbatlasDiskPartitionQueueDepth(cfg MetricConfig) metricMongod
 }
 
 type metricMongodbatlasDiskPartitionSpaceAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                    // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionSpaceAverageMetricConfig // metric config provided by user.
+	capacity      int                                               // max observed number of data points added to the metric.
+	aggDataPoints []float64                                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.space.average metric with initial data.
@@ -1407,17 +1638,48 @@ func (m *metricMongodbatlasDiskPartitionSpaceAverage) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionSpaceAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionSpaceAverageMetricAttributeKeyDiskStatus) {
+		dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1430,13 +1692,18 @@ func (m *metricMongodbatlasDiskPartitionSpaceAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionSpaceAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionSpaceAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionSpaceAverage {
+func newMetricMongodbatlasDiskPartitionSpaceAverage(cfg MongodbatlasDiskPartitionSpaceAverageMetricConfig) metricMongodbatlasDiskPartitionSpaceAverage {
 	m := metricMongodbatlasDiskPartitionSpaceAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -1447,9 +1714,10 @@ func newMetricMongodbatlasDiskPartitionSpaceAverage(cfg MetricConfig) metricMong
 }
 
 type metricMongodbatlasDiskPartitionSpaceMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionSpaceMaxMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.space.max metric with initial data.
@@ -1459,17 +1727,48 @@ func (m *metricMongodbatlasDiskPartitionSpaceMax) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionSpaceMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionSpaceMaxMetricAttributeKeyDiskStatus) {
+		dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1482,13 +1781,18 @@ func (m *metricMongodbatlasDiskPartitionSpaceMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionSpaceMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionSpaceMax(cfg MetricConfig) metricMongodbatlasDiskPartitionSpaceMax {
+func newMetricMongodbatlasDiskPartitionSpaceMax(cfg MongodbatlasDiskPartitionSpaceMaxMetricConfig) metricMongodbatlasDiskPartitionSpaceMax {
 	m := metricMongodbatlasDiskPartitionSpaceMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1499,9 +1803,10 @@ func newMetricMongodbatlasDiskPartitionSpaceMax(cfg MetricConfig) metricMongodba
 }
 
 type metricMongodbatlasDiskPartitionThroughput struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionThroughputMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []float64                                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.throughput metric with initial data.
@@ -1511,17 +1816,48 @@ func (m *metricMongodbatlasDiskPartitionThroughput) init() {
 	m.data.SetUnit("By/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionThroughput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionThroughputMetricAttributeKeyDiskDirection) {
+		dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_direction", diskDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1534,13 +1870,18 @@ func (m *metricMongodbatlasDiskPartitionThroughput) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionThroughput) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionThroughput(cfg MetricConfig) metricMongodbatlasDiskPartitionThroughput {
+func newMetricMongodbatlasDiskPartitionThroughput(cfg MongodbatlasDiskPartitionThroughputMetricConfig) metricMongodbatlasDiskPartitionThroughput {
 	m := metricMongodbatlasDiskPartitionThroughput{config: cfg}
 
 	if cfg.Enabled {
@@ -1551,9 +1892,10 @@ func newMetricMongodbatlasDiskPartitionThroughput(cfg MetricConfig) metricMongod
 }
 
 type metricMongodbatlasDiskPartitionUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                    // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                               // max observed number of data points added to the metric.
+	aggDataPoints []float64                                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.usage.average metric with initial data.
@@ -1563,17 +1905,48 @@ func (m *metricMongodbatlasDiskPartitionUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionUsageAverageMetricAttributeKeyDiskStatus) {
+		dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1586,13 +1959,18 @@ func (m *metricMongodbatlasDiskPartitionUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUsageAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionUsageAverage {
+func newMetricMongodbatlasDiskPartitionUsageAverage(cfg MongodbatlasDiskPartitionUsageAverageMetricConfig) metricMongodbatlasDiskPartitionUsageAverage {
 	m := metricMongodbatlasDiskPartitionUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -1603,9 +1981,10 @@ func newMetricMongodbatlasDiskPartitionUsageAverage(cfg MetricConfig) metricMong
 }
 
 type metricMongodbatlasDiskPartitionUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        MongodbatlasDiskPartitionUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.disk.partition.usage.max metric with initial data.
@@ -1615,17 +1994,48 @@ func (m *metricMongodbatlasDiskPartitionUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasDiskPartitionUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasDiskPartitionUsageMaxMetricAttributeKeyDiskStatus) {
+		dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1638,13 +2048,18 @@ func (m *metricMongodbatlasDiskPartitionUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUsageMax(cfg MetricConfig) metricMongodbatlasDiskPartitionUsageMax {
+func newMetricMongodbatlasDiskPartitionUsageMax(cfg MongodbatlasDiskPartitionUsageMaxMetricConfig) metricMongodbatlasDiskPartitionUsageMax {
 	m := metricMongodbatlasDiskPartitionUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1655,9 +2070,9 @@ func newMetricMongodbatlasDiskPartitionUsageMax(cfg MetricConfig) metricMongodba
 }
 
 type metricMongodbatlasDiskPartitionUtilizationAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                          // data buffer for generated metric.
+	config   MongodbatlasDiskPartitionUtilizationAverageMetricConfig // metric config provided by user.
+	capacity int                                                     // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.disk.partition.utilization.average metric with initial data.
@@ -1694,7 +2109,7 @@ func (m *metricMongodbatlasDiskPartitionUtilizationAverage) emit(metrics pmetric
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUtilizationAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionUtilizationAverage {
+func newMetricMongodbatlasDiskPartitionUtilizationAverage(cfg MongodbatlasDiskPartitionUtilizationAverageMetricConfig) metricMongodbatlasDiskPartitionUtilizationAverage {
 	m := metricMongodbatlasDiskPartitionUtilizationAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -1705,9 +2120,9 @@ func newMetricMongodbatlasDiskPartitionUtilizationAverage(cfg MetricConfig) metr
 }
 
 type metricMongodbatlasDiskPartitionUtilizationMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                      // data buffer for generated metric.
+	config   MongodbatlasDiskPartitionUtilizationMaxMetricConfig // metric config provided by user.
+	capacity int                                                 // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.disk.partition.utilization.max metric with initial data.
@@ -1744,7 +2159,7 @@ func (m *metricMongodbatlasDiskPartitionUtilizationMax) emit(metrics pmetric.Met
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUtilizationMax(cfg MetricConfig) metricMongodbatlasDiskPartitionUtilizationMax {
+func newMetricMongodbatlasDiskPartitionUtilizationMax(cfg MongodbatlasDiskPartitionUtilizationMaxMetricConfig) metricMongodbatlasDiskPartitionUtilizationMax {
 	m := metricMongodbatlasDiskPartitionUtilizationMax{config: cfg}
 
 	if cfg.Enabled {
@@ -1755,9 +2170,10 @@ func newMetricMongodbatlasDiskPartitionUtilizationMax(cfg MetricConfig) metricMo
 }
 
 type metricMongodbatlasProcessAsserts struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        MongodbatlasProcessAssertsMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []float64                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.asserts metric with initial data.
@@ -1767,17 +2183,48 @@ func (m *metricMongodbatlasProcessAsserts) init() {
 	m.data.SetUnit("{assertions}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessAsserts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, assertTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessAssertsMetricAttributeKeyAssertType) {
+		dp.Attributes().PutStr("assert_type", assertTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("assert_type", assertTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1790,13 +2237,18 @@ func (m *metricMongodbatlasProcessAsserts) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessAsserts) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessAsserts(cfg MetricConfig) metricMongodbatlasProcessAsserts {
+func newMetricMongodbatlasProcessAsserts(cfg MongodbatlasProcessAssertsMetricConfig) metricMongodbatlasProcessAsserts {
 	m := metricMongodbatlasProcessAsserts{config: cfg}
 
 	if cfg.Enabled {
@@ -1807,9 +2259,9 @@ func newMetricMongodbatlasProcessAsserts(cfg MetricConfig) metricMongodbatlasPro
 }
 
 type metricMongodbatlasProcessBackgroundFlush struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                 // data buffer for generated metric.
+	config   MongodbatlasProcessBackgroundFlushMetricConfig // metric config provided by user.
+	capacity int                                            // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.background_flush metric with initial data.
@@ -1846,7 +2298,7 @@ func (m *metricMongodbatlasProcessBackgroundFlush) emit(metrics pmetric.MetricSl
 	}
 }
 
-func newMetricMongodbatlasProcessBackgroundFlush(cfg MetricConfig) metricMongodbatlasProcessBackgroundFlush {
+func newMetricMongodbatlasProcessBackgroundFlush(cfg MongodbatlasProcessBackgroundFlushMetricConfig) metricMongodbatlasProcessBackgroundFlush {
 	m := metricMongodbatlasProcessBackgroundFlush{config: cfg}
 
 	if cfg.Enabled {
@@ -1857,9 +2309,10 @@ func newMetricMongodbatlasProcessBackgroundFlush(cfg MetricConfig) metricMongodb
 }
 
 type metricMongodbatlasProcessCacheIo struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        MongodbatlasProcessCacheIoMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []float64                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cache.io metric with initial data.
@@ -1869,17 +2322,48 @@ func (m *metricMongodbatlasProcessCacheIo) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCacheIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cacheDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCacheIoMetricAttributeKeyCacheDirection) {
+		dp.Attributes().PutStr("cache_direction", cacheDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cache_direction", cacheDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1892,13 +2376,18 @@ func (m *metricMongodbatlasProcessCacheIo) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCacheIo) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCacheIo(cfg MetricConfig) metricMongodbatlasProcessCacheIo {
+func newMetricMongodbatlasProcessCacheIo(cfg MongodbatlasProcessCacheIoMetricConfig) metricMongodbatlasProcessCacheIo {
 	m := metricMongodbatlasProcessCacheIo{config: cfg}
 
 	if cfg.Enabled {
@@ -1909,9 +2398,10 @@ func newMetricMongodbatlasProcessCacheIo(cfg MetricConfig) metricMongodbatlasPro
 }
 
 type metricMongodbatlasProcessCacheRatio struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        MongodbatlasProcessCacheRatioMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cache.ratio metric with initial data.
@@ -1921,17 +2411,48 @@ func (m *metricMongodbatlasProcessCacheRatio) init() {
 	m.data.SetUnit("%")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCacheRatio) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cacheRatioTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCacheRatioMetricAttributeKeyCacheRatioType) {
+		dp.Attributes().PutStr("cache_ratio_type", cacheRatioTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cache_ratio_type", cacheRatioTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1944,13 +2465,18 @@ func (m *metricMongodbatlasProcessCacheRatio) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCacheRatio) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCacheRatio(cfg MetricConfig) metricMongodbatlasProcessCacheRatio {
+func newMetricMongodbatlasProcessCacheRatio(cfg MongodbatlasProcessCacheRatioMetricConfig) metricMongodbatlasProcessCacheRatio {
 	m := metricMongodbatlasProcessCacheRatio{config: cfg}
 
 	if cfg.Enabled {
@@ -1961,9 +2487,10 @@ func newMetricMongodbatlasProcessCacheRatio(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasProcessCacheSize struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        MongodbatlasProcessCacheSizeMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []float64                                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cache.size metric with initial data.
@@ -1975,17 +2502,48 @@ func (m *metricMongodbatlasProcessCacheSize) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCacheSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cacheStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCacheSizeMetricAttributeKeyCacheStatus) {
+		dp.Attributes().PutStr("cache_status", cacheStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cache_status", cacheStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1998,13 +2556,18 @@ func (m *metricMongodbatlasProcessCacheSize) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCacheSize) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCacheSize(cfg MetricConfig) metricMongodbatlasProcessCacheSize {
+func newMetricMongodbatlasProcessCacheSize(cfg MongodbatlasProcessCacheSizeMetricConfig) metricMongodbatlasProcessCacheSize {
 	m := metricMongodbatlasProcessCacheSize{config: cfg}
 
 	if cfg.Enabled {
@@ -2015,9 +2578,9 @@ func newMetricMongodbatlasProcessCacheSize(cfg MetricConfig) metricMongodbatlasP
 }
 
 type metricMongodbatlasProcessConnections struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                             // data buffer for generated metric.
+	config   MongodbatlasProcessConnectionsMetricConfig // metric config provided by user.
+	capacity int                                        // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.connections metric with initial data.
@@ -2056,7 +2619,7 @@ func (m *metricMongodbatlasProcessConnections) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricMongodbatlasProcessConnections(cfg MetricConfig) metricMongodbatlasProcessConnections {
+func newMetricMongodbatlasProcessConnections(cfg MongodbatlasProcessConnectionsMetricConfig) metricMongodbatlasProcessConnections {
 	m := metricMongodbatlasProcessConnections{config: cfg}
 
 	if cfg.Enabled {
@@ -2067,9 +2630,10 @@ func newMetricMongodbatlasProcessConnections(cfg MetricConfig) metricMongodbatla
 }
 
 type metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                                   // data buffer for generated metric.
+	config        MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                                              // max observed number of data points added to the metric.
+	aggDataPoints []float64                                                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.children.normalized.usage.average metric with initial data.
@@ -2079,17 +2643,48 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2102,13 +2697,18 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) updateCapac
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage {
+func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageAverage(cfg MongodbatlasProcessCPUChildrenNormalizedUsageAverageMetricConfig) metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage {
 	m := metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -2119,9 +2719,10 @@ func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageAverage(cfg MetricCon
 }
 
 type metricMongodbatlasProcessCPUChildrenNormalizedUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                               // data buffer for generated metric.
+	config        MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                                                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.children.normalized.usage.max metric with initial data.
@@ -2131,17 +2732,48 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2154,13 +2786,18 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) updateCapacity(
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenNormalizedUsageMax {
+func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageMax(cfg MongodbatlasProcessCPUChildrenNormalizedUsageMaxMetricConfig) metricMongodbatlasProcessCPUChildrenNormalizedUsageMax {
 	m := metricMongodbatlasProcessCPUChildrenNormalizedUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -2171,9 +2808,10 @@ func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageMax(cfg MetricConfig)
 }
 
 type metricMongodbatlasProcessCPUChildrenUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                         // data buffer for generated metric.
+	config        MongodbatlasProcessCPUChildrenUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                                    // max observed number of data points added to the metric.
+	aggDataPoints []float64                                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.children.usage.average metric with initial data.
@@ -2183,17 +2821,48 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUChildrenUsageAverageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2206,13 +2875,18 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenUsageAverage {
+func newMetricMongodbatlasProcessCPUChildrenUsageAverage(cfg MongodbatlasProcessCPUChildrenUsageAverageMetricConfig) metricMongodbatlasProcessCPUChildrenUsageAverage {
 	m := metricMongodbatlasProcessCPUChildrenUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -2223,9 +2897,10 @@ func newMetricMongodbatlasProcessCPUChildrenUsageAverage(cfg MetricConfig) metri
 }
 
 type metricMongodbatlasProcessCPUChildrenUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                     // data buffer for generated metric.
+	config        MongodbatlasProcessCPUChildrenUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                                // max observed number of data points added to the metric.
+	aggDataPoints []float64                                          // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.children.usage.max metric with initial data.
@@ -2235,17 +2910,48 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUChildrenUsageMaxMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2258,13 +2964,18 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenUsageMax {
+func newMetricMongodbatlasProcessCPUChildrenUsageMax(cfg MongodbatlasProcessCPUChildrenUsageMaxMetricConfig) metricMongodbatlasProcessCPUChildrenUsageMax {
 	m := metricMongodbatlasProcessCPUChildrenUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -2275,9 +2986,10 @@ func newMetricMongodbatlasProcessCPUChildrenUsageMax(cfg MetricConfig) metricMon
 }
 
 type metricMongodbatlasProcessCPUNormalizedUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                           // data buffer for generated metric.
+	config        MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                                      // max observed number of data points added to the metric.
+	aggDataPoints []float64                                                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.normalized.usage.average metric with initial data.
@@ -2287,17 +2999,48 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUNormalizedUsageAverageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2310,13 +3053,18 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUNormalizedUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUNormalizedUsageAverage {
+func newMetricMongodbatlasProcessCPUNormalizedUsageAverage(cfg MongodbatlasProcessCPUNormalizedUsageAverageMetricConfig) metricMongodbatlasProcessCPUNormalizedUsageAverage {
 	m := metricMongodbatlasProcessCPUNormalizedUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -2327,9 +3075,10 @@ func newMetricMongodbatlasProcessCPUNormalizedUsageAverage(cfg MetricConfig) met
 }
 
 type metricMongodbatlasProcessCPUNormalizedUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                       // data buffer for generated metric.
+	config        MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                                  // max observed number of data points added to the metric.
+	aggDataPoints []float64                                            // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.normalized.usage.max metric with initial data.
@@ -2339,17 +3088,48 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUNormalizedUsageMaxMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2362,13 +3142,18 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUNormalizedUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUNormalizedUsageMax {
+func newMetricMongodbatlasProcessCPUNormalizedUsageMax(cfg MongodbatlasProcessCPUNormalizedUsageMaxMetricConfig) metricMongodbatlasProcessCPUNormalizedUsageMax {
 	m := metricMongodbatlasProcessCPUNormalizedUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -2379,9 +3164,10 @@ func newMetricMongodbatlasProcessCPUNormalizedUsageMax(cfg MetricConfig) metricM
 }
 
 type metricMongodbatlasProcessCPUUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                 // data buffer for generated metric.
+	config        MongodbatlasProcessCPUUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                            // max observed number of data points added to the metric.
+	aggDataPoints []float64                                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.usage.average metric with initial data.
@@ -2391,17 +3177,48 @@ func (m *metricMongodbatlasProcessCPUUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUUsageAverageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2414,13 +3231,18 @@ func (m *metricMongodbatlasProcessCPUUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUUsageAverage {
+func newMetricMongodbatlasProcessCPUUsageAverage(cfg MongodbatlasProcessCPUUsageAverageMetricConfig) metricMongodbatlasProcessCPUUsageAverage {
 	m := metricMongodbatlasProcessCPUUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -2431,9 +3253,10 @@ func newMetricMongodbatlasProcessCPUUsageAverage(cfg MetricConfig) metricMongodb
 }
 
 type metricMongodbatlasProcessCPUUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                             // data buffer for generated metric.
+	config        MongodbatlasProcessCPUUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cpu.usage.max metric with initial data.
@@ -2443,17 +3266,48 @@ func (m *metricMongodbatlasProcessCPUUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCPUUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCPUUsageMaxMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2466,13 +3320,18 @@ func (m *metricMongodbatlasProcessCPUUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUUsageMax {
+func newMetricMongodbatlasProcessCPUUsageMax(cfg MongodbatlasProcessCPUUsageMaxMetricConfig) metricMongodbatlasProcessCPUUsageMax {
 	m := metricMongodbatlasProcessCPUUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -2483,9 +3342,10 @@ func newMetricMongodbatlasProcessCPUUsageMax(cfg MetricConfig) metricMongodbatla
 }
 
 type metricMongodbatlasProcessCursors struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        MongodbatlasProcessCursorsMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []float64                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.cursors metric with initial data.
@@ -2495,17 +3355,48 @@ func (m *metricMongodbatlasProcessCursors) init() {
 	m.data.SetUnit("{cursors}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessCursors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cursorStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessCursorsMetricAttributeKeyCursorState) {
+		dp.Attributes().PutStr("cursor_state", cursorStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cursor_state", cursorStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2518,13 +3409,18 @@ func (m *metricMongodbatlasProcessCursors) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCursors) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCursors(cfg MetricConfig) metricMongodbatlasProcessCursors {
+func newMetricMongodbatlasProcessCursors(cfg MongodbatlasProcessCursorsMetricConfig) metricMongodbatlasProcessCursors {
 	m := metricMongodbatlasProcessCursors{config: cfg}
 
 	if cfg.Enabled {
@@ -2535,9 +3431,10 @@ func newMetricMongodbatlasProcessCursors(cfg MetricConfig) metricMongodbatlasPro
 }
 
 type metricMongodbatlasProcessDbDocumentRate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        MongodbatlasProcessDbDocumentRateMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.db.document.rate metric with initial data.
@@ -2547,17 +3444,48 @@ func (m *metricMongodbatlasProcessDbDocumentRate) init() {
 	m.data.SetUnit("{documents}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessDbDocumentRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, documentStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbDocumentRateMetricAttributeKeyDocumentStatus) {
+		dp.Attributes().PutStr("document_status", documentStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("document_status", documentStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2570,13 +3498,18 @@ func (m *metricMongodbatlasProcessDbDocumentRate) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbDocumentRate) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbDocumentRate(cfg MetricConfig) metricMongodbatlasProcessDbDocumentRate {
+func newMetricMongodbatlasProcessDbDocumentRate(cfg MongodbatlasProcessDbDocumentRateMetricConfig) metricMongodbatlasProcessDbDocumentRate {
 	m := metricMongodbatlasProcessDbDocumentRate{config: cfg}
 
 	if cfg.Enabled {
@@ -2587,9 +3520,10 @@ func newMetricMongodbatlasProcessDbDocumentRate(cfg MetricConfig) metricMongodba
 }
 
 type metricMongodbatlasProcessDbOperationsRate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        MongodbatlasProcessDbOperationsRateMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []float64                                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.db.operations.rate metric with initial data.
@@ -2599,18 +3533,51 @@ func (m *metricMongodbatlasProcessDbOperationsRate) init() {
 	m.data.SetUnit("{operations}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessDbOperationsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, operationAttributeValue string, clusterRoleAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbOperationsRateMetricAttributeKeyOperation) {
+		dp.Attributes().PutStr("operation", operationAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbOperationsRateMetricAttributeKeyClusterRole) {
+		dp.Attributes().PutStr("cluster_role", clusterRoleAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("operation", operationAttributeValue)
-	dp.Attributes().PutStr("cluster_role", clusterRoleAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2623,13 +3590,18 @@ func (m *metricMongodbatlasProcessDbOperationsRate) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbOperationsRate) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbOperationsRate(cfg MetricConfig) metricMongodbatlasProcessDbOperationsRate {
+func newMetricMongodbatlasProcessDbOperationsRate(cfg MongodbatlasProcessDbOperationsRateMetricConfig) metricMongodbatlasProcessDbOperationsRate {
 	m := metricMongodbatlasProcessDbOperationsRate{config: cfg}
 
 	if cfg.Enabled {
@@ -2640,9 +3612,10 @@ func newMetricMongodbatlasProcessDbOperationsRate(cfg MetricConfig) metricMongod
 }
 
 type metricMongodbatlasProcessDbOperationsTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        MongodbatlasProcessDbOperationsTimeMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []float64                                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.db.operations.time metric with initial data.
@@ -2654,17 +3627,48 @@ func (m *metricMongodbatlasProcessDbOperationsTime) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessDbOperationsTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, executionTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbOperationsTimeMetricAttributeKeyExecutionType) {
+		dp.Attributes().PutStr("execution_type", executionTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("execution_type", executionTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2677,13 +3681,18 @@ func (m *metricMongodbatlasProcessDbOperationsTime) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbOperationsTime) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbOperationsTime(cfg MetricConfig) metricMongodbatlasProcessDbOperationsTime {
+func newMetricMongodbatlasProcessDbOperationsTime(cfg MongodbatlasProcessDbOperationsTimeMetricConfig) metricMongodbatlasProcessDbOperationsTime {
 	m := metricMongodbatlasProcessDbOperationsTime{config: cfg}
 
 	if cfg.Enabled {
@@ -2694,9 +3703,10 @@ func newMetricMongodbatlasProcessDbOperationsTime(cfg MetricConfig) metricMongod
 }
 
 type metricMongodbatlasProcessDbQueryExecutorScanned struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                        // data buffer for generated metric.
+	config        MongodbatlasProcessDbQueryExecutorScannedMetricConfig // metric config provided by user.
+	capacity      int                                                   // max observed number of data points added to the metric.
+	aggDataPoints []float64                                             // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.db.query_executor.scanned metric with initial data.
@@ -2706,17 +3716,48 @@ func (m *metricMongodbatlasProcessDbQueryExecutorScanned) init() {
 	m.data.SetUnit("{objects}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessDbQueryExecutorScanned) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, scannedTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbQueryExecutorScannedMetricAttributeKeyScannedType) {
+		dp.Attributes().PutStr("scanned_type", scannedTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("scanned_type", scannedTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2729,13 +3770,18 @@ func (m *metricMongodbatlasProcessDbQueryExecutorScanned) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbQueryExecutorScanned) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbQueryExecutorScanned(cfg MetricConfig) metricMongodbatlasProcessDbQueryExecutorScanned {
+func newMetricMongodbatlasProcessDbQueryExecutorScanned(cfg MongodbatlasProcessDbQueryExecutorScannedMetricConfig) metricMongodbatlasProcessDbQueryExecutorScanned {
 	m := metricMongodbatlasProcessDbQueryExecutorScanned{config: cfg}
 
 	if cfg.Enabled {
@@ -2746,9 +3792,10 @@ func newMetricMongodbatlasProcessDbQueryExecutorScanned(cfg MetricConfig) metric
 }
 
 type metricMongodbatlasProcessDbQueryTargetingScannedPerReturned struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                                    // data buffer for generated metric.
+	config        MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig // metric config provided by user.
+	capacity      int                                                               // max observed number of data points added to the metric.
+	aggDataPoints []float64                                                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.db.query_targeting.scanned_per_returned metric with initial data.
@@ -2758,17 +3805,48 @@ func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) init() {
 	m.data.SetUnit("{scanned}/{returned}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, scannedTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricAttributeKeyScannedType) {
+		dp.Attributes().PutStr("scanned_type", scannedTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("scanned_type", scannedTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2781,13 +3859,18 @@ func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) updateCapa
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(cfg MetricConfig) metricMongodbatlasProcessDbQueryTargetingScannedPerReturned {
+func newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(cfg MongodbatlasProcessDbQueryTargetingScannedPerReturnedMetricConfig) metricMongodbatlasProcessDbQueryTargetingScannedPerReturned {
 	m := metricMongodbatlasProcessDbQueryTargetingScannedPerReturned{config: cfg}
 
 	if cfg.Enabled {
@@ -2798,9 +3881,10 @@ func newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(cfg MetricCo
 }
 
 type metricMongodbatlasProcessDbStorage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        MongodbatlasProcessDbStorageMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []float64                                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.db.storage metric with initial data.
@@ -2810,17 +3894,48 @@ func (m *metricMongodbatlasProcessDbStorage) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessDbStorage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, storageStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessDbStorageMetricAttributeKeyStorageStatus) {
+		dp.Attributes().PutStr("storage_status", storageStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("storage_status", storageStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2833,13 +3948,18 @@ func (m *metricMongodbatlasProcessDbStorage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbStorage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbStorage(cfg MetricConfig) metricMongodbatlasProcessDbStorage {
+func newMetricMongodbatlasProcessDbStorage(cfg MongodbatlasProcessDbStorageMetricConfig) metricMongodbatlasProcessDbStorage {
 	m := metricMongodbatlasProcessDbStorage{config: cfg}
 
 	if cfg.Enabled {
@@ -2850,9 +3970,10 @@ func newMetricMongodbatlasProcessDbStorage(cfg MetricConfig) metricMongodbatlasP
 }
 
 type metricMongodbatlasProcessGlobalLock struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        MongodbatlasProcessGlobalLockMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.global_lock metric with initial data.
@@ -2862,17 +3983,48 @@ func (m *metricMongodbatlasProcessGlobalLock) init() {
 	m.data.SetUnit("{locks}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessGlobalLock) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, globalLockStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessGlobalLockMetricAttributeKeyGlobalLockState) {
+		dp.Attributes().PutStr("global_lock_state", globalLockStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("global_lock_state", globalLockStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2885,13 +4037,18 @@ func (m *metricMongodbatlasProcessGlobalLock) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessGlobalLock) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessGlobalLock(cfg MetricConfig) metricMongodbatlasProcessGlobalLock {
+func newMetricMongodbatlasProcessGlobalLock(cfg MongodbatlasProcessGlobalLockMetricConfig) metricMongodbatlasProcessGlobalLock {
 	m := metricMongodbatlasProcessGlobalLock{config: cfg}
 
 	if cfg.Enabled {
@@ -2902,9 +4059,9 @@ func newMetricMongodbatlasProcessGlobalLock(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasProcessIndexBtreeMissRatio struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   MongodbatlasProcessIndexBtreeMissRatioMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.index.btree_miss_ratio metric with initial data.
@@ -2941,7 +4098,7 @@ func (m *metricMongodbatlasProcessIndexBtreeMissRatio) emit(metrics pmetric.Metr
 	}
 }
 
-func newMetricMongodbatlasProcessIndexBtreeMissRatio(cfg MetricConfig) metricMongodbatlasProcessIndexBtreeMissRatio {
+func newMetricMongodbatlasProcessIndexBtreeMissRatio(cfg MongodbatlasProcessIndexBtreeMissRatioMetricConfig) metricMongodbatlasProcessIndexBtreeMissRatio {
 	m := metricMongodbatlasProcessIndexBtreeMissRatio{config: cfg}
 
 	if cfg.Enabled {
@@ -2952,9 +4109,10 @@ func newMetricMongodbatlasProcessIndexBtreeMissRatio(cfg MetricConfig) metricMon
 }
 
 type metricMongodbatlasProcessIndexCounters struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        MongodbatlasProcessIndexCountersMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.index.counters metric with initial data.
@@ -2964,17 +4122,48 @@ func (m *metricMongodbatlasProcessIndexCounters) init() {
 	m.data.SetUnit("{indexes}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessIndexCounters) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, btreeCounterTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessIndexCountersMetricAttributeKeyBtreeCounterType) {
+		dp.Attributes().PutStr("btree_counter_type", btreeCounterTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("btree_counter_type", btreeCounterTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2987,13 +4176,18 @@ func (m *metricMongodbatlasProcessIndexCounters) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessIndexCounters) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessIndexCounters(cfg MetricConfig) metricMongodbatlasProcessIndexCounters {
+func newMetricMongodbatlasProcessIndexCounters(cfg MongodbatlasProcessIndexCountersMetricConfig) metricMongodbatlasProcessIndexCounters {
 	m := metricMongodbatlasProcessIndexCounters{config: cfg}
 
 	if cfg.Enabled {
@@ -3004,9 +4198,9 @@ func newMetricMongodbatlasProcessIndexCounters(cfg MetricConfig) metricMongodbat
 }
 
 type metricMongodbatlasProcessJournalingCommits struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                   // data buffer for generated metric.
+	config   MongodbatlasProcessJournalingCommitsMetricConfig // metric config provided by user.
+	capacity int                                              // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.journaling.commits metric with initial data.
@@ -3043,7 +4237,7 @@ func (m *metricMongodbatlasProcessJournalingCommits) emit(metrics pmetric.Metric
 	}
 }
 
-func newMetricMongodbatlasProcessJournalingCommits(cfg MetricConfig) metricMongodbatlasProcessJournalingCommits {
+func newMetricMongodbatlasProcessJournalingCommits(cfg MongodbatlasProcessJournalingCommitsMetricConfig) metricMongodbatlasProcessJournalingCommits {
 	m := metricMongodbatlasProcessJournalingCommits{config: cfg}
 
 	if cfg.Enabled {
@@ -3054,9 +4248,9 @@ func newMetricMongodbatlasProcessJournalingCommits(cfg MetricConfig) metricMongo
 }
 
 type metricMongodbatlasProcessJournalingDataFiles struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   MongodbatlasProcessJournalingDataFilesMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.journaling.data_files metric with initial data.
@@ -3093,7 +4287,7 @@ func (m *metricMongodbatlasProcessJournalingDataFiles) emit(metrics pmetric.Metr
 	}
 }
 
-func newMetricMongodbatlasProcessJournalingDataFiles(cfg MetricConfig) metricMongodbatlasProcessJournalingDataFiles {
+func newMetricMongodbatlasProcessJournalingDataFiles(cfg MongodbatlasProcessJournalingDataFilesMetricConfig) metricMongodbatlasProcessJournalingDataFiles {
 	m := metricMongodbatlasProcessJournalingDataFiles{config: cfg}
 
 	if cfg.Enabled {
@@ -3104,9 +4298,9 @@ func newMetricMongodbatlasProcessJournalingDataFiles(cfg MetricConfig) metricMon
 }
 
 type metricMongodbatlasProcessJournalingWritten struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                   // data buffer for generated metric.
+	config   MongodbatlasProcessJournalingWrittenMetricConfig // metric config provided by user.
+	capacity int                                              // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.journaling.written metric with initial data.
@@ -3143,7 +4337,7 @@ func (m *metricMongodbatlasProcessJournalingWritten) emit(metrics pmetric.Metric
 	}
 }
 
-func newMetricMongodbatlasProcessJournalingWritten(cfg MetricConfig) metricMongodbatlasProcessJournalingWritten {
+func newMetricMongodbatlasProcessJournalingWritten(cfg MongodbatlasProcessJournalingWrittenMetricConfig) metricMongodbatlasProcessJournalingWritten {
 	m := metricMongodbatlasProcessJournalingWritten{config: cfg}
 
 	if cfg.Enabled {
@@ -3154,9 +4348,10 @@ func newMetricMongodbatlasProcessJournalingWritten(cfg MetricConfig) metricMongo
 }
 
 type metricMongodbatlasProcessMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                             // data buffer for generated metric.
+	config        MongodbatlasProcessMemoryUsageMetricConfig // metric config provided by user.
+	capacity      int                                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.memory.usage metric with initial data.
@@ -3166,17 +4361,48 @@ func (m *metricMongodbatlasProcessMemoryUsage) init() {
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessMemoryUsageMetricAttributeKeyMemoryState) {
+		dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3189,13 +4415,18 @@ func (m *metricMongodbatlasProcessMemoryUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessMemoryUsage(cfg MetricConfig) metricMongodbatlasProcessMemoryUsage {
+func newMetricMongodbatlasProcessMemoryUsage(cfg MongodbatlasProcessMemoryUsageMetricConfig) metricMongodbatlasProcessMemoryUsage {
 	m := metricMongodbatlasProcessMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -3206,9 +4437,10 @@ func newMetricMongodbatlasProcessMemoryUsage(cfg MetricConfig) metricMongodbatla
 }
 
 type metricMongodbatlasProcessNetworkIo struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        MongodbatlasProcessNetworkIoMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []float64                                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.network.io metric with initial data.
@@ -3218,17 +4450,48 @@ func (m *metricMongodbatlasProcessNetworkIo) init() {
 	m.data.SetUnit("By/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessNetworkIoMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3241,13 +4504,18 @@ func (m *metricMongodbatlasProcessNetworkIo) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessNetworkIo) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessNetworkIo(cfg MetricConfig) metricMongodbatlasProcessNetworkIo {
+func newMetricMongodbatlasProcessNetworkIo(cfg MongodbatlasProcessNetworkIoMetricConfig) metricMongodbatlasProcessNetworkIo {
 	m := metricMongodbatlasProcessNetworkIo{config: cfg}
 
 	if cfg.Enabled {
@@ -3258,9 +4526,9 @@ func newMetricMongodbatlasProcessNetworkIo(cfg MetricConfig) metricMongodbatlasP
 }
 
 type metricMongodbatlasProcessNetworkRequests struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                 // data buffer for generated metric.
+	config   MongodbatlasProcessNetworkRequestsMetricConfig // metric config provided by user.
+	capacity int                                            // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.network.requests metric with initial data.
@@ -3299,7 +4567,7 @@ func (m *metricMongodbatlasProcessNetworkRequests) emit(metrics pmetric.MetricSl
 	}
 }
 
-func newMetricMongodbatlasProcessNetworkRequests(cfg MetricConfig) metricMongodbatlasProcessNetworkRequests {
+func newMetricMongodbatlasProcessNetworkRequests(cfg MongodbatlasProcessNetworkRequestsMetricConfig) metricMongodbatlasProcessNetworkRequests {
 	m := metricMongodbatlasProcessNetworkRequests{config: cfg}
 
 	if cfg.Enabled {
@@ -3310,9 +4578,9 @@ func newMetricMongodbatlasProcessNetworkRequests(cfg MetricConfig) metricMongodb
 }
 
 type metricMongodbatlasProcessOplogRate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   MongodbatlasProcessOplogRateMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.oplog.rate metric with initial data.
@@ -3349,7 +4617,7 @@ func (m *metricMongodbatlasProcessOplogRate) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMongodbatlasProcessOplogRate(cfg MetricConfig) metricMongodbatlasProcessOplogRate {
+func newMetricMongodbatlasProcessOplogRate(cfg MongodbatlasProcessOplogRateMetricConfig) metricMongodbatlasProcessOplogRate {
 	m := metricMongodbatlasProcessOplogRate{config: cfg}
 
 	if cfg.Enabled {
@@ -3360,9 +4628,10 @@ func newMetricMongodbatlasProcessOplogRate(cfg MetricConfig) metricMongodbatlasP
 }
 
 type metricMongodbatlasProcessOplogTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        MongodbatlasProcessOplogTimeMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []float64                                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.oplog.time metric with initial data.
@@ -3372,17 +4641,48 @@ func (m *metricMongodbatlasProcessOplogTime) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessOplogTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, oplogTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessOplogTimeMetricAttributeKeyOplogType) {
+		dp.Attributes().PutStr("oplog_type", oplogTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("oplog_type", oplogTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3395,13 +4695,18 @@ func (m *metricMongodbatlasProcessOplogTime) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessOplogTime) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessOplogTime(cfg MetricConfig) metricMongodbatlasProcessOplogTime {
+func newMetricMongodbatlasProcessOplogTime(cfg MongodbatlasProcessOplogTimeMetricConfig) metricMongodbatlasProcessOplogTime {
 	m := metricMongodbatlasProcessOplogTime{config: cfg}
 
 	if cfg.Enabled {
@@ -3412,9 +4717,10 @@ func newMetricMongodbatlasProcessOplogTime(cfg MetricConfig) metricMongodbatlasP
 }
 
 type metricMongodbatlasProcessPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        MongodbatlasProcessPageFaultsMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.page_faults metric with initial data.
@@ -3424,17 +4730,48 @@ func (m *metricMongodbatlasProcessPageFaults) init() {
 	m.data.SetUnit("{faults}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryIssueTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessPageFaultsMetricAttributeKeyMemoryIssueType) {
+		dp.Attributes().PutStr("memory_issue_type", memoryIssueTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_issue_type", memoryIssueTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3447,13 +4784,18 @@ func (m *metricMongodbatlasProcessPageFaults) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessPageFaults) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessPageFaults(cfg MetricConfig) metricMongodbatlasProcessPageFaults {
+func newMetricMongodbatlasProcessPageFaults(cfg MongodbatlasProcessPageFaultsMetricConfig) metricMongodbatlasProcessPageFaults {
 	m := metricMongodbatlasProcessPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -3464,9 +4806,9 @@ func newMetricMongodbatlasProcessPageFaults(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasProcessRestarts struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   MongodbatlasProcessRestartsMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.process.restarts metric with initial data.
@@ -3503,7 +4845,7 @@ func (m *metricMongodbatlasProcessRestarts) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMongodbatlasProcessRestarts(cfg MetricConfig) metricMongodbatlasProcessRestarts {
+func newMetricMongodbatlasProcessRestarts(cfg MongodbatlasProcessRestartsMetricConfig) metricMongodbatlasProcessRestarts {
 	m := metricMongodbatlasProcessRestarts{config: cfg}
 
 	if cfg.Enabled {
@@ -3514,9 +4856,10 @@ func newMetricMongodbatlasProcessRestarts(cfg MetricConfig) metricMongodbatlasPr
 }
 
 type metricMongodbatlasProcessTickets struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        MongodbatlasProcessTicketsMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []float64                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.process.tickets metric with initial data.
@@ -3526,17 +4869,48 @@ func (m *metricMongodbatlasProcessTickets) init() {
 	m.data.SetUnit("{tickets}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasProcessTickets) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, ticketTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasProcessTicketsMetricAttributeKeyTicketType) {
+		dp.Attributes().PutStr("ticket_type", ticketTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("ticket_type", ticketTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3549,13 +4923,18 @@ func (m *metricMongodbatlasProcessTickets) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessTickets) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessTickets(cfg MetricConfig) metricMongodbatlasProcessTickets {
+func newMetricMongodbatlasProcessTickets(cfg MongodbatlasProcessTicketsMetricConfig) metricMongodbatlasProcessTickets {
 	m := metricMongodbatlasProcessTickets{config: cfg}
 
 	if cfg.Enabled {
@@ -3566,9 +4945,10 @@ func newMetricMongodbatlasProcessTickets(cfg MetricConfig) metricMongodbatlasPro
 }
 
 type metricMongodbatlasSystemCPUNormalizedUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                          // data buffer for generated metric.
+	config        MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                                     // max observed number of data points added to the metric.
+	aggDataPoints []float64                                               // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.cpu.normalized.usage.average metric with initial data.
@@ -3578,17 +4958,48 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemCPUNormalizedUsageAverageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3601,13 +5012,18 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUNormalizedUsageAverage(cfg MetricConfig) metricMongodbatlasSystemCPUNormalizedUsageAverage {
+func newMetricMongodbatlasSystemCPUNormalizedUsageAverage(cfg MongodbatlasSystemCPUNormalizedUsageAverageMetricConfig) metricMongodbatlasSystemCPUNormalizedUsageAverage {
 	m := metricMongodbatlasSystemCPUNormalizedUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -3618,9 +5034,10 @@ func newMetricMongodbatlasSystemCPUNormalizedUsageAverage(cfg MetricConfig) metr
 }
 
 type metricMongodbatlasSystemCPUNormalizedUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                      // data buffer for generated metric.
+	config        MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                                 // max observed number of data points added to the metric.
+	aggDataPoints []float64                                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.cpu.normalized.usage.max metric with initial data.
@@ -3630,17 +5047,48 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemCPUNormalizedUsageMaxMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3653,13 +5101,18 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUNormalizedUsageMax(cfg MetricConfig) metricMongodbatlasSystemCPUNormalizedUsageMax {
+func newMetricMongodbatlasSystemCPUNormalizedUsageMax(cfg MongodbatlasSystemCPUNormalizedUsageMaxMetricConfig) metricMongodbatlasSystemCPUNormalizedUsageMax {
 	m := metricMongodbatlasSystemCPUNormalizedUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -3670,9 +5123,10 @@ func newMetricMongodbatlasSystemCPUNormalizedUsageMax(cfg MetricConfig) metricMo
 }
 
 type metricMongodbatlasSystemCPUUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        MongodbatlasSystemCPUUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.cpu.usage.average metric with initial data.
@@ -3682,17 +5136,48 @@ func (m *metricMongodbatlasSystemCPUUsageAverage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemCPUUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemCPUUsageAverageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3705,13 +5190,18 @@ func (m *metricMongodbatlasSystemCPUUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUUsageAverage(cfg MetricConfig) metricMongodbatlasSystemCPUUsageAverage {
+func newMetricMongodbatlasSystemCPUUsageAverage(cfg MongodbatlasSystemCPUUsageAverageMetricConfig) metricMongodbatlasSystemCPUUsageAverage {
 	m := metricMongodbatlasSystemCPUUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -3722,9 +5212,10 @@ func newMetricMongodbatlasSystemCPUUsageAverage(cfg MetricConfig) metricMongodba
 }
 
 type metricMongodbatlasSystemCPUUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        MongodbatlasSystemCPUUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.cpu.usage.max metric with initial data.
@@ -3734,17 +5225,48 @@ func (m *metricMongodbatlasSystemCPUUsageMax) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemCPUUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemCPUUsageMaxMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3757,13 +5279,18 @@ func (m *metricMongodbatlasSystemCPUUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUUsageMax(cfg MetricConfig) metricMongodbatlasSystemCPUUsageMax {
+func newMetricMongodbatlasSystemCPUUsageMax(cfg MongodbatlasSystemCPUUsageMaxMetricConfig) metricMongodbatlasSystemCPUUsageMax {
 	m := metricMongodbatlasSystemCPUUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -3774,9 +5301,10 @@ func newMetricMongodbatlasSystemCPUUsageMax(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasSystemFtsCPUNormalizedUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                      // data buffer for generated metric.
+	config        MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig // metric config provided by user.
+	capacity      int                                                 // max observed number of data points added to the metric.
+	aggDataPoints []float64                                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.fts.cpu.normalized.usage metric with initial data.
@@ -3786,17 +5314,48 @@ func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemFtsCPUNormalizedUsageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3809,13 +5368,18 @@ func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsCPUNormalizedUsage(cfg MetricConfig) metricMongodbatlasSystemFtsCPUNormalizedUsage {
+func newMetricMongodbatlasSystemFtsCPUNormalizedUsage(cfg MongodbatlasSystemFtsCPUNormalizedUsageMetricConfig) metricMongodbatlasSystemFtsCPUNormalizedUsage {
 	m := metricMongodbatlasSystemFtsCPUNormalizedUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -3826,9 +5390,10 @@ func newMetricMongodbatlasSystemFtsCPUNormalizedUsage(cfg MetricConfig) metricMo
 }
 
 type metricMongodbatlasSystemFtsCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        MongodbatlasSystemFtsCPUUsageMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.fts.cpu.usage metric with initial data.
@@ -3838,17 +5403,48 @@ func (m *metricMongodbatlasSystemFtsCPUUsage) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemFtsCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemFtsCPUUsageMetricAttributeKeyCPUState) {
+		dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3861,13 +5457,18 @@ func (m *metricMongodbatlasSystemFtsCPUUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsCPUUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsCPUUsage(cfg MetricConfig) metricMongodbatlasSystemFtsCPUUsage {
+func newMetricMongodbatlasSystemFtsCPUUsage(cfg MongodbatlasSystemFtsCPUUsageMetricConfig) metricMongodbatlasSystemFtsCPUUsage {
 	m := metricMongodbatlasSystemFtsCPUUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -3878,9 +5479,9 @@ func newMetricMongodbatlasSystemFtsCPUUsage(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasSystemFtsDiskUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   MongodbatlasSystemFtsDiskUsedMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
 }
 
 // init fills mongodbatlas.system.fts.disk.used metric with initial data.
@@ -3917,7 +5518,7 @@ func (m *metricMongodbatlasSystemFtsDiskUsed) emit(metrics pmetric.MetricSlice) 
 	}
 }
 
-func newMetricMongodbatlasSystemFtsDiskUsed(cfg MetricConfig) metricMongodbatlasSystemFtsDiskUsed {
+func newMetricMongodbatlasSystemFtsDiskUsed(cfg MongodbatlasSystemFtsDiskUsedMetricConfig) metricMongodbatlasSystemFtsDiskUsed {
 	m := metricMongodbatlasSystemFtsDiskUsed{config: cfg}
 
 	if cfg.Enabled {
@@ -3928,9 +5529,10 @@ func newMetricMongodbatlasSystemFtsDiskUsed(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasSystemFtsMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        MongodbatlasSystemFtsMemoryUsageMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.fts.memory.usage metric with initial data.
@@ -3942,17 +5544,48 @@ func (m *metricMongodbatlasSystemFtsMemoryUsage) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemFtsMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemFtsMemoryUsageMetricAttributeKeyMemoryState) {
+		dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3965,13 +5598,18 @@ func (m *metricMongodbatlasSystemFtsMemoryUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsMemoryUsage(cfg MetricConfig) metricMongodbatlasSystemFtsMemoryUsage {
+func newMetricMongodbatlasSystemFtsMemoryUsage(cfg MongodbatlasSystemFtsMemoryUsageMetricConfig) metricMongodbatlasSystemFtsMemoryUsage {
 	m := metricMongodbatlasSystemFtsMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -3982,9 +5620,10 @@ func newMetricMongodbatlasSystemFtsMemoryUsage(cfg MetricConfig) metricMongodbat
 }
 
 type metricMongodbatlasSystemMemoryUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                   // data buffer for generated metric.
+	config        MongodbatlasSystemMemoryUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                              // max observed number of data points added to the metric.
+	aggDataPoints []float64                                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.memory.usage.average metric with initial data.
@@ -3994,17 +5633,48 @@ func (m *metricMongodbatlasSystemMemoryUsageAverage) init() {
 	m.data.SetUnit("KiBy")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemMemoryUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemMemoryUsageAverageMetricAttributeKeyMemoryStatus) {
+		dp.Attributes().PutStr("memory_status", memoryStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_status", memoryStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4017,13 +5687,18 @@ func (m *metricMongodbatlasSystemMemoryUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemMemoryUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemMemoryUsageAverage(cfg MetricConfig) metricMongodbatlasSystemMemoryUsageAverage {
+func newMetricMongodbatlasSystemMemoryUsageAverage(cfg MongodbatlasSystemMemoryUsageAverageMetricConfig) metricMongodbatlasSystemMemoryUsageAverage {
 	m := metricMongodbatlasSystemMemoryUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -4034,9 +5709,10 @@ func newMetricMongodbatlasSystemMemoryUsageAverage(cfg MetricConfig) metricMongo
 }
 
 type metricMongodbatlasSystemMemoryUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        MongodbatlasSystemMemoryUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.memory.usage.max metric with initial data.
@@ -4046,17 +5722,48 @@ func (m *metricMongodbatlasSystemMemoryUsageMax) init() {
 	m.data.SetUnit("KiBy")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemMemoryUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStatusAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemMemoryUsageMaxMetricAttributeKeyMemoryStatus) {
+		dp.Attributes().PutStr("memory_status", memoryStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_status", memoryStatusAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4069,13 +5776,18 @@ func (m *metricMongodbatlasSystemMemoryUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemMemoryUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemMemoryUsageMax(cfg MetricConfig) metricMongodbatlasSystemMemoryUsageMax {
+func newMetricMongodbatlasSystemMemoryUsageMax(cfg MongodbatlasSystemMemoryUsageMaxMetricConfig) metricMongodbatlasSystemMemoryUsageMax {
 	m := metricMongodbatlasSystemMemoryUsageMax{config: cfg}
 
 	if cfg.Enabled {
@@ -4086,9 +5798,10 @@ func newMetricMongodbatlasSystemMemoryUsageMax(cfg MetricConfig) metricMongodbat
 }
 
 type metricMongodbatlasSystemNetworkIoAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                 // data buffer for generated metric.
+	config        MongodbatlasSystemNetworkIoAverageMetricConfig // metric config provided by user.
+	capacity      int                                            // max observed number of data points added to the metric.
+	aggDataPoints []float64                                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.network.io.average metric with initial data.
@@ -4098,17 +5811,48 @@ func (m *metricMongodbatlasSystemNetworkIoAverage) init() {
 	m.data.SetUnit("By/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemNetworkIoAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemNetworkIoAverageMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4121,13 +5865,18 @@ func (m *metricMongodbatlasSystemNetworkIoAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemNetworkIoAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemNetworkIoAverage(cfg MetricConfig) metricMongodbatlasSystemNetworkIoAverage {
+func newMetricMongodbatlasSystemNetworkIoAverage(cfg MongodbatlasSystemNetworkIoAverageMetricConfig) metricMongodbatlasSystemNetworkIoAverage {
 	m := metricMongodbatlasSystemNetworkIoAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -4138,9 +5887,10 @@ func newMetricMongodbatlasSystemNetworkIoAverage(cfg MetricConfig) metricMongodb
 }
 
 type metricMongodbatlasSystemNetworkIoMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                             // data buffer for generated metric.
+	config        MongodbatlasSystemNetworkIoMaxMetricConfig // metric config provided by user.
+	capacity      int                                        // max observed number of data points added to the metric.
+	aggDataPoints []float64                                  // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.network.io.max metric with initial data.
@@ -4150,17 +5900,48 @@ func (m *metricMongodbatlasSystemNetworkIoMax) init() {
 	m.data.SetUnit("By/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemNetworkIoMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemNetworkIoMaxMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4173,13 +5954,18 @@ func (m *metricMongodbatlasSystemNetworkIoMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemNetworkIoMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemNetworkIoMax(cfg MetricConfig) metricMongodbatlasSystemNetworkIoMax {
+func newMetricMongodbatlasSystemNetworkIoMax(cfg MongodbatlasSystemNetworkIoMaxMetricConfig) metricMongodbatlasSystemNetworkIoMax {
 	m := metricMongodbatlasSystemNetworkIoMax{config: cfg}
 
 	if cfg.Enabled {
@@ -4190,9 +5976,10 @@ func newMetricMongodbatlasSystemNetworkIoMax(cfg MetricConfig) metricMongodbatla
 }
 
 type metricMongodbatlasSystemPagingIoAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        MongodbatlasSystemPagingIoAverageMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.paging.io.average metric with initial data.
@@ -4202,17 +5989,48 @@ func (m *metricMongodbatlasSystemPagingIoAverage) init() {
 	m.data.SetUnit("{pages}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemPagingIoAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemPagingIoAverageMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4225,13 +6043,18 @@ func (m *metricMongodbatlasSystemPagingIoAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingIoAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingIoAverage(cfg MetricConfig) metricMongodbatlasSystemPagingIoAverage {
+func newMetricMongodbatlasSystemPagingIoAverage(cfg MongodbatlasSystemPagingIoAverageMetricConfig) metricMongodbatlasSystemPagingIoAverage {
 	m := metricMongodbatlasSystemPagingIoAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -4242,9 +6065,10 @@ func newMetricMongodbatlasSystemPagingIoAverage(cfg MetricConfig) metricMongodba
 }
 
 type metricMongodbatlasSystemPagingIoMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        MongodbatlasSystemPagingIoMaxMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []float64                                 // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.paging.io.max metric with initial data.
@@ -4254,17 +6078,48 @@ func (m *metricMongodbatlasSystemPagingIoMax) init() {
 	m.data.SetUnit("{pages}/s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemPagingIoMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemPagingIoMaxMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4277,13 +6132,18 @@ func (m *metricMongodbatlasSystemPagingIoMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingIoMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingIoMax(cfg MetricConfig) metricMongodbatlasSystemPagingIoMax {
+func newMetricMongodbatlasSystemPagingIoMax(cfg MongodbatlasSystemPagingIoMaxMetricConfig) metricMongodbatlasSystemPagingIoMax {
 	m := metricMongodbatlasSystemPagingIoMax{config: cfg}
 
 	if cfg.Enabled {
@@ -4294,9 +6154,10 @@ func newMetricMongodbatlasSystemPagingIoMax(cfg MetricConfig) metricMongodbatlas
 }
 
 type metricMongodbatlasSystemPagingUsageAverage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                   // data buffer for generated metric.
+	config        MongodbatlasSystemPagingUsageAverageMetricConfig // metric config provided by user.
+	capacity      int                                              // max observed number of data points added to the metric.
+	aggDataPoints []float64                                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.paging.usage.average metric with initial data.
@@ -4306,17 +6167,48 @@ func (m *metricMongodbatlasSystemPagingUsageAverage) init() {
 	m.data.SetUnit("KiBy")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemPagingUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemPagingUsageAverageMetricAttributeKeyMemoryState) {
+		dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4329,13 +6221,18 @@ func (m *metricMongodbatlasSystemPagingUsageAverage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingUsageAverage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingUsageAverage(cfg MetricConfig) metricMongodbatlasSystemPagingUsageAverage {
+func newMetricMongodbatlasSystemPagingUsageAverage(cfg MongodbatlasSystemPagingUsageAverageMetricConfig) metricMongodbatlasSystemPagingUsageAverage {
 	m := metricMongodbatlasSystemPagingUsageAverage{config: cfg}
 
 	if cfg.Enabled {
@@ -4346,9 +6243,10 @@ func newMetricMongodbatlasSystemPagingUsageAverage(cfg MetricConfig) metricMongo
 }
 
 type metricMongodbatlasSystemPagingUsageMax struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        MongodbatlasSystemPagingUsageMaxMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills mongodbatlas.system.paging.usage.max metric with initial data.
@@ -4358,17 +6256,48 @@ func (m *metricMongodbatlasSystemPagingUsageMax) init() {
 	m.data.SetUnit("KiBy")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMongodbatlasSystemPagingUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbatlasSystemPagingUsageMaxMetricAttributeKeyMemoryState) {
+		dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("memory_state", memoryStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4381,13 +6310,18 @@ func (m *metricMongodbatlasSystemPagingUsageMax) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingUsageMax) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingUsageMax(cfg MetricConfig) metricMongodbatlasSystemPagingUsageMax {
+func newMetricMongodbatlasSystemPagingUsageMax(cfg MongodbatlasSystemPagingUsageMaxMetricConfig) metricMongodbatlasSystemPagingUsageMax {
 	m := metricMongodbatlasSystemPagingUsageMax{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,64 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["MongodbatlasDbCounts"] = mb.metricMongodbatlasDbCounts.config.AggregationStrategy
+			aggMap["MongodbatlasDbSize"] = mb.metricMongodbatlasDbSize.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionIopsAverage"] = mb.metricMongodbatlasDiskPartitionIopsAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionIopsMax"] = mb.metricMongodbatlasDiskPartitionIopsMax.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionLatencyAverage"] = mb.metricMongodbatlasDiskPartitionLatencyAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionLatencyMax"] = mb.metricMongodbatlasDiskPartitionLatencyMax.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionSpaceAverage"] = mb.metricMongodbatlasDiskPartitionSpaceAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionSpaceMax"] = mb.metricMongodbatlasDiskPartitionSpaceMax.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionThroughput"] = mb.metricMongodbatlasDiskPartitionThroughput.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionUsageAverage"] = mb.metricMongodbatlasDiskPartitionUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionUsageMax"] = mb.metricMongodbatlasDiskPartitionUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessAsserts"] = mb.metricMongodbatlasProcessAsserts.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCacheIo"] = mb.metricMongodbatlasProcessCacheIo.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCacheRatio"] = mb.metricMongodbatlasProcessCacheRatio.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCacheSize"] = mb.metricMongodbatlasProcessCacheSize.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenNormalizedUsageAverage"] = mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenNormalizedUsageMax"] = mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenUsageAverage"] = mb.metricMongodbatlasProcessCPUChildrenUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenUsageMax"] = mb.metricMongodbatlasProcessCPUChildrenUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUNormalizedUsageAverage"] = mb.metricMongodbatlasProcessCPUNormalizedUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUNormalizedUsageMax"] = mb.metricMongodbatlasProcessCPUNormalizedUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUUsageAverage"] = mb.metricMongodbatlasProcessCPUUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUUsageMax"] = mb.metricMongodbatlasProcessCPUUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCursors"] = mb.metricMongodbatlasProcessCursors.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbDocumentRate"] = mb.metricMongodbatlasProcessDbDocumentRate.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbOperationsRate"] = mb.metricMongodbatlasProcessDbOperationsRate.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbOperationsTime"] = mb.metricMongodbatlasProcessDbOperationsTime.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbQueryExecutorScanned"] = mb.metricMongodbatlasProcessDbQueryExecutorScanned.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbQueryTargetingScannedPerReturned"] = mb.metricMongodbatlasProcessDbQueryTargetingScannedPerReturned.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbStorage"] = mb.metricMongodbatlasProcessDbStorage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessGlobalLock"] = mb.metricMongodbatlasProcessGlobalLock.config.AggregationStrategy
+			aggMap["MongodbatlasProcessIndexCounters"] = mb.metricMongodbatlasProcessIndexCounters.config.AggregationStrategy
+			aggMap["MongodbatlasProcessMemoryUsage"] = mb.metricMongodbatlasProcessMemoryUsage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessNetworkIo"] = mb.metricMongodbatlasProcessNetworkIo.config.AggregationStrategy
+			aggMap["MongodbatlasProcessOplogTime"] = mb.metricMongodbatlasProcessOplogTime.config.AggregationStrategy
+			aggMap["MongodbatlasProcessPageFaults"] = mb.metricMongodbatlasProcessPageFaults.config.AggregationStrategy
+			aggMap["MongodbatlasProcessTickets"] = mb.metricMongodbatlasProcessTickets.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUNormalizedUsageAverage"] = mb.metricMongodbatlasSystemCPUNormalizedUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUNormalizedUsageMax"] = mb.metricMongodbatlasSystemCPUNormalizedUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUUsageAverage"] = mb.metricMongodbatlasSystemCPUUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUUsageMax"] = mb.metricMongodbatlasSystemCPUUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemFtsCPUNormalizedUsage"] = mb.metricMongodbatlasSystemFtsCPUNormalizedUsage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemFtsCPUUsage"] = mb.metricMongodbatlasSystemFtsCPUUsage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemFtsMemoryUsage"] = mb.metricMongodbatlasSystemFtsMemoryUsage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemMemoryUsageAverage"] = mb.metricMongodbatlasSystemMemoryUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemMemoryUsageMax"] = mb.metricMongodbatlasSystemMemoryUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemNetworkIoAverage"] = mb.metricMongodbatlasSystemNetworkIoAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemNetworkIoMax"] = mb.metricMongodbatlasSystemNetworkIoMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingIoAverage"] = mb.metricMongodbatlasSystemPagingIoAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingIoMax"] = mb.metricMongodbatlasSystemPagingIoMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingUsageAverage"] = mb.metricMongodbatlasSystemPagingUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingUsageMax"] = mb.metricMongodbatlasSystemPagingUsageMax.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,26 +131,44 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDbCountsDataPoint(ts, 1, AttributeObjectTypeCollection)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDbCountsDataPoint(ts, 3, AttributeObjectTypeIndex)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDbSizeDataPoint(ts, 1, AttributeObjectTypeCollection)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDbSizeDataPoint(ts, 3, AttributeObjectTypeIndex)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionIopsAverageDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionIopsAverageDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionIopsMaxDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionIopsMaxDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionLatencyAverageDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionLatencyAverageDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionQueueDepthDataPoint(ts, 1)
@@ -97,21 +176,36 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionSpaceAverageDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionSpaceAverageDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionSpaceMaxDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionSpaceMaxDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionThroughputDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionThroughputDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -124,6 +218,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessAssertsDataPoint(ts, 1, AttributeAssertTypeRegular)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessAssertsDataPoint(ts, 3, AttributeAssertTypeWarning)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -132,13 +229,22 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCacheIoDataPoint(ts, 1, AttributeCacheDirectionReadInto)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCacheIoDataPoint(ts, 3, AttributeCacheDirectionWrittenFrom)
+			}
 
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCacheRatioDataPoint(ts, 1, AttributeCacheRatioTypeCacheFill)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCacheRatioDataPoint(ts, 3, AttributeCacheRatioTypeDirtyFill)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCacheSizeDataPoint(ts, 1, AttributeCacheStatusDirty)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCacheSizeDataPoint(ts, 3, AttributeCacheStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -147,66 +253,114 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUNormalizedUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUNormalizedUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUNormalizedUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUNormalizedUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCursorsDataPoint(ts, 1, AttributeCursorStateTimedOut)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCursorsDataPoint(ts, 3, AttributeCursorStateOpen)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbDocumentRateDataPoint(ts, 1, AttributeDocumentStatusReturned)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbDocumentRateDataPoint(ts, 3, AttributeDocumentStatusInserted)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbOperationsRateDataPoint(ts, 1, AttributeOperationCmd, AttributeClusterRolePrimary)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbOperationsRateDataPoint(ts, 3, AttributeOperationQuery, AttributeClusterRoleReplica)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbOperationsTimeDataPoint(ts, 1, AttributeExecutionTypeReads)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbOperationsTimeDataPoint(ts, 3, AttributeExecutionTypeWrites)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbQueryExecutorScannedDataPoint(ts, 1, AttributeScannedTypeIndexItems)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbQueryExecutorScannedDataPoint(ts, 3, AttributeScannedTypeObjects)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbQueryTargetingScannedPerReturnedDataPoint(ts, 1, AttributeScannedTypeIndexItems)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbQueryTargetingScannedPerReturnedDataPoint(ts, 3, AttributeScannedTypeObjects)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbStorageDataPoint(ts, 1, AttributeStorageStatusTotal)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbStorageDataPoint(ts, 3, AttributeStorageStatusDataSize)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessGlobalLockDataPoint(ts, 1, AttributeGlobalLockStateCurrentQueueTotal)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessGlobalLockDataPoint(ts, 3, AttributeGlobalLockStateCurrentQueueReaders)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -215,6 +369,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessIndexCountersDataPoint(ts, 1, AttributeBtreeCounterTypeAccesses)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessIndexCountersDataPoint(ts, 3, AttributeBtreeCounterTypeHits)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -231,10 +388,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessMemoryUsageDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessMemoryUsageDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessNetworkIoDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessNetworkIoDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -247,10 +410,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessOplogTimeDataPoint(ts, 1, AttributeOplogTypeSlaveLagMasterTime)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessOplogTimeDataPoint(ts, 3, AttributeOplogTypeMasterTime)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessPageFaultsDataPoint(ts, 1, AttributeMemoryIssueTypeExtraInfo)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessPageFaultsDataPoint(ts, 3, AttributeMemoryIssueTypeGlobalAccessesNotInMemory)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -259,30 +428,51 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessTicketsDataPoint(ts, 1, AttributeTicketTypeAvailableReads)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessTicketsDataPoint(ts, 3, AttributeTicketTypeAvailableWrites)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUNormalizedUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUNormalizedUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUNormalizedUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUNormalizedUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemFtsCPUNormalizedUsageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemFtsCPUNormalizedUsageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemFtsCPUUsageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemFtsCPUUsageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -291,38 +481,65 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemFtsMemoryUsageDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemFtsMemoryUsageDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemMemoryUsageAverageDataPoint(ts, 1, AttributeMemoryStatusAvailable)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemMemoryUsageAverageDataPoint(ts, 3, AttributeMemoryStatusBuffers)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemMemoryUsageMaxDataPoint(ts, 1, AttributeMemoryStatusAvailable)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemMemoryUsageMaxDataPoint(ts, 3, AttributeMemoryStatusBuffers)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemNetworkIoAverageDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemNetworkIoAverageDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemNetworkIoMaxDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemNetworkIoMaxDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingIoAverageDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingIoAverageDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingIoMaxDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingIoMaxDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingUsageAverageDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingUsageAverageDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingUsageMaxDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingUsageMaxDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetMongodbAtlasClusterName("mongodb_atlas.cluster.name-val")
@@ -340,6 +557,60 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetMongodbAtlasUserAlias("mongodb_atlas.user.alias-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricMongodbatlasDbCounts.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDbSize.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionIopsAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionIopsMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionLatencyAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionLatencyMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionSpaceAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionSpaceMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionThroughput.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessAsserts.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCacheIo.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCacheRatio.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCacheSize.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUNormalizedUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUNormalizedUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCursors.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbDocumentRate.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbOperationsRate.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbOperationsTime.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbQueryExecutorScanned.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbQueryTargetingScannedPerReturned.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbStorage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessGlobalLock.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessIndexCounters.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessMemoryUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessNetworkIo.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessOplogTime.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessPageFaults.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessTickets.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUNormalizedUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUNormalizedUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemFtsCPUNormalizedUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemFtsCPUUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemFtsMemoryUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemMemoryUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemMemoryUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemNetworkIoAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemNetworkIoMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingIoAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingIoMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingUsageMax.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -367,95 +638,245 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "mongodbatlas.db.counts":
-					assert.False(t, validatedMetrics["mongodbatlas.db.counts"], "Found a duplicate in the metrics slice: mongodbatlas.db.counts")
-					validatedMetrics["mongodbatlas.db.counts"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Database feature size", mi.Description())
-					assert.Equal(t, "{objects}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
-					assert.True(t, ok)
-					assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.db.counts"], "Found a duplicate in the metrics slice: mongodbatlas.db.counts")
+						validatedMetrics["mongodbatlas.db.counts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "{objects}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
+						assert.True(t, ok)
+						assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.db.counts"], "Found a duplicate in the metrics slice: mongodbatlas.db.counts")
+						validatedMetrics["mongodbatlas.db.counts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "{objects}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.db.counts"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("object_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.db.size":
-					assert.False(t, validatedMetrics["mongodbatlas.db.size"], "Found a duplicate in the metrics slice: mongodbatlas.db.size")
-					validatedMetrics["mongodbatlas.db.size"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Database feature size", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
-					assert.True(t, ok)
-					assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.db.size"], "Found a duplicate in the metrics slice: mongodbatlas.db.size")
+						validatedMetrics["mongodbatlas.db.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
+						assert.True(t, ok)
+						assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.db.size"], "Found a duplicate in the metrics slice: mongodbatlas.db.size")
+						validatedMetrics["mongodbatlas.db.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.db.size"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("object_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.iops.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.average")
-					validatedMetrics["mongodbatlas.disk.partition.iops.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition iops", mi.Description())
-					assert.Equal(t, "{ops}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.average")
+						validatedMetrics["mongodbatlas.disk.partition.iops.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.average")
+						validatedMetrics["mongodbatlas.disk.partition.iops.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.iops.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.iops.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.max")
-					validatedMetrics["mongodbatlas.disk.partition.iops.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition iops", mi.Description())
-					assert.Equal(t, "{ops}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.max")
+						validatedMetrics["mongodbatlas.disk.partition.iops.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.max")
+						validatedMetrics["mongodbatlas.disk.partition.iops.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.iops.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.latency.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.average")
-					validatedMetrics["mongodbatlas.disk.partition.latency.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition latency", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.average")
+						validatedMetrics["mongodbatlas.disk.partition.latency.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.average")
+						validatedMetrics["mongodbatlas.disk.partition.latency.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.latency.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.latency.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.max")
-					validatedMetrics["mongodbatlas.disk.partition.latency.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition latency", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.max")
+						validatedMetrics["mongodbatlas.disk.partition.latency.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.max")
+						validatedMetrics["mongodbatlas.disk.partition.latency.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.latency.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.queue.depth":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.queue.depth"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.queue.depth")
 					validatedMetrics["mongodbatlas.disk.partition.queue.depth"] = true
@@ -469,80 +890,205 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.disk.partition.space.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.average")
-					validatedMetrics["mongodbatlas.disk.partition.space.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition space", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.average")
+						validatedMetrics["mongodbatlas.disk.partition.space.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.average")
+						validatedMetrics["mongodbatlas.disk.partition.space.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.space.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.space.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.max")
-					validatedMetrics["mongodbatlas.disk.partition.space.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition space", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.max")
+						validatedMetrics["mongodbatlas.disk.partition.space.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.max")
+						validatedMetrics["mongodbatlas.disk.partition.space.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.space.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.throughput":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.throughput"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.throughput")
-					validatedMetrics["mongodbatlas.disk.partition.throughput"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk throughput", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.throughput"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.throughput")
+						validatedMetrics["mongodbatlas.disk.partition.throughput"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk throughput", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.throughput"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.throughput")
+						validatedMetrics["mongodbatlas.disk.partition.throughput"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk throughput", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.throughput"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
-					validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
+						validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
+						validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
-					validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
+						validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
+						validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.utilization.average":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.average")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.average"] = true
@@ -568,20 +1114,45 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.asserts":
-					assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
-					validatedMetrics["mongodbatlas.process.asserts"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Number of assertions per second", mi.Description())
-					assert.Equal(t, "{assertions}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					assertTypeAttrVal, ok := dp.Attributes().Get("assert_type")
-					assert.True(t, ok)
-					assert.Equal(t, "regular", assertTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
+						validatedMetrics["mongodbatlas.process.asserts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of assertions per second", mi.Description())
+						assert.Equal(t, "{assertions}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						assertTypeAttrVal, ok := dp.Attributes().Get("assert_type")
+						assert.True(t, ok)
+						assert.Equal(t, "regular", assertTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
+						validatedMetrics["mongodbatlas.process.asserts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of assertions per second", mi.Description())
+						assert.Equal(t, "{assertions}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.asserts"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("assert_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.background_flush":
 					assert.False(t, validatedMetrics["mongodbatlas.process.background_flush"], "Found a duplicate in the metrics slice: mongodbatlas.process.background_flush")
 					validatedMetrics["mongodbatlas.process.background_flush"] = true
@@ -595,52 +1166,129 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.cache.io":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cache.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.io")
-					validatedMetrics["mongodbatlas.process.cache.io"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Cache throughput (per second)", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cacheDirectionAttrVal, ok := dp.Attributes().Get("cache_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read_into", cacheDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.io")
+						validatedMetrics["mongodbatlas.process.cache.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache throughput (per second)", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cacheDirectionAttrVal, ok := dp.Attributes().Get("cache_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read_into", cacheDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.io")
+						validatedMetrics["mongodbatlas.process.cache.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache throughput (per second)", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cache.io"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cache_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cache.ratio":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cache.ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.ratio")
-					validatedMetrics["mongodbatlas.process.cache.ratio"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Cache ratios represented as (%)", mi.Description())
-					assert.Equal(t, "%", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cacheRatioTypeAttrVal, ok := dp.Attributes().Get("cache_ratio_type")
-					assert.True(t, ok)
-					assert.Equal(t, "cache_fill", cacheRatioTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.ratio")
+						validatedMetrics["mongodbatlas.process.cache.ratio"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache ratios represented as (%)", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cacheRatioTypeAttrVal, ok := dp.Attributes().Get("cache_ratio_type")
+						assert.True(t, ok)
+						assert.Equal(t, "cache_fill", cacheRatioTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.ratio")
+						validatedMetrics["mongodbatlas.process.cache.ratio"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache ratios represented as (%)", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cache.ratio"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cache_ratio_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cache.size":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cache.size"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.size")
-					validatedMetrics["mongodbatlas.process.cache.size"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Cache sizes", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cacheStatusAttrVal, ok := dp.Attributes().Get("cache_status")
-					assert.True(t, ok)
-					assert.Equal(t, "dirty", cacheStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.size"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.size")
+						validatedMetrics["mongodbatlas.process.cache.size"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cache sizes", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cacheStatusAttrVal, ok := dp.Attributes().Get("cache_status")
+						assert.True(t, ok)
+						assert.Equal(t, "dirty", cacheStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.size"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.size")
+						validatedMetrics["mongodbatlas.process.cache.size"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cache sizes", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cache.size"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cache_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.connections":
 					assert.False(t, validatedMetrics["mongodbatlas.process.connections"], "Found a duplicate in the metrics slice: mongodbatlas.process.connections")
 					validatedMetrics["mongodbatlas.process.connections"] = true
@@ -656,250 +1304,654 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.cpu.children.normalized.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.normalized.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.children.normalized.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.normalized.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.children.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.children.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.children.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.children.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.normalized.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.normalized.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.normalized.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.normalized.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cursors":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cursors"], "Found a duplicate in the metrics slice: mongodbatlas.process.cursors")
-					validatedMetrics["mongodbatlas.process.cursors"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Number of cursors", mi.Description())
-					assert.Equal(t, "{cursors}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cursorStateAttrVal, ok := dp.Attributes().Get("cursor_state")
-					assert.True(t, ok)
-					assert.Equal(t, "timed_out", cursorStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cursors"], "Found a duplicate in the metrics slice: mongodbatlas.process.cursors")
+						validatedMetrics["mongodbatlas.process.cursors"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of cursors", mi.Description())
+						assert.Equal(t, "{cursors}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cursorStateAttrVal, ok := dp.Attributes().Get("cursor_state")
+						assert.True(t, ok)
+						assert.Equal(t, "timed_out", cursorStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cursors"], "Found a duplicate in the metrics slice: mongodbatlas.process.cursors")
+						validatedMetrics["mongodbatlas.process.cursors"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of cursors", mi.Description())
+						assert.Equal(t, "{cursors}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cursors"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cursor_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.document.rate":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.document.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.document.rate")
-					validatedMetrics["mongodbatlas.process.db.document.rate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Document access rates", mi.Description())
-					assert.Equal(t, "{documents}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					documentStatusAttrVal, ok := dp.Attributes().Get("document_status")
-					assert.True(t, ok)
-					assert.Equal(t, "returned", documentStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.document.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.document.rate")
+						validatedMetrics["mongodbatlas.process.db.document.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Document access rates", mi.Description())
+						assert.Equal(t, "{documents}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						documentStatusAttrVal, ok := dp.Attributes().Get("document_status")
+						assert.True(t, ok)
+						assert.Equal(t, "returned", documentStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.document.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.document.rate")
+						validatedMetrics["mongodbatlas.process.db.document.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Document access rates", mi.Description())
+						assert.Equal(t, "{documents}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.document.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("document_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.operations.rate":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.rate")
-					validatedMetrics["mongodbatlas.process.db.operations.rate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "DB Operation Rates", mi.Description())
-					assert.Equal(t, "{operations}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					operationAttrVal, ok := dp.Attributes().Get("operation")
-					assert.True(t, ok)
-					assert.Equal(t, "cmd", operationAttrVal.Str())
-					clusterRoleAttrVal, ok := dp.Attributes().Get("cluster_role")
-					assert.True(t, ok)
-					assert.Equal(t, "primary", clusterRoleAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.rate")
+						validatedMetrics["mongodbatlas.process.db.operations.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "DB Operation Rates", mi.Description())
+						assert.Equal(t, "{operations}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						operationAttrVal, ok := dp.Attributes().Get("operation")
+						assert.True(t, ok)
+						assert.Equal(t, "cmd", operationAttrVal.Str())
+						clusterRoleAttrVal, ok := dp.Attributes().Get("cluster_role")
+						assert.True(t, ok)
+						assert.Equal(t, "primary", clusterRoleAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.rate")
+						validatedMetrics["mongodbatlas.process.db.operations.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "DB Operation Rates", mi.Description())
+						assert.Equal(t, "{operations}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.operations.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("operation")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("cluster_role")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.operations.time":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.time")
-					validatedMetrics["mongodbatlas.process.db.operations.time"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "DB Operation Times", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					executionTypeAttrVal, ok := dp.Attributes().Get("execution_type")
-					assert.True(t, ok)
-					assert.Equal(t, "reads", executionTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.time")
+						validatedMetrics["mongodbatlas.process.db.operations.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "DB Operation Times", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						executionTypeAttrVal, ok := dp.Attributes().Get("execution_type")
+						assert.True(t, ok)
+						assert.Equal(t, "reads", executionTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.time")
+						validatedMetrics["mongodbatlas.process.db.operations.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "DB Operation Times", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.operations.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("execution_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.query_executor.scanned":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.query_executor.scanned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_executor.scanned")
-					validatedMetrics["mongodbatlas.process.db.query_executor.scanned"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Scanned objects", mi.Description())
-					assert.Equal(t, "{objects}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
-					assert.True(t, ok)
-					assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_executor.scanned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_executor.scanned")
+						validatedMetrics["mongodbatlas.process.db.query_executor.scanned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects", mi.Description())
+						assert.Equal(t, "{objects}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
+						assert.True(t, ok)
+						assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_executor.scanned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_executor.scanned")
+						validatedMetrics["mongodbatlas.process.db.query_executor.scanned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects", mi.Description())
+						assert.Equal(t, "{objects}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.query_executor.scanned"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("scanned_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.query_targeting.scanned_per_returned":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_targeting.scanned_per_returned")
-					validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Scanned objects per returned", mi.Description())
-					assert.Equal(t, "{scanned}/{returned}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
-					assert.True(t, ok)
-					assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_targeting.scanned_per_returned")
+						validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects per returned", mi.Description())
+						assert.Equal(t, "{scanned}/{returned}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
+						assert.True(t, ok)
+						assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_targeting.scanned_per_returned")
+						validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects per returned", mi.Description())
+						assert.Equal(t, "{scanned}/{returned}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.query_targeting.scanned_per_returned"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("scanned_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.storage":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.storage"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.storage")
-					validatedMetrics["mongodbatlas.process.db.storage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Storage used by the database", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					storageStatusAttrVal, ok := dp.Attributes().Get("storage_status")
-					assert.True(t, ok)
-					assert.Equal(t, "total", storageStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.storage"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.storage")
+						validatedMetrics["mongodbatlas.process.db.storage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Storage used by the database", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						storageStatusAttrVal, ok := dp.Attributes().Get("storage_status")
+						assert.True(t, ok)
+						assert.Equal(t, "total", storageStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.storage"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.storage")
+						validatedMetrics["mongodbatlas.process.db.storage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Storage used by the database", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.storage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("storage_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.global_lock":
-					assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
-					validatedMetrics["mongodbatlas.process.global_lock"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Number and status of locks", mi.Description())
-					assert.Equal(t, "{locks}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					globalLockStateAttrVal, ok := dp.Attributes().Get("global_lock_state")
-					assert.True(t, ok)
-					assert.Equal(t, "current_queue_total", globalLockStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
+						validatedMetrics["mongodbatlas.process.global_lock"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number and status of locks", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						globalLockStateAttrVal, ok := dp.Attributes().Get("global_lock_state")
+						assert.True(t, ok)
+						assert.Equal(t, "current_queue_total", globalLockStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
+						validatedMetrics["mongodbatlas.process.global_lock"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number and status of locks", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.global_lock"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("global_lock_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.index.btree_miss_ratio":
 					assert.False(t, validatedMetrics["mongodbatlas.process.index.btree_miss_ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.btree_miss_ratio")
 					validatedMetrics["mongodbatlas.process.index.btree_miss_ratio"] = true
@@ -913,20 +1965,45 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.index.counters":
-					assert.False(t, validatedMetrics["mongodbatlas.process.index.counters"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.counters")
-					validatedMetrics["mongodbatlas.process.index.counters"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Indexes", mi.Description())
-					assert.Equal(t, "{indexes}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					btreeCounterTypeAttrVal, ok := dp.Attributes().Get("btree_counter_type")
-					assert.True(t, ok)
-					assert.Equal(t, "accesses", btreeCounterTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.index.counters"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.counters")
+						validatedMetrics["mongodbatlas.process.index.counters"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Indexes", mi.Description())
+						assert.Equal(t, "{indexes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						btreeCounterTypeAttrVal, ok := dp.Attributes().Get("btree_counter_type")
+						assert.True(t, ok)
+						assert.Equal(t, "accesses", btreeCounterTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.index.counters"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.counters")
+						validatedMetrics["mongodbatlas.process.index.counters"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Indexes", mi.Description())
+						assert.Equal(t, "{indexes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.index.counters"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("btree_counter_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.journaling.commits":
 					assert.False(t, validatedMetrics["mongodbatlas.process.journaling.commits"], "Found a duplicate in the metrics slice: mongodbatlas.process.journaling.commits")
 					validatedMetrics["mongodbatlas.process.journaling.commits"] = true
@@ -964,35 +2041,85 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.memory.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.process.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.memory.usage")
-					validatedMetrics["mongodbatlas.process.memory.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Memory Usage", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.memory.usage")
+						validatedMetrics["mongodbatlas.process.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Memory Usage", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.memory.usage")
+						validatedMetrics["mongodbatlas.process.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Memory Usage", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.memory.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.network.io":
-					assert.False(t, validatedMetrics["mongodbatlas.process.network.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.io")
-					validatedMetrics["mongodbatlas.process.network.io"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Network IO", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.network.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.io")
+						validatedMetrics["mongodbatlas.process.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.network.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.io")
+						validatedMetrics["mongodbatlas.process.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.network.io"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.network.requests":
 					assert.False(t, validatedMetrics["mongodbatlas.process.network.requests"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.requests")
 					validatedMetrics["mongodbatlas.process.network.requests"] = true
@@ -1020,35 +2147,85 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.oplog.time":
-					assert.False(t, validatedMetrics["mongodbatlas.process.oplog.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.oplog.time")
-					validatedMetrics["mongodbatlas.process.oplog.time"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Execution time by operation", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					oplogTypeAttrVal, ok := dp.Attributes().Get("oplog_type")
-					assert.True(t, ok)
-					assert.Equal(t, "slave_lag_master_time", oplogTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.oplog.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.oplog.time")
+						validatedMetrics["mongodbatlas.process.oplog.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Execution time by operation", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						oplogTypeAttrVal, ok := dp.Attributes().Get("oplog_type")
+						assert.True(t, ok)
+						assert.Equal(t, "slave_lag_master_time", oplogTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.oplog.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.oplog.time")
+						validatedMetrics["mongodbatlas.process.oplog.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Execution time by operation", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.oplog.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("oplog_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.page_faults":
-					assert.False(t, validatedMetrics["mongodbatlas.process.page_faults"], "Found a duplicate in the metrics slice: mongodbatlas.process.page_faults")
-					validatedMetrics["mongodbatlas.process.page_faults"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Page faults", mi.Description())
-					assert.Equal(t, "{faults}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryIssueTypeAttrVal, ok := dp.Attributes().Get("memory_issue_type")
-					assert.True(t, ok)
-					assert.Equal(t, "extra_info", memoryIssueTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.page_faults"], "Found a duplicate in the metrics slice: mongodbatlas.process.page_faults")
+						validatedMetrics["mongodbatlas.process.page_faults"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Page faults", mi.Description())
+						assert.Equal(t, "{faults}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryIssueTypeAttrVal, ok := dp.Attributes().Get("memory_issue_type")
+						assert.True(t, ok)
+						assert.Equal(t, "extra_info", memoryIssueTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.page_faults"], "Found a duplicate in the metrics slice: mongodbatlas.process.page_faults")
+						validatedMetrics["mongodbatlas.process.page_faults"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Page faults", mi.Description())
+						assert.Equal(t, "{faults}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.page_faults"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_issue_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.restarts":
 					assert.False(t, validatedMetrics["mongodbatlas.process.restarts"], "Found a duplicate in the metrics slice: mongodbatlas.process.restarts")
 					validatedMetrics["mongodbatlas.process.restarts"] = true
@@ -1062,110 +2239,285 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.tickets":
-					assert.False(t, validatedMetrics["mongodbatlas.process.tickets"], "Found a duplicate in the metrics slice: mongodbatlas.process.tickets")
-					validatedMetrics["mongodbatlas.process.tickets"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Tickets", mi.Description())
-					assert.Equal(t, "{tickets}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					ticketTypeAttrVal, ok := dp.Attributes().Get("ticket_type")
-					assert.True(t, ok)
-					assert.Equal(t, "available_reads", ticketTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.tickets"], "Found a duplicate in the metrics slice: mongodbatlas.process.tickets")
+						validatedMetrics["mongodbatlas.process.tickets"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Tickets", mi.Description())
+						assert.Equal(t, "{tickets}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						ticketTypeAttrVal, ok := dp.Attributes().Get("ticket_type")
+						assert.True(t, ok)
+						assert.Equal(t, "available_reads", ticketTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.tickets"], "Found a duplicate in the metrics slice: mongodbatlas.process.tickets")
+						validatedMetrics["mongodbatlas.process.tickets"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Tickets", mi.Description())
+						assert.Equal(t, "{tickets}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.tickets"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("ticket_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.normalized.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.average")
-					validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.normalized.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.normalized.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.max")
-					validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.normalized.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.average")
-					validatedMetrics["mongodbatlas.system.cpu.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.max")
-					validatedMetrics["mongodbatlas.system.cpu.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.fts.cpu.normalized.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.normalized.usage")
-					validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Full text search disk usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.normalized.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full text search disk usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.normalized.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full text search disk usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.fts.cpu.normalized.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.fts.cpu.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.usage")
-					validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Full-text search (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full-text search (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full-text search (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.fts.cpu.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.fts.disk.used":
 					assert.False(t, validatedMetrics["mongodbatlas.system.fts.disk.used"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.disk.used")
 					validatedMetrics["mongodbatlas.system.fts.disk.used"] = true
@@ -1179,142 +2531,369 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.system.fts.memory.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.system.fts.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.memory.usage")
-					validatedMetrics["mongodbatlas.system.fts.memory.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Full-text search", mi.Description())
-					assert.Equal(t, "MiBy", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.memory.usage")
+						validatedMetrics["mongodbatlas.system.fts.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Full-text search", mi.Description())
+						assert.Equal(t, "MiBy", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.memory.usage")
+						validatedMetrics["mongodbatlas.system.fts.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Full-text search", mi.Description())
+						assert.Equal(t, "MiBy", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.fts.memory.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.memory.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.average")
-					validatedMetrics["mongodbatlas.system.memory.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Memory Usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
-					assert.True(t, ok)
-					assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.average")
+						validatedMetrics["mongodbatlas.system.memory.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
+						assert.True(t, ok)
+						assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.average")
+						validatedMetrics["mongodbatlas.system.memory.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.memory.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.memory.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.max")
-					validatedMetrics["mongodbatlas.system.memory.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Memory Usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
-					assert.True(t, ok)
-					assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.max")
+						validatedMetrics["mongodbatlas.system.memory.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
+						assert.True(t, ok)
+						assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.max")
+						validatedMetrics["mongodbatlas.system.memory.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.memory.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.network.io.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.network.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.average")
-					validatedMetrics["mongodbatlas.system.network.io.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Network IO", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.average")
+						validatedMetrics["mongodbatlas.system.network.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.average")
+						validatedMetrics["mongodbatlas.system.network.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.network.io.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.network.io.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.network.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.max")
-					validatedMetrics["mongodbatlas.system.network.io.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Network IO", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.max")
+						validatedMetrics["mongodbatlas.system.network.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.max")
+						validatedMetrics["mongodbatlas.system.network.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.network.io.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.io.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.average")
-					validatedMetrics["mongodbatlas.system.paging.io.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap IO", mi.Description())
-					assert.Equal(t, "{pages}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.average")
+						validatedMetrics["mongodbatlas.system.paging.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.average")
+						validatedMetrics["mongodbatlas.system.paging.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.io.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.io.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.max")
-					validatedMetrics["mongodbatlas.system.paging.io.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap IO", mi.Description())
-					assert.Equal(t, "{pages}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.max")
+						validatedMetrics["mongodbatlas.system.paging.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.max")
+						validatedMetrics["mongodbatlas.system.paging.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.io.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.average")
-					validatedMetrics["mongodbatlas.system.paging.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.average")
+						validatedMetrics["mongodbatlas.system.paging.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.average")
+						validatedMetrics["mongodbatlas.system.paging.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.max")
-					validatedMetrics["mongodbatlas.system.paging.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.max")
+						validatedMetrics["mongodbatlas.system.paging.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.max")
+						validatedMetrics["mongodbatlas.system.paging.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
@@ -3,80 +3,112 @@ all_set:
   metrics:
     mongodbatlas.db.counts:
       enabled: true
+      attributes: ["object_type"]
     mongodbatlas.db.size:
       enabled: true
+      attributes: ["object_type"]
     mongodbatlas.disk.partition.iops.average:
       enabled: true
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.iops.max:
       enabled: true
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.latency.average:
       enabled: true
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.latency.max:
       enabled: true
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.queue.depth:
       enabled: true
     mongodbatlas.disk.partition.space.average:
       enabled: true
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.space.max:
       enabled: true
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.throughput:
       enabled: true
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.usage.average:
       enabled: true
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.usage.max:
       enabled: true
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.utilization.average:
       enabled: true
     mongodbatlas.disk.partition.utilization.max:
       enabled: true
     mongodbatlas.process.asserts:
       enabled: true
+      attributes: ["assert_type"]
     mongodbatlas.process.background_flush:
       enabled: true
     mongodbatlas.process.cache.io:
       enabled: true
+      attributes: ["cache_direction"]
     mongodbatlas.process.cache.ratio:
       enabled: true
+      attributes: ["cache_ratio_type"]
     mongodbatlas.process.cache.size:
       enabled: true
+      attributes: ["cache_status"]
     mongodbatlas.process.connections:
       enabled: true
     mongodbatlas.process.cpu.children.normalized.usage.average:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.children.normalized.usage.max:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.children.usage.average:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.children.usage.max:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.normalized.usage.average:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.normalized.usage.max:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.usage.average:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.usage.max:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.process.cursors:
       enabled: true
+      attributes: ["cursor_state"]
     mongodbatlas.process.db.document.rate:
       enabled: true
+      attributes: ["document_status"]
     mongodbatlas.process.db.operations.rate:
       enabled: true
+      attributes: ["operation","cluster_role"]
     mongodbatlas.process.db.operations.time:
       enabled: true
+      attributes: ["execution_type"]
     mongodbatlas.process.db.query_executor.scanned:
       enabled: true
+      attributes: ["scanned_type"]
     mongodbatlas.process.db.query_targeting.scanned_per_returned:
       enabled: true
+      attributes: ["scanned_type"]
     mongodbatlas.process.db.storage:
       enabled: true
+      attributes: ["storage_status"]
     mongodbatlas.process.global_lock:
       enabled: true
+      attributes: ["global_lock_state"]
     mongodbatlas.process.index.btree_miss_ratio:
       enabled: true
     mongodbatlas.process.index.counters:
       enabled: true
+      attributes: ["btree_counter_type"]
     mongodbatlas.process.journaling.commits:
       enabled: true
     mongodbatlas.process.journaling.data_files:
@@ -85,52 +117,283 @@ all_set:
       enabled: true
     mongodbatlas.process.memory.usage:
       enabled: true
+      attributes: ["memory_state"]
     mongodbatlas.process.network.io:
       enabled: true
+      attributes: ["direction"]
     mongodbatlas.process.network.requests:
       enabled: true
     mongodbatlas.process.oplog.rate:
       enabled: true
     mongodbatlas.process.oplog.time:
       enabled: true
+      attributes: ["oplog_type"]
     mongodbatlas.process.page_faults:
       enabled: true
+      attributes: ["memory_issue_type"]
     mongodbatlas.process.restarts:
       enabled: true
     mongodbatlas.process.tickets:
       enabled: true
+      attributes: ["ticket_type"]
     mongodbatlas.system.cpu.normalized.usage.average:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.system.cpu.normalized.usage.max:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.system.cpu.usage.average:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.system.cpu.usage.max:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.system.fts.cpu.normalized.usage:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.system.fts.cpu.usage:
       enabled: true
+      attributes: ["cpu_state"]
     mongodbatlas.system.fts.disk.used:
       enabled: true
     mongodbatlas.system.fts.memory.usage:
       enabled: true
+      attributes: ["memory_state"]
     mongodbatlas.system.memory.usage.average:
       enabled: true
+      attributes: ["memory_status"]
     mongodbatlas.system.memory.usage.max:
       enabled: true
+      attributes: ["memory_status"]
     mongodbatlas.system.network.io.average:
       enabled: true
+      attributes: ["direction"]
     mongodbatlas.system.network.io.max:
       enabled: true
+      attributes: ["direction"]
     mongodbatlas.system.paging.io.average:
       enabled: true
+      attributes: ["direction"]
     mongodbatlas.system.paging.io.max:
       enabled: true
+      attributes: ["direction"]
     mongodbatlas.system.paging.usage.average:
       enabled: true
+      attributes: ["memory_state"]
     mongodbatlas.system.paging.usage.max:
       enabled: true
+      attributes: ["memory_state"]
+  resource_attributes:
+    mongodb_atlas.cluster.name:
+      enabled: true
+    mongodb_atlas.db.name:
+      enabled: true
+    mongodb_atlas.disk.partition:
+      enabled: true
+    mongodb_atlas.host.name:
+      enabled: true
+    mongodb_atlas.org_name:
+      enabled: true
+    mongodb_atlas.process.id:
+      enabled: true
+    mongodb_atlas.process.port:
+      enabled: true
+    mongodb_atlas.process.type_name:
+      enabled: true
+    mongodb_atlas.project.id:
+      enabled: true
+    mongodb_atlas.project.name:
+      enabled: true
+    mongodb_atlas.provider.name:
+      enabled: true
+    mongodb_atlas.region.name:
+      enabled: true
+    mongodb_atlas.user.alias:
+      enabled: true
+reaggregate_set:
+  metrics:
+    mongodbatlas.db.counts:
+      enabled: true
+      attributes: []
+    mongodbatlas.db.size:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.iops.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.iops.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.latency.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.latency.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.queue.depth:
+      enabled: true
+    mongodbatlas.disk.partition.space.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.space.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.throughput:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.disk.partition.utilization.average:
+      enabled: true
+    mongodbatlas.disk.partition.utilization.max:
+      enabled: true
+    mongodbatlas.process.asserts:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.background_flush:
+      enabled: true
+    mongodbatlas.process.cache.io:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cache.ratio:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cache.size:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.connections:
+      enabled: true
+    mongodbatlas.process.cpu.children.normalized.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.children.normalized.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.children.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.children.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.normalized.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.normalized.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cpu.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.cursors:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.db.document.rate:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.db.operations.rate:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.db.operations.time:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.db.query_executor.scanned:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.db.query_targeting.scanned_per_returned:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.db.storage:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.global_lock:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.index.btree_miss_ratio:
+      enabled: true
+    mongodbatlas.process.index.counters:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.journaling.commits:
+      enabled: true
+    mongodbatlas.process.journaling.data_files:
+      enabled: true
+    mongodbatlas.process.journaling.written:
+      enabled: true
+    mongodbatlas.process.memory.usage:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.network.io:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.network.requests:
+      enabled: true
+    mongodbatlas.process.oplog.rate:
+      enabled: true
+    mongodbatlas.process.oplog.time:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.page_faults:
+      enabled: true
+      attributes: []
+    mongodbatlas.process.restarts:
+      enabled: true
+    mongodbatlas.process.tickets:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.cpu.normalized.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.cpu.normalized.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.cpu.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.cpu.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.fts.cpu.normalized.usage:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.fts.cpu.usage:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.fts.disk.used:
+      enabled: true
+    mongodbatlas.system.fts.memory.usage:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.memory.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.memory.usage.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.network.io.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.network.io.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.paging.io.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.paging.io.max:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.paging.usage.average:
+      enabled: true
+      attributes: []
+    mongodbatlas.system.paging.usage.max:
+      enabled: true
+      attributes: []
   resource_attributes:
     mongodb_atlas.cluster.name:
       enabled: true
@@ -162,80 +425,112 @@ none_set:
   metrics:
     mongodbatlas.db.counts:
       enabled: false
+      attributes: ["object_type"]
     mongodbatlas.db.size:
       enabled: false
+      attributes: ["object_type"]
     mongodbatlas.disk.partition.iops.average:
       enabled: false
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.iops.max:
       enabled: false
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.latency.average:
       enabled: false
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.latency.max:
       enabled: false
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.queue.depth:
       enabled: false
     mongodbatlas.disk.partition.space.average:
       enabled: false
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.space.max:
       enabled: false
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.throughput:
       enabled: false
+      attributes: ["disk_direction"]
     mongodbatlas.disk.partition.usage.average:
       enabled: false
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.usage.max:
       enabled: false
+      attributes: ["disk_status"]
     mongodbatlas.disk.partition.utilization.average:
       enabled: false
     mongodbatlas.disk.partition.utilization.max:
       enabled: false
     mongodbatlas.process.asserts:
       enabled: false
+      attributes: ["assert_type"]
     mongodbatlas.process.background_flush:
       enabled: false
     mongodbatlas.process.cache.io:
       enabled: false
+      attributes: ["cache_direction"]
     mongodbatlas.process.cache.ratio:
       enabled: false
+      attributes: ["cache_ratio_type"]
     mongodbatlas.process.cache.size:
       enabled: false
+      attributes: ["cache_status"]
     mongodbatlas.process.connections:
       enabled: false
     mongodbatlas.process.cpu.children.normalized.usage.average:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.children.normalized.usage.max:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.children.usage.average:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.children.usage.max:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.normalized.usage.average:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.normalized.usage.max:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.usage.average:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cpu.usage.max:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.process.cursors:
       enabled: false
+      attributes: ["cursor_state"]
     mongodbatlas.process.db.document.rate:
       enabled: false
+      attributes: ["document_status"]
     mongodbatlas.process.db.operations.rate:
       enabled: false
+      attributes: ["operation","cluster_role"]
     mongodbatlas.process.db.operations.time:
       enabled: false
+      attributes: ["execution_type"]
     mongodbatlas.process.db.query_executor.scanned:
       enabled: false
+      attributes: ["scanned_type"]
     mongodbatlas.process.db.query_targeting.scanned_per_returned:
       enabled: false
+      attributes: ["scanned_type"]
     mongodbatlas.process.db.storage:
       enabled: false
+      attributes: ["storage_status"]
     mongodbatlas.process.global_lock:
       enabled: false
+      attributes: ["global_lock_state"]
     mongodbatlas.process.index.btree_miss_ratio:
       enabled: false
     mongodbatlas.process.index.counters:
       enabled: false
+      attributes: ["btree_counter_type"]
     mongodbatlas.process.journaling.commits:
       enabled: false
     mongodbatlas.process.journaling.data_files:
@@ -244,52 +539,72 @@ none_set:
       enabled: false
     mongodbatlas.process.memory.usage:
       enabled: false
+      attributes: ["memory_state"]
     mongodbatlas.process.network.io:
       enabled: false
+      attributes: ["direction"]
     mongodbatlas.process.network.requests:
       enabled: false
     mongodbatlas.process.oplog.rate:
       enabled: false
     mongodbatlas.process.oplog.time:
       enabled: false
+      attributes: ["oplog_type"]
     mongodbatlas.process.page_faults:
       enabled: false
+      attributes: ["memory_issue_type"]
     mongodbatlas.process.restarts:
       enabled: false
     mongodbatlas.process.tickets:
       enabled: false
+      attributes: ["ticket_type"]
     mongodbatlas.system.cpu.normalized.usage.average:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.system.cpu.normalized.usage.max:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.system.cpu.usage.average:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.system.cpu.usage.max:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.system.fts.cpu.normalized.usage:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.system.fts.cpu.usage:
       enabled: false
+      attributes: ["cpu_state"]
     mongodbatlas.system.fts.disk.used:
       enabled: false
     mongodbatlas.system.fts.memory.usage:
       enabled: false
+      attributes: ["memory_state"]
     mongodbatlas.system.memory.usage.average:
       enabled: false
+      attributes: ["memory_status"]
     mongodbatlas.system.memory.usage.max:
       enabled: false
+      attributes: ["memory_status"]
     mongodbatlas.system.network.io.average:
       enabled: false
+      attributes: ["direction"]
     mongodbatlas.system.network.io.max:
       enabled: false
+      attributes: ["direction"]
     mongodbatlas.system.paging.io.average:
       enabled: false
+      attributes: ["direction"]
     mongodbatlas.system.paging.io.max:
       enabled: false
+      attributes: ["direction"]
     mongodbatlas.system.paging.usage.average:
       enabled: false
+      attributes: ["memory_state"]
     mongodbatlas.system.paging.usage.max:
       enabled: false
+      attributes: ["memory_state"]
   resource_attributes:
     mongodb_atlas.cluster.name:
       enabled: false

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -1,6 +1,7 @@
 display_name: MongoDB Atlas Receiver
 type: mongodb_atlas
 deprecated_type: mongodbatlas
+reaggregation_enabled: true
 
 description: |
   The MongoDB Atlas Receiver receives metrics from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) 
@@ -74,6 +75,7 @@ resource_attributes:
 attributes:
   assert_type:
     description: MongoDB assertion type
+    requirement_level: recommended
     type: string
     enum:
       - regular
@@ -82,6 +84,7 @@ attributes:
       - user
   btree_counter_type:
     description: Database index effectiveness
+    requirement_level: recommended
     type: string
     enum:
       - accesses
@@ -89,30 +92,35 @@ attributes:
       - misses
   cache_direction:
     description: Whether read into or written from
+    requirement_level: recommended
     type: string
     enum:
       - read_into
       - written_from
   cache_ratio_type:
     description: Cache ratio type
+    requirement_level: recommended
     type: string
     enum:
       - cache_fill
       - dirty_fill
   cache_status:
     description: Cache status
+    requirement_level: recommended
     type: string
     enum:
       - dirty
       - used
   cluster_role:
     description: Whether process is acting as replica or primary
+    requirement_level: recommended
     type: string
     enum:
       - primary
       - replica
   cpu_state:
     description: CPU state
+    requirement_level: recommended
     type: string
     enum:
       - kernel
@@ -125,18 +133,21 @@ attributes:
       - steal
   cursor_state:
     description: Whether cursor is open or timed out
+    requirement_level: recommended
     type: string
     enum:
       - timed_out
       - open
   direction:
     description: Network traffic direction
+    requirement_level: recommended
     type: string
     enum:
       - receive
       - transmit
   disk_direction:
     description: Measurement type for disk operation
+    requirement_level: recommended
     type: string
     enum:
       - read
@@ -144,12 +155,14 @@ attributes:
       - total
   disk_status:
     description: Disk measurement type
+    requirement_level: recommended
     type: string
     enum:
       - free
       - used
   document_status:
     description: Status of documents in the database
+    requirement_level: recommended
     type: string
     enum:
       - returned
@@ -158,6 +171,7 @@ attributes:
       - deleted
   execution_type:
     description: Type of command
+    requirement_level: recommended
     type: string
     enum:
       - reads
@@ -165,6 +179,7 @@ attributes:
       - commands
   global_lock_state:
     description: Which queue is locked
+    requirement_level: recommended
     type: string
     enum:
       - current_queue_total
@@ -172,6 +187,7 @@ attributes:
       - current_queue_writers
   memory_issue_type:
     description: Type of memory issue encountered
+    requirement_level: recommended
     type: string
     enum:
       - extra_info
@@ -179,6 +195,7 @@ attributes:
       - exceptions_thrown
   memory_state:
     description: Memory usage type
+    requirement_level: recommended
     type: string
     enum:
       - resident
@@ -190,6 +207,7 @@ attributes:
       - used
   memory_status:
     description: Memory measurement type
+    requirement_level: recommended
     type: string
     enum:
       - available
@@ -200,6 +218,7 @@ attributes:
       - used
   object_type:
     description: MongoDB object type
+    requirement_level: recommended
     type: string
     enum:
       - collection
@@ -211,6 +230,7 @@ attributes:
       - data
   operation:
     description: Type of database operation
+    requirement_level: recommended
     type: string
     enum:
       - cmd
@@ -223,6 +243,7 @@ attributes:
       - ttl_deleted
   oplog_type:
     description: Oplog type
+    requirement_level: recommended
     type: string
     enum:
       - slave_lag_master_time
@@ -230,12 +251,14 @@ attributes:
       - master_lag_time_diff
   scanned_type:
     description: Objects or indexes scanned during query
+    requirement_level: recommended
     type: string
     enum:
       - index_items
       - objects
   storage_status:
     description: Views on database size
+    requirement_level: recommended
     type: string
     enum:
       - total
@@ -244,6 +267,7 @@ attributes:
       - data_size_wo_system
   ticket_type:
     description: Type of ticket available
+    requirement_level: recommended
     type: string
     enum:
       - available_reads


### PR DESCRIPTION
Fixes #46365, part of #45396.

Adds `reaggregation_enabled: true` to `metadata.yaml` and sets `requirement_level: recommended` on all 23 metric attributes. This enables consumers to re-aggregate MongoDB Atlas metrics with a subset of attribute labels without losing data.

No existing configuration files are broken by this change.

Generated files updated via `go generate ./...`.