### PR TITLE
receiver/httpcheck: fix duplicate TLS cert remaining metric per scrape

### DIFF
--- a/.chloggen/47740-httpcheck-duplicate-tls-metric.yaml
+++ b/.chloggen/47740-httpcheck-duplicate-tls-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/httpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicate TLS cert remaining metric data points emitted per scrape.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-httpcheck-duplicate-tls-metric.yaml
+++ b/.chloggen/fix-httpcheck-duplicate-tls-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/httpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicate TLS cert remaining metric data point emitted per scrape
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -400,22 +400,6 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 			h.mb.RecordHttpcheckClientRequestDurationDataPoint(now, requestMs, endpoint)
 			h.mb.RecordHttpcheckResponseDurationDataPoint(now, responseMs, endpoint)
 
-			// Check if TLS metric is enabled and this is an HTTPS endpoint
-			if h.cfg.Metrics.HttpcheckTLSCertRemaining.Enabled && resp != nil && resp.TLS != nil {
-				// Extract TLS info directly from the HTTP response
-				issuer, commonName, sans, timeLeft := extractTLSInfo(resp.TLS)
-				if issuer != "" || commonName != "" || len(sans) > 0 {
-					h.mb.RecordHttpcheckTLSCertRemainingDataPoint(
-						now,
-						timeLeft,
-						endpoint,
-						issuer,
-						commonName,
-						sans,
-					)
-				}
-			}
-
 			statusCode := 0
 			if err != nil {
 				h.mb.RecordHttpcheckErrorDataPoint(


### PR DESCRIPTION
## Description

Fixes #47740

The `RecordHttpcheckTLSCertRemainingDataPoint` was being called twice per scrape — once at the beginning of the metric recording block (after `mux.Lock()`) and again after the timing metric recordings. This caused duplicate TLS cert remaining data points to be emitted.

## Changes

Removed the duplicate TLS cert recording block that appeared after the timing metric recordings (~lines 403-417 in `scraper.go`). The first block (~lines 353-366) is retained and is sufficient.

## Testing

Existing tests cover TLS metric recording. The fix only removes a duplicate call.