### PR TITLE
fix(processor/schema): skip MetricTypeEmpty instead of erroring

### DIFF
--- a/.chloggen/fix-schema-processor-empty-metric.yaml
+++ b/.chloggen/fix-schema-processor-empty-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/schema
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip uninitialised metrics (MetricTypeEmpty) instead of returning an unsupported metric type error
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47428]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/schemaprocessor/internal/transformer/attributes_operators.go
+++ b/processor/schemaprocessor/internal/transformer/attributes_operators.go
@@ -25,9 +25,10 @@ type MetricAttributes struct {
 func (MetricAttributes) IsMigrator() {}
 
 func (o MetricAttributes) Do(ss migrate.StateSelector, metric pmetric.Metric) error {
-	// todo(ankit) handle MetricTypeEmpty
 	var datam alias.Attributed
 	switch metric.Type() {
+	case pmetric.MetricTypeEmpty:
+		return nil
 	case pmetric.MetricTypeExponentialHistogram:
 		for dp := 0; dp < metric.ExponentialHistogram().DataPoints().Len(); dp++ {
 			datam = metric.ExponentialHistogram().DataPoints().At(dp)

--- a/processor/schemaprocessor/internal/transformer/attributes_test.go
+++ b/processor/schemaprocessor/internal/transformer/attributes_test.go
@@ -16,6 +16,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor/internal/migrate"
 )
 
+func TestMetricAttributesEmptyType(t *testing.T) {
+	transformer := MetricAttributes{
+		AttributeChange: migrate.NewAttributeChangeSet(map[string]string{
+			"old": "new",
+		}),
+	}
+	metric := pmetric.NewMetric() // MetricTypeEmpty by default
+	err := transformer.Do(migrate.StateSelectorApply, metric)
+	assert.NoError(t, err, "MetricTypeEmpty should be skipped, not error")
+}
+
 func TestAttributeTransformers(t *testing.T) {
 	attrChange := migrate.NewAttributeChangeSet(map[string]string{
 		"service_version": "service.version",

--- a/processor/schemaprocessor/internal/transformer/conditional_attributes.go
+++ b/processor/schemaprocessor/internal/transformer/conditional_attributes.go
@@ -22,9 +22,10 @@ type MetricDataPointAttributes struct {
 func (MetricDataPointAttributes) IsMigrator() {}
 
 func (o MetricDataPointAttributes) Do(ss migrate.StateSelector, metric pmetric.Metric) error {
-	// todo(ankit) handle MetricTypeEmpty
 	var datam alias.Attributed
 	switch metric.Type() {
+	case pmetric.MetricTypeEmpty:
+		return nil
 	case pmetric.MetricTypeExponentialHistogram:
 		for dp := 0; dp < metric.ExponentialHistogram().DataPoints().Len(); dp++ {
 			datam = metric.ExponentialHistogram().DataPoints().At(dp)

--- a/processor/schemaprocessor/internal/transformer/conditional_attributes_test.go
+++ b/processor/schemaprocessor/internal/transformer/conditional_attributes_test.go
@@ -22,6 +22,17 @@ func assertAttributeEquals(t *testing.T, attributes pcommon.Map, key, value stri
 	require.Equal(t, value, val.Str())
 }
 
+func TestMetricDataPointAttributesEmptyType(t *testing.T) {
+	transformer := MetricDataPointAttributes{
+		ConditionalAttributeChange: migrate.NewConditionalAttributeSet(map[string]string{
+			"old": "new",
+		}, "some_metric"),
+	}
+	metric := pmetric.NewMetric() // MetricTypeEmpty by default
+	err := transformer.Do(migrate.StateSelectorApply, metric)
+	require.NoError(t, err, "MetricTypeEmpty should be skipped, not error")
+}
+
 func TestMetricDataPointAttributesTransformer(t *testing.T) {
 	attrChange := migrate.NewConditionalAttributeSet(map[string]string{
 		"service_version": "service.version",


### PR DESCRIPTION
#### Description

The `MetricAttributes` and `MetricDataPointAttributes` transformers returned `"unsupported metric type"` for `MetricTypeEmpty` (the zero value of `pmetric.MetricType`). This caused uninitialised metrics to fail the entire scope during schema translation.

An empty metric has no data points to process, so skipping it is the correct behaviour. Both transformers already had `// todo(ankit) handle MetricTypeEmpty` comments acknowledging the gap.

#### Link to tracking issue

Part of #47428

#### Testing

- Added `TestMetricAttributesEmptyType` for `MetricAttributes`
- Added `TestMetricDataPointAttributesEmptyType` for `MetricDataPointAttributes`
- Both verify that `MetricTypeEmpty` returns `nil` instead of an error

All existing tests pass.

#### Documentation

No documentation changes required.