### PR TITLE
[pkg/batchperresourceattr] Add WithMetadataInjection option

### DIFF
--- a/.chloggen/batchperresourceattr-metadata-injection.yaml
+++ b/.chloggen/batchperresourceattr-metadata-injection.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pkg/batchperresourceattr
+note: Add `WithMetadataInjection()` option to inject batched resource attribute values as `client.Metadata` into the context passed to the next consumer.
+issues: [47695]
+change_logs: [api]

--- a/pkg/batchperresourceattr/batchperresourceattr.go
+++ b/pkg/batchperresourceattr/batchperresourceattr.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -16,22 +18,59 @@ import (
 
 var separator = string([]byte{0x0, 0x1})
 
-type batchTraces struct {
-	attrKeys []string
-	next     consumer.Traces
+// Option configures a batch consumer created by this package.
+type Option func(*options)
+
+type options struct {
+	injectMetadata bool
 }
 
-func NewBatchPerResourceTraces(attrKey string, next consumer.Traces) consumer.Traces {
-	return &batchTraces{
-		attrKeys: []string{attrKey},
-		next:     next,
+// WithMetadataInjection enables injecting the batched resource attribute
+// values as client.Metadata into the context before forwarding each
+// sub-batch to the next consumer. This allows downstream components (e.g.
+// an exporterhelper batcher with Partition.MetadataKeys configured) to
+// partition requests by the same keys used for batching.
+func WithMetadataInjection() Option {
+	return func(o *options) {
+		o.injectMetadata = true
 	}
 }
 
-func NewMultiBatchPerResourceTraces(attrKeys []string, next consumer.Traces) consumer.Traces {
+// injectAttrMetadata returns a new context with client.Metadata populated
+// from the given attribute map for the specified keys. Keys absent from the
+// map are omitted. If no keys are found the original context is returned.
+func injectAttrMetadata(ctx context.Context, attrs pcommon.Map, attrKeys []string) context.Context {
+	meta := map[string][]string{}
+	for _, k := range attrKeys {
+		if v, ok := attrs.Get(k); ok {
+			meta[k] = []string{v.Str()}
+		}
+	}
+	if len(meta) == 0 {
+		return ctx
+	}
+	return client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(meta)})
+}
+
+type batchTraces struct {
+	attrKeys       []string
+	injectMetadata bool
+	next           consumer.Traces
+}
+
+func NewBatchPerResourceTraces(attrKey string, next consumer.Traces, opts ...Option) consumer.Traces {
+	return NewMultiBatchPerResourceTraces([]string{attrKey}, next, opts...)
+}
+
+func NewMultiBatchPerResourceTraces(attrKeys []string, next consumer.Traces, opts ...Option) consumer.Traces {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return &batchTraces{
-		attrKeys: attrKeys,
-		next:     next,
+		attrKeys:       attrKeys,
+		injectMetadata: o.injectMetadata,
+		next:           next,
 	}
 }
 
@@ -45,6 +84,9 @@ func (bt *batchTraces) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 	lenRss := rss.Len()
 	// If zero or one resource spans just call next.
 	if lenRss <= 1 {
+		if bt.injectMetadata && lenRss == 1 {
+			ctx = injectAttrMetadata(ctx, rss.At(0).Resource().Attributes(), bt.attrKeys)
+		}
 		return bt.next.ConsumeTraces(ctx, td)
 	}
 
@@ -63,6 +105,9 @@ func (bt *batchTraces) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 	}
 	// If there is a single attribute value, then call next.
 	if len(indicesByAttr) <= 1 {
+		if bt.injectMetadata {
+			ctx = injectAttrMetadata(ctx, rss.At(0).Resource().Attributes(), bt.attrKeys)
+		}
 		return bt.next.ConsumeTraces(ctx, td)
 	}
 
@@ -74,27 +119,34 @@ func (bt *batchTraces) ConsumeTraces(ctx context.Context, td ptrace.Traces) erro
 			rs := rss.At(i)
 			rs.CopyTo(tracesForAttr.ResourceSpans().AppendEmpty())
 		}
-		errs = multierr.Append(errs, bt.next.ConsumeTraces(ctx, tracesForAttr))
+		callCtx := ctx
+		if bt.injectMetadata {
+			callCtx = injectAttrMetadata(ctx, rss.At(indices[0]).Resource().Attributes(), bt.attrKeys)
+		}
+		errs = multierr.Append(errs, bt.next.ConsumeTraces(callCtx, tracesForAttr))
 	}
 	return errs
 }
 
 type batchMetrics struct {
-	attrKeys []string
-	next     consumer.Metrics
+	attrKeys       []string
+	injectMetadata bool
+	next           consumer.Metrics
 }
 
-func NewBatchPerResourceMetrics(attrKey string, next consumer.Metrics) consumer.Metrics {
-	return &batchMetrics{
-		attrKeys: []string{attrKey},
-		next:     next,
+func NewBatchPerResourceMetrics(attrKey string, next consumer.Metrics, opts ...Option) consumer.Metrics {
+	return NewMultiBatchPerResourceMetrics([]string{attrKey}, next, opts...)
+}
+
+func NewMultiBatchPerResourceMetrics(attrKeys []string, next consumer.Metrics, opts ...Option) consumer.Metrics {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
 	}
-}
-
-func NewMultiBatchPerResourceMetrics(attrKeys []string, next consumer.Metrics) consumer.Metrics {
 	return &batchMetrics{
-		attrKeys: attrKeys,
-		next:     next,
+		attrKeys:       attrKeys,
+		injectMetadata: o.injectMetadata,
+		next:           next,
 	}
 }
 
@@ -108,6 +160,9 @@ func (bt *batchMetrics) ConsumeMetrics(ctx context.Context, td pmetric.Metrics) 
 	lenRms := rms.Len()
 	// If zero or one resource metrics just call next.
 	if lenRms <= 1 {
+		if bt.injectMetadata && lenRms == 1 {
+			ctx = injectAttrMetadata(ctx, rms.At(0).Resource().Attributes(), bt.attrKeys)
+		}
 		return bt.next.ConsumeMetrics(ctx, td)
 	}
 
@@ -124,6 +179,9 @@ func (bt *batchMetrics) ConsumeMetrics(ctx context.Context, td pmetric.Metrics) 
 	}
 	// If there is a single attribute value, then call next.
 	if len(indicesByAttr) <= 1 {
+		if bt.injectMetadata {
+			ctx = injectAttrMetadata(ctx, rms.At(0).Resource().Attributes(), bt.attrKeys)
+		}
 		return bt.next.ConsumeMetrics(ctx, td)
 	}
 
@@ -135,27 +193,34 @@ func (bt *batchMetrics) ConsumeMetrics(ctx context.Context, td pmetric.Metrics) 
 			rm := rms.At(i)
 			rm.CopyTo(metricsForAttr.ResourceMetrics().AppendEmpty())
 		}
-		errs = multierr.Append(errs, bt.next.ConsumeMetrics(ctx, metricsForAttr))
+		callCtx := ctx
+		if bt.injectMetadata {
+			callCtx = injectAttrMetadata(ctx, rms.At(indices[0]).Resource().Attributes(), bt.attrKeys)
+		}
+		errs = multierr.Append(errs, bt.next.ConsumeMetrics(callCtx, metricsForAttr))
 	}
 	return errs
 }
 
 type batchLogs struct {
-	attrKeys []string
-	next     consumer.Logs
+	attrKeys       []string
+	injectMetadata bool
+	next           consumer.Logs
 }
 
-func NewBatchPerResourceLogs(attrKey string, next consumer.Logs) consumer.Logs {
-	return &batchLogs{
-		attrKeys: []string{attrKey},
-		next:     next,
+func NewBatchPerResourceLogs(attrKey string, next consumer.Logs, opts ...Option) consumer.Logs {
+	return NewMultiBatchPerResourceLogs([]string{attrKey}, next, opts...)
+}
+
+func NewMultiBatchPerResourceLogs(attrKeys []string, next consumer.Logs, opts ...Option) consumer.Logs {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
 	}
-}
-
-func NewMultiBatchPerResourceLogs(attrKeys []string, next consumer.Logs) consumer.Logs {
 	return &batchLogs{
-		attrKeys: attrKeys,
-		next:     next,
+		attrKeys:       attrKeys,
+		injectMetadata: o.injectMetadata,
+		next:           next,
 	}
 }
 
@@ -169,6 +234,9 @@ func (bt *batchLogs) ConsumeLogs(ctx context.Context, td plog.Logs) error {
 	lenRls := rls.Len()
 	// If zero or one resource logs just call next.
 	if lenRls <= 1 {
+		if bt.injectMetadata && lenRls == 1 {
+			ctx = injectAttrMetadata(ctx, rls.At(0).Resource().Attributes(), bt.attrKeys)
+		}
 		return bt.next.ConsumeLogs(ctx, td)
 	}
 
@@ -185,6 +253,9 @@ func (bt *batchLogs) ConsumeLogs(ctx context.Context, td plog.Logs) error {
 	}
 	// If there is a single attribute value, then call next.
 	if len(indicesByAttr) <= 1 {
+		if bt.injectMetadata {
+			ctx = injectAttrMetadata(ctx, rls.At(0).Resource().Attributes(), bt.attrKeys)
+		}
 		return bt.next.ConsumeLogs(ctx, td)
 	}
 
@@ -196,7 +267,11 @@ func (bt *batchLogs) ConsumeLogs(ctx context.Context, td plog.Logs) error {
 			rl := rls.At(i)
 			rl.CopyTo(logsForAttr.ResourceLogs().AppendEmpty())
 		}
-		errs = multierr.Append(errs, bt.next.ConsumeLogs(ctx, logsForAttr))
+		callCtx := ctx
+		if bt.injectMetadata {
+			callCtx = injectAttrMetadata(ctx, rls.At(indices[0]).Resource().Attributes(), bt.attrKeys)
+		}
+		errs = multierr.Append(errs, bt.next.ConsumeLogs(callCtx, logsForAttr))
 	}
 	return errs
 }

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -463,7 +463,7 @@ type ctxTracesSink struct {
 	consumertest.TracesSink
 }
 
-func (_ *ctxTracesSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (*ctxTracesSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 func (s *ctxTracesSink) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	s.contexts = append(s.contexts, ctx)
 	return s.TracesSink.ConsumeTraces(ctx, td)
@@ -475,7 +475,7 @@ type ctxMetricsSink struct {
 	consumertest.MetricsSink
 }
 
-func (_ *ctxMetricsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (*ctxMetricsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 func (s *ctxMetricsSink) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	s.contexts = append(s.contexts, ctx)
 	return s.MetricsSink.ConsumeMetrics(ctx, md)
@@ -487,7 +487,7 @@ type ctxLogsSink struct {
 	consumertest.LogsSink
 }
 
-func (_ *ctxLogsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (*ctxLogsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 func (s *ctxLogsSink) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	s.contexts = append(s.contexts, ctx)
 	return s.LogsSink.ConsumeLogs(ctx, ld)

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -463,7 +463,7 @@ type ctxTracesSink struct {
 	consumertest.TracesSink
 }
 
-func (s *ctxTracesSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (_ *ctxTracesSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 func (s *ctxTracesSink) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	s.contexts = append(s.contexts, ctx)
 	return s.TracesSink.ConsumeTraces(ctx, td)
@@ -475,7 +475,7 @@ type ctxMetricsSink struct {
 	consumertest.MetricsSink
 }
 
-func (s *ctxMetricsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (_ *ctxMetricsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 func (s *ctxMetricsSink) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	s.contexts = append(s.contexts, ctx)
 	return s.MetricsSink.ConsumeMetrics(ctx, md)
@@ -487,7 +487,7 @@ type ctxLogsSink struct {
 	consumertest.LogsSink
 }
 
-func (s *ctxLogsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (_ *ctxLogsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 func (s *ctxLogsSink) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	s.contexts = append(s.contexts, ctx)
 	return s.LogsSink.ConsumeLogs(ctx, ld)

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -4,6 +4,7 @@
 package batchperresourceattr
 
 import (
+	"context"
 	"errors"
 	"math/rand/v2"
 	"sort"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -452,6 +455,173 @@ func fillResourceLogs(rs plog.ResourceLogs, kv ...string) {
 	firstLogRecord.SetFlags(plog.LogRecordFlags(rand.Int32()))
 	secondLogRecord := ils.LogRecords().AppendEmpty()
 	secondLogRecord.SetFlags(plog.LogRecordFlags(rand.Int32()))
+}
+
+// ctxTracesSink records the context passed to each ConsumeTraces call.
+type ctxTracesSink struct {
+	contexts []context.Context
+	consumertest.TracesSink
+}
+
+func (s *ctxTracesSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (s *ctxTracesSink) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	s.contexts = append(s.contexts, ctx)
+	return s.TracesSink.ConsumeTraces(ctx, td)
+}
+
+// ctxMetricsSink records the context passed to each ConsumeMetrics call.
+type ctxMetricsSink struct {
+	contexts []context.Context
+	consumertest.MetricsSink
+}
+
+func (s *ctxMetricsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (s *ctxMetricsSink) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	s.contexts = append(s.contexts, ctx)
+	return s.MetricsSink.ConsumeMetrics(ctx, md)
+}
+
+// ctxLogsSink records the context passed to each ConsumeLogs call.
+type ctxLogsSink struct {
+	contexts []context.Context
+	consumertest.LogsSink
+}
+
+func (s *ctxLogsSink) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (s *ctxLogsSink) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	s.contexts = append(s.contexts, ctx)
+	return s.LogsSink.ConsumeLogs(ctx, ld)
+}
+
+func TestWithMetadataInjectionTraces(t *testing.T) {
+	t.Run("single resource injects metadata", func(t *testing.T) {
+		inBatch := ptrace.NewTraces()
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "val1")
+
+		sink := &ctxTracesSink{}
+		bpr := NewBatchPerResourceTraces("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeTraces(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 1)
+		meta := client.FromContext(sink.contexts[0]).Metadata
+		assert.Equal(t, []string{"val1"}, meta.Get("attr_key"))
+	})
+
+	t.Run("multiple resources same value injects shared metadata", func(t *testing.T) {
+		inBatch := ptrace.NewTraces()
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "shared")
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "shared")
+
+		sink := &ctxTracesSink{}
+		bpr := NewBatchPerResourceTraces("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeTraces(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 1)
+		assert.Equal(t, []string{"shared"}, client.FromContext(sink.contexts[0]).Metadata.Get("attr_key"))
+	})
+
+	t.Run("multiple resources different values each batch gets own metadata", func(t *testing.T) {
+		inBatch := ptrace.NewTraces()
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "a")
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "b")
+
+		sink := &ctxTracesSink{}
+		bpr := NewBatchPerResourceTraces("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeTraces(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 2)
+		vals := []string{
+			client.FromContext(sink.contexts[0]).Metadata.Get("attr_key")[0],
+			client.FromContext(sink.contexts[1]).Metadata.Get("attr_key")[0],
+		}
+		assert.ElementsMatch(t, []string{"a", "b"}, vals)
+	})
+
+	t.Run("no metadata when option not set", func(t *testing.T) {
+		inBatch := ptrace.NewTraces()
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "attr_key", "val1")
+
+		sink := &ctxTracesSink{}
+		bpr := NewBatchPerResourceTraces("attr_key", sink)
+		require.NoError(t, bpr.ConsumeTraces(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 1)
+		assert.Empty(t, client.FromContext(sink.contexts[0]).Metadata.Get("attr_key"))
+	})
+
+	t.Run("key absent from resource omitted from metadata", func(t *testing.T) {
+		inBatch := ptrace.NewTraces()
+		fillResourceSpans(inBatch.ResourceSpans().AppendEmpty(), "other_key", "val")
+
+		sink := &ctxTracesSink{}
+		bpr := NewBatchPerResourceTraces("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeTraces(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 1)
+		assert.Empty(t, client.FromContext(sink.contexts[0]).Metadata.Get("attr_key"))
+	})
+}
+
+func TestWithMetadataInjectionMetrics(t *testing.T) {
+	t.Run("single resource injects metadata", func(t *testing.T) {
+		inBatch := pmetric.NewMetrics()
+		fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "val1")
+
+		sink := &ctxMetricsSink{}
+		bpr := NewBatchPerResourceMetrics("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeMetrics(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 1)
+		assert.Equal(t, []string{"val1"}, client.FromContext(sink.contexts[0]).Metadata.Get("attr_key"))
+	})
+
+	t.Run("multiple resources different values each batch gets own metadata", func(t *testing.T) {
+		inBatch := pmetric.NewMetrics()
+		fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "a")
+		fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", "b")
+
+		sink := &ctxMetricsSink{}
+		bpr := NewBatchPerResourceMetrics("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeMetrics(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 2)
+		vals := []string{
+			client.FromContext(sink.contexts[0]).Metadata.Get("attr_key")[0],
+			client.FromContext(sink.contexts[1]).Metadata.Get("attr_key")[0],
+		}
+		assert.ElementsMatch(t, []string{"a", "b"}, vals)
+	})
+}
+
+func TestWithMetadataInjectionLogs(t *testing.T) {
+	t.Run("single resource injects metadata", func(t *testing.T) {
+		inBatch := plog.NewLogs()
+		fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "val1")
+
+		sink := &ctxLogsSink{}
+		bpr := NewBatchPerResourceLogs("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeLogs(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 1)
+		assert.Equal(t, []string{"val1"}, client.FromContext(sink.contexts[0]).Metadata.Get("attr_key"))
+	})
+
+	t.Run("multiple resources different values each batch gets own metadata", func(t *testing.T) {
+		inBatch := plog.NewLogs()
+		fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "a")
+		fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", "b")
+
+		sink := &ctxLogsSink{}
+		bpr := NewBatchPerResourceLogs("attr_key", sink, WithMetadataInjection())
+		require.NoError(t, bpr.ConsumeLogs(t.Context(), inBatch))
+
+		require.Len(t, sink.contexts, 2)
+		vals := []string{
+			client.FromContext(sink.contexts[0]).Metadata.Get("attr_key")[0],
+			client.FromContext(sink.contexts[1]).Metadata.Get("attr_key")[0],
+		}
+		assert.ElementsMatch(t, []string{"a", "b"}, vals)
+	})
 }
 
 func BenchmarkBatchPerResourceTraces(b *testing.B) {

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/collector/client v1.56.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/consumer v1.56.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/consumer/consumertest v0.150.1-0.20260415114935-307e3abdbae9
 	go.opentelemetry.io/collector/pdata v1.56.1-0.20260415114935-307e3abdbae9

--- a/pkg/batchperresourceattr/go.sum
+++ b/pkg/batchperresourceattr/go.sum
@@ -26,6 +26,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.opentelemetry.io/collector/client v1.56.1-0.20260415114935-307e3abdbae9 h1:qaxVLASxLeP5bOIqCnRNRSG9oEWLqTMFYo3DML42leA=
+go.opentelemetry.io/collector/client v1.56.1-0.20260415114935-307e3abdbae9/go.mod h1:YuTzJMXKK5rZ22Qii6J7FmkM7o90U+bLwy+KXI41XYM=
 go.opentelemetry.io/collector/consumer v1.56.1-0.20260415114935-307e3abdbae9 h1:qCKwxOp1z45u46MT8ClkYvDR9bwhVfw/HX9DiTLEkng=
 go.opentelemetry.io/collector/consumer v1.56.1-0.20260415114935-307e3abdbae9/go.mod h1:FpnfeTLQAdcOtzrkQ36Z+E5aconIymkv9xpJuAdLvy0=
 go.opentelemetry.io/collector/consumer/consumertest v0.150.1-0.20260415114935-307e3abdbae9 h1:LvAok9boau4UhPXLGzP7rRRUJ2Yxn1xCrJsu863hQEA=


### PR DESCRIPTION
Updates #47695

Adds an optional WithMetadataInjection() functional option that injects the batched resource attribute values as client.Metadata into the context before forwarding each sub-batch to the next consumer.

This allows downstream components such as an exporterhelper batcher with Partition.MetadataKeys configured to partition requests by the same keys used for batching without requiring a separate middleware.