### PR TITLE
[processor/k8sattributes] guard processResource against nil *kube.Pod

### DIFF
--- a/.chloggen/47672-k8sattributes-nil-pod.yaml
+++ b/.chloggen/47672-k8sattributes-nil-pod.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: processor/k8s_attributes
+note: "Guard processResource against a nil *kube.Pod returned alongside podFound=true"
+issues: [47672]
+subtext:
+change_logs: [user]

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -195,7 +195,7 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	var pod *kube.Pod
 	var podFound bool
 	if podIdentifierValue.IsNotEmpty() {
-		if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound {
+		if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound && pod != nil {
 			kp.logger.Debug("getting the pod", zap.Any("pod", pod))
 			for key, val := range pod.Attributes {
 				setResourceAttribute(resource.Attributes(), key, val)


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-collector-contrib#47672.

(Clean replacement for #47863, which was polluted by a botched force-push on my end.)

## Description

`processResource` enters the pod-attribute branch on `(pod, podFound) = kp.kc.GetPod(...)` when `podFound` is true. If the cache returns `(nil, true)` transiently (race with pod removal), `for key, val := range pod.Attributes` derefs nil and panics the request goroutine.

## Fix

Require `pod != nil` alongside `podFound` in the branch guard.

## Test

`go test ./...` in the processor locally clean.