### PR TITLE
fix[receiver/windows_event_log]: Support the deprecated name windowseventlog

### DIFF
--- a/.chloggen/receiver_windowseventlog_support_deprecated_type.yaml
+++ b/.chloggen/receiver_windowseventlog_support_deprecated_type.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/windowseventlog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support the deprecated name windowseventlog for the windows_event_log receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47773]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is a fix for a bug in the recent receiver rename in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47359
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/receiver_windowseventlog_support_deprecated_type.yaml
+++ b/.chloggen/receiver_windowseventlog_support_deprecated_type.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/windowseventlog
+component: receiver/windows_event_log
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support the deprecated name windowseventlog for the windows_event_log receiver.

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
@@ -57,7 +58,7 @@ func createLogsReceiver(
 	// Wrap the consumer with SID enrichment
 	enrichedConsumer := newSIDEnrichingConsumer(nextConsumer, cache, set.Logger)
 
-	stanzaFactory := adapter.NewFactory(receiverType{}, metadata.LogsStability)
+	stanzaFactory := adapter.NewFactory(receiverType{}, metadata.LogsStability, xreceiver.WithDeprecatedTypeAlias(metadata.DeprecatedType))
 
 	if metadata.DomainControllersAutodiscoveryFeatureGate.IsEnabled() && receiverCfg.DiscoverDomainControllers {
 		remoteConfigs, err := getDomainControllersRemoteConfig(set.Logger, receiverCfg.InputConfig.Remote.Username, receiverCfg.InputConfig.Remote.Password)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47359, the deprecated windowseventlog type was appropriately added to the receiver factory, but not to the underlying Stanza factory. This results in the collector failing to start when used with a config that uses this deprecated type.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47773

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Confirmed the receiver successfully runs with a configuration using windowseventlog instead of windows_event_log.
