### PR TITLE
[receiver/awscloudwatch] Use LogGroupIdentifier for cross-account log groups

### DIFF
--- a/.chloggen/fix-cloudwatch-cross-account-arn.yaml
+++ b/.chloggen/fix-cloudwatch-cross-account-arn.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use LogGroupIdentifier (ARN) instead of LogGroupName for cross-account log group discovery via OAM, fixing ResourceNotFoundException errors.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46159]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -54,16 +54,21 @@ type client interface {
 }
 
 type streamNames struct {
-	group string
-	names []*string
+	group           string
+	groupIdentifier string
+	names           []*string
 }
 
 func (sn *streamNames) request(limit int, nextToken string, st, et *time.Time) *cloudwatchlogs.FilterLogEventsInput {
 	base := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupName: &sn.group,
-		StartTime:    aws.Int64(st.UnixMilli()),
-		EndTime:      aws.Int64(et.UnixMilli()),
-		Limit:        aws.Int32(int32(limit)),
+		StartTime: aws.Int64(st.UnixMilli()),
+		EndTime:   aws.Int64(et.UnixMilli()),
+		Limit:     aws.Int32(int32(limit)),
+	}
+	if sn.groupIdentifier != "" {
+		base.LogGroupIdentifier = &sn.groupIdentifier
+	} else {
+		base.LogGroupName = &sn.group
 	}
 	if len(sn.names) > 0 {
 		base.LogStreamNames = aws.ToStringSlice(sn.names)
@@ -79,17 +84,22 @@ func (sn *streamNames) groupName() string {
 }
 
 type streamPrefix struct {
-	group  string
-	prefix *string
+	group           string
+	groupIdentifier string
+	prefix          *string
 }
 
 func (sp *streamPrefix) request(limit int, nextToken string, st, et *time.Time) *cloudwatchlogs.FilterLogEventsInput {
 	base := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupName:        &sp.group,
 		StartTime:           aws.Int64(st.UnixMilli()),
 		EndTime:             aws.Int64(et.UnixMilli()),
 		Limit:               aws.Int32(int32(limit)),
 		LogStreamNamePrefix: sp.prefix,
+	}
+	if sp.groupIdentifier != "" {
+		base.LogGroupIdentifier = &sp.groupIdentifier
+	} else {
+		base.LogGroupName = &sp.group
 	}
 	if nextToken != "" {
 		base.NextToken = aws.String(nextToken)
@@ -452,18 +462,23 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 
 			numGroups++
 
+			var groupArn string
+			if lg.Arn != nil {
+				groupArn = *lg.Arn
+			}
+
 			// default behavior is to collect all if not stream filtered
 			if len(auto.Streams.Names) == 0 && len(auto.Streams.Prefixes) == 0 {
-				groups = append(groups, &streamNames{group: *lg.LogGroupName})
+				groups = append(groups, &streamNames{group: *lg.LogGroupName, groupIdentifier: groupArn})
 				continue
 			}
 
 			for _, prefix := range auto.Streams.Prefixes {
-				groups = append(groups, &streamPrefix{group: *lg.LogGroupName, prefix: prefix})
+				groups = append(groups, &streamPrefix{group: *lg.LogGroupName, groupIdentifier: groupArn, prefix: prefix})
 			}
 
 			if len(auto.Streams.Names) > 0 {
-				groups = append(groups, &streamNames{group: *lg.LogGroupName, names: auto.Streams.Names})
+				groups = append(groups, &streamNames{group: *lg.LogGroupName, groupIdentifier: groupArn, names: auto.Streams.Names})
 			}
 		}
 		nextToken = dlgResults.NextToken


### PR DESCRIPTION
## Summary

Fix cross-account log group discovery via AWS OAM by using `LogGroupIdentifier` (ARN) instead of `LogGroupName` in `FilterLogEvents` calls.

Fixes #46159

## Problem

When using the AWS CloudWatch receiver with `include_linked_accounts: true` and `account_identifiers` for cross-account log collection via AWS OAM:

1. `DescribeLogGroups` correctly discovers log groups from linked accounts
2. But `FilterLogEvents` uses `LogGroupName` (just the name), which only searches the monitoring account's own log groups
3. AWS requires the full ARN via `LogGroupIdentifier` to read logs from linked accounts
4. Result: `ResourceNotFoundException` for every cross-account log group

## Fix

- Added `groupIdentifier` field to `streamNames` and `streamPrefix` structs to store the log group ARN
- Modified `discoverGroups()` to capture `lg.Arn` from the `DescribeLogGroups` response
- Modified `request()` methods to use `LogGroupIdentifier` when an ARN is available, falling back to `LogGroupName` for single-account scenarios (backward compatible)

## Test Plan

- [x] All existing tests pass
- [x] Code compiles cleanly
- [x] Backward compatible — single-account scenarios continue using `LogGroupName` since ARN won't be set for non-cross-account groups