### PR TITLE
exporter/splunk_hec: disable HTML escape on event JSON encoder

### DIFF
--- a/.chloggen/46545-splunkhec-disable-html-escape.yaml
+++ b/.chloggen/46545-splunkhec-disable-html-escape.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/splunk_hec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable HTML escaping in the event marshaller so log bodies or event fields containing `<`, `>`, or `&` are delivered to Splunk as the original characters instead of `\u003c`, `\u003e`, `\u0026`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46545]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+change_logs: [user]

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -686,6 +686,13 @@ func marshalEvent(event *translator.Event, sizeLimit uint, writer io.Writer) (er
 	defer jsonBufferPool.Put(buf)
 
 	enc := json.NewEncoder(buf)
+	// json.NewEncoder defaults to escaping HTML characters (`<`, `>`, `&`
+	// become `\u003c`, `\u003e`, `\u0026`). Splunk HEC receives the JSON
+	// verbatim, so log bodies that legitimately contain those characters
+	// reach Splunk with the escape sequences instead of the original
+	// bytes (#46545). Splunk HEC is not an HTML sink, so the encoder
+	// does not need the HTML-safety default.
+	enc.SetEscapeHTML(false)
 	if err := enc.Encode(event); err != nil {
 		return nil, err
 	}

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
+	splunktranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/splunk"
 )
 
 var requestTimeRegex = regexp.MustCompile(`time":(\d+)`)
@@ -2263,6 +2264,31 @@ func TestBatcherPartitionsByHecToken(t *testing.T) {
 		requests := runBatchedLogExport(t, makeCfg(), ld, 1)
 		assert.Equal(t, "Splunk token-same", requests[0].headers.Get("Authorization"))
 	})
+}
+
+// TestMarshalEvent_DoesNotEscapeHTML verifies that marshalEvent encodes events
+// without escaping HTML metacharacters (<, >, &). Splunk HEC receives the
+// JSON verbatim, so escaping those bytes corrupts log bodies that
+// legitimately contain them. Regression test for #46545.
+func TestMarshalEvent_DoesNotEscapeHTML(t *testing.T) {
+	event := &splunktranslator.Event{
+		Event:  "<a>hello & 'world'</a>",
+		Host:   "h",
+		Source: "s",
+		Fields: map[string]any{"raw": "x<y>z&w"},
+	}
+
+	var buf bytes.Buffer
+	jsonErr, writeErr := marshalEvent(event, 1024, &buf)
+	require.NoError(t, jsonErr)
+	require.NoError(t, writeErr)
+
+	out := buf.String()
+	assert.Contains(t, out, "<a>hello & 'world'</a>")
+	assert.Contains(t, out, "x<y>z&w")
+	assert.NotContains(t, out, `\u003c`)
+	assert.NotContains(t, out, `\u003e`)
+	assert.NotContains(t, out, `\u0026`)
 }
 
 // validateCompressedContains validates that GZipped `got` contains `expected` strings


### PR DESCRIPTION
**Description:**

`json.NewEncoder` defaults to escaping HTML metacharacters (`<`, `>`, `&`) as `\u003c`, `\u003e`, `\u0026`. Splunk HEC receives the JSON verbatim, so log bodies and event fields that legitimately contain those characters reach Splunk with the escape sequences instead of the original bytes.

**Fix:** call `enc.SetEscapeHTML(false)` on the encoder used in `marshalEvent`. Splunk HEC is not an HTML sink, so the encoder does not need the HTML-safety default.

**Link to tracking issue:** Fixes #46545

**Testing:** `go test ./exporter/splunkhecexporter/... -count=1` passes (full suite in 33s).

**Documentation:** Added `.chloggen/46545-splunkhec-disable-html-escape.yaml` under `bug_fix`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
Assisted-by: Claude Opus 4.7
