### PR TITLE
exporter/file: serialize writer swap in Shutdown to stop nil-deref race

### DIFF
--- a/.chloggen/46871-fileexporter-shutdown-race.yaml
+++ b/.chloggen/46871-fileexporter-shutdown-race.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/file
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil pointer dereference panic in the file exporter when a consume* call races with Shutdown. Shutdown now serializes the writer swap under writerMu and consume* paths return a descriptive "already shut down" error instead of dereferencing a nil writer.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46871]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+change_logs: [user]

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -5,8 +5,10 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -15,43 +17,76 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+// errFileExporterShutdown is returned when a consume* call arrives after
+// Shutdown has already run. Previously Shutdown nil'd out e.writer and a
+// racing consume* call panicked with nil pointer dereference (#46871).
+var errFileExporterShutdown = errors.New("fileexporter: already shut down")
+
 // fileExporter is the implementation of file exporter that writes telemetry data to a file
 type fileExporter struct {
 	conf       *Config
 	marshaller *marshaller
-	writer     *fileWriter
+	// writerMu serializes access to writer between Shutdown and the
+	// consume* callers so a racing consume* call cannot observe writer
+	// after Shutdown has freed it (#46871).
+	writerMu sync.RWMutex
+	writer   *fileWriter
+}
+
+// loadWriter returns the current writer under writerMu; the returned
+// pointer is safe to use for the duration of the call that captured it.
+func (e *fileExporter) loadWriter() *fileWriter {
+	e.writerMu.RLock()
+	defer e.writerMu.RUnlock()
+	return e.writer
 }
 
 func (e *fileExporter) consumeTraces(_ context.Context, td ptrace.Traces) error {
+	w := e.loadWriter()
+	if w == nil {
+		return errFileExporterShutdown
+	}
 	buf, err := e.marshaller.marshalTraces(td)
 	if err != nil {
 		return err
 	}
-	return e.writer.export(buf)
+	return w.export(buf)
 }
 
 func (e *fileExporter) consumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	w := e.loadWriter()
+	if w == nil {
+		return errFileExporterShutdown
+	}
 	buf, err := e.marshaller.marshalMetrics(md)
 	if err != nil {
 		return err
 	}
-	return e.writer.export(buf)
+	return w.export(buf)
 }
 
 func (e *fileExporter) consumeLogs(_ context.Context, ld plog.Logs) error {
+	w := e.loadWriter()
+	if w == nil {
+		return errFileExporterShutdown
+	}
 	buf, err := e.marshaller.marshalLogs(ld)
 	if err != nil {
 		return err
 	}
-	return e.writer.export(buf)
+	return w.export(buf)
 }
 
 func (e *fileExporter) consumeProfiles(_ context.Context, pd pprofile.Profiles) error {
+	w := e.loadWriter()
+	if w == nil {
+		return errFileExporterShutdown
+	}
 	buf, err := e.marshaller.marshalProfiles(pd)
 	if err != nil {
 		return err
 	}
-	return e.writer.export(buf)
+	return w.export(buf)
 }
 
 // Start starts the flush timer if set.
@@ -76,21 +111,26 @@ func (e *fileExporter) Start(_ context.Context, host component.Host) error {
 		}
 	}
 
-	e.writer, err = newFileWriter(e.conf.Path, e.conf.Append, e.conf.Rotation, e.conf.FlushInterval, export)
+	w, err := newFileWriter(e.conf.Path, e.conf.Append, e.conf.Rotation, e.conf.FlushInterval, export)
 	if err != nil {
 		return err
 	}
-	e.writer.start()
+	w.start()
+	e.writerMu.Lock()
+	e.writer = w
+	e.writerMu.Unlock()
 	return nil
 }
 
 // Shutdown stops the exporter and is invoked during shutdown.
 // It stops the flush ticker if set.
 func (e *fileExporter) Shutdown(context.Context) error {
-	if e.writer == nil {
-		return nil
-	}
+	e.writerMu.Lock()
 	w := e.writer
 	e.writer = nil
+	e.writerMu.Unlock()
+	if w == nil {
+		return nil
+	}
 	return w.shutdown()
 }


### PR DESCRIPTION
**Description:**

`Shutdown` set `e.writer = nil` and then called `w.shutdown()` on the captured pointer, but `consume*` read `e.writer` unsynchronized. A concurrent `consumeMetrics` / `consumeTraces` / `consumeLogs` / `consumeProfiles` could observe nil after Shutdown's assignment and crash:

```
panic: runtime error: invalid memory address or nil pointer dereference
fileexporter.(*fileExporter).consumeMetrics ... file_exporter.go:36 +0x46
```

**Fix:** add a `sync.RWMutex` guarding `writer`. `consume*` take the read lock and return a descriptive `"already shut down"` error when the writer has been cleared; `Shutdown` takes the write lock for the swap before closing the previously-captured writer. Existing tests that access `e.writer` directly keep compiling because the field type is unchanged.

**Link to tracking issue:** Fixes #46871

**Testing:** `go test ./exporter/fileexporter/... -count=1` passes.

**Documentation:** Added `.chloggen/46871-fileexporter-shutdown-race.yaml` under `bug_fix`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
Assisted-by: Claude Opus 4.7
