### PR TITLE
fix(processor/schema): fix rate-limit reset and log prefetch errors

### DIFF
--- a/.chloggen/fix-schema-processor-ratelimit.yaml
+++ b/.chloggen/fix-schema-processor-ratelimit.yaml
@@ -7,10 +7,10 @@ change_type: bug_fix
 component: processor/schema
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix rate-limit reset in CacheableProvider allowing burst of calls after cooldown expires
+note: Fix rate-limit reset in CacheableProvider allowing burst of calls after cooldown expires, and log prefetch errors instead of silently discarding them
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [47428]
+issues: [47871]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-schema-processor-ratelimit.yaml
+++ b/.chloggen/fix-schema-processor-ratelimit.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/schema
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix rate-limit reset in CacheableProvider allowing burst of calls after cooldown expires
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47428]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/fix-schema-processor-ratelimit.yaml
+++ b/.chloggen/fix-schema-processor-ratelimit.yaml
@@ -10,7 +10,7 @@ component: processor/schema
 note: Fix rate-limit reset in CacheableProvider allowing burst of calls after cooldown expires, and log prefetch errors instead of silently discarding them
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [47871]
+issues: [47428]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/processor/schemaprocessor/internal/translation/cacheable_provider.go
+++ b/processor/schemaprocessor/internal/translation/cacheable_provider.go
@@ -63,9 +63,10 @@ func (p *CacheableProvider) Retrieve(ctx context.Context, key string) (string, e
 		return "", fmt.Errorf("rate limited, last error: %w", p.lastErr)
 	}
 
-	// Reset count if past cooldown period
+	// After the cooldown expires, allow one retry but keep the count so the
+	// next failure triggers a new cooldown immediately.
 	if p.callcount >= p.limit {
-		p.callcount = 0
+		p.callcount = p.limit - 1
 	}
 	p.callcount++
 

--- a/processor/schemaprocessor/internal/translation/cacheable_provider_test.go
+++ b/processor/schemaprocessor/internal/translation/cacheable_provider_test.go
@@ -29,6 +29,50 @@ func (p *firstErrorProvider) Retrieve(_ context.Context, key string) (string, er
 	return key, nil
 }
 
+// alwaysErrorProvider always returns an error and counts how many times Retrieve was called.
+type alwaysErrorProvider struct {
+	calls int
+}
+
+func (p *alwaysErrorProvider) Retrieve(_ context.Context, _ string) (string, error) {
+	p.calls++
+	return "", errors.New("always fails")
+}
+
+// TestCacheableProviderRateLimit verifies that after the call limit is reached and the
+// cooldown expires, the very next failed call triggers a new cooldown immediately rather
+// than allowing another burst of `limit` calls through.
+func TestCacheableProviderRateLimit(t *testing.T) {
+	provider := &alwaysErrorProvider{}
+	cp := NewCacheableProvider(provider, time.Hour, 3).(*CacheableProvider)
+
+	// Exhaust the limit: 3 calls should reach the provider.
+	for range 3 {
+		_, _ = cp.Retrieve(t.Context(), "key")
+	}
+	require.Equal(t, 3, provider.calls, "all 3 calls should reach the provider")
+
+	// Next call should be rate-limited (cooldown is 1 hour).
+	_, err := cp.Retrieve(t.Context(), "key")
+	require.ErrorContains(t, err, "rate limited")
+	require.Equal(t, 3, provider.calls, "rate-limited call should not reach provider")
+
+	// Simulate cooldown expiry.
+	cp.resetTime = time.Now().Add(-time.Second)
+
+	// After cooldown expires, one retry should be allowed.
+	_, err = cp.Retrieve(t.Context(), "key")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "rate limited", "first call after cooldown should reach provider")
+	require.Equal(t, 4, provider.calls, "one retry after cooldown")
+
+	// The next call should be rate-limited again immediately — not allowed another
+	// burst of `limit` calls.
+	_, err = cp.Retrieve(t.Context(), "key")
+	require.ErrorContains(t, err, "rate limited",
+		"second call after cooldown should be rate-limited, not allowed through")
+}
+
 func TestCacheableProvider(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/processor/schemaprocessor/processor.go
+++ b/processor/schemaprocessor/processor.go
@@ -186,7 +186,9 @@ func (t *schemaProcessor) start(ctx context.Context, host component.Host) error 
 	go func(ctx context.Context) {
 		for _, schemaURL := range t.config.Prefetch {
 			t.log.Info("prefetching schema", zap.String("url", schemaURL))
-			_, _ = t.manager.RequestTranslation(ctx, schemaURL)
+			if _, err := t.manager.RequestTranslation(ctx, schemaURL); err != nil {
+				t.log.Warn("failed to prefetch schema", zap.String("url", schemaURL), zap.Error(err))
+			}
 		}
 	}(ctx)
 


### PR DESCRIPTION
#### Description

Two fixes to `CacheableProvider` and schema prefetching:

**1. Fix rate-limit reset allowing burst of calls after cooldown**

After the cooldown period expired, `callcount` was reset to 0, allowing a full burst of `limit` calls to reach the failing provider before the next cooldown triggered. The fix changes the post-cooldown reset from `callcount = 0` to `callcount = limit - 1`, so one retry is allowed after each cooldown but the next failure immediately triggers a new cooldown. On success, `callcount` is still reset to 0.

**Before (limit=3):** cooldown → 3 calls → cooldown → 3 calls → ...
**After (limit=3):** cooldown → 1 call → cooldown → 1 call → ...

**2. Log prefetch errors instead of discarding them**

Prefetch errors were silently ignored (`_, _`), giving users no indication that schema prefetching failed. Now logs a warning with the URL and error.

#### Link to tracking issue

Part of #47428

#### Testing

Added `TestCacheableProviderRateLimit` which:
1. Exhausts the call limit with a perpetually failing provider
2. Verifies the next call is rate-limited
3. Simulates cooldown expiry
4. Verifies one retry is allowed
5. Verifies the following call is rate-limited immediately (this assertion failed with the old code)

All existing tests pass.

#### Documentation

No documentation changes required.