### PR TITLE
[pkg/ottl] Enhance ConvertTextToElementsXML function by limiting the maximum XML nesting depth

### DIFF
--- a/.chloggen/enhance_text_to_xml_conversion.yaml
+++ b/.chloggen/enhance_text_to_xml_conversion.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enhanced ConvertTextToElementsXML function by limiting the maximum XML nesting depth.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47873]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -782,6 +782,7 @@ The `ConvertTextToElementsXML` Converter returns an edited version of an XML str
 
 `target` is a Getter that returns a string. This string should be in XML format.
 If `target` is not a string, nil, or cannot be parsed as XML, `ConvertTextToElementsXML` will return an error.
+Conversion is bounded by a maximum XML nesting depth of 10,000 levels; deeper documents return an error.
 
 `xpath` (optional) is a string that specifies an [XPath](https://www.w3.org/TR/1999/REC-xpath-19991116/) expression that
 selects one or more elements. Content will only be converted within the result(s) of the xpath. The default is `/`.

--- a/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml.go
+++ b/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml.go
@@ -6,6 +6,7 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/antchfx/xmlquery"
 
@@ -54,22 +55,28 @@ func convertTextToElementsXML[K any](target ottl.StringGetter[K], xPath, element
 			return nil, err
 		}
 		for _, n := range xmlquery.Find(doc, xPath) {
-			convertTextToElementsForNode(n, elementName)
+			if err := convertTextToElementsForNode(n, elementName, 0); err != nil {
+				return nil, err
+			}
 		}
 		return doc.OutputXML(false), nil
 	}
 }
 
-func convertTextToElementsForNode(parent *xmlquery.Node, elementName string) {
+func convertTextToElementsForNode(parent *xmlquery.Node, elementName string, depth int) error {
+	if depth > maxXMLElementDepth {
+		return fmt.Errorf("exceeded maximum XML nesting depth of %d", maxXMLElementDepth)
+	}
+
 	switch parent.Type {
 	case xmlquery.ElementNode: // ok
 	case xmlquery.DocumentNode: // ok
 	default:
-		return
+		return nil
 	}
 
 	if parent.FirstChild == nil {
-		return
+		return nil
 	}
 
 	// Convert any child nodes and count text and element nodes.
@@ -77,7 +84,9 @@ func convertTextToElementsForNode(parent *xmlquery.Node, elementName string) {
 	for child := parent.FirstChild; child != nil; child = child.NextSibling {
 		switch child.Type {
 		case xmlquery.ElementNode:
-			convertTextToElementsForNode(child, elementName)
+			if err := convertTextToElementsForNode(child, elementName, depth+1); err != nil {
+				return err
+			}
 			elementCount++
 		case xmlquery.TextNode:
 			valueCount++
@@ -86,7 +95,7 @@ func convertTextToElementsForNode(parent *xmlquery.Node, elementName string) {
 
 	// If there are no values to wrap, or if there is exactly one value OR one element, this node is all set.
 	if valueCount == 0 || elementCount+valueCount <= 1 {
-		return
+		return nil
 	}
 
 	// At this point, we either have multiple values, or a mix of values and elements.
@@ -105,4 +114,6 @@ func convertTextToElementsForNode(parent *xmlquery.Node, elementName string) {
 		child.FirstChild = newTextNode
 		child.LastChild = newTextNode
 	}
+
+	return nil
 }

--- a/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml_test.go
@@ -5,6 +5,7 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,4 +126,21 @@ func TestCreateConvertTextToElementsXMLFunc(t *testing.T) {
 	assert.NotNil(t, exprFunc)
 	_, err = exprFunc(t.Context(), nil)
 	assert.Error(t, err)
+}
+
+func TestConvertTextToElementsXMLMaxDepth(t *testing.T) {
+	exprFunc := convertTextToElementsXML(
+		ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) {
+				const depth = maxXMLElementDepth + 2
+				return strings.Repeat("<a>", depth) + strings.Repeat("</a>", depth), nil
+			},
+		},
+		"/",
+		"value",
+	)
+
+	_, err := exprFunc(t.Context(), nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "exceeded maximum XML nesting depth")
 }


### PR DESCRIPTION
… 

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added a max depth limitation to `ConvertTextToElementsXML` function to avoid possible stack overflows.

#### Testing
Added unit tests
