### PR TITLE
[exporter/signalfx] Support deployment.environment.name for correlation

### DIFF
--- a/.chloggen/signalfxexporter-apm-deployment-environment-name.yaml
+++ b/.chloggen/signalfxexporter-apm-deployment-environment-name.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: APM correlation now recognizes `deployment.environment.name` in addition to the deprecated `deployment.environment` attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47862]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
@@ -136,11 +136,14 @@ func (a *ActiveServiceTracker) processEnvironment(res pcommon.Resource, now time
 	}
 
 	// Determine the environment value from the incoming spans.
-	// First check "deployment.environment" attribute.
+	// First check "deployment.environment.name" attribute (new OTel standard).
+	// Then check "deployment.environment" attribute (deprecated).
 	// Then, try "environment" attribute (SignalFx schema).
 	// Otherwise, use the same fallback value as set on the backend.
 	var environment string
-	if env, ok := attrs.Get("deployment.environment"); ok {
+	if env, ok := attrs.Get("deployment.environment.name"); ok {
+		environment = env.Str()
+	} else if env, ok = attrs.Get("deployment.environment"); ok {
 		environment = env.Str()
 	} else if env, ok = attrs.Get("environment"); ok {
 		environment = env.Str()

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
@@ -119,6 +119,56 @@ func (c *correlationTestClient) getCorrelations() []*correlations.Correlation {
 
 var _ correlations.CorrelationClient = &correlationTestClient{}
 
+func TestEnvironmentAttributePriority(t *testing.T) {
+	hostIDDims := map[string]string{"host": "test"}
+
+	tests := []struct {
+		name    string
+		attrs   map[string]string
+		wantEnv string
+	}{
+		{
+			name:    "deployment.environment.name takes precedence",
+			attrs:   map[string]string{"deployment.environment.name": "new-env", "deployment.environment": "old-env", "environment": "sfx-env"},
+			wantEnv: "new-env",
+		},
+		{
+			name:    "deployment.environment used when name absent",
+			attrs:   map[string]string{"deployment.environment": "old-env", "environment": "sfx-env"},
+			wantEnv: "old-env",
+		},
+		{
+			name:    "environment used when both deployment attrs absent",
+			attrs:   map[string]string{"environment": "sfx-env"},
+			wantEnv: "sfx-env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			correlationClient := &correlationTestClient{}
+			a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, DefaultDimsToSyncSource)
+
+			fakeTraces := ptrace.NewTraces()
+			newResourceWithAttrs(hostIDDims, tt.attrs).
+				CopyTo(fakeTraces.ResourceSpans().AppendEmpty().Resource())
+			a.ProcessTraces(t.Context(), fakeTraces)
+
+			cors := correlationClient.getCorrelations()
+			var envCors []*correlations.Correlation
+			for _, c := range cors {
+				if c.Type == correlations.Environment {
+					envCors = append(envCors, c)
+				}
+			}
+			assert.NotEmpty(t, envCors, "expected environment correlations")
+			for _, c := range envCors {
+				assert.Equal(t, tt.wantEnv, c.Value)
+			}
+		})
+	}
+}
+
 func TestCorrelationEmptyEnvironment(t *testing.T) {
 	var wg sync.WaitGroup
 	correlationClient := &correlationTestClient{


### PR DESCRIPTION
Tracing consumer in Signalfx exporter (APM correlation) needs to look for `deployment.environment.name` in addition to `deployment.environment` as `deployment.environment` is being deprecated.
