### PR TITLE
[pkg/ottl] Fix `Substring`  bounds validation

### DIFF
--- a/.chloggen/validate_substring_bounds.yaml
+++ b/.chloggen/validate_substring_bounds.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added validation for substring function to ensure start and length parameters do not exceed the target string length."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47764]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -51,8 +51,8 @@ func substring[K any](target ottl.StringGetter[K], startGetter, lengthGetter ott
 		if err != nil {
 			return nil, err
 		}
-		if (start + length) > int64(len(val)) {
-			return nil, fmt.Errorf("invalid range for substring function, %d cannot be greater than the length of target string(%d)", start+length, len(val))
+		if start > int64(len(val)) || length > int64(len(val))-start {
+			return nil, fmt.Errorf("invalid range for substring function, start(%d)+length(%d) cannot be greater than the length of target string(%d)", start, length, len(val))
 		}
 		return val[start : start+length], nil
 	}

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -5,6 +5,7 @@ package ottlfuncs
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,6 +165,42 @@ func Test_substring_error(t *testing.T) {
 			length: &ottl.StandardIntGetter[any]{
 				Getter: func(context.Context, any) (any, error) {
 					return int64(20), nil
+				},
+			},
+		},
+		{
+			name: "substring with start+length overflowing int64",
+			target: &ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return "123456789", nil
+				},
+			},
+			start: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(math.MaxInt64 - 2), nil
+				},
+			},
+			length: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(10), nil
+				},
+			},
+		},
+		{
+			name: "substring with length overflowing int64 while start is in range",
+			target: &ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return "123456789", nil
+				},
+			},
+			start: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(5), nil
+				},
+			},
+			length: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(math.MaxInt64), nil
 				},
 			},
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The previous Substring function could fail during validation if there was an integer overflow, making it pass current validation but access to an invalid slice position. This small fix covers that case and adds a couple of unit tests.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added proper unit tests.
