### PR TITLE
feat(receiver/couchdb): enable dynamic metric reaggregation

### DIFF
--- a/.chloggen/46351-couchdb-enable-reaggregation.yaml
+++ b/.chloggen/46351-couchdb-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/couchdb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the CouchDB receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46351]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/couchdbreceiver/generated_package_test.go
+++ b/receiver/couchdbreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package couchdbreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/couchdbreceiver/generated_package_test.go
+++ b/receiver/couchdbreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package couchdbreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/couchdbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/couchdbreceiver/internal/metadata/config.schema.yaml
@@ -25,6 +25,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "operation"
+            default:
+              - "operation"
       couchdb.file_descriptor.open:
         description: "CouchdbFileDescriptorOpenMetricConfig provides config for the couchdb.file_descriptor.open metric."
         type: object
@@ -46,6 +62,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.method"
+            default:
+              - "http.method"
       couchdb.httpd.responses:
         description: "CouchdbHttpdResponsesMetricConfig provides config for the couchdb.httpd.responses metric."
         type: object
@@ -53,6 +85,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "http.status_code"
+            default:
+              - "http.status_code"
       couchdb.httpd.views:
         description: "CouchdbHttpdViewsMetricConfig provides config for the couchdb.httpd.views metric."
         type: object
@@ -60,6 +108,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "view"
+            default:
+              - "view"
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for couchdb resource attributes.
     type: object

--- a/receiver/couchdbreceiver/internal/metadata/generated_config.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,19 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// CouchdbAverageRequestTimeMetricConfig provides config for the couchdb.average_request_time metric.
+type CouchdbAverageRequestTimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *CouchdbAverageRequestTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -27,43 +29,303 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+// CouchdbDatabaseOpenMetricConfig provides config for the couchdb.database.open metric.
+type CouchdbDatabaseOpenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *CouchdbDatabaseOpenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// CouchdbDatabaseOperationsMetricAttributeKey specifies the key of an attribute for the couchdb.database.operations metric.
+type CouchdbDatabaseOperationsMetricAttributeKey string
+
+const (
+	CouchdbDatabaseOperationsMetricAttributeKeyOperation CouchdbDatabaseOperationsMetricAttributeKey = "operation"
+)
+
+// CouchdbDatabaseOperationsMetricConfig provides config for the couchdb.database.operations metric.
+type CouchdbDatabaseOperationsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []CouchdbDatabaseOperationsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *CouchdbDatabaseOperationsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *CouchdbDatabaseOperationsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case CouchdbDatabaseOperationsMetricAttributeKeyOperation:
+		default:
+			return fmt.Errorf("metric couchdb.database.operations doesn't have an attribute %v, valid attributes: [operation]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// CouchdbFileDescriptorOpenMetricConfig provides config for the couchdb.file_descriptor.open metric.
+type CouchdbFileDescriptorOpenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *CouchdbFileDescriptorOpenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// CouchdbHttpdBulkRequestsMetricConfig provides config for the couchdb.httpd.bulk_requests metric.
+type CouchdbHttpdBulkRequestsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *CouchdbHttpdBulkRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// CouchdbHttpdRequestsMetricAttributeKey specifies the key of an attribute for the couchdb.httpd.requests metric.
+type CouchdbHttpdRequestsMetricAttributeKey string
+
+const (
+	CouchdbHttpdRequestsMetricAttributeKeyHTTPMethod CouchdbHttpdRequestsMetricAttributeKey = "http.method"
+)
+
+// CouchdbHttpdRequestsMetricConfig provides config for the couchdb.httpd.requests metric.
+type CouchdbHttpdRequestsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []CouchdbHttpdRequestsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *CouchdbHttpdRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *CouchdbHttpdRequestsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case CouchdbHttpdRequestsMetricAttributeKeyHTTPMethod:
+		default:
+			return fmt.Errorf("metric couchdb.httpd.requests doesn't have an attribute %v, valid attributes: [http.method]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// CouchdbHttpdResponsesMetricAttributeKey specifies the key of an attribute for the couchdb.httpd.responses metric.
+type CouchdbHttpdResponsesMetricAttributeKey string
+
+const (
+	CouchdbHttpdResponsesMetricAttributeKeyHTTPStatusCode CouchdbHttpdResponsesMetricAttributeKey = "http.status_code"
+)
+
+// CouchdbHttpdResponsesMetricConfig provides config for the couchdb.httpd.responses metric.
+type CouchdbHttpdResponsesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []CouchdbHttpdResponsesMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *CouchdbHttpdResponsesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *CouchdbHttpdResponsesMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case CouchdbHttpdResponsesMetricAttributeKeyHTTPStatusCode:
+		default:
+			return fmt.Errorf("metric couchdb.httpd.responses doesn't have an attribute %v, valid attributes: [http.status_code]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// CouchdbHttpdViewsMetricAttributeKey specifies the key of an attribute for the couchdb.httpd.views metric.
+type CouchdbHttpdViewsMetricAttributeKey string
+
+const (
+	CouchdbHttpdViewsMetricAttributeKeyView CouchdbHttpdViewsMetricAttributeKey = "view"
+)
+
+// CouchdbHttpdViewsMetricConfig provides config for the couchdb.httpd.views metric.
+type CouchdbHttpdViewsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []CouchdbHttpdViewsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *CouchdbHttpdViewsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *CouchdbHttpdViewsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case CouchdbHttpdViewsMetricAttributeKeyView:
+		default:
+			return fmt.Errorf("metric couchdb.httpd.views doesn't have an attribute %v, valid attributes: [view]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MetricsConfig provides config for couchdb metrics.
 type MetricsConfig struct {
-	CouchdbAverageRequestTime MetricConfig `mapstructure:"couchdb.average_request_time"`
-	CouchdbDatabaseOpen       MetricConfig `mapstructure:"couchdb.database.open"`
-	CouchdbDatabaseOperations MetricConfig `mapstructure:"couchdb.database.operations"`
-	CouchdbFileDescriptorOpen MetricConfig `mapstructure:"couchdb.file_descriptor.open"`
-	CouchdbHttpdBulkRequests  MetricConfig `mapstructure:"couchdb.httpd.bulk_requests"`
-	CouchdbHttpdRequests      MetricConfig `mapstructure:"couchdb.httpd.requests"`
-	CouchdbHttpdResponses     MetricConfig `mapstructure:"couchdb.httpd.responses"`
-	CouchdbHttpdViews         MetricConfig `mapstructure:"couchdb.httpd.views"`
+	CouchdbAverageRequestTime CouchdbAverageRequestTimeMetricConfig `mapstructure:"couchdb.average_request_time"`
+	CouchdbDatabaseOpen       CouchdbDatabaseOpenMetricConfig       `mapstructure:"couchdb.database.open"`
+	CouchdbDatabaseOperations CouchdbDatabaseOperationsMetricConfig `mapstructure:"couchdb.database.operations"`
+	CouchdbFileDescriptorOpen CouchdbFileDescriptorOpenMetricConfig `mapstructure:"couchdb.file_descriptor.open"`
+	CouchdbHttpdBulkRequests  CouchdbHttpdBulkRequestsMetricConfig  `mapstructure:"couchdb.httpd.bulk_requests"`
+	CouchdbHttpdRequests      CouchdbHttpdRequestsMetricConfig      `mapstructure:"couchdb.httpd.requests"`
+	CouchdbHttpdResponses     CouchdbHttpdResponsesMetricConfig     `mapstructure:"couchdb.httpd.responses"`
+	CouchdbHttpdViews         CouchdbHttpdViewsMetricConfig         `mapstructure:"couchdb.httpd.views"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		CouchdbAverageRequestTime: MetricConfig{
+		CouchdbAverageRequestTime: CouchdbAverageRequestTimeMetricConfig{
 			Enabled: true,
 		},
-		CouchdbDatabaseOpen: MetricConfig{
+		CouchdbDatabaseOpen: CouchdbDatabaseOpenMetricConfig{
 			Enabled: true,
 		},
-		CouchdbDatabaseOperations: MetricConfig{
+		CouchdbDatabaseOperations: CouchdbDatabaseOperationsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []CouchdbDatabaseOperationsMetricAttributeKey{CouchdbDatabaseOperationsMetricAttributeKeyOperation},
+		},
+		CouchdbFileDescriptorOpen: CouchdbFileDescriptorOpenMetricConfig{
 			Enabled: true,
 		},
-		CouchdbFileDescriptorOpen: MetricConfig{
+		CouchdbHttpdBulkRequests: CouchdbHttpdBulkRequestsMetricConfig{
 			Enabled: true,
 		},
-		CouchdbHttpdBulkRequests: MetricConfig{
-			Enabled: true,
+		CouchdbHttpdRequests: CouchdbHttpdRequestsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []CouchdbHttpdRequestsMetricAttributeKey{CouchdbHttpdRequestsMetricAttributeKeyHTTPMethod},
 		},
-		CouchdbHttpdRequests: MetricConfig{
-			Enabled: true,
+		CouchdbHttpdResponses: CouchdbHttpdResponsesMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []CouchdbHttpdResponsesMetricAttributeKey{CouchdbHttpdResponsesMetricAttributeKeyHTTPStatusCode},
 		},
-		CouchdbHttpdResponses: MetricConfig{
-			Enabled: true,
-		},
-		CouchdbHttpdViews: MetricConfig{
-			Enabled: true,
+		CouchdbHttpdViews: CouchdbHttpdViewsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []CouchdbHttpdViewsMetricAttributeKey{CouchdbHttpdViewsMetricAttributeKeyView},
 		},
 	}
 }

--- a/receiver/couchdbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/couchdbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,29 +27,37 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					CouchdbAverageRequestTime: MetricConfig{
+					CouchdbAverageRequestTime: CouchdbAverageRequestTimeMetricConfig{
 						Enabled: true,
 					},
-					CouchdbDatabaseOpen: MetricConfig{
+					CouchdbDatabaseOpen: CouchdbDatabaseOpenMetricConfig{
 						Enabled: true,
 					},
-					CouchdbDatabaseOperations: MetricConfig{
+					CouchdbDatabaseOperations: CouchdbDatabaseOperationsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbDatabaseOperationsMetricAttributeKey{CouchdbDatabaseOperationsMetricAttributeKeyOperation},
+					},
+					CouchdbFileDescriptorOpen: CouchdbFileDescriptorOpenMetricConfig{
 						Enabled: true,
 					},
-					CouchdbFileDescriptorOpen: MetricConfig{
+					CouchdbHttpdBulkRequests: CouchdbHttpdBulkRequestsMetricConfig{
 						Enabled: true,
 					},
-					CouchdbHttpdBulkRequests: MetricConfig{
-						Enabled: true,
+					CouchdbHttpdRequests: CouchdbHttpdRequestsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbHttpdRequestsMetricAttributeKey{CouchdbHttpdRequestsMetricAttributeKeyHTTPMethod},
 					},
-					CouchdbHttpdRequests: MetricConfig{
-						Enabled: true,
+					CouchdbHttpdResponses: CouchdbHttpdResponsesMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbHttpdResponsesMetricAttributeKey{CouchdbHttpdResponsesMetricAttributeKeyHTTPStatusCode},
 					},
-					CouchdbHttpdResponses: MetricConfig{
-						Enabled: true,
-					},
-					CouchdbHttpdViews: MetricConfig{
-						Enabled: true,
+					CouchdbHttpdViews: CouchdbHttpdViewsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbHttpdViewsMetricAttributeKey{CouchdbHttpdViewsMetricAttributeKeyView},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -60,29 +69,37 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					CouchdbAverageRequestTime: MetricConfig{
+					CouchdbAverageRequestTime: CouchdbAverageRequestTimeMetricConfig{
 						Enabled: false,
 					},
-					CouchdbDatabaseOpen: MetricConfig{
+					CouchdbDatabaseOpen: CouchdbDatabaseOpenMetricConfig{
 						Enabled: false,
 					},
-					CouchdbDatabaseOperations: MetricConfig{
+					CouchdbDatabaseOperations: CouchdbDatabaseOperationsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbDatabaseOperationsMetricAttributeKey{CouchdbDatabaseOperationsMetricAttributeKeyOperation},
+					},
+					CouchdbFileDescriptorOpen: CouchdbFileDescriptorOpenMetricConfig{
 						Enabled: false,
 					},
-					CouchdbFileDescriptorOpen: MetricConfig{
+					CouchdbHttpdBulkRequests: CouchdbHttpdBulkRequestsMetricConfig{
 						Enabled: false,
 					},
-					CouchdbHttpdBulkRequests: MetricConfig{
-						Enabled: false,
+					CouchdbHttpdRequests: CouchdbHttpdRequestsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbHttpdRequestsMetricAttributeKey{CouchdbHttpdRequestsMetricAttributeKeyHTTPMethod},
 					},
-					CouchdbHttpdRequests: MetricConfig{
-						Enabled: false,
+					CouchdbHttpdResponses: CouchdbHttpdResponsesMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbHttpdResponsesMetricAttributeKey{CouchdbHttpdResponsesMetricAttributeKeyHTTPStatusCode},
 					},
-					CouchdbHttpdResponses: MetricConfig{
-						Enabled: false,
-					},
-					CouchdbHttpdViews: MetricConfig{
-						Enabled: false,
+					CouchdbHttpdViews: CouchdbHttpdViewsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []CouchdbHttpdViewsMetricAttributeKey{CouchdbHttpdViewsMetricAttributeKeyView},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -94,7 +111,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(CouchdbAverageRequestTimeMetricConfig{}, CouchdbDatabaseOpenMetricConfig{}, CouchdbDatabaseOperationsMetricConfig{}, CouchdbFileDescriptorOpenMetricConfig{}, CouchdbHttpdBulkRequestsMetricConfig{}, CouchdbHttpdRequestsMetricConfig{}, CouchdbHttpdResponsesMetricConfig{}, CouchdbHttpdViewsMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeHTTPMethod specifies the value http.method attribute.
@@ -153,9 +161,9 @@ type metricInfo struct {
 }
 
 type metricCouchdbAverageRequestTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   CouchdbAverageRequestTimeMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills couchdb.average_request_time metric with initial data.
@@ -192,7 +200,7 @@ func (m *metricCouchdbAverageRequestTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricCouchdbAverageRequestTime(cfg MetricConfig) metricCouchdbAverageRequestTime {
+func newMetricCouchdbAverageRequestTime(cfg CouchdbAverageRequestTimeMetricConfig) metricCouchdbAverageRequestTime {
 	m := metricCouchdbAverageRequestTime{config: cfg}
 
 	if cfg.Enabled {
@@ -203,9 +211,9 @@ func newMetricCouchdbAverageRequestTime(cfg MetricConfig) metricCouchdbAverageRe
 }
 
 type metricCouchdbDatabaseOpen struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   CouchdbDatabaseOpenMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
 }
 
 // init fills couchdb.database.open metric with initial data.
@@ -244,7 +252,7 @@ func (m *metricCouchdbDatabaseOpen) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricCouchdbDatabaseOpen(cfg MetricConfig) metricCouchdbDatabaseOpen {
+func newMetricCouchdbDatabaseOpen(cfg CouchdbDatabaseOpenMetricConfig) metricCouchdbDatabaseOpen {
 	m := metricCouchdbDatabaseOpen{config: cfg}
 
 	if cfg.Enabled {
@@ -255,9 +263,10 @@ func newMetricCouchdbDatabaseOpen(cfg MetricConfig) metricCouchdbDatabaseOpen {
 }
 
 type metricCouchdbDatabaseOperations struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        CouchdbDatabaseOperationsMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
 }
 
 // init fills couchdb.database.operations metric with initial data.
@@ -269,17 +278,48 @@ func (m *metricCouchdbDatabaseOperations) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricCouchdbDatabaseOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, CouchdbDatabaseOperationsMetricAttributeKeyOperation) {
+		dp.Attributes().PutStr("operation", operationAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("operation", operationAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -292,13 +332,18 @@ func (m *metricCouchdbDatabaseOperations) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbDatabaseOperations) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbDatabaseOperations(cfg MetricConfig) metricCouchdbDatabaseOperations {
+func newMetricCouchdbDatabaseOperations(cfg CouchdbDatabaseOperationsMetricConfig) metricCouchdbDatabaseOperations {
 	m := metricCouchdbDatabaseOperations{config: cfg}
 
 	if cfg.Enabled {
@@ -309,9 +354,9 @@ func newMetricCouchdbDatabaseOperations(cfg MetricConfig) metricCouchdbDatabaseO
 }
 
 type metricCouchdbFileDescriptorOpen struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   CouchdbFileDescriptorOpenMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills couchdb.file_descriptor.open metric with initial data.
@@ -350,7 +395,7 @@ func (m *metricCouchdbFileDescriptorOpen) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricCouchdbFileDescriptorOpen(cfg MetricConfig) metricCouchdbFileDescriptorOpen {
+func newMetricCouchdbFileDescriptorOpen(cfg CouchdbFileDescriptorOpenMetricConfig) metricCouchdbFileDescriptorOpen {
 	m := metricCouchdbFileDescriptorOpen{config: cfg}
 
 	if cfg.Enabled {
@@ -361,9 +406,9 @@ func newMetricCouchdbFileDescriptorOpen(cfg MetricConfig) metricCouchdbFileDescr
 }
 
 type metricCouchdbHttpdBulkRequests struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   CouchdbHttpdBulkRequestsMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills couchdb.httpd.bulk_requests metric with initial data.
@@ -402,7 +447,7 @@ func (m *metricCouchdbHttpdBulkRequests) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricCouchdbHttpdBulkRequests(cfg MetricConfig) metricCouchdbHttpdBulkRequests {
+func newMetricCouchdbHttpdBulkRequests(cfg CouchdbHttpdBulkRequestsMetricConfig) metricCouchdbHttpdBulkRequests {
 	m := metricCouchdbHttpdBulkRequests{config: cfg}
 
 	if cfg.Enabled {
@@ -413,9 +458,10 @@ func newMetricCouchdbHttpdBulkRequests(cfg MetricConfig) metricCouchdbHttpdBulkR
 }
 
 type metricCouchdbHttpdRequests struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        CouchdbHttpdRequestsMetricConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                          // slice containing number of aggregated datapoints at each index
 }
 
 // init fills couchdb.httpd.requests metric with initial data.
@@ -427,17 +473,48 @@ func (m *metricCouchdbHttpdRequests) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricCouchdbHttpdRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpMethodAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, CouchdbHttpdRequestsMetricAttributeKeyHTTPMethod) {
+		dp.Attributes().PutStr("http.method", httpMethodAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.method", httpMethodAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -450,13 +527,18 @@ func (m *metricCouchdbHttpdRequests) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdRequests) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdRequests(cfg MetricConfig) metricCouchdbHttpdRequests {
+func newMetricCouchdbHttpdRequests(cfg CouchdbHttpdRequestsMetricConfig) metricCouchdbHttpdRequests {
 	m := metricCouchdbHttpdRequests{config: cfg}
 
 	if cfg.Enabled {
@@ -467,9 +549,10 @@ func newMetricCouchdbHttpdRequests(cfg MetricConfig) metricCouchdbHttpdRequests 
 }
 
 type metricCouchdbHttpdResponses struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                    // data buffer for generated metric.
+	config        CouchdbHttpdResponsesMetricConfig // metric config provided by user.
+	capacity      int                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                           // slice containing number of aggregated datapoints at each index
 }
 
 // init fills couchdb.httpd.responses metric with initial data.
@@ -481,17 +564,48 @@ func (m *metricCouchdbHttpdResponses) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricCouchdbHttpdResponses) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpStatusCodeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, CouchdbHttpdResponsesMetricAttributeKeyHTTPStatusCode) {
+		dp.Attributes().PutStr("http.status_code", httpStatusCodeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("http.status_code", httpStatusCodeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -504,13 +618,18 @@ func (m *metricCouchdbHttpdResponses) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdResponses) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdResponses(cfg MetricConfig) metricCouchdbHttpdResponses {
+func newMetricCouchdbHttpdResponses(cfg CouchdbHttpdResponsesMetricConfig) metricCouchdbHttpdResponses {
 	m := metricCouchdbHttpdResponses{config: cfg}
 
 	if cfg.Enabled {
@@ -521,9 +640,10 @@ func newMetricCouchdbHttpdResponses(cfg MetricConfig) metricCouchdbHttpdResponse
 }
 
 type metricCouchdbHttpdViews struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        CouchdbHttpdViewsMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills couchdb.httpd.views metric with initial data.
@@ -535,17 +655,48 @@ func (m *metricCouchdbHttpdViews) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricCouchdbHttpdViews) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, viewAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, CouchdbHttpdViewsMetricAttributeKeyView) {
+		dp.Attributes().PutStr("view", viewAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("view", viewAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -558,13 +709,18 @@ func (m *metricCouchdbHttpdViews) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdViews) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdViews(cfg MetricConfig) metricCouchdbHttpdViews {
+func newMetricCouchdbHttpdViews(cfg CouchdbHttpdViewsMetricConfig) metricCouchdbHttpdViews {
 	m := metricCouchdbHttpdViews{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,16 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["CouchdbDatabaseOperations"] = mb.metricCouchdbDatabaseOperations.config.AggregationStrategy
+			aggMap["CouchdbHttpdRequests"] = mb.metricCouchdbHttpdRequests.config.AggregationStrategy
+			aggMap["CouchdbHttpdResponses"] = mb.metricCouchdbHttpdResponses.config.AggregationStrategy
+			aggMap["CouchdbHttpdViews"] = mb.metricCouchdbHttpdViews.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -78,6 +91,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordCouchdbDatabaseOperationsDataPoint(ts, 1, AttributeOperationWrites)
+			if tt.name == "reaggregate_set" {
+				mb.RecordCouchdbDatabaseOperationsDataPoint(ts, 3, AttributeOperationReads)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -90,19 +106,34 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordCouchdbHttpdRequestsDataPoint(ts, 1, AttributeHTTPMethodCOPY)
+			if tt.name == "reaggregate_set" {
+				mb.RecordCouchdbHttpdRequestsDataPoint(ts, 3, AttributeHTTPMethodDELETE)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordCouchdbHttpdResponsesDataPoint(ts, 1, "http.status_code-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordCouchdbHttpdResponsesDataPoint(ts, 3, "http.status_code-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordCouchdbHttpdViewsDataPoint(ts, 1, AttributeViewTemporaryViewReads)
+			if tt.name == "reaggregate_set" {
+				mb.RecordCouchdbHttpdViewsDataPoint(ts, 3, AttributeViewViewReads)
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetCouchdbNodeName("couchdb.node.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricCouchdbDatabaseOperations.aggDataPoints)
+				assert.Empty(t, mb.metricCouchdbHttpdRequests.aggDataPoints)
+				assert.Empty(t, mb.metricCouchdbHttpdResponses.aggDataPoints)
+				assert.Empty(t, mb.metricCouchdbHttpdViews.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -156,22 +187,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "couchdb.database.operations":
-					assert.False(t, validatedMetrics["couchdb.database.operations"], "Found a duplicate in the metrics slice: couchdb.database.operations")
-					validatedMetrics["couchdb.database.operations"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of database operations.", mi.Description())
-					assert.Equal(t, "{operations}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					operationAttrVal, ok := dp.Attributes().Get("operation")
-					assert.True(t, ok)
-					assert.Equal(t, "writes", operationAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["couchdb.database.operations"], "Found a duplicate in the metrics slice: couchdb.database.operations")
+						validatedMetrics["couchdb.database.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of database operations.", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						operationAttrVal, ok := dp.Attributes().Get("operation")
+						assert.True(t, ok)
+						assert.Equal(t, "writes", operationAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["couchdb.database.operations"], "Found a duplicate in the metrics slice: couchdb.database.operations")
+						validatedMetrics["couchdb.database.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of database operations.", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["couchdb.database.operations"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("operation")
+						assert.False(t, ok)
+					}
 				case "couchdb.file_descriptor.open":
 					assert.False(t, validatedMetrics["couchdb.file_descriptor.open"], "Found a duplicate in the metrics slice: couchdb.file_descriptor.open")
 					validatedMetrics["couchdb.file_descriptor.open"] = true
@@ -201,56 +259,137 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "couchdb.httpd.requests":
-					assert.False(t, validatedMetrics["couchdb.httpd.requests"], "Found a duplicate in the metrics slice: couchdb.httpd.requests")
-					validatedMetrics["couchdb.httpd.requests"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of HTTP requests by method.", mi.Description())
-					assert.Equal(t, "{requests}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					httpMethodAttrVal, ok := dp.Attributes().Get("http.method")
-					assert.True(t, ok)
-					assert.Equal(t, "COPY", httpMethodAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["couchdb.httpd.requests"], "Found a duplicate in the metrics slice: couchdb.httpd.requests")
+						validatedMetrics["couchdb.httpd.requests"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of HTTP requests by method.", mi.Description())
+						assert.Equal(t, "{requests}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						httpMethodAttrVal, ok := dp.Attributes().Get("http.method")
+						assert.True(t, ok)
+						assert.Equal(t, "COPY", httpMethodAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["couchdb.httpd.requests"], "Found a duplicate in the metrics slice: couchdb.httpd.requests")
+						validatedMetrics["couchdb.httpd.requests"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of HTTP requests by method.", mi.Description())
+						assert.Equal(t, "{requests}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["couchdb.httpd.requests"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.method")
+						assert.False(t, ok)
+					}
 				case "couchdb.httpd.responses":
-					assert.False(t, validatedMetrics["couchdb.httpd.responses"], "Found a duplicate in the metrics slice: couchdb.httpd.responses")
-					validatedMetrics["couchdb.httpd.responses"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of each HTTP status code.", mi.Description())
-					assert.Equal(t, "{responses}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					httpStatusCodeAttrVal, ok := dp.Attributes().Get("http.status_code")
-					assert.True(t, ok)
-					assert.Equal(t, "http.status_code-val", httpStatusCodeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["couchdb.httpd.responses"], "Found a duplicate in the metrics slice: couchdb.httpd.responses")
+						validatedMetrics["couchdb.httpd.responses"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of each HTTP status code.", mi.Description())
+						assert.Equal(t, "{responses}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						httpStatusCodeAttrVal, ok := dp.Attributes().Get("http.status_code")
+						assert.True(t, ok)
+						assert.Equal(t, "http.status_code-val", httpStatusCodeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["couchdb.httpd.responses"], "Found a duplicate in the metrics slice: couchdb.httpd.responses")
+						validatedMetrics["couchdb.httpd.responses"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of each HTTP status code.", mi.Description())
+						assert.Equal(t, "{responses}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["couchdb.httpd.responses"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("http.status_code")
+						assert.False(t, ok)
+					}
 				case "couchdb.httpd.views":
-					assert.False(t, validatedMetrics["couchdb.httpd.views"], "Found a duplicate in the metrics slice: couchdb.httpd.views")
-					validatedMetrics["couchdb.httpd.views"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of views read.", mi.Description())
-					assert.Equal(t, "{views}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					viewAttrVal, ok := dp.Attributes().Get("view")
-					assert.True(t, ok)
-					assert.Equal(t, "temporary_view_reads", viewAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["couchdb.httpd.views"], "Found a duplicate in the metrics slice: couchdb.httpd.views")
+						validatedMetrics["couchdb.httpd.views"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of views read.", mi.Description())
+						assert.Equal(t, "{views}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						viewAttrVal, ok := dp.Attributes().Get("view")
+						assert.True(t, ok)
+						assert.Equal(t, "temporary_view_reads", viewAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["couchdb.httpd.views"], "Found a duplicate in the metrics slice: couchdb.httpd.views")
+						validatedMetrics["couchdb.httpd.views"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of views read.", mi.Description())
+						assert.Equal(t, "{views}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["couchdb.httpd.views"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("view")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/couchdbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/couchdbreceiver/internal/metadata/testdata/config.yaml
@@ -7,16 +7,45 @@ all_set:
       enabled: true
     couchdb.database.operations:
       enabled: true
+      attributes: ["operation"]
     couchdb.file_descriptor.open:
       enabled: true
     couchdb.httpd.bulk_requests:
       enabled: true
     couchdb.httpd.requests:
       enabled: true
+      attributes: ["http.method"]
     couchdb.httpd.responses:
       enabled: true
+      attributes: ["http.status_code"]
     couchdb.httpd.views:
       enabled: true
+      attributes: ["view"]
+  resource_attributes:
+    couchdb.node.name:
+      enabled: true
+reaggregate_set:
+  metrics:
+    couchdb.average_request_time:
+      enabled: true
+    couchdb.database.open:
+      enabled: true
+    couchdb.database.operations:
+      enabled: true
+      attributes: []
+    couchdb.file_descriptor.open:
+      enabled: true
+    couchdb.httpd.bulk_requests:
+      enabled: true
+    couchdb.httpd.requests:
+      enabled: true
+      attributes: []
+    couchdb.httpd.responses:
+      enabled: true
+      attributes: []
+    couchdb.httpd.views:
+      enabled: true
+      attributes: []
   resource_attributes:
     couchdb.node.name:
       enabled: true
@@ -28,16 +57,20 @@ none_set:
       enabled: false
     couchdb.database.operations:
       enabled: false
+      attributes: ["operation"]
     couchdb.file_descriptor.open:
       enabled: false
     couchdb.httpd.bulk_requests:
       enabled: false
     couchdb.httpd.requests:
       enabled: false
+      attributes: ["http.method"]
     couchdb.httpd.responses:
       enabled: false
+      attributes: ["http.status_code"]
     couchdb.httpd.views:
       enabled: false
+      attributes: ["view"]
   resource_attributes:
     couchdb.node.name:
       enabled: false

--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: CouchDB Receiver
 type: couchdb
+reaggregation_enabled: true
 
 description: |
   This receiver fetches stats from a CouchDB server using the `/_node/{node-name}/_stats/couchdb`
@@ -24,17 +25,21 @@ resource_attributes:
 attributes:
   http.method:
     description: An HTTP request method.
+    requirement_level: recommended
     type: string
     enum: [COPY, DELETE, GET, HEAD, OPTIONS, POST, PUT]
   http.status_code:
     description: An HTTP status code.
+    requirement_level: recommended
     type: string
   operation:
     description: The operation type.
+    requirement_level: recommended
     type: string
     enum: [writes, reads]
   view:
     description: The view type.
+    requirement_level: recommended
     type: string
     enum: [temporary_view_reads, view_reads]
 

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -147,14 +147,14 @@ func TestMetricSettings(t *testing.T) {
 	mockClient.On("GetStats", "_local").Return(getStats("response_2.31.json"))
 	mbc := metadata.DefaultMetricsBuilderConfig()
 	mbc.Metrics = metadata.MetricsConfig{
-		CouchdbAverageRequestTime: metadata.MetricConfig{Enabled: false},
-		CouchdbDatabaseOpen:       metadata.MetricConfig{Enabled: false},
-		CouchdbDatabaseOperations: metadata.MetricConfig{Enabled: true},
-		CouchdbFileDescriptorOpen: metadata.MetricConfig{Enabled: false},
-		CouchdbHttpdBulkRequests:  metadata.MetricConfig{Enabled: false},
-		CouchdbHttpdRequests:      metadata.MetricConfig{Enabled: false},
-		CouchdbHttpdResponses:     metadata.MetricConfig{Enabled: false},
-		CouchdbHttpdViews:         metadata.MetricConfig{Enabled: false},
+		CouchdbAverageRequestTime: metadata.CouchdbAverageRequestTimeMetricConfig{Enabled: false},
+		CouchdbDatabaseOpen:       metadata.CouchdbDatabaseOpenMetricConfig{Enabled: false},
+		CouchdbDatabaseOperations: metadata.CouchdbDatabaseOperationsMetricConfig{Enabled: true, AggregationStrategy: metadata.AggregationStrategySum, EnabledAttributes: []metadata.CouchdbDatabaseOperationsMetricAttributeKey{metadata.CouchdbDatabaseOperationsMetricAttributeKeyOperation}},
+		CouchdbFileDescriptorOpen: metadata.CouchdbFileDescriptorOpenMetricConfig{Enabled: false},
+		CouchdbHttpdBulkRequests:  metadata.CouchdbHttpdBulkRequestsMetricConfig{Enabled: false},
+		CouchdbHttpdRequests:      metadata.CouchdbHttpdRequestsMetricConfig{Enabled: false},
+		CouchdbHttpdResponses:     metadata.CouchdbHttpdResponsesMetricConfig{Enabled: false},
+		CouchdbHttpdViews:         metadata.CouchdbHttpdViewsMetricConfig{Enabled: false},
 	}
 	cfg := &Config{
 		ClientConfig:         confighttp.NewDefaultClientConfig(),


### PR DESCRIPTION
Fixes #46351, part of #45396.

Adds `reaggregation_enabled: true` to `metadata.yaml` and sets `requirement_level: recommended` on all 4 metric attributes. This enables consumers to re-aggregate CouchDB metrics with a subset of attribute labels without losing data.

No existing configuration files are broken by this change.

Generated files updated via `go generate ./...`.