### PR TITLE
exporter/awsxray: declare MutatesData so fanout clones traces

### DIFF
--- a/.chloggen/46889-awsxray-mutates-data.yaml
+++ b/.chloggen/46889-awsxray-mutates-data.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/awsxray
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Declare `consumer.Capabilities{MutatesData: true}` so traces pipelines with multiple exporters no longer panic with "invalid access to shared data" when `makeEndTimeAndInProgress` removes the `aws.xray.inprogress` attribute.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46889]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+change_logs: [user]

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	"github.com/aws/smithy-go"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -82,6 +83,13 @@ func newTracesExporter(ctx context.Context, cfg *Config, set exporter.Settings, 
 			_ = logger.Sync()
 			return nil
 		}),
+		// The exporter mutates span attributes (removes the
+		// aws.xray.inprogress attribute in makeEndTimeAndInProgress).
+		// Declare that so the collector clones the traces before fanout;
+		// otherwise a traces pipeline with multiple exporters panics with
+		// "invalid access to shared data" on the first span that carries
+		// the attribute (#46889).
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 	)
 }
 


### PR DESCRIPTION
**Description:**

`makeEndTimeAndInProgress` calls `attributes.Remove(aws.xray.inprogress)` on every span whose conversion path sets the `inProgress` flag (added in #43962). The factory, however, builds the exporter without `WithCapabilities(consumer.Capabilities{MutatesData: true})`, so the collector's fanout consumer assumes the traces are immutable and does not clone them. Any traces pipeline that fans out to `awsxray` plus another exporter panics on the first inprogress span:

```
panic: invalid access to shared data
```

**Fix:** declare the capability. Fanout now hands `awsxray` its own copy and `attributes.Remove` no longer races with sibling exporters.

**Link to tracking issue:** Fixes #46889

**Testing:** `go test ./exporter/awsxrayexporter/... -count=1` passes.

**Documentation:** Added `.chloggen/46889-awsxray-mutates-data.yaml` under `bug_fix`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
Assisted-by: Claude Opus 4.7
