### PR TITLE
prometheusexporter: drop delta metrics

### DIFF
--- a/.chloggen/prom-delta-drop.yaml
+++ b/.chloggen/prom-delta-drop.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate support for delta metrics. Use the deltatocumulative processor instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47721]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter/internal/metadata"
 )
 
 // stringBuilderPool is a pool of strings.Builder instances to reduce allocations
@@ -199,6 +201,11 @@ func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, scopeName, s
 		return n
 	}
 
+	if metadata.ExporterPrometheusexporterDropDeltaMetricsFeatureGate.IsEnabled() && doubleSum.AggregationTemporality() == pmetric.AggregationTemporalityDelta {
+		a.logger.Debug("dropping delta sum metric", zap.String("metric_name", metric.Name()))
+		return 0
+	}
+
 	// Drop non-monotonic and non-cumulative metrics
 	if doubleSum.AggregationTemporality() == pmetric.AggregationTemporalityDelta && !doubleSum.IsMonotonic() {
 		a.logger.Debug("refusing non-monotonic delta sum metric",
@@ -258,6 +265,12 @@ func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, scopeName, s
 
 func (a *lastValueAccumulator) accumulateHistogram(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) (n int) {
 	histogram := metric.Histogram()
+
+	if metadata.ExporterPrometheusexporterDropDeltaMetricsFeatureGate.IsEnabled() && histogram.AggregationTemporality() == pmetric.AggregationTemporalityDelta {
+		a.logger.Debug("dropping delta histogram metric", zap.String("metric_name", metric.Name()))
+		return 0
+	}
+
 	a.logger.Debug("Accumulate histogram.....")
 	dps := histogram.DataPoints()
 
@@ -327,6 +340,12 @@ func (a *lastValueAccumulator) accumulateHistogram(metric pmetric.Metric, scopeN
 
 func (a *lastValueAccumulator) accumulateExponentialHistogram(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) (n int) {
 	expHistogram := metric.ExponentialHistogram()
+
+	if metadata.ExporterPrometheusexporterDropDeltaMetricsFeatureGate.IsEnabled() && expHistogram.AggregationTemporality() == pmetric.AggregationTemporalityDelta {
+		a.logger.Debug("dropping delta exponential histogram metric", zap.String("metric_name", metric.Name()))
+		return 0
+	}
+
 	a.logger.Debug("Accumulate native histogram.....")
 	dps := expHistogram.DataPoints()
 

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
@@ -1135,4 +1136,58 @@ func TestAccumulateSum_RefusedNonMonotonicDelta_Logging(t *testing.T) {
 	require.Equal(t, "test_refused_metric", fieldMap["metric_name"])
 	require.Equal(t, "non-monotonic sum with delta aggregation temporality is not supported", fieldMap["reason"])
 	require.Equal(t, int64(2), fieldMap["data_points_refused"])
+}
+
+func TestAccumulateDeltaMetrics_FeatureGateEnabled(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("exporter.prometheusexporter.DropDeltaMetrics", true)
+	require.NoError(t, err)
+	defer func() { _ = featuregate.GlobalRegistry().Set("exporter.prometheusexporter.DropDeltaMetrics", false) }()
+
+	tests := []struct {
+		name       string
+		fillMetric func(pmetric.Metric)
+	}{
+		{
+			name: "DeltaSum",
+			fillMetric: func(metric pmetric.Metric) {
+				metric.SetName("test_metric")
+				metric.SetEmptySum().SetIsMonotonic(true)
+				metric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				dp := metric.Sum().DataPoints().AppendEmpty()
+				dp.SetIntValue(42)
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			},
+		},
+		{
+			name: "DeltaHistogram",
+			fillMetric: func(metric pmetric.Metric) {
+				metric.SetName("test_metric")
+				metric.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				dp := metric.Histogram().DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			},
+		},
+		{
+			name: "DeltaExponentialHistogram",
+			fillMetric: func(metric pmetric.Metric) {
+				metric.SetName("test_metric")
+				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceMetrics := pmetric.NewResourceMetrics()
+			ilm := resourceMetrics.ScopeMetrics().AppendEmpty()
+			ilm.Scope().SetName("test")
+			tt.fillMetric(ilm.Metrics().AppendEmpty())
+
+			a := newAccumulator(zap.NewNop(), 1*time.Hour).(*lastValueAccumulator)
+			n := a.Accumulate(resourceMetrics)
+			require.Equal(t, 0, n)
+		})
+	}
 }

--- a/exporter/prometheusexporter/documentation.md
+++ b/exporter/prometheusexporter/documentation.md
@@ -9,5 +9,6 @@ This component has the following feature gates:
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
 | `exporter.prometheusexporter.DisableAddMetricSuffixes` | alpha | When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used | v0.132.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-specification/pull/4533) |
+| `exporter.prometheusexporter.DropDeltaMetrics` | alpha | When enabled, drops all metrics with Delta aggregation temporality. Users should use the deltatocumulative processor instead. | v0.151.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47721) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
+++ b/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
@@ -13,3 +13,11 @@ var ExporterPrometheusexporterDisableAddMetricSuffixesFeatureGate = featuregate.
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-specification/pull/4533"),
 	featuregate.WithRegisterFromVersion("v0.132.0"),
 )
+
+var ExporterPrometheusexporterDropDeltaMetricsFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.prometheusexporter.DropDeltaMetrics",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, drops all metrics with Delta aggregation temporality. Users should use the deltatocumulative processor instead."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47721"),
+	featuregate.WithRegisterFromVersion("v0.151.0"),
+)

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -17,6 +17,11 @@ feature_gates:
     stage: alpha
     from_version: "v0.132.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-specification/pull/4533
+  - id: exporter.prometheusexporter.DropDeltaMetrics
+    description: When enabled, drops all metrics with Delta aggregation temporality. Users should use the deltatocumulative processor instead.
+    stage: alpha
+    from_version: "v0.151.0"
+    reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47721
 
 tests:
   config:


### PR DESCRIPTION
#### Description

We are considering removing language in the spec that suggests converting delta to cumulative in prometheus exporters.  This would be the first step in that direction.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47721

#### Testing

Added a unit test for when the feature gate is enabled.

#### Documentation

Updated the README.md