### PR TITLE
[storage/filestorage] Implement `storage.Walker` in the file storage extension

### DIFF
--- a/.chloggen/extend-filestorage-interface.yaml
+++ b/.chloggen/extend-filestorage-interface.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/file_storage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Implement `storage.Walker` interface to allow iterating over all stored keys with deferred operations
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47755]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -17,7 +17,12 @@ import (
 	"go.uber.org/zap"
 )
 
-var defaultBucket = []byte(`default`)
+var (
+	defaultBucket = []byte(`default`)
+
+	// Ensure fileStorageClient implements the Walker interface
+	_ storage.Walker = (*fileStorageClient)(nil)
+)
 
 const (
 	TempDbPrefix = "tempdb"
@@ -109,38 +114,82 @@ func (c *fileStorageClient) Batch(_ context.Context, ops ...*storage.Operation) 
 			return errors.New("storage not initialized")
 		}
 
-		var err error
-		for _, op := range ops {
-			switch op.Type {
-			case storage.Get:
-				value := bucket.Get([]byte(op.Key))
-				if value != nil {
-					// the output of Bucket.Get is only valid within a transaction, so we need to make a copy
-					// to be able to return the value
-					op.Value = make([]byte, len(value))
-					copy(op.Value, value)
-				} else {
-					op.Value = nil
-				}
-			case storage.Set:
-				err = bucket.Put([]byte(op.Key), op.Value)
-			case storage.Delete:
-				err = bucket.Delete([]byte(op.Key))
-			default:
-				return errors.New("wrong operation type")
-			}
-
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
+		return updateBucket(bucket, ops...)
 	}
 
 	c.compactionMutex.RLock()
 	defer c.compactionMutex.RUnlock()
 	return c.db.Update(batch)
+}
+
+// Walk implements storage.Walker.
+func (c *fileStorageClient) Walk(ctx context.Context, fn storage.WalkFunc) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	c.compactionMutex.RLock()
+	defer c.compactionMutex.RUnlock()
+
+	if c.closed {
+		return errors.New("storage is closed")
+	}
+
+	return c.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(defaultBucket)
+		if bucket == nil {
+			return errors.New("storage not initialized")
+		}
+
+		var opBatch []*storage.Operation
+		cur := bucket.Cursor()
+		for k, v := cur.First(); k != nil; k, v = cur.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			ops, err := fn(string(k), v)
+			if err != nil {
+				if errors.Is(err, storage.SkipAll) {
+					opBatch = append(opBatch, ops...)
+					return updateBucket(bucket, opBatch...)
+				}
+				return err
+			}
+			opBatch = append(opBatch, ops...)
+		}
+		return updateBucket(bucket, opBatch...)
+	})
+}
+
+// updateBucket executes the specified operations in order for a given bucket. Get operation results are updated in place
+func updateBucket(bucket *bbolt.Bucket, ops ...*storage.Operation) error {
+	var err error
+	for _, op := range ops {
+		switch op.Type {
+		case storage.Get:
+			value := bucket.Get([]byte(op.Key))
+			if value != nil {
+				// the output of Bucket.Get is only valid within a transaction, so we need to make a copy
+				// to be able to return the value
+				op.Value = make([]byte, len(value))
+				copy(op.Value, value)
+			} else {
+				op.Value = nil
+			}
+		case storage.Set:
+			err = bucket.Put([]byte(op.Key), op.Value)
+		case storage.Delete:
+			err = bucket.Delete([]byte(op.Key))
+		default:
+			return errors.New("wrong operation type")
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Close will close the database

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -162,6 +162,7 @@ func (c *fileStorageClient) Walk(ctx context.Context, fn storage.WalkFunc) error
 }
 
 // updateBucket executes the specified operations in order for a given bucket. Get operation results are updated in place
+// The function caller must hold a read lock on compactionMutex.
 func updateBucket(bucket *bbolt.Bucket, ops ...*storage.Operation) error {
 	var err error
 	for _, op := range ops {

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -4,6 +4,8 @@
 package filestorage
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -720,4 +722,231 @@ func BenchmarkClientCompactDb(b *testing.B) {
 
 		require.NoError(b, client.Close(ctx))
 	}
+}
+
+func TestWalk(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		var count int
+		err = client.Walk(ctx, func(_ string, _ []byte) ([]*storage.Operation, error) {
+			count++
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Zero(t, count)
+	})
+
+	t.Run("order_and_stop", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "b", []byte("2")))
+		require.NoError(t, client.Set(ctx, "a", []byte("1")))
+		require.NoError(t, client.Set(ctx, "c", []byte("3")))
+
+		var keys []string
+		err = client.Walk(ctx, func(key string, _ []byte) ([]*storage.Operation, error) {
+			keys = append(keys, key)
+			if key == "b" {
+				return nil, storage.SkipAll
+			}
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"a", "b"}, keys)
+	})
+
+	t.Run("error_from_callback", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "x", []byte("1")))
+
+		testErr := errors.New("cb")
+		err = client.Walk(ctx, func(_ string, _ []byte) ([]*storage.Operation, error) {
+			return nil, testErr
+		})
+		require.ErrorIs(t, err, testErr)
+	})
+
+	t.Run("context_cancelled_before_walk", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx, cancel := context.WithCancel(t.Context())
+		require.NoError(t, client.Set(ctx, "k", []byte("v")))
+
+		cancel()
+		err = client.Walk(ctx, func(_ string, _ []byte) ([]*storage.Operation, error) {
+			t.Fatal("callback must not be invoked with a cancelled context")
+			return nil, nil
+		})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("uninitialized_bucket", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		require.NoError(t, client.db.Update(func(tx *bbolt.Tx) error {
+			return tx.DeleteBucket(defaultBucket)
+		}))
+
+		err = client.Walk(t.Context(), func(_ string, _ []byte) ([]*storage.Operation, error) {
+			return nil, nil
+		})
+		require.Error(t, err)
+		require.Equal(t, "storage not initialized", err.Error())
+	})
+
+	t.Run("after_close", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "k", []byte("v")))
+		require.NoError(t, client.Close(ctx))
+
+		err = client.Walk(ctx, func(_ string, _ []byte) ([]*storage.Operation, error) {
+			return nil, nil
+		})
+		require.Error(t, err)
+		require.Equal(t, "storage is closed", err.Error())
+	})
+
+	t.Run("deferred_ops_applied", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "a", []byte("1")))
+		require.NoError(t, client.Set(ctx, "b", []byte("2")))
+
+		err = client.Walk(ctx, func(key string, _ []byte) ([]*storage.Operation, error) {
+			switch key {
+			case "a":
+				return []*storage.Operation{storage.SetOperation("c", []byte("3"))}, nil
+			case "b":
+				return []*storage.Operation{storage.DeleteOperation("a")}, nil
+			}
+			return nil, nil
+		})
+		require.NoError(t, err)
+
+		v, err := client.Get(ctx, "c")
+		require.NoError(t, err)
+		require.Equal(t, []byte("3"), v)
+
+		v, err = client.Get(ctx, "a")
+		require.NoError(t, err)
+		require.Nil(t, v, "deferred delete should have removed key 'a'")
+	})
+
+	t.Run("deferred_ops_on_stop", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "a", []byte("1")))
+		require.NoError(t, client.Set(ctx, "b", []byte("2")))
+
+		err = client.Walk(ctx, func(key string, _ []byte) ([]*storage.Operation, error) {
+			if key == "a" {
+				return []*storage.Operation{storage.SetOperation("x", []byte("stop"))}, storage.SkipAll
+			}
+			t.Fatal("iteration should have stopped at key 'a'")
+			return nil, nil
+		})
+		require.NoError(t, err)
+
+		v, err := client.Get(ctx, "x")
+		require.NoError(t, err)
+		require.Equal(t, []byte("stop"), v)
+	})
+
+	t.Run("no_ops_on_error", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "a", []byte("1")))
+		require.NoError(t, client.Set(ctx, "b", []byte("2")))
+
+		cbErr := errors.New("fail")
+		err = client.Walk(ctx, func(key string, _ []byte) ([]*storage.Operation, error) {
+			if key == "a" {
+				return []*storage.Operation{storage.SetOperation("x", []byte("nope"))}, nil
+			}
+			return []*storage.Operation{storage.SetOperation("y", []byte("nope2"))}, cbErr
+		})
+		require.ErrorIs(t, err, cbErr)
+
+		v, err := client.Get(ctx, "x")
+		require.NoError(t, err)
+		require.Nil(t, v, "deferred ops from earlier keys must not be applied when a later callback errors")
+
+		v, err = client.Get(ctx, "y")
+		require.NoError(t, err)
+		require.Nil(t, v, "ops returned alongside an error must not be applied")
+	})
+
+	t.Run("context_cancelled_mid_iteration", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx, cancel := context.WithCancel(t.Context())
+		require.NoError(t, client.Set(ctx, "a", []byte("1")))
+		require.NoError(t, client.Set(ctx, "b", []byte("2")))
+
+		err = client.Walk(ctx, func(key string, _ []byte) ([]*storage.Operation, error) {
+			if key == "a" {
+				cancel()
+			}
+			return nil, nil
+		})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("values_match_stored", func(t *testing.T) {
+		dbFile := filepath.Join(t.TempDir(), "db")
+		client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close(t.Context())) })
+
+		ctx := t.Context()
+		require.NoError(t, client.Set(ctx, "a", []byte("val-a")))
+		require.NoError(t, client.Set(ctx, "b", []byte("val-b")))
+
+		got := map[string]string{}
+		err = client.Walk(ctx, func(key string, value []byte) ([]*storage.Operation, error) {
+			got[key] = string(value)
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"a": "val-a", "b": "val-b"}, got)
+	})
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Consumers can now iterate through stored entries and implement various behaviors like garbage collections or migrations.

See the original issue for more details https://github.com/open-telemetry/opentelemetry-collector/issues/15191

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tests were added to have full coverage of the newly introduced code.
