### PR TITLE
processor/logstransform: don't tie converter loop to Start context

### DIFF
--- a/.chloggen/31140-logstransform-long-lived-context.yaml
+++ b/.chloggen/31140-logstransform-long-lived-context.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: processor/logstransform
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Detach the converter loop goroutine from the Start context per component.Component contract; the loop now runs under a dedicated context.Background()-derived context that is cancelled on Shutdown instead of the soon-cancelled Start context.
+note: Fix a bug where the logstransform processor's internal converter loop was tied to the short-lived Start context, causing the processor to stop processing logs shortly after startup. The loop now runs for the full lifetime of the component and stops cleanly on Shutdown.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [31140]

--- a/.chloggen/31140-logstransform-long-lived-context.yaml
+++ b/.chloggen/31140-logstransform-long-lived-context.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/logstransform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Detach the converter loop goroutine from the Start context per component.Component contract; the loop now runs under a dedicated context.Background()-derived context that is cancelled on Shutdown instead of the soon-cancelled Start context.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31140]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+change_logs: [user]

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -35,6 +35,7 @@ type logsTransformProcessor struct {
 	emitter       helper.LogEmitter
 	fromConverter *adapter.FromPdataConverter
 	shutdownFns   []component.ShutdownFunc
+	wg            sync.WaitGroup
 }
 
 func newProcessor(config *Config, nextConsumer consumer.Logs, set component.TelemetrySettings) (*logsTransformProcessor, error) {
@@ -122,12 +123,10 @@ func (ltp *logsTransformProcessor) startFromConverter() {
 // startConverterLoop starts the converter loop, which reads all the logs translated by the fromConverter and then forwards
 // them to pipeline
 func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context) {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go ltp.converterLoop(ctx, wg)
+	ltp.wg.Go(func() { ltp.converterLoop(ctx) })
 
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
-		wg.Wait()
+		ltp.wg.Wait()
 		return nil
 	})
 }
@@ -159,9 +158,7 @@ func (ltp *logsTransformProcessor) ConsumeLogs(_ context.Context, ld plog.Logs) 
 
 // converterLoop reads the log entries produced by the fromConverter and sends them
 // into the pipeline
-func (ltp *logsTransformProcessor) converterLoop(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (ltp *logsTransformProcessor) converterLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -77,7 +77,7 @@ func (ltp *logsTransformProcessor) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) error {
+func (ltp *logsTransformProcessor) Start(_ context.Context, _ component.Host) error {
 	wkrCount := int(math.Max(1, float64(runtime.NumCPU())))
 	ltp.fromConverter = adapter.NewFromPdataConverter(ltp.set, wkrCount)
 
@@ -94,7 +94,17 @@ func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) 
 	if err != nil {
 		return err
 	}
-	ltp.startConverterLoop(ctx)
+	// component.Start documents that any long-running operation must not
+	// use the context passed to Start (the collector cancels it shortly
+	// after Start returns). The converter loop is exactly such a long-
+	// running goroutine, so derive a dedicated context that is cancelled
+	// by the shutdown path instead (#31140).
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
+		loopCancel()
+		return nil
+	})
+	ltp.startConverterLoop(loopCtx)
 	ltp.startFromConverter()
 
 	return nil


### PR DESCRIPTION
**Description:**

`component.Component.Start` documents that the context passed in is cancelled shortly after `Start` returns, so any long-running goroutine must derive its own context from `context.Background()`. The logstransform processor's converter loop was wired directly to the `Start` context, which works by accident today (no caller cancels before the first record) but violates the contract and could silently stop processing under a slow startup.

**Fix:** derive a dedicated context from `context.Background()`, cancel it via a shutdown hook, and pass that to `startConverterLoop`.

**Link to tracking issue:** Fixes #31140

**Testing:** `go test ./processor/logstransformprocessor/... -count=1 -short` passes.

**Documentation:** Added `.chloggen/31140-logstransform-long-lived-context.yaml` under `bug_fix`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
Assisted-by: Claude Opus 4.7
