### PR TITLE
feat(azureencodingextension): map PIM event properties for Administrative Activity Logs

### DIFF
--- a/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
+++ b/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
@@ -18,8 +18,10 @@ issues: [47566]
 subtext: |
   Azure PIM (Privileged Identity Management) events share the Administrative category with
   standard audit events but carry a different properties payload. All PIM-specific fields
-  were silently dropped. This change adds explicit mappings under azure.pim.* for all known
-  PIM fields and parses CallerInfo into a structured slice of {identity_type, identity_value} maps.
+  were silently dropped. This change adds explicit mappings for all known PIM fields:
+  generic Azure concepts use cloud.account.id and azure.{tenant,resource}.* attributes,
+  while PIM-specific fields use azure.pim.*. CallerInfo is parsed into a structured slice
+  of {identity_type, identity_value} maps.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
+++ b/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/encoding/azureencodingextension
+component: extension/azure_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Map PIM event properties for Administrative Activity Logs

--- a/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
+++ b/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
@@ -20,8 +20,9 @@ subtext: |
   standard audit events but carry a different properties payload. All PIM-specific fields
   were silently dropped. This change adds explicit mappings for all known PIM fields:
   generic Azure concepts use cloud.account.id and azure.{tenant,resource}.* attributes,
-  while PIM-specific fields use azure.pim.*. CallerInfo is parsed into a structured slice
-  of {identity_type, identity_value} maps.
+  while PIM-specific fields use azure.pim.*. CallerInfo is projected to flat per-identity
+  attributes (azure.pim.caller.upn, azure.pim.caller.object_id, azure.pim.caller.username,
+  ...) keyed by the lowercased snake_case identity type.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
+++ b/.chloggen/47856-azureencodingextension-pim-activity-log-attributes.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/encoding/azureencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Map PIM event properties for Administrative Activity Logs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47566]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Azure PIM (Privileged Identity Management) events share the Administrative category with
+  standard audit events but carry a different properties payload. All PIM-specific fields
+  were silently dropped. This change adds explicit mappings under azure.pim.* for all known
+  PIM fields and parses CallerInfo into a structured slice of {identity_type, identity_value} maps.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/README.md
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/README.md
@@ -600,6 +600,32 @@ Activity Logs are a type of Azure platform log that provides insight into subscr
 | `message`                 | `azure.administrative.message`      | Log Attribute |
 | `hierarchy`               | `azure.administrative.hierarchy`    | Log Attribute |
 
+#### Administrative — PIM (Privileged Identity Management)
+
+PIM events share the `Administrative` category but are identified by `ResourceProviderName: azurerbac`.
+They carry a different `properties` payload; the following fields are additive and do not affect standard
+Administrative events. Microsoft does not publish a formal schema for this payload; fields are derived
+from real event samples.
+
+| Azure "properties" Field  | OpenTelemetry                              | OpenTelemetry Scope | Notes |
+|---------------------------|--------------------------------------------|---------------------|-------|
+| `SubscriptionID`          | `cloud.account.id`                         | Log Attribute | `null` when resource-scoped |
+| `ResourceGroupName`       | `azure.resource.group.name`                | Log Attribute | |
+| `ResourceProviderName`    | `azure.resource.provider.name`             | Log Attribute | Always `azurerbac` for PIM events |
+| `ResourceType`            | `azure.resource.type`                      | Log Attribute | |
+| `TenantID`                | `azure.tenant.id`                          | Log Attribute | |
+| `EventName`               | `azure.pim.event.name`                     | Log Attribute | e.g. `ActivateRole`, `CreateRequestRoleActivation`, `RemoveActivatedRole` |
+| `EventID`                 | `azure.pim.event.id`                       | Log Attribute | |
+| `RoleAssignmentRequestId` | `azure.pim.role.assignment.request.id`     | Log Attribute | Links request and completion events |
+| `RoleDefinition`          | `azure.pim.role.definition.name`           | Log Attribute | Human-readable role name |
+| `RoleDefinitionOriginId`  | `azure.pim.role.definition.origin.id`      | Log Attribute | Full ARM resource ID of the role definition |
+| `CallerInfo` (JSON array) | `azure.pim.caller.<identity_type>`         | Log Attribute | One attribute per entry; key is the lowercased snake_case `CallerIdentityType` (e.g. `azure.pim.caller.upn`, `azure.pim.caller.object_id`) |
+| `Justification`           | `azure.pim.justification`                  | Log Attribute | Absent on system-driven revocations |
+| `SubjectID`               | `azure.pim.subject.id`                     | Log Attribute | |
+| `SubjectName`             | `azure.pim.subject.name`                   | Log Attribute | |
+| `ActionType`              | `azure.pim.action.type`                    | Log Attribute | `Grant` or `Revoke`; absent on request events |
+| `OriginRoleAssignmentId`  | `azure.pim.role.assignment.origin.id`      | Log Attribute | Absent on request events |
+
 ### Alert
 
 | Azure "properties" Field  | OpenTelemetry                       | OpenTelemetry Scope |

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -93,22 +93,105 @@ const (
 	attributeAzureAdministrativeHierarchy = "azure.administrative.hierarchy"
 )
 
-// azureAdministrativeLog represents an Administrative activity log
+// Non-SemConv attributes for PIM (Privileged Identity Management) events,
+// which arrive as Administrative category Activity Logs with ResourceProviderName=azurerbac.
+// Microsoft does not publish a formal schema for the properties payload; these fields
+// are derived from real PIM event samples.
+// See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47566
+const (
+	attributeAzurePIMSubscriptionID          = "azure.pim.subscription_id"
+	attributeAzurePIMResourceGroupName       = "azure.pim.resource.group_name"
+	attributeAzurePIMResourceProviderName    = "azure.pim.resource.provider_name"
+	attributeAzurePIMResourceType            = "azure.pim.resource.type"
+	attributeAzurePIMTenantID                = "azure.pim.tenant_id"
+	attributeAzurePIMEventName               = "azure.pim.event.name"
+	attributeAzurePIMEventID                 = "azure.pim.event.id"
+	attributeAzurePIMRoleAssignmentRequestID = "azure.pim.role.assignment.request_id"
+	attributeAzurePIMRoleDefinition          = "azure.pim.role.definition"
+	attributeAzurePIMRoleDefinitionOriginID  = "azure.pim.role.definition.origin_id"
+	attributeAzurePIMCallerInfo              = "azure.pim.caller"
+	attributeAzurePIMJustification           = "azure.pim.justification"
+	attributeAzurePIMSubjectID               = "azure.pim.subject.id"
+	attributeAzurePIMSubjectName             = "azure.pim.subject.name"
+	attributeAzurePIMActionType              = "azure.pim.action.type"
+	attributeAzurePIMOriginRoleAssignmentID  = "azure.pim.role.assignment.origin_id"
+)
+
+// pimCallerIdentity represents one entry in the CallerInfo JSON array
+type pimCallerIdentity struct {
+	IdentityType  string `json:"CallerIdentityType"`
+	IdentityValue string `json:"CallerIdentityValue"`
+}
+
+// azureAdministrativeLog represents an Administrative activity log.
+// It covers both standard Administrative events (entity/message/hierarchy)
+// and PIM events (azurerbac provider), which share the same category but
+// carry a completely different properties payload.
 // See: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log-schema#administrative-category
 type azureAdministrativeLog struct {
 	activityLogRecordBase
 
 	Properties struct {
+		// Standard Administrative fields
 		Entity    string `json:"entity"`
 		Message   string `json:"message"`
 		Hierarchy string `json:"hierarchy"`
+
+		// PIM-specific fields (ResourceProviderName=azurerbac)
+		SubscriptionID          *string `json:"SubscriptionID"`
+		ResourceGroupName       string  `json:"ResourceGroupName"`
+		ResourceProviderName    string  `json:"ResourceProviderName"`
+		ResourceType            string  `json:"ResourceType"`
+		TenantID                string  `json:"TenantID"`
+		EventName               string  `json:"EventName"`
+		EventID                 string  `json:"EventID"`
+		RoleAssignmentRequestID string  `json:"RoleAssignmentRequestId"`
+		RoleDefinition          string  `json:"RoleDefinition"`
+		RoleDefinitionOriginID  string  `json:"RoleDefinitionOriginId"`
+		CallerInfo              string  `json:"CallerInfo"`
+		Justification           string  `json:"Justification"`
+		SubjectID               string  `json:"SubjectID"`
+		SubjectName             string  `json:"SubjectName"`
+		ActionType              string  `json:"ActionType"`
+		OriginRoleAssignmentID  string  `json:"OriginRoleAssignmentId"`
 	} `json:"properties"`
 }
 
 func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Value) error {
+	// Standard Administrative fields
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeEntity, r.Properties.Entity)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeMessage, r.Properties.Message)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeHierarchy, r.Properties.Hierarchy)
+
+	// PIM fields
+	unmarshaler.AttrPutStrPtrIf(attrs, attributeAzurePIMSubscriptionID, r.Properties.SubscriptionID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMResourceGroupName, r.Properties.ResourceGroupName)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMResourceProviderName, r.Properties.ResourceProviderName)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMResourceType, r.Properties.ResourceType)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMTenantID, r.Properties.TenantID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMEventName, r.Properties.EventName)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMEventID, r.Properties.EventID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleAssignmentRequestID, r.Properties.RoleAssignmentRequestID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleDefinition, r.Properties.RoleDefinition)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleDefinitionOriginID, r.Properties.RoleDefinitionOriginID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMJustification, r.Properties.Justification)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMSubjectID, r.Properties.SubjectID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMSubjectName, r.Properties.SubjectName)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMActionType, r.Properties.ActionType)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMOriginRoleAssignmentID, r.Properties.OriginRoleAssignmentID)
+
+	// CallerInfo is a JSON-encoded array of identity entries
+	if r.Properties.CallerInfo != "" {
+		var callers []pimCallerIdentity
+		if err := gojson.Unmarshal([]byte(r.Properties.CallerInfo), &callers); err == nil && len(callers) > 0 {
+			callerSlice := attrs.PutEmptySlice(attributeAzurePIMCallerInfo)
+			for _, c := range callers {
+				m := callerSlice.AppendEmpty().SetEmptyMap()
+				m.PutStr("identity_type", c.IdentityType)
+				m.PutStr("identity_value", c.IdentityValue)
+			}
+		}
+	}
 
 	return nil
 }

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -167,6 +167,9 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeHierarchy, r.Properties.Hierarchy)
 
 	// PIM fields
+	// SubscriptionID is also set as a resource attribute (cloud.account.id) by unmarshaler.go from
+	// the resource ID; setting it here at the log record level mirrors that for PIM events where the
+	// subscription appears in properties but not in the resource ID path (e.g. resource-scoped events).
 	unmarshaler.AttrPutStrPtrIf(attrs, string(conventions.CloudAccountIDKey), r.Properties.SubscriptionID)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureResourceGroupName, r.Properties.ResourceGroupName)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureResourceProviderName, r.Properties.ResourceProviderName)
@@ -189,7 +192,7 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 	// Microsoft are captured automatically.
 	if r.Properties.CallerInfo != "" {
 		var callers []pimCallerIdentity
-		if err := gojson.Unmarshal([]byte(r.Properties.CallerInfo), &callers); err == nil {
+		if err := gojson.Unmarshal([]byte(r.Properties.CallerInfo), &callers); err == nil && len(callers) > 0 {
 			for _, c := range callers {
 				if c.IdentityType == "" {
 					continue

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -93,28 +93,31 @@ const (
 	attributeAzureAdministrativeHierarchy = "azure.administrative.hierarchy"
 )
 
+// Generic Azure attributes carried by PIM events but not PIM-specific.
+// Defined here for now; can be promoted to a shared location if other categories adopt them.
+const (
+	attributeAzureResourceGroupName    = "azure.resource.group.name"
+	attributeAzureResourceProviderName = "azure.resource.provider.name"
+	attributeAzureResourceType         = "azure.resource.type"
+)
+
 // Non-SemConv attributes for PIM (Privileged Identity Management) events,
 // which arrive as Administrative category Activity Logs with ResourceProviderName=azurerbac.
 // Microsoft does not publish a formal schema for the properties payload; these fields
 // are derived from real PIM event samples.
 // See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47566
 const (
-	attributeAzurePIMSubscriptionID          = "azure.pim.subscription_id"
-	attributeAzurePIMResourceGroupName       = "azure.pim.resource.group_name"
-	attributeAzurePIMResourceProviderName    = "azure.pim.resource.provider_name"
-	attributeAzurePIMResourceType            = "azure.pim.resource.type"
-	attributeAzurePIMTenantID                = "azure.pim.tenant_id"
 	attributeAzurePIMEventName               = "azure.pim.event.name"
 	attributeAzurePIMEventID                 = "azure.pim.event.id"
-	attributeAzurePIMRoleAssignmentRequestID = "azure.pim.role.assignment.request_id"
-	attributeAzurePIMRoleDefinition          = "azure.pim.role.definition"
-	attributeAzurePIMRoleDefinitionOriginID  = "azure.pim.role.definition.origin_id"
+	attributeAzurePIMRoleAssignmentRequestID = "azure.pim.role.assignment.request.id"
+	attributeAzurePIMRoleDefinitionName      = "azure.pim.role.definition.name"
+	attributeAzurePIMRoleDefinitionOriginID  = "azure.pim.role.definition.origin.id"
 	attributeAzurePIMCallerInfo              = "azure.pim.caller"
 	attributeAzurePIMJustification           = "azure.pim.justification"
 	attributeAzurePIMSubjectID               = "azure.pim.subject.id"
 	attributeAzurePIMSubjectName             = "azure.pim.subject.name"
 	attributeAzurePIMActionType              = "azure.pim.action.type"
-	attributeAzurePIMOriginRoleAssignmentID  = "azure.pim.role.assignment.origin_id"
+	attributeAzurePIMRoleAssignmentOriginID  = "azure.pim.role.assignment.origin.id"
 )
 
 // pimCallerIdentity represents one entry in the CallerInfo JSON array
@@ -164,21 +167,21 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeHierarchy, r.Properties.Hierarchy)
 
 	// PIM fields
-	unmarshaler.AttrPutStrPtrIf(attrs, attributeAzurePIMSubscriptionID, r.Properties.SubscriptionID)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMResourceGroupName, r.Properties.ResourceGroupName)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMResourceProviderName, r.Properties.ResourceProviderName)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMResourceType, r.Properties.ResourceType)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMTenantID, r.Properties.TenantID)
+	unmarshaler.AttrPutStrPtrIf(attrs, string(conventions.CloudAccountIDKey), r.Properties.SubscriptionID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzureResourceGroupName, r.Properties.ResourceGroupName)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzureResourceProviderName, r.Properties.ResourceProviderName)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzureResourceType, r.Properties.ResourceType)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzureTenantID, r.Properties.TenantID)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMEventName, r.Properties.EventName)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMEventID, r.Properties.EventID)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleAssignmentRequestID, r.Properties.RoleAssignmentRequestID)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleDefinition, r.Properties.RoleDefinition)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleDefinitionName, r.Properties.RoleDefinition)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleDefinitionOriginID, r.Properties.RoleDefinitionOriginID)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMJustification, r.Properties.Justification)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMSubjectID, r.Properties.SubjectID)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMSubjectName, r.Properties.SubjectName)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMActionType, r.Properties.ActionType)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMOriginRoleAssignmentID, r.Properties.OriginRoleAssignmentID)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleAssignmentOriginID, r.Properties.OriginRoleAssignmentID)
 
 	// CallerInfo is a JSON-encoded array of identity entries
 	if r.Properties.CallerInfo != "" {

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -112,7 +112,7 @@ const (
 	attributeAzurePIMRoleAssignmentRequestID = "azure.pim.role.assignment.request.id"
 	attributeAzurePIMRoleDefinitionName      = "azure.pim.role.definition.name"
 	attributeAzurePIMRoleDefinitionOriginID  = "azure.pim.role.definition.origin.id"
-	attributeAzurePIMCallerInfo              = "azure.pim.caller"
+	attributeAzurePIMCallerPrefix            = "azure.pim.caller."
 	attributeAzurePIMJustification           = "azure.pim.justification"
 	attributeAzurePIMSubjectID               = "azure.pim.subject.id"
 	attributeAzurePIMSubjectName             = "azure.pim.subject.name"
@@ -183,20 +183,46 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMActionType, r.Properties.ActionType)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMRoleAssignmentOriginID, r.Properties.OriginRoleAssignmentID)
 
-	// CallerInfo is a JSON-encoded array of identity entries
+	// CallerInfo is a JSON-encoded array of identity facets describing the same caller
+	// (UPN, ObjectID, Username, Name, ObjectClass, ...). Project each entry to a flat
+	// attribute keyed by the lowercased snake_case identity type so new types added by
+	// Microsoft are captured automatically.
 	if r.Properties.CallerInfo != "" {
 		var callers []pimCallerIdentity
-		if err := gojson.Unmarshal([]byte(r.Properties.CallerInfo), &callers); err == nil && len(callers) > 0 {
-			callerSlice := attrs.PutEmptySlice(attributeAzurePIMCallerInfo)
+		if err := gojson.Unmarshal([]byte(r.Properties.CallerInfo), &callers); err == nil {
 			for _, c := range callers {
-				m := callerSlice.AppendEmpty().SetEmptyMap()
-				m.PutStr("identity_type", c.IdentityType)
-				m.PutStr("identity_value", c.IdentityValue)
+				if c.IdentityType == "" {
+					continue
+				}
+				unmarshaler.AttrPutStrIf(attrs, attributeAzurePIMCallerPrefix+pimCallerKey(c.IdentityType), c.IdentityValue)
 			}
 		}
 	}
 
 	return nil
+}
+
+// pimCallerKey converts a CallerIdentityType (PascalCase, e.g. "ObjectID", "UPN",
+// "Username") into a lowercase snake_case suffix appended to azure.pim.caller.
+// Examples: "UPN" -> "upn", "ObjectID" -> "object_id", "ObjectClass" -> "object_class",
+// "Username" -> "username", "Name" -> "name".
+func pimCallerKey(identityType string) string {
+	var b strings.Builder
+	b.Grow(len(identityType) + 4)
+	runes := []rune(identityType)
+	for i, r := range runes {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			prev := runes[i-1]
+			isPrevLowerOrDigit := (prev >= 'a' && prev <= 'z') || (prev >= '0' && prev <= '9')
+			isPrevUpper := prev >= 'A' && prev <= 'Z'
+			isNextLower := i+1 < len(runes) && runes[i+1] >= 'a' && runes[i+1] <= 'z'
+			if isPrevLowerOrDigit || (isPrevUpper && isNextLower) {
+				b.WriteByte('_')
+			}
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(b.String())
 }
 
 // ------------------------------------------------------------

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs_test.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs_test.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPimCallerKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Known CallerIdentityType values from real PIM events
+		{input: "UPN", want: "upn"},
+		{input: "ObjectID", want: "object_id"},
+		{input: "Username", want: "username"},
+		{input: "Name", want: "name"},
+		{input: "ObjectClass", want: "object_class"},
+		// Other plausible Microsoft identity types
+		{input: "ID", want: "id"},
+		{input: "DisplayName", want: "display_name"},
+		{input: "SomeHTTPField", want: "some_http_field"},
+		{input: "ServicePrincipalID", want: "service_principal_id"},
+		// Edge cases
+		{input: "", want: ""},
+		{input: "A", want: "a"},
+		{input: "alreadylower", want: "alreadylower"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, pimCallerKey(tt.input))
+		})
+	}
+}

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log.json
@@ -1,0 +1,84 @@
+{
+    "records": [
+        {
+            "location": "global",
+            "resultType": "Succeeded",
+            "time": "2026-04-10T21:43:40.2657554Z",
+            "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000001/RESOURCEGROUPS/myresourcegroupname/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/mykeyvaultname",
+            "correlationId": "00000000-0000-0000-0000-000000000002",
+            "operationName": "Remove member from role (PIM activation expired)",
+            "category": "Administrative",
+            "properties": {
+                "SubscriptionID": null,
+                "ResourceGroupName": "mykeyvaultname",
+                "ResourceProviderName": "azurerbac",
+                "ResourceType": "Microsoft.KeyVault/vaults",
+                "TenantID": "00000000-0000-0000-0000-000000000003",
+                "EventName": "RemoveActivatedRole",
+                "EventID": "00000000-0000-0000-0000-000000000004",
+                "ActionType": "Revoke",
+                "OriginRoleAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/myresourcegroupname/providers/Microsoft.KeyVault/vaults/mykeyvaultname/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000005",
+                "RoleAssignmentRequestId": "00000000-0000-0000-0000-000000000006",
+                "RoleDefinition": "Key Vault Crypto Officer",
+                "RoleDefinitionOriginId": "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000007",
+                "CallerInfo": "[{\"CallerIdentityType\":\"UPN\",\"CallerIdentityValue\":\"\"},{\"CallerIdentityType\":\"ObjectID\",\"CallerIdentityValue\":\"00000000-0000-0000-0000-000000000008\"},{\"CallerIdentityType\":\"Username\",\"CallerIdentityValue\":\"AzureADPIM\"},{\"CallerIdentityType\":\"Name\",\"CallerIdentityValue\":\"AzureADPIM\"},{\"CallerIdentityType\":\"ObjectClass\",\"CallerIdentityValue\":\"User\"}]",
+                "SubjectID": "00000000-0000-0000-0000-000000000009",
+                "SubjectName": "User LastName"
+            }
+        },
+        {
+            "location": "global",
+            "resultType": "Succeeded",
+            "time": "2026-04-11T21:23:28.7182817Z",
+            "callerIpAddress": "203.0.113.10",
+            "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000001",
+            "correlationId": "00000000-0000-0000-0000-000000000010",
+            "operationName": "Add member to role requested (PIM activation)",
+            "category": "Administrative",
+            "properties": {
+                "SubscriptionID": "00000000-0000-0000-0000-000000000001",
+                "ResourceGroupName": "MyAzureSubscriptionName",
+                "ResourceProviderName": "azurerbac",
+                "ResourceType": "subscription",
+                "TenantID": "00000000-0000-0000-0000-000000000003",
+                "EventName": "CreateRequestRoleActivation",
+                "EventID": "00000000-0000-0000-0000-000000000011",
+                "RoleAssignmentRequestId": "00000000-0000-0000-0000-000000000012",
+                "RoleDefinition": "Storage Blob Data Contributor",
+                "RoleDefinitionOriginId": "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000013",
+                "CallerInfo": "[{\"CallerIdentityType\":\"UPN\",\"CallerIdentityValue\":\"user@example.com\"},{\"CallerIdentityType\":\"ObjectID\",\"CallerIdentityValue\":\"00000000-0000-0000-0000-000000000008\"},{\"CallerIdentityType\":\"Username\",\"CallerIdentityValue\":\"User LastName\"},{\"CallerIdentityType\":\"Name\",\"CallerIdentityValue\":\"User LastName\"},{\"CallerIdentityType\":\"ObjectClass\",\"CallerIdentityValue\":\"User\"}]",
+                "Justification": "I need access to complete my task.",
+                "SubjectID": "00000000-0000-0000-0000-000000000009",
+                "SubjectName": "User LastName"
+            }
+        },
+        {
+            "location": "global",
+            "resultType": "Succeeded",
+            "time": "2026-04-11T21:23:30.4212011Z",
+            "callerIpAddress": "203.0.113.10",
+            "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000001",
+            "correlationId": "00000000-0000-0000-0000-000000000010",
+            "operationName": "Add member to role completed (PIM activation)",
+            "category": "Administrative",
+            "properties": {
+                "SubscriptionID": "00000000-0000-0000-0000-000000000001",
+                "ResourceGroupName": "MyAzureSubscriptionName",
+                "ResourceProviderName": "azurerbac",
+                "ResourceType": "subscription",
+                "TenantID": "00000000-0000-0000-0000-000000000003",
+                "EventName": "ActivateRole",
+                "EventID": "00000000-0000-0000-0000-000000000014",
+                "ActionType": "Grant",
+                "OriginRoleAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000015",
+                "RoleAssignmentRequestId": "00000000-0000-0000-0000-000000000012",
+                "RoleDefinition": "Storage Blob Data Contributor",
+                "RoleDefinitionOriginId": "/subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000013",
+                "CallerInfo": "[{\"CallerIdentityType\":\"UPN\",\"CallerIdentityValue\":\"user@example.com\"},{\"CallerIdentityType\":\"ObjectID\",\"CallerIdentityValue\":\"00000000-0000-0000-0000-000000000008\"},{\"CallerIdentityType\":\"Username\",\"CallerIdentityValue\":\"User LastName\"},{\"CallerIdentityType\":\"Name\",\"CallerIdentityValue\":\"User LastName\"},{\"CallerIdentityType\":\"ObjectClass\",\"CallerIdentityValue\":\"User\"}]",
+                "Justification": "I need access to complete my task.",
+                "SubjectID": "00000000-0000-0000-0000-000000000009",
+                "SubjectName": "User LastName"
+            }
+        }
+    ]
+}

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log_expected.yaml
@@ -28,16 +28,16 @@ resourceLogs:
               - key: azure.correlation_id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000002
-              - key: azure.pim.resource.group_name
+              - key: azure.resource.group.name
                 value:
                   stringValue: mykeyvaultname
-              - key: azure.pim.resource.provider_name
+              - key: azure.resource.provider.name
                 value:
                   stringValue: azurerbac
-              - key: azure.pim.resource.type
+              - key: azure.resource.type
                 value:
                   stringValue: Microsoft.KeyVault/vaults
-              - key: azure.pim.tenant_id
+              - key: azure.tenant.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000003
               - key: azure.pim.event.name
@@ -46,13 +46,13 @@ resourceLogs:
               - key: azure.pim.event.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000004
-              - key: azure.pim.role.assignment.request_id
+              - key: azure.pim.role.assignment.request.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000006
-              - key: azure.pim.role.definition
+              - key: azure.pim.role.definition.name
                 value:
                   stringValue: Key Vault Crypto Officer
-              - key: azure.pim.role.definition.origin_id
+              - key: azure.pim.role.definition.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000007
               - key: azure.pim.subject.id
@@ -64,7 +64,7 @@ resourceLogs:
               - key: azure.pim.action.type
                 value:
                   stringValue: Revoke
-              - key: azure.pim.role.assignment.origin_id
+              - key: azure.pim.role.assignment.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/myresourcegroupname/providers/Microsoft.KeyVault/vaults/mykeyvaultname/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000005
               - key: azure.pim.caller
@@ -152,19 +152,19 @@ resourceLogs:
               - key: azure.correlation_id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000010
-              - key: azure.pim.subscription_id
+              - key: cloud.account.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000001
-              - key: azure.pim.resource.group_name
+              - key: azure.resource.group.name
                 value:
                   stringValue: MyAzureSubscriptionName
-              - key: azure.pim.resource.provider_name
+              - key: azure.resource.provider.name
                 value:
                   stringValue: azurerbac
-              - key: azure.pim.resource.type
+              - key: azure.resource.type
                 value:
                   stringValue: subscription
-              - key: azure.pim.tenant_id
+              - key: azure.tenant.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000003
               - key: azure.pim.event.name
@@ -173,13 +173,13 @@ resourceLogs:
               - key: azure.pim.event.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000011
-              - key: azure.pim.role.assignment.request_id
+              - key: azure.pim.role.assignment.request.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000012
-              - key: azure.pim.role.definition
+              - key: azure.pim.role.definition.name
                 value:
                   stringValue: Storage Blob Data Contributor
-              - key: azure.pim.role.definition.origin_id
+              - key: azure.pim.role.definition.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000013
               - key: azure.pim.justification
@@ -253,19 +253,19 @@ resourceLogs:
               - key: azure.correlation_id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000010
-              - key: azure.pim.subscription_id
+              - key: cloud.account.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000001
-              - key: azure.pim.resource.group_name
+              - key: azure.resource.group.name
                 value:
                   stringValue: MyAzureSubscriptionName
-              - key: azure.pim.resource.provider_name
+              - key: azure.resource.provider.name
                 value:
                   stringValue: azurerbac
-              - key: azure.pim.resource.type
+              - key: azure.resource.type
                 value:
                   stringValue: subscription
-              - key: azure.pim.tenant_id
+              - key: azure.tenant.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000003
               - key: azure.pim.event.name
@@ -274,13 +274,13 @@ resourceLogs:
               - key: azure.pim.event.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000014
-              - key: azure.pim.role.assignment.request_id
+              - key: azure.pim.role.assignment.request.id
                 value:
                   stringValue: 00000000-0000-0000-0000-000000000012
-              - key: azure.pim.role.definition
+              - key: azure.pim.role.definition.name
                 value:
                   stringValue: Storage Blob Data Contributor
-              - key: azure.pim.role.definition.origin_id
+              - key: azure.pim.role.definition.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000013
               - key: azure.pim.justification
@@ -295,7 +295,7 @@ resourceLogs:
               - key: azure.pim.action.type
                 value:
                   stringValue: Grant
-              - key: azure.pim.role.assignment.origin_id
+              - key: azure.pim.role.assignment.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000015
               - key: azure.pim.caller

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log_expected.yaml
@@ -67,50 +67,18 @@ resourceLogs:
               - key: azure.pim.role.assignment.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/myresourcegroupname/providers/Microsoft.KeyVault/vaults/mykeyvaultname/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000005
-              - key: azure.pim.caller
+              - key: azure.pim.caller.object_id
                 value:
-                  arrayValue:
-                    values:
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: UPN
-                            - key: identity_value
-                              value:
-                                stringValue: ""
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: ObjectID
-                            - key: identity_value
-                              value:
-                                stringValue: 00000000-0000-0000-0000-000000000008
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: Username
-                            - key: identity_value
-                              value:
-                                stringValue: AzureADPIM
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: Name
-                            - key: identity_value
-                              value:
-                                stringValue: AzureADPIM
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: ObjectClass
-                            - key: identity_value
-                              value:
-                                stringValue: User
+                  stringValue: 00000000-0000-0000-0000-000000000008
+              - key: azure.pim.caller.username
+                value:
+                  stringValue: AzureADPIM
+              - key: azure.pim.caller.name
+                value:
+                  stringValue: AzureADPIM
+              - key: azure.pim.caller.object_class
+                value:
+                  stringValue: User
             body: {}
             timeUnixNano: "1775857420265755400"
         scope:
@@ -191,50 +159,21 @@ resourceLogs:
               - key: azure.pim.subject.name
                 value:
                   stringValue: User LastName
-              - key: azure.pim.caller
+              - key: azure.pim.caller.upn
                 value:
-                  arrayValue:
-                    values:
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: UPN
-                            - key: identity_value
-                              value:
-                                stringValue: user@example.com
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: ObjectID
-                            - key: identity_value
-                              value:
-                                stringValue: 00000000-0000-0000-0000-000000000008
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: Username
-                            - key: identity_value
-                              value:
-                                stringValue: User LastName
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: Name
-                            - key: identity_value
-                              value:
-                                stringValue: User LastName
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: ObjectClass
-                            - key: identity_value
-                              value:
-                                stringValue: User
+                  stringValue: user@example.com
+              - key: azure.pim.caller.object_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000008
+              - key: azure.pim.caller.username
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.caller.name
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.caller.object_class
+                value:
+                  stringValue: User
             body: {}
             timeUnixNano: "1775942608718281700"
           - attributes:
@@ -298,50 +237,21 @@ resourceLogs:
               - key: azure.pim.role.assignment.origin.id
                 value:
                   stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000015
-              - key: azure.pim.caller
+              - key: azure.pim.caller.upn
                 value:
-                  arrayValue:
-                    values:
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: UPN
-                            - key: identity_value
-                              value:
-                                stringValue: user@example.com
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: ObjectID
-                            - key: identity_value
-                              value:
-                                stringValue: 00000000-0000-0000-0000-000000000008
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: Username
-                            - key: identity_value
-                              value:
-                                stringValue: User LastName
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: Name
-                            - key: identity_value
-                              value:
-                                stringValue: User LastName
-                      - kvlistValue:
-                          values:
-                            - key: identity_type
-                              value:
-                                stringValue: ObjectClass
-                            - key: identity_value
-                              value:
-                                stringValue: User
+                  stringValue: user@example.com
+              - key: azure.pim.caller.object_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000008
+              - key: azure.pim.caller.username
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.caller.name
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.caller.object_class
+                value:
+                  stringValue: User
             body: {}
             timeUnixNano: "1775942610421201100"
         scope:

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/pim-log_expected.yaml
@@ -1,0 +1,353 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: azure
+        - key: cloudevents.event_source
+          value:
+            stringValue: azure.resource.log
+        - key: cloud.resource_id
+          value:
+            stringValue: /SUBSCRIPTIONS/00000000-0000-0000-0000-000000000001/RESOURCEGROUPS/myresourcegroupname/PROVIDERS/MICROSOFT.KEYVAULT/VAULTS/mykeyvaultname
+        - key: cloud.region
+          value:
+            stringValue: global
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: azure.category
+                value:
+                  stringValue: Administrative
+              - key: azure.operation.name
+                value:
+                  stringValue: Remove member from role (PIM activation expired)
+              - key: azure.result.type
+                value:
+                  stringValue: Succeeded
+              - key: azure.correlation_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000002
+              - key: azure.pim.resource.group_name
+                value:
+                  stringValue: mykeyvaultname
+              - key: azure.pim.resource.provider_name
+                value:
+                  stringValue: azurerbac
+              - key: azure.pim.resource.type
+                value:
+                  stringValue: Microsoft.KeyVault/vaults
+              - key: azure.pim.tenant_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000003
+              - key: azure.pim.event.name
+                value:
+                  stringValue: RemoveActivatedRole
+              - key: azure.pim.event.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000004
+              - key: azure.pim.role.assignment.request_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000006
+              - key: azure.pim.role.definition
+                value:
+                  stringValue: Key Vault Crypto Officer
+              - key: azure.pim.role.definition.origin_id
+                value:
+                  stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000007
+              - key: azure.pim.subject.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000009
+              - key: azure.pim.subject.name
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.action.type
+                value:
+                  stringValue: Revoke
+              - key: azure.pim.role.assignment.origin_id
+                value:
+                  stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/myresourcegroupname/providers/Microsoft.KeyVault/vaults/mykeyvaultname/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000005
+              - key: azure.pim.caller
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: UPN
+                            - key: identity_value
+                              value:
+                                stringValue: ""
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: ObjectID
+                            - key: identity_value
+                              value:
+                                stringValue: 00000000-0000-0000-0000-000000000008
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: Username
+                            - key: identity_value
+                              value:
+                                stringValue: AzureADPIM
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: Name
+                            - key: identity_value
+                              value:
+                                stringValue: AzureADPIM
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: ObjectClass
+                            - key: identity_value
+                              value:
+                                stringValue: User
+            body: {}
+            timeUnixNano: "1775857420265755400"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.activity
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
+          version: test-version
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: azure
+        - key: cloudevents.event_source
+          value:
+            stringValue: azure.resource.log
+        - key: cloud.resource_id
+          value:
+            stringValue: /SUBSCRIPTIONS/00000000-0000-0000-0000-000000000001
+        - key: cloud.region
+          value:
+            stringValue: global
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: azure.category
+                value:
+                  stringValue: Administrative
+              - key: azure.operation.name
+                value:
+                  stringValue: Add member to role requested (PIM activation)
+              - key: azure.result.type
+                value:
+                  stringValue: Succeeded
+              - key: network.peer.address
+                value:
+                  stringValue: 203.0.113.10
+              - key: azure.correlation_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000010
+              - key: azure.pim.subscription_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000001
+              - key: azure.pim.resource.group_name
+                value:
+                  stringValue: MyAzureSubscriptionName
+              - key: azure.pim.resource.provider_name
+                value:
+                  stringValue: azurerbac
+              - key: azure.pim.resource.type
+                value:
+                  stringValue: subscription
+              - key: azure.pim.tenant_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000003
+              - key: azure.pim.event.name
+                value:
+                  stringValue: CreateRequestRoleActivation
+              - key: azure.pim.event.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000011
+              - key: azure.pim.role.assignment.request_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000012
+              - key: azure.pim.role.definition
+                value:
+                  stringValue: Storage Blob Data Contributor
+              - key: azure.pim.role.definition.origin_id
+                value:
+                  stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000013
+              - key: azure.pim.justification
+                value:
+                  stringValue: I need access to complete my task.
+              - key: azure.pim.subject.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000009
+              - key: azure.pim.subject.name
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.caller
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: UPN
+                            - key: identity_value
+                              value:
+                                stringValue: user@example.com
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: ObjectID
+                            - key: identity_value
+                              value:
+                                stringValue: 00000000-0000-0000-0000-000000000008
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: Username
+                            - key: identity_value
+                              value:
+                                stringValue: User LastName
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: Name
+                            - key: identity_value
+                              value:
+                                stringValue: User LastName
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: ObjectClass
+                            - key: identity_value
+                              value:
+                                stringValue: User
+            body: {}
+            timeUnixNano: "1775942608718281700"
+          - attributes:
+              - key: azure.category
+                value:
+                  stringValue: Administrative
+              - key: azure.operation.name
+                value:
+                  stringValue: Add member to role completed (PIM activation)
+              - key: azure.result.type
+                value:
+                  stringValue: Succeeded
+              - key: network.peer.address
+                value:
+                  stringValue: 203.0.113.10
+              - key: azure.correlation_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000010
+              - key: azure.pim.subscription_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000001
+              - key: azure.pim.resource.group_name
+                value:
+                  stringValue: MyAzureSubscriptionName
+              - key: azure.pim.resource.provider_name
+                value:
+                  stringValue: azurerbac
+              - key: azure.pim.resource.type
+                value:
+                  stringValue: subscription
+              - key: azure.pim.tenant_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000003
+              - key: azure.pim.event.name
+                value:
+                  stringValue: ActivateRole
+              - key: azure.pim.event.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000014
+              - key: azure.pim.role.assignment.request_id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000012
+              - key: azure.pim.role.definition
+                value:
+                  stringValue: Storage Blob Data Contributor
+              - key: azure.pim.role.definition.origin_id
+                value:
+                  stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000013
+              - key: azure.pim.justification
+                value:
+                  stringValue: I need access to complete my task.
+              - key: azure.pim.subject.id
+                value:
+                  stringValue: 00000000-0000-0000-0000-000000000009
+              - key: azure.pim.subject.name
+                value:
+                  stringValue: User LastName
+              - key: azure.pim.action.type
+                value:
+                  stringValue: Grant
+              - key: azure.pim.role.assignment.origin_id
+                value:
+                  stringValue: /subscriptions/00000000-0000-0000-0000-000000000001/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000015
+              - key: azure.pim.caller
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: UPN
+                            - key: identity_value
+                              value:
+                                stringValue: user@example.com
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: ObjectID
+                            - key: identity_value
+                              value:
+                                stringValue: 00000000-0000-0000-0000-000000000008
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: Username
+                            - key: identity_value
+                              value:
+                                stringValue: User LastName
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: Name
+                            - key: identity_value
+                              value:
+                                stringValue: User LastName
+                      - kvlistValue:
+                          values:
+                            - key: identity_type
+                              value:
+                                stringValue: ObjectClass
+                            - key: identity_value
+                              value:
+                                stringValue: User
+            body: {}
+            timeUnixNano: "1775942610421201100"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: azure.activity
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
+          version: test-version


### PR DESCRIPTION
Fixes #47566.

## Problem

Azure PIM (Privileged Identity Management) events arrive as `category: Administrative` Activity Logs with `ResourceProviderName: azurerbac`. The `azureAdministrativeLog` struct only mapped three `properties` fields (`entity`, `message`, `hierarchy`), which match standard Administrative audit events. PIM events carry a completely different payload — all PIM-specific fields were silently dropped with no error or warning.

Before this change, a PIM role activation produced only:
```
azure.category, azure.correlation_id, azure.operation.name, azure.result.type, network.peer.address
```

## Solution

Expand `azureAdministrativeLog.Properties` to cover known PIM fields. Fields that describe generic Azure concepts (subscription, tenant, resource group/type/provider) are mapped to existing SemConv or generic `azure.*` attributes; PIM-specific fields use the `azure.pim.*` namespace. The `CallerInfo` field (a JSON-encoded array of identity entries) is projected to flat per-identity attributes keyed by the lowercased snake_case identity type (e.g. `azure.pim.caller.upn`, `azure.pim.caller.object_id`), consistent with how `azure.policy.policies` and `azure.servicehealth.impact.services` are handled.

> **Note**: Microsoft does not publish a formal schema for the `properties` payload of PIM events. The field list is derived from real event samples provided in #47566.

## New attributes

| `properties` key | OTel attribute | Notes |
|---|---|---|
| `SubscriptionID` | `cloud.account.id` | Optional — `null` when scoped to a specific resource. SemConv; matches the resource-level mapping in `unmarshaler.go` |
| `ResourceGroupName` | `azure.resource.group.name` | |
| `ResourceProviderName` | `azure.resource.provider.name` | Always `azurerbac` for PIM events |
| `ResourceType` | `azure.resource.type` | |
| `TenantID` | `azure.tenant.id` | Reuses the existing `attributeAzureTenantID` constant from `unmarshaler.go` |
| `EventName` | `azure.pim.event.name` | e.g. `ActivateRole`, `CreateRequestRoleActivation`, `RemoveActivatedRole` |
| `EventID` | `azure.pim.event.id` | |
| `RoleAssignmentRequestId` | `azure.pim.role.assignment.request.id` | Links request and completion events |
| `RoleDefinition` | `azure.pim.role.definition.name` | Human-readable role name |
| `RoleDefinitionOriginId` | `azure.pim.role.definition.origin.id` | Full ARM resource ID of the role definition |
| `CallerInfo` (JSON array) | `azure.pim.caller.<identity_type>` | One attribute per entry; key is the lowercased snake_case `CallerIdentityType` (e.g. `azure.pim.caller.upn`, `azure.pim.caller.object_id`). Unknown future types from Microsoft are captured automatically. |
| `Justification` | `azure.pim.justification` | Absent on system-driven revocations |
| `SubjectID` | `azure.pim.subject.id` | |
| `SubjectName` | `azure.pim.subject.name` | |
| `ActionType` | `azure.pim.action.type` | `Grant` or `Revoke`; absent on request events |
| `OriginRoleAssignmentId` | `azure.pim.role.assignment.origin.id` | Absent on request events |

Latest revision addresses @thompson-tomo's review feedback: drops the `azure.pim.*` prefix from generic Azure concepts, applies OTel SemConv dot-separator convention throughout, and resolves the namespace collision where `azure.pim.role.definition` was both a leaf attribute and the parent of `…origin_id`.

## Backward compatibility

Standard Administrative events (`entity`, `message`, `hierarchy`) are unaffected. The new PIM fields are additive.

## Out of scope

The `azure.unmapped_attributes` fallback (option 2 from @axw's comment) is left for a separate PR to avoid scope creep.

## Testing

Golden file test covering three PIM event shapes:
- `Add member to role requested` — activation request with `Justification`, no `ActionType`
- `Add member to role completed` — grant with `ActionType=Grant` and `OriginRoleAssignmentId`
- `Remove member from role (expired)` — revocation with `ActionType=Revoke` and `null` `SubscriptionID`

Unit tests for `pimCallerKey` covering all known `CallerIdentityType` values (`UPN`, `ObjectID`, `Username`, `Name`, `ObjectClass`), additional plausible types, and edge cases.

README updated with a PIM attribute mapping table under the Administrative section.