### PR TITLE
[exporter/azuremonitor] prefer host.name for CloudRoleInstance

### DIFF
--- a/.chloggen/47657-azuremonitor-prefer-host-name.yaml
+++ b/.chloggen/47657-azuremonitor-prefer-host-name.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: exporter/azuremonitor
+note: Prefer host.name over service.instance.id when populating CloudRoleInstance
+issues: [47657]
+subtext:
+change_logs: [user]

--- a/exporter/azuremonitorexporter/contracts_utils.go
+++ b/exporter/azuremonitorexporter/contracts_utils.go
@@ -36,7 +36,9 @@ func applyCloudTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes p
 		envelope.Tags[contracts.CloudRole] = cloudRole
 	}
 
-	if serviceInstance, exists := resourceAttributes.Get(string(conventions.ServiceInstanceIDKey)); exists {
+	if hostName, exists := resourceAttributes.Get(string(conventions.HostNameKey)); exists {
+		envelope.Tags[contracts.CloudRoleInstance] = hostName.Str()
+	} else if serviceInstance, exists := resourceAttributes.Get(string(conventions.ServiceInstanceIDKey)); exists {
 		envelope.Tags[contracts.CloudRoleInstance] = serviceInstance.Str()
 	}
 


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-collector-contrib#47657.

(Re-opened clean from #47837 which was polluted by a botched force-push on my end; see that PR's final comment.)

Azure Container Apps and other workload-identity environments populate `service.instance.id` with a random uuid that is useless in Application Insights' "role instance" views. `host.name` carries the revision / replica hostname operators actually recognise. Prefer `host.name` when present and fall back to `service.instance.id` so existing deployments that rely on it keep working.