### PR TITLE
exporter/clickhouse: backtick-quote cluster_name in ON CLUSTER clause

### DIFF
--- a/.chloggen/46946-clickhouse-cluster-quoting.yaml
+++ b/.chloggen/46946-clickhouse-cluster-quoting.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Backtick-quote `cluster_name` in the emitted `ON CLUSTER <name>` clause so cluster identifiers containing dashes, spaces, or other non-alphanumeric characters (for example `ch-cluster`) are accepted by the ClickHouse parser instead of failing schema creation with a syntax error.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46946]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+change_logs: [user]

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -314,5 +315,12 @@ func (cfg *Config) clusterString() string {
 		return ""
 	}
 
-	return fmt.Sprintf("ON CLUSTER %s", cfg.ClusterName)
+	// Backtick-quote the cluster identifier so names containing
+	// dashes, spaces, or other non-alphanumeric characters are accepted
+	// by the ClickHouse parser. Previously `cluster_name: "ch-cluster"`
+	// produced `ON CLUSTER ch-cluster`, which ClickHouse rejected with a
+	// syntax error (#46946). Embedded backticks are doubled per
+	// ClickHouse's quoted-identifier escape rule.
+	escaped := strings.ReplaceAll(cfg.ClusterName, "`", "``")
+	return fmt.Sprintf("ON CLUSTER `%s`", escaped)
 }

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -653,11 +653,19 @@ func TestClusterString(t *testing.T) {
 		},
 		{
 			input:    "cluster_a_b",
-			expected: "ON CLUSTER cluster_a_b",
+			expected: "ON CLUSTER `cluster_a_b`",
 		},
 		{
 			input:    "cluster a b",
-			expected: "ON CLUSTER cluster a b",
+			expected: "ON CLUSTER `cluster a b`",
+		},
+		{
+			input:    "ch-cluster",
+			expected: "ON CLUSTER `ch-cluster`",
+		},
+		{
+			input:    "weird`name",
+			expected: "ON CLUSTER `weird``name`",
 		},
 	}
 


### PR DESCRIPTION
**Description:**

`clusterString` emitted `ON CLUSTER <name>` with no quoting. A valid `cluster_name` containing a dash (`ch-cluster` is the one the reporter hit), a space, or any non-alphanumeric identifier character caused ClickHouse to reject every schema-creation DDL and the pipeline failed to start:

```
failed to start "clickhouse" exporter: create database: code: 62,
message: Syntax error: failed at position 51 (-): -cluster
```

**Fix:** backtick-quote the identifier, doubling any embedded backtick per ClickHouse's quoted-identifier escape rule. Existing tests updated to the quoted form plus two new cases covering `ch-cluster` and `weird` + backtick + `name`.

**Link to tracking issue:** Fixes #46946

**Testing:** `go test ./exporter/clickhouseexporter/... -count=1` passes.

**Documentation:** Added `.chloggen/46946-clickhouse-cluster-quoting.yaml` under `bug_fix`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
Assisted-by: Claude Opus 4.7
