### PR TITLE
[all] preserve effective config fidelity for component configs

### DIFF
--- a/.chloggen/confmap-marshal-effective-config-fidelity.yaml
+++ b/.chloggen/confmap-marshal-effective-config-fidelity.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: all
+note: Preserve print-config and effective-config fidelity for component configs that rely on generic confmap marshaling.
+issues: [47760]
+subtext: |
+  Adds explicit confmap marshalers for component configs that embedded unexported squashed fields and could lose
+  effective configuration content in print-config output.
+change_logs: [user]

--- a/exporter/datasetexporter/config.go
+++ b/exporter/datasetexporter/config.go
@@ -49,6 +49,8 @@ type TracesSettings struct {
 	exportSettings `mapstructure:",squash"`
 }
 
+var _ confmap.Marshaler = TracesSettings{}
+
 // newDefaultTracesSettings returns the default settings for TracesSettings.
 func newDefaultTracesSettings() TracesSettings {
 	return TracesSettings{
@@ -98,6 +100,8 @@ type LogsSettings struct {
 	exportSettings `mapstructure:",squash"`
 }
 
+var _ confmap.Marshaler = LogsSettings{}
+
 // newDefaultLogsSettings returns the default settings for LogsSettings.
 func newDefaultLogsSettings() LogsSettings {
 	return LogsSettings{
@@ -109,6 +113,38 @@ func newDefaultLogsSettings() LogsSettings {
 		DecomposedComplexMessagePrefix: logsDecomposedComplexMessageFieldPrefixDefault,
 		exportSettings:                 newDefaultExportSettings(),
 	}
+}
+
+func (c TracesSettings) Marshal(conf *confmap.Conf) error {
+	return conf.Marshal(struct {
+		ExportSeparator            string `mapstructure:"export_separator"`
+		ExportDistinguishingSuffix string `mapstructure:"export_distinguishing_suffix"`
+	}{
+		ExportSeparator:            c.ExportSeparator,
+		ExportDistinguishingSuffix: c.ExportDistinguishingSuffix,
+	})
+}
+
+func (c LogsSettings) Marshal(conf *confmap.Conf) error {
+	return conf.Marshal(struct {
+		ExportResourceInfo             bool   `mapstructure:"export_resource_info_on_event"`
+		ExportResourcePrefix           string `mapstructure:"export_resource_prefix"`
+		ExportScopeInfo                bool   `mapstructure:"export_scope_info_on_event"`
+		ExportScopePrefix              string `mapstructure:"export_scope_prefix"`
+		DecomposeComplexMessageField   bool   `mapstructure:"decompose_complex_message_field"`
+		DecomposedComplexMessagePrefix string `mapstructure:"decomposed_complex_message_prefix"`
+		ExportSeparator                string `mapstructure:"export_separator"`
+		ExportDistinguishingSuffix     string `mapstructure:"export_distinguishing_suffix"`
+	}{
+		ExportResourceInfo:             c.ExportResourceInfo,
+		ExportResourcePrefix:           c.ExportResourcePrefix,
+		ExportScopeInfo:                c.ExportScopeInfo,
+		ExportScopePrefix:              c.ExportScopePrefix,
+		DecomposeComplexMessageField:   c.DecomposeComplexMessageField,
+		DecomposedComplexMessagePrefix: c.DecomposedComplexMessagePrefix,
+		ExportSeparator:                c.ExportSeparator,
+		ExportDistinguishingSuffix:     c.ExportDistinguishingSuffix,
+	})
 }
 
 const (

--- a/exporter/datasetexporter/config_test.go
+++ b/exporter/datasetexporter/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -128,4 +129,42 @@ func TestConfigUseProvidedExportScopeInfoValue(t *testing.T) {
 	err := config.Unmarshal(configMap)
 	assert.NoError(t, err)
 	assert.False(t, config.ExportScopeInfo)
+}
+
+func TestConfigMarshalRoundTripPreservesExportSettings(t *testing.T) {
+	f := NewFactory()
+	config := f.CreateDefaultConfig().(*Config)
+	configMap := confmap.NewFromStringMap(map[string]any{
+		"dataset_url": "https://example.com",
+		"api_key":     "secret",
+		"traces": map[string]any{
+			"export_separator":             "::",
+			"export_distinguishing_suffix": "__",
+		},
+		"logs": map[string]any{
+			"export_scope_prefix":          "scope.",
+			"export_separator":             "//",
+			"export_distinguishing_suffix": "++",
+		},
+	})
+	require.NoError(t, config.Unmarshal(configMap))
+
+	out := confmap.New()
+	require.NoError(t, out.Marshal(config))
+
+	roundTrip := out.ToStringMap()
+	assert.Equal(t, map[string]any{
+		"export_separator":             "::",
+		"export_distinguishing_suffix": "__",
+	}, roundTrip["traces"])
+	assert.Equal(t, map[string]any{
+		"decompose_complex_message_field":   false,
+		"decomposed_complex_message_prefix": "body.map.",
+		"export_resource_info_on_event":     false,
+		"export_resource_prefix":            "resource.attributes.",
+		"export_scope_info_on_event":        true,
+		"export_scope_prefix":               "scope.",
+		"export_separator":                  "//",
+		"export_distinguishing_suffix":      "++",
+	}, roundTrip["logs"])
 }

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/confmap"
 	"go.uber.org/zap"
 )
 
@@ -115,6 +116,24 @@ type httpFields struct {
 	commonFields `mapstructure:",squash"`
 
 	PollingInterval time.Duration `mapstructure:"polling_interval"`
+}
+
+var _ confmap.Marshaler = httpFields{}
+
+func (h httpFields) Marshal(conf *confmap.Conf) error {
+	return conf.Marshal(struct {
+		Endpoint        string                         `mapstructure:"endpoint"`
+		TLS             configtls.ClientConfig         `mapstructure:"tls,omitempty"`
+		Headers         map[string]configopaque.String `mapstructure:"headers,omitempty"`
+		Auth            component.ID                   `mapstructure:"auth,omitempty"`
+		PollingInterval time.Duration                  `mapstructure:"polling_interval"`
+	}{
+		Endpoint:        h.Endpoint,
+		TLS:             h.TLS,
+		Headers:         h.Headers,
+		Auth:            h.Auth,
+		PollingInterval: h.PollingInterval,
+	})
 }
 
 func (h *httpFields) Validate() error {

--- a/extension/opampextension/config_test.go
+++ b/extension/opampextension/config_test.go
@@ -73,6 +73,31 @@ func TestUnmarshalHttpConfig(t *testing.T) {
 		}, cfg)
 }
 
+func TestMarshalHttpConfigPreservesEmbeddedFields(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cm := confmap.NewFromStringMap(map[string]any{
+		"server": map[string]any{
+			"http": map[string]any{
+				"endpoint":         "https://127.0.0.1:4320/v1/opamp",
+				"headers":          map[string]any{"x-test": "abc"},
+				"auth":             "basicauth/client",
+				"polling_interval": "17s",
+			},
+		},
+	})
+	require.NoError(t, cm.Unmarshal(cfg))
+
+	out := confmap.New()
+	require.NoError(t, out.Marshal(cfg))
+
+	server := out.ToStringMap()["server"].(map[string]any)
+	http := server["http"].(map[string]any)
+	assert.Equal(t, "https://127.0.0.1:4320/v1/opamp", http["endpoint"])
+	assert.Equal(t, map[string]any{"x-test": "[REDACTED]"}, http["headers"])
+	assert.Equal(t, "basicauth/client", http["auth"])
+	assert.Equal(t, time.Duration(17*time.Second), http["polling_interval"])
+}
+
 func TestConfig_Getters(t *testing.T) {
 	type fields struct {
 		Server *OpAMPServer

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -5,9 +5,11 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tailstorageextension"
@@ -98,7 +100,7 @@ type sharedPolicyCfg struct {
 	// Configs for OTTL condition filter sampling policy evaluator
 	OTTLConditionCfg OTTLConditionCfg `mapstructure:"ottl_condition"`
 	// Configs for any extensions that are used.
-	ExtensionCfg map[string]map[string]any `mapstructure:",remain"`
+	ExtensionCfg map[string]any `mapstructure:",remain"`
 }
 
 // CompositeSubPolicyCfg holds the common configuration to all policies under composite policy.
@@ -358,6 +360,85 @@ type Config struct {
 	// If the trace size exceeds this it will be dropped before the decision period to keep memory more predictable.
 	// A 0 value disables dropping large traces early.
 	MaximumTraceSizeBytes uint64 `mapstructure:"maximum_trace_size_bytes"`
+}
+
+var (
+	_ confmap.Marshaler = PolicyCfg{}
+	_ confmap.Marshaler = CompositeSubPolicyCfg{}
+	_ confmap.Marshaler = AndSubPolicyCfg{}
+	_ confmap.Marshaler = NotSubPolicyCfg{}
+)
+
+func marshalPolicy(conf *confmap.Conf, shared sharedPolicyCfg, extra map[string]any) error {
+	fields := map[string]any{
+		"name": shared.Name,
+		"type": shared.Type,
+	}
+
+	maps.Copy(fields, shared.ExtensionCfg)
+
+	switch shared.Type {
+	case Latency:
+		fields[string(Latency)] = shared.LatencyCfg
+	case NumericAttribute:
+		fields[string(NumericAttribute)] = shared.NumericAttributeCfg
+	case Probabilistic:
+		fields[string(Probabilistic)] = shared.ProbabilisticCfg
+	case StatusCode:
+		fields[string(StatusCode)] = shared.StatusCodeCfg
+	case StringAttribute:
+		fields[string(StringAttribute)] = shared.StringAttributeCfg
+	case RateLimiting:
+		fields[string(RateLimiting)] = shared.RateLimitingCfg
+	case BytesLimiting:
+		fields[string(BytesLimiting)] = shared.BytesLimitingCfg
+	case SpanCount:
+		fields[string(SpanCount)] = shared.SpanCountCfg
+	case TraceState:
+		fields[string(TraceState)] = shared.TraceStateCfg
+	case BooleanAttribute:
+		fields[string(BooleanAttribute)] = shared.BooleanAttributeCfg
+	case OTTLCondition:
+		fields[string(OTTLCondition)] = shared.OTTLConditionCfg
+	}
+
+	maps.Copy(fields, extra)
+
+	return conf.Marshal(fields)
+}
+
+func (p PolicyCfg) Marshal(conf *confmap.Conf) error {
+	extra := map[string]any{}
+
+	switch p.Type {
+	case Composite:
+		extra[string(Composite)] = p.CompositeCfg
+	case And:
+		extra[string(And)] = p.AndCfg
+	case Not:
+		extra[string(Not)] = p.NotCfg
+	case Drop:
+		extra[string(Drop)] = p.DropCfg
+	}
+
+	return marshalPolicy(conf, p.sharedPolicyCfg, extra)
+}
+
+func (p CompositeSubPolicyCfg) Marshal(conf *confmap.Conf) error {
+	extra := map[string]any{}
+	if p.Type == And {
+		extra[string(And)] = p.AndCfg
+	}
+
+	return marshalPolicy(conf, p.sharedPolicyCfg, extra)
+}
+
+func (p AndSubPolicyCfg) Marshal(conf *confmap.Conf) error {
+	return marshalPolicy(conf, p.sharedPolicyCfg, nil)
+}
+
+func (p NotSubPolicyCfg) Marshal(conf *confmap.Conf) error {
+	return marshalPolicy(conf, p.sharedPolicyCfg, nil)
 }
 
 func (cfg *Config) Validate() error {

--- a/processor/tailsamplingprocessor/config.schema.yaml
+++ b/processor/tailsamplingprocessor/config.schema.yaml
@@ -15,9 +15,7 @@ $defs:
         description: Configs for any extensions that are used.
         type: object
         additionalProperties:
-          type: object
-          additionalProperties:
-            x-customType: any
+          x-customType: any
       boolean_attribute:
         description: Configs for boolean attribute filter sampling policy evaluator.
         $ref: boolean_attribute_cfg
@@ -109,9 +107,7 @@ $defs:
         description: Configs for any extensions that are used.
         type: object
         additionalProperties:
-          type: object
-          additionalProperties:
-            x-customType: any
+          x-customType: any
       and:
         description: Configs for and policy evaluator.
         $ref: and_cfg
@@ -197,9 +193,7 @@ $defs:
         description: Configs for any extensions that are used.
         type: object
         additionalProperties:
-          type: object
-          additionalProperties:
-            x-customType: any
+          x-customType: any
       boolean_attribute:
         description: Configs for boolean attribute filter sampling policy evaluator.
         $ref: boolean_attribute_cfg
@@ -279,9 +273,7 @@ $defs:
         description: Configs for any extensions that are used.
         type: object
         additionalProperties:
-          type: object
-          additionalProperties:
-            x-customType: any
+          x-customType: any
       and:
         description: Configs for defining and policy
         $ref: and_cfg

--- a/processor/tailsamplingprocessor/config_test.go
+++ b/processor/tailsamplingprocessor/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/featuregate"
 
@@ -210,6 +211,237 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		}, cfg)
+}
+
+func TestConfigMarshalPoliciesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		SamplingStrategy: samplingStrategyTraceComplete,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "baseline",
+					Type: Probabilistic,
+					ProbabilisticCfg: ProbabilisticCfg{
+						HashSalt:           "salt",
+						SamplingPercentage: 1,
+					},
+				},
+			},
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "errors",
+					Type: StatusCode,
+					StatusCodeCfg: StatusCodeCfg{
+						StatusCodes: []string{"ERROR"},
+					},
+				},
+			},
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "fanout",
+					Type: And,
+				},
+				AndCfg: AndCfg{
+					SubPolicyCfg: []AndSubPolicyCfg{
+						{
+							sharedPolicyCfg: sharedPolicyCfg{
+								Name: "http-only",
+								Type: StringAttribute,
+								StringAttributeCfg: StringAttributeCfg{
+									Key:    "service.name",
+									Values: []string{"api"},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "not-latency",
+					Type: Not,
+				},
+				NotCfg: NotCfg{
+					SubPolicy: NotSubPolicyCfg{
+						sharedPolicyCfg: sharedPolicyCfg{
+							Name: "slow",
+							Type: Latency,
+							LatencyCfg: LatencyCfg{
+								ThresholdMs: 5000,
+							},
+						},
+					},
+				},
+			},
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "composite",
+					Type: Composite,
+				},
+				CompositeCfg: CompositeCfg{
+					MaxTotalSpansPerSecond: 100,
+					PolicyOrder:            []string{"nested-and", "nested-prob"},
+					SubPolicyCfg: []CompositeSubPolicyCfg{
+						{
+							sharedPolicyCfg: sharedPolicyCfg{
+								Name: "nested-and",
+								Type: And,
+							},
+							AndCfg: AndCfg{
+								SubPolicyCfg: []AndSubPolicyCfg{
+									{
+										sharedPolicyCfg: sharedPolicyCfg{
+											Name: "nested-status",
+											Type: StatusCode,
+											StatusCodeCfg: StatusCodeCfg{
+												StatusCodes: []string{"ERROR", "UNSET"},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							sharedPolicyCfg: sharedPolicyCfg{
+								Name: "nested-prob",
+								Type: Probabilistic,
+								ProbabilisticCfg: ProbabilisticCfg{
+									SamplingPercentage: 10,
+								},
+							},
+						},
+					},
+					RateAllocation: []RateAllocationCfg{
+						{
+							Policy:  "nested-prob",
+							Percent: 25,
+						},
+					},
+				},
+			},
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "drop-debug",
+					Type: Drop,
+				},
+				DropCfg: DropCfg{
+					SubPolicyCfg: []AndSubPolicyCfg{
+						{
+							sharedPolicyCfg: sharedPolicyCfg{
+								Name: "debug-attr",
+								Type: BooleanAttribute,
+								BooleanAttributeCfg: BooleanAttributeCfg{
+									Key:   "debug",
+									Value: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "extension-policy",
+					Type: PolicyType("custom_extension"),
+					ExtensionCfg: map[string]any{
+						"custom_extension": map[string]any{"mode": "keep"},
+					},
+				},
+			},
+		},
+	}
+
+	cm := confmap.New()
+	require.NoError(t, cm.Marshal(cfg))
+
+	policies, ok := cm.ToStringMap()["policies"].([]any)
+	require.True(t, ok)
+	require.Len(t, policies, 7)
+
+	baseline := policies[0].(map[string]any)
+	assert.Equal(t, "baseline", baseline["name"])
+	assert.Equal(t, Probabilistic, baseline["type"])
+	assert.Equal(t, map[string]any{
+		"hash_salt":           "salt",
+		"sampling_percentage": 1.0,
+	}, baseline["probabilistic"])
+
+	errors := policies[1].(map[string]any)
+	assert.Equal(t, "errors", errors["name"])
+	assert.Equal(t, StatusCode, errors["type"])
+	assert.Equal(t, map[string]any{
+		"status_codes": []any{"ERROR"},
+	}, errors["status_code"])
+
+	fanout := policies[2].(map[string]any)
+	assert.Equal(t, "fanout", fanout["name"])
+	assert.Equal(t, And, fanout["type"])
+	fanoutAnd := fanout["and"].(map[string]any)
+	fanoutSub := fanoutAnd["and_sub_policy"].([]any)[0].(map[string]any)
+	assert.Equal(t, "http-only", fanoutSub["name"])
+	assert.Equal(t, StringAttribute, fanoutSub["type"])
+	assert.Equal(t, map[string]any{
+		"cache_max_size":         0,
+		"enabled_regex_matching": false,
+		"invert_match":           false,
+		"key":                    "service.name",
+		"values":                 []any{"api"},
+	}, fanoutSub["string_attribute"])
+
+	notLatency := policies[3].(map[string]any)
+	assert.Equal(t, "not-latency", notLatency["name"])
+	assert.Equal(t, Not, notLatency["type"])
+	notSub := notLatency["not"].(map[string]any)["not_sub_policy"].(map[string]any)
+	assert.Equal(t, "slow", notSub["name"])
+	assert.Equal(t, Latency, notSub["type"])
+	assert.Equal(t, map[string]any{
+		"threshold_ms":       int64(5000),
+		"upper_threshold_ms": int64(0),
+	}, notSub["latency"])
+
+	composite := policies[4].(map[string]any)
+	assert.Equal(t, "composite", composite["name"])
+	assert.Equal(t, Composite, composite["type"])
+	compositeCfg := composite["composite"].(map[string]any)
+	assert.Equal(t, int64(100), compositeCfg["max_total_spans_per_second"])
+	assert.Equal(t, []any{"nested-and", "nested-prob"}, compositeCfg["policy_order"])
+	compositePolicies := compositeCfg["composite_sub_policy"].([]any)
+	require.Len(t, compositePolicies, 2)
+	nestedAnd := compositePolicies[0].(map[string]any)
+	assert.Equal(t, "nested-and", nestedAnd["name"])
+	assert.Equal(t, And, nestedAnd["type"])
+	nestedStatus := nestedAnd["and"].(map[string]any)["and_sub_policy"].([]any)[0].(map[string]any)
+	assert.Equal(t, "nested-status", nestedStatus["name"])
+	assert.Equal(t, StatusCode, nestedStatus["type"])
+	assert.Equal(t, map[string]any{
+		"status_codes": []any{"ERROR", "UNSET"},
+	}, nestedStatus["status_code"])
+	nestedProb := compositePolicies[1].(map[string]any)
+	assert.Equal(t, "nested-prob", nestedProb["name"])
+	assert.Equal(t, Probabilistic, nestedProb["type"])
+	assert.Equal(t, map[string]any{
+		"hash_salt":           "",
+		"sampling_percentage": 10.0,
+	}, nestedProb["probabilistic"])
+
+	dropDebug := policies[5].(map[string]any)
+	assert.Equal(t, "drop-debug", dropDebug["name"])
+	assert.Equal(t, Drop, dropDebug["type"])
+	dropSub := dropDebug["drop"].(map[string]any)["drop_sub_policy"].([]any)[0].(map[string]any)
+	assert.Equal(t, "debug-attr", dropSub["name"])
+	assert.Equal(t, BooleanAttribute, dropSub["type"])
+	assert.Equal(t, map[string]any{
+		"invert_match": false,
+		"key":          "debug",
+		"value":        true,
+	}, dropSub["boolean_attribute"])
+
+	extensionPolicy := policies[6].(map[string]any)
+	assert.Equal(t, "extension-policy", extensionPolicy["name"])
+	assert.Equal(t, PolicyType("custom_extension"), extensionPolicy["type"])
+	assert.Equal(t, map[string]any{"mode": "keep"}, extensionPolicy["custom_extension"])
 }
 
 func TestConfigValidateTailStorageFeatureGate(t *testing.T) {

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -429,7 +429,11 @@ func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedP
 		t := string(cfg.Type)
 		extension, ok := policyExtensions[t]
 		if ok {
-			evaluator, err := extension.NewEvaluator(cfg.Name, cfg.ExtensionCfg[t])
+			extensionCfg, ok := cfg.ExtensionCfg[t].(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("unable to load extension %s: invalid configuration type %T", t, cfg.ExtensionCfg[t])
+			}
+			evaluator, err := extension.NewEvaluator(cfg.Name, extensionCfg)
 			if err != nil {
 				return nil, fmt.Errorf("unable to load extension %s: %w", t, err)
 			}

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -1498,8 +1498,8 @@ func TestExtension(t *testing.T) {
 				sharedPolicyCfg: sharedPolicyCfg{
 					Name: "extension",
 					Type: "my_extension",
-					ExtensionCfg: map[string]map[string]any{
-						"my_extension": {
+					ExtensionCfg: map[string]any{
+						"my_extension": map[string]any{
 							"foo": "bar",
 						},
 					},

--- a/receiver/huaweicloudcesreceiver/config.go
+++ b/receiver/huaweicloudcesreceiver/config.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 	"go.uber.org/multierr"
 )
@@ -79,7 +80,48 @@ type huaweiSessionConfig struct {
 	ProxyPassword string `mapstructure:"proxy_password"`
 }
 
-var _ component.Config = (*Config)(nil)
+var (
+	_ component.Config  = (*Config)(nil)
+	_ confmap.Marshaler = Config{}
+)
+
+func (config Config) Marshal(conf *confmap.Conf) error {
+	return conf.Marshal(struct {
+		scraperhelper.ControllerConfig `mapstructure:",squash"`
+		confighttp.ClientConfig        `mapstructure:",squash"`
+		Nodes                          []string                  `mapstructure:"nodes"`
+		SkipClusterMetrics             bool                      `mapstructure:"skip_cluster_metrics"`
+		Indices                        []string                  `mapstructure:"indices"`
+		AccessKey                      configopaque.String       `mapstructure:"access_key"`
+		SecretKey                      configopaque.String       `mapstructure:"secret_key"`
+		NoVerifySSL                    bool                      `mapstructure:"no_verify_ssl"`
+		ProxyAddress                   string                    `mapstructure:"proxy_address"`
+		ProxyUser                      string                    `mapstructure:"proxy_user"`
+		ProxyPassword                  string                    `mapstructure:"proxy_password"`
+		ProjectID                      string                    `mapstructure:"project_id"`
+		RegionID                       string                    `mapstructure:"region_id"`
+		Period                         int32                     `mapstructure:"period"`
+		Filter                         string                    `mapstructure:"filter"`
+		BackOffConfig                  configretry.BackOffConfig `mapstructure:"retry_on_failure"`
+	}{
+		ControllerConfig:   config.ControllerConfig,
+		ClientConfig:       config.ClientConfig,
+		Nodes:              config.Nodes,
+		SkipClusterMetrics: config.SkipClusterMetrics,
+		Indices:            config.Indices,
+		AccessKey:          config.AccessKey,
+		SecretKey:          config.SecretKey,
+		NoVerifySSL:        config.NoVerifySSL,
+		ProxyAddress:       config.ProxyAddress,
+		ProxyUser:          config.ProxyUser,
+		ProxyPassword:      config.ProxyPassword,
+		ProjectID:          config.ProjectID,
+		RegionID:           config.RegionID,
+		Period:             config.Period,
+		Filter:             config.Filter,
+		BackOffConfig:      config.BackOffConfig,
+	})
+}
 
 // These valid periods are defined by CES API constraints: https://support.huaweicloud.com/intl/en-us/api-ces/ces_03_0034.html#section3
 var validPeriods = []int32{1, 300, 1200, 3600, 14400, 86400}

--- a/receiver/huaweicloudcesreceiver/factory_test.go
+++ b/receiver/huaweicloudcesreceiver/factory_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -41,4 +43,34 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	receiver, err := factory.CreateMetrics(t.Context(), receivertest.NewNopSettings(metadata.Type), config, nextConsumer)
 	assert.NoError(t, err)
 	assert.NotNil(t, receiver)
+}
+
+func TestConfigMarshalRoundTripPreservesSessionConfig(t *testing.T) {
+	config := NewFactory().CreateDefaultConfig().(*Config)
+	in := confmap.NewFromStringMap(map[string]any{
+		"collection_interval": "1m",
+		"endpoint":            "https://example.invalid",
+		"access_key":          "ak",
+		"secret_key":          "sk",
+		"proxy_address":       "http://proxy.invalid:8080",
+		"proxy_user":          "u",
+		"proxy_password":      "p",
+		"project_id":          "proj",
+		"region_id":           "eu-test-1",
+		"period":              300,
+		"filter":              "max",
+	})
+	require.NoError(t, in.Unmarshal(config))
+
+	out := confmap.New()
+	require.NoError(t, out.Marshal(config))
+
+	roundTrip := out.ToStringMap()
+	assert.Equal(t, "[REDACTED]", roundTrip["access_key"])
+	assert.Equal(t, "[REDACTED]", roundTrip["secret_key"])
+	assert.Equal(t, "http://proxy.invalid:8080", roundTrip["proxy_address"])
+	assert.Equal(t, "u", roundTrip["proxy_user"])
+	assert.Equal(t, "p", roundTrip["proxy_password"])
+	assert.Equal(t, "proj", roundTrip["project_id"])
+	assert.Equal(t, "eu-test-1", roundTrip["region_id"])
 }

--- a/receiver/simpleprometheusreceiver/config.go
+++ b/receiver/simpleprometheusreceiver/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/confmap"
 )
 
 // Config defines configuration for simple prometheus receiver.
@@ -27,6 +28,32 @@ type Config struct {
 	UseServiceAccount bool `mapstructure:"use_service_account"`
 	// JobName allows users to customize the job name optionally.
 	JobName string `mapstructure:"job_name"`
+}
+
+var _ confmap.Marshaler = Config{}
+
+func (c Config) Marshal(conf *confmap.Conf) error {
+	return conf.Marshal(struct {
+		confighttp.ClientConfig `mapstructure:",squash"`
+		TLSEnabled              bool              `mapstructure:"tls_enabled"`
+		TLSConfig               tlsConfig         `mapstructure:"tls_config"`
+		CollectionInterval      time.Duration     `mapstructure:"collection_interval"`
+		MetricsPath             string            `mapstructure:"metrics_path"`
+		Params                  url.Values        `mapstructure:"params,omitempty"`
+		Labels                  map[string]string `mapstructure:"labels,omitempty"`
+		UseServiceAccount       bool              `mapstructure:"use_service_account"`
+		JobName                 string            `mapstructure:"job_name"`
+	}{
+		ClientConfig:       c.ClientConfig,
+		TLSEnabled:         c.TLSEnabled,
+		TLSConfig:          c.TLSConfig,
+		CollectionInterval: c.CollectionInterval,
+		MetricsPath:        c.MetricsPath,
+		Params:             c.Params,
+		Labels:             c.Labels,
+		UseServiceAccount:  c.UseServiceAccount,
+		JobName:            c.JobName,
+	})
 }
 
 // TODO: Move to a common package for use by other receivers and also pull

--- a/receiver/simpleprometheusreceiver/config_test.go
+++ b/receiver/simpleprometheusreceiver/config_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
@@ -96,4 +97,32 @@ func TestLoadConfig(t *testing.T) {
 			assert.Equal(t, tt.expected, cfg)
 		})
 	}
+}
+
+func TestMarshalRoundTripPreservesDeprecatedHTTPConfig(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	in := confmap.NewFromStringMap(map[string]any{
+		"endpoint":     "example.invalid:9443",
+		"metrics_path": "/m",
+		"tls_enabled":  true,
+		"tls_config": map[string]any{
+			"ca_file":              "ca.pem",
+			"cert_file":            "cert.pem",
+			"key_file":             "key.pem",
+			"insecure_skip_verify": true,
+		},
+	})
+	require.NoError(t, in.Unmarshal(cfg))
+
+	out := confmap.New()
+	require.NoError(t, out.Marshal(cfg))
+
+	roundTrip := out.ToStringMap()
+	assert.Equal(t, true, roundTrip["tls_enabled"])
+	assert.Equal(t, map[string]any{
+		"ca_file":              "ca.pem",
+		"cert_file":            "cert.pem",
+		"key_file":             "key.pem",
+		"insecure_skip_verify": true,
+	}, roundTrip["tls_config"])
 }


### PR DESCRIPTION
#### Link to tracking issue

Fixes #47760

#### Summary

Fix component configs that lose fields when generic `confmap.Marshal` renders the
collector's effective configuration.

This keeps `print-config` and other effective-config views faithful to the config
that was actually accepted during unmarshal, instead of silently dropping fields
that live in embedded unexported squashed structs.

#### Example

With a config like:

```yaml
processors:
  tail_sampling:
    policies:
      - name: keep-errors
        type: status_code
        status_code:
          status_codes: [ERROR]
      - name: baseline-1pct
        type: probabilistic
        probabilistic:
          sampling_percentage: 1
```

the rendered effective config could currently collapse those policy entries to:

```yaml
processors:
  tail_sampling:
    policies:
      - and:
          and_sub_policy: []
        composite:
          composite_sub_policy: []
          max_total_spans_per_second: 0
          policy_order: []
          rate_allocation: []
        drop:
          drop_sub_policy: []
        not:
          not_sub_policy: {}
      - and:
          and_sub_policy: []
        composite:
          composite_sub_policy: []
          max_total_spans_per_second: 0
          policy_order: []
          rate_allocation: []
        drop:
          drop_sub_policy: []
        not:
          not_sub_policy: {}
```

Expected output:

```yaml
processors:
  tail_sampling:
    policies:
      - name: keep-errors
        type: status_code
        status_code:
          status_codes: [ERROR]
      - name: baseline-1pct
        type: probabilistic
        probabilistic:
          sampling_percentage: 1
```

This PR adds explicit `confmap.Marshaler` implementations for the affected
component configs so those fields remain present in effective-config output.

#### Testing

Ran:

```bash
cd processor/tailsamplingprocessor && go test ./...
cd exporter/datasetexporter && go test ./...
cd extension/opampextension && go test ./...
cd receiver/huaweicloudcesreceiver && go test ./...
cd receiver/simpleprometheusreceiver && go test ./...
```

Also verified with focused round-trip tests that the affected fields survive
`confmap.Marshal` output after unmarshaling.

#### Documentation

Added:
- changelog fragment
- audit note documenting the confirmed pattern matches in contrib
