### PR TITLE
[chore] skip a failed test on Windows

### DIFF
--- a/receiver/tcpcheckreceiver/scraper_test.go
+++ b/receiver/tcpcheckreceiver/scraper_test.go
@@ -289,6 +289,9 @@ func updateErrorCodeInMetrics(metrics pmetric.Metrics, errorCode string) pmetric
 }
 
 func TestScraper_ErrorEnumCounts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("knonw failure on windows, see http://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47826")
+	}
 	// Test multiple endpoints with different error types
 	endpoints := []string{
 		"invalid:host", // Invalid host format for invalid_endpoint


### PR DESCRIPTION
#### Description
Skip TestScraper_ErrorEnumCounts on Windows, it failed consistently.

#### Link to tracking issue
http://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47826