### PR TITLE
[receiver/awss3] strip .zst suffix after zstd decompression

### DIFF
--- a/.chloggen/47802-awss3receiver-strip-zst-suffix.yaml
+++ b/.chloggen/47802-awss3receiver-strip-zst-suffix.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: receiver/awss3
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Strip the `.zst` suffix from the object key after zstd decompression so files written by `awss3exporter` with `compression: zstd` (e.g. `foo.binpb.zst`) are correctly parsed instead of being dropped as "Unsupported file format".
+note: "Strip the `.zst` suffix from the object key after zstd decompression so files written by `awss3exporter` with `compression: zstd` (e.g. `foo.binpb.zst`) are correctly parsed instead of being dropped as \"Unsupported file format\"."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [47802]

--- a/.chloggen/47802-awss3receiver-strip-zst-suffix.yaml
+++ b/.chloggen/47802-awss3receiver-strip-zst-suffix.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awss3
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Strip the `.zst` suffix from the object key after zstd decompression so files written by `awss3exporter` with `compression: zstd` (e.g. `foo.binpb.zst`) are correctly parsed instead of being dropped as "Unsupported file format".
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47802]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+change_logs: [user]

--- a/receiver/awss3receiver/receiver.go
+++ b/receiver/awss3receiver/receiver.go
@@ -153,6 +153,14 @@ func (r *awss3Receiver) receiveBytes(ctx context.Context, key string, data []byt
 				err = closeErr
 			}
 		}()
+		// Strip the compression suffix so the downstream format
+		// detection sees the underlying marshaler's suffix (.json /
+		// .binpb). Matches the .gz branch; without it, a file written
+		// by awss3exporter with compression: zstd (e.g. foo.binpb.zst)
+		// loops back through processReceivedData with key still ending
+		// in .zst, falls through every format check, and is dropped
+		// with "Unsupported file format" (#47802).
+		key = strings.TrimSuffix(key, ".zst")
 		data, err = io.ReadAll(decompressedReader)
 		if err != nil {
 			return err

--- a/receiver/awss3receiver/receiver_test.go
+++ b/receiver/awss3receiver/receiver_test.go
@@ -294,9 +294,6 @@ func Test_receiveBytes_traces(t *testing.T) {
 			if err := r.receiveBytes(t.Context(), tt.args.key, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("receiveBytes() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			// Without this assertion the wantTrace=true cases silently pass
-			// when nothing was consumed (the consumer callback never fires).
-			// That gap masked the .zst-suffix bug fixed by this PR (#47802).
 			if tt.wantTrace && !traceConsumed {
 				t.Errorf("receiveBytes() expected trace to be consumed, none received")
 			}

--- a/receiver/awss3receiver/receiver_test.go
+++ b/receiver/awss3receiver/receiver_test.go
@@ -265,8 +265,10 @@ func Test_receiveBytes_traces(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var traceConsumed bool
 			tracesConsumer, _ := consumer.NewTraces(func(_ context.Context, td ptrace.Traces) error {
 				t.Helper()
+				traceConsumed = true
 				if !tt.wantTrace {
 					t.Errorf("receiveBytes() received unexpected trace")
 				} else {
@@ -291,6 +293,12 @@ func Test_receiveBytes_traces(t *testing.T) {
 			}
 			if err := r.receiveBytes(t.Context(), tt.args.key, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("receiveBytes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			// Without this assertion the wantTrace=true cases silently pass
+			// when nothing was consumed (the consumer callback never fires).
+			// That gap masked the .zst-suffix bug fixed by this PR (#47802).
+			if tt.wantTrace && !traceConsumed {
+				t.Errorf("receiveBytes() expected trace to be consumed, none received")
 			}
 		})
 	}
@@ -444,10 +452,12 @@ func Test_receiveBytes_metrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var metricConsumed bool
 			tracesConsumer, _ := consumer.NewMetrics(func(_ context.Context, md pmetric.Metrics) error {
 				t.Helper()
+				metricConsumed = true
 				if !tt.wantMetric {
-					t.Errorf("receiveBytes() received unexpected trace")
+					t.Errorf("receiveBytes() received unexpected metric")
 				} else {
 					require.Equal(t, testMetric, md)
 				}
@@ -470,6 +480,9 @@ func Test_receiveBytes_metrics(t *testing.T) {
 			}
 			if err := r.receiveBytes(t.Context(), tt.args.key, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("receiveBytes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantMetric && !metricConsumed {
+				t.Errorf("receiveBytes() expected metric to be consumed, none received")
 			}
 		})
 	}
@@ -623,10 +636,12 @@ func Test_receiveBytes_logs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var logConsumed bool
 			tracesConsumer, _ := consumer.NewLogs(func(_ context.Context, ld plog.Logs) error {
 				t.Helper()
+				logConsumed = true
 				if !tt.wantMetric {
-					t.Errorf("receiveBytes() received unexpected trace")
+					t.Errorf("receiveBytes() received unexpected log")
 				} else {
 					require.Equal(t, testLog, ld)
 				}
@@ -649,6 +664,9 @@ func Test_receiveBytes_logs(t *testing.T) {
 			}
 			if err := r.receiveBytes(t.Context(), tt.args.key, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("receiveBytes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantMetric && !logConsumed {
+				t.Errorf("receiveBytes() expected log to be consumed, none received")
 			}
 		})
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue. Ex. Adding a feature - Explain what this achieves.-->
#### Description

`awss3exporter` writes files like `foo.binpb.zst` when configured with `compression: zstd`. On the receiver side, `newAWSS3Receiver`'s decompress block decompresses the body but does not strip the `.zst` suffix from the key the way the gzip branch strips `.gz`. `processReceivedData` then falls through every format check (`.json` / `.binpb`) and drops the data with "Unsupported file format" - no telemetry reaches the downstream pipeline.

```go
// existing gzip branch, already trims the suffix
key = strings.TrimSuffix(key, ".gz")

// the zstd branch used to return without trimming, so downstream
// only saw ".binpb.zst" which matched nothing.
```

This PR adds `key = strings.TrimSuffix(key, ".zst")` right before the decompressed body is handed to the format dispatcher, matching the gzip branch. Uncompressed and gzip paths are untouched.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- `go build ./...` and `go test ./... -count=1` in `receiver/awss3receiver/` pass locally
- Bench config from the issue (awss3exporter → awss3receiver, both with `compression: zstd` / `marshaler: otlp_proto`) now delivers traces/metrics/logs through the pipeline instead of logging "Unsupported file format"

<!--Describe the documentation added.-->
#### Documentation

Added a `.chloggen` entry (`47802-awss3receiver-strip-zst-suffix.yaml`, `bug_fix` for `receiver/awss3`).

<!--Please delete paragraphs that you did not use before submitting.-->
#### Link to tracking issue

Fixes #47802

<!--Follow the issue triage process (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/ISSUE_TRIAGE.md#disclosing-the-use-of-ai)  to disclose use of AI.-->
Assisted-by: Claude Opus 4.7

