### PR TITLE
[receiver/tlscheck] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46383-tlscheck-enable-reaggregation.yaml
+++ b/.chloggen/46383-tlscheck-enable-reaggregation.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: receiver/tlscheck
+
+note: Enables dynamic metric reaggregation in the TLS Check receiver. This does not break existing configuration files.
+
+issues: [46383]
+
+subtext:
+
+change_logs: [user]

--- a/.chloggen/46383-tlscheck-enable-reaggregation.yaml
+++ b/.chloggen/46383-tlscheck-enable-reaggregation.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 
-component: receiver/tlscheck
+component: receiver/tls_check
 
 note: Enables dynamic metric reaggregation in the TLS Check receiver. This does not break existing configuration files.
 

--- a/receiver/tlscheckreceiver/documentation.md
+++ b/receiver/tlscheckreceiver/documentation.md
@@ -26,7 +26,7 @@ Time in seconds until certificate expiry, as specified by `NotAfter` field in th
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | tlscheck.x509.issuer | The entity that issued the certificate. | Any Str | Recommended | - |
 | tlscheck.x509.cn | The commonName in the subject of the certificate. | Any Str | Recommended | - |
-| tlscheck.x509.san | The Subject Alternative Name of the certificate. | Any Slice | Recommended | - |
+| tlscheck.x509.san | The Subject Alternative Name of the certificate. | Any Slice | Opt-In | - |
 
 ## Resource Attributes
 

--- a/receiver/tlscheckreceiver/generated_package_test.go
+++ b/receiver/tlscheckreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package tlscheckreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/tlscheckreceiver/generated_package_test.go
+++ b/receiver/tlscheckreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package tlscheckreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/tlscheckreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/tlscheckreceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,25 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "tlscheck.x509.issuer"
+                - "tlscheck.x509.cn"
+                - "tlscheck.x509.san"
+            default:
+              - "tlscheck.x509.issuer"
+              - "tlscheck.x509.cn"
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for tls_check resource attributes.
     type: object

--- a/receiver/tlscheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,31 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// TlscheckTimeLeftMetricAttributeKey specifies the key of an attribute for the tlscheck.time_left metric.
+type TlscheckTimeLeftMetricAttributeKey string
+
+const (
+	TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer TlscheckTimeLeftMetricAttributeKey = "tlscheck.x509.issuer"
+	TlscheckTimeLeftMetricAttributeKeyTlscheckX509Cn     TlscheckTimeLeftMetricAttributeKey = "tlscheck.x509.cn"
+	TlscheckTimeLeftMetricAttributeKeyTlscheckX509San    TlscheckTimeLeftMetricAttributeKey = "tlscheck.x509.san"
+)
+
+// TlscheckTimeLeftMetricConfig provides config for the tlscheck.time_left metric.
+type TlscheckTimeLeftMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []TlscheckTimeLeftMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *TlscheckTimeLeftMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -27,15 +41,35 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+func (ms *TlscheckTimeLeftMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer, TlscheckTimeLeftMetricAttributeKeyTlscheckX509Cn, TlscheckTimeLeftMetricAttributeKeyTlscheckX509San:
+		default:
+			return fmt.Errorf("metric tlscheck.time_left doesn't have an attribute %v, valid attributes: [tlscheck.x509.issuer, tlscheck.x509.cn, tlscheck.x509.san]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MetricsConfig provides config for tls_check metrics.
 type MetricsConfig struct {
-	TlscheckTimeLeft MetricConfig `mapstructure:"tlscheck.time_left"`
+	TlscheckTimeLeft TlscheckTimeLeftMetricConfig `mapstructure:"tlscheck.time_left"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		TlscheckTimeLeft: MetricConfig{
-			Enabled: true,
+		TlscheckTimeLeft: TlscheckTimeLeftMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []TlscheckTimeLeftMetricAttributeKey{TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer, TlscheckTimeLeftMetricAttributeKeyTlscheckX509Cn},
 		},
 	}
 }

--- a/receiver/tlscheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/tlscheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,8 +27,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					TlscheckTimeLeft: MetricConfig{
-						Enabled: true,
+					TlscheckTimeLeft: TlscheckTimeLeftMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TlscheckTimeLeftMetricAttributeKey{TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer, TlscheckTimeLeftMetricAttributeKeyTlscheckX509Cn, TlscheckTimeLeftMetricAttributeKeyTlscheckX509San},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -39,8 +42,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					TlscheckTimeLeft: MetricConfig{
-						Enabled: false,
+					TlscheckTimeLeft: TlscheckTimeLeftMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TlscheckTimeLeftMetricAttributeKey{TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer, TlscheckTimeLeftMetricAttributeKeyTlscheckX509Cn, TlscheckTimeLeftMetricAttributeKeyTlscheckX509San},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -52,7 +57,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(TlscheckTimeLeftMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/tlscheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -27,9 +35,10 @@ type metricInfo struct {
 }
 
 type metricTlscheckTimeLeft struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric               // data buffer for generated metric.
+	config        TlscheckTimeLeftMetricConfig // metric config provided by user.
+	capacity      int                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills tlscheck.time_left metric with initial data.
@@ -39,19 +48,54 @@ func (m *metricTlscheckTimeLeft) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTlscheckTimeLeft) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tlscheckX509IssuerAttributeValue string, tlscheckX509CnAttributeValue string, tlscheckX509SanAttributeValue []any) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer) {
+		dp.Attributes().PutStr("tlscheck.x509.issuer", tlscheckX509IssuerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, TlscheckTimeLeftMetricAttributeKeyTlscheckX509Cn) {
+		dp.Attributes().PutStr("tlscheck.x509.cn", tlscheckX509CnAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, TlscheckTimeLeftMetricAttributeKeyTlscheckX509San) {
+		dp.Attributes().PutEmptySlice("tlscheck.x509.san").FromRaw(tlscheckX509SanAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("tlscheck.x509.issuer", tlscheckX509IssuerAttributeValue)
-	dp.Attributes().PutStr("tlscheck.x509.cn", tlscheckX509CnAttributeValue)
-	dp.Attributes().PutEmptySlice("tlscheck.x509.san").FromRaw(tlscheckX509SanAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -64,13 +108,18 @@ func (m *metricTlscheckTimeLeft) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTlscheckTimeLeft) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricTlscheckTimeLeft(cfg MetricConfig) metricTlscheckTimeLeft {
+func newMetricTlscheckTimeLeft(cfg TlscheckTimeLeftMetricConfig) metricTlscheckTimeLeft {
 	m := metricTlscheckTimeLeft{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/tlscheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["TlscheckTimeLeft"] = mb.metricTlscheckTimeLeft.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,11 +80,17 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTlscheckTimeLeftDataPoint(ts, 1, "tlscheck.x509.issuer-val", "tlscheck.x509.cn-val", []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"})
+			if tt.name == "reaggregate_set" {
+				mb.RecordTlscheckTimeLeftDataPoint(ts, 3, "tlscheck.x509.issuer-val-2", "tlscheck.x509.cn-val-2", []any{"tlscheck.x509.san-item3", "tlscheck.x509.san-item4"})
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetTlscheckTarget("tlscheck.target-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricTlscheckTimeLeft.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -102,26 +118,52 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "tlscheck.time_left":
-					assert.False(t, validatedMetrics["tlscheck.time_left"], "Found a duplicate in the metrics slice: tlscheck.time_left")
-					validatedMetrics["tlscheck.time_left"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					tlscheckX509IssuerAttrVal, ok := dp.Attributes().Get("tlscheck.x509.issuer")
-					assert.True(t, ok)
-					assert.Equal(t, "tlscheck.x509.issuer-val", tlscheckX509IssuerAttrVal.Str())
-					tlscheckX509CnAttrVal, ok := dp.Attributes().Get("tlscheck.x509.cn")
-					assert.True(t, ok)
-					assert.Equal(t, "tlscheck.x509.cn-val", tlscheckX509CnAttrVal.Str())
-					tlscheckX509SanAttrVal, ok := dp.Attributes().Get("tlscheck.x509.san")
-					assert.True(t, ok)
-					assert.Equal(t, []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"}, tlscheckX509SanAttrVal.Slice().AsRaw())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["tlscheck.time_left"], "Found a duplicate in the metrics slice: tlscheck.time_left")
+						validatedMetrics["tlscheck.time_left"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						tlscheckX509IssuerAttrVal, ok := dp.Attributes().Get("tlscheck.x509.issuer")
+						assert.True(t, ok)
+						assert.Equal(t, "tlscheck.x509.issuer-val", tlscheckX509IssuerAttrVal.Str())
+						tlscheckX509CnAttrVal, ok := dp.Attributes().Get("tlscheck.x509.cn")
+						assert.True(t, ok)
+						assert.Equal(t, "tlscheck.x509.cn-val", tlscheckX509CnAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["tlscheck.time_left"], "Found a duplicate in the metrics slice: tlscheck.time_left")
+						validatedMetrics["tlscheck.time_left"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["tlscheck.time_left"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("tlscheck.x509.issuer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("tlscheck.x509.cn")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("tlscheck.x509.san")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/tlscheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/tlscheckreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,15 @@ all_set:
   metrics:
     tlscheck.time_left:
       enabled: true
+      attributes: ["tlscheck.x509.issuer","tlscheck.x509.cn","tlscheck.x509.san"]
+  resource_attributes:
+    tlscheck.target:
+      enabled: true
+reaggregate_set:
+  metrics:
+    tlscheck.time_left:
+      enabled: true
+      attributes: []
   resource_attributes:
     tlscheck.target:
       enabled: true
@@ -10,6 +19,7 @@ none_set:
   metrics:
     tlscheck.time_left:
       enabled: false
+      attributes: ["tlscheck.x509.issuer","tlscheck.x509.cn","tlscheck.x509.san"]
   resource_attributes:
     tlscheck.target:
       enabled: false

--- a/receiver/tlscheckreceiver/metadata.yaml
+++ b/receiver/tlscheckreceiver/metadata.yaml
@@ -1,6 +1,7 @@
 display_name: TLS Check Receiver
 type: tls_check
 deprecated_type: tlscheck
+reaggregation_enabled: true
 
 description: This receiver emits metrics about x.509 certificates.
 
@@ -21,12 +22,15 @@ resource_attributes:
 attributes:
   tlscheck.x509.cn:
     description: The commonName in the subject of the certificate.
+    requirement_level: recommended
     type: string
   tlscheck.x509.issuer:
     description: The entity that issued the certificate.
+    requirement_level: recommended
     type: string
   tlscheck.x509.san:
     description: The Subject Alternative Name of the certificate.
+    requirement_level: opt_in
     type: slice
 
 metrics:


### PR DESCRIPTION
Part of #45396.

## Summary

Sets `reaggregation_enabled: true` in `metadata.yaml` and assigns requirement levels to the three x.509 certificate attributes:

| Attribute | Level | Rationale |
|-----------|-------|-----------|
| `tlscheck.x509.cn` | `recommended` | Enabled by default; identifies the cert subject |
| `tlscheck.x509.issuer` | `recommended` | Enabled by default; identifies the cert authority |
| `tlscheck.x509.san` | `opt_in` | Disabled by default; SANs can be many/verbose |

The `tlscheck.target` is already a resource attribute so no metric attribute needs `required` level.

Generated metadata files with mdatagen.

## Note

When running `mdatagen` with `recommended`/`opt_in` attributes but no `required` attribute, the generated `generated_config.go` imports `"slices"` unconditionally but never calls any `slices.*` function, causing a compile error. A fix has been submitted to the upstream mdatagen template: open-telemetry/opentelemetry-collector#15145. The files in this PR were generated with that fix applied.

## Testing

All existing `receiver/tlscheckreceiver` tests pass with the changes applied:

\`\`\`
ok  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
ok  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver/internal/metadata
\`\`\`