### PR TITLE
[fluentforwardreceiver] fix: isolate ResourceLogs per event in collector

### DIFF
--- a/receiver/fluentforwardreceiver/collector.go
+++ b/receiver/fluentforwardreceiver/collector.go
@@ -14,10 +14,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver/internal/metadata"
 )
 
-// collector acts as an aggregator of LogRecords so that we don't have to
-// generate as many plog.Logs instances...we can pre-batch the LogRecord
-// instances from several Forward events into one to hopefully reduce
-// allocations and GC overhead.
+// collector aggregates LogRecords from multiple Forward events into a single
+// plog.Logs per ConsumeLogs call for batching efficiency. Each event is placed
+// in its own ResourceLogs to ensure resource attribute isolation.
 type collector struct {
 	nextConsumer     consumer.Logs
 	eventCh          <-chan event
@@ -47,13 +46,12 @@ func (c *collector) processEvents(ctx context.Context) {
 			return
 		case e := <-c.eventCh:
 			out := plog.NewLogs()
-			rls := out.ResourceLogs().AppendEmpty()
-			logSlice := rls.ScopeLogs().AppendEmpty().LogRecords()
-			e.LogRecords().MoveAndAppendTo(logSlice)
+			appendEventToLogs(out, e)
 
-			// Pull out anything waiting on the eventCh to get better
-			// efficiency on LogResource allocations.
-			c.fillBufferUntilChanEmpty(logSlice)
+			// Drain anything waiting on the eventCh into the same plog.Logs
+			// for batching efficiency. Each event gets its own ResourceLogs to
+			// ensure resource attribute isolation across events.
+			c.fillBufferUntilChanEmpty(out)
 
 			logRecordCount := out.LogRecordCount()
 			c.telemetryBuilder.FluentRecordsGenerated.Add(ctx, int64(logRecordCount))
@@ -64,11 +62,19 @@ func (c *collector) processEvents(ctx context.Context) {
 	}
 }
 
-func (c *collector) fillBufferUntilChanEmpty(dest plog.LogRecordSlice) {
+// appendEventToLogs places an event's log records into a new ResourceLogs
+// within out, ensuring resource attribute isolation between events.
+func appendEventToLogs(out plog.Logs, e event) {
+	rls := out.ResourceLogs().AppendEmpty()
+	logSlice := rls.ScopeLogs().AppendEmpty().LogRecords()
+	e.LogRecords().MoveAndAppendTo(logSlice)
+}
+
+func (c *collector) fillBufferUntilChanEmpty(out plog.Logs) {
 	for {
 		select {
 		case e := <-c.eventCh:
-			e.LogRecords().MoveAndAppendTo(dest)
+			appendEventToLogs(out, e)
 		default:
 			return
 		}

--- a/receiver/fluentforwardreceiver/collector_test.go
+++ b/receiver/fluentforwardreceiver/collector_test.go
@@ -16,10 +16,10 @@ type fakeEvent struct {
 	records plog.LogRecordSlice
 }
 
-func (f *fakeEvent) DecodeMsg(_ *msgp.Reader) error  { return nil }
+func (*fakeEvent) DecodeMsg(_ *msgp.Reader) error    { return nil }
 func (f *fakeEvent) LogRecords() plog.LogRecordSlice { return f.records }
-func (f *fakeEvent) Chunk() string                   { return "" }
-func (f *fakeEvent) Compressed() string              { return "" }
+func (*fakeEvent) Chunk() string                     { return "" }
+func (*fakeEvent) Compressed() string                { return "" }
 
 func newFakeEvent(numRecords int) event {
 	records := plog.NewLogRecordSlice()

--- a/receiver/fluentforwardreceiver/collector_test.go
+++ b/receiver/fluentforwardreceiver/collector_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fluentforwardreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// fakeEvent is a minimal event implementation for collector unit tests.
+type fakeEvent struct {
+	records plog.LogRecordSlice
+}
+
+func (f *fakeEvent) DecodeMsg(_ *msgp.Reader) error  { return nil }
+func (f *fakeEvent) LogRecords() plog.LogRecordSlice { return f.records }
+func (f *fakeEvent) Chunk() string                   { return "" }
+func (f *fakeEvent) Compressed() string              { return "" }
+
+func newFakeEvent(numRecords int) event {
+	records := plog.NewLogRecordSlice()
+	for range numRecords {
+		records.AppendEmpty()
+	}
+	return &fakeEvent{records: records}
+}
+
+// TestAppendEventToLogsIsolation verifies that each call to appendEventToLogs
+// creates a distinct ResourceLogs, so resource attributes set by downstream
+// processors are scoped to a single event only.
+func TestAppendEventToLogsIsolation(t *testing.T) {
+	out := plog.NewLogs()
+
+	appendEventToLogs(out, newFakeEvent(2))
+	appendEventToLogs(out, newFakeEvent(3))
+
+	require.Equal(t, 2, out.ResourceLogs().Len())
+	require.Equal(t, 2, out.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().Len())
+	require.Equal(t, 3, out.ResourceLogs().At(1).ScopeLogs().At(0).LogRecords().Len())
+}
+
+// TestFillBufferUntilChanEmptyIsolation verifies that draining multiple events
+// from the channel produces one ResourceLogs per event rather than merging all
+// records into a shared ResourceLogs.
+func TestFillBufferUntilChanEmptyIsolation(t *testing.T) {
+	const N = 5
+	eventCh := make(chan event, N)
+	for range N {
+		eventCh <- newFakeEvent(1)
+	}
+
+	c := &collector{eventCh: eventCh}
+	out := plog.NewLogs()
+	c.fillBufferUntilChanEmpty(out)
+
+	require.Equal(t, N, out.ResourceLogs().Len())
+	for i := range N {
+		require.Equal(t, 1, out.ResourceLogs().At(i).ScopeLogs().At(0).LogRecords().Len(),
+			"event %d should be in its own ResourceLogs", i)
+	}
+}


### PR DESCRIPTION
Fixes #47757

## Description

All Forward events batched in `fillBufferUntilChanEmpty` were merged into a single `ResourceLogs` via a shared `LogRecordSlice`. Downstream processors that enrich resource attributes (e.g. `resourcedetectionprocessor`, `k8sattributesprocessor`) would incorrectly apply attributes to all events in a batch rather than the originating event only.

### Changes

**`collector.go`**
- Extract `appendEventToLogs(out plog.Logs, e event)` helper — creates a new `ResourceLogs` per event
- Change `fillBufferUntilChanEmpty` signature from `(dest plog.LogRecordSlice)` to `(out plog.Logs)` and use `appendEventToLogs`
- Update `processEvents` accordingly

**`collector_test.go`** (new)
- `TestAppendEventToLogsIsolation` — asserts two events produce two distinct `ResourceLogs`
- `TestFillBufferUntilChanEmptyIsolation` — asserts N buffered events produce N `ResourceLogs`

Batching efficiency (single `ConsumeLogs` call per drain cycle) is preserved.

## Testing

```
go test ./receiver/fluentforwardreceiver/... -run "TestAppendEventToLogsIsolation|TestFillBufferUntilChanEmptyIsolation" -v
```

Both tests pass. All existing tests continue to pass.

Assisted-by: Claude Sonnet 4.6