### PR TITLE
[exporter/splunkhec] Remove deprecated batcher config

### DIFF
--- a/.chloggen/splunkhec-remove-deprecated-batcher.yaml
+++ b/.chloggen/splunkhec-remove-deprecated-batcher.yaml
@@ -1,0 +1,5 @@
+change_type: breaking
+component: exporter/splunk_hec
+note: Remove deprecated `batcher` config field. Use `sending_queue::batch` instead.
+issues: [47737]
+change_logs: [user, api]

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	translator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/splunk"
@@ -56,22 +55,11 @@ type HecTelemetry struct {
 	ExtraAttributes map[string]string `mapstructure:"extra_attributes"`
 }
 
-type DeprecatedBatchConfig struct {
-	Enabled      bool                            `mapstructure:"enabled"`
-	FlushTimeout time.Duration                   `mapstructure:"flush_timeout"`
-	Sizer        exporterhelper.RequestSizerType `mapstructure:"sizer"`
-	MinSize      int64                           `mapstructure:"min_size"`
-	MaxSize      int64                           `mapstructure:"max_size"`
-	isSet        bool                            `mapstructure:"-"`
-}
-
 // Config defines configuration for Splunk exporter.
 type Config struct {
 	confighttp.ClientConfig   `mapstructure:",squash"`
 	QueueSettings             configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:"sending_queue"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
-	// DeprecatedBatcher is the deprecated batcher configuration.
-	DeprecatedBatcher DeprecatedBatchConfig `mapstructure:"batcher"`
 
 	// LogDataEnabled can be used to disable sending logs by the exporter.
 	LogDataEnabled bool `mapstructure:"log_data_enabled"`
@@ -140,36 +128,6 @@ type Config struct {
 
 	// Telemetry is the configuration for splunk hec exporter telemetry
 	Telemetry HecTelemetry `mapstructure:"telemetry"`
-}
-
-func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
-	if err := conf.Unmarshal(cfg); err != nil {
-		return err
-	}
-	if conf.IsSet("batcher") {
-		cfg.DeprecatedBatcher.isSet = true
-		if cfg.QueueSettings.HasValue() && cfg.QueueSettings.Get().Batch.HasValue() {
-			return errors.New(`deprecated "batcher" cannot be set along with "sending_queue::batch"`)
-		}
-		if cfg.DeprecatedBatcher.Enabled {
-			wasEnabled := cfg.QueueSettings.HasValue()
-
-			cfg.QueueSettings.GetOrInsertDefault().Batch = configoptional.Some(exporterhelper.BatchConfig{
-				FlushTimeout: cfg.DeprecatedBatcher.FlushTimeout,
-				Sizer:        cfg.DeprecatedBatcher.Sizer,
-				MinSize:      cfg.DeprecatedBatcher.MinSize,
-				MaxSize:      cfg.DeprecatedBatcher.MaxSize,
-			})
-
-			// If the deprecated batcher is enabled without a queue, enable blocking queue to replicate the
-			// behavior of the deprecated batcher.
-			if !wasEnabled {
-				cfg.QueueSettings.Get().WaitForResult = true
-			}
-		}
-	}
-
-	return nil
 }
 
 func (cfg *Config) getURL() (out *url.URL, err error) {

--- a/exporter/splunkhecexporter/config.schema.yaml
+++ b/exporter/splunkhecexporter/config.schema.yaml
@@ -1,20 +1,4 @@
 $defs:
-  deprecated_batch_config:
-    type: object
-    properties:
-      enabled:
-        type: boolean
-      flush_timeout:
-        type: string
-        format: duration
-      max_size:
-        type: integer
-        x-customType: int64
-      min_size:
-        type: integer
-        x-customType: int64
-      sizer:
-        $ref: go.opentelemetry.io/collector/exporter/exporterhelper.request_sizer_type
   hec_heartbeat:
     description: HecHeartbeat defines the heartbeat information for the exporter
     type: object
@@ -46,9 +30,6 @@ $defs:
 description: Config defines configuration for Splunk exporter.
 type: object
 properties:
-  batcher:
-    description: DeprecatedBatcher is the deprecated batcher configuration.
-    $ref: deprecated_batch_config
   disable_compression:
     description: Disable GZip compression. Defaults to false.
     type: boolean

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
@@ -103,7 +102,6 @@ func createTracesExporter(
 	config component.Config,
 ) (exporter.Traces, error) {
 	cfg := config.(*Config)
-	showDeprecationWarnings(cfg, set.Logger)
 	c := newTracesClient(set, cfg)
 
 	e, err := exporterhelper.NewTraces(
@@ -140,7 +138,6 @@ func createMetricsExporter(
 	config component.Config,
 ) (exporter.Metrics, error) {
 	cfg := config.(*Config)
-	showDeprecationWarnings(cfg, set.Logger)
 	c := newMetricsClient(set, cfg)
 
 	e, err := exporterhelper.NewMetrics(
@@ -177,7 +174,6 @@ func createLogsExporter(
 	config component.Config,
 ) (exporter exporter.Logs, err error) {
 	cfg := config.(*Config)
-	showDeprecationWarnings(cfg, set.Logger)
 	c := newLogsClient(set, cfg)
 
 	logsExporter, err := exporterhelper.NewLogs(
@@ -240,10 +236,4 @@ func hecQueueSettings(qs configoptional.Optional[exporterhelper.QueueBatchConfig
 	}
 	qCopy.Batch = configoptional.Some(bCopy)
 	return configoptional.Some(qCopy)
-}
-
-func showDeprecationWarnings(cfg *Config, logger *zap.Logger) {
-	if cfg.DeprecatedBatcher.isSet {
-		logger.Warn("The 'batcher' field is deprecated and will be removed in a future release. Use 'sending_queue::batch' instead.")
-	}
 }


### PR DESCRIPTION
Remove `batcher` field from the configuration interface which has been deprecated for a while. Users should use `sending_queue::batch` instead.

### Migrating from `batcher` to `sending_queue::batch`

The `batcher` field in `exporter/splunk_hec` has been removed. Replace it with `sending_queue::batch`.

### Before

```yaml
  exporters:
    splunk_hec:
      token: "..."
      endpoint: "https://splunk:8088"
      batcher:
        enabled: true
        flush_timeout: 200ms
        sizer: requests
        min_size: 100
        max_size: 1000
```

###  After

```yaml
  exporters:
    splunk_hec:
      token: "..."
      endpoint: "https://splunk:8088"
      sending_queue:
        batch:
          flush_timeout: 200ms
          sizer: requests
          min_size: 100
          max_size: 1000
```

If you previously used batcher without an explicit `sending_queue`, mark the queue as blocking by setting `wait_for_result` to `true`.

```yaml
  sending_queue:
    wait_for_result: true
    batch:
```