### PR TITLE
[k8sattributes] Disable otelcol.k8s.pod.association metric until pod_identifier attribute is properly calculated

### DIFF
--- a/.chloggen/disable_pod_association_metric.yaml
+++ b/.chloggen/disable_pod_association_metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/k8s_attributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable otelcol.k8s.pod.association metric until pod_identifier attribute is properly calculated
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47669]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/k8sattributesprocessor/metadata.yaml
+++ b/processor/k8sattributesprocessor/metadata.yaml
@@ -203,6 +203,13 @@ attributes:
 
 telemetry:
   metrics:
+    # The metric is not in use currently.
+    # It can be used once pod_identifier attribute is properly calculated
+    # ensuring that it doesn't cause high cardinality issues.
+    # If each unique value of pod_identifier creates a new metric time series,
+    # memory grows proportionally to the number of distinct pods seen over the collector's lifetime
+    # impacting the component's performance.
+    # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47669
     k8s.pod.association:
       prefix: otelcol.
       enabled: false

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -18,8 +17,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.uber.org/zap"
 
@@ -142,7 +139,7 @@ func (kp *kubernetesprocessor) Shutdown(context.Context) error {
 func (kp *kubernetesprocessor) processTraces(ctx context.Context, td ptrace.Traces) (ptrace.Traces, error) {
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
-		kp.processResource(ctx, rss.At(i).Resource(), "traces")
+		kp.processResource(ctx, rss.At(i).Resource())
 	}
 
 	return td, nil
@@ -152,7 +149,7 @@ func (kp *kubernetesprocessor) processTraces(ctx context.Context, td ptrace.Trac
 func (kp *kubernetesprocessor) processMetrics(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
 	rm := md.ResourceMetrics()
 	for i := 0; i < rm.Len(); i++ {
-		kp.processResource(ctx, rm.At(i).Resource(), "metrics")
+		kp.processResource(ctx, rm.At(i).Resource())
 	}
 
 	return md, nil
@@ -162,7 +159,7 @@ func (kp *kubernetesprocessor) processMetrics(ctx context.Context, md pmetric.Me
 func (kp *kubernetesprocessor) processLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
 	rl := ld.ResourceLogs()
 	for i := 0; i < rl.Len(); i++ {
-		kp.processResource(ctx, rl.At(i).Resource(), "logs")
+		kp.processResource(ctx, rl.At(i).Resource())
 	}
 
 	return ld, nil
@@ -172,14 +169,14 @@ func (kp *kubernetesprocessor) processLogs(ctx context.Context, ld plog.Logs) (p
 func (kp *kubernetesprocessor) processProfiles(ctx context.Context, pd pprofile.Profiles) (pprofile.Profiles, error) {
 	rp := pd.ResourceProfiles()
 	for i := 0; i < rp.Len(); i++ {
-		kp.processResource(ctx, rp.At(i).Resource(), "profiles")
+		kp.processResource(ctx, rp.At(i).Resource())
 	}
 
 	return pd, nil
 }
 
 // processResource adds Pod metadata tags to resource based on pod association configuration
-func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pcommon.Resource, signalType string) {
+func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pcommon.Resource) {
 	podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
 	kp.logger.Debug("evaluating pod identifier", zap.Any("value", podIdentifierValue))
 
@@ -197,21 +194,9 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 
 	var pod *kube.Pod
 	var podFound bool
-	podIdentifierStr := buildPodIdentifierString(podIdentifierValue)
 	if podIdentifierValue.IsNotEmpty() {
 		if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound {
 			kp.logger.Debug("getting the pod", zap.Any("pod", pod))
-
-			// Record successful pod association
-			if kp.telemetry != nil {
-				successAttr := metric.WithAttributes(
-					attribute.String("status", "success"),
-					attribute.String("pod_identifier", podIdentifierStr),
-					attribute.String("otelcol.signal", signalType),
-				)
-				kp.telemetry.K8sPodAssociation.Add(ctx, 1, successAttr)
-			}
-
 			for key, val := range pod.Attributes {
 				setResourceAttribute(resource.Attributes(), key, val)
 			}
@@ -219,26 +204,10 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 		} else {
 			// Record failed pod association
 			kp.logger.Debug("pod not found", zap.Any("podIdentifier", podIdentifierValue))
-			if kp.telemetry != nil {
-				errorAttr := metric.WithAttributes(
-					attribute.String("status", "error"),
-					attribute.String("pod_identifier", podIdentifierStr),
-					attribute.String("otelcol.signal", signalType),
-				)
-				kp.telemetry.K8sPodAssociation.Add(ctx, 1, errorAttr)
-			}
 		}
 	} else {
 		// Record failed pod association when no identifier found
 		kp.logger.Debug("no pod identifier found")
-		if kp.telemetry != nil {
-			errorAttr := metric.WithAttributes(
-				attribute.String("status", "error"),
-				attribute.String("pod_identifier", podIdentifierStr),
-				attribute.String("otelcol.signal", signalType),
-			)
-			kp.telemetry.K8sPodAssociation.Add(ctx, 1, errorAttr)
-		}
 	}
 
 	namespace := getNamespace(pod, resource.Attributes())
@@ -485,20 +454,6 @@ func (kp *kubernetesprocessor) getUIDForPodsNode(nodeName string) string {
 		return ""
 	}
 	return node.NodeUID
-}
-
-// buildPodIdentifierString combines all identifier values into a comma-separated string
-func buildPodIdentifierString(podIdentifierValue kube.PodIdentifier) string {
-	var identifiers []string
-	for i := range podIdentifierValue {
-		if podIdentifierValue[i].Value != "" {
-			identifiers = append(identifiers, podIdentifierValue[i].Value)
-		}
-	}
-	if len(identifiers) > 0 {
-		return strings.Join(identifiers, ",")
-	}
-	return "unknown"
 }
 
 // intFromAttribute extracts int value from an attribute stored as string or int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Disabling the `otelcol.k8s.pod.association` for now until we can properly provide the `pod_identifier` attribute without causing high cardinality as explained by https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47669#issuecomment-4259518961.

The metric was recently introduced and is still in development hence we can revert its usage temporarily until we have a proper fix.