### PR TITLE
[receiver/googlecloudpubsubreceiver] Fix flaky TestReceiver flow control

### DIFF
--- a/receiver/googlecloudpubsubreceiver/receiver_test.go
+++ b/receiver/googlecloudpubsubreceiver/receiver_test.go
@@ -79,6 +79,10 @@ func createBaseReceiver() (*pstest.Server, *pubsubReceiver) {
 				Timeout: 12 * time.Second,
 			},
 			Subscription: "projects/my-project/subscriptions/otlp",
+			FlowControlConfig: FlowControlConfig{
+				StreamAckDeadline:       60 * time.Second,
+				TriggerAckBatchDuration: 10 * time.Second,
+			},
 		},
 	}
 }
@@ -165,6 +169,10 @@ func TestReceiver(t *testing.T) {
 				Timeout: 1 * time.Second,
 			},
 			Subscription: "projects/my-project/subscriptions/otlp",
+			FlowControlConfig: FlowControlConfig{
+				StreamAckDeadline:       60 * time.Second,
+				TriggerAckBatchDuration: 10 * time.Second,
+			},
 		},
 		tracesConsumer:  traceSink,
 		metricsConsumer: metricSink,


### PR DESCRIPTION
I took another look at this flake because the timeouts kept happening even after my last attempt to fix it (#47557).

The Problem:  
The test was starting the receiver with an empty Config{}. This accidentally triggered a loop in the background that burned 100% CPU doing nothing. 
On a resource constrained CI runners, this  was starving the actual message receiving code.

The Evidence: 
I was able to 100% reproduce the hang on my local machine by forcing the test to run on a single core (GOMAXPROCS=1)

Without this fix: The test hangs and crashes after 5 minutes.
With this fix: 50 iterations pass in less than 3 seconds.

Fixes #47661