### PR TITLE
receiver/azuremonitor: fix StartTimestamp > Timestamp in batch API path

### DIFF
--- a/.chloggen/fix-azuremonitor-batch-start-timestamp.yaml
+++ b/.chloggen/fix-azuremonitor-batch-start-timestamp.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/azuremonitor
+component: receiver/azure_monitor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix StartTimestamp being greater than Timestamp in batch API path

--- a/.chloggen/fix-azuremonitor-batch-start-timestamp.yaml
+++ b/.chloggen/fix-azuremonitor-batch-start-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix StartTimestamp being greater than Timestamp in batch API path
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47705]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azuremonitorreceiver/internal/metadata/metrics.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/metrics.go
@@ -194,7 +194,7 @@ func (mb *MetricsBuilder) AddDataPoint(
 		}
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
+	dp.SetStartTimestamp(ts)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleValue(val)
 	dp.Attributes().PutStr("azuremonitor.resource_id", resourceID)

--- a/receiver/azuremonitorreceiver/internal/metadata/metrics_test.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/metrics_test.go
@@ -75,6 +75,15 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			assert.Equal(t, 1, rm.ScopeMetrics().Len())
+
+			// StartTimestamp must equal the data point timestamp, not mb.startTime.
+			// When the batch API is used, ts comes from Azure's aggregation window
+			// (potentially hours in the past), while mb.startTime is the scrape
+			// time. Setting StartTimestamp=mb.startTime > ts violates the OTel spec.
+			dp := rm.ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0)
+			assert.Equal(t, ts, dp.StartTimestamp(),
+				"StartTimestamp must equal the data point Timestamp, not mb.startTime")
+			assert.Equal(t, ts, dp.Timestamp())
 		})
 	}
 }


### PR DESCRIPTION
Fixes #47705

## Problem

When `use_batch_api: true`, `processQueryTimeseriesData` in `scraper_batch.go` sets the data point timestamp (`ts`) from `metricValue.TimeStamp` — Azure's aggregation window end time, which can be up to an hour in the past.

However, `AddDataPoint` in `internal/metadata/metrics.go` was calling:

```go
dp.SetStartTimestamp(mb.startTime)  // scrape time (now)
dp.SetTimestamp(ts)                 // Azure aggregation time (past)
```

This results in `StartTimestamp > Timestamp`, which violates the [OTel data model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#resets-and-gaps) requirement that `StartTimestamp <= Timestamp`. Downstream consumers such as Prometheus remote-write reject these data points.

## Fix

Use `ts` for `StartTimestamp` so it always equals `Timestamp`:

```go
dp.SetStartTimestamp(ts)
dp.SetTimestamp(ts)
```

For the non-batch scraper, `ts = time.Now()` so the behaviour is unchanged (StartTimestamp ≈ Timestamp ≈ now). For the batch scraper, StartTimestamp now correctly equals the aggregation window timestamp instead of the scrape time.

## Testing

- All 95 existing tests pass.
- Added an assertion in `metrics_test.go` that explicitly verifies `StartTimestamp == Timestamp` (the existing tests used `IgnoreStartTimestamp()` and did not catch this regression).