### PR TITLE
[receiver/httpcheck] record tls cert metric once per scrape

### DIFF
--- a/.chloggen/47741-httpcheck-tls-cert-remaining.yaml
+++ b/.chloggen/47741-httpcheck-tls-cert-remaining.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/httpcheckreceiver
+component: receiver/http_check
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Ensure httpcheck.tls.cert_remaining is emitted once per scrape.

--- a/.chloggen/47741-httpcheck-tls-cert-remaining.yaml
+++ b/.chloggen/47741-httpcheck-tls-cert-remaining.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/httpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure httpcheck.tls.cert_remaining is emitted once per scrape.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/47741-httpcheck-tls-cert-remaining.yaml
+++ b/.chloggen/47741-httpcheck-tls-cert-remaining.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/httpcheck
+component: receiver/httpcheckreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Ensure httpcheck.tls.cert_remaining is emitted once per scrape.

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -349,21 +349,6 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 
 			mux.Lock()
 
-			// Check if TLS metric is enabled and this is an HTTPS endpoint
-			if h.cfg.Metrics.HttpcheckTLSCertRemaining.Enabled && resp != nil && resp.TLS != nil {
-				// Extract TLS info directly from the HTTP response
-				issuer, commonName, sans, timeLeft := extractTLSInfo(resp.TLS)
-				if issuer != "" || commonName != "" || len(sans) > 0 {
-					h.mb.RecordHttpcheckTLSCertRemainingDataPoint(
-						now,
-						timeLeft,
-						h.cfg.Targets[targetIndex].Endpoint,
-						issuer,
-						commonName,
-						sans,
-					)
-				}
-			}
 			// Record timing breakdown metrics
 			dnsMs, tcpMs, tlsMs, requestMs, responseMs := timing.getDurations()
 			endpoint := h.cfg.Targets[targetIndex].Endpoint

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -277,7 +277,9 @@ func TestHTTPSWithTLS(t *testing.T) {
 		if metric.Name() == "httpcheck.tls.cert_remaining" {
 			found = true
 			assert.Equal(t, pmetric.MetricTypeGauge, metric.Type())
-			dp := metric.Gauge().DataPoints().At(0)
+			dps := metric.Gauge().DataPoints()
+			require.Equal(t, 1, dps.Len())
+			dp := dps.At(0)
 
 			// Check attributes
 			attrs := dp.Attributes()


### PR DESCRIPTION
## Summary
- remove the duplicated httpcheck.tls.cert_remaining recording block in scraper.go
- keep a single TLS cert metric emission per endpoint scrape
- tighten test coverage to assert exactly one data point is emitted in the HTTPS TLS metric test

Fixes #47740.

## Testing
- cd receiver/httpcheckreceiver && go test ./...
