### PR TITLE
[pkg/translator/faro] Translate Device, OS, InstallationID, and Excep…

### DIFF
--- a/.chloggen/47708-faro-device-os-installation-fatal.yaml
+++ b/.chloggen/47708-faro-device-os-installation-fatal.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/faro
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Translate new Faro payload fields Meta.Device, Meta.OS, App.InstallationID, and Exception.Fatal.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47708]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/47708-faro-device-os-installation-fatal.yaml
+++ b/.chloggen/47708-faro-device-os-installation-fatal.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: pkg/translator/faro
+component: pkg/faro
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Translate new Faro payload fields Meta.Device, Meta.OS, App.InstallationID, and Exception.Fatal.

--- a/exporter/faroexporter/go.mod
+++ b/exporter/faroexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroex
 go 1.25.0
 
 require (
-	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc
+	github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/faro v0.150.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.56.1-0.20260415114935-307e3abdbae9
@@ -56,7 +56,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oapi-codegen/runtime v1.3.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/exporter/faroexporter/go.sum
+++ b/exporter/faroexporter/go.sum
@@ -43,8 +43,8 @@ github.com/google/go-tpm-tools v0.4.7/go.mod h1:gSyXTZHe3fgbzb6WEGd90QucmsnT1SRd
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc h1:o8BraeLtggPjb/n91jvQT4SgGn8j0jxOyIGEQSoIXwU=
-github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc/go.mod h1:4CP5sfwz5+uVfNgCeA5/N6csXnzOgnkgT1jh57ASaK4=
+github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0 h1:Fn+bnFLPyiwdEyHBglm9ecq8lyZoSC+3j+lQ+VloW6k=
+github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0/go.mod h1:vdBM4aXmP5ugU5uBnBVOMVzr/JUWk92PkKP9kW7BKfg=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
@@ -78,8 +78,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
-github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oapi-codegen/runtime v1.3.1 h1:RgDY6J4OGQLbRXhG/Xpt3vSVqYpHQS7hN4m85+5xB9g=
+github.com/oapi-codegen/runtime v1.3.1/go.mod h1:kOdeacKy7t40Rclb1je37ZLFboFxh+YLy0zaPCMibPY=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/translator/faro/go.mod
+++ b/pkg/translator/faro/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-logfmt/logfmt v0.6.1
-	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc
+	github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.150.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.150.0
 	github.com/stretchr/testify v1.11.1
@@ -31,7 +31,7 @@ require (
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oapi-codegen/runtime v1.3.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.150.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/pkg/translator/faro/go.sum
+++ b/pkg/translator/faro/go.sum
@@ -23,8 +23,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc h1:o8BraeLtggPjb/n91jvQT4SgGn8j0jxOyIGEQSoIXwU=
-github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc/go.mod h1:4CP5sfwz5+uVfNgCeA5/N6csXnzOgnkgT1jh57ASaK4=
+github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0 h1:Fn+bnFLPyiwdEyHBglm9ecq8lyZoSC+3j+lQ+VloW6k=
+github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0/go.mod h1:vdBM4aXmP5ugU5uBnBVOMVzr/JUWk92PkKP9kW7BKfg=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -44,8 +44,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
-github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oapi-codegen/runtime v1.3.1 h1:RgDY6J4OGQLbRXhG/Xpt3vSVqYpHQS7hN4m85+5xB9g=
+github.com/oapi-codegen/runtime v1.3.1/go.mod h1:kOdeacKy7t40Rclb1je37ZLFboFxh+YLy0zaPCMibPY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/pkg/translator/faro/keyval.go
+++ b/pkg/translator/faro/keyval.go
@@ -102,6 +102,9 @@ func exceptionToKeyVal(e *faroTypes.Exception) *keyVal {
 	keyValAdd(kv, faroLogLevel, string(faroTypes.LogLevelError))
 	keyValAdd(kv, faroExceptionType, e.Type)
 	keyValAdd(kv, faroExceptionValue, e.Value)
+	if e.Fatal {
+		keyValAdd(kv, faroExceptionFatal, strconv.FormatBool(e.Fatal))
+	}
 	keyValAdd(kv, faroExceptionStacktrace, exceptionToString(e))
 	mergeKeyVal(kv, traceToKeyVal(e.Trace))
 	mergeKeyValWithPrefix(kv, keyValFromMap(e.Context), faroContextPrefix)
@@ -192,6 +195,8 @@ func metaToKeyVal(m faroTypes.Meta) *keyVal {
 	mergeKeyVal(kv, sessionToKeyVal(m.Session))
 	mergeKeyVal(kv, pageToKeyVal(m.Page))
 	mergeKeyVal(kv, browserToKeyVal(m.Browser))
+	mergeKeyVal(kv, deviceToKeyVal(m.Device))
+	mergeKeyVal(kv, osToKeyVal(m.OS))
 	mergeKeyVal(kv, k6ToKeyVal(m.K6))
 	mergeKeyVal(kv, viewToKeyVal(m.View))
 	mergeKeyVal(kv, geoToKeyVal(m.Geo))
@@ -230,6 +235,7 @@ func appToKeyVal(a faroTypes.App) *keyVal {
 	keyValAdd(kv, faroAppRelease, a.Release)
 	keyValAdd(kv, faroAppVersion, a.Version)
 	keyValAdd(kv, faroAppEnvironment, a.Environment)
+	keyValAdd(kv, faroAppInstallationID, a.InstallationID)
 	return kv
 }
 
@@ -286,6 +292,30 @@ func browserToKeyVal(b faroTypes.Browser) *keyVal {
 		return kv
 	}
 
+	return kv
+}
+
+// deviceToKeyVal produces key->value representation of Device metadata
+func deviceToKeyVal(d faroTypes.Device) *keyVal {
+	kv := newKeyVal()
+	keyValAdd(kv, faroDeviceManufacturer, d.Manufacturer)
+	keyValAdd(kv, faroDeviceModelIdentifier, d.ModelIdentifier)
+	keyValAdd(kv, faroDeviceModelName, d.ModelName)
+	keyValAdd(kv, faroDeviceBrand, d.Brand)
+	if d.IsPhysical {
+		keyValAdd(kv, faroDeviceIsPhysical, strconv.FormatBool(d.IsPhysical))
+	}
+	keyValAdd(kv, faroDeviceType, d.Type)
+	return kv
+}
+
+// osToKeyVal produces key->value representation of OS metadata
+func osToKeyVal(o faroTypes.OS) *keyVal {
+	kv := newKeyVal()
+	keyValAdd(kv, faroOSName, o.Name)
+	keyValAdd(kv, faroOSVersion, o.Version)
+	keyValAdd(kv, faroOSBuildID, o.BuildID)
+	keyValAdd(kv, faroOSDetail, o.Detail)
 	return kv
 }
 

--- a/pkg/translator/faro/logs_to_faro.go
+++ b/pkg/translator/faro/logs_to_faro.go
@@ -34,13 +34,14 @@ const (
 	faroSDKVersion      = "sdk_version"
 	faroSDKIntegrations = "sdk_integrations"
 
-	faroApp            = "app"
-	faroAppName        = "app_name"
-	faroAppNamespace   = "app_namespace"
-	faroAppRelease     = "app_release"
-	faroAppVersion     = "app_version"
-	faroAppBundleID    = "app_bundle_id"
-	faroAppEnvironment = "app_environment"
+	faroApp               = "app"
+	faroAppName           = "app_name"
+	faroAppNamespace      = "app_namespace"
+	faroAppRelease        = "app_release"
+	faroAppVersion        = "app_version"
+	faroAppBundleID       = "app_bundle_id"
+	faroAppEnvironment    = "app_environment"
+	faroAppInstallationID = "app_installation_id"
 
 	faroBrowserName           = "browser_name"
 	faroBrowserVersion        = "browser_version"
@@ -55,6 +56,18 @@ const (
 
 	faroBrand        = "brand"
 	faroBrandVersion = "version"
+
+	faroDeviceManufacturer    = "device_manufacturer"
+	faroDeviceModelIdentifier = "device_model_identifier"
+	faroDeviceModelName       = "device_model_name"
+	faroDeviceBrand           = "device_brand"
+	faroDeviceIsPhysical      = "device_is_physical"
+	faroDeviceType            = "device_type"
+
+	faroOSName    = "os_name"
+	faroOSVersion = "os_version"
+	faroOSBuildID = "os_build_id"
+	faroOSDetail  = "os_detail"
 
 	faroGeoContinentIso   = "geo_continent_iso"
 	faroGeoCountryIso     = "geo_country_iso"
@@ -93,6 +106,7 @@ const (
 	faroExceptionValue      = "value"
 	faroExceptionHash       = "hash"
 	faroExceptionStacktrace = "stacktrace"
+	faroExceptionFatal      = "fatal"
 
 	faroStacktraceFunction = "function"
 	faroStackTraceModule   = "module"
@@ -304,6 +318,11 @@ func extractMetaFromKeyVal(kv map[string]string, rl pcommon.Resource) (faroTypes
 	if err != nil {
 		return meta, err
 	}
+	device, err := extractDeviceFromKeyVal(kv)
+	if err != nil {
+		return meta, err
+	}
+	osMeta := extractOSFromKeyVal(kv)
 	geo := extractGeoFromKeyVal(kv)
 	k6, err := extractK6FromKeyVal(kv)
 	if err != nil {
@@ -317,6 +336,8 @@ func extractMetaFromKeyVal(kv map[string]string, rl pcommon.Resource) (faroTypes
 
 	meta.App = app
 	meta.Browser = *browser
+	meta.Device = device
+	meta.OS = osMeta
 	meta.Geo = geo
 	meta.K6 = k6
 	meta.Page = page
@@ -427,6 +448,9 @@ func extractAppFromKeyVal(kv map[string]string, rl pcommon.Resource) faroTypes.A
 			app.Environment = environment
 		}
 	}
+	if installationID, ok := kv[faroAppInstallationID]; ok {
+		app.InstallationID = installationID
+	}
 	return app
 }
 
@@ -513,6 +537,50 @@ func extractBrowserBrandsFromKeyVal(kv map[string]string) (faroTypes.Browser_Bra
 		}
 	}
 	return brands, nil
+}
+
+func extractDeviceFromKeyVal(kv map[string]string) (faroTypes.Device, error) {
+	var device faroTypes.Device
+	if manufacturer, ok := kv[faroDeviceManufacturer]; ok {
+		device.Manufacturer = manufacturer
+	}
+	if modelIdentifier, ok := kv[faroDeviceModelIdentifier]; ok {
+		device.ModelIdentifier = modelIdentifier
+	}
+	if modelName, ok := kv[faroDeviceModelName]; ok {
+		device.ModelName = modelName
+	}
+	if brand, ok := kv[faroDeviceBrand]; ok {
+		device.Brand = brand
+	}
+	if isPhysical, ok := kv[faroDeviceIsPhysical]; ok {
+		parsed, err := strconv.ParseBool(isPhysical)
+		if err != nil {
+			return device, err
+		}
+		device.IsPhysical = parsed
+	}
+	if deviceType, ok := kv[faroDeviceType]; ok {
+		device.Type = deviceType
+	}
+	return device, nil
+}
+
+func extractOSFromKeyVal(kv map[string]string) faroTypes.OS {
+	var osMeta faroTypes.OS
+	if name, ok := kv[faroOSName]; ok {
+		osMeta.Name = name
+	}
+	if version, ok := kv[faroOSVersion]; ok {
+		osMeta.Version = version
+	}
+	if buildID, ok := kv[faroOSBuildID]; ok {
+		osMeta.BuildID = buildID
+	}
+	if detail, ok := kv[faroOSDetail]; ok {
+		osMeta.Detail = detail
+	}
+	return osMeta
 }
 
 func extractGeoFromKeyVal(kv map[string]string) faroTypes.Geo {
@@ -696,6 +764,13 @@ func extractExceptionFromKeyVal(kv map[string]string) (faroTypes.Exception, erro
 	}
 	if exceptionValue, ok := kv[faroExceptionValue]; ok {
 		exception.Value = exceptionValue
+	}
+	if fatal, ok := kv[faroExceptionFatal]; ok {
+		parsed, err := strconv.ParseBool(fatal)
+		if err != nil {
+			return exception, err
+		}
+		exception.Fatal = parsed
 	}
 	exceptionContext := extractExceptionContextFromKeyVal(kv)
 	if len(exceptionContext) > 0 {

--- a/pkg/translator/faro/logs_to_faro_test.go
+++ b/pkg/translator/faro/logs_to_faro_test.go
@@ -5,6 +5,7 @@ package faro // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
 	"testing"
 	"time"
@@ -366,9 +367,7 @@ func Test_extractExceptionFromKeyVal_Fatal(t *testing.T) {
 			"type":  "NullPointerException",
 			"value": "something bad",
 		}
-		for k, v := range extra {
-			kv[k] = v
-		}
+		maps.Copy(kv, extra)
 		return kv
 	}
 	testcases := []struct {

--- a/pkg/translator/faro/logs_to_faro_test.go
+++ b/pkg/translator/faro/logs_to_faro_test.go
@@ -248,6 +248,170 @@ func Test_extractK6FromKeyVal(t *testing.T) {
 	}
 }
 
+func Test_extractDeviceFromKeyVal(t *testing.T) {
+	testcases := []struct {
+		name    string
+		kv      map[string]string
+		want    faroTypes.Device
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty kv yields zero-value Device",
+			kv:      map[string]string{},
+			want:    faroTypes.Device{},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "all fields populated",
+			kv: map[string]string{
+				"device_manufacturer":     "Apple",
+				"device_model_identifier": "iPhone14,5",
+				"device_model_name":       "iPhone 13",
+				"device_brand":            "iPhone",
+				"device_is_physical":      "true",
+				"device_type":             "mobile",
+			},
+			want: faroTypes.Device{
+				Manufacturer:    "Apple",
+				ModelIdentifier: "iPhone14,5",
+				ModelName:       "iPhone 13",
+				Brand:           "iPhone",
+				IsPhysical:      true,
+				Type:            "mobile",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "device_is_physical cannot be parsed as boolean",
+			kv: map[string]string{
+				"device_is_physical": "nope",
+			},
+			want:    faroTypes.Device{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractDeviceFromKeyVal(tt.kv)
+			if !tt.wantErr(t, err, fmt.Sprintf("extractDeviceFromKeyVal(%v)", tt.kv)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "extractDeviceFromKeyVal(%v)", tt.kv)
+		})
+	}
+}
+
+func Test_extractOSFromKeyVal(t *testing.T) {
+	testcases := []struct {
+		name string
+		kv   map[string]string
+		want faroTypes.OS
+	}{
+		{
+			name: "empty kv yields zero-value OS",
+			kv:   map[string]string{},
+			want: faroTypes.OS{},
+		},
+		{
+			name: "all fields populated",
+			kv: map[string]string{
+				"os_name":     "iOS",
+				"os_version":  "18.1",
+				"os_build_id": "22G91",
+				"os_detail":   "iOS 18.1 (22G91)",
+			},
+			want: faroTypes.OS{
+				Name:    "iOS",
+				Version: "18.1",
+				BuildID: "22G91",
+				Detail:  "iOS 18.1 (22G91)",
+			},
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractOSFromKeyVal(tt.kv))
+		})
+	}
+}
+
+func Test_extractAppFromKeyVal_InstallationID(t *testing.T) {
+	testcases := []struct {
+		name string
+		kv   map[string]string
+		want string
+	}{
+		{
+			name: "installation_id absent",
+			kv:   map[string]string{},
+			want: "",
+		},
+		{
+			name: "installation_id present",
+			kv:   map[string]string{"app_installation_id": "install-abc-123"},
+			want: "install-abc-123",
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			app := extractAppFromKeyVal(tt.kv, pcommon.NewResource())
+			assert.Equal(t, tt.want, app.InstallationID)
+		})
+	}
+}
+
+func Test_extractExceptionFromKeyVal_Fatal(t *testing.T) {
+	baseKV := func(extra map[string]string) map[string]string {
+		kv := map[string]string{
+			"type":  "NullPointerException",
+			"value": "something bad",
+		}
+		for k, v := range extra {
+			kv[k] = v
+		}
+		return kv
+	}
+	testcases := []struct {
+		name      string
+		kv        map[string]string
+		wantFatal bool
+		wantErr   assert.ErrorAssertionFunc
+	}{
+		{
+			name:      "fatal absent defaults to false",
+			kv:        baseKV(nil),
+			wantFatal: false,
+			wantErr:   assert.NoError,
+		},
+		{
+			name:      "fatal=true parses as true",
+			kv:        baseKV(map[string]string{"fatal": "true"}),
+			wantFatal: true,
+			wantErr:   assert.NoError,
+		},
+		{
+			name:      "fatal=false parses as false",
+			kv:        baseKV(map[string]string{"fatal": "false"}),
+			wantFatal: false,
+			wantErr:   assert.NoError,
+		},
+		{
+			name:    "fatal cannot be parsed as boolean",
+			kv:      baseKV(map[string]string{"fatal": "nope"}),
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			exception, err := extractExceptionFromKeyVal(tt.kv)
+			if !tt.wantErr(t, err, fmt.Sprintf("extractExceptionFromKeyVal(%v)", tt.kv)) {
+				return
+			}
+			assert.Equal(t, tt.wantFatal, exception.Fatal)
+		})
+	}
+}
+
 func Test_parseFrameFromString(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/pkg/translator/faro/testdata/general/payload.json
+++ b/pkg/translator/faro/testdata/general/payload.json
@@ -62,6 +62,7 @@
       {
         "type": "Error",
         "value": "Cannot read property 'find' of undefined",
+        "fatal": true,
         "stacktrace": {
           "frames": [
             {
@@ -272,7 +273,8 @@
         "release": "0.8.2",
         "version": "abcdefg",
         "environment": "production",
-        "bundleId": "testBundleId"
+        "bundleId": "testBundleId",
+        "installationId": "install-abc-123"
       },
       "user": {
         "username": "testuser",
@@ -296,6 +298,20 @@
         "version": "88.12.1",
         "os": "linux",
         "mobile": false
+      },
+      "device": {
+        "manufacturer": "Apple",
+        "model_identifier": "iPhone14,5",
+        "model_name": "iPhone 13",
+        "brand": "iPhone",
+        "is_physical": true,
+        "type": "mobile"
+      },
+      "os": {
+        "name": "iOS",
+        "version": "18.1",
+        "build_id": "22G91",
+        "detail": "iOS 18.1 (22G91)"
       },
       "view": {
         "name": "foobar"

--- a/pkg/translator/faro/testdata/general/plogs.yaml
+++ b/pkg/translator/faro/testdata/general/plogs.yaml
@@ -1,64 +1,62 @@
 resourceLogs:
-- resource:
-    attributes:
-    - key: service.name
-      value:
-        stringValue: testapp
-    - key: service.version
-      value:
-        stringValue: abcdefg
-    - key: deployment.environment
-      value:
-        stringValue: production
-    - key: service.namespace
-      value:
-        stringValue: testnamespace
-    - key: app_bundle_id
-      value:
-        stringValue: testBundleId
-  scopeLogs:
-  - logRecords:
-    - attributes:
-      - key: kind
-        value:
-          stringValue: log
-      body:
-        stringValue: timestamp=2021-09-30T10:46:17.68Z kind=log level=info message="opened pricing page" context_component=AppRoot context_page=Pricing traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar
-      spanId: 562474ddde25561b
-      traceId: 46d38efbe623342af29992782992000a
-    - attributes:
-      - key: kind
-        value:
-          stringValue: log
-      body:
-        stringValue: timestamp=2021-09-30T10:46:17.68Z kind=log level=trace message="loading price list" context_component=AppRoot context_page=Pricing traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar
-      spanId: 562474ddde25561b
-      traceId: 46d38efbe623342af29992782992000a
-    - attributes:
-      - key: kind
-        value:
-          stringValue: exception
-      - key: hash
-        value:
-          stringValue: "7881982385208174497"
-      body:
-        stringValue: 'timestamp=2021-09-30T10:46:17.68Z kind=exception level=error type=Error value="Cannot read property ''find'' of undefined" stacktrace="Error: Cannot read property ''find'' of undefined\n  at ? (http://fe:3002/static/js/vendors~main.chunk.js:8639:42)\n  at dispatchAction (http://fe:3002/static/js/vendors~main.chunk.js:268095:9)\n  at scheduleUpdateOnFiber (http://fe:3002/static/js/vendors~main.chunk.js:273726:13)\n  at flushSyncCallbackQueue (http://fe:3002/static/js/vendors~main.chunk.js:263362:7)\n  at flushSyncCallbackQueueImpl (http://fe:3002/static/js/vendors~main.chunk.js:263374:13)\n  at runWithPriority$1 (http://fe:3002/static/js/vendors~main.chunk.js:263325:14)\n  at unstable_runWithPriority (http://fe:3002/static/js/vendors~main.chunk.js:291265:16)\n  at ? (http://fe:3002/static/js/vendors~main.chunk.js:263379:30)\n  at performSyncWorkOnRoot (http://fe:3002/static/js/vendors~main.chunk.js:274126:22)\n  at renderRootSync (http://fe:3002/static/js/vendors~main.chunk.js:274509:11)\n  at workLoopSync (http://fe:3002/static/js/vendors~main.chunk.js:274543:9)\n  at performUnitOfWork (http://fe:3002/static/js/vendors~main.chunk.js:274606:16)\n  at beginWork$1 (http://fe:3002/static/js/vendors~main.chunk.js:275746:18)\n  at beginWork (http://fe:3002/static/js/vendors~main.chunk.js:270944:20)\n  at updateFunctionComponent (http://fe:3002/static/js/vendors~main.chunk.js:269291:24)\n  at renderWithHooks (http://fe:3002/static/js/vendors~main.chunk.js:266969:22)\n  at ? (http://fe:3002/static/js/main.chunk.js:2600:74)\n  at useGetBooksQuery (http://fe:3002/static/js/main.chunk.js:1299:65)\n  at Module.useQuery (http://fe:3002/static/js/vendors~main.chunk.js:8495:85)\n  at useBaseQuery (http://fe:3002/static/js/vendors~main.chunk.js:8656:83)\n  at useDeepMemo (http://fe:3002/static/js/vendors~main.chunk.js:8696:14)\n  at ? (http://fe:3002/static/js/vendors~main.chunk.js:8657:55)\n  at QueryData.execute (http://fe:3002/static/js/vendors~main.chunk.js:7883:47)\n  at QueryData.getExecuteResult (http://fe:3002/static/js/vendors~main.chunk.js:7944:23)\n  at QueryData._this.getQueryResult (http://fe:3002/static/js/vendors~main.chunk.js:7790:19)\n  at new ApolloError (http://fe:3002/static/js/vendors~main.chunk.js:5164:24)" traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b context_ReactError="Annoying Error" context_component=ReactErrorBoundary sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar'
-      spanId: 562474ddde25561b
-      traceId: 46d38efbe623342af29992782992000a
-    - attributes:
-      - key: kind
-        value:
-          stringValue: measurement
-      body:
-        stringValue: timestamp=2021-09-30T10:46:17.68Z kind=measurement level=info type="page load" context_hello=world ttfb=14.000000 ttfcp=22.120000 ttfp=20.120000 traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b value_ttfb=14 value_ttfcp=22.12 value_ttfp=20.12 sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar
-      spanId: 562474ddde25561b
-      traceId: 46d38efbe623342af29992782992000a
-    - attributes:
-      - key: kind
-        value:
-          stringValue: event
-      body:
-        stringValue: timestamp=2023-11-16T10:00:55.995Z kind=event level=info event_name=faro.performanceEntry event_domain=browser event_data_connectEnd=3656 event_data_connectStart=337 event_data_decodedBodySize=0 event_data_domainLookupEnd=590 event_data_domainLookupStart=588 event_data_duration=3371 event_data_encodedBodySize=0 event_data_entryType=resource event_data_fetchStart=331 event_data_initiatorType=other event_data_name=https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css.map event_data_nextHopProtocol=h2 event_data_redirectEnd=0 event_data_redirectStart=0 event_data_requestStart=3656 event_data_responseEnd=3702 event_data_responseStart=3690 event_data_secureConnectionStart=3638 event_data_serverTiming=[] event_data_startTime=331 event_data_transferSize=0 event_data_workerStart=0 sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false view_name=foobar
-      spanId: ""
-      traceId: ""
-    scope: {}
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: testapp
+        - key: service.version
+          value:
+            stringValue: abcdefg
+        - key: deployment.environment
+          value:
+            stringValue: production
+        - key: service.namespace
+          value:
+            stringValue: testnamespace
+        - key: app_bundle_id
+          value:
+            stringValue: testBundleId
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: kind
+                value:
+                  stringValue: log
+            body:
+              stringValue: timestamp=2021-09-30T10:46:17.68Z kind=log level=info message="opened pricing page" context_component=AppRoot context_page=Pricing traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production app_installation_id=install-abc-123 user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false device_manufacturer=Apple device_model_identifier=iPhone14,5 device_model_name="iPhone 13" device_brand=iPhone device_is_physical=true device_type=mobile os_name=iOS os_version=18.1 os_build_id=22G91 os_detail="iOS 18.1 (22G91)" view_name=foobar
+            spanId: 562474ddde25561b
+            traceId: 46d38efbe623342af29992782992000a
+          - attributes:
+              - key: kind
+                value:
+                  stringValue: log
+            body:
+              stringValue: timestamp=2021-09-30T10:46:17.68Z kind=log level=trace message="loading price list" context_component=AppRoot context_page=Pricing traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production app_installation_id=install-abc-123 user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false device_manufacturer=Apple device_model_identifier=iPhone14,5 device_model_name="iPhone 13" device_brand=iPhone device_is_physical=true device_type=mobile os_name=iOS os_version=18.1 os_build_id=22G91 os_detail="iOS 18.1 (22G91)" view_name=foobar
+            spanId: 562474ddde25561b
+            traceId: 46d38efbe623342af29992782992000a
+          - attributes:
+              - key: kind
+                value:
+                  stringValue: exception
+              - key: hash
+                value:
+                  stringValue: "7881982385208174497"
+            body:
+              stringValue: 'timestamp=2021-09-30T10:46:17.68Z kind=exception level=error type=Error value="Cannot read property ''find'' of undefined" fatal=true stacktrace="Error: Cannot read property ''find'' of undefined\n  at ? (http://fe:3002/static/js/vendors~main.chunk.js:8639:42)\n  at dispatchAction (http://fe:3002/static/js/vendors~main.chunk.js:268095:9)\n  at scheduleUpdateOnFiber (http://fe:3002/static/js/vendors~main.chunk.js:273726:13)\n  at flushSyncCallbackQueue (http://fe:3002/static/js/vendors~main.chunk.js:263362:7)\n  at flushSyncCallbackQueueImpl (http://fe:3002/static/js/vendors~main.chunk.js:263374:13)\n  at runWithPriority$1 (http://fe:3002/static/js/vendors~main.chunk.js:263325:14)\n  at unstable_runWithPriority (http://fe:3002/static/js/vendors~main.chunk.js:291265:16)\n  at ? (http://fe:3002/static/js/vendors~main.chunk.js:263379:30)\n  at performSyncWorkOnRoot (http://fe:3002/static/js/vendors~main.chunk.js:274126:22)\n  at renderRootSync (http://fe:3002/static/js/vendors~main.chunk.js:274509:11)\n  at workLoopSync (http://fe:3002/static/js/vendors~main.chunk.js:274543:9)\n  at performUnitOfWork (http://fe:3002/static/js/vendors~main.chunk.js:274606:16)\n  at beginWork$1 (http://fe:3002/static/js/vendors~main.chunk.js:275746:18)\n  at beginWork (http://fe:3002/static/js/vendors~main.chunk.js:270944:20)\n  at updateFunctionComponent (http://fe:3002/static/js/vendors~main.chunk.js:269291:24)\n  at renderWithHooks (http://fe:3002/static/js/vendors~main.chunk.js:266969:22)\n  at ? (http://fe:3002/static/js/main.chunk.js:2600:74)\n  at useGetBooksQuery (http://fe:3002/static/js/main.chunk.js:1299:65)\n  at Module.useQuery (http://fe:3002/static/js/vendors~main.chunk.js:8495:85)\n  at useBaseQuery (http://fe:3002/static/js/vendors~main.chunk.js:8656:83)\n  at useDeepMemo (http://fe:3002/static/js/vendors~main.chunk.js:8696:14)\n  at ? (http://fe:3002/static/js/vendors~main.chunk.js:8657:55)\n  at QueryData.execute (http://fe:3002/static/js/vendors~main.chunk.js:7883:47)\n  at QueryData.getExecuteResult (http://fe:3002/static/js/vendors~main.chunk.js:7944:23)\n  at QueryData._this.getQueryResult (http://fe:3002/static/js/vendors~main.chunk.js:7790:19)\n  at new ApolloError (http://fe:3002/static/js/vendors~main.chunk.js:5164:24)" traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b context_ReactError="Annoying Error" context_component=ReactErrorBoundary sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production app_installation_id=install-abc-123 user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false device_manufacturer=Apple device_model_identifier=iPhone14,5 device_model_name="iPhone 13" device_brand=iPhone device_is_physical=true device_type=mobile os_name=iOS os_version=18.1 os_build_id=22G91 os_detail="iOS 18.1 (22G91)" view_name=foobar'
+            spanId: 562474ddde25561b
+            traceId: 46d38efbe623342af29992782992000a
+          - attributes:
+              - key: kind
+                value:
+                  stringValue: measurement
+            body:
+              stringValue: timestamp=2021-09-30T10:46:17.68Z kind=measurement level=info type="page load" context_hello=world ttfb=14.000000 ttfcp=22.120000 ttfp=20.120000 traceID=46d38efbe623342af29992782992000a spanID=562474ddde25561b value_ttfb=14 value_ttfcp=22.12 value_ttfp=20.12 sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production app_installation_id=install-abc-123 user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false device_manufacturer=Apple device_model_identifier=iPhone14,5 device_model_name="iPhone 13" device_brand=iPhone device_is_physical=true device_type=mobile os_name=iOS os_version=18.1 os_build_id=22G91 os_detail="iOS 18.1 (22G91)" view_name=foobar
+            spanId: 562474ddde25561b
+            traceId: 46d38efbe623342af29992782992000a
+          - attributes:
+              - key: kind
+                value:
+                  stringValue: event
+            body:
+              stringValue: timestamp=2023-11-16T10:00:55.995Z kind=event level=info event_name=faro.performanceEntry event_domain=browser event_data_connectEnd=3656 event_data_connectStart=337 event_data_decodedBodySize=0 event_data_domainLookupEnd=590 event_data_domainLookupStart=588 event_data_duration=3371 event_data_encodedBodySize=0 event_data_entryType=resource event_data_fetchStart=331 event_data_initiatorType=other event_data_name=https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css.map event_data_nextHopProtocol=h2 event_data_redirectEnd=0 event_data_redirectStart=0 event_data_requestStart=3656 event_data_responseEnd=3702 event_data_responseStart=3690 event_data_secureConnectionStart=3638 event_data_serverTiming=[] event_data_startTime=331 event_data_transferSize=0 event_data_workerStart=0 sdk_name=grafana-frontend-agent sdk_version=1.3.5 app_name=testapp app_namespace=testnamespace app_release=0.8.2 app_version=abcdefg app_environment=production app_installation_id=install-abc-123 user_email=geralt@kaermorhen.org user_id=123 user_username=testuser user_attr_foo=bar session_id=abcd session_attr_time_elapsed=100s page_url=https://example.com/page browser_name=chrome browser_version=88.12.1 browser_os=linux browser_mobile=false device_manufacturer=Apple device_model_identifier=iPhone14,5 device_model_name="iPhone 13" device_brand=iPhone device_is_physical=true device_type=mobile os_name=iOS os_version=18.1 os_build_id=22G91 os_detail="iOS 18.1 (22G91)" view_name=foobar
+        scope: {}

--- a/receiver/faroreceiver/go.mod
+++ b/receiver/faroreceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/farore
 go 1.25.0
 
 require (
-	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc
+	github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component/componentstatus v0.150.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/config/confighttp v0.150.1-0.20260415114935-307e3abdbae9
@@ -40,7 +40,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oapi-codegen/runtime v1.3.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.150.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/receiver/faroreceiver/go.sum
+++ b/receiver/faroreceiver/go.sum
@@ -41,8 +41,8 @@ github.com/google/go-tpm-tools v0.4.7/go.mod h1:gSyXTZHe3fgbzb6WEGd90QucmsnT1SRd
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc h1:o8BraeLtggPjb/n91jvQT4SgGn8j0jxOyIGEQSoIXwU=
-github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc/go.mod h1:4CP5sfwz5+uVfNgCeA5/N6csXnzOgnkgT1jh57ASaK4=
+github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0 h1:Fn+bnFLPyiwdEyHBglm9ecq8lyZoSC+3j+lQ+VloW6k=
+github.com/grafana/faro/pkg/go v0.0.0-20260417105458-85a56593ffb0/go.mod h1:vdBM4aXmP5ugU5uBnBVOMVzr/JUWk92PkKP9kW7BKfg=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -74,8 +74,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
-github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oapi-codegen/runtime v1.3.1 h1:RgDY6J4OGQLbRXhG/Xpt3vSVqYpHQS7hN4m85+5xB9g=
+github.com/oapi-codegen/runtime v1.3.1/go.mod h1:kOdeacKy7t40Rclb1je37ZLFboFxh+YLy0zaPCMibPY=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
#### Description

Extends `pkg/translator/faro` to carry four new Faro payload fields through the logfmt round-trip:

- `Meta.Device`
- `Meta.OS`
- `App.InstallationID`
- `Exception.Fatal`

These were added to Faro payload for better mobile use case support.

#### Link to tracking issue

Fixes #47708

#### Testing

Unit tests for `extractDeviceFromKeyVal` (happy path + invalid bool), `extractOSFromKeyVal`, `extractAppFromKeyVal` (InstallationID), and `extractExceptionFromKeyVal` (Fatal absent / true / false / invalid). The general testdata fixture (`payload.json` + `plogs.yaml`) is updated to cover the new fields end-to-end.