### PR TITLE
feat(receiver/memcached): enable dynamic metric reaggregation

### DIFF
--- a/.chloggen/46364-memcached-enable-reaggregation.yaml
+++ b/.chloggen/46364-memcached-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/memcached
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the Memcached receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46364]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/memcachedreceiver/generated_package_test.go
+++ b/receiver/memcachedreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package memcachedreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/memcachedreceiver/generated_package_test.go
+++ b/receiver/memcachedreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package memcachedreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/memcachedreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/memcachedreceiver/internal/metadata/config.schema.yaml
@@ -18,6 +18,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "command"
+            default:
+              - "command"
       memcached.connections.current:
         description: "MemcachedConnectionsCurrentMetricConfig provides config for the memcached.connections.current metric."
         type: object
@@ -39,6 +55,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "state"
+            default:
+              - "state"
       memcached.current_items:
         description: "MemcachedCurrentItemsMetricConfig provides config for the memcached.current_items metric."
         type: object
@@ -60,6 +92,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "direction"
+            default:
+              - "direction"
       memcached.operation_hit_ratio:
         description: "MemcachedOperationHitRatioMetricConfig provides config for the memcached.operation_hit_ratio metric."
         type: object
@@ -67,6 +115,22 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "operation"
+            default:
+              - "operation"
       memcached.operations:
         description: "MemcachedOperationsMetricConfig provides config for the memcached.operations metric."
         type: object
@@ -74,6 +138,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "type"
+                - "operation"
+            default:
+              - "type"
+              - "operation"
       memcached.threads:
         description: "MemcachedThreadsMetricConfig provides config for the memcached.threads metric."
         type: object

--- a/receiver/memcachedreceiver/internal/metadata/generated_config.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_config.go
@@ -3,16 +3,359 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// MemcachedBytesMetricConfig provides config for the memcached.bytes metric.
+type MemcachedBytesMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *MemcachedBytesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MemcachedCommandsMetricAttributeKey specifies the key of an attribute for the memcached.commands metric.
+type MemcachedCommandsMetricAttributeKey string
+
+const (
+	MemcachedCommandsMetricAttributeKeyCommand MemcachedCommandsMetricAttributeKey = "command"
+)
+
+// MemcachedCommandsMetricConfig provides config for the memcached.commands metric.
+type MemcachedCommandsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MemcachedCommandsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MemcachedCommandsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MemcachedCommandsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MemcachedCommandsMetricAttributeKeyCommand:
+		default:
+			return fmt.Errorf("metric memcached.commands doesn't have an attribute %v, valid attributes: [command]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MemcachedConnectionsCurrentMetricConfig provides config for the memcached.connections.current metric.
+type MemcachedConnectionsCurrentMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MemcachedConnectionsCurrentMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MemcachedConnectionsTotalMetricConfig provides config for the memcached.connections.total metric.
+type MemcachedConnectionsTotalMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MemcachedConnectionsTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MemcachedCPUUsageMetricAttributeKey specifies the key of an attribute for the memcached.cpu.usage metric.
+type MemcachedCPUUsageMetricAttributeKey string
+
+const (
+	MemcachedCPUUsageMetricAttributeKeyState MemcachedCPUUsageMetricAttributeKey = "state"
+)
+
+// MemcachedCPUUsageMetricConfig provides config for the memcached.cpu.usage metric.
+type MemcachedCPUUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MemcachedCPUUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MemcachedCPUUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MemcachedCPUUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MemcachedCPUUsageMetricAttributeKeyState:
+		default:
+			return fmt.Errorf("metric memcached.cpu.usage doesn't have an attribute %v, valid attributes: [state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MemcachedCurrentItemsMetricConfig provides config for the memcached.current_items metric.
+type MemcachedCurrentItemsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MemcachedCurrentItemsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MemcachedEvictionsMetricConfig provides config for the memcached.evictions metric.
+type MemcachedEvictionsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MemcachedEvictionsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MemcachedNetworkMetricAttributeKey specifies the key of an attribute for the memcached.network metric.
+type MemcachedNetworkMetricAttributeKey string
+
+const (
+	MemcachedNetworkMetricAttributeKeyDirection MemcachedNetworkMetricAttributeKey = "direction"
+)
+
+// MemcachedNetworkMetricConfig provides config for the memcached.network metric.
+type MemcachedNetworkMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MemcachedNetworkMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MemcachedNetworkMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MemcachedNetworkMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MemcachedNetworkMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric memcached.network doesn't have an attribute %v, valid attributes: [direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MemcachedOperationHitRatioMetricAttributeKey specifies the key of an attribute for the memcached.operation_hit_ratio metric.
+type MemcachedOperationHitRatioMetricAttributeKey string
+
+const (
+	MemcachedOperationHitRatioMetricAttributeKeyOperation MemcachedOperationHitRatioMetricAttributeKey = "operation"
+)
+
+// MemcachedOperationHitRatioMetricConfig provides config for the memcached.operation_hit_ratio metric.
+type MemcachedOperationHitRatioMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MemcachedOperationHitRatioMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MemcachedOperationHitRatioMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MemcachedOperationHitRatioMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MemcachedOperationHitRatioMetricAttributeKeyOperation:
+		default:
+			return fmt.Errorf("metric memcached.operation_hit_ratio doesn't have an attribute %v, valid attributes: [operation]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MemcachedOperationsMetricAttributeKey specifies the key of an attribute for the memcached.operations metric.
+type MemcachedOperationsMetricAttributeKey string
+
+const (
+	MemcachedOperationsMetricAttributeKeyType      MemcachedOperationsMetricAttributeKey = "type"
+	MemcachedOperationsMetricAttributeKeyOperation MemcachedOperationsMetricAttributeKey = "operation"
+)
+
+// MemcachedOperationsMetricConfig provides config for the memcached.operations metric.
+type MemcachedOperationsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MemcachedOperationsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MemcachedOperationsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MemcachedOperationsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MemcachedOperationsMetricAttributeKeyType, MemcachedOperationsMetricAttributeKeyOperation:
+		default:
+			return fmt.Errorf("metric memcached.operations doesn't have an attribute %v, valid attributes: [type, operation]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MemcachedThreadsMetricConfig provides config for the memcached.threads metric.
+type MemcachedThreadsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MemcachedThreadsMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -28,52 +371,62 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for memcached metrics.
 type MetricsConfig struct {
-	MemcachedBytes              MetricConfig `mapstructure:"memcached.bytes"`
-	MemcachedCommands           MetricConfig `mapstructure:"memcached.commands"`
-	MemcachedConnectionsCurrent MetricConfig `mapstructure:"memcached.connections.current"`
-	MemcachedConnectionsTotal   MetricConfig `mapstructure:"memcached.connections.total"`
-	MemcachedCPUUsage           MetricConfig `mapstructure:"memcached.cpu.usage"`
-	MemcachedCurrentItems       MetricConfig `mapstructure:"memcached.current_items"`
-	MemcachedEvictions          MetricConfig `mapstructure:"memcached.evictions"`
-	MemcachedNetwork            MetricConfig `mapstructure:"memcached.network"`
-	MemcachedOperationHitRatio  MetricConfig `mapstructure:"memcached.operation_hit_ratio"`
-	MemcachedOperations         MetricConfig `mapstructure:"memcached.operations"`
-	MemcachedThreads            MetricConfig `mapstructure:"memcached.threads"`
+	MemcachedBytes              MemcachedBytesMetricConfig              `mapstructure:"memcached.bytes"`
+	MemcachedCommands           MemcachedCommandsMetricConfig           `mapstructure:"memcached.commands"`
+	MemcachedConnectionsCurrent MemcachedConnectionsCurrentMetricConfig `mapstructure:"memcached.connections.current"`
+	MemcachedConnectionsTotal   MemcachedConnectionsTotalMetricConfig   `mapstructure:"memcached.connections.total"`
+	MemcachedCPUUsage           MemcachedCPUUsageMetricConfig           `mapstructure:"memcached.cpu.usage"`
+	MemcachedCurrentItems       MemcachedCurrentItemsMetricConfig       `mapstructure:"memcached.current_items"`
+	MemcachedEvictions          MemcachedEvictionsMetricConfig          `mapstructure:"memcached.evictions"`
+	MemcachedNetwork            MemcachedNetworkMetricConfig            `mapstructure:"memcached.network"`
+	MemcachedOperationHitRatio  MemcachedOperationHitRatioMetricConfig  `mapstructure:"memcached.operation_hit_ratio"`
+	MemcachedOperations         MemcachedOperationsMetricConfig         `mapstructure:"memcached.operations"`
+	MemcachedThreads            MemcachedThreadsMetricConfig            `mapstructure:"memcached.threads"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		MemcachedBytes: MetricConfig{
+		MemcachedBytes: MemcachedBytesMetricConfig{
 			Enabled: true,
 		},
-		MemcachedCommands: MetricConfig{
+		MemcachedCommands: MemcachedCommandsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MemcachedCommandsMetricAttributeKey{MemcachedCommandsMetricAttributeKeyCommand},
+		},
+		MemcachedConnectionsCurrent: MemcachedConnectionsCurrentMetricConfig{
 			Enabled: true,
 		},
-		MemcachedConnectionsCurrent: MetricConfig{
+		MemcachedConnectionsTotal: MemcachedConnectionsTotalMetricConfig{
 			Enabled: true,
 		},
-		MemcachedConnectionsTotal: MetricConfig{
+		MemcachedCPUUsage: MemcachedCPUUsageMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MemcachedCPUUsageMetricAttributeKey{MemcachedCPUUsageMetricAttributeKeyState},
+		},
+		MemcachedCurrentItems: MemcachedCurrentItemsMetricConfig{
 			Enabled: true,
 		},
-		MemcachedCPUUsage: MetricConfig{
+		MemcachedEvictions: MemcachedEvictionsMetricConfig{
 			Enabled: true,
 		},
-		MemcachedCurrentItems: MetricConfig{
-			Enabled: true,
+		MemcachedNetwork: MemcachedNetworkMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MemcachedNetworkMetricAttributeKey{MemcachedNetworkMetricAttributeKeyDirection},
 		},
-		MemcachedEvictions: MetricConfig{
-			Enabled: true,
+		MemcachedOperationHitRatio: MemcachedOperationHitRatioMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MemcachedOperationHitRatioMetricAttributeKey{MemcachedOperationHitRatioMetricAttributeKeyOperation},
 		},
-		MemcachedNetwork: MetricConfig{
-			Enabled: true,
+		MemcachedOperations: MemcachedOperationsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MemcachedOperationsMetricAttributeKey{MemcachedOperationsMetricAttributeKeyType, MemcachedOperationsMetricAttributeKeyOperation},
 		},
-		MemcachedOperationHitRatio: MetricConfig{
-			Enabled: true,
-		},
-		MemcachedOperations: MetricConfig{
-			Enabled: true,
-		},
-		MemcachedThreads: MetricConfig{
+		MemcachedThreads: MemcachedThreadsMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/memcachedreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/memcachedreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,37 +27,47 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					MemcachedBytes: MetricConfig{
+					MemcachedBytes: MemcachedBytesMetricConfig{
 						Enabled: true,
 					},
-					MemcachedCommands: MetricConfig{
+					MemcachedCommands: MemcachedCommandsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedCommandsMetricAttributeKey{MemcachedCommandsMetricAttributeKeyCommand},
+					},
+					MemcachedConnectionsCurrent: MemcachedConnectionsCurrentMetricConfig{
 						Enabled: true,
 					},
-					MemcachedConnectionsCurrent: MetricConfig{
+					MemcachedConnectionsTotal: MemcachedConnectionsTotalMetricConfig{
 						Enabled: true,
 					},
-					MemcachedConnectionsTotal: MetricConfig{
+					MemcachedCPUUsage: MemcachedCPUUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedCPUUsageMetricAttributeKey{MemcachedCPUUsageMetricAttributeKeyState},
+					},
+					MemcachedCurrentItems: MemcachedCurrentItemsMetricConfig{
 						Enabled: true,
 					},
-					MemcachedCPUUsage: MetricConfig{
+					MemcachedEvictions: MemcachedEvictionsMetricConfig{
 						Enabled: true,
 					},
-					MemcachedCurrentItems: MetricConfig{
-						Enabled: true,
+					MemcachedNetwork: MemcachedNetworkMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedNetworkMetricAttributeKey{MemcachedNetworkMetricAttributeKeyDirection},
 					},
-					MemcachedEvictions: MetricConfig{
-						Enabled: true,
+					MemcachedOperationHitRatio: MemcachedOperationHitRatioMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MemcachedOperationHitRatioMetricAttributeKey{MemcachedOperationHitRatioMetricAttributeKeyOperation},
 					},
-					MemcachedNetwork: MetricConfig{
-						Enabled: true,
+					MemcachedOperations: MemcachedOperationsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedOperationsMetricAttributeKey{MemcachedOperationsMetricAttributeKeyType, MemcachedOperationsMetricAttributeKeyOperation},
 					},
-					MemcachedOperationHitRatio: MetricConfig{
-						Enabled: true,
-					},
-					MemcachedOperations: MetricConfig{
-						Enabled: true,
-					},
-					MemcachedThreads: MetricConfig{
+					MemcachedThreads: MemcachedThreadsMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -66,37 +77,47 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					MemcachedBytes: MetricConfig{
+					MemcachedBytes: MemcachedBytesMetricConfig{
 						Enabled: false,
 					},
-					MemcachedCommands: MetricConfig{
+					MemcachedCommands: MemcachedCommandsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedCommandsMetricAttributeKey{MemcachedCommandsMetricAttributeKeyCommand},
+					},
+					MemcachedConnectionsCurrent: MemcachedConnectionsCurrentMetricConfig{
 						Enabled: false,
 					},
-					MemcachedConnectionsCurrent: MetricConfig{
+					MemcachedConnectionsTotal: MemcachedConnectionsTotalMetricConfig{
 						Enabled: false,
 					},
-					MemcachedConnectionsTotal: MetricConfig{
+					MemcachedCPUUsage: MemcachedCPUUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedCPUUsageMetricAttributeKey{MemcachedCPUUsageMetricAttributeKeyState},
+					},
+					MemcachedCurrentItems: MemcachedCurrentItemsMetricConfig{
 						Enabled: false,
 					},
-					MemcachedCPUUsage: MetricConfig{
+					MemcachedEvictions: MemcachedEvictionsMetricConfig{
 						Enabled: false,
 					},
-					MemcachedCurrentItems: MetricConfig{
-						Enabled: false,
+					MemcachedNetwork: MemcachedNetworkMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedNetworkMetricAttributeKey{MemcachedNetworkMetricAttributeKeyDirection},
 					},
-					MemcachedEvictions: MetricConfig{
-						Enabled: false,
+					MemcachedOperationHitRatio: MemcachedOperationHitRatioMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MemcachedOperationHitRatioMetricAttributeKey{MemcachedOperationHitRatioMetricAttributeKeyOperation},
 					},
-					MemcachedNetwork: MetricConfig{
-						Enabled: false,
+					MemcachedOperations: MemcachedOperationsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MemcachedOperationsMetricAttributeKey{MemcachedOperationsMetricAttributeKeyType, MemcachedOperationsMetricAttributeKeyOperation},
 					},
-					MemcachedOperationHitRatio: MetricConfig{
-						Enabled: false,
-					},
-					MemcachedOperations: MetricConfig{
-						Enabled: false,
-					},
-					MemcachedThreads: MetricConfig{
+					MemcachedThreads: MemcachedThreadsMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -106,7 +127,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MemcachedBytesMetricConfig{}, MemcachedCommandsMetricConfig{}, MemcachedConnectionsCurrentMetricConfig{}, MemcachedConnectionsTotalMetricConfig{}, MemcachedCPUUsageMetricConfig{}, MemcachedCurrentItemsMetricConfig{}, MemcachedEvictionsMetricConfig{}, MemcachedNetworkMetricConfig{}, MemcachedOperationHitRatioMetricConfig{}, MemcachedOperationsMetricConfig{}, MemcachedThreadsMetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
@@ -3,12 +3,20 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeCommand specifies the value command attribute.
@@ -208,9 +216,9 @@ type metricInfo struct {
 }
 
 type metricMemcachedBytes struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   MemcachedBytesMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills memcached.bytes metric with initial data.
@@ -247,7 +255,7 @@ func (m *metricMemcachedBytes) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMemcachedBytes(cfg MetricConfig) metricMemcachedBytes {
+func newMetricMemcachedBytes(cfg MemcachedBytesMetricConfig) metricMemcachedBytes {
 	m := metricMemcachedBytes{config: cfg}
 
 	if cfg.Enabled {
@@ -258,9 +266,10 @@ func newMetricMemcachedBytes(cfg MetricConfig) metricMemcachedBytes {
 }
 
 type metricMemcachedCommands struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        MemcachedCommandsMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills memcached.commands metric with initial data.
@@ -272,17 +281,48 @@ func (m *metricMemcachedCommands) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMemcachedCommands) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, commandAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MemcachedCommandsMetricAttributeKeyCommand) {
+		dp.Attributes().PutStr("command", commandAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("command", commandAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -295,13 +335,18 @@ func (m *metricMemcachedCommands) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMemcachedCommands) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMemcachedCommands(cfg MetricConfig) metricMemcachedCommands {
+func newMetricMemcachedCommands(cfg MemcachedCommandsMetricConfig) metricMemcachedCommands {
 	m := metricMemcachedCommands{config: cfg}
 
 	if cfg.Enabled {
@@ -312,9 +357,9 @@ func newMetricMemcachedCommands(cfg MetricConfig) metricMemcachedCommands {
 }
 
 type metricMemcachedConnectionsCurrent struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   MemcachedConnectionsCurrentMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills memcached.connections.current metric with initial data.
@@ -353,7 +398,7 @@ func (m *metricMemcachedConnectionsCurrent) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMemcachedConnectionsCurrent(cfg MetricConfig) metricMemcachedConnectionsCurrent {
+func newMetricMemcachedConnectionsCurrent(cfg MemcachedConnectionsCurrentMetricConfig) metricMemcachedConnectionsCurrent {
 	m := metricMemcachedConnectionsCurrent{config: cfg}
 
 	if cfg.Enabled {
@@ -364,9 +409,9 @@ func newMetricMemcachedConnectionsCurrent(cfg MetricConfig) metricMemcachedConne
 }
 
 type metricMemcachedConnectionsTotal struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   MemcachedConnectionsTotalMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills memcached.connections.total metric with initial data.
@@ -405,7 +450,7 @@ func (m *metricMemcachedConnectionsTotal) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMemcachedConnectionsTotal(cfg MetricConfig) metricMemcachedConnectionsTotal {
+func newMetricMemcachedConnectionsTotal(cfg MemcachedConnectionsTotalMetricConfig) metricMemcachedConnectionsTotal {
 	m := metricMemcachedConnectionsTotal{config: cfg}
 
 	if cfg.Enabled {
@@ -416,9 +461,10 @@ func newMetricMemcachedConnectionsTotal(cfg MetricConfig) metricMemcachedConnect
 }
 
 type metricMemcachedCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        MemcachedCPUUsageMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []float64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills memcached.cpu.usage metric with initial data.
@@ -430,17 +476,48 @@ func (m *metricMemcachedCPUUsage) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMemcachedCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MemcachedCPUUsageMetricAttributeKeyState) {
+		dp.Attributes().PutStr("state", stateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("state", stateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -453,13 +530,18 @@ func (m *metricMemcachedCPUUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMemcachedCPUUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMemcachedCPUUsage(cfg MetricConfig) metricMemcachedCPUUsage {
+func newMetricMemcachedCPUUsage(cfg MemcachedCPUUsageMetricConfig) metricMemcachedCPUUsage {
 	m := metricMemcachedCPUUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -470,9 +552,9 @@ func newMetricMemcachedCPUUsage(cfg MetricConfig) metricMemcachedCPUUsage {
 }
 
 type metricMemcachedCurrentItems struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   MemcachedCurrentItemsMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills memcached.current_items metric with initial data.
@@ -511,7 +593,7 @@ func (m *metricMemcachedCurrentItems) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMemcachedCurrentItems(cfg MetricConfig) metricMemcachedCurrentItems {
+func newMetricMemcachedCurrentItems(cfg MemcachedCurrentItemsMetricConfig) metricMemcachedCurrentItems {
 	m := metricMemcachedCurrentItems{config: cfg}
 
 	if cfg.Enabled {
@@ -522,9 +604,9 @@ func newMetricMemcachedCurrentItems(cfg MetricConfig) metricMemcachedCurrentItem
 }
 
 type metricMemcachedEvictions struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   MemcachedEvictionsMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills memcached.evictions metric with initial data.
@@ -563,7 +645,7 @@ func (m *metricMemcachedEvictions) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMemcachedEvictions(cfg MetricConfig) metricMemcachedEvictions {
+func newMetricMemcachedEvictions(cfg MemcachedEvictionsMetricConfig) metricMemcachedEvictions {
 	m := metricMemcachedEvictions{config: cfg}
 
 	if cfg.Enabled {
@@ -574,9 +656,10 @@ func newMetricMemcachedEvictions(cfg MetricConfig) metricMemcachedEvictions {
 }
 
 type metricMemcachedNetwork struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric               // data buffer for generated metric.
+	config        MemcachedNetworkMetricConfig // metric config provided by user.
+	capacity      int                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills memcached.network metric with initial data.
@@ -588,17 +671,48 @@ func (m *metricMemcachedNetwork) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMemcachedNetwork) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MemcachedNetworkMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -611,13 +725,18 @@ func (m *metricMemcachedNetwork) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMemcachedNetwork) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMemcachedNetwork(cfg MetricConfig) metricMemcachedNetwork {
+func newMetricMemcachedNetwork(cfg MemcachedNetworkMetricConfig) metricMemcachedNetwork {
 	m := metricMemcachedNetwork{config: cfg}
 
 	if cfg.Enabled {
@@ -628,9 +747,10 @@ func newMetricMemcachedNetwork(cfg MetricConfig) metricMemcachedNetwork {
 }
 
 type metricMemcachedOperationHitRatio struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        MemcachedOperationHitRatioMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []float64                              // slice containing number of aggregated datapoints at each index
 }
 
 // init fills memcached.operation_hit_ratio metric with initial data.
@@ -640,17 +760,48 @@ func (m *metricMemcachedOperationHitRatio) init() {
 	m.data.SetUnit("%")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMemcachedOperationHitRatio) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, operationAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MemcachedOperationHitRatioMetricAttributeKeyOperation) {
+		dp.Attributes().PutStr("operation", operationAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("operation", operationAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -663,13 +814,18 @@ func (m *metricMemcachedOperationHitRatio) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMemcachedOperationHitRatio) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMemcachedOperationHitRatio(cfg MetricConfig) metricMemcachedOperationHitRatio {
+func newMetricMemcachedOperationHitRatio(cfg MemcachedOperationHitRatioMetricConfig) metricMemcachedOperationHitRatio {
 	m := metricMemcachedOperationHitRatio{config: cfg}
 
 	if cfg.Enabled {
@@ -680,9 +836,10 @@ func newMetricMemcachedOperationHitRatio(cfg MetricConfig) metricMemcachedOperat
 }
 
 type metricMemcachedOperations struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        MemcachedOperationsMetricConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills memcached.operations metric with initial data.
@@ -694,18 +851,51 @@ func (m *metricMemcachedOperations) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricMemcachedOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, typeAttributeValue string, operationAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MemcachedOperationsMetricAttributeKeyType) {
+		dp.Attributes().PutStr("type", typeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, MemcachedOperationsMetricAttributeKeyOperation) {
+		dp.Attributes().PutStr("operation", operationAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("type", typeAttributeValue)
-	dp.Attributes().PutStr("operation", operationAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -718,13 +908,18 @@ func (m *metricMemcachedOperations) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMemcachedOperations) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMemcachedOperations(cfg MetricConfig) metricMemcachedOperations {
+func newMetricMemcachedOperations(cfg MemcachedOperationsMetricConfig) metricMemcachedOperations {
 	m := metricMemcachedOperations{config: cfg}
 
 	if cfg.Enabled {
@@ -735,9 +930,9 @@ func newMetricMemcachedOperations(cfg MetricConfig) metricMemcachedOperations {
 }
 
 type metricMemcachedThreads struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   MemcachedThreadsMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills memcached.threads metric with initial data.
@@ -776,7 +971,7 @@ func (m *metricMemcachedThreads) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricMemcachedThreads(cfg MetricConfig) metricMemcachedThreads {
+func newMetricMemcachedThreads(cfg MemcachedThreadsMetricConfig) metricMemcachedThreads {
 	m := metricMemcachedThreads{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -37,6 +38,11 @@ func TestMetricsBuilder(t *testing.T) {
 			resAttrsSet: testDataSetAll,
 		},
 		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
+		},
+		{
 			name:        "none_set",
 			metricsSet:  testDataSetNone,
 			resAttrsSet: testDataSetNone,
@@ -51,9 +57,17 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["MemcachedCommands"] = mb.metricMemcachedCommands.config.AggregationStrategy
+			aggMap["MemcachedCPUUsage"] = mb.metricMemcachedCPUUsage.config.AggregationStrategy
+			aggMap["MemcachedNetwork"] = mb.metricMemcachedNetwork.config.AggregationStrategy
+			aggMap["MemcachedOperationHitRatio"] = mb.metricMemcachedOperationHitRatio.config.AggregationStrategy
+			aggMap["MemcachedOperations"] = mb.metricMemcachedOperations.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -65,6 +79,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMemcachedCommandsDataPoint(ts, 1, AttributeCommandGet)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMemcachedCommandsDataPoint(ts, 3, AttributeCommandSet)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -77,6 +94,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMemcachedCPUUsageDataPoint(ts, 1, AttributeStateSystem)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMemcachedCPUUsageDataPoint(ts, 3, AttributeStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -89,14 +109,23 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMemcachedNetworkDataPoint(ts, 1, AttributeDirectionSent)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMemcachedNetworkDataPoint(ts, 3, AttributeDirectionReceived)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMemcachedOperationHitRatioDataPoint(ts, 1, AttributeOperationIncrement)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMemcachedOperationHitRatioDataPoint(ts, 3, AttributeOperationDecrement)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMemcachedOperationsDataPoint(ts, 1, AttributeTypeHit, AttributeOperationIncrement)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMemcachedOperationsDataPoint(ts, 3, AttributeTypeMiss, AttributeOperationDecrement)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -104,6 +133,13 @@ func TestMetricsBuilder(t *testing.T) {
 
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricMemcachedCommands.aggDataPoints)
+				assert.Empty(t, mb.metricMemcachedCPUUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMemcachedNetwork.aggDataPoints)
+				assert.Empty(t, mb.metricMemcachedOperationHitRatio.aggDataPoints)
+				assert.Empty(t, mb.metricMemcachedOperations.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -143,22 +179,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "memcached.commands":
-					assert.False(t, validatedMetrics["memcached.commands"], "Found a duplicate in the metrics slice: memcached.commands")
-					validatedMetrics["memcached.commands"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Commands executed.", mi.Description())
-					assert.Equal(t, "{commands}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					commandAttrVal, ok := dp.Attributes().Get("command")
-					assert.True(t, ok)
-					assert.Equal(t, "get", commandAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["memcached.commands"], "Found a duplicate in the metrics slice: memcached.commands")
+						validatedMetrics["memcached.commands"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Commands executed.", mi.Description())
+						assert.Equal(t, "{commands}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						commandAttrVal, ok := dp.Attributes().Get("command")
+						assert.True(t, ok)
+						assert.Equal(t, "get", commandAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["memcached.commands"], "Found a duplicate in the metrics slice: memcached.commands")
+						validatedMetrics["memcached.commands"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Commands executed.", mi.Description())
+						assert.Equal(t, "{commands}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["memcached.commands"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("command")
+						assert.False(t, ok)
+					}
 				case "memcached.connections.current":
 					assert.False(t, validatedMetrics["memcached.connections.current"], "Found a duplicate in the metrics slice: memcached.connections.current")
 					validatedMetrics["memcached.connections.current"] = true
@@ -188,22 +251,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "memcached.cpu.usage":
-					assert.False(t, validatedMetrics["memcached.cpu.usage"], "Found a duplicate in the metrics slice: memcached.cpu.usage")
-					validatedMetrics["memcached.cpu.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Accumulated user and system time.", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					stateAttrVal, ok := dp.Attributes().Get("state")
-					assert.True(t, ok)
-					assert.Equal(t, "system", stateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["memcached.cpu.usage"], "Found a duplicate in the metrics slice: memcached.cpu.usage")
+						validatedMetrics["memcached.cpu.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Accumulated user and system time.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						stateAttrVal, ok := dp.Attributes().Get("state")
+						assert.True(t, ok)
+						assert.Equal(t, "system", stateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["memcached.cpu.usage"], "Found a duplicate in the metrics slice: memcached.cpu.usage")
+						validatedMetrics["memcached.cpu.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Accumulated user and system time.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["memcached.cpu.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("state")
+						assert.False(t, ok)
+					}
 				case "memcached.current_items":
 					assert.False(t, validatedMetrics["memcached.current_items"], "Found a duplicate in the metrics slice: memcached.current_items")
 					validatedMetrics["memcached.current_items"] = true
@@ -233,57 +323,138 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "memcached.network":
-					assert.False(t, validatedMetrics["memcached.network"], "Found a duplicate in the metrics slice: memcached.network")
-					validatedMetrics["memcached.network"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Bytes transferred over the network.", mi.Description())
-					assert.Equal(t, "by", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "sent", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["memcached.network"], "Found a duplicate in the metrics slice: memcached.network")
+						validatedMetrics["memcached.network"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Bytes transferred over the network.", mi.Description())
+						assert.Equal(t, "by", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "sent", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["memcached.network"], "Found a duplicate in the metrics slice: memcached.network")
+						validatedMetrics["memcached.network"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Bytes transferred over the network.", mi.Description())
+						assert.Equal(t, "by", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["memcached.network"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "memcached.operation_hit_ratio":
-					assert.False(t, validatedMetrics["memcached.operation_hit_ratio"], "Found a duplicate in the metrics slice: memcached.operation_hit_ratio")
-					validatedMetrics["memcached.operation_hit_ratio"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.", mi.Description())
-					assert.Equal(t, "%", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					operationAttrVal, ok := dp.Attributes().Get("operation")
-					assert.True(t, ok)
-					assert.Equal(t, "increment", operationAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["memcached.operation_hit_ratio"], "Found a duplicate in the metrics slice: memcached.operation_hit_ratio")
+						validatedMetrics["memcached.operation_hit_ratio"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						operationAttrVal, ok := dp.Attributes().Get("operation")
+						assert.True(t, ok)
+						assert.Equal(t, "increment", operationAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["memcached.operation_hit_ratio"], "Found a duplicate in the metrics slice: memcached.operation_hit_ratio")
+						validatedMetrics["memcached.operation_hit_ratio"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["memcached.operation_hit_ratio"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("operation")
+						assert.False(t, ok)
+					}
 				case "memcached.operations":
-					assert.False(t, validatedMetrics["memcached.operations"], "Found a duplicate in the metrics slice: memcached.operations")
-					validatedMetrics["memcached.operations"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Operation counts.", mi.Description())
-					assert.Equal(t, "{operations}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					typeAttrVal, ok := dp.Attributes().Get("type")
-					assert.True(t, ok)
-					assert.Equal(t, "hit", typeAttrVal.Str())
-					operationAttrVal, ok := dp.Attributes().Get("operation")
-					assert.True(t, ok)
-					assert.Equal(t, "increment", operationAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["memcached.operations"], "Found a duplicate in the metrics slice: memcached.operations")
+						validatedMetrics["memcached.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Operation counts.", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						typeAttrVal, ok := dp.Attributes().Get("type")
+						assert.True(t, ok)
+						assert.Equal(t, "hit", typeAttrVal.Str())
+						operationAttrVal, ok := dp.Attributes().Get("operation")
+						assert.True(t, ok)
+						assert.Equal(t, "increment", operationAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["memcached.operations"], "Found a duplicate in the metrics slice: memcached.operations")
+						validatedMetrics["memcached.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Operation counts.", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["memcached.operations"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("type")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("operation")
+						assert.False(t, ok)
+					}
 				case "memcached.threads":
 					assert.False(t, validatedMetrics["memcached.threads"], "Found a duplicate in the metrics slice: memcached.threads")
 					validatedMetrics["memcached.threads"] = true

--- a/receiver/memcachedreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/memcachedreceiver/internal/metadata/testdata/config.yaml
@@ -5,22 +5,56 @@ all_set:
       enabled: true
     memcached.commands:
       enabled: true
+      attributes: ["command"]
     memcached.connections.current:
       enabled: true
     memcached.connections.total:
       enabled: true
     memcached.cpu.usage:
       enabled: true
+      attributes: ["state"]
     memcached.current_items:
       enabled: true
     memcached.evictions:
       enabled: true
     memcached.network:
       enabled: true
+      attributes: ["direction"]
     memcached.operation_hit_ratio:
       enabled: true
+      attributes: ["operation"]
     memcached.operations:
       enabled: true
+      attributes: ["type","operation"]
+    memcached.threads:
+      enabled: true
+reaggregate_set:
+  metrics:
+    memcached.bytes:
+      enabled: true
+    memcached.commands:
+      enabled: true
+      attributes: []
+    memcached.connections.current:
+      enabled: true
+    memcached.connections.total:
+      enabled: true
+    memcached.cpu.usage:
+      enabled: true
+      attributes: []
+    memcached.current_items:
+      enabled: true
+    memcached.evictions:
+      enabled: true
+    memcached.network:
+      enabled: true
+      attributes: []
+    memcached.operation_hit_ratio:
+      enabled: true
+      attributes: []
+    memcached.operations:
+      enabled: true
+      attributes: []
     memcached.threads:
       enabled: true
 none_set:
@@ -29,21 +63,26 @@ none_set:
       enabled: false
     memcached.commands:
       enabled: false
+      attributes: ["command"]
     memcached.connections.current:
       enabled: false
     memcached.connections.total:
       enabled: false
     memcached.cpu.usage:
       enabled: false
+      attributes: ["state"]
     memcached.current_items:
       enabled: false
     memcached.evictions:
       enabled: false
     memcached.network:
       enabled: false
+      attributes: ["direction"]
     memcached.operation_hit_ratio:
       enabled: false
+      attributes: ["operation"]
     memcached.operations:
       enabled: false
+      attributes: ["type","operation"]
     memcached.threads:
       enabled: false

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: Memcached Receiver
 type: memcached
+reaggregation_enabled: true
 
 description: |
   This receiver can fetch stats from a Memcached instance using the [stats
@@ -20,6 +21,7 @@ status:
 attributes:
   command:
     description: The type of command.
+    requirement_level: recommended
     type: string
     enum:
       - get
@@ -28,12 +30,14 @@ attributes:
       - touch
   direction:
     description: Direction of data flow.
+    requirement_level: recommended
     type: string
     enum:
       - sent
       - received
   operation:
     description: The type of operation.
+    requirement_level: recommended
     type: string
     enum:
       - increment
@@ -41,6 +45,7 @@ attributes:
       - get
   state:
     description: The type of CPU usage.
+    requirement_level: recommended
     type: string
     enum:
       - system
@@ -48,6 +53,7 @@ attributes:
 
   type:
     description: Result of cache request.
+    requirement_level: recommended
     type: string
     enum:
       - hit

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,64 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["MongodbatlasDbCounts"] = mb.metricMongodbatlasDbCounts.config.AggregationStrategy
+			aggMap["MongodbatlasDbSize"] = mb.metricMongodbatlasDbSize.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionIopsAverage"] = mb.metricMongodbatlasDiskPartitionIopsAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionIopsMax"] = mb.metricMongodbatlasDiskPartitionIopsMax.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionLatencyAverage"] = mb.metricMongodbatlasDiskPartitionLatencyAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionLatencyMax"] = mb.metricMongodbatlasDiskPartitionLatencyMax.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionSpaceAverage"] = mb.metricMongodbatlasDiskPartitionSpaceAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionSpaceMax"] = mb.metricMongodbatlasDiskPartitionSpaceMax.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionThroughput"] = mb.metricMongodbatlasDiskPartitionThroughput.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionUsageAverage"] = mb.metricMongodbatlasDiskPartitionUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasDiskPartitionUsageMax"] = mb.metricMongodbatlasDiskPartitionUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessAsserts"] = mb.metricMongodbatlasProcessAsserts.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCacheIo"] = mb.metricMongodbatlasProcessCacheIo.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCacheRatio"] = mb.metricMongodbatlasProcessCacheRatio.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCacheSize"] = mb.metricMongodbatlasProcessCacheSize.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenNormalizedUsageAverage"] = mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenNormalizedUsageMax"] = mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenUsageAverage"] = mb.metricMongodbatlasProcessCPUChildrenUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUChildrenUsageMax"] = mb.metricMongodbatlasProcessCPUChildrenUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUNormalizedUsageAverage"] = mb.metricMongodbatlasProcessCPUNormalizedUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUNormalizedUsageMax"] = mb.metricMongodbatlasProcessCPUNormalizedUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUUsageAverage"] = mb.metricMongodbatlasProcessCPUUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCPUUsageMax"] = mb.metricMongodbatlasProcessCPUUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasProcessCursors"] = mb.metricMongodbatlasProcessCursors.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbDocumentRate"] = mb.metricMongodbatlasProcessDbDocumentRate.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbOperationsRate"] = mb.metricMongodbatlasProcessDbOperationsRate.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbOperationsTime"] = mb.metricMongodbatlasProcessDbOperationsTime.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbQueryExecutorScanned"] = mb.metricMongodbatlasProcessDbQueryExecutorScanned.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbQueryTargetingScannedPerReturned"] = mb.metricMongodbatlasProcessDbQueryTargetingScannedPerReturned.config.AggregationStrategy
+			aggMap["MongodbatlasProcessDbStorage"] = mb.metricMongodbatlasProcessDbStorage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessGlobalLock"] = mb.metricMongodbatlasProcessGlobalLock.config.AggregationStrategy
+			aggMap["MongodbatlasProcessIndexCounters"] = mb.metricMongodbatlasProcessIndexCounters.config.AggregationStrategy
+			aggMap["MongodbatlasProcessMemoryUsage"] = mb.metricMongodbatlasProcessMemoryUsage.config.AggregationStrategy
+			aggMap["MongodbatlasProcessNetworkIo"] = mb.metricMongodbatlasProcessNetworkIo.config.AggregationStrategy
+			aggMap["MongodbatlasProcessOplogTime"] = mb.metricMongodbatlasProcessOplogTime.config.AggregationStrategy
+			aggMap["MongodbatlasProcessPageFaults"] = mb.metricMongodbatlasProcessPageFaults.config.AggregationStrategy
+			aggMap["MongodbatlasProcessTickets"] = mb.metricMongodbatlasProcessTickets.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUNormalizedUsageAverage"] = mb.metricMongodbatlasSystemCPUNormalizedUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUNormalizedUsageMax"] = mb.metricMongodbatlasSystemCPUNormalizedUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUUsageAverage"] = mb.metricMongodbatlasSystemCPUUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemCPUUsageMax"] = mb.metricMongodbatlasSystemCPUUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemFtsCPUNormalizedUsage"] = mb.metricMongodbatlasSystemFtsCPUNormalizedUsage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemFtsCPUUsage"] = mb.metricMongodbatlasSystemFtsCPUUsage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemFtsMemoryUsage"] = mb.metricMongodbatlasSystemFtsMemoryUsage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemMemoryUsageAverage"] = mb.metricMongodbatlasSystemMemoryUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemMemoryUsageMax"] = mb.metricMongodbatlasSystemMemoryUsageMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemNetworkIoAverage"] = mb.metricMongodbatlasSystemNetworkIoAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemNetworkIoMax"] = mb.metricMongodbatlasSystemNetworkIoMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingIoAverage"] = mb.metricMongodbatlasSystemPagingIoAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingIoMax"] = mb.metricMongodbatlasSystemPagingIoMax.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingUsageAverage"] = mb.metricMongodbatlasSystemPagingUsageAverage.config.AggregationStrategy
+			aggMap["MongodbatlasSystemPagingUsageMax"] = mb.metricMongodbatlasSystemPagingUsageMax.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,26 +131,44 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDbCountsDataPoint(ts, 1, AttributeObjectTypeCollection)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDbCountsDataPoint(ts, 3, AttributeObjectTypeIndex)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDbSizeDataPoint(ts, 1, AttributeObjectTypeCollection)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDbSizeDataPoint(ts, 3, AttributeObjectTypeIndex)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionIopsAverageDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionIopsAverageDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionIopsMaxDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionIopsMaxDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionLatencyAverageDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionLatencyAverageDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionQueueDepthDataPoint(ts, 1)
@@ -97,21 +176,36 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionSpaceAverageDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionSpaceAverageDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionSpaceMaxDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionSpaceMaxDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionThroughputDataPoint(ts, 1, AttributeDiskDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionThroughputDataPoint(ts, 3, AttributeDiskDirectionWrite)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, 1, AttributeDiskStatusFree)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, 3, AttributeDiskStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -124,6 +218,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessAssertsDataPoint(ts, 1, AttributeAssertTypeRegular)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessAssertsDataPoint(ts, 3, AttributeAssertTypeWarning)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -132,13 +229,22 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCacheIoDataPoint(ts, 1, AttributeCacheDirectionReadInto)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCacheIoDataPoint(ts, 3, AttributeCacheDirectionWrittenFrom)
+			}
 
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCacheRatioDataPoint(ts, 1, AttributeCacheRatioTypeCacheFill)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCacheRatioDataPoint(ts, 3, AttributeCacheRatioTypeDirtyFill)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCacheSizeDataPoint(ts, 1, AttributeCacheStatusDirty)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCacheSizeDataPoint(ts, 3, AttributeCacheStatusUsed)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -147,66 +253,114 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenNormalizedUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUChildrenUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUChildrenUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUNormalizedUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUNormalizedUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUNormalizedUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUNormalizedUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCPUUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCPUUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessCursorsDataPoint(ts, 1, AttributeCursorStateTimedOut)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessCursorsDataPoint(ts, 3, AttributeCursorStateOpen)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbDocumentRateDataPoint(ts, 1, AttributeDocumentStatusReturned)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbDocumentRateDataPoint(ts, 3, AttributeDocumentStatusInserted)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbOperationsRateDataPoint(ts, 1, AttributeOperationCmd, AttributeClusterRolePrimary)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbOperationsRateDataPoint(ts, 3, AttributeOperationQuery, AttributeClusterRoleReplica)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbOperationsTimeDataPoint(ts, 1, AttributeExecutionTypeReads)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbOperationsTimeDataPoint(ts, 3, AttributeExecutionTypeWrites)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbQueryExecutorScannedDataPoint(ts, 1, AttributeScannedTypeIndexItems)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbQueryExecutorScannedDataPoint(ts, 3, AttributeScannedTypeObjects)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbQueryTargetingScannedPerReturnedDataPoint(ts, 1, AttributeScannedTypeIndexItems)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbQueryTargetingScannedPerReturnedDataPoint(ts, 3, AttributeScannedTypeObjects)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbStorageDataPoint(ts, 1, AttributeStorageStatusTotal)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessDbStorageDataPoint(ts, 3, AttributeStorageStatusDataSize)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessGlobalLockDataPoint(ts, 1, AttributeGlobalLockStateCurrentQueueTotal)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessGlobalLockDataPoint(ts, 3, AttributeGlobalLockStateCurrentQueueReaders)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -215,6 +369,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessIndexCountersDataPoint(ts, 1, AttributeBtreeCounterTypeAccesses)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessIndexCountersDataPoint(ts, 3, AttributeBtreeCounterTypeHits)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -231,10 +388,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessMemoryUsageDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessMemoryUsageDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessNetworkIoDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessNetworkIoDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -247,10 +410,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessOplogTimeDataPoint(ts, 1, AttributeOplogTypeSlaveLagMasterTime)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessOplogTimeDataPoint(ts, 3, AttributeOplogTypeMasterTime)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessPageFaultsDataPoint(ts, 1, AttributeMemoryIssueTypeExtraInfo)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessPageFaultsDataPoint(ts, 3, AttributeMemoryIssueTypeGlobalAccessesNotInMemory)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -259,30 +428,51 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessTicketsDataPoint(ts, 1, AttributeTicketTypeAvailableReads)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasProcessTicketsDataPoint(ts, 3, AttributeTicketTypeAvailableWrites)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUNormalizedUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUNormalizedUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUNormalizedUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUNormalizedUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUUsageAverageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUUsageAverageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemCPUUsageMaxDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemCPUUsageMaxDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemFtsCPUNormalizedUsageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemFtsCPUNormalizedUsageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemFtsCPUUsageDataPoint(ts, 1, AttributeCPUStateKernel)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemFtsCPUUsageDataPoint(ts, 3, AttributeCPUStateUser)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -291,38 +481,65 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemFtsMemoryUsageDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemFtsMemoryUsageDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemMemoryUsageAverageDataPoint(ts, 1, AttributeMemoryStatusAvailable)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemMemoryUsageAverageDataPoint(ts, 3, AttributeMemoryStatusBuffers)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemMemoryUsageMaxDataPoint(ts, 1, AttributeMemoryStatusAvailable)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemMemoryUsageMaxDataPoint(ts, 3, AttributeMemoryStatusBuffers)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemNetworkIoAverageDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemNetworkIoAverageDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemNetworkIoMaxDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemNetworkIoMaxDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingIoAverageDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingIoAverageDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingIoMaxDataPoint(ts, 1, AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingIoMaxDataPoint(ts, 3, AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingUsageAverageDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingUsageAverageDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasSystemPagingUsageMaxDataPoint(ts, 1, AttributeMemoryStateResident)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbatlasSystemPagingUsageMaxDataPoint(ts, 3, AttributeMemoryStateVirtual)
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetMongodbAtlasClusterName("mongodb_atlas.cluster.name-val")
@@ -340,6 +557,60 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetMongodbAtlasUserAlias("mongodb_atlas.user.alias-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricMongodbatlasDbCounts.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDbSize.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionIopsAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionIopsMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionLatencyAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionLatencyMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionSpaceAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionSpaceMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionThroughput.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasDiskPartitionUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessAsserts.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCacheIo.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCacheRatio.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCacheSize.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenNormalizedUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUChildrenUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUNormalizedUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUNormalizedUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCPUUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessCursors.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbDocumentRate.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbOperationsRate.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbOperationsTime.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbQueryExecutorScanned.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbQueryTargetingScannedPerReturned.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessDbStorage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessGlobalLock.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessIndexCounters.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessMemoryUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessNetworkIo.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessOplogTime.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessPageFaults.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasProcessTickets.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUNormalizedUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUNormalizedUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemCPUUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemFtsCPUNormalizedUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemFtsCPUUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemFtsMemoryUsage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemMemoryUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemMemoryUsageMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemNetworkIoAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemNetworkIoMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingIoAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingIoMax.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingUsageAverage.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbatlasSystemPagingUsageMax.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -367,95 +638,245 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "mongodbatlas.db.counts":
-					assert.False(t, validatedMetrics["mongodbatlas.db.counts"], "Found a duplicate in the metrics slice: mongodbatlas.db.counts")
-					validatedMetrics["mongodbatlas.db.counts"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Database feature size", mi.Description())
-					assert.Equal(t, "{objects}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
-					assert.True(t, ok)
-					assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.db.counts"], "Found a duplicate in the metrics slice: mongodbatlas.db.counts")
+						validatedMetrics["mongodbatlas.db.counts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "{objects}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
+						assert.True(t, ok)
+						assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.db.counts"], "Found a duplicate in the metrics slice: mongodbatlas.db.counts")
+						validatedMetrics["mongodbatlas.db.counts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "{objects}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.db.counts"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("object_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.db.size":
-					assert.False(t, validatedMetrics["mongodbatlas.db.size"], "Found a duplicate in the metrics slice: mongodbatlas.db.size")
-					validatedMetrics["mongodbatlas.db.size"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Database feature size", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
-					assert.True(t, ok)
-					assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.db.size"], "Found a duplicate in the metrics slice: mongodbatlas.db.size")
+						validatedMetrics["mongodbatlas.db.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						objectTypeAttrVal, ok := dp.Attributes().Get("object_type")
+						assert.True(t, ok)
+						assert.Equal(t, "collection", objectTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.db.size"], "Found a duplicate in the metrics slice: mongodbatlas.db.size")
+						validatedMetrics["mongodbatlas.db.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Database feature size", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.db.size"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("object_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.iops.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.average")
-					validatedMetrics["mongodbatlas.disk.partition.iops.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition iops", mi.Description())
-					assert.Equal(t, "{ops}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.average")
+						validatedMetrics["mongodbatlas.disk.partition.iops.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.average")
+						validatedMetrics["mongodbatlas.disk.partition.iops.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.iops.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.iops.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.max")
-					validatedMetrics["mongodbatlas.disk.partition.iops.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition iops", mi.Description())
-					assert.Equal(t, "{ops}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.max")
+						validatedMetrics["mongodbatlas.disk.partition.iops.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.iops.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.iops.max")
+						validatedMetrics["mongodbatlas.disk.partition.iops.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition iops", mi.Description())
+						assert.Equal(t, "{ops}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.iops.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.latency.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.average")
-					validatedMetrics["mongodbatlas.disk.partition.latency.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition latency", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.average")
+						validatedMetrics["mongodbatlas.disk.partition.latency.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.average")
+						validatedMetrics["mongodbatlas.disk.partition.latency.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.latency.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.latency.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.max")
-					validatedMetrics["mongodbatlas.disk.partition.latency.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition latency", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.max")
+						validatedMetrics["mongodbatlas.disk.partition.latency.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.latency.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.latency.max")
+						validatedMetrics["mongodbatlas.disk.partition.latency.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition latency", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.latency.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.queue.depth":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.queue.depth"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.queue.depth")
 					validatedMetrics["mongodbatlas.disk.partition.queue.depth"] = true
@@ -469,80 +890,205 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.disk.partition.space.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.average")
-					validatedMetrics["mongodbatlas.disk.partition.space.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition space", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.average")
+						validatedMetrics["mongodbatlas.disk.partition.space.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.average")
+						validatedMetrics["mongodbatlas.disk.partition.space.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.space.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.space.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.max")
-					validatedMetrics["mongodbatlas.disk.partition.space.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition space", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.max")
+						validatedMetrics["mongodbatlas.disk.partition.space.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.space.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.space.max")
+						validatedMetrics["mongodbatlas.disk.partition.space.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition space", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.space.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.throughput":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.throughput"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.throughput")
-					validatedMetrics["mongodbatlas.disk.partition.throughput"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk throughput", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.throughput"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.throughput")
+						validatedMetrics["mongodbatlas.disk.partition.throughput"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk throughput", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskDirectionAttrVal, ok := dp.Attributes().Get("disk_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.throughput"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.throughput")
+						validatedMetrics["mongodbatlas.disk.partition.throughput"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk throughput", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.throughput"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
-					validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
+						validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
+						validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
-					validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", diskStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
+						validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						diskStatusAttrVal, ok := dp.Attributes().Get("disk_status")
+						assert.True(t, ok)
+						assert.Equal(t, "free", diskStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
+						validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Disk partition usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.disk.partition.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("disk_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.disk.partition.utilization.average":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.average")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.average"] = true
@@ -568,20 +1114,45 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.asserts":
-					assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
-					validatedMetrics["mongodbatlas.process.asserts"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Number of assertions per second", mi.Description())
-					assert.Equal(t, "{assertions}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					assertTypeAttrVal, ok := dp.Attributes().Get("assert_type")
-					assert.True(t, ok)
-					assert.Equal(t, "regular", assertTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
+						validatedMetrics["mongodbatlas.process.asserts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of assertions per second", mi.Description())
+						assert.Equal(t, "{assertions}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						assertTypeAttrVal, ok := dp.Attributes().Get("assert_type")
+						assert.True(t, ok)
+						assert.Equal(t, "regular", assertTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
+						validatedMetrics["mongodbatlas.process.asserts"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of assertions per second", mi.Description())
+						assert.Equal(t, "{assertions}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.asserts"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("assert_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.background_flush":
 					assert.False(t, validatedMetrics["mongodbatlas.process.background_flush"], "Found a duplicate in the metrics slice: mongodbatlas.process.background_flush")
 					validatedMetrics["mongodbatlas.process.background_flush"] = true
@@ -595,52 +1166,129 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.cache.io":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cache.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.io")
-					validatedMetrics["mongodbatlas.process.cache.io"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Cache throughput (per second)", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cacheDirectionAttrVal, ok := dp.Attributes().Get("cache_direction")
-					assert.True(t, ok)
-					assert.Equal(t, "read_into", cacheDirectionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.io")
+						validatedMetrics["mongodbatlas.process.cache.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache throughput (per second)", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cacheDirectionAttrVal, ok := dp.Attributes().Get("cache_direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read_into", cacheDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.io")
+						validatedMetrics["mongodbatlas.process.cache.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache throughput (per second)", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cache.io"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cache_direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cache.ratio":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cache.ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.ratio")
-					validatedMetrics["mongodbatlas.process.cache.ratio"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Cache ratios represented as (%)", mi.Description())
-					assert.Equal(t, "%", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cacheRatioTypeAttrVal, ok := dp.Attributes().Get("cache_ratio_type")
-					assert.True(t, ok)
-					assert.Equal(t, "cache_fill", cacheRatioTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.ratio")
+						validatedMetrics["mongodbatlas.process.cache.ratio"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache ratios represented as (%)", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cacheRatioTypeAttrVal, ok := dp.Attributes().Get("cache_ratio_type")
+						assert.True(t, ok)
+						assert.Equal(t, "cache_fill", cacheRatioTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.ratio")
+						validatedMetrics["mongodbatlas.process.cache.ratio"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cache ratios represented as (%)", mi.Description())
+						assert.Equal(t, "%", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cache.ratio"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cache_ratio_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cache.size":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cache.size"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.size")
-					validatedMetrics["mongodbatlas.process.cache.size"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Cache sizes", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cacheStatusAttrVal, ok := dp.Attributes().Get("cache_status")
-					assert.True(t, ok)
-					assert.Equal(t, "dirty", cacheStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.size"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.size")
+						validatedMetrics["mongodbatlas.process.cache.size"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cache sizes", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cacheStatusAttrVal, ok := dp.Attributes().Get("cache_status")
+						assert.True(t, ok)
+						assert.Equal(t, "dirty", cacheStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cache.size"], "Found a duplicate in the metrics slice: mongodbatlas.process.cache.size")
+						validatedMetrics["mongodbatlas.process.cache.size"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cache sizes", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cache.size"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cache_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.connections":
 					assert.False(t, validatedMetrics["mongodbatlas.process.connections"], "Found a duplicate in the metrics slice: mongodbatlas.process.connections")
 					validatedMetrics["mongodbatlas.process.connections"] = true
@@ -656,250 +1304,654 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.cpu.children.normalized.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.normalized.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.children.normalized.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.normalized.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.children.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.children.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.children.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.children.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.children.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.children.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.children.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage for child processes (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.children.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.normalized.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.normalized.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.normalized.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage, normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.normalized.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.average")
-					validatedMetrics["mongodbatlas.process.cpu.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.average")
+						validatedMetrics["mongodbatlas.process.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cpu.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.max")
-					validatedMetrics["mongodbatlas.process.cpu.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.process.cpu.usage.max")
+						validatedMetrics["mongodbatlas.process.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cpu.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.cursors":
-					assert.False(t, validatedMetrics["mongodbatlas.process.cursors"], "Found a duplicate in the metrics slice: mongodbatlas.process.cursors")
-					validatedMetrics["mongodbatlas.process.cursors"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Number of cursors", mi.Description())
-					assert.Equal(t, "{cursors}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cursorStateAttrVal, ok := dp.Attributes().Get("cursor_state")
-					assert.True(t, ok)
-					assert.Equal(t, "timed_out", cursorStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cursors"], "Found a duplicate in the metrics slice: mongodbatlas.process.cursors")
+						validatedMetrics["mongodbatlas.process.cursors"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of cursors", mi.Description())
+						assert.Equal(t, "{cursors}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cursorStateAttrVal, ok := dp.Attributes().Get("cursor_state")
+						assert.True(t, ok)
+						assert.Equal(t, "timed_out", cursorStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.cursors"], "Found a duplicate in the metrics slice: mongodbatlas.process.cursors")
+						validatedMetrics["mongodbatlas.process.cursors"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of cursors", mi.Description())
+						assert.Equal(t, "{cursors}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.cursors"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cursor_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.document.rate":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.document.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.document.rate")
-					validatedMetrics["mongodbatlas.process.db.document.rate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Document access rates", mi.Description())
-					assert.Equal(t, "{documents}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					documentStatusAttrVal, ok := dp.Attributes().Get("document_status")
-					assert.True(t, ok)
-					assert.Equal(t, "returned", documentStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.document.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.document.rate")
+						validatedMetrics["mongodbatlas.process.db.document.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Document access rates", mi.Description())
+						assert.Equal(t, "{documents}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						documentStatusAttrVal, ok := dp.Attributes().Get("document_status")
+						assert.True(t, ok)
+						assert.Equal(t, "returned", documentStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.document.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.document.rate")
+						validatedMetrics["mongodbatlas.process.db.document.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Document access rates", mi.Description())
+						assert.Equal(t, "{documents}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.document.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("document_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.operations.rate":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.rate")
-					validatedMetrics["mongodbatlas.process.db.operations.rate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "DB Operation Rates", mi.Description())
-					assert.Equal(t, "{operations}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					operationAttrVal, ok := dp.Attributes().Get("operation")
-					assert.True(t, ok)
-					assert.Equal(t, "cmd", operationAttrVal.Str())
-					clusterRoleAttrVal, ok := dp.Attributes().Get("cluster_role")
-					assert.True(t, ok)
-					assert.Equal(t, "primary", clusterRoleAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.rate")
+						validatedMetrics["mongodbatlas.process.db.operations.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "DB Operation Rates", mi.Description())
+						assert.Equal(t, "{operations}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						operationAttrVal, ok := dp.Attributes().Get("operation")
+						assert.True(t, ok)
+						assert.Equal(t, "cmd", operationAttrVal.Str())
+						clusterRoleAttrVal, ok := dp.Attributes().Get("cluster_role")
+						assert.True(t, ok)
+						assert.Equal(t, "primary", clusterRoleAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.rate"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.rate")
+						validatedMetrics["mongodbatlas.process.db.operations.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "DB Operation Rates", mi.Description())
+						assert.Equal(t, "{operations}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.operations.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("operation")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("cluster_role")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.operations.time":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.time")
-					validatedMetrics["mongodbatlas.process.db.operations.time"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "DB Operation Times", mi.Description())
-					assert.Equal(t, "ms", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					executionTypeAttrVal, ok := dp.Attributes().Get("execution_type")
-					assert.True(t, ok)
-					assert.Equal(t, "reads", executionTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.time")
+						validatedMetrics["mongodbatlas.process.db.operations.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "DB Operation Times", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						executionTypeAttrVal, ok := dp.Attributes().Get("execution_type")
+						assert.True(t, ok)
+						assert.Equal(t, "reads", executionTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.operations.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.operations.time")
+						validatedMetrics["mongodbatlas.process.db.operations.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "DB Operation Times", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.operations.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("execution_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.query_executor.scanned":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.query_executor.scanned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_executor.scanned")
-					validatedMetrics["mongodbatlas.process.db.query_executor.scanned"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Scanned objects", mi.Description())
-					assert.Equal(t, "{objects}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
-					assert.True(t, ok)
-					assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_executor.scanned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_executor.scanned")
+						validatedMetrics["mongodbatlas.process.db.query_executor.scanned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects", mi.Description())
+						assert.Equal(t, "{objects}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
+						assert.True(t, ok)
+						assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_executor.scanned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_executor.scanned")
+						validatedMetrics["mongodbatlas.process.db.query_executor.scanned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects", mi.Description())
+						assert.Equal(t, "{objects}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.query_executor.scanned"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("scanned_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.query_targeting.scanned_per_returned":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_targeting.scanned_per_returned")
-					validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Scanned objects per returned", mi.Description())
-					assert.Equal(t, "{scanned}/{returned}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
-					assert.True(t, ok)
-					assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_targeting.scanned_per_returned")
+						validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects per returned", mi.Description())
+						assert.Equal(t, "{scanned}/{returned}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						scannedTypeAttrVal, ok := dp.Attributes().Get("scanned_type")
+						assert.True(t, ok)
+						assert.Equal(t, "index_items", scannedTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.query_targeting.scanned_per_returned")
+						validatedMetrics["mongodbatlas.process.db.query_targeting.scanned_per_returned"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Scanned objects per returned", mi.Description())
+						assert.Equal(t, "{scanned}/{returned}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.query_targeting.scanned_per_returned"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("scanned_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.db.storage":
-					assert.False(t, validatedMetrics["mongodbatlas.process.db.storage"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.storage")
-					validatedMetrics["mongodbatlas.process.db.storage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Storage used by the database", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					storageStatusAttrVal, ok := dp.Attributes().Get("storage_status")
-					assert.True(t, ok)
-					assert.Equal(t, "total", storageStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.storage"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.storage")
+						validatedMetrics["mongodbatlas.process.db.storage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Storage used by the database", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						storageStatusAttrVal, ok := dp.Attributes().Get("storage_status")
+						assert.True(t, ok)
+						assert.Equal(t, "total", storageStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.db.storage"], "Found a duplicate in the metrics slice: mongodbatlas.process.db.storage")
+						validatedMetrics["mongodbatlas.process.db.storage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Storage used by the database", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.db.storage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("storage_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.global_lock":
-					assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
-					validatedMetrics["mongodbatlas.process.global_lock"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Number and status of locks", mi.Description())
-					assert.Equal(t, "{locks}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					globalLockStateAttrVal, ok := dp.Attributes().Get("global_lock_state")
-					assert.True(t, ok)
-					assert.Equal(t, "current_queue_total", globalLockStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
+						validatedMetrics["mongodbatlas.process.global_lock"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number and status of locks", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						globalLockStateAttrVal, ok := dp.Attributes().Get("global_lock_state")
+						assert.True(t, ok)
+						assert.Equal(t, "current_queue_total", globalLockStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
+						validatedMetrics["mongodbatlas.process.global_lock"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number and status of locks", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.global_lock"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("global_lock_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.index.btree_miss_ratio":
 					assert.False(t, validatedMetrics["mongodbatlas.process.index.btree_miss_ratio"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.btree_miss_ratio")
 					validatedMetrics["mongodbatlas.process.index.btree_miss_ratio"] = true
@@ -913,20 +1965,45 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.index.counters":
-					assert.False(t, validatedMetrics["mongodbatlas.process.index.counters"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.counters")
-					validatedMetrics["mongodbatlas.process.index.counters"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Indexes", mi.Description())
-					assert.Equal(t, "{indexes}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					btreeCounterTypeAttrVal, ok := dp.Attributes().Get("btree_counter_type")
-					assert.True(t, ok)
-					assert.Equal(t, "accesses", btreeCounterTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.index.counters"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.counters")
+						validatedMetrics["mongodbatlas.process.index.counters"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Indexes", mi.Description())
+						assert.Equal(t, "{indexes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						btreeCounterTypeAttrVal, ok := dp.Attributes().Get("btree_counter_type")
+						assert.True(t, ok)
+						assert.Equal(t, "accesses", btreeCounterTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.index.counters"], "Found a duplicate in the metrics slice: mongodbatlas.process.index.counters")
+						validatedMetrics["mongodbatlas.process.index.counters"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Indexes", mi.Description())
+						assert.Equal(t, "{indexes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.index.counters"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("btree_counter_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.journaling.commits":
 					assert.False(t, validatedMetrics["mongodbatlas.process.journaling.commits"], "Found a duplicate in the metrics slice: mongodbatlas.process.journaling.commits")
 					validatedMetrics["mongodbatlas.process.journaling.commits"] = true
@@ -964,35 +2041,85 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.memory.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.process.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.memory.usage")
-					validatedMetrics["mongodbatlas.process.memory.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Memory Usage", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.memory.usage")
+						validatedMetrics["mongodbatlas.process.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Memory Usage", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.memory.usage")
+						validatedMetrics["mongodbatlas.process.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Memory Usage", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.memory.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.network.io":
-					assert.False(t, validatedMetrics["mongodbatlas.process.network.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.io")
-					validatedMetrics["mongodbatlas.process.network.io"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Network IO", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.network.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.io")
+						validatedMetrics["mongodbatlas.process.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.network.io"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.io")
+						validatedMetrics["mongodbatlas.process.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.network.io"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.network.requests":
 					assert.False(t, validatedMetrics["mongodbatlas.process.network.requests"], "Found a duplicate in the metrics slice: mongodbatlas.process.network.requests")
 					validatedMetrics["mongodbatlas.process.network.requests"] = true
@@ -1020,35 +2147,85 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.oplog.time":
-					assert.False(t, validatedMetrics["mongodbatlas.process.oplog.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.oplog.time")
-					validatedMetrics["mongodbatlas.process.oplog.time"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Execution time by operation", mi.Description())
-					assert.Equal(t, "s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					oplogTypeAttrVal, ok := dp.Attributes().Get("oplog_type")
-					assert.True(t, ok)
-					assert.Equal(t, "slave_lag_master_time", oplogTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.oplog.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.oplog.time")
+						validatedMetrics["mongodbatlas.process.oplog.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Execution time by operation", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						oplogTypeAttrVal, ok := dp.Attributes().Get("oplog_type")
+						assert.True(t, ok)
+						assert.Equal(t, "slave_lag_master_time", oplogTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.oplog.time"], "Found a duplicate in the metrics slice: mongodbatlas.process.oplog.time")
+						validatedMetrics["mongodbatlas.process.oplog.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Execution time by operation", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.oplog.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("oplog_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.page_faults":
-					assert.False(t, validatedMetrics["mongodbatlas.process.page_faults"], "Found a duplicate in the metrics slice: mongodbatlas.process.page_faults")
-					validatedMetrics["mongodbatlas.process.page_faults"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Page faults", mi.Description())
-					assert.Equal(t, "{faults}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryIssueTypeAttrVal, ok := dp.Attributes().Get("memory_issue_type")
-					assert.True(t, ok)
-					assert.Equal(t, "extra_info", memoryIssueTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.page_faults"], "Found a duplicate in the metrics slice: mongodbatlas.process.page_faults")
+						validatedMetrics["mongodbatlas.process.page_faults"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Page faults", mi.Description())
+						assert.Equal(t, "{faults}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryIssueTypeAttrVal, ok := dp.Attributes().Get("memory_issue_type")
+						assert.True(t, ok)
+						assert.Equal(t, "extra_info", memoryIssueTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.page_faults"], "Found a duplicate in the metrics slice: mongodbatlas.process.page_faults")
+						validatedMetrics["mongodbatlas.process.page_faults"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Page faults", mi.Description())
+						assert.Equal(t, "{faults}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.page_faults"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_issue_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.process.restarts":
 					assert.False(t, validatedMetrics["mongodbatlas.process.restarts"], "Found a duplicate in the metrics slice: mongodbatlas.process.restarts")
 					validatedMetrics["mongodbatlas.process.restarts"] = true
@@ -1062,110 +2239,285 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.process.tickets":
-					assert.False(t, validatedMetrics["mongodbatlas.process.tickets"], "Found a duplicate in the metrics slice: mongodbatlas.process.tickets")
-					validatedMetrics["mongodbatlas.process.tickets"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Tickets", mi.Description())
-					assert.Equal(t, "{tickets}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					ticketTypeAttrVal, ok := dp.Attributes().Get("ticket_type")
-					assert.True(t, ok)
-					assert.Equal(t, "available_reads", ticketTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.process.tickets"], "Found a duplicate in the metrics slice: mongodbatlas.process.tickets")
+						validatedMetrics["mongodbatlas.process.tickets"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Tickets", mi.Description())
+						assert.Equal(t, "{tickets}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						ticketTypeAttrVal, ok := dp.Attributes().Get("ticket_type")
+						assert.True(t, ok)
+						assert.Equal(t, "available_reads", ticketTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.process.tickets"], "Found a duplicate in the metrics slice: mongodbatlas.process.tickets")
+						validatedMetrics["mongodbatlas.process.tickets"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Tickets", mi.Description())
+						assert.Equal(t, "{tickets}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.process.tickets"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("ticket_type")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.normalized.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.average")
-					validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.normalized.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.normalized.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.max")
-					validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Normalized to pct", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.normalized.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.normalized.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Normalized to pct", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.normalized.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.average")
-					validatedMetrics["mongodbatlas.system.cpu.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.average")
+						validatedMetrics["mongodbatlas.system.cpu.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.cpu.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.max")
-					validatedMetrics["mongodbatlas.system.cpu.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System CPU Usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.cpu.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.cpu.usage.max")
+						validatedMetrics["mongodbatlas.system.cpu.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System CPU Usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.cpu.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.fts.cpu.normalized.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.normalized.usage")
-					validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Full text search disk usage (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.normalized.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full text search disk usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.normalized.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.normalized.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full text search disk usage (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.fts.cpu.normalized.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.fts.cpu.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.usage")
-					validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Full-text search (%)", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full-text search (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuStateAttrVal, ok := dp.Attributes().Get("cpu_state")
+						assert.True(t, ok)
+						assert.Equal(t, "kernel", cpuStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.cpu.usage")
+						validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Full-text search (%)", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.fts.cpu.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("cpu_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.fts.disk.used":
 					assert.False(t, validatedMetrics["mongodbatlas.system.fts.disk.used"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.disk.used")
 					validatedMetrics["mongodbatlas.system.fts.disk.used"] = true
@@ -1179,142 +2531,369 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodbatlas.system.fts.memory.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.system.fts.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.memory.usage")
-					validatedMetrics["mongodbatlas.system.fts.memory.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Full-text search", mi.Description())
-					assert.Equal(t, "MiBy", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.memory.usage")
+						validatedMetrics["mongodbatlas.system.fts.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Full-text search", mi.Description())
+						assert.Equal(t, "MiBy", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.fts.memory.usage"], "Found a duplicate in the metrics slice: mongodbatlas.system.fts.memory.usage")
+						validatedMetrics["mongodbatlas.system.fts.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Full-text search", mi.Description())
+						assert.Equal(t, "MiBy", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.fts.memory.usage"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.memory.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.average")
-					validatedMetrics["mongodbatlas.system.memory.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Memory Usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
-					assert.True(t, ok)
-					assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.average")
+						validatedMetrics["mongodbatlas.system.memory.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
+						assert.True(t, ok)
+						assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.average")
+						validatedMetrics["mongodbatlas.system.memory.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.memory.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.memory.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.max")
-					validatedMetrics["mongodbatlas.system.memory.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Memory Usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
-					assert.True(t, ok)
-					assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.max")
+						validatedMetrics["mongodbatlas.system.memory.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStatusAttrVal, ok := dp.Attributes().Get("memory_status")
+						assert.True(t, ok)
+						assert.Equal(t, "available", memoryStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.memory.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.memory.usage.max")
+						validatedMetrics["mongodbatlas.system.memory.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Memory Usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.memory.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_status")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.network.io.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.network.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.average")
-					validatedMetrics["mongodbatlas.system.network.io.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Network IO", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.average")
+						validatedMetrics["mongodbatlas.system.network.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.average")
+						validatedMetrics["mongodbatlas.system.network.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.network.io.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.network.io.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.network.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.max")
-					validatedMetrics["mongodbatlas.system.network.io.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "System Network IO", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.max")
+						validatedMetrics["mongodbatlas.system.network.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.network.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.network.io.max")
+						validatedMetrics["mongodbatlas.system.network.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "System Network IO", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.network.io.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.io.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.average")
-					validatedMetrics["mongodbatlas.system.paging.io.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap IO", mi.Description())
-					assert.Equal(t, "{pages}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.average")
+						validatedMetrics["mongodbatlas.system.paging.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.average")
+						validatedMetrics["mongodbatlas.system.paging.io.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.io.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.io.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.max")
-					validatedMetrics["mongodbatlas.system.paging.io.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap IO", mi.Description())
-					assert.Equal(t, "{pages}/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.max")
+						validatedMetrics["mongodbatlas.system.paging.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.io.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.io.max")
+						validatedMetrics["mongodbatlas.system.paging.io.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap IO", mi.Description())
+						assert.Equal(t, "{pages}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.io.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.average")
-					validatedMetrics["mongodbatlas.system.paging.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.average")
+						validatedMetrics["mongodbatlas.system.paging.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.average")
+						validatedMetrics["mongodbatlas.system.paging.usage.average"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.usage.average"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				case "mongodbatlas.system.paging.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.max")
-					validatedMetrics["mongodbatlas.system.paging.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Swap usage", mi.Description())
-					assert.Equal(t, "KiBy", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-					memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
-					assert.True(t, ok)
-					assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.max")
+						validatedMetrics["mongodbatlas.system.paging.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory_state")
+						assert.True(t, ok)
+						assert.Equal(t, "resident", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodbatlas.system.paging.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.system.paging.usage.max")
+						validatedMetrics["mongodbatlas.system.paging.usage.max"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Swap usage", mi.Description())
+						assert.Equal(t, "KiBy", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodbatlas.system.paging.usage.max"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("memory_state")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #46364, part of #45396.

Adds `reaggregation_enabled: true` to `metadata.yaml` and sets `requirement_level: recommended` on all 5 metric attributes. This enables consumers to re-aggregate Memcached metrics with a subset of attribute labels without losing data.

No existing configuration files are broken by this change.

Generated files updated via `go generate ./...`.