### PR TITLE
[receiver/github] fix enforcement of require headers on every webhook request

### DIFF
--- a/.chloggen/githubreceiver-enforce-required-headers.yaml
+++ b/.chloggen/githubreceiver-enforce-required-headers.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/github
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the enforcement of configured `required_headers` on incoming webhook requests.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/githubreceiver-enforce-required-headers.yaml
+++ b/.chloggen/githubreceiver-enforce-required-headers.yaml
@@ -10,7 +10,7 @@ component: receiver/github
 note: Fix the enforcement of configured `required_headers` on incoming webhook requests.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47854]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/githubreceiver/README.md
+++ b/receiver/githubreceiver/README.md
@@ -160,7 +160,7 @@ The WebHook configuration exposes the following settings:
 * `path`: (default = `/events`) - The path for Action events to be sent to.
 * `health_path`: (default = `/health`) - The path for health checks.
 * `secret`: (optional) - The secret used to [validates the payload][valid].
-* `required_header`: (optional) - The required header key and value for incoming requests.
+* `required_headers`: (optional) - One or more header key/value pairs that every webhook request must carry (the health check endpoint is exempt). Requests missing any configured header, or carrying the wrong value, are rejected before the payload is parsed. GitHub itself does not send custom request headers, so this setting is intended for deployments where a front-end WAF or proxy injects the agreed header.
 * `service_name`: (optional) - The service name for the traces. See the
 [Configuring Service Name](#configuring-service-name) section for more
 information.

--- a/receiver/githubreceiver/trace_receiver.go
+++ b/receiver/githubreceiver/trace_receiver.go
@@ -131,6 +131,14 @@ func (gtr *githubTracesReceiver) Shutdown(_ context.Context) error {
 func (gtr *githubTracesReceiver) handleReq(w http.ResponseWriter, req *http.Request) {
 	ctx := gtr.obsrecv.StartTracesOp(req.Context())
 
+	for k, v := range gtr.cfg.WebHook.RequiredHeaders {
+		if req.Header.Get(k) != string(v) {
+			gtr.logger.Sugar().Debugf("required header check failed", zap.String("header", k))
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+	}
+
 	p, err := github.ValidatePayload(req, []byte(gtr.cfg.WebHook.Secret))
 	if err != nil {
 		gtr.logger.Sugar().Debugf("unable to validate payload", zap.Error(err))

--- a/receiver/githubreceiver/trace_receiver_test.go
+++ b/receiver/githubreceiver/trace_receiver_test.go
@@ -6,12 +6,14 @@ package githubreceiver // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -83,4 +85,79 @@ func TestHealthCheck(t *testing.T) {
 
 	response := w.Result()
 	require.Equal(t, http.StatusOK, response.StatusCode)
+}
+
+func TestHandleReq_RequiredHeaders(t *testing.T) {
+	tests := []struct {
+		name            string
+		requiredHeaders map[string]configopaque.String
+		reqHeaders      map[string]string
+		wantStatus      int
+	}{
+		{
+			name:            "valid_request_with_required_headers",
+			requiredHeaders: map[string]configopaque.String{"X-Proxy-Auth": "abc"},
+			reqHeaders: map[string]string{
+				"X-Proxy-Auth":   "abc",
+				"X-GitHub-Event": "ping",
+				"Content-Type":   "application/json",
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:            "missing_required_header",
+			requiredHeaders: map[string]configopaque.String{"X-Proxy-Auth": "abc"},
+			reqHeaders: map[string]string{
+				"X-GitHub-Event": "ping",
+				"Content-Type":   "application/json",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:            "wrong_required_header_value",
+			requiredHeaders: map[string]configopaque.String{"X-Proxy-Auth": "abc"},
+			reqHeaders: map[string]string{
+				"X-Proxy-Auth":   "wrong",
+				"X-GitHub-Event": "ping",
+				"Content-Type":   "application/json",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:            "no_required_headers_configured",
+			requiredHeaders: nil,
+			reqHeaders: map[string]string{
+				"X-GitHub-Event": "ping",
+				"Content-Type":   "application/json",
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.WebHook.NetAddr.Endpoint = "localhost:0"
+			if tt.requiredHeaders != nil {
+				cfg.WebHook.RequiredHeaders = tt.requiredHeaders
+			}
+
+			sink := new(consumertest.TracesSink)
+			r, err := newTracesReceiver(receivertest.NewNopSettings(metadata.Type), cfg, sink)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/events",
+				strings.NewReader(`{}`))
+			for k, v := range tt.reqHeaders {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+			r.handleReq(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Result().StatusCode)
+			if tt.wantStatus == http.StatusBadRequest {
+				require.Equal(t, 0, sink.SpanCount(), "consumer must not be called when header check fails")
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### Description

The GitHub receiver can be configured with `required_headers` when set behind a WAF or proxy. The receiver would validate the configuration, but did not validate the headers on each webhook request. This meant that payloads would still be allowed even when they didn't have the required header set by a WAF or proxy.

#### Link to tracking issue
Fixes GHSA-w5cv-pw74-4rxc
