### PR TITLE
[processor/lookup] Add traces and metrics support

### DIFF
--- a/.chloggen/lookup-processor-traces-metrics.yaml
+++ b/.chloggen/lookup-processor-traces-metrics.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/lookup
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add traces and metrics support to the lookup processor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47777]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Traces use ottlspan context (span-level lookups) and metrics use ottldatapoint context
+  (datapoint-level lookups across all metric types).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/lookupprocessor/README.md
+++ b/processor/lookupprocessor/README.md
@@ -5,12 +5,10 @@ The lookup processor enriches telemetry signals by performing external lookups t
 evaluates an [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md) value
 expression to extract a lookup key, queries a lookup source, and writes the results as new attributes.
 
-Currently supports logs, with metrics and traces support planned.
-
 
 | Status        |           |
 | ------------- |-----------|
-| Stability     | [development]: logs   |
+| Stability     | [development]: logs, traces, metrics   |
 | Distributions | [] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aprocessor%2Flookup%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aprocessor%2Flookup) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aprocessor%2Flookup%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aprocessor%2Flookup) |
 | Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=processor_lookup)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=processor_lookup&displayType=list) |
@@ -51,11 +49,24 @@ Each entry in `lookups` defines a lookup rule:
 | `context` | Default context for destination attributes: `record`, `resource` | `record` |
 | `attributes` | List of attribute mappings for writing results (required, at least one) | - |
 
-The `key` field supports any [OTTL value expression], including paths across contexts and converters:
+The `key` field supports any [OTTL value expression], including paths across contexts and converters. The path prefix depends on the signal type:
 
-- `log.attributes["user.id"]` - record attribute
-- `resource.attributes["service.name"]` - resource attribute
-- `Trim(log.attributes["raw.id"])` - apply a converter
+| Signal  | OTTL context | Record-level path prefix |
+|---------|-------------|--------------------------|
+| Logs    | `ottllog`       | `log.attributes["..."]`       |
+| Traces  | `ottlspan`      | `span.attributes["..."]`      |
+| Metrics | `ottldatapoint` | `datapoint.attributes["..."]` |
+
+Resource attributes use `resource.attributes["..."]` for all signals. A context prefix is always required; bare `attributes["..."]` paths are rejected at configuration time.
+
+Examples:
+
+- `attributes["user.id"]` - record attribute (works for all signals)
+- `log.attributes["user.id"]` - log record attribute (logs only)
+- `span.attributes["user.id"]` - span attribute (traces only)
+- `datapoint.attributes["host.id"]` - datapoint attribute (metrics only)
+- `resource.attributes["service.name"]` - resource attribute (all signals)
+- `Trim(attributes["raw.id"])` - apply a converter
 
 [OTTL value expression]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md#value-expressions
 
@@ -130,8 +141,8 @@ processors:
 
 ### Context
 
-- **record**: Read from and write to record-level attributes (log records, spans, metric data points) (default)
-- **resource**: Read from and write to resource attributes
+- **record**: Write to the signal's record-level attributes (default). This maps to log record attributes for logs, span attributes for traces, and datapoint attributes for metrics. For metrics, lookups are evaluated for each datapoint across all metric types (Gauge, Sum, Histogram, ExponentialHistogram, Summary).
+- **resource**: Write to resource attributes.
 
 The `context` field on a key sets the default for all its destination attributes. Each attribute mapping can override this with its own `context` field.
 

--- a/processor/lookupprocessor/factory.go
+++ b/processor/lookupprocessor/factory.go
@@ -10,11 +10,16 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/source/dns"
@@ -91,6 +96,8 @@ func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 		metadata.Type,
 		f.createDefaultConfig,
 		processor.WithLogs(f.createLogsProcessor, metadata.LogsStability),
+		processor.WithTraces(f.createTracesProcessor, metadata.TracesStability),
+		processor.WithMetrics(f.createMetricsProcessor, metadata.MetricsStability),
 	)
 }
 
@@ -129,14 +136,102 @@ func (f *lookupProcessorFactory) createLogsProcessor(
 		return nil, err
 	}
 
-	proc := newLookupProcessor(source, lookups, set.Logger)
+	proc := newLookupProcessor[*ottllog.TransformContext](source, lookups, set.Logger)
 
 	return processorhelper.NewLogs(
 		ctx,
 		set,
 		cfg,
 		next,
-		proc.processLogs,
+		func(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
+			return processLogs(ctx, proc, ld)
+		},
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(proc.Start),
+		processorhelper.WithShutdown(proc.Shutdown),
+	)
+}
+
+func (f *lookupProcessorFactory) createTracesProcessor(
+	ctx context.Context,
+	set processor.Settings,
+	cfg component.Config,
+	next consumer.Traces,
+) (processor.Traces, error) {
+	processorCfg := cfg.(*Config)
+
+	source, err := f.createSource(ctx, set, processorCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, err := ottlspan.NewParser(
+		ottlfuncs.StandardConverters[*ottlspan.TransformContext](),
+		set.TelemetrySettings,
+		ottlspan.EnablePathContextNames(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTTL parser: %w", err)
+	}
+
+	lookups, err := parseLookups(parser, processorCfg.Lookups)
+	if err != nil {
+		return nil, err
+	}
+
+	proc := newLookupProcessor[*ottlspan.TransformContext](source, lookups, set.Logger)
+
+	return processorhelper.NewTraces(
+		ctx,
+		set,
+		cfg,
+		next,
+		func(ctx context.Context, td ptrace.Traces) (ptrace.Traces, error) {
+			return processTraces(ctx, proc, td)
+		},
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(proc.Start),
+		processorhelper.WithShutdown(proc.Shutdown),
+	)
+}
+
+func (f *lookupProcessorFactory) createMetricsProcessor(
+	ctx context.Context,
+	set processor.Settings,
+	cfg component.Config,
+	next consumer.Metrics,
+) (processor.Metrics, error) {
+	processorCfg := cfg.(*Config)
+
+	source, err := f.createSource(ctx, set, processorCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, err := ottldatapoint.NewParser(
+		ottlfuncs.StandardConverters[*ottldatapoint.TransformContext](),
+		set.TelemetrySettings,
+		ottldatapoint.EnablePathContextNames(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTTL parser: %w", err)
+	}
+
+	lookups, err := parseLookups(parser, processorCfg.Lookups)
+	if err != nil {
+		return nil, err
+	}
+
+	proc := newLookupProcessor[*ottldatapoint.TransformContext](source, lookups, set.Logger)
+
+	return processorhelper.NewMetrics(
+		ctx,
+		set,
+		cfg,
+		next,
+		func(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
+			return processMetrics(ctx, proc, md)
+		},
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithStart(proc.Start),
 		processorhelper.WithShutdown(proc.Shutdown),
@@ -144,20 +239,20 @@ func (f *lookupProcessorFactory) createLogsProcessor(
 }
 
 // parsedLookup holds a lookup config with its pre-parsed OTTL key expression.
-type parsedLookup struct {
-	keyExpr    *ottl.ValueExpression[*ottllog.TransformContext]
+type parsedLookup[T any] struct {
+	keyExpr    *ottl.ValueExpression[T]
 	context    ContextID
 	attributes []AttributeMapping
 }
 
-func parseLookups(parser ottl.Parser[*ottllog.TransformContext], configs []LookupConfig) ([]parsedLookup, error) {
-	lookups := make([]parsedLookup, len(configs))
+func parseLookups[T any](parser ottl.Parser[T], configs []LookupConfig) ([]parsedLookup[T], error) {
+	lookups := make([]parsedLookup[T], len(configs))
 	for i, cfg := range configs {
 		keyExpr, err := parser.ParseValueExpression(cfg.Key)
 		if err != nil {
 			return nil, fmt.Errorf("lookups[%d]: failed to parse key expression %q: %w", i, cfg.Key, err)
 		}
-		lookups[i] = parsedLookup{
+		lookups[i] = parsedLookup[T]{
 			keyExpr:    keyExpr,
 			context:    cfg.GetContext(),
 			attributes: cfg.Attributes,

--- a/processor/lookupprocessor/factory.go
+++ b/processor/lookupprocessor/factory.go
@@ -10,9 +10,6 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 
@@ -136,16 +133,14 @@ func (f *lookupProcessorFactory) createLogsProcessor(
 		return nil, err
 	}
 
-	proc := newLookupProcessor[*ottllog.TransformContext](source, lookups, set.Logger)
+	proc := &logsLookupProcessor{newLookupProcessor[*ottllog.TransformContext](source, lookups, set.Logger)}
 
 	return processorhelper.NewLogs(
 		ctx,
 		set,
 		cfg,
 		next,
-		func(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
-			return processLogs(ctx, proc, ld)
-		},
+		proc.processLogs,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithStart(proc.Start),
 		processorhelper.WithShutdown(proc.Shutdown),
@@ -179,16 +174,14 @@ func (f *lookupProcessorFactory) createTracesProcessor(
 		return nil, err
 	}
 
-	proc := newLookupProcessor[*ottlspan.TransformContext](source, lookups, set.Logger)
+	proc := &tracesLookupProcessor{newLookupProcessor[*ottlspan.TransformContext](source, lookups, set.Logger)}
 
 	return processorhelper.NewTraces(
 		ctx,
 		set,
 		cfg,
 		next,
-		func(ctx context.Context, td ptrace.Traces) (ptrace.Traces, error) {
-			return processTraces(ctx, proc, td)
-		},
+		proc.processTraces,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithStart(proc.Start),
 		processorhelper.WithShutdown(proc.Shutdown),
@@ -222,16 +215,14 @@ func (f *lookupProcessorFactory) createMetricsProcessor(
 		return nil, err
 	}
 
-	proc := newLookupProcessor[*ottldatapoint.TransformContext](source, lookups, set.Logger)
+	proc := &metricsLookupProcessor{newLookupProcessor[*ottldatapoint.TransformContext](source, lookups, set.Logger)}
 
 	return processorhelper.NewMetrics(
 		ctx,
 		set,
 		cfg,
 		next,
-		func(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
-			return processMetrics(ctx, proc, md)
-		},
+		proc.processMetrics,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithStart(proc.Start),
 		processorhelper.WithShutdown(proc.Shutdown),

--- a/processor/lookupprocessor/factory_test.go
+++ b/processor/lookupprocessor/factory_test.go
@@ -11,18 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
 )
 
-func testLookupConfig() LookupConfig {
+func testLookupConfig(key string) LookupConfig {
 	return LookupConfig{
-		Key: `log.attributes["test.key"]`,
-		Attributes: []AttributeMapping{
-			{Destination: "test.result"},
-		},
+		Key:        key,
+		Attributes: []AttributeMapping{{Destination: "test.result"}},
 	}
 }
 
@@ -59,7 +58,7 @@ func TestNewFactoryWithOptions(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.Source.Type = "mock"
-	cfg.Lookups = []LookupConfig{testLookupConfig()}
+	cfg.Lookups = []LookupConfig{testLookupConfig(`log.attributes["test.key"]`)}
 
 	settings := processortest.NewNopSettings(metadata.Type)
 	sink := consumertest.NewNop()
@@ -77,7 +76,7 @@ func TestFactoryCreatesLogsProcessor(t *testing.T) {
 	factory := NewFactory()
 
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Lookups = []LookupConfig{testLookupConfig()}
+	cfg.Lookups = []LookupConfig{testLookupConfig(`log.attributes["test.key"]`)}
 
 	settings := processortest.NewNopSettings(metadata.Type)
 
@@ -90,26 +89,38 @@ func TestFactoryCreatesLogsProcessor(t *testing.T) {
 	require.NoError(t, proc.Shutdown(t.Context()))
 }
 
-func TestFactoryRejectsTracesProcessor(t *testing.T) {
+func TestFactoryCreatesTracesProcessor(t *testing.T) {
 	factory := NewFactory()
 
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Lookups = []LookupConfig{testLookupConfig()}
+	cfg.Lookups = []LookupConfig{testLookupConfig(`span.attributes["test.key"]`)}
+
 	settings := processortest.NewNopSettings(metadata.Type)
 
-	_, err := factory.CreateTraces(t.Context(), settings, cfg, consumertest.NewNop())
-	require.Error(t, err)
+	proc, err := factory.CreateTraces(t.Context(), settings, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, proc.Start(t.Context(), host))
+	require.NoError(t, proc.Shutdown(t.Context()))
 }
 
-func TestFactoryRejectsMetricsProcessor(t *testing.T) {
+func TestFactoryCreatesMetricsProcessor(t *testing.T) {
 	factory := NewFactory()
 
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Lookups = []LookupConfig{testLookupConfig()}
+	cfg.Lookups = []LookupConfig{testLookupConfig(`datapoint.attributes["test.key"]`)}
+
 	settings := processortest.NewNopSettings(metadata.Type)
 
-	_, err := factory.CreateMetrics(t.Context(), settings, cfg, consumertest.NewNop())
-	require.Error(t, err)
+	proc, err := factory.CreateMetrics(t.Context(), settings, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, proc.Start(t.Context(), host))
+	require.NoError(t, proc.Shutdown(t.Context()))
 }
 
 func TestFactoryUnknownSourceType(t *testing.T) {
@@ -117,7 +128,7 @@ func TestFactoryUnknownSourceType(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.Source.Type = "unknown"
-	cfg.Lookups = []LookupConfig{testLookupConfig()}
+	cfg.Lookups = []LookupConfig{testLookupConfig(`log.attributes["test.key"]`)}
 
 	settings := processortest.NewNopSettings(metadata.Type)
 
@@ -146,7 +157,7 @@ func TestWithSourcesReplacesDefaults(t *testing.T) {
 	factory := NewFactoryWithOptions(WithSources(customFactory))
 
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Lookups = []LookupConfig{testLookupConfig()}
+	cfg.Lookups = []LookupConfig{testLookupConfig(`log.attributes["test.key"]`)}
 
 	// noop should not be available anymore
 	cfg.Source.Type = "noop"
@@ -279,6 +290,73 @@ func TestContextIDUnmarshalText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeyExpressionContextNames(t *testing.T) {
+	// Each signal's parser must accept its own context-prefixed path forms and
+	// reject bare paths (enforced by EnablePathContextNames).
+	tests := []struct {
+		name     string
+		validKey string
+		create   func(factory processor.Factory, cfg *Config) error
+	}{
+		{
+			name:     "logs accepts log.attributes prefix",
+			validKey: `log.attributes["k"]`,
+			create: func(factory processor.Factory, cfg *Config) error {
+				_, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+				return err
+			},
+		},
+		{
+			name:     "traces accepts span.attributes prefix",
+			validKey: `span.attributes["k"]`,
+			create: func(factory processor.Factory, cfg *Config) error {
+				_, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+				return err
+			},
+		},
+		{
+			name:     "metrics accepts datapoint.attributes prefix",
+			validKey: `datapoint.attributes["k"]`,
+			create: func(factory processor.Factory, cfg *Config) error {
+				_, err := factory.CreateMetrics(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+				return err
+			},
+		},
+		{
+			name:     "resource.attributes accepted by all — test with logs",
+			validKey: `resource.attributes["k"]`,
+			create: func(factory processor.Factory, cfg *Config) error {
+				_, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig().(*Config)
+			cfg.Lookups = []LookupConfig{{
+				Key:        tt.validKey,
+				Attributes: []AttributeMapping{{Destination: "test.result"}},
+			}}
+			require.NoError(t, tt.create(factory, cfg))
+		})
+	}
+
+	t.Run("bare path rejected", func(t *testing.T) {
+		factory := NewFactory()
+		cfg := factory.CreateDefaultConfig().(*Config)
+		cfg.Lookups = []LookupConfig{{
+			Key:        `attributes["k"]`,
+			Attributes: []AttributeMapping{{Destination: "test.result"}},
+		}}
+		_, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing context name")
+	})
 }
 
 func TestInvalidKeyExpression(t *testing.T) {

--- a/processor/lookupprocessor/generated_component_test.go
+++ b/processor/lookupprocessor/generated_component_test.go
@@ -44,6 +44,20 @@ func TestComponentLifecycle(t *testing.T) {
 				return factory.CreateLogs(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
+
+		{
+			name: "metrics",
+			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateMetrics(ctx, set, cfg, consumertest.NewNop())
+			},
+		},
+
+		{
+			name: "traces",
+			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+				return factory.CreateTraces(ctx, set, cfg, consumertest.NewNop())
+			},
+		},
 	}
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/processor/lookupprocessor/internal/metadata/generated_status.go
+++ b/processor/lookupprocessor/internal/metadata/generated_status.go
@@ -14,5 +14,7 @@ var (
 )
 
 const (
-	LogsStability = component.StabilityLevelDevelopment
+	LogsStability    = component.StabilityLevelDevelopment
+	TracesStability  = component.StabilityLevelDevelopment
+	MetricsStability = component.StabilityLevelDevelopment
 )

--- a/processor/lookupprocessor/metadata.yaml
+++ b/processor/lookupprocessor/metadata.yaml
@@ -6,12 +6,10 @@ description: |
   evaluates an [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md) value
   expression to extract a lookup key, queries a lookup source, and writes the results as new attributes.
 
-  Currently supports logs, with metrics and traces support planned.
-
 status:
   class: processor
   stability:
-    development: [logs]
+    development: [logs, traces, metrics]
   distributions: []
   codeowners:
     active: [jsvd, dehaansa, VihasMakwana]
@@ -19,7 +17,7 @@ status:
 tests:
   config:
     lookups:
-      - key: log.attributes["test.key"]
+      - key: resource.attributes["test.key"]
         attributes:
           - destination: test.result
             default: "not-found"

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -10,98 +10,87 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
 )
 
-type lookupProcessor struct {
+// lookupProcessor is generic over the OTTL transform context type.
+type lookupProcessor[T any] struct {
 	source  lookupsource.Source
-	lookups []parsedLookup
+	lookups []parsedLookup[T]
 	logger  *zap.Logger
 }
 
-func newLookupProcessor(source lookupsource.Source, lookups []parsedLookup, logger *zap.Logger) *lookupProcessor {
-	return &lookupProcessor{
+func newLookupProcessor[T any](source lookupsource.Source, lookups []parsedLookup[T], logger *zap.Logger) *lookupProcessor[T] {
+	return &lookupProcessor[T]{
 		source:  source,
 		lookups: lookups,
 		logger:  logger,
 	}
 }
 
-func (p *lookupProcessor) Start(ctx context.Context, host component.Host) error {
+func (p *lookupProcessor[T]) Start(ctx context.Context, host component.Host) error {
 	return p.source.Start(ctx, host)
 }
 
-func (p *lookupProcessor) Shutdown(ctx context.Context) error {
+func (p *lookupProcessor[T]) Shutdown(ctx context.Context) error {
 	return p.source.Shutdown(ctx)
 }
 
-func (p *lookupProcessor) processLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
-	resourceLogs := ld.ResourceLogs()
-	for i := 0; i < resourceLogs.Len(); i++ {
-		rl := resourceLogs.At(i)
-		resourceAttrs := rl.Resource().Attributes()
-
-		scopeLogs := rl.ScopeLogs()
-		for j := 0; j < scopeLogs.Len(); j++ {
-			sl := scopeLogs.At(j)
-			logRecords := sl.LogRecords()
-			for k := 0; k < logRecords.Len(); k++ {
-				lr := logRecords.At(k)
-				logAttrs := lr.Attributes()
-
-				tCtx := ottllog.NewTransformContextPtr(rl, sl, lr)
-
-				for li := range p.lookups {
-					p.processLookup(ctx, tCtx, &p.lookups[li], logAttrs, resourceAttrs)
-				}
-
-				tCtx.Close()
-			}
+func (p *lookupProcessor[T]) evalAndProcess(ctx context.Context, tCtx T, recordAttrs, resourceAttrs pcommon.Map) {
+	for li := range p.lookups {
+		lookup := &p.lookups[li]
+		rawKey, err := lookup.keyExpr.Eval(ctx, tCtx)
+		if err != nil {
+			p.logger.Debug("failed to evaluate key expression", zap.Error(err))
+			continue
 		}
+		processLookupResult(ctx, p.source, p.logger, rawKey, lookup.context, lookup.attributes, recordAttrs, resourceAttrs)
 	}
-
-	return ld, nil
 }
 
-func (p *lookupProcessor) processLookup(
+// processLookupResult performs the source lookup and writes results to record or resource attributes.
+// If the key is nil or empty, or if the lookup fails, the function returns without writing.
+func processLookupResult(
 	ctx context.Context,
-	tCtx *ottllog.TransformContext,
-	lookup *parsedLookup,
-	logAttrs pcommon.Map,
+	source lookupsource.Source,
+	logger *zap.Logger,
+	key any,
+	lookupCtx ContextID,
+	attributes []AttributeMapping,
+	recordAttrs pcommon.Map,
 	resourceAttrs pcommon.Map,
 ) {
-	rawKey, err := lookup.keyExpr.Eval(ctx, tCtx)
+	if key == nil {
+		return
+	}
+
+	keyStr := anyToString(key)
+	if keyStr == "" {
+		return
+	}
+
+	result, found, err := source.Lookup(ctx, keyStr)
 	if err != nil {
-		p.logger.Debug("failed to evaluate key expression", zap.Error(err))
-		return
-	}
-	if rawKey == nil {
+		logger.Debug("lookup failed", zap.String("key", keyStr), zap.Error(err))
 		return
 	}
 
-	key := anyToString(rawKey)
-	if key == "" {
-		return
-	}
-
-	result, found, err := p.source.Lookup(ctx, key)
-	if err != nil {
-		p.logger.Debug("lookup failed", zap.String("key", key), zap.Error(err))
-		return
-	}
-
-	for ai := range lookup.attributes {
-		attr := &lookup.attributes[ai]
-		attrCtx := attr.GetContext(lookup.context)
+	for ai := range attributes {
+		attr := &attributes[ai]
+		attrCtx := attr.GetContext(lookupCtx)
 
 		var attrs pcommon.Map
 		if attrCtx == ContextResource {
 			attrs = resourceAttrs
 		} else {
-			attrs = logAttrs
+			attrs = recordAttrs
 		}
 
 		value, ok := extractValue(result, found, attr)
@@ -112,6 +101,94 @@ func (p *lookupProcessor) processLookup(
 		if err := attrs.PutEmpty(attr.Destination).FromRaw(value); err != nil {
 			attrs.PutStr(attr.Destination, fmt.Sprintf("%v", value))
 		}
+	}
+}
+
+func processLogs(ctx context.Context, p *lookupProcessor[*ottllog.TransformContext], ld plog.Logs) (plog.Logs, error) {
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		resourceAttrs := rl.Resource().Attributes()
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				lr := sl.LogRecords().At(k)
+				tCtx := ottllog.NewTransformContextPtr(rl, sl, lr)
+				p.evalAndProcess(ctx, tCtx, lr.Attributes(), resourceAttrs)
+				tCtx.Close()
+			}
+		}
+	}
+	return ld, nil
+}
+
+func processTraces(ctx context.Context, p *lookupProcessor[*ottlspan.TransformContext], td ptrace.Traces) (ptrace.Traces, error) {
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+		resourceAttrs := rs.Resource().Attributes()
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+				p.evalAndProcess(ctx, tCtx, span.Attributes(), resourceAttrs)
+				tCtx.Close()
+			}
+		}
+	}
+	return td, nil
+}
+
+func processMetrics(ctx context.Context, p *lookupProcessor[*ottldatapoint.TransformContext], md pmetric.Metrics) (pmetric.Metrics, error) {
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		resourceAttrs := rm.Resource().Attributes()
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					processDataPoints(ctx, p, m.Gauge().DataPoints(), rm, sm, m, resourceAttrs)
+				case pmetric.MetricTypeSum:
+					processDataPoints(ctx, p, m.Sum().DataPoints(), rm, sm, m, resourceAttrs)
+				case pmetric.MetricTypeHistogram:
+					processDataPoints(ctx, p, m.Histogram().DataPoints(), rm, sm, m, resourceAttrs)
+				case pmetric.MetricTypeExponentialHistogram:
+					processDataPoints(ctx, p, m.ExponentialHistogram().DataPoints(), rm, sm, m, resourceAttrs)
+				case pmetric.MetricTypeSummary:
+					processDataPoints(ctx, p, m.Summary().DataPoints(), rm, sm, m, resourceAttrs)
+				}
+			}
+		}
+	}
+	return md, nil
+}
+
+// dataPointSlice is a generic interface for pmetric datapoint slices.
+type dataPointSlice[DP dataPointWithAttributes] interface {
+	Len() int
+	At(int) DP
+}
+
+// dataPointWithAttributes is satisfied by all pmetric datapoint types.
+type dataPointWithAttributes interface {
+	Attributes() pcommon.Map
+}
+
+func processDataPoints[DP dataPointWithAttributes](
+	ctx context.Context,
+	p *lookupProcessor[*ottldatapoint.TransformContext],
+	dps dataPointSlice[DP],
+	rm pmetric.ResourceMetrics,
+	sm pmetric.ScopeMetrics,
+	m pmetric.Metric,
+	resourceAttrs pcommon.Map,
+) {
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		p.evalAndProcess(ctx, tCtx, dp.Attributes(), resourceAttrs)
+		tCtx.Close()
 	}
 }
 

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -104,7 +104,11 @@ func processLookupResult(
 	}
 }
 
-func processLogs(ctx context.Context, p *lookupProcessor[*ottllog.TransformContext], ld plog.Logs) (plog.Logs, error) {
+type logsLookupProcessor struct {
+	*lookupProcessor[*ottllog.TransformContext]
+}
+
+func (p *logsLookupProcessor) processLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
 		resourceAttrs := rl.Resource().Attributes()
@@ -121,7 +125,11 @@ func processLogs(ctx context.Context, p *lookupProcessor[*ottllog.TransformConte
 	return ld, nil
 }
 
-func processTraces(ctx context.Context, p *lookupProcessor[*ottlspan.TransformContext], td ptrace.Traces) (ptrace.Traces, error) {
+type tracesLookupProcessor struct {
+	*lookupProcessor[*ottlspan.TransformContext]
+}
+
+func (p *tracesLookupProcessor) processTraces(ctx context.Context, td ptrace.Traces) (ptrace.Traces, error) {
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		rs := td.ResourceSpans().At(i)
 		resourceAttrs := rs.Resource().Attributes()
@@ -138,7 +146,11 @@ func processTraces(ctx context.Context, p *lookupProcessor[*ottlspan.TransformCo
 	return td, nil
 }
 
-func processMetrics(ctx context.Context, p *lookupProcessor[*ottldatapoint.TransformContext], md pmetric.Metrics) (pmetric.Metrics, error) {
+type metricsLookupProcessor struct {
+	*lookupProcessor[*ottldatapoint.TransformContext]
+}
+
+func (p *metricsLookupProcessor) processMetrics(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		rm := md.ResourceMetrics().At(i)
 		resourceAttrs := rm.Resource().Attributes()
@@ -148,15 +160,15 @@ func processMetrics(ctx context.Context, p *lookupProcessor[*ottldatapoint.Trans
 				m := sm.Metrics().At(k)
 				switch m.Type() {
 				case pmetric.MetricTypeGauge:
-					processDataPoints(ctx, p, m.Gauge().DataPoints(), rm, sm, m, resourceAttrs)
+					processDataPoints(ctx, p.lookupProcessor, m.Gauge().DataPoints(), rm, sm, m, resourceAttrs)
 				case pmetric.MetricTypeSum:
-					processDataPoints(ctx, p, m.Sum().DataPoints(), rm, sm, m, resourceAttrs)
+					processDataPoints(ctx, p.lookupProcessor, m.Sum().DataPoints(), rm, sm, m, resourceAttrs)
 				case pmetric.MetricTypeHistogram:
-					processDataPoints(ctx, p, m.Histogram().DataPoints(), rm, sm, m, resourceAttrs)
+					processDataPoints(ctx, p.lookupProcessor, m.Histogram().DataPoints(), rm, sm, m, resourceAttrs)
 				case pmetric.MetricTypeExponentialHistogram:
-					processDataPoints(ctx, p, m.ExponentialHistogram().DataPoints(), rm, sm, m, resourceAttrs)
+					processDataPoints(ctx, p.lookupProcessor, m.ExponentialHistogram().DataPoints(), rm, sm, m, resourceAttrs)
 				case pmetric.MetricTypeSummary:
-					processDataPoints(ctx, p, m.Summary().DataPoints(), rm, sm, m, resourceAttrs)
+					processDataPoints(ctx, p.lookupProcessor, m.Summary().DataPoints(), rm, sm, m, resourceAttrs)
 				}
 			}
 		}

--- a/processor/lookupprocessor/processor_test.go
+++ b/processor/lookupprocessor/processor_test.go
@@ -5,6 +5,7 @@ package lookupprocessor
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processortest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/metadata"
@@ -20,13 +23,10 @@ import (
 )
 
 func TestProcessorLookup(t *testing.T) {
-	// Create a mock source with test mappings
 	mappings := map[string]any{
-		"user001":      "Alice Johnson",
-		"user002":      "Bob Smith",
-		"user003":      "Charlie Brown",
-		"svc-frontend": "Frontend Web App",
-		"svc-backend":  "Backend API Service",
+		"key1":  "val1",
+		"key2":  "val2",
+		"rsrc1": "rsrcval1",
 	}
 
 	factory := NewFactoryWithOptions(WithSources(mockMapSourceFactory(mappings)))
@@ -34,20 +34,17 @@ func TestProcessorLookup(t *testing.T) {
 		Source: SourceConfig{Type: "mockmap"},
 		Lookups: []LookupConfig{
 			{
-				Key:     `log.attributes["user.id"]`,
+				Key:     `log.attributes["k"]`,
 				Context: ContextRecord,
 				Attributes: []AttributeMapping{
-					{
-						Destination: "user.name",
-						Default:     "Unknown User",
-					},
+					{Destination: "out", Default: "default"},
 				},
 			},
 			{
-				Key:     `resource.attributes["service.name"]`,
+				Key:     `resource.attributes["rk"]`,
 				Context: ContextResource,
 				Attributes: []AttributeMapping{
-					{Destination: "service.display_name"},
+					{Destination: "rout"},
 				},
 			},
 		},
@@ -65,21 +62,12 @@ func TestProcessorLookup(t *testing.T) {
 
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
-	rl.Resource().Attributes().PutStr("service.name", "svc-frontend")
+	rl.Resource().Attributes().PutStr("rk", "rsrc1")
 
 	sl := rl.ScopeLogs().AppendEmpty()
-
-	log1 := sl.LogRecords().AppendEmpty()
-	log1.Body().SetStr("User logged in")
-	log1.Attributes().PutStr("user.id", "user001")
-
-	log2 := sl.LogRecords().AppendEmpty()
-	log2.Body().SetStr("User performed action")
-	log2.Attributes().PutStr("user.id", "user999")
-
-	log3 := sl.LogRecords().AppendEmpty()
-	log3.Body().SetStr("User logged out")
-	log3.Attributes().PutStr("user.id", "user002")
+	sl.LogRecords().AppendEmpty().Attributes().PutStr("k", "key1")
+	sl.LogRecords().AppendEmpty().Attributes().PutStr("k", "missing")
+	sl.LogRecords().AppendEmpty().Attributes().PutStr("k", "key2")
 
 	err = proc.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
@@ -87,25 +75,300 @@ func TestProcessorLookup(t *testing.T) {
 	require.Len(t, sink.AllLogs(), 1)
 	processedLogs := sink.AllLogs()[0]
 
-	resource := processedLogs.ResourceLogs().At(0).Resource()
-	serviceName, ok := resource.Attributes().Get("service.display_name")
-	assert.True(t, ok, "service.display_name should be set")
-	assert.Equal(t, "Frontend Web App", serviceName.Str())
-
-	logRecords := processedLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
-	require.Equal(t, 3, logRecords.Len())
-
-	userName1, ok := logRecords.At(0).Attributes().Get("user.name")
+	rout, ok := processedLogs.ResourceLogs().At(0).Resource().Attributes().Get("rout")
 	assert.True(t, ok)
-	assert.Equal(t, "Alice Johnson", userName1.Str())
+	assert.Equal(t, "rsrcval1", rout.Str())
 
-	userName2, ok := logRecords.At(1).Attributes().Get("user.name")
-	assert.True(t, ok)
-	assert.Equal(t, "Unknown User", userName2.Str())
+	records := processedLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Equal(t, 3, records.Len())
 
-	userName3, ok := logRecords.At(2).Attributes().Get("user.name")
+	out1, ok := records.At(0).Attributes().Get("out")
 	assert.True(t, ok)
-	assert.Equal(t, "Bob Smith", userName3.Str())
+	assert.Equal(t, "val1", out1.Str())
+
+	out2, ok := records.At(1).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "default", out2.Str())
+
+	out3, ok := records.At(2).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val2", out3.Str())
+}
+
+func TestProcessorTracesLookup(t *testing.T) {
+	mappings := map[string]any{
+		"key1":  "val1",
+		"key2":  "val2",
+		"rsrc1": "rsrcval1",
+	}
+
+	factory := NewFactoryWithOptions(WithSources(mockMapSourceFactory(mappings)))
+	cfg := &Config{
+		Source: SourceConfig{Type: "mockmap"},
+		Lookups: []LookupConfig{
+			{
+				Key:     `span.attributes["k"]`,
+				Context: ContextRecord,
+				Attributes: []AttributeMapping{
+					{Destination: "out", Default: "default"},
+				},
+			},
+			{
+				Key:     `resource.attributes["rk"]`,
+				Context: ContextResource,
+				Attributes: []AttributeMapping{
+					{Destination: "rout"},
+				},
+			},
+		},
+	}
+
+	sink := &consumertest.TracesSink{}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateTraces(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, proc.Start(t.Context(), host))
+	defer func() { _ = proc.Shutdown(t.Context()) }()
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("rk", "rsrc1")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Spans().AppendEmpty().Attributes().PutStr("k", "key1")
+	ss.Spans().AppendEmpty().Attributes().PutStr("k", "missing")
+	ss.Spans().AppendEmpty().Attributes().PutStr("k", "key2")
+
+	err = proc.ConsumeTraces(t.Context(), traces)
+	require.NoError(t, err)
+
+	require.Len(t, sink.AllTraces(), 1)
+	processedTraces := sink.AllTraces()[0]
+
+	rout, ok := processedTraces.ResourceSpans().At(0).Resource().Attributes().Get("rout")
+	assert.True(t, ok)
+	assert.Equal(t, "rsrcval1", rout.Str())
+
+	spans := processedTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 3, spans.Len())
+
+	out1, ok := spans.At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val1", out1.Str())
+
+	out2, ok := spans.At(1).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "default", out2.Str())
+
+	out3, ok := spans.At(2).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val2", out3.Str())
+}
+
+func TestProcessorMetricsLookup(t *testing.T) {
+	mappings := map[string]any{
+		"key1":  "val1",
+		"key2":  "val2",
+		"rsrc1": "rsrcval1",
+	}
+
+	factory := NewFactoryWithOptions(WithSources(mockMapSourceFactory(mappings)))
+	cfg := &Config{
+		Source: SourceConfig{Type: "mockmap"},
+		Lookups: []LookupConfig{
+			{
+				Key:     `datapoint.attributes["k"]`,
+				Context: ContextRecord,
+				Attributes: []AttributeMapping{
+					{Destination: "out", Default: "default"},
+				},
+			},
+			{
+				Key:     `resource.attributes["rk"]`,
+				Context: ContextResource,
+				Attributes: []AttributeMapping{
+					{Destination: "rout"},
+				},
+			},
+		},
+	}
+
+	sink := &consumertest.MetricsSink{}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateMetrics(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, proc.Start(t.Context(), host))
+	defer func() { _ = proc.Shutdown(t.Context()) }()
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("rk", "rsrc1")
+	sm := rm.ScopeMetrics().AppendEmpty()
+
+	gaugeMetric := sm.Metrics().AppendEmpty()
+	gaugeMetric.SetName("gauge")
+	gaugeMetric.SetEmptyGauge().DataPoints().AppendEmpty().Attributes().PutStr("k", "key1")
+	gaugeMetric.Gauge().DataPoints().AppendEmpty().Attributes().PutStr("k", "missing")
+
+	sumMetric := sm.Metrics().AppendEmpty()
+	sumMetric.SetName("sum")
+	sumMetric.SetEmptySum().DataPoints().AppendEmpty().Attributes().PutStr("k", "key2")
+
+	histMetric := sm.Metrics().AppendEmpty()
+	histMetric.SetName("hist")
+	histMetric.SetEmptyHistogram().DataPoints().AppendEmpty().Attributes().PutStr("k", "key1")
+
+	expHistMetric := sm.Metrics().AppendEmpty()
+	expHistMetric.SetName("exphist")
+	expHistMetric.SetEmptyExponentialHistogram().DataPoints().AppendEmpty().Attributes().PutStr("k", "key2")
+
+	summaryMetric := sm.Metrics().AppendEmpty()
+	summaryMetric.SetName("summary")
+	summaryMetric.SetEmptySummary().DataPoints().AppendEmpty().Attributes().PutStr("k", "key1")
+
+	err = proc.ConsumeMetrics(t.Context(), md)
+	require.NoError(t, err)
+
+	require.Len(t, sink.AllMetrics(), 1)
+	processedMetrics := sink.AllMetrics()[0]
+
+	rout, ok := processedMetrics.ResourceMetrics().At(0).Resource().Attributes().Get("rout")
+	assert.True(t, ok)
+	assert.Equal(t, "rsrcval1", rout.Str())
+
+	metrics := processedMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	require.Equal(t, 5, metrics.Len())
+
+	out, ok := metrics.At(0).Gauge().DataPoints().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val1", out.Str())
+
+	out, ok = metrics.At(0).Gauge().DataPoints().At(1).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "default", out.Str())
+
+	out, ok = metrics.At(1).Sum().DataPoints().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val2", out.Str())
+
+	out, ok = metrics.At(2).Histogram().DataPoints().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val1", out.Str())
+
+	out, ok = metrics.At(3).ExponentialHistogram().DataPoints().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val2", out.Str())
+
+	out, ok = metrics.At(4).Summary().DataPoints().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val1", out.Str())
+}
+
+func TestProcessorLookupError(t *testing.T) {
+	errSource := lookupsource.NewSourceFactory(
+		"errsource",
+		func() lookupsource.SourceConfig { return &mockSourceConfig{} },
+		func(_ context.Context, _ lookupsource.CreateSettings, _ lookupsource.SourceConfig) (lookupsource.Source, error) {
+			return lookupsource.NewSource(
+				func(_ context.Context, _ string) (any, bool, error) {
+					return nil, false, errors.New("source error")
+				},
+				func() string { return "errsource" },
+				nil,
+				nil,
+			), nil
+		},
+	)
+
+	factory := NewFactoryWithOptions(WithSources(errSource))
+	cfg := &Config{
+		Source: SourceConfig{Type: "errsource"},
+		Lookups: []LookupConfig{
+			{
+				Key:        `log.attributes["k"]`,
+				Attributes: []AttributeMapping{{Destination: "out"}},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, proc.Start(t.Context(), host))
+	defer func() { _ = proc.Shutdown(t.Context()) }()
+
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().PutStr("k", "anything")
+
+	require.NoError(t, proc.ConsumeLogs(t.Context(), logs))
+
+	records := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	_, ok := records.At(0).Attributes().Get("out")
+	assert.False(t, ok, "out should not be set when lookup errors")
+}
+
+func TestProcessorMultipleResourcesAndScopes(t *testing.T) {
+	mappings := map[string]any{
+		"key1": "val1",
+		"key2": "val2",
+	}
+
+	factory := NewFactoryWithOptions(WithSources(mockMapSourceFactory(mappings)))
+	cfg := &Config{
+		Source: SourceConfig{Type: "mockmap"},
+		Lookups: []LookupConfig{
+			{
+				Key:        `log.attributes["k"]`,
+				Attributes: []AttributeMapping{{Destination: "out"}},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, proc.Start(t.Context(), host))
+	defer func() { _ = proc.Shutdown(t.Context()) }()
+
+	logs := plog.NewLogs()
+
+	rl1 := logs.ResourceLogs().AppendEmpty()
+	rl1.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().PutStr("k", "key1")
+	rl1.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().PutStr("k", "key2")
+
+	rl2 := logs.ResourceLogs().AppendEmpty()
+	rl2.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().PutStr("k", "key1")
+
+	require.NoError(t, proc.ConsumeLogs(t.Context(), logs))
+
+	processedLogs := sink.AllLogs()[0]
+	require.Equal(t, 2, processedLogs.ResourceLogs().Len())
+
+	out, ok := processedLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val1", out.Str())
+
+	out, ok = processedLogs.ResourceLogs().At(0).ScopeLogs().At(1).LogRecords().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val2", out.Str())
+
+	out, ok = processedLogs.ResourceLogs().At(1).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get("out")
+	assert.True(t, ok)
+	assert.Equal(t, "val1", out.Str())
 }
 
 func TestProcessorMapResult(t *testing.T) {


### PR DESCRIPTION
#### Description

Extend the lookup processor to support all three core telemetry signals (logs, traces, metrics) instead of logs only.

Profiling will be added later.