### PR TITLE
[chore][pkg/translator/jaeger] drop semconv v1.25.0 import

### DIFF
--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventionsv125 "go.opentelemetry.io/otel/semconv/v1.25.0"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
@@ -288,7 +287,7 @@ func setInternalSpanStatus(attrs pcommon.Map, span ptrace.Span) {
 		// otel.status_message tag will have already been removed if
 		// statusExists is true.
 		attrs.Remove(string(conventions.OTelStatusCodeKey))
-	} else if httpCodeAttr, ok := attrs.Get(string(conventionsv125.HTTPStatusCodeKey)); !statusExists && ok {
+	} else if httpCodeAttr, ok := attrs.Get("http.status_code"); !statusExists && ok {
 		// Fallback to introspecting if this span represents a failed HTTP
 		// request or response, but again, only do so if the `error` tag was
 		// not set to true and no explicit status was sent.


### PR DESCRIPTION
Drops the only remaining `semconv/v1.25.0` usage in this package
(`HTTPStatusCodeKey` at jaegerproto_to_traces.go:291) in favor of the
literal `"http.status_code"`. Incoming Jaeger spans emit the legacy tag,
so the key string itself can't change; this just removes the unused
semconv import.

No behavior change.

Fixes #45036