### PR TITLE
[receiver/k8sclusterreceiver] fix intermittent e2e TestE2ENamespaceScoped failure due to ambiguous PVC resource matching

### DIFF
--- a/receiver/k8sclusterreceiver/e2e_test.go
+++ b/receiver/k8sclusterreceiver/e2e_test.go
@@ -129,7 +129,7 @@ func TestE2EClusterScoped(t *testing.T) {
 			pmetrictest.ChangeResourceAttributeValue("k8s.node.uid", replaceWithStar),
 			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolume.name", replaceWithStar),
 			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolume.uid", replaceWithStar),
-			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolumeclaim.name", replaceWithStar),
+			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolumeclaim.name", shortenNames),
 			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolumeclaim.uid", replaceWithStar),
 			pmetrictest.ChangeResourceAttributeValue("k8s.pod.name", shortenNames),
 			pmetrictest.ChangeResourceAttributeValue("k8s.pod.uid", replaceWithStar),
@@ -229,7 +229,7 @@ func TestE2ENamespaceScoped(t *testing.T) {
 			pmetrictest.ChangeResourceAttributeValue("k8s.job.uid", replaceWithStar),
 			pmetrictest.ChangeResourceAttributeValue("k8s.namespace.uid", replaceWithStar),
 			pmetrictest.ChangeResourceAttributeValue("k8s.node.uid", replaceWithStar),
-			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolumeclaim.name", replaceWithStar),
+			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolumeclaim.name", shortenNames),
 			pmetrictest.ChangeResourceAttributeValue("k8s.persistentvolumeclaim.uid", replaceWithStar),
 			pmetrictest.ChangeResourceAttributeValue("k8s.pod.name", shortenNames),
 			pmetrictest.ChangeResourceAttributeValue("k8s.pod.uid", replaceWithStar),
@@ -382,6 +382,9 @@ func shortenNames(value string) string {
 	}
 	if strings.HasPrefix(value, "test-k8scluster-receiver-job") {
 		return "test-k8scluster-receiver-job"
+	}
+	if strings.HasPrefix(value, "test-k8scluster-receiver-statefulset-pvc") {
+		return "test-k8scluster-receiver-statefulset-pvc"
 	}
 	return value
 }


### PR DESCRIPTION
## Description

Fixes an intermittent failure in `TestE2ENamespaceScoped` (and the same latent bug in `TestE2EClusterScoped`) caused by two PVC resources becoming indistinguishable after attribute transformation.

**Root cause:** Both test scenarios create two PVCs in the same namespace with the same storage class:
- A standalone PVC (`test-k8scluster-receiver-pvc`) in **Pending** phase → emits 2 metrics
- A StatefulSet PVC (`test-k8scluster-receiver-statefulset-pvc-...-0`) in **Bound** phase → emits 3 metrics

`replaceWithStar` was applied to `k8s.persistentvolumeclaim.name` and `k8s.persistentvolumeclaim.uid`, making both resource attribute maps identical. `CompareMetrics` matches resources by `reflect.DeepEqual` on attributes, and since Go map iteration is non-deterministic, the pairing was sometimes reversed — causing "number of metrics doesn't match expected: 3, actual: 2" (and vice versa).

**Fix:** Use `shortenNames` instead of `replaceWithStar` for `k8s.persistentvolumeclaim.name`, and add a prefix case for `test-k8scluster-receiver-statefulset-pvc` so the two PVCs retain distinct shortened names after transformation, making the resource matching deterministic.

## Testing

The fix prevents the ambiguous matching without requiring changes to expected YAML files, since `ChangeResourceAttributeValue` applies the transformation to both expected and actual sides equally.