### PR TITLE
[processor/resourcedetection] don't abort docker detector on container lookup failure

### DIFF
--- a/.chloggen/46275-resourcedetection-docker-soft-fail.yaml
+++ b/.chloggen/46275-resourcedetection-docker-soft-fail.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: processor/resourcedetection
+note: "Docker detector no longer discards host.name and os.type when the container lookup fails"
+issues: [46275]
+subtext:
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/internal/docker/docker.go
+++ b/processor/resourcedetectionprocessor/internal/docker/docker.go
@@ -57,13 +57,19 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		return pcommon.NewResource(), "", fmt.Errorf("failed getting OS hostname: %w", err)
 	}
 
-	info, err := d.provider.ContainerInfo(ctx)
-	if err != nil {
-		return pcommon.NewResource(), "", fmt.Errorf("failed getting container info: %w", err)
-	}
-
 	d.rb.SetHostName(hostname)
 	d.rb.SetOsType(osType)
+
+	info, err := d.provider.ContainerInfo(ctx)
+	if err != nil {
+		// Container lookup fails when the collector can't match its
+		// container by hostname (for example network_mode: host). Log
+		// at Debug and return the host.name / os.type we already have
+		// instead of discarding the whole detection.
+		d.logger.Debug("docker detector: failed getting container info; emitting host.name and os.type only", zap.Error(err))
+		return d.rb.Emit(), conventions.SchemaURL, nil
+	}
+
 	d.rb.SetContainerName(info.Name)
 	d.rb.SetContainerImageName(info.Image)
 


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-collector-contrib#46275.

(Clean replacement for #47838, which was polluted by a botched force-push on my end.)

## Description

When the collector runs with `network_mode: host` (or any mode where the Docker daemon can't match the collector's container by hostname), `ContainerInfo` returns an error and the detector discards `host.name` and `os.type` on the way out. Log at Debug and return the two attributes already populated instead.

## Test

`go test ./processor/resourcedetectionprocessor/...` locally clean.