### PR TITLE
[receiver/nsxt] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46369-nsxt-enable-reaggregation.yaml
+++ b/.chloggen/46369-nsxt-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/nsxt
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the NSX-T receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46369]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/nsxtreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/nsxtreceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "class"
+            default:
+              - "class"
       nsxt.node.filesystem.usage:
         description: "NsxtNodeFilesystemUsageMetricConfig provides config for the nsxt.node.filesystem.usage metric."
         type: object
@@ -18,6 +34,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "state"
+            default:
+              - "state"
       nsxt.node.filesystem.utilization:
         description: "NsxtNodeFilesystemUtilizationMetricConfig provides config for the nsxt.node.filesystem.utilization metric."
         type: object
@@ -46,6 +78,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       nsxt.node.network.packet.count:
         description: "NsxtNodeNetworkPacketCountMetricConfig provides config for the nsxt.node.network.packet.count metric."
         type: object
@@ -53,6 +101,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+                - "type"
+            default:
+              - "direction"
+              - "type"
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for nsxt resource attributes.
     type: object

--- a/receiver/nsxtreceiver/internal/metadata/generated_config.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,29 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// NsxtNodeCPUUtilizationMetricAttributeKey specifies the key of an attribute for the nsxt.node.cpu.utilization metric.
+type NsxtNodeCPUUtilizationMetricAttributeKey string
+
+const (
+	NsxtNodeCPUUtilizationMetricAttributeKeyClass NsxtNodeCPUUtilizationMetricAttributeKey = "class"
+)
+
+// NsxtNodeCPUUtilizationMetricConfig provides config for the nsxt.node.cpu.utilization metric.
+type NsxtNodeCPUUtilizationMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []NsxtNodeCPUUtilizationMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *NsxtNodeCPUUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -27,39 +39,270 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+func (ms *NsxtNodeCPUUtilizationMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case NsxtNodeCPUUtilizationMetricAttributeKeyClass:
+		default:
+			return fmt.Errorf("metric nsxt.node.cpu.utilization doesn't have an attribute %v, valid attributes: [class]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// NsxtNodeFilesystemUsageMetricAttributeKey specifies the key of an attribute for the nsxt.node.filesystem.usage metric.
+type NsxtNodeFilesystemUsageMetricAttributeKey string
+
+const (
+	NsxtNodeFilesystemUsageMetricAttributeKeyDiskState NsxtNodeFilesystemUsageMetricAttributeKey = "state"
+)
+
+// NsxtNodeFilesystemUsageMetricConfig provides config for the nsxt.node.filesystem.usage metric.
+type NsxtNodeFilesystemUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []NsxtNodeFilesystemUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *NsxtNodeFilesystemUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *NsxtNodeFilesystemUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case NsxtNodeFilesystemUsageMetricAttributeKeyDiskState:
+		default:
+			return fmt.Errorf("metric nsxt.node.filesystem.usage doesn't have an attribute %v, valid attributes: [state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// NsxtNodeFilesystemUtilizationMetricConfig provides config for the nsxt.node.filesystem.utilization metric.
+type NsxtNodeFilesystemUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *NsxtNodeFilesystemUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// NsxtNodeMemoryCacheUsageMetricConfig provides config for the nsxt.node.memory.cache.usage metric.
+type NsxtNodeMemoryCacheUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *NsxtNodeMemoryCacheUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// NsxtNodeMemoryUsageMetricConfig provides config for the nsxt.node.memory.usage metric.
+type NsxtNodeMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *NsxtNodeMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// NsxtNodeNetworkIoMetricAttributeKey specifies the key of an attribute for the nsxt.node.network.io metric.
+type NsxtNodeNetworkIoMetricAttributeKey string
+
+const (
+	NsxtNodeNetworkIoMetricAttributeKeyDirection NsxtNodeNetworkIoMetricAttributeKey = "direction"
+)
+
+// NsxtNodeNetworkIoMetricConfig provides config for the nsxt.node.network.io metric.
+type NsxtNodeNetworkIoMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []NsxtNodeNetworkIoMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *NsxtNodeNetworkIoMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *NsxtNodeNetworkIoMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case NsxtNodeNetworkIoMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric nsxt.node.network.io doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// NsxtNodeNetworkPacketCountMetricAttributeKey specifies the key of an attribute for the nsxt.node.network.packet.count metric.
+type NsxtNodeNetworkPacketCountMetricAttributeKey string
+
+const (
+	NsxtNodeNetworkPacketCountMetricAttributeKeyDirection  NsxtNodeNetworkPacketCountMetricAttributeKey = "direction"
+	NsxtNodeNetworkPacketCountMetricAttributeKeyPacketType NsxtNodeNetworkPacketCountMetricAttributeKey = "type"
+)
+
+// NsxtNodeNetworkPacketCountMetricConfig provides config for the nsxt.node.network.packet.count metric.
+type NsxtNodeNetworkPacketCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []NsxtNodeNetworkPacketCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *NsxtNodeNetworkPacketCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *NsxtNodeNetworkPacketCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case NsxtNodeNetworkPacketCountMetricAttributeKeyDirection, NsxtNodeNetworkPacketCountMetricAttributeKeyPacketType:
+		default:
+			return fmt.Errorf("metric nsxt.node.network.packet.count doesn't have an attribute %v, valid attributes: [direction, type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MetricsConfig provides config for nsxt metrics.
 type MetricsConfig struct {
-	NsxtNodeCPUUtilization        MetricConfig `mapstructure:"nsxt.node.cpu.utilization"`
-	NsxtNodeFilesystemUsage       MetricConfig `mapstructure:"nsxt.node.filesystem.usage"`
-	NsxtNodeFilesystemUtilization MetricConfig `mapstructure:"nsxt.node.filesystem.utilization"`
-	NsxtNodeMemoryCacheUsage      MetricConfig `mapstructure:"nsxt.node.memory.cache.usage"`
-	NsxtNodeMemoryUsage           MetricConfig `mapstructure:"nsxt.node.memory.usage"`
-	NsxtNodeNetworkIo             MetricConfig `mapstructure:"nsxt.node.network.io"`
-	NsxtNodeNetworkPacketCount    MetricConfig `mapstructure:"nsxt.node.network.packet.count"`
+	NsxtNodeCPUUtilization        NsxtNodeCPUUtilizationMetricConfig        `mapstructure:"nsxt.node.cpu.utilization"`
+	NsxtNodeFilesystemUsage       NsxtNodeFilesystemUsageMetricConfig       `mapstructure:"nsxt.node.filesystem.usage"`
+	NsxtNodeFilesystemUtilization NsxtNodeFilesystemUtilizationMetricConfig `mapstructure:"nsxt.node.filesystem.utilization"`
+	NsxtNodeMemoryCacheUsage      NsxtNodeMemoryCacheUsageMetricConfig      `mapstructure:"nsxt.node.memory.cache.usage"`
+	NsxtNodeMemoryUsage           NsxtNodeMemoryUsageMetricConfig           `mapstructure:"nsxt.node.memory.usage"`
+	NsxtNodeNetworkIo             NsxtNodeNetworkIoMetricConfig             `mapstructure:"nsxt.node.network.io"`
+	NsxtNodeNetworkPacketCount    NsxtNodeNetworkPacketCountMetricConfig    `mapstructure:"nsxt.node.network.packet.count"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		NsxtNodeCPUUtilization: MetricConfig{
+		NsxtNodeCPUUtilization: NsxtNodeCPUUtilizationMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []NsxtNodeCPUUtilizationMetricAttributeKey{NsxtNodeCPUUtilizationMetricAttributeKeyClass},
+		},
+		NsxtNodeFilesystemUsage: NsxtNodeFilesystemUsageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []NsxtNodeFilesystemUsageMetricAttributeKey{NsxtNodeFilesystemUsageMetricAttributeKeyDiskState},
+		},
+		NsxtNodeFilesystemUtilization: NsxtNodeFilesystemUtilizationMetricConfig{
 			Enabled: true,
 		},
-		NsxtNodeFilesystemUsage: MetricConfig{
+		NsxtNodeMemoryCacheUsage: NsxtNodeMemoryCacheUsageMetricConfig{
 			Enabled: true,
 		},
-		NsxtNodeFilesystemUtilization: MetricConfig{
+		NsxtNodeMemoryUsage: NsxtNodeMemoryUsageMetricConfig{
 			Enabled: true,
 		},
-		NsxtNodeMemoryCacheUsage: MetricConfig{
-			Enabled: true,
+		NsxtNodeNetworkIo: NsxtNodeNetworkIoMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []NsxtNodeNetworkIoMetricAttributeKey{NsxtNodeNetworkIoMetricAttributeKeyDirection},
 		},
-		NsxtNodeMemoryUsage: MetricConfig{
-			Enabled: true,
-		},
-		NsxtNodeNetworkIo: MetricConfig{
-			Enabled: true,
-		},
-		NsxtNodeNetworkPacketCount: MetricConfig{
-			Enabled: true,
+		NsxtNodeNetworkPacketCount: NsxtNodeNetworkPacketCountMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []NsxtNodeNetworkPacketCountMetricAttributeKey{NsxtNodeNetworkPacketCountMetricAttributeKeyDirection, NsxtNodeNetworkPacketCountMetricAttributeKeyPacketType},
 		},
 	}
 }

--- a/receiver/nsxtreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_config_test.go
@@ -26,26 +26,34 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NsxtNodeCPUUtilization: MetricConfig{
+					NsxtNodeCPUUtilization: NsxtNodeCPUUtilizationMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []NsxtNodeCPUUtilizationMetricAttributeKey{NsxtNodeCPUUtilizationMetricAttributeKeyClass},
+					},
+					NsxtNodeFilesystemUsage: NsxtNodeFilesystemUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NsxtNodeFilesystemUsageMetricAttributeKey{NsxtNodeFilesystemUsageMetricAttributeKeyDiskState},
+					},
+					NsxtNodeFilesystemUtilization: NsxtNodeFilesystemUtilizationMetricConfig{
 						Enabled: true,
 					},
-					NsxtNodeFilesystemUsage: MetricConfig{
+					NsxtNodeMemoryCacheUsage: NsxtNodeMemoryCacheUsageMetricConfig{
 						Enabled: true,
 					},
-					NsxtNodeFilesystemUtilization: MetricConfig{
+					NsxtNodeMemoryUsage: NsxtNodeMemoryUsageMetricConfig{
 						Enabled: true,
 					},
-					NsxtNodeMemoryCacheUsage: MetricConfig{
-						Enabled: true,
+					NsxtNodeNetworkIo: NsxtNodeNetworkIoMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NsxtNodeNetworkIoMetricAttributeKey{NsxtNodeNetworkIoMetricAttributeKeyDirection},
 					},
-					NsxtNodeMemoryUsage: MetricConfig{
-						Enabled: true,
-					},
-					NsxtNodeNetworkIo: MetricConfig{
-						Enabled: true,
-					},
-					NsxtNodeNetworkPacketCount: MetricConfig{
-						Enabled: true,
+					NsxtNodeNetworkPacketCount: NsxtNodeNetworkPacketCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NsxtNodeNetworkPacketCountMetricAttributeKey{NsxtNodeNetworkPacketCountMetricAttributeKeyDirection, NsxtNodeNetworkPacketCountMetricAttributeKeyPacketType},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -60,26 +68,34 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NsxtNodeCPUUtilization: MetricConfig{
+					NsxtNodeCPUUtilization: NsxtNodeCPUUtilizationMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []NsxtNodeCPUUtilizationMetricAttributeKey{NsxtNodeCPUUtilizationMetricAttributeKeyClass},
+					},
+					NsxtNodeFilesystemUsage: NsxtNodeFilesystemUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NsxtNodeFilesystemUsageMetricAttributeKey{NsxtNodeFilesystemUsageMetricAttributeKeyDiskState},
+					},
+					NsxtNodeFilesystemUtilization: NsxtNodeFilesystemUtilizationMetricConfig{
 						Enabled: false,
 					},
-					NsxtNodeFilesystemUsage: MetricConfig{
+					NsxtNodeMemoryCacheUsage: NsxtNodeMemoryCacheUsageMetricConfig{
 						Enabled: false,
 					},
-					NsxtNodeFilesystemUtilization: MetricConfig{
+					NsxtNodeMemoryUsage: NsxtNodeMemoryUsageMetricConfig{
 						Enabled: false,
 					},
-					NsxtNodeMemoryCacheUsage: MetricConfig{
-						Enabled: false,
+					NsxtNodeNetworkIo: NsxtNodeNetworkIoMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NsxtNodeNetworkIoMetricAttributeKey{NsxtNodeNetworkIoMetricAttributeKeyDirection},
 					},
-					NsxtNodeMemoryUsage: MetricConfig{
-						Enabled: false,
-					},
-					NsxtNodeNetworkIo: MetricConfig{
-						Enabled: false,
-					},
-					NsxtNodeNetworkPacketCount: MetricConfig{
-						Enabled: false,
+					NsxtNodeNetworkPacketCount: NsxtNodeNetworkPacketCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []NsxtNodeNetworkPacketCountMetricAttributeKey{NsxtNodeNetworkPacketCountMetricAttributeKeyDirection, NsxtNodeNetworkPacketCountMetricAttributeKeyPacketType},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -94,7 +110,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(NsxtNodeCPUUtilizationMetricConfig{}, NsxtNodeFilesystemUsageMetricConfig{}, NsxtNodeFilesystemUtilizationMetricConfig{}, NsxtNodeMemoryCacheUsageMetricConfig{}, NsxtNodeMemoryUsageMetricConfig{}, NsxtNodeNetworkIoMetricConfig{}, NsxtNodeNetworkPacketCountMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeClass specifies the value class attribute.
@@ -159,9 +167,10 @@ type metricInfo struct {
 }
 
 type metricNsxtNodeCPUUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        NsxtNodeCPUUtilizationMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []float64                          // slice containing number of aggregated datapoints at each index
 }
 
 // init fills nsxt.node.cpu.utilization metric with initial data.
@@ -171,17 +180,48 @@ func (m *metricNsxtNodeCPUUtilization) init() {
 	m.data.SetUnit("%")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricNsxtNodeCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, classAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, NsxtNodeCPUUtilizationMetricAttributeKeyClass) {
+		dp.Attributes().PutStr("class", classAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("class", classAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -194,13 +234,18 @@ func (m *metricNsxtNodeCPUUtilization) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricNsxtNodeCPUUtilization) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricNsxtNodeCPUUtilization(cfg MetricConfig) metricNsxtNodeCPUUtilization {
+func newMetricNsxtNodeCPUUtilization(cfg NsxtNodeCPUUtilizationMetricConfig) metricNsxtNodeCPUUtilization {
 	m := metricNsxtNodeCPUUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -211,9 +256,10 @@ func newMetricNsxtNodeCPUUtilization(cfg MetricConfig) metricNsxtNodeCPUUtilizat
 }
 
 type metricNsxtNodeFilesystemUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        NsxtNodeFilesystemUsageMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
 }
 
 // init fills nsxt.node.filesystem.usage metric with initial data.
@@ -225,17 +271,48 @@ func (m *metricNsxtNodeFilesystemUsage) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricNsxtNodeFilesystemUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, NsxtNodeFilesystemUsageMetricAttributeKeyDiskState) {
+		dp.Attributes().PutStr("state", diskStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("state", diskStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -248,13 +325,18 @@ func (m *metricNsxtNodeFilesystemUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricNsxtNodeFilesystemUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricNsxtNodeFilesystemUsage(cfg MetricConfig) metricNsxtNodeFilesystemUsage {
+func newMetricNsxtNodeFilesystemUsage(cfg NsxtNodeFilesystemUsageMetricConfig) metricNsxtNodeFilesystemUsage {
 	m := metricNsxtNodeFilesystemUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -265,9 +347,9 @@ func newMetricNsxtNodeFilesystemUsage(cfg MetricConfig) metricNsxtNodeFilesystem
 }
 
 type metricNsxtNodeFilesystemUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   NsxtNodeFilesystemUtilizationMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
 }
 
 // init fills nsxt.node.filesystem.utilization metric with initial data.
@@ -304,7 +386,7 @@ func (m *metricNsxtNodeFilesystemUtilization) emit(metrics pmetric.MetricSlice) 
 	}
 }
 
-func newMetricNsxtNodeFilesystemUtilization(cfg MetricConfig) metricNsxtNodeFilesystemUtilization {
+func newMetricNsxtNodeFilesystemUtilization(cfg NsxtNodeFilesystemUtilizationMetricConfig) metricNsxtNodeFilesystemUtilization {
 	m := metricNsxtNodeFilesystemUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -315,9 +397,9 @@ func newMetricNsxtNodeFilesystemUtilization(cfg MetricConfig) metricNsxtNodeFile
 }
 
 type metricNsxtNodeMemoryCacheUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   NsxtNodeMemoryCacheUsageMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills nsxt.node.memory.cache.usage metric with initial data.
@@ -356,7 +438,7 @@ func (m *metricNsxtNodeMemoryCacheUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricNsxtNodeMemoryCacheUsage(cfg MetricConfig) metricNsxtNodeMemoryCacheUsage {
+func newMetricNsxtNodeMemoryCacheUsage(cfg NsxtNodeMemoryCacheUsageMetricConfig) metricNsxtNodeMemoryCacheUsage {
 	m := metricNsxtNodeMemoryCacheUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -367,9 +449,9 @@ func newMetricNsxtNodeMemoryCacheUsage(cfg MetricConfig) metricNsxtNodeMemoryCac
 }
 
 type metricNsxtNodeMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   NsxtNodeMemoryUsageMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
 }
 
 // init fills nsxt.node.memory.usage metric with initial data.
@@ -408,7 +490,7 @@ func (m *metricNsxtNodeMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricNsxtNodeMemoryUsage(cfg MetricConfig) metricNsxtNodeMemoryUsage {
+func newMetricNsxtNodeMemoryUsage(cfg NsxtNodeMemoryUsageMetricConfig) metricNsxtNodeMemoryUsage {
 	m := metricNsxtNodeMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -419,9 +501,10 @@ func newMetricNsxtNodeMemoryUsage(cfg MetricConfig) metricNsxtNodeMemoryUsage {
 }
 
 type metricNsxtNodeNetworkIo struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        NsxtNodeNetworkIoMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills nsxt.node.network.io metric with initial data.
@@ -433,17 +516,48 @@ func (m *metricNsxtNodeNetworkIo) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricNsxtNodeNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, NsxtNodeNetworkIoMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -456,13 +570,18 @@ func (m *metricNsxtNodeNetworkIo) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricNsxtNodeNetworkIo) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricNsxtNodeNetworkIo(cfg MetricConfig) metricNsxtNodeNetworkIo {
+func newMetricNsxtNodeNetworkIo(cfg NsxtNodeNetworkIoMetricConfig) metricNsxtNodeNetworkIo {
 	m := metricNsxtNodeNetworkIo{config: cfg}
 
 	if cfg.Enabled {
@@ -473,9 +592,10 @@ func newMetricNsxtNodeNetworkIo(cfg MetricConfig) metricNsxtNodeNetworkIo {
 }
 
 type metricNsxtNodeNetworkPacketCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        NsxtNodeNetworkPacketCountMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []int64                                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills nsxt.node.network.packet.count metric with initial data.
@@ -487,18 +607,51 @@ func (m *metricNsxtNodeNetworkPacketCount) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricNsxtNodeNetworkPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string, packetTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, NsxtNodeNetworkPacketCountMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, NsxtNodeNetworkPacketCountMetricAttributeKeyPacketType) {
+		dp.Attributes().PutStr("type", packetTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
-	dp.Attributes().PutStr("type", packetTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -511,13 +664,18 @@ func (m *metricNsxtNodeNetworkPacketCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricNsxtNodeNetworkPacketCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricNsxtNodeNetworkPacketCount(cfg MetricConfig) metricNsxtNodeNetworkPacketCount {
+func newMetricNsxtNodeNetworkPacketCount(cfg NsxtNodeNetworkPacketCountMetricConfig) metricNsxtNodeNetworkPacketCount {
 	m := metricNsxtNodeNetworkPacketCount{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,16 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["NsxtNodeCPUUtilization"] = mb.metricNsxtNodeCPUUtilization.config.AggregationStrategy
+			aggMap["NsxtNodeFilesystemUsage"] = mb.metricNsxtNodeFilesystemUsage.config.AggregationStrategy
+			aggMap["NsxtNodeNetworkIo"] = mb.metricNsxtNodeNetworkIo.config.AggregationStrategy
+			aggMap["NsxtNodeNetworkPacketCount"] = mb.metricNsxtNodeNetworkPacketCount.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,10 +83,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordNsxtNodeCPUUtilizationDataPoint(ts, 1, AttributeClassDatapath)
+			if tt.name == "reaggregate_set" {
+				mb.RecordNsxtNodeCPUUtilizationDataPoint(ts, 3, AttributeClassServices)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordNsxtNodeFilesystemUsageDataPoint(ts, 1, AttributeDiskStateUsed)
+			if tt.name == "reaggregate_set" {
+				mb.RecordNsxtNodeFilesystemUsageDataPoint(ts, 3, AttributeDiskStateAvailable)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -90,10 +109,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordNsxtNodeNetworkIoDataPoint(ts, 1, AttributeDirectionReceived)
+			if tt.name == "reaggregate_set" {
+				mb.RecordNsxtNodeNetworkIoDataPoint(ts, 3, AttributeDirectionTransmitted)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordNsxtNodeNetworkPacketCountDataPoint(ts, 1, AttributeDirectionReceived, AttributePacketTypeDropped)
+			if tt.name == "reaggregate_set" {
+				mb.RecordNsxtNodeNetworkPacketCountDataPoint(ts, 3, AttributeDirectionTransmitted, AttributePacketTypeErrored)
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetDeviceID("device.id-val")
@@ -102,6 +127,12 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetNsxtNodeType("nsxt.node.type-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricNsxtNodeCPUUtilization.aggDataPoints)
+				assert.Empty(t, mb.metricNsxtNodeFilesystemUsage.aggDataPoints)
+				assert.Empty(t, mb.metricNsxtNodeNetworkIo.aggDataPoints)
+				assert.Empty(t, mb.metricNsxtNodeNetworkPacketCount.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -129,37 +160,89 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "nsxt.node.cpu.utilization":
-					assert.False(t, validatedMetrics["nsxt.node.cpu.utilization"], "Found a duplicate in the metrics slice: nsxt.node.cpu.utilization")
-					validatedMetrics["nsxt.node.cpu.utilization"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "The average amount of CPU being used by the node.", mi.Description())
-					assert.Equal(t, "%", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					classAttrVal, ok := dp.Attributes().Get("class")
-					assert.True(t, ok)
-					assert.Equal(t, "datapath", classAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["nsxt.node.cpu.utilization"], "Found a duplicate in the metrics slice: nsxt.node.cpu.utilization")
+						validatedMetrics["nsxt.node.cpu.utilization"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The average amount of CPU being used by the node.", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						classAttrVal, ok := dp.Attributes().Get("class")
+						assert.True(t, ok)
+						assert.Equal(t, "datapath", classAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["nsxt.node.cpu.utilization"], "Found a duplicate in the metrics slice: nsxt.node.cpu.utilization")
+						validatedMetrics["nsxt.node.cpu.utilization"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The average amount of CPU being used by the node.", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["nsxt.node.cpu.utilization"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("class")
+						assert.False(t, ok)
+					}
 				case "nsxt.node.filesystem.usage":
-					assert.False(t, validatedMetrics["nsxt.node.filesystem.usage"], "Found a duplicate in the metrics slice: nsxt.node.filesystem.usage")
-					validatedMetrics["nsxt.node.filesystem.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The amount of storage space used by the node.", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					diskStateAttrVal, ok := dp.Attributes().Get("state")
-					assert.True(t, ok)
-					assert.Equal(t, "used", diskStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["nsxt.node.filesystem.usage"], "Found a duplicate in the metrics slice: nsxt.node.filesystem.usage")
+						validatedMetrics["nsxt.node.filesystem.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The amount of storage space used by the node.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						diskStateAttrVal, ok := dp.Attributes().Get("state")
+						assert.True(t, ok)
+						assert.Equal(t, "used", diskStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["nsxt.node.filesystem.usage"], "Found a duplicate in the metrics slice: nsxt.node.filesystem.usage")
+						validatedMetrics["nsxt.node.filesystem.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The amount of storage space used by the node.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["nsxt.node.filesystem.usage"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("state")
+						assert.False(t, ok)
+					}
 				case "nsxt.node.filesystem.utilization":
 					assert.False(t, validatedMetrics["nsxt.node.filesystem.utilization"], "Found a duplicate in the metrics slice: nsxt.node.filesystem.utilization")
 					validatedMetrics["nsxt.node.filesystem.utilization"] = true
@@ -201,42 +284,98 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "nsxt.node.network.io":
-					assert.False(t, validatedMetrics["nsxt.node.network.io"], "Found a duplicate in the metrics slice: nsxt.node.network.io")
-					validatedMetrics["nsxt.node.network.io"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of bytes which have flowed through the network interface.", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "received", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["nsxt.node.network.io"], "Found a duplicate in the metrics slice: nsxt.node.network.io")
+						validatedMetrics["nsxt.node.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of bytes which have flowed through the network interface.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "received", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["nsxt.node.network.io"], "Found a duplicate in the metrics slice: nsxt.node.network.io")
+						validatedMetrics["nsxt.node.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of bytes which have flowed through the network interface.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["nsxt.node.network.io"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "nsxt.node.network.packet.count":
-					assert.False(t, validatedMetrics["nsxt.node.network.packet.count"], "Found a duplicate in the metrics slice: nsxt.node.network.packet.count")
-					validatedMetrics["nsxt.node.network.packet.count"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of packets which have flowed through the network interface on the node.", mi.Description())
-					assert.Equal(t, "{packets}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "received", directionAttrVal.Str())
-					packetTypeAttrVal, ok := dp.Attributes().Get("type")
-					assert.True(t, ok)
-					assert.Equal(t, "dropped", packetTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["nsxt.node.network.packet.count"], "Found a duplicate in the metrics slice: nsxt.node.network.packet.count")
+						validatedMetrics["nsxt.node.network.packet.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of packets which have flowed through the network interface on the node.", mi.Description())
+						assert.Equal(t, "{packets}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "received", directionAttrVal.Str())
+						packetTypeAttrVal, ok := dp.Attributes().Get("type")
+						assert.True(t, ok)
+						assert.Equal(t, "dropped", packetTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["nsxt.node.network.packet.count"], "Found a duplicate in the metrics slice: nsxt.node.network.packet.count")
+						validatedMetrics["nsxt.node.network.packet.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of packets which have flowed through the network interface on the node.", mi.Description())
+						assert.Equal(t, "{packets}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["nsxt.node.network.packet.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("type")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/nsxtreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/nsxtreceiver/internal/metadata/testdata/config.yaml
@@ -3,8 +3,10 @@ all_set:
   metrics:
     nsxt.node.cpu.utilization:
       enabled: true
+      attributes: ["class"]
     nsxt.node.filesystem.usage:
       enabled: true
+      attributes: ["state"]
     nsxt.node.filesystem.utilization:
       enabled: true
     nsxt.node.memory.cache.usage:
@@ -13,8 +15,39 @@ all_set:
       enabled: true
     nsxt.node.network.io:
       enabled: true
+      attributes: ["direction"]
     nsxt.node.network.packet.count:
       enabled: true
+      attributes: ["direction","type"]
+  resource_attributes:
+    device.id:
+      enabled: true
+    nsxt.node.id:
+      enabled: true
+    nsxt.node.name:
+      enabled: true
+    nsxt.node.type:
+      enabled: true
+reaggregate_set:
+  metrics:
+    nsxt.node.cpu.utilization:
+      enabled: true
+      attributes: []
+    nsxt.node.filesystem.usage:
+      enabled: true
+      attributes: []
+    nsxt.node.filesystem.utilization:
+      enabled: true
+    nsxt.node.memory.cache.usage:
+      enabled: true
+    nsxt.node.memory.usage:
+      enabled: true
+    nsxt.node.network.io:
+      enabled: true
+      attributes: []
+    nsxt.node.network.packet.count:
+      enabled: true
+      attributes: []
   resource_attributes:
     device.id:
       enabled: true
@@ -28,8 +61,10 @@ none_set:
   metrics:
     nsxt.node.cpu.utilization:
       enabled: false
+      attributes: ["class"]
     nsxt.node.filesystem.usage:
       enabled: false
+      attributes: ["state"]
     nsxt.node.filesystem.utilization:
       enabled: false
     nsxt.node.memory.cache.usage:
@@ -38,8 +73,10 @@ none_set:
       enabled: false
     nsxt.node.network.io:
       enabled: false
+      attributes: ["direction"]
     nsxt.node.network.packet.count:
       enabled: false
+      attributes: ["direction","type"]
   resource_attributes:
     device.id:
       enabled: false

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: NSX-T Receiver
 type: nsxt
+reaggregation_enabled: true
 
 description: |
   This receiver fetches metrics important to run virtual networking using NSX-T. The receiver ingests metrics via the
@@ -35,12 +36,14 @@ resource_attributes:
 attributes:
   class:
     description: The CPU usage of the architecture allocated for either DPDK (datapath) or non-DPDK (services) processes.
+    requirement_level: recommended
     type: string
     enum:
       - datapath
       - services
   direction:
     description: The direction of network flow.
+    requirement_level: recommended
     type: string
     enum:
       - received
@@ -48,6 +51,7 @@ attributes:
   disk_state:
     name_override: state
     description: The state of storage space.
+    requirement_level: recommended
     type: string
     enum:
       - used
@@ -55,6 +59,7 @@ attributes:
   packet.type:
     name_override: type
     description: The type of packet counter.
+    requirement_level: recommended
     type: string
     enum:
       - dropped


### PR DESCRIPTION
Fixes #46369
Part of #45396

## Summary

- Set `reaggregation_enabled: true` in `metadata.yaml`
- Added `requirement_level: recommended` to all attributes (`class`, `direction`, `disk_state`, `packet.type`)
- Ran `go generate ./...`, `make gci`, and `make chlog-validate` to regenerate all derived files
- Removed unused `slices` import from generated code (upstream mdatagen template bug open-telemetry/opentelemetry-collector#15145)

## Test plan

- [x] `go test ./...` in `receiver/nsxtreceiver/` - all tests pass
- [x] `make chlog-validate` - valid
- [x] `make gci` - no diffs
- [x] `schemagen` - schema up to date