### PR TITLE
feat(receiver/redfish): enable dynamic metric reaggregation

### DIFF
--- a/.chloggen/46375-redfish-enable-reaggregation.yaml
+++ b/.chloggen/46375-redfish-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/redfish
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the Redfish receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46375]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/redfishreceiver/generated_package_test.go
+++ b/receiver/redfishreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package redfishreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/redfishreceiver/generated_package_test.go
+++ b/receiver/redfishreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package redfishreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/redfishreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/redfishreceiver/internal/metadata/config.schema.yaml
@@ -11,6 +11,36 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "chassis.asset_tag"
+                - "chassis.model"
+                - "chassis.name"
+                - "chassis.manufacturer"
+                - "chassis.serial_number"
+                - "chassis.sku"
+                - "chassis.chassis_type"
+            default:
+              - "chassis.id"
+              - "chassis.asset_tag"
+              - "chassis.model"
+              - "chassis.name"
+              - "chassis.manufacturer"
+              - "chassis.serial_number"
+              - "chassis.sku"
+              - "chassis.chassis_type"
       chassis.status.health:
         description: "ChassisStatusHealthMetricConfig provides config for the chassis.status.health metric."
         type: object
@@ -18,6 +48,36 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "chassis.asset_tag"
+                - "chassis.model"
+                - "chassis.name"
+                - "chassis.manufacturer"
+                - "chassis.serial_number"
+                - "chassis.sku"
+                - "chassis.chassis_type"
+            default:
+              - "chassis.id"
+              - "chassis.asset_tag"
+              - "chassis.model"
+              - "chassis.name"
+              - "chassis.manufacturer"
+              - "chassis.serial_number"
+              - "chassis.sku"
+              - "chassis.chassis_type"
       chassis.status.state:
         description: "ChassisStatusStateMetricConfig provides config for the chassis.status.state metric."
         type: object
@@ -25,6 +85,36 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "chassis.asset_tag"
+                - "chassis.model"
+                - "chassis.name"
+                - "chassis.manufacturer"
+                - "chassis.serial_number"
+                - "chassis.sku"
+                - "chassis.chassis_type"
+            default:
+              - "chassis.id"
+              - "chassis.asset_tag"
+              - "chassis.model"
+              - "chassis.name"
+              - "chassis.manufacturer"
+              - "chassis.serial_number"
+              - "chassis.sku"
+              - "chassis.chassis_type"
       fan.reading:
         description: "FanReadingMetricConfig provides config for the fan.reading metric."
         type: object
@@ -32,6 +122,26 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "fan.name"
+                - "fan.reading_units"
+            default:
+              - "chassis.id"
+              - "fan.name"
+              - "fan.reading_units"
       fan.status.health:
         description: "FanStatusHealthMetricConfig provides config for the fan.status.health metric."
         type: object
@@ -39,6 +149,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "fan.name"
+            default:
+              - "chassis.id"
+              - "fan.name"
       fan.status.state:
         description: "FanStatusStateMetricConfig provides config for the fan.status.state metric."
         type: object
@@ -46,6 +174,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "fan.name"
+            default:
+              - "chassis.id"
+              - "fan.name"
       system.powerstate:
         description: "SystemPowerstateMetricConfig provides config for the system.powerstate metric."
         type: object
@@ -53,6 +199,38 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "system.id"
+                - "system.asset_tag"
+                - "system.bios_version"
+                - "system.model"
+                - "system.name"
+                - "system.manufacturer"
+                - "system.serial_number"
+                - "system.sku"
+                - "system.system_type"
+            default:
+              - "system.id"
+              - "system.asset_tag"
+              - "system.bios_version"
+              - "system.model"
+              - "system.name"
+              - "system.manufacturer"
+              - "system.serial_number"
+              - "system.sku"
+              - "system.system_type"
       system.status.health:
         description: "SystemStatusHealthMetricConfig provides config for the system.status.health metric."
         type: object
@@ -60,6 +238,38 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "system.id"
+                - "system.asset_tag"
+                - "system.bios_version"
+                - "system.model"
+                - "system.name"
+                - "system.manufacturer"
+                - "system.serial_number"
+                - "system.sku"
+                - "system.system_type"
+            default:
+              - "system.id"
+              - "system.asset_tag"
+              - "system.bios_version"
+              - "system.model"
+              - "system.name"
+              - "system.manufacturer"
+              - "system.serial_number"
+              - "system.sku"
+              - "system.system_type"
       system.status.state:
         description: "SystemStatusStateMetricConfig provides config for the system.status.state metric."
         type: object
@@ -67,6 +277,38 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "system.id"
+                - "system.asset_tag"
+                - "system.bios_version"
+                - "system.model"
+                - "system.name"
+                - "system.manufacturer"
+                - "system.serial_number"
+                - "system.sku"
+                - "system.system_type"
+            default:
+              - "system.id"
+              - "system.asset_tag"
+              - "system.bios_version"
+              - "system.model"
+              - "system.name"
+              - "system.manufacturer"
+              - "system.serial_number"
+              - "system.sku"
+              - "system.system_type"
       temperature.reading:
         description: "TemperatureReadingMetricConfig provides config for the temperature.reading metric."
         type: object
@@ -74,6 +316,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "temperature.name"
+            default:
+              - "chassis.id"
+              - "temperature.name"
       temperature.status.health:
         description: "TemperatureStatusHealthMetricConfig provides config for the temperature.status.health metric."
         type: object
@@ -81,6 +341,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "temperature.name"
+            default:
+              - "chassis.id"
+              - "temperature.name"
       temperature.status.state:
         description: "TemperatureStatusStateMetricConfig provides config for the temperature.status.state metric."
         type: object
@@ -88,6 +366,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "chassis.id"
+                - "temperature.name"
+            default:
+              - "chassis.id"
+              - "temperature.name"
   resource_attributes_config:
     description: ResourceAttributesConfig provides config for redfish resource attributes.
     type: object

--- a/receiver/redfishreceiver/internal/metadata/generated_config.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,36 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// ChassisPowerstateMetricAttributeKey specifies the key of an attribute for the chassis.powerstate metric.
+type ChassisPowerstateMetricAttributeKey string
+
+const (
+	ChassisPowerstateMetricAttributeKeyChassisID           ChassisPowerstateMetricAttributeKey = "chassis.id"
+	ChassisPowerstateMetricAttributeKeyChassisAssetTag     ChassisPowerstateMetricAttributeKey = "chassis.asset_tag"
+	ChassisPowerstateMetricAttributeKeyChassisModel        ChassisPowerstateMetricAttributeKey = "chassis.model"
+	ChassisPowerstateMetricAttributeKeyChassisName         ChassisPowerstateMetricAttributeKey = "chassis.name"
+	ChassisPowerstateMetricAttributeKeyChassisManufacturer ChassisPowerstateMetricAttributeKey = "chassis.manufacturer"
+	ChassisPowerstateMetricAttributeKeyChassisSerialNumber ChassisPowerstateMetricAttributeKey = "chassis.serial_number"
+	ChassisPowerstateMetricAttributeKeyChassisSku          ChassisPowerstateMetricAttributeKey = "chassis.sku"
+	ChassisPowerstateMetricAttributeKeyChassisChassisType  ChassisPowerstateMetricAttributeKey = "chassis.chassis_type"
+)
+
+// ChassisPowerstateMetricConfig provides config for the chassis.powerstate metric.
+type ChassisPowerstateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ChassisPowerstateMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ChassisPowerstateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -27,59 +46,674 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+func (ms *ChassisPowerstateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ChassisPowerstateMetricAttributeKeyChassisID, ChassisPowerstateMetricAttributeKeyChassisAssetTag, ChassisPowerstateMetricAttributeKeyChassisModel, ChassisPowerstateMetricAttributeKeyChassisName, ChassisPowerstateMetricAttributeKeyChassisManufacturer, ChassisPowerstateMetricAttributeKeyChassisSerialNumber, ChassisPowerstateMetricAttributeKeyChassisSku, ChassisPowerstateMetricAttributeKeyChassisChassisType:
+		default:
+			return fmt.Errorf("metric chassis.powerstate doesn't have an attribute %v, valid attributes: [chassis.id, chassis.asset_tag, chassis.model, chassis.name, chassis.manufacturer, chassis.serial_number, chassis.sku, chassis.chassis_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ChassisStatusHealthMetricAttributeKey specifies the key of an attribute for the chassis.status.health metric.
+type ChassisStatusHealthMetricAttributeKey string
+
+const (
+	ChassisStatusHealthMetricAttributeKeyChassisID           ChassisStatusHealthMetricAttributeKey = "chassis.id"
+	ChassisStatusHealthMetricAttributeKeyChassisAssetTag     ChassisStatusHealthMetricAttributeKey = "chassis.asset_tag"
+	ChassisStatusHealthMetricAttributeKeyChassisModel        ChassisStatusHealthMetricAttributeKey = "chassis.model"
+	ChassisStatusHealthMetricAttributeKeyChassisName         ChassisStatusHealthMetricAttributeKey = "chassis.name"
+	ChassisStatusHealthMetricAttributeKeyChassisManufacturer ChassisStatusHealthMetricAttributeKey = "chassis.manufacturer"
+	ChassisStatusHealthMetricAttributeKeyChassisSerialNumber ChassisStatusHealthMetricAttributeKey = "chassis.serial_number"
+	ChassisStatusHealthMetricAttributeKeyChassisSku          ChassisStatusHealthMetricAttributeKey = "chassis.sku"
+	ChassisStatusHealthMetricAttributeKeyChassisChassisType  ChassisStatusHealthMetricAttributeKey = "chassis.chassis_type"
+)
+
+// ChassisStatusHealthMetricConfig provides config for the chassis.status.health metric.
+type ChassisStatusHealthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ChassisStatusHealthMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ChassisStatusHealthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ChassisStatusHealthMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ChassisStatusHealthMetricAttributeKeyChassisID, ChassisStatusHealthMetricAttributeKeyChassisAssetTag, ChassisStatusHealthMetricAttributeKeyChassisModel, ChassisStatusHealthMetricAttributeKeyChassisName, ChassisStatusHealthMetricAttributeKeyChassisManufacturer, ChassisStatusHealthMetricAttributeKeyChassisSerialNumber, ChassisStatusHealthMetricAttributeKeyChassisSku, ChassisStatusHealthMetricAttributeKeyChassisChassisType:
+		default:
+			return fmt.Errorf("metric chassis.status.health doesn't have an attribute %v, valid attributes: [chassis.id, chassis.asset_tag, chassis.model, chassis.name, chassis.manufacturer, chassis.serial_number, chassis.sku, chassis.chassis_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// ChassisStatusStateMetricAttributeKey specifies the key of an attribute for the chassis.status.state metric.
+type ChassisStatusStateMetricAttributeKey string
+
+const (
+	ChassisStatusStateMetricAttributeKeyChassisID           ChassisStatusStateMetricAttributeKey = "chassis.id"
+	ChassisStatusStateMetricAttributeKeyChassisAssetTag     ChassisStatusStateMetricAttributeKey = "chassis.asset_tag"
+	ChassisStatusStateMetricAttributeKeyChassisModel        ChassisStatusStateMetricAttributeKey = "chassis.model"
+	ChassisStatusStateMetricAttributeKeyChassisName         ChassisStatusStateMetricAttributeKey = "chassis.name"
+	ChassisStatusStateMetricAttributeKeyChassisManufacturer ChassisStatusStateMetricAttributeKey = "chassis.manufacturer"
+	ChassisStatusStateMetricAttributeKeyChassisSerialNumber ChassisStatusStateMetricAttributeKey = "chassis.serial_number"
+	ChassisStatusStateMetricAttributeKeyChassisSku          ChassisStatusStateMetricAttributeKey = "chassis.sku"
+	ChassisStatusStateMetricAttributeKeyChassisChassisType  ChassisStatusStateMetricAttributeKey = "chassis.chassis_type"
+)
+
+// ChassisStatusStateMetricConfig provides config for the chassis.status.state metric.
+type ChassisStatusStateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ChassisStatusStateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ChassisStatusStateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ChassisStatusStateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ChassisStatusStateMetricAttributeKeyChassisID, ChassisStatusStateMetricAttributeKeyChassisAssetTag, ChassisStatusStateMetricAttributeKeyChassisModel, ChassisStatusStateMetricAttributeKeyChassisName, ChassisStatusStateMetricAttributeKeyChassisManufacturer, ChassisStatusStateMetricAttributeKeyChassisSerialNumber, ChassisStatusStateMetricAttributeKeyChassisSku, ChassisStatusStateMetricAttributeKeyChassisChassisType:
+		default:
+			return fmt.Errorf("metric chassis.status.state doesn't have an attribute %v, valid attributes: [chassis.id, chassis.asset_tag, chassis.model, chassis.name, chassis.manufacturer, chassis.serial_number, chassis.sku, chassis.chassis_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// FanReadingMetricAttributeKey specifies the key of an attribute for the fan.reading metric.
+type FanReadingMetricAttributeKey string
+
+const (
+	FanReadingMetricAttributeKeyChassisID       FanReadingMetricAttributeKey = "chassis.id"
+	FanReadingMetricAttributeKeyFanName         FanReadingMetricAttributeKey = "fan.name"
+	FanReadingMetricAttributeKeyFanReadingUnits FanReadingMetricAttributeKey = "fan.reading_units"
+)
+
+// FanReadingMetricConfig provides config for the fan.reading metric.
+type FanReadingMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []FanReadingMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *FanReadingMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *FanReadingMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case FanReadingMetricAttributeKeyChassisID, FanReadingMetricAttributeKeyFanName, FanReadingMetricAttributeKeyFanReadingUnits:
+		default:
+			return fmt.Errorf("metric fan.reading doesn't have an attribute %v, valid attributes: [chassis.id, fan.name, fan.reading_units]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// FanStatusHealthMetricAttributeKey specifies the key of an attribute for the fan.status.health metric.
+type FanStatusHealthMetricAttributeKey string
+
+const (
+	FanStatusHealthMetricAttributeKeyChassisID FanStatusHealthMetricAttributeKey = "chassis.id"
+	FanStatusHealthMetricAttributeKeyFanName   FanStatusHealthMetricAttributeKey = "fan.name"
+)
+
+// FanStatusHealthMetricConfig provides config for the fan.status.health metric.
+type FanStatusHealthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []FanStatusHealthMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *FanStatusHealthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *FanStatusHealthMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case FanStatusHealthMetricAttributeKeyChassisID, FanStatusHealthMetricAttributeKeyFanName:
+		default:
+			return fmt.Errorf("metric fan.status.health doesn't have an attribute %v, valid attributes: [chassis.id, fan.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// FanStatusStateMetricAttributeKey specifies the key of an attribute for the fan.status.state metric.
+type FanStatusStateMetricAttributeKey string
+
+const (
+	FanStatusStateMetricAttributeKeyChassisID FanStatusStateMetricAttributeKey = "chassis.id"
+	FanStatusStateMetricAttributeKeyFanName   FanStatusStateMetricAttributeKey = "fan.name"
+)
+
+// FanStatusStateMetricConfig provides config for the fan.status.state metric.
+type FanStatusStateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []FanStatusStateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *FanStatusStateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *FanStatusStateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case FanStatusStateMetricAttributeKeyChassisID, FanStatusStateMetricAttributeKeyFanName:
+		default:
+			return fmt.Errorf("metric fan.status.state doesn't have an attribute %v, valid attributes: [chassis.id, fan.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SystemPowerstateMetricAttributeKey specifies the key of an attribute for the system.powerstate metric.
+type SystemPowerstateMetricAttributeKey string
+
+const (
+	SystemPowerstateMetricAttributeKeySystemID           SystemPowerstateMetricAttributeKey = "system.id"
+	SystemPowerstateMetricAttributeKeySystemAssetTag     SystemPowerstateMetricAttributeKey = "system.asset_tag"
+	SystemPowerstateMetricAttributeKeySystemBiosVersion  SystemPowerstateMetricAttributeKey = "system.bios_version"
+	SystemPowerstateMetricAttributeKeySystemModel        SystemPowerstateMetricAttributeKey = "system.model"
+	SystemPowerstateMetricAttributeKeySystemName         SystemPowerstateMetricAttributeKey = "system.name"
+	SystemPowerstateMetricAttributeKeySystemManufacturer SystemPowerstateMetricAttributeKey = "system.manufacturer"
+	SystemPowerstateMetricAttributeKeySystemSerialNumber SystemPowerstateMetricAttributeKey = "system.serial_number"
+	SystemPowerstateMetricAttributeKeySystemSku          SystemPowerstateMetricAttributeKey = "system.sku"
+	SystemPowerstateMetricAttributeKeySystemSystemType   SystemPowerstateMetricAttributeKey = "system.system_type"
+)
+
+// SystemPowerstateMetricConfig provides config for the system.powerstate metric.
+type SystemPowerstateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SystemPowerstateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SystemPowerstateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SystemPowerstateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SystemPowerstateMetricAttributeKeySystemID, SystemPowerstateMetricAttributeKeySystemAssetTag, SystemPowerstateMetricAttributeKeySystemBiosVersion, SystemPowerstateMetricAttributeKeySystemModel, SystemPowerstateMetricAttributeKeySystemName, SystemPowerstateMetricAttributeKeySystemManufacturer, SystemPowerstateMetricAttributeKeySystemSerialNumber, SystemPowerstateMetricAttributeKeySystemSku, SystemPowerstateMetricAttributeKeySystemSystemType:
+		default:
+			return fmt.Errorf("metric system.powerstate doesn't have an attribute %v, valid attributes: [system.id, system.asset_tag, system.bios_version, system.model, system.name, system.manufacturer, system.serial_number, system.sku, system.system_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SystemStatusHealthMetricAttributeKey specifies the key of an attribute for the system.status.health metric.
+type SystemStatusHealthMetricAttributeKey string
+
+const (
+	SystemStatusHealthMetricAttributeKeySystemID           SystemStatusHealthMetricAttributeKey = "system.id"
+	SystemStatusHealthMetricAttributeKeySystemAssetTag     SystemStatusHealthMetricAttributeKey = "system.asset_tag"
+	SystemStatusHealthMetricAttributeKeySystemBiosVersion  SystemStatusHealthMetricAttributeKey = "system.bios_version"
+	SystemStatusHealthMetricAttributeKeySystemModel        SystemStatusHealthMetricAttributeKey = "system.model"
+	SystemStatusHealthMetricAttributeKeySystemName         SystemStatusHealthMetricAttributeKey = "system.name"
+	SystemStatusHealthMetricAttributeKeySystemManufacturer SystemStatusHealthMetricAttributeKey = "system.manufacturer"
+	SystemStatusHealthMetricAttributeKeySystemSerialNumber SystemStatusHealthMetricAttributeKey = "system.serial_number"
+	SystemStatusHealthMetricAttributeKeySystemSku          SystemStatusHealthMetricAttributeKey = "system.sku"
+	SystemStatusHealthMetricAttributeKeySystemSystemType   SystemStatusHealthMetricAttributeKey = "system.system_type"
+)
+
+// SystemStatusHealthMetricConfig provides config for the system.status.health metric.
+type SystemStatusHealthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SystemStatusHealthMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SystemStatusHealthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SystemStatusHealthMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SystemStatusHealthMetricAttributeKeySystemID, SystemStatusHealthMetricAttributeKeySystemAssetTag, SystemStatusHealthMetricAttributeKeySystemBiosVersion, SystemStatusHealthMetricAttributeKeySystemModel, SystemStatusHealthMetricAttributeKeySystemName, SystemStatusHealthMetricAttributeKeySystemManufacturer, SystemStatusHealthMetricAttributeKeySystemSerialNumber, SystemStatusHealthMetricAttributeKeySystemSku, SystemStatusHealthMetricAttributeKeySystemSystemType:
+		default:
+			return fmt.Errorf("metric system.status.health doesn't have an attribute %v, valid attributes: [system.id, system.asset_tag, system.bios_version, system.model, system.name, system.manufacturer, system.serial_number, system.sku, system.system_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SystemStatusStateMetricAttributeKey specifies the key of an attribute for the system.status.state metric.
+type SystemStatusStateMetricAttributeKey string
+
+const (
+	SystemStatusStateMetricAttributeKeySystemID           SystemStatusStateMetricAttributeKey = "system.id"
+	SystemStatusStateMetricAttributeKeySystemAssetTag     SystemStatusStateMetricAttributeKey = "system.asset_tag"
+	SystemStatusStateMetricAttributeKeySystemBiosVersion  SystemStatusStateMetricAttributeKey = "system.bios_version"
+	SystemStatusStateMetricAttributeKeySystemModel        SystemStatusStateMetricAttributeKey = "system.model"
+	SystemStatusStateMetricAttributeKeySystemName         SystemStatusStateMetricAttributeKey = "system.name"
+	SystemStatusStateMetricAttributeKeySystemManufacturer SystemStatusStateMetricAttributeKey = "system.manufacturer"
+	SystemStatusStateMetricAttributeKeySystemSerialNumber SystemStatusStateMetricAttributeKey = "system.serial_number"
+	SystemStatusStateMetricAttributeKeySystemSku          SystemStatusStateMetricAttributeKey = "system.sku"
+	SystemStatusStateMetricAttributeKeySystemSystemType   SystemStatusStateMetricAttributeKey = "system.system_type"
+)
+
+// SystemStatusStateMetricConfig provides config for the system.status.state metric.
+type SystemStatusStateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SystemStatusStateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SystemStatusStateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SystemStatusStateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SystemStatusStateMetricAttributeKeySystemID, SystemStatusStateMetricAttributeKeySystemAssetTag, SystemStatusStateMetricAttributeKeySystemBiosVersion, SystemStatusStateMetricAttributeKeySystemModel, SystemStatusStateMetricAttributeKeySystemName, SystemStatusStateMetricAttributeKeySystemManufacturer, SystemStatusStateMetricAttributeKeySystemSerialNumber, SystemStatusStateMetricAttributeKeySystemSku, SystemStatusStateMetricAttributeKeySystemSystemType:
+		default:
+			return fmt.Errorf("metric system.status.state doesn't have an attribute %v, valid attributes: [system.id, system.asset_tag, system.bios_version, system.model, system.name, system.manufacturer, system.serial_number, system.sku, system.system_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// TemperatureReadingMetricAttributeKey specifies the key of an attribute for the temperature.reading metric.
+type TemperatureReadingMetricAttributeKey string
+
+const (
+	TemperatureReadingMetricAttributeKeyChassisID       TemperatureReadingMetricAttributeKey = "chassis.id"
+	TemperatureReadingMetricAttributeKeyTemperatureName TemperatureReadingMetricAttributeKey = "temperature.name"
+)
+
+// TemperatureReadingMetricConfig provides config for the temperature.reading metric.
+type TemperatureReadingMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []TemperatureReadingMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *TemperatureReadingMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *TemperatureReadingMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case TemperatureReadingMetricAttributeKeyChassisID, TemperatureReadingMetricAttributeKeyTemperatureName:
+		default:
+			return fmt.Errorf("metric temperature.reading doesn't have an attribute %v, valid attributes: [chassis.id, temperature.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// TemperatureStatusHealthMetricAttributeKey specifies the key of an attribute for the temperature.status.health metric.
+type TemperatureStatusHealthMetricAttributeKey string
+
+const (
+	TemperatureStatusHealthMetricAttributeKeyChassisID       TemperatureStatusHealthMetricAttributeKey = "chassis.id"
+	TemperatureStatusHealthMetricAttributeKeyTemperatureName TemperatureStatusHealthMetricAttributeKey = "temperature.name"
+)
+
+// TemperatureStatusHealthMetricConfig provides config for the temperature.status.health metric.
+type TemperatureStatusHealthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []TemperatureStatusHealthMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *TemperatureStatusHealthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *TemperatureStatusHealthMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case TemperatureStatusHealthMetricAttributeKeyChassisID, TemperatureStatusHealthMetricAttributeKeyTemperatureName:
+		default:
+			return fmt.Errorf("metric temperature.status.health doesn't have an attribute %v, valid attributes: [chassis.id, temperature.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// TemperatureStatusStateMetricAttributeKey specifies the key of an attribute for the temperature.status.state metric.
+type TemperatureStatusStateMetricAttributeKey string
+
+const (
+	TemperatureStatusStateMetricAttributeKeyChassisID       TemperatureStatusStateMetricAttributeKey = "chassis.id"
+	TemperatureStatusStateMetricAttributeKeyTemperatureName TemperatureStatusStateMetricAttributeKey = "temperature.name"
+)
+
+// TemperatureStatusStateMetricConfig provides config for the temperature.status.state metric.
+type TemperatureStatusStateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []TemperatureStatusStateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *TemperatureStatusStateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *TemperatureStatusStateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case TemperatureStatusStateMetricAttributeKeyChassisID, TemperatureStatusStateMetricAttributeKeyTemperatureName:
+		default:
+			return fmt.Errorf("metric temperature.status.state doesn't have an attribute %v, valid attributes: [chassis.id, temperature.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MetricsConfig provides config for redfish metrics.
 type MetricsConfig struct {
-	ChassisPowerstate       MetricConfig `mapstructure:"chassis.powerstate"`
-	ChassisStatusHealth     MetricConfig `mapstructure:"chassis.status.health"`
-	ChassisStatusState      MetricConfig `mapstructure:"chassis.status.state"`
-	FanReading              MetricConfig `mapstructure:"fan.reading"`
-	FanStatusHealth         MetricConfig `mapstructure:"fan.status.health"`
-	FanStatusState          MetricConfig `mapstructure:"fan.status.state"`
-	SystemPowerstate        MetricConfig `mapstructure:"system.powerstate"`
-	SystemStatusHealth      MetricConfig `mapstructure:"system.status.health"`
-	SystemStatusState       MetricConfig `mapstructure:"system.status.state"`
-	TemperatureReading      MetricConfig `mapstructure:"temperature.reading"`
-	TemperatureStatusHealth MetricConfig `mapstructure:"temperature.status.health"`
-	TemperatureStatusState  MetricConfig `mapstructure:"temperature.status.state"`
+	ChassisPowerstate       ChassisPowerstateMetricConfig       `mapstructure:"chassis.powerstate"`
+	ChassisStatusHealth     ChassisStatusHealthMetricConfig     `mapstructure:"chassis.status.health"`
+	ChassisStatusState      ChassisStatusStateMetricConfig      `mapstructure:"chassis.status.state"`
+	FanReading              FanReadingMetricConfig              `mapstructure:"fan.reading"`
+	FanStatusHealth         FanStatusHealthMetricConfig         `mapstructure:"fan.status.health"`
+	FanStatusState          FanStatusStateMetricConfig          `mapstructure:"fan.status.state"`
+	SystemPowerstate        SystemPowerstateMetricConfig        `mapstructure:"system.powerstate"`
+	SystemStatusHealth      SystemStatusHealthMetricConfig      `mapstructure:"system.status.health"`
+	SystemStatusState       SystemStatusStateMetricConfig       `mapstructure:"system.status.state"`
+	TemperatureReading      TemperatureReadingMetricConfig      `mapstructure:"temperature.reading"`
+	TemperatureStatusHealth TemperatureStatusHealthMetricConfig `mapstructure:"temperature.status.health"`
+	TemperatureStatusState  TemperatureStatusStateMetricConfig  `mapstructure:"temperature.status.state"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		ChassisPowerstate: MetricConfig{
-			Enabled: true,
+		ChassisPowerstate: ChassisPowerstateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []ChassisPowerstateMetricAttributeKey{ChassisPowerstateMetricAttributeKeyChassisID, ChassisPowerstateMetricAttributeKeyChassisAssetTag, ChassisPowerstateMetricAttributeKeyChassisModel, ChassisPowerstateMetricAttributeKeyChassisName, ChassisPowerstateMetricAttributeKeyChassisManufacturer, ChassisPowerstateMetricAttributeKeyChassisSerialNumber, ChassisPowerstateMetricAttributeKeyChassisSku, ChassisPowerstateMetricAttributeKeyChassisChassisType},
 		},
-		ChassisStatusHealth: MetricConfig{
-			Enabled: true,
+		ChassisStatusHealth: ChassisStatusHealthMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []ChassisStatusHealthMetricAttributeKey{ChassisStatusHealthMetricAttributeKeyChassisID, ChassisStatusHealthMetricAttributeKeyChassisAssetTag, ChassisStatusHealthMetricAttributeKeyChassisModel, ChassisStatusHealthMetricAttributeKeyChassisName, ChassisStatusHealthMetricAttributeKeyChassisManufacturer, ChassisStatusHealthMetricAttributeKeyChassisSerialNumber, ChassisStatusHealthMetricAttributeKeyChassisSku, ChassisStatusHealthMetricAttributeKeyChassisChassisType},
 		},
-		ChassisStatusState: MetricConfig{
-			Enabled: true,
+		ChassisStatusState: ChassisStatusStateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []ChassisStatusStateMetricAttributeKey{ChassisStatusStateMetricAttributeKeyChassisID, ChassisStatusStateMetricAttributeKeyChassisAssetTag, ChassisStatusStateMetricAttributeKeyChassisModel, ChassisStatusStateMetricAttributeKeyChassisName, ChassisStatusStateMetricAttributeKeyChassisManufacturer, ChassisStatusStateMetricAttributeKeyChassisSerialNumber, ChassisStatusStateMetricAttributeKeyChassisSku, ChassisStatusStateMetricAttributeKeyChassisChassisType},
 		},
-		FanReading: MetricConfig{
-			Enabled: true,
+		FanReading: FanReadingMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []FanReadingMetricAttributeKey{FanReadingMetricAttributeKeyChassisID, FanReadingMetricAttributeKeyFanName, FanReadingMetricAttributeKeyFanReadingUnits},
 		},
-		FanStatusHealth: MetricConfig{
-			Enabled: true,
+		FanStatusHealth: FanStatusHealthMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []FanStatusHealthMetricAttributeKey{FanStatusHealthMetricAttributeKeyChassisID, FanStatusHealthMetricAttributeKeyFanName},
 		},
-		FanStatusState: MetricConfig{
-			Enabled: true,
+		FanStatusState: FanStatusStateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []FanStatusStateMetricAttributeKey{FanStatusStateMetricAttributeKeyChassisID, FanStatusStateMetricAttributeKeyFanName},
 		},
-		SystemPowerstate: MetricConfig{
-			Enabled: true,
+		SystemPowerstate: SystemPowerstateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SystemPowerstateMetricAttributeKey{SystemPowerstateMetricAttributeKeySystemID, SystemPowerstateMetricAttributeKeySystemAssetTag, SystemPowerstateMetricAttributeKeySystemBiosVersion, SystemPowerstateMetricAttributeKeySystemModel, SystemPowerstateMetricAttributeKeySystemName, SystemPowerstateMetricAttributeKeySystemManufacturer, SystemPowerstateMetricAttributeKeySystemSerialNumber, SystemPowerstateMetricAttributeKeySystemSku, SystemPowerstateMetricAttributeKeySystemSystemType},
 		},
-		SystemStatusHealth: MetricConfig{
-			Enabled: true,
+		SystemStatusHealth: SystemStatusHealthMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SystemStatusHealthMetricAttributeKey{SystemStatusHealthMetricAttributeKeySystemID, SystemStatusHealthMetricAttributeKeySystemAssetTag, SystemStatusHealthMetricAttributeKeySystemBiosVersion, SystemStatusHealthMetricAttributeKeySystemModel, SystemStatusHealthMetricAttributeKeySystemName, SystemStatusHealthMetricAttributeKeySystemManufacturer, SystemStatusHealthMetricAttributeKeySystemSerialNumber, SystemStatusHealthMetricAttributeKeySystemSku, SystemStatusHealthMetricAttributeKeySystemSystemType},
 		},
-		SystemStatusState: MetricConfig{
-			Enabled: true,
+		SystemStatusState: SystemStatusStateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SystemStatusStateMetricAttributeKey{SystemStatusStateMetricAttributeKeySystemID, SystemStatusStateMetricAttributeKeySystemAssetTag, SystemStatusStateMetricAttributeKeySystemBiosVersion, SystemStatusStateMetricAttributeKeySystemModel, SystemStatusStateMetricAttributeKeySystemName, SystemStatusStateMetricAttributeKeySystemManufacturer, SystemStatusStateMetricAttributeKeySystemSerialNumber, SystemStatusStateMetricAttributeKeySystemSku, SystemStatusStateMetricAttributeKeySystemSystemType},
 		},
-		TemperatureReading: MetricConfig{
-			Enabled: true,
+		TemperatureReading: TemperatureReadingMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []TemperatureReadingMetricAttributeKey{TemperatureReadingMetricAttributeKeyChassisID, TemperatureReadingMetricAttributeKeyTemperatureName},
 		},
-		TemperatureStatusHealth: MetricConfig{
-			Enabled: true,
+		TemperatureStatusHealth: TemperatureStatusHealthMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []TemperatureStatusHealthMetricAttributeKey{TemperatureStatusHealthMetricAttributeKeyChassisID, TemperatureStatusHealthMetricAttributeKeyTemperatureName},
 		},
-		TemperatureStatusState: MetricConfig{
-			Enabled: true,
+		TemperatureStatusState: TemperatureStatusStateMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []TemperatureStatusStateMetricAttributeKey{TemperatureStatusStateMetricAttributeKeyChassisID, TemperatureStatusStateMetricAttributeKeyTemperatureName},
 		},
 	}
 }

--- a/receiver/redfishreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/redfishreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,41 +27,65 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ChassisPowerstate: MetricConfig{
-						Enabled: true,
+					ChassisPowerstate: ChassisPowerstateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ChassisPowerstateMetricAttributeKey{ChassisPowerstateMetricAttributeKeyChassisID, ChassisPowerstateMetricAttributeKeyChassisAssetTag, ChassisPowerstateMetricAttributeKeyChassisModel, ChassisPowerstateMetricAttributeKeyChassisName, ChassisPowerstateMetricAttributeKeyChassisManufacturer, ChassisPowerstateMetricAttributeKeyChassisSerialNumber, ChassisPowerstateMetricAttributeKeyChassisSku, ChassisPowerstateMetricAttributeKeyChassisChassisType},
 					},
-					ChassisStatusHealth: MetricConfig{
-						Enabled: true,
+					ChassisStatusHealth: ChassisStatusHealthMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ChassisStatusHealthMetricAttributeKey{ChassisStatusHealthMetricAttributeKeyChassisID, ChassisStatusHealthMetricAttributeKeyChassisAssetTag, ChassisStatusHealthMetricAttributeKeyChassisModel, ChassisStatusHealthMetricAttributeKeyChassisName, ChassisStatusHealthMetricAttributeKeyChassisManufacturer, ChassisStatusHealthMetricAttributeKeyChassisSerialNumber, ChassisStatusHealthMetricAttributeKeyChassisSku, ChassisStatusHealthMetricAttributeKeyChassisChassisType},
 					},
-					ChassisStatusState: MetricConfig{
-						Enabled: true,
+					ChassisStatusState: ChassisStatusStateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ChassisStatusStateMetricAttributeKey{ChassisStatusStateMetricAttributeKeyChassisID, ChassisStatusStateMetricAttributeKeyChassisAssetTag, ChassisStatusStateMetricAttributeKeyChassisModel, ChassisStatusStateMetricAttributeKeyChassisName, ChassisStatusStateMetricAttributeKeyChassisManufacturer, ChassisStatusStateMetricAttributeKeyChassisSerialNumber, ChassisStatusStateMetricAttributeKeyChassisSku, ChassisStatusStateMetricAttributeKeyChassisChassisType},
 					},
-					FanReading: MetricConfig{
-						Enabled: true,
+					FanReading: FanReadingMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []FanReadingMetricAttributeKey{FanReadingMetricAttributeKeyChassisID, FanReadingMetricAttributeKeyFanName, FanReadingMetricAttributeKeyFanReadingUnits},
 					},
-					FanStatusHealth: MetricConfig{
-						Enabled: true,
+					FanStatusHealth: FanStatusHealthMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []FanStatusHealthMetricAttributeKey{FanStatusHealthMetricAttributeKeyChassisID, FanStatusHealthMetricAttributeKeyFanName},
 					},
-					FanStatusState: MetricConfig{
-						Enabled: true,
+					FanStatusState: FanStatusStateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []FanStatusStateMetricAttributeKey{FanStatusStateMetricAttributeKeyChassisID, FanStatusStateMetricAttributeKeyFanName},
 					},
-					SystemPowerstate: MetricConfig{
-						Enabled: true,
+					SystemPowerstate: SystemPowerstateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemPowerstateMetricAttributeKey{SystemPowerstateMetricAttributeKeySystemID, SystemPowerstateMetricAttributeKeySystemAssetTag, SystemPowerstateMetricAttributeKeySystemBiosVersion, SystemPowerstateMetricAttributeKeySystemModel, SystemPowerstateMetricAttributeKeySystemName, SystemPowerstateMetricAttributeKeySystemManufacturer, SystemPowerstateMetricAttributeKeySystemSerialNumber, SystemPowerstateMetricAttributeKeySystemSku, SystemPowerstateMetricAttributeKeySystemSystemType},
 					},
-					SystemStatusHealth: MetricConfig{
-						Enabled: true,
+					SystemStatusHealth: SystemStatusHealthMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemStatusHealthMetricAttributeKey{SystemStatusHealthMetricAttributeKeySystemID, SystemStatusHealthMetricAttributeKeySystemAssetTag, SystemStatusHealthMetricAttributeKeySystemBiosVersion, SystemStatusHealthMetricAttributeKeySystemModel, SystemStatusHealthMetricAttributeKeySystemName, SystemStatusHealthMetricAttributeKeySystemManufacturer, SystemStatusHealthMetricAttributeKeySystemSerialNumber, SystemStatusHealthMetricAttributeKeySystemSku, SystemStatusHealthMetricAttributeKeySystemSystemType},
 					},
-					SystemStatusState: MetricConfig{
-						Enabled: true,
+					SystemStatusState: SystemStatusStateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemStatusStateMetricAttributeKey{SystemStatusStateMetricAttributeKeySystemID, SystemStatusStateMetricAttributeKeySystemAssetTag, SystemStatusStateMetricAttributeKeySystemBiosVersion, SystemStatusStateMetricAttributeKeySystemModel, SystemStatusStateMetricAttributeKeySystemName, SystemStatusStateMetricAttributeKeySystemManufacturer, SystemStatusStateMetricAttributeKeySystemSerialNumber, SystemStatusStateMetricAttributeKeySystemSku, SystemStatusStateMetricAttributeKeySystemSystemType},
 					},
-					TemperatureReading: MetricConfig{
-						Enabled: true,
+					TemperatureReading: TemperatureReadingMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TemperatureReadingMetricAttributeKey{TemperatureReadingMetricAttributeKeyChassisID, TemperatureReadingMetricAttributeKeyTemperatureName},
 					},
-					TemperatureStatusHealth: MetricConfig{
-						Enabled: true,
+					TemperatureStatusHealth: TemperatureStatusHealthMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TemperatureStatusHealthMetricAttributeKey{TemperatureStatusHealthMetricAttributeKeyChassisID, TemperatureStatusHealthMetricAttributeKeyTemperatureName},
 					},
-					TemperatureStatusState: MetricConfig{
-						Enabled: true,
+					TemperatureStatusState: TemperatureStatusStateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TemperatureStatusStateMetricAttributeKey{TemperatureStatusStateMetricAttributeKeyChassisID, TemperatureStatusStateMetricAttributeKeyTemperatureName},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -73,41 +98,65 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ChassisPowerstate: MetricConfig{
-						Enabled: false,
+					ChassisPowerstate: ChassisPowerstateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ChassisPowerstateMetricAttributeKey{ChassisPowerstateMetricAttributeKeyChassisID, ChassisPowerstateMetricAttributeKeyChassisAssetTag, ChassisPowerstateMetricAttributeKeyChassisModel, ChassisPowerstateMetricAttributeKeyChassisName, ChassisPowerstateMetricAttributeKeyChassisManufacturer, ChassisPowerstateMetricAttributeKeyChassisSerialNumber, ChassisPowerstateMetricAttributeKeyChassisSku, ChassisPowerstateMetricAttributeKeyChassisChassisType},
 					},
-					ChassisStatusHealth: MetricConfig{
-						Enabled: false,
+					ChassisStatusHealth: ChassisStatusHealthMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ChassisStatusHealthMetricAttributeKey{ChassisStatusHealthMetricAttributeKeyChassisID, ChassisStatusHealthMetricAttributeKeyChassisAssetTag, ChassisStatusHealthMetricAttributeKeyChassisModel, ChassisStatusHealthMetricAttributeKeyChassisName, ChassisStatusHealthMetricAttributeKeyChassisManufacturer, ChassisStatusHealthMetricAttributeKeyChassisSerialNumber, ChassisStatusHealthMetricAttributeKeyChassisSku, ChassisStatusHealthMetricAttributeKeyChassisChassisType},
 					},
-					ChassisStatusState: MetricConfig{
-						Enabled: false,
+					ChassisStatusState: ChassisStatusStateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ChassisStatusStateMetricAttributeKey{ChassisStatusStateMetricAttributeKeyChassisID, ChassisStatusStateMetricAttributeKeyChassisAssetTag, ChassisStatusStateMetricAttributeKeyChassisModel, ChassisStatusStateMetricAttributeKeyChassisName, ChassisStatusStateMetricAttributeKeyChassisManufacturer, ChassisStatusStateMetricAttributeKeyChassisSerialNumber, ChassisStatusStateMetricAttributeKeyChassisSku, ChassisStatusStateMetricAttributeKeyChassisChassisType},
 					},
-					FanReading: MetricConfig{
-						Enabled: false,
+					FanReading: FanReadingMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []FanReadingMetricAttributeKey{FanReadingMetricAttributeKeyChassisID, FanReadingMetricAttributeKeyFanName, FanReadingMetricAttributeKeyFanReadingUnits},
 					},
-					FanStatusHealth: MetricConfig{
-						Enabled: false,
+					FanStatusHealth: FanStatusHealthMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []FanStatusHealthMetricAttributeKey{FanStatusHealthMetricAttributeKeyChassisID, FanStatusHealthMetricAttributeKeyFanName},
 					},
-					FanStatusState: MetricConfig{
-						Enabled: false,
+					FanStatusState: FanStatusStateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []FanStatusStateMetricAttributeKey{FanStatusStateMetricAttributeKeyChassisID, FanStatusStateMetricAttributeKeyFanName},
 					},
-					SystemPowerstate: MetricConfig{
-						Enabled: false,
+					SystemPowerstate: SystemPowerstateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemPowerstateMetricAttributeKey{SystemPowerstateMetricAttributeKeySystemID, SystemPowerstateMetricAttributeKeySystemAssetTag, SystemPowerstateMetricAttributeKeySystemBiosVersion, SystemPowerstateMetricAttributeKeySystemModel, SystemPowerstateMetricAttributeKeySystemName, SystemPowerstateMetricAttributeKeySystemManufacturer, SystemPowerstateMetricAttributeKeySystemSerialNumber, SystemPowerstateMetricAttributeKeySystemSku, SystemPowerstateMetricAttributeKeySystemSystemType},
 					},
-					SystemStatusHealth: MetricConfig{
-						Enabled: false,
+					SystemStatusHealth: SystemStatusHealthMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemStatusHealthMetricAttributeKey{SystemStatusHealthMetricAttributeKeySystemID, SystemStatusHealthMetricAttributeKeySystemAssetTag, SystemStatusHealthMetricAttributeKeySystemBiosVersion, SystemStatusHealthMetricAttributeKeySystemModel, SystemStatusHealthMetricAttributeKeySystemName, SystemStatusHealthMetricAttributeKeySystemManufacturer, SystemStatusHealthMetricAttributeKeySystemSerialNumber, SystemStatusHealthMetricAttributeKeySystemSku, SystemStatusHealthMetricAttributeKeySystemSystemType},
 					},
-					SystemStatusState: MetricConfig{
-						Enabled: false,
+					SystemStatusState: SystemStatusStateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemStatusStateMetricAttributeKey{SystemStatusStateMetricAttributeKeySystemID, SystemStatusStateMetricAttributeKeySystemAssetTag, SystemStatusStateMetricAttributeKeySystemBiosVersion, SystemStatusStateMetricAttributeKeySystemModel, SystemStatusStateMetricAttributeKeySystemName, SystemStatusStateMetricAttributeKeySystemManufacturer, SystemStatusStateMetricAttributeKeySystemSerialNumber, SystemStatusStateMetricAttributeKeySystemSku, SystemStatusStateMetricAttributeKeySystemSystemType},
 					},
-					TemperatureReading: MetricConfig{
-						Enabled: false,
+					TemperatureReading: TemperatureReadingMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TemperatureReadingMetricAttributeKey{TemperatureReadingMetricAttributeKeyChassisID, TemperatureReadingMetricAttributeKeyTemperatureName},
 					},
-					TemperatureStatusHealth: MetricConfig{
-						Enabled: false,
+					TemperatureStatusHealth: TemperatureStatusHealthMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TemperatureStatusHealthMetricAttributeKey{TemperatureStatusHealthMetricAttributeKeyChassisID, TemperatureStatusHealthMetricAttributeKeyTemperatureName},
 					},
-					TemperatureStatusState: MetricConfig{
-						Enabled: false,
+					TemperatureStatusState: TemperatureStatusStateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []TemperatureStatusStateMetricAttributeKey{TemperatureStatusStateMetricAttributeKeyChassisID, TemperatureStatusStateMetricAttributeKeyTemperatureName},
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
@@ -120,7 +169,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ChassisPowerstateMetricConfig{}, ChassisStatusHealthMetricConfig{}, ChassisStatusStateMetricConfig{}, FanReadingMetricConfig{}, FanStatusHealthMetricConfig{}, FanStatusStateMetricConfig{}, SystemPowerstateMetricConfig{}, SystemStatusHealthMetricConfig{}, SystemStatusStateMetricConfig{}, TemperatureReadingMetricConfig{}, TemperatureStatusHealthMetricConfig{}, TemperatureStatusStateMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/redfishreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -71,9 +79,10 @@ type metricInfo struct {
 }
 
 type metricChassisPowerstate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        ChassisPowerstateMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills chassis.powerstate metric with initial data.
@@ -83,24 +92,69 @@ func (m *metricChassisPowerstate) init() {
 	m.data.SetUnit("{powerstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricChassisPowerstate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, chassisAssetTagAttributeValue string, chassisModelAttributeValue string, chassisNameAttributeValue string, chassisManufacturerAttributeValue string, chassisSerialNumberAttributeValue string, chassisSkuAttributeValue string, chassisChassisTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisAssetTag) {
+		dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisModel) {
+		dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisName) {
+		dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisManufacturer) {
+		dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisSerialNumber) {
+		dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisSku) {
+		dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisPowerstateMetricAttributeKeyChassisChassisType) {
+		dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
-	dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
-	dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
-	dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
-	dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
-	dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
-	dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -113,13 +167,18 @@ func (m *metricChassisPowerstate) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricChassisPowerstate) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricChassisPowerstate(cfg MetricConfig) metricChassisPowerstate {
+func newMetricChassisPowerstate(cfg ChassisPowerstateMetricConfig) metricChassisPowerstate {
 	m := metricChassisPowerstate{config: cfg}
 
 	if cfg.Enabled {
@@ -130,9 +189,10 @@ func newMetricChassisPowerstate(cfg MetricConfig) metricChassisPowerstate {
 }
 
 type metricChassisStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        ChassisStatusHealthMetricConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills chassis.status.health metric with initial data.
@@ -142,24 +202,69 @@ func (m *metricChassisStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricChassisStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, chassisAssetTagAttributeValue string, chassisModelAttributeValue string, chassisNameAttributeValue string, chassisManufacturerAttributeValue string, chassisSerialNumberAttributeValue string, chassisSkuAttributeValue string, chassisChassisTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisAssetTag) {
+		dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisModel) {
+		dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisName) {
+		dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisManufacturer) {
+		dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisSerialNumber) {
+		dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisSku) {
+		dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusHealthMetricAttributeKeyChassisChassisType) {
+		dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
-	dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
-	dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
-	dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
-	dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
-	dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
-	dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -172,13 +277,18 @@ func (m *metricChassisStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricChassisStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricChassisStatusHealth(cfg MetricConfig) metricChassisStatusHealth {
+func newMetricChassisStatusHealth(cfg ChassisStatusHealthMetricConfig) metricChassisStatusHealth {
 	m := metricChassisStatusHealth{config: cfg}
 
 	if cfg.Enabled {
@@ -189,9 +299,10 @@ func newMetricChassisStatusHealth(cfg MetricConfig) metricChassisStatusHealth {
 }
 
 type metricChassisStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        ChassisStatusStateMetricConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills chassis.status.state metric with initial data.
@@ -201,24 +312,69 @@ func (m *metricChassisStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricChassisStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, chassisAssetTagAttributeValue string, chassisModelAttributeValue string, chassisNameAttributeValue string, chassisManufacturerAttributeValue string, chassisSerialNumberAttributeValue string, chassisSkuAttributeValue string, chassisChassisTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisAssetTag) {
+		dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisModel) {
+		dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisName) {
+		dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisManufacturer) {
+		dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisSerialNumber) {
+		dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisSku) {
+		dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ChassisStatusStateMetricAttributeKeyChassisChassisType) {
+		dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
-	dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
-	dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
-	dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
-	dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
-	dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
-	dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -231,13 +387,18 @@ func (m *metricChassisStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricChassisStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricChassisStatusState(cfg MetricConfig) metricChassisStatusState {
+func newMetricChassisStatusState(cfg ChassisStatusStateMetricConfig) metricChassisStatusState {
 	m := metricChassisStatusState{config: cfg}
 
 	if cfg.Enabled {
@@ -248,9 +409,10 @@ func newMetricChassisStatusState(cfg MetricConfig) metricChassisStatusState {
 }
 
 type metricFanReading struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric         // data buffer for generated metric.
+	config        FanReadingMetricConfig // metric config provided by user.
+	capacity      int                    // max observed number of data points added to the metric.
+	aggDataPoints []int64                // slice containing number of aggregated datapoints at each index
 }
 
 // init fills fan.reading metric with initial data.
@@ -260,19 +422,54 @@ func (m *metricFanReading) init() {
 	m.data.SetUnit("{}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFanReading) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, fanNameAttributeValue string, fanReadingUnitsAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, FanReadingMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, FanReadingMetricAttributeKeyFanName) {
+		dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, FanReadingMetricAttributeKeyFanReadingUnits) {
+		dp.Attributes().PutStr("fan.reading_units", fanReadingUnitsAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
-	dp.Attributes().PutStr("fan.reading_units", fanReadingUnitsAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -285,13 +482,18 @@ func (m *metricFanReading) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFanReading) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFanReading(cfg MetricConfig) metricFanReading {
+func newMetricFanReading(cfg FanReadingMetricConfig) metricFanReading {
 	m := metricFanReading{config: cfg}
 
 	if cfg.Enabled {
@@ -302,9 +504,10 @@ func newMetricFanReading(cfg MetricConfig) metricFanReading {
 }
 
 type metricFanStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric              // data buffer for generated metric.
+	config        FanStatusHealthMetricConfig // metric config provided by user.
+	capacity      int                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills fan.status.health metric with initial data.
@@ -314,18 +517,51 @@ func (m *metricFanStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFanStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, fanNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, FanStatusHealthMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, FanStatusHealthMetricAttributeKeyFanName) {
+		dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -338,13 +574,18 @@ func (m *metricFanStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFanStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFanStatusHealth(cfg MetricConfig) metricFanStatusHealth {
+func newMetricFanStatusHealth(cfg FanStatusHealthMetricConfig) metricFanStatusHealth {
 	m := metricFanStatusHealth{config: cfg}
 
 	if cfg.Enabled {
@@ -355,9 +596,10 @@ func newMetricFanStatusHealth(cfg MetricConfig) metricFanStatusHealth {
 }
 
 type metricFanStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric             // data buffer for generated metric.
+	config        FanStatusStateMetricConfig // metric config provided by user.
+	capacity      int                        // max observed number of data points added to the metric.
+	aggDataPoints []int64                    // slice containing number of aggregated datapoints at each index
 }
 
 // init fills fan.status.state metric with initial data.
@@ -367,18 +609,51 @@ func (m *metricFanStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFanStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, fanNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, FanStatusStateMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, FanStatusStateMetricAttributeKeyFanName) {
+		dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -391,13 +666,18 @@ func (m *metricFanStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFanStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFanStatusState(cfg MetricConfig) metricFanStatusState {
+func newMetricFanStatusState(cfg FanStatusStateMetricConfig) metricFanStatusState {
 	m := metricFanStatusState{config: cfg}
 
 	if cfg.Enabled {
@@ -408,9 +688,10 @@ func newMetricFanStatusState(cfg MetricConfig) metricFanStatusState {
 }
 
 type metricSystemPowerstate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric               // data buffer for generated metric.
+	config        SystemPowerstateMetricConfig // metric config provided by user.
+	capacity      int                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills system.powerstate metric with initial data.
@@ -420,25 +701,72 @@ func (m *metricSystemPowerstate) init() {
 	m.data.SetUnit("{powerstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSystemPowerstate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemIDAttributeValue string, systemAssetTagAttributeValue string, systemBiosVersionAttributeValue string, systemModelAttributeValue string, systemNameAttributeValue string, systemManufacturerAttributeValue string, systemSerialNumberAttributeValue string, systemSkuAttributeValue string, systemSystemTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemID) {
+		dp.Attributes().PutStr("system.id", systemIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemAssetTag) {
+		dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemBiosVersion) {
+		dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemModel) {
+		dp.Attributes().PutStr("system.model", systemModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemName) {
+		dp.Attributes().PutStr("system.name", systemNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemManufacturer) {
+		dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemSerialNumber) {
+		dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemSku) {
+		dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemPowerstateMetricAttributeKeySystemSystemType) {
+		dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("system.id", systemIDAttributeValue)
-	dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
-	dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
-	dp.Attributes().PutStr("system.model", systemModelAttributeValue)
-	dp.Attributes().PutStr("system.name", systemNameAttributeValue)
-	dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
-	dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
-	dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
-	dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -451,13 +779,18 @@ func (m *metricSystemPowerstate) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemPowerstate) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemPowerstate(cfg MetricConfig) metricSystemPowerstate {
+func newMetricSystemPowerstate(cfg SystemPowerstateMetricConfig) metricSystemPowerstate {
 	m := metricSystemPowerstate{config: cfg}
 
 	if cfg.Enabled {
@@ -468,9 +801,10 @@ func newMetricSystemPowerstate(cfg MetricConfig) metricSystemPowerstate {
 }
 
 type metricSystemStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        SystemStatusHealthMetricConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills system.status.health metric with initial data.
@@ -480,25 +814,72 @@ func (m *metricSystemStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSystemStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemIDAttributeValue string, systemAssetTagAttributeValue string, systemBiosVersionAttributeValue string, systemModelAttributeValue string, systemNameAttributeValue string, systemManufacturerAttributeValue string, systemSerialNumberAttributeValue string, systemSkuAttributeValue string, systemSystemTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemID) {
+		dp.Attributes().PutStr("system.id", systemIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemAssetTag) {
+		dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemBiosVersion) {
+		dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemModel) {
+		dp.Attributes().PutStr("system.model", systemModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemName) {
+		dp.Attributes().PutStr("system.name", systemNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemManufacturer) {
+		dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemSerialNumber) {
+		dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemSku) {
+		dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusHealthMetricAttributeKeySystemSystemType) {
+		dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("system.id", systemIDAttributeValue)
-	dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
-	dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
-	dp.Attributes().PutStr("system.model", systemModelAttributeValue)
-	dp.Attributes().PutStr("system.name", systemNameAttributeValue)
-	dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
-	dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
-	dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
-	dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -511,13 +892,18 @@ func (m *metricSystemStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemStatusHealth(cfg MetricConfig) metricSystemStatusHealth {
+func newMetricSystemStatusHealth(cfg SystemStatusHealthMetricConfig) metricSystemStatusHealth {
 	m := metricSystemStatusHealth{config: cfg}
 
 	if cfg.Enabled {
@@ -528,9 +914,10 @@ func newMetricSystemStatusHealth(cfg MetricConfig) metricSystemStatusHealth {
 }
 
 type metricSystemStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                // data buffer for generated metric.
+	config        SystemStatusStateMetricConfig // metric config provided by user.
+	capacity      int                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills system.status.state metric with initial data.
@@ -540,25 +927,72 @@ func (m *metricSystemStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSystemStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemIDAttributeValue string, systemAssetTagAttributeValue string, systemBiosVersionAttributeValue string, systemModelAttributeValue string, systemNameAttributeValue string, systemManufacturerAttributeValue string, systemSerialNumberAttributeValue string, systemSkuAttributeValue string, systemSystemTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemID) {
+		dp.Attributes().PutStr("system.id", systemIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemAssetTag) {
+		dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemBiosVersion) {
+		dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemModel) {
+		dp.Attributes().PutStr("system.model", systemModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemName) {
+		dp.Attributes().PutStr("system.name", systemNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemManufacturer) {
+		dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemSerialNumber) {
+		dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemSku) {
+		dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemStatusStateMetricAttributeKeySystemSystemType) {
+		dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("system.id", systemIDAttributeValue)
-	dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
-	dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
-	dp.Attributes().PutStr("system.model", systemModelAttributeValue)
-	dp.Attributes().PutStr("system.name", systemNameAttributeValue)
-	dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
-	dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
-	dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
-	dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -571,13 +1005,18 @@ func (m *metricSystemStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemStatusState(cfg MetricConfig) metricSystemStatusState {
+func newMetricSystemStatusState(cfg SystemStatusStateMetricConfig) metricSystemStatusState {
 	m := metricSystemStatusState{config: cfg}
 
 	if cfg.Enabled {
@@ -588,9 +1027,10 @@ func newMetricSystemStatusState(cfg MetricConfig) metricSystemStatusState {
 }
 
 type metricTemperatureReading struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        TemperatureReadingMetricConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills temperature.reading metric with initial data.
@@ -600,18 +1040,51 @@ func (m *metricTemperatureReading) init() {
 	m.data.SetUnit("°C")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTemperatureReading) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, temperatureNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, TemperatureReadingMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, TemperatureReadingMetricAttributeKeyTemperatureName) {
+		dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -624,13 +1097,18 @@ func (m *metricTemperatureReading) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTemperatureReading) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricTemperatureReading(cfg MetricConfig) metricTemperatureReading {
+func newMetricTemperatureReading(cfg TemperatureReadingMetricConfig) metricTemperatureReading {
 	m := metricTemperatureReading{config: cfg}
 
 	if cfg.Enabled {
@@ -641,9 +1119,10 @@ func newMetricTemperatureReading(cfg MetricConfig) metricTemperatureReading {
 }
 
 type metricTemperatureStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        TemperatureStatusHealthMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
 }
 
 // init fills temperature.status.health metric with initial data.
@@ -653,18 +1132,51 @@ func (m *metricTemperatureStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTemperatureStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, temperatureNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, TemperatureStatusHealthMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, TemperatureStatusHealthMetricAttributeKeyTemperatureName) {
+		dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -677,13 +1189,18 @@ func (m *metricTemperatureStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTemperatureStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricTemperatureStatusHealth(cfg MetricConfig) metricTemperatureStatusHealth {
+func newMetricTemperatureStatusHealth(cfg TemperatureStatusHealthMetricConfig) metricTemperatureStatusHealth {
 	m := metricTemperatureStatusHealth{config: cfg}
 
 	if cfg.Enabled {
@@ -694,9 +1211,10 @@ func newMetricTemperatureStatusHealth(cfg MetricConfig) metricTemperatureStatusH
 }
 
 type metricTemperatureStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        TemperatureStatusStateMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []int64                            // slice containing number of aggregated datapoints at each index
 }
 
 // init fills temperature.status.state metric with initial data.
@@ -706,18 +1224,51 @@ func (m *metricTemperatureStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTemperatureStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, temperatureNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, TemperatureStatusStateMetricAttributeKeyChassisID) {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, TemperatureStatusStateMetricAttributeKeyTemperatureName) {
+		dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -730,13 +1281,18 @@ func (m *metricTemperatureStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTemperatureStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricTemperatureStatusState(cfg MetricConfig) metricTemperatureStatusState {
+func newMetricTemperatureStatusState(cfg TemperatureStatusStateMetricConfig) metricTemperatureStatusState {
 	m := metricTemperatureStatusState{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/redfishreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,24 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["ChassisPowerstate"] = mb.metricChassisPowerstate.config.AggregationStrategy
+			aggMap["ChassisStatusHealth"] = mb.metricChassisStatusHealth.config.AggregationStrategy
+			aggMap["ChassisStatusState"] = mb.metricChassisStatusState.config.AggregationStrategy
+			aggMap["FanReading"] = mb.metricFanReading.config.AggregationStrategy
+			aggMap["FanStatusHealth"] = mb.metricFanStatusHealth.config.AggregationStrategy
+			aggMap["FanStatusState"] = mb.metricFanStatusState.config.AggregationStrategy
+			aggMap["SystemPowerstate"] = mb.metricSystemPowerstate.config.AggregationStrategy
+			aggMap["SystemStatusHealth"] = mb.metricSystemStatusHealth.config.AggregationStrategy
+			aggMap["SystemStatusState"] = mb.metricSystemStatusState.config.AggregationStrategy
+			aggMap["TemperatureReading"] = mb.metricTemperatureReading.config.AggregationStrategy
+			aggMap["TemperatureStatusHealth"] = mb.metricTemperatureStatusHealth.config.AggregationStrategy
+			aggMap["TemperatureStatusState"] = mb.metricTemperatureStatusState.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,56 +91,106 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordChassisPowerstateDataPoint(ts, 1, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordChassisPowerstateDataPoint(ts, 3, "chassis.id-val-2", "chassis.asset_tag-val-2", "chassis.model-val-2", "chassis.name-val-2", "chassis.manufacturer-val-2", "chassis.serial_number-val-2", "chassis.sku-val-2", "chassis.chassis_type-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordChassisStatusHealthDataPoint(ts, 1, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordChassisStatusHealthDataPoint(ts, 3, "chassis.id-val-2", "chassis.asset_tag-val-2", "chassis.model-val-2", "chassis.name-val-2", "chassis.manufacturer-val-2", "chassis.serial_number-val-2", "chassis.sku-val-2", "chassis.chassis_type-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordChassisStatusStateDataPoint(ts, 1, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordChassisStatusStateDataPoint(ts, 3, "chassis.id-val-2", "chassis.asset_tag-val-2", "chassis.model-val-2", "chassis.name-val-2", "chassis.manufacturer-val-2", "chassis.serial_number-val-2", "chassis.sku-val-2", "chassis.chassis_type-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFanReadingDataPoint(ts, 1, "chassis.id-val", "fan.name-val", "fan.reading_units-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFanReadingDataPoint(ts, 3, "chassis.id-val-2", "fan.name-val-2", "fan.reading_units-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFanStatusHealthDataPoint(ts, 1, "chassis.id-val", "fan.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFanStatusHealthDataPoint(ts, 3, "chassis.id-val-2", "fan.name-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFanStatusStateDataPoint(ts, 1, "chassis.id-val", "fan.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFanStatusStateDataPoint(ts, 3, "chassis.id-val-2", "fan.name-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemPowerstateDataPoint(ts, 1, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemPowerstateDataPoint(ts, 3, "system.id-val-2", "system.asset_tag-val-2", "system.bios_version-val-2", "system.model-val-2", "system.name-val-2", "system.manufacturer-val-2", "system.serial_number-val-2", "system.sku-val-2", "system.system_type-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemStatusHealthDataPoint(ts, 1, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemStatusHealthDataPoint(ts, 3, "system.id-val-2", "system.asset_tag-val-2", "system.bios_version-val-2", "system.model-val-2", "system.name-val-2", "system.manufacturer-val-2", "system.serial_number-val-2", "system.sku-val-2", "system.system_type-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemStatusStateDataPoint(ts, 1, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemStatusStateDataPoint(ts, 3, "system.id-val-2", "system.asset_tag-val-2", "system.bios_version-val-2", "system.model-val-2", "system.name-val-2", "system.manufacturer-val-2", "system.serial_number-val-2", "system.sku-val-2", "system.system_type-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTemperatureReadingDataPoint(ts, 1, "chassis.id-val", "temperature.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordTemperatureReadingDataPoint(ts, 3, "chassis.id-val-2", "temperature.name-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTemperatureStatusHealthDataPoint(ts, 1, "chassis.id-val", "temperature.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordTemperatureStatusHealthDataPoint(ts, 3, "chassis.id-val-2", "temperature.name-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTemperatureStatusStateDataPoint(ts, 1, "chassis.id-val", "temperature.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordTemperatureStatusStateDataPoint(ts, 3, "chassis.id-val-2", "temperature.name-val-2")
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetHostName("host.name-val")
 			rb.SetURLFull("url.full-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricChassisPowerstate.aggDataPoints)
+				assert.Empty(t, mb.metricChassisStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricChassisStatusState.aggDataPoints)
+				assert.Empty(t, mb.metricFanReading.aggDataPoints)
+				assert.Empty(t, mb.metricFanStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricFanStatusState.aggDataPoints)
+				assert.Empty(t, mb.metricSystemPowerstate.aggDataPoints)
+				assert.Empty(t, mb.metricSystemStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricSystemStatusState.aggDataPoints)
+				assert.Empty(t, mb.metricTemperatureReading.aggDataPoints)
+				assert.Empty(t, mb.metricTemperatureStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricTemperatureStatusState.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -147,341 +218,745 @@ func TestMetricsBuilder(t *testing.T) {
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
 				case "chassis.powerstate":
-					assert.False(t, validatedMetrics["chassis.powerstate"], "Found a duplicate in the metrics slice: chassis.powerstate")
-					validatedMetrics["chassis.powerstate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the power state of a chassis (-1 unknown, 0 off, 1 on).", mi.Description())
-					assert.Equal(t, "{powerstate}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					chassisAssetTagAttrVal, ok := dp.Attributes().Get("chassis.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.asset_tag-val", chassisAssetTagAttrVal.Str())
-					chassisModelAttrVal, ok := dp.Attributes().Get("chassis.model")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.model-val", chassisModelAttrVal.Str())
-					chassisNameAttrVal, ok := dp.Attributes().Get("chassis.name")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.name-val", chassisNameAttrVal.Str())
-					chassisManufacturerAttrVal, ok := dp.Attributes().Get("chassis.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.manufacturer-val", chassisManufacturerAttrVal.Str())
-					chassisSerialNumberAttrVal, ok := dp.Attributes().Get("chassis.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.serial_number-val", chassisSerialNumberAttrVal.Str())
-					chassisSkuAttrVal, ok := dp.Attributes().Get("chassis.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.sku-val", chassisSkuAttrVal.Str())
-					chassisChassisTypeAttrVal, ok := dp.Attributes().Get("chassis.chassis_type")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.chassis_type-val", chassisChassisTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["chassis.powerstate"], "Found a duplicate in the metrics slice: chassis.powerstate")
+						validatedMetrics["chassis.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a chassis (-1 unknown, 0 off, 1 on).", mi.Description())
+						assert.Equal(t, "{powerstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						chassisAssetTagAttrVal, ok := dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.asset_tag-val", chassisAssetTagAttrVal.Str())
+						chassisModelAttrVal, ok := dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.model-val", chassisModelAttrVal.Str())
+						chassisNameAttrVal, ok := dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.name-val", chassisNameAttrVal.Str())
+						chassisManufacturerAttrVal, ok := dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.manufacturer-val", chassisManufacturerAttrVal.Str())
+						chassisSerialNumberAttrVal, ok := dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.serial_number-val", chassisSerialNumberAttrVal.Str())
+						chassisSkuAttrVal, ok := dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.sku-val", chassisSkuAttrVal.Str())
+						chassisChassisTypeAttrVal, ok := dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.chassis_type-val", chassisChassisTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["chassis.powerstate"], "Found a duplicate in the metrics slice: chassis.powerstate")
+						validatedMetrics["chassis.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a chassis (-1 unknown, 0 off, 1 on).", mi.Description())
+						assert.Equal(t, "{powerstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["chassis.powerstate"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.model")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.sku")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.False(t, ok)
+					}
 				case "chassis.status.health":
-					assert.False(t, validatedMetrics["chassis.status.health"], "Found a duplicate in the metrics slice: chassis.status.health")
-					validatedMetrics["chassis.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
-					assert.Equal(t, "{statushealth}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					chassisAssetTagAttrVal, ok := dp.Attributes().Get("chassis.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.asset_tag-val", chassisAssetTagAttrVal.Str())
-					chassisModelAttrVal, ok := dp.Attributes().Get("chassis.model")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.model-val", chassisModelAttrVal.Str())
-					chassisNameAttrVal, ok := dp.Attributes().Get("chassis.name")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.name-val", chassisNameAttrVal.Str())
-					chassisManufacturerAttrVal, ok := dp.Attributes().Get("chassis.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.manufacturer-val", chassisManufacturerAttrVal.Str())
-					chassisSerialNumberAttrVal, ok := dp.Attributes().Get("chassis.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.serial_number-val", chassisSerialNumberAttrVal.Str())
-					chassisSkuAttrVal, ok := dp.Attributes().Get("chassis.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.sku-val", chassisSkuAttrVal.Str())
-					chassisChassisTypeAttrVal, ok := dp.Attributes().Get("chassis.chassis_type")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.chassis_type-val", chassisChassisTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["chassis.status.health"], "Found a duplicate in the metrics slice: chassis.status.health")
+						validatedMetrics["chassis.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						chassisAssetTagAttrVal, ok := dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.asset_tag-val", chassisAssetTagAttrVal.Str())
+						chassisModelAttrVal, ok := dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.model-val", chassisModelAttrVal.Str())
+						chassisNameAttrVal, ok := dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.name-val", chassisNameAttrVal.Str())
+						chassisManufacturerAttrVal, ok := dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.manufacturer-val", chassisManufacturerAttrVal.Str())
+						chassisSerialNumberAttrVal, ok := dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.serial_number-val", chassisSerialNumberAttrVal.Str())
+						chassisSkuAttrVal, ok := dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.sku-val", chassisSkuAttrVal.Str())
+						chassisChassisTypeAttrVal, ok := dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.chassis_type-val", chassisChassisTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["chassis.status.health"], "Found a duplicate in the metrics slice: chassis.status.health")
+						validatedMetrics["chassis.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["chassis.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.model")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.sku")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.False(t, ok)
+					}
 				case "chassis.status.state":
-					assert.False(t, validatedMetrics["chassis.status.state"], "Found a duplicate in the metrics slice: chassis.status.state")
-					validatedMetrics["chassis.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
-					assert.Equal(t, "{statusstate}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					chassisAssetTagAttrVal, ok := dp.Attributes().Get("chassis.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.asset_tag-val", chassisAssetTagAttrVal.Str())
-					chassisModelAttrVal, ok := dp.Attributes().Get("chassis.model")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.model-val", chassisModelAttrVal.Str())
-					chassisNameAttrVal, ok := dp.Attributes().Get("chassis.name")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.name-val", chassisNameAttrVal.Str())
-					chassisManufacturerAttrVal, ok := dp.Attributes().Get("chassis.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.manufacturer-val", chassisManufacturerAttrVal.Str())
-					chassisSerialNumberAttrVal, ok := dp.Attributes().Get("chassis.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.serial_number-val", chassisSerialNumberAttrVal.Str())
-					chassisSkuAttrVal, ok := dp.Attributes().Get("chassis.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.sku-val", chassisSkuAttrVal.Str())
-					chassisChassisTypeAttrVal, ok := dp.Attributes().Get("chassis.chassis_type")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.chassis_type-val", chassisChassisTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["chassis.status.state"], "Found a duplicate in the metrics slice: chassis.status.state")
+						validatedMetrics["chassis.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						chassisAssetTagAttrVal, ok := dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.asset_tag-val", chassisAssetTagAttrVal.Str())
+						chassisModelAttrVal, ok := dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.model-val", chassisModelAttrVal.Str())
+						chassisNameAttrVal, ok := dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.name-val", chassisNameAttrVal.Str())
+						chassisManufacturerAttrVal, ok := dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.manufacturer-val", chassisManufacturerAttrVal.Str())
+						chassisSerialNumberAttrVal, ok := dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.serial_number-val", chassisSerialNumberAttrVal.Str())
+						chassisSkuAttrVal, ok := dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.sku-val", chassisSkuAttrVal.Str())
+						chassisChassisTypeAttrVal, ok := dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.chassis_type-val", chassisChassisTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["chassis.status.state"], "Found a duplicate in the metrics slice: chassis.status.state")
+						validatedMetrics["chassis.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["chassis.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.model")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.sku")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.False(t, ok)
+					}
 				case "fan.reading":
-					assert.False(t, validatedMetrics["fan.reading"], "Found a duplicate in the metrics slice: fan.reading")
-					validatedMetrics["fan.reading"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the reading of a chassis fan.", mi.Description())
-					assert.Equal(t, "{}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					fanNameAttrVal, ok := dp.Attributes().Get("fan.name")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.name-val", fanNameAttrVal.Str())
-					fanReadingUnitsAttrVal, ok := dp.Attributes().Get("fan.reading_units")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.reading_units-val", fanReadingUnitsAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["fan.reading"], "Found a duplicate in the metrics slice: fan.reading")
+						validatedMetrics["fan.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis fan.", mi.Description())
+						assert.Equal(t, "{}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						fanNameAttrVal, ok := dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.name-val", fanNameAttrVal.Str())
+						fanReadingUnitsAttrVal, ok := dp.Attributes().Get("fan.reading_units")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.reading_units-val", fanReadingUnitsAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["fan.reading"], "Found a duplicate in the metrics slice: fan.reading")
+						validatedMetrics["fan.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis fan.", mi.Description())
+						assert.Equal(t, "{}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["fan.reading"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("fan.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("fan.reading_units")
+						assert.False(t, ok)
+					}
 				case "fan.status.health":
-					assert.False(t, validatedMetrics["fan.status.health"], "Found a duplicate in the metrics slice: fan.status.health")
-					validatedMetrics["fan.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
-					assert.Equal(t, "{statushealth}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					fanNameAttrVal, ok := dp.Attributes().Get("fan.name")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.name-val", fanNameAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["fan.status.health"], "Found a duplicate in the metrics slice: fan.status.health")
+						validatedMetrics["fan.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						fanNameAttrVal, ok := dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.name-val", fanNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["fan.status.health"], "Found a duplicate in the metrics slice: fan.status.health")
+						validatedMetrics["fan.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["fan.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("fan.name")
+						assert.False(t, ok)
+					}
 				case "fan.status.state":
-					assert.False(t, validatedMetrics["fan.status.state"], "Found a duplicate in the metrics slice: fan.status.state")
-					validatedMetrics["fan.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
-					assert.Equal(t, "{statusstate}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					fanNameAttrVal, ok := dp.Attributes().Get("fan.name")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.name-val", fanNameAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["fan.status.state"], "Found a duplicate in the metrics slice: fan.status.state")
+						validatedMetrics["fan.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						fanNameAttrVal, ok := dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.name-val", fanNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["fan.status.state"], "Found a duplicate in the metrics slice: fan.status.state")
+						validatedMetrics["fan.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["fan.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("fan.name")
+						assert.False(t, ok)
+					}
 				case "system.powerstate":
-					assert.False(t, validatedMetrics["system.powerstate"], "Found a duplicate in the metrics slice: system.powerstate")
-					validatedMetrics["system.powerstate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the power state of a system (-1 unknown, 0 off, 1 on).", mi.Description())
-					assert.Equal(t, "{powerstate}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					systemIDAttrVal, ok := dp.Attributes().Get("system.id")
-					assert.True(t, ok)
-					assert.Equal(t, "system.id-val", systemIDAttrVal.Str())
-					systemAssetTagAttrVal, ok := dp.Attributes().Get("system.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "system.asset_tag-val", systemAssetTagAttrVal.Str())
-					systemBiosVersionAttrVal, ok := dp.Attributes().Get("system.bios_version")
-					assert.True(t, ok)
-					assert.Equal(t, "system.bios_version-val", systemBiosVersionAttrVal.Str())
-					systemModelAttrVal, ok := dp.Attributes().Get("system.model")
-					assert.True(t, ok)
-					assert.Equal(t, "system.model-val", systemModelAttrVal.Str())
-					systemNameAttrVal, ok := dp.Attributes().Get("system.name")
-					assert.True(t, ok)
-					assert.Equal(t, "system.name-val", systemNameAttrVal.Str())
-					systemManufacturerAttrVal, ok := dp.Attributes().Get("system.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "system.manufacturer-val", systemManufacturerAttrVal.Str())
-					systemSerialNumberAttrVal, ok := dp.Attributes().Get("system.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "system.serial_number-val", systemSerialNumberAttrVal.Str())
-					systemSkuAttrVal, ok := dp.Attributes().Get("system.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "system.sku-val", systemSkuAttrVal.Str())
-					systemSystemTypeAttrVal, ok := dp.Attributes().Get("system.system_type")
-					assert.True(t, ok)
-					assert.Equal(t, "system.system_type-val", systemSystemTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.powerstate"], "Found a duplicate in the metrics slice: system.powerstate")
+						validatedMetrics["system.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a system (-1 unknown, 0 off, 1 on).", mi.Description())
+						assert.Equal(t, "{powerstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						systemIDAttrVal, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						assert.Equal(t, "system.id-val", systemIDAttrVal.Str())
+						systemAssetTagAttrVal, ok := dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "system.asset_tag-val", systemAssetTagAttrVal.Str())
+						systemBiosVersionAttrVal, ok := dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						assert.Equal(t, "system.bios_version-val", systemBiosVersionAttrVal.Str())
+						systemModelAttrVal, ok := dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						assert.Equal(t, "system.model-val", systemModelAttrVal.Str())
+						systemNameAttrVal, ok := dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						assert.Equal(t, "system.name-val", systemNameAttrVal.Str())
+						systemManufacturerAttrVal, ok := dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "system.manufacturer-val", systemManufacturerAttrVal.Str())
+						systemSerialNumberAttrVal, ok := dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "system.serial_number-val", systemSerialNumberAttrVal.Str())
+						systemSkuAttrVal, ok := dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "system.sku-val", systemSkuAttrVal.Str())
+						systemSystemTypeAttrVal, ok := dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+						assert.Equal(t, "system.system_type-val", systemSystemTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.powerstate"], "Found a duplicate in the metrics slice: system.powerstate")
+						validatedMetrics["system.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a system (-1 unknown, 0 off, 1 on).", mi.Description())
+						assert.Equal(t, "{powerstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.powerstate"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("system.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.asset_tag")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.bios_version")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.model")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.manufacturer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.serial_number")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.sku")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.system_type")
+						assert.False(t, ok)
+					}
 				case "system.status.health":
-					assert.False(t, validatedMetrics["system.status.health"], "Found a duplicate in the metrics slice: system.status.health")
-					validatedMetrics["system.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
-					assert.Equal(t, "{statushealth}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					systemIDAttrVal, ok := dp.Attributes().Get("system.id")
-					assert.True(t, ok)
-					assert.Equal(t, "system.id-val", systemIDAttrVal.Str())
-					systemAssetTagAttrVal, ok := dp.Attributes().Get("system.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "system.asset_tag-val", systemAssetTagAttrVal.Str())
-					systemBiosVersionAttrVal, ok := dp.Attributes().Get("system.bios_version")
-					assert.True(t, ok)
-					assert.Equal(t, "system.bios_version-val", systemBiosVersionAttrVal.Str())
-					systemModelAttrVal, ok := dp.Attributes().Get("system.model")
-					assert.True(t, ok)
-					assert.Equal(t, "system.model-val", systemModelAttrVal.Str())
-					systemNameAttrVal, ok := dp.Attributes().Get("system.name")
-					assert.True(t, ok)
-					assert.Equal(t, "system.name-val", systemNameAttrVal.Str())
-					systemManufacturerAttrVal, ok := dp.Attributes().Get("system.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "system.manufacturer-val", systemManufacturerAttrVal.Str())
-					systemSerialNumberAttrVal, ok := dp.Attributes().Get("system.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "system.serial_number-val", systemSerialNumberAttrVal.Str())
-					systemSkuAttrVal, ok := dp.Attributes().Get("system.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "system.sku-val", systemSkuAttrVal.Str())
-					systemSystemTypeAttrVal, ok := dp.Attributes().Get("system.system_type")
-					assert.True(t, ok)
-					assert.Equal(t, "system.system_type-val", systemSystemTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.status.health"], "Found a duplicate in the metrics slice: system.status.health")
+						validatedMetrics["system.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						systemIDAttrVal, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						assert.Equal(t, "system.id-val", systemIDAttrVal.Str())
+						systemAssetTagAttrVal, ok := dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "system.asset_tag-val", systemAssetTagAttrVal.Str())
+						systemBiosVersionAttrVal, ok := dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						assert.Equal(t, "system.bios_version-val", systemBiosVersionAttrVal.Str())
+						systemModelAttrVal, ok := dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						assert.Equal(t, "system.model-val", systemModelAttrVal.Str())
+						systemNameAttrVal, ok := dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						assert.Equal(t, "system.name-val", systemNameAttrVal.Str())
+						systemManufacturerAttrVal, ok := dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "system.manufacturer-val", systemManufacturerAttrVal.Str())
+						systemSerialNumberAttrVal, ok := dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "system.serial_number-val", systemSerialNumberAttrVal.Str())
+						systemSkuAttrVal, ok := dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "system.sku-val", systemSkuAttrVal.Str())
+						systemSystemTypeAttrVal, ok := dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+						assert.Equal(t, "system.system_type-val", systemSystemTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.status.health"], "Found a duplicate in the metrics slice: system.status.health")
+						validatedMetrics["system.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("system.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.asset_tag")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.bios_version")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.model")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.manufacturer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.serial_number")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.sku")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.system_type")
+						assert.False(t, ok)
+					}
 				case "system.status.state":
-					assert.False(t, validatedMetrics["system.status.state"], "Found a duplicate in the metrics slice: system.status.state")
-					validatedMetrics["system.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
-					assert.Equal(t, "{statusstate}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					systemIDAttrVal, ok := dp.Attributes().Get("system.id")
-					assert.True(t, ok)
-					assert.Equal(t, "system.id-val", systemIDAttrVal.Str())
-					systemAssetTagAttrVal, ok := dp.Attributes().Get("system.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "system.asset_tag-val", systemAssetTagAttrVal.Str())
-					systemBiosVersionAttrVal, ok := dp.Attributes().Get("system.bios_version")
-					assert.True(t, ok)
-					assert.Equal(t, "system.bios_version-val", systemBiosVersionAttrVal.Str())
-					systemModelAttrVal, ok := dp.Attributes().Get("system.model")
-					assert.True(t, ok)
-					assert.Equal(t, "system.model-val", systemModelAttrVal.Str())
-					systemNameAttrVal, ok := dp.Attributes().Get("system.name")
-					assert.True(t, ok)
-					assert.Equal(t, "system.name-val", systemNameAttrVal.Str())
-					systemManufacturerAttrVal, ok := dp.Attributes().Get("system.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "system.manufacturer-val", systemManufacturerAttrVal.Str())
-					systemSerialNumberAttrVal, ok := dp.Attributes().Get("system.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "system.serial_number-val", systemSerialNumberAttrVal.Str())
-					systemSkuAttrVal, ok := dp.Attributes().Get("system.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "system.sku-val", systemSkuAttrVal.Str())
-					systemSystemTypeAttrVal, ok := dp.Attributes().Get("system.system_type")
-					assert.True(t, ok)
-					assert.Equal(t, "system.system_type-val", systemSystemTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.status.state"], "Found a duplicate in the metrics slice: system.status.state")
+						validatedMetrics["system.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						systemIDAttrVal, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						assert.Equal(t, "system.id-val", systemIDAttrVal.Str())
+						systemAssetTagAttrVal, ok := dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "system.asset_tag-val", systemAssetTagAttrVal.Str())
+						systemBiosVersionAttrVal, ok := dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						assert.Equal(t, "system.bios_version-val", systemBiosVersionAttrVal.Str())
+						systemModelAttrVal, ok := dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						assert.Equal(t, "system.model-val", systemModelAttrVal.Str())
+						systemNameAttrVal, ok := dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						assert.Equal(t, "system.name-val", systemNameAttrVal.Str())
+						systemManufacturerAttrVal, ok := dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "system.manufacturer-val", systemManufacturerAttrVal.Str())
+						systemSerialNumberAttrVal, ok := dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "system.serial_number-val", systemSerialNumberAttrVal.Str())
+						systemSkuAttrVal, ok := dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "system.sku-val", systemSkuAttrVal.Str())
+						systemSystemTypeAttrVal, ok := dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+						assert.Equal(t, "system.system_type-val", systemSystemTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.status.state"], "Found a duplicate in the metrics slice: system.status.state")
+						validatedMetrics["system.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("system.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.asset_tag")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.bios_version")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.model")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.manufacturer")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.serial_number")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.sku")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("system.system_type")
+						assert.False(t, ok)
+					}
 				case "temperature.reading":
-					assert.False(t, validatedMetrics["temperature.reading"], "Found a duplicate in the metrics slice: temperature.reading")
-					validatedMetrics["temperature.reading"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the reading of a chassis temperature.", mi.Description())
-					assert.Equal(t, "°C", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					temperatureNameAttrVal, ok := dp.Attributes().Get("temperature.name")
-					assert.True(t, ok)
-					assert.Equal(t, "temperature.name-val", temperatureNameAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["temperature.reading"], "Found a duplicate in the metrics slice: temperature.reading")
+						validatedMetrics["temperature.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis temperature.", mi.Description())
+						assert.Equal(t, "°C", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						temperatureNameAttrVal, ok := dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+						assert.Equal(t, "temperature.name-val", temperatureNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["temperature.reading"], "Found a duplicate in the metrics slice: temperature.reading")
+						validatedMetrics["temperature.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis temperature.", mi.Description())
+						assert.Equal(t, "°C", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["temperature.reading"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("temperature.name")
+						assert.False(t, ok)
+					}
 				case "temperature.status.health":
-					assert.False(t, validatedMetrics["temperature.status.health"], "Found a duplicate in the metrics slice: temperature.status.health")
-					validatedMetrics["temperature.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
-					assert.Equal(t, "{statushealth}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					temperatureNameAttrVal, ok := dp.Attributes().Get("temperature.name")
-					assert.True(t, ok)
-					assert.Equal(t, "temperature.name-val", temperatureNameAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["temperature.status.health"], "Found a duplicate in the metrics slice: temperature.status.health")
+						validatedMetrics["temperature.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						temperatureNameAttrVal, ok := dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+						assert.Equal(t, "temperature.name-val", temperatureNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["temperature.status.health"], "Found a duplicate in the metrics slice: temperature.status.health")
+						validatedMetrics["temperature.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 warning).", mi.Description())
+						assert.Equal(t, "{statushealth}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["temperature.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("temperature.name")
+						assert.False(t, ok)
+					}
 				case "temperature.status.state":
-					assert.False(t, validatedMetrics["temperature.status.state"], "Found a duplicate in the metrics slice: temperature.status.state")
-					validatedMetrics["temperature.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
-					assert.Equal(t, "{statusstate}", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
-					temperatureNameAttrVal, ok := dp.Attributes().Get("temperature.name")
-					assert.True(t, ok)
-					assert.Equal(t, "temperature.name-val", temperatureNameAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["temperature.status.state"], "Found a duplicate in the metrics slice: temperature.status.state")
+						validatedMetrics["temperature.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						chassisIDAttrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", chassisIDAttrVal.Str())
+						temperatureNameAttrVal, ok := dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+						assert.Equal(t, "temperature.name-val", temperatureNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["temperature.status.state"], "Found a duplicate in the metrics slice: temperature.status.state")
+						validatedMetrics["temperature.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).", mi.Description())
+						assert.Equal(t, "{statusstate}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["temperature.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("temperature.name")
+						assert.False(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/redfishreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/redfishreceiver/internal/metadata/testdata/config.yaml
@@ -3,28 +3,83 @@ all_set:
   metrics:
     chassis.powerstate:
       enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.health:
       enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.state:
       enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     fan.reading:
       enabled: true
+      attributes: ["chassis.id","fan.name","fan.reading_units"]
     fan.status.health:
       enabled: true
+      attributes: ["chassis.id","fan.name"]
     fan.status.state:
       enabled: true
+      attributes: ["chassis.id","fan.name"]
     system.powerstate:
       enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.health:
       enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.state:
       enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     temperature.reading:
       enabled: true
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.health:
       enabled: true
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.state:
       enabled: true
+      attributes: ["chassis.id","temperature.name"]
+  resource_attributes:
+    host.name:
+      enabled: true
+    url.full:
+      enabled: true
+reaggregate_set:
+  metrics:
+    chassis.powerstate:
+      enabled: true
+      attributes: []
+    chassis.status.health:
+      enabled: true
+      attributes: []
+    chassis.status.state:
+      enabled: true
+      attributes: []
+    fan.reading:
+      enabled: true
+      attributes: []
+    fan.status.health:
+      enabled: true
+      attributes: []
+    fan.status.state:
+      enabled: true
+      attributes: []
+    system.powerstate:
+      enabled: true
+      attributes: []
+    system.status.health:
+      enabled: true
+      attributes: []
+    system.status.state:
+      enabled: true
+      attributes: []
+    temperature.reading:
+      enabled: true
+      attributes: []
+    temperature.status.health:
+      enabled: true
+      attributes: []
+    temperature.status.state:
+      enabled: true
+      attributes: []
   resource_attributes:
     host.name:
       enabled: true
@@ -34,28 +89,40 @@ none_set:
   metrics:
     chassis.powerstate:
       enabled: false
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.health:
       enabled: false
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.state:
       enabled: false
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     fan.reading:
       enabled: false
+      attributes: ["chassis.id","fan.name","fan.reading_units"]
     fan.status.health:
       enabled: false
+      attributes: ["chassis.id","fan.name"]
     fan.status.state:
       enabled: false
+      attributes: ["chassis.id","fan.name"]
     system.powerstate:
       enabled: false
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.health:
       enabled: false
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.state:
       enabled: false
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     temperature.reading:
       enabled: false
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.health:
       enabled: false
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.state:
       enabled: false
+      attributes: ["chassis.id","temperature.name"]
   resource_attributes:
     host.name:
       enabled: false

--- a/receiver/redfishreceiver/metadata.yaml
+++ b/receiver/redfishreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: Redfish Receiver
 type: redfish
+reaggregation_enabled: true
 
 description: |
   This receiver fetches metrics for a server running a [Redfish](https://en.wikipedia.org/wiki/Redfish_(specification))
@@ -25,63 +26,83 @@ resource_attributes:
 attributes:
   chassis.asset_tag:
     description: Chassis asset tag.
+    requirement_level: recommended
     type: string
   chassis.chassis_type:
     description: Chassis type.
+    requirement_level: recommended
     type: string
   chassis.id:
     description: Chassis id.
+    requirement_level: recommended
     type: string
   chassis.manufacturer:
     description: Chassis manufacturer.
+    requirement_level: recommended
     type: string
   chassis.model:
     description: Chassis model.
+    requirement_level: recommended
     type: string
   chassis.name:
     description: Chassis name.
+    requirement_level: recommended
     type: string
   chassis.serial_number:
     description: Chassis serial number.
+    requirement_level: recommended
     type: string
   chassis.sku:
     description: Chassis sku.
+    requirement_level: recommended
     type: string
   fan.name:
     description: Fan name.
+    requirement_level: recommended
     type: string
   fan.reading_units:
     description: Fan reading units.
+    requirement_level: recommended
     type: string
   system.asset_tag:
     description: System asset tag.
+    requirement_level: recommended
     type: string
   system.bios_version:
     description: System bios version.
+    requirement_level: recommended
     type: string
   system.id:
     description: System id.
+    requirement_level: recommended
     type: string
   system.manufacturer:
     description: System manufacturer.
+    requirement_level: recommended
     type: string
   system.model:
     description: System model.
+    requirement_level: recommended
     type: string
   system.name:
     description: System name.
+    requirement_level: recommended
     type: string
   system.serial_number:
     description: System serial number.
+    requirement_level: recommended
     type: string
   system.sku:
     description: System sku.
+    requirement_level: recommended
     type: string
   system.system_type:
     description: System type.
+    requirement_level: recommended
     type: string
   temperature.name:
     description: Temperature name.
+    requirement_level: recommended
     type: string
 
 metrics:


### PR DESCRIPTION
Fixes #46375, part of #45396.

Adds `reaggregation_enabled: true` to `metadata.yaml` and sets `requirement_level: recommended` on all 20 metric attributes. This enables consumers to re-aggregate Redfish metrics with a subset of attribute labels without losing data.

No existing configuration files are broken by this change.

Generated files updated via `go generate ./...`.