### PR TITLE
[exporter/prometheus] Document native histogram support

### DIFF
--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -64,6 +64,14 @@ exporters:
 
 Given the example, metrics will be available at `https://1.2.3.4:1234/metrics`.
 
+### Native Histograms
+
+The exporter supports [Prometheus native histograms](https://prometheus.io/docs/concepts/native_histograms/). OpenTelemetry exponential histograms are automatically converted to the Prometheus native histogram format.
+
+To scrape native histograms, configure your Prometheus server to [scrape using protobuf format](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-native-histograms) and to accept native histograms.
+
+Note that this exporter does not currently support exemplars for native histograms.
+
 ### Feature gates
 
 There are also flags that control translation behavior. [See the documentation for the Prometheus translator module](../../pkg/translator/prometheus/) for more information.


### PR DESCRIPTION
## Summary

Documents native histogram support in the Prometheus exporter README.

Fixes #47160

## Changes

Added a "Native Histograms" section to the README that documents:
- Exponential histograms are automatically converted to Prometheus native histogram format
- `enable_open_metrics: true` is required (protobuf content negotiation)
- Prometheus server must be configured to accept native histograms
- Exemplars are currently not supported for native histograms