### PR TITLE
intervalprocessor: align flush ticks to wall-clock boundaries

### DIFF
--- a/.chloggen/47875.yaml
+++ b/.chloggen/47875.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/interval
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an opt-in interval processor setting to align flush ticks to wall-clock interval boundaries at startup so replicas can remain in phase.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47875]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/intervalprocessor/README.md
+++ b/processor/intervalprocessor/README.md
@@ -17,7 +17,7 @@
 
 ## Description
 
-The interval processor (`intervalprocessor`) aggregates metrics and periodically forwards the latest values to the next component in the pipeline. The processor supports aggregating the following metric types:
+The interval processor (`intervalprocessor`) aggregates metrics and periodically forwards the latest values to the next component in the pipeline. It can optionally align export ticks to wall-clock interval boundaries (for example, `:00`, `:30` with `30s`) so replicas stay in phase after restarts. The processor supports aggregating the following metric types:
 
 * Monotonically increasing, cumulative sums
 * Monotonically increasing, cumulative histograms
@@ -38,9 +38,12 @@ The following settings can be optionally configured:
 
 ```yaml
 interval:
-  # The interval in which the processor should export the aggregated metrics. 
+  # The interval in which the processor should export the aggregated metrics.
   [ interval: <duration> | default = 60s ]
-  
+
+  # Whether to align export ticks to wall-clock interval boundaries.
+  [ align_to_wall_clock: <bool> | default = false ]
+
   pass_through:
     # Whether gauges should be aggregated or passed through to the next component as they are
     [ gauge: <bool> | default = false ]

--- a/processor/intervalprocessor/config.go
+++ b/processor/intervalprocessor/config.go
@@ -18,6 +18,9 @@ var _ component.Config = (*Config)(nil)
 type Config struct {
 	// Interval is the time interval at which the processor will aggregate metrics.
 	Interval time.Duration `mapstructure:"interval"`
+	// AlignToWallClock controls whether flushes should align to wall-clock interval boundaries.
+	// When true and interval is 30s, flushes occur on :00, :30, :00, :30 across replicas.
+	AlignToWallClock bool `mapstructure:"align_to_wall_clock"`
 	// PassThrough is a configuration that determines whether gauge and summary metrics should be passed through
 	// as they are or aggregated.
 	PassThrough PassThrough `mapstructure:"pass_through"`

--- a/processor/intervalprocessor/config.schema.yaml
+++ b/processor/intervalprocessor/config.schema.yaml
@@ -15,6 +15,9 @@ properties:
     description: Interval is the time interval at which the processor will aggregate metrics.
     type: string
     format: duration
+  align_to_wall_clock:
+    description: AlignToWallClock controls whether flushes should align to wall-clock interval boundaries. When true and interval is 30s, flushes occur on :00, :30, :00, :30 across replicas.
+    type: boolean
   pass_through:
     description: PassThrough is a configuration that determines whether gauge and summary metrics should be passed through as they are or aggregated.
     $ref: pass_through

--- a/processor/intervalprocessor/factory.go
+++ b/processor/intervalprocessor/factory.go
@@ -25,7 +25,8 @@ func NewFactory() processor.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Interval: 60 * time.Second,
+		Interval:         60 * time.Second,
+		AlignToWallClock: false,
 		PassThrough: PassThrough{
 			Gauge:   false,
 			Summary: false,

--- a/processor/intervalprocessor/processor.go
+++ b/processor/intervalprocessor/processor.go
@@ -70,23 +70,72 @@ func newProcessor(config *Config, log *zap.Logger, nextConsumer consumer.Metrics
 }
 
 func (p *intervalProcessor) Start(_ context.Context, _ component.Host) error {
-	exportTicker := time.NewTicker(p.config.Interval)
+	if !p.config.AlignToWallClock {
+		exportTicker := time.NewTicker(p.config.Interval)
+		p.wg.Go(func() {
+			defer exportTicker.Stop()
+
+			for {
+				select {
+				case <-p.ctx.Done():
+					// Flush remaining buffered metrics before exiting.
+					// Use context.Background() since p.ctx is already cancelled.
+					p.exportMetrics(context.Background())
+					return
+				case <-exportTicker.C:
+					p.exportMetrics(p.ctx)
+				}
+			}
+		})
+
+		return nil
+	}
+
+	firstFlushTimer := time.NewTimer(timeUntilNextIntervalBoundary(time.Now(), p.config.Interval))
+	firstFlushTick := firstFlushTimer.C
+
+	var exportTicker *time.Ticker
+	var exportTickerTick <-chan time.Time
+
 	p.wg.Go(func() {
+		defer firstFlushTimer.Stop()
+		defer func() {
+			if exportTicker != nil {
+				exportTicker.Stop()
+			}
+		}()
+
 		for {
 			select {
 			case <-p.ctx.Done():
-				exportTicker.Stop()
 				// Flush remaining buffered metrics before exiting.
 				// Use context.Background() since p.ctx is already cancelled.
 				p.exportMetrics(context.Background())
 				return
-			case <-exportTicker.C:
+			case <-firstFlushTick:
+				// Create the periodic ticker before exporting the first aligned batch so
+				// steady-state cadence remains anchored to the wall-clock boundary time
+				// instead of first export completion time.
+				exportTicker = time.NewTicker(p.config.Interval)
+				exportTickerTick = exportTicker.C
+				firstFlushTick = nil
+				p.exportMetrics(p.ctx)
+			case <-exportTickerTick:
 				p.exportMetrics(p.ctx)
 			}
 		}
 	})
 
 	return nil
+}
+
+func timeUntilNextIntervalBoundary(now time.Time, interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+
+	nextBoundary := now.Truncate(interval).Add(interval)
+	return nextBoundary.Sub(now)
 }
 
 func (p *intervalProcessor) Shutdown(_ context.Context) error {

--- a/processor/intervalprocessor/processor_test.go
+++ b/processor/intervalprocessor/processor_test.go
@@ -145,3 +145,52 @@ func TestFlushOnShutdown(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, pmetrictest.CompareMetrics(expectedExportData, allMetrics[1]))
 }
+
+func TestTimeUntilNextIntervalBoundary(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		now      time.Time
+		interval time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "already_on_boundary_waits_full_interval",
+			now:      time.Date(2026, time.April, 23, 8, 0, 0, 0, time.UTC),
+			interval: 30 * time.Second,
+			expected: 30 * time.Second,
+		},
+		{
+			name:     "partial_interval_waits_until_next_boundary",
+			now:      time.Date(2026, time.April, 23, 8, 0, 17, 500_000_000, time.UTC),
+			interval: 30 * time.Second,
+			expected: 12*time.Second + 500*time.Millisecond,
+		},
+		{
+			name:     "subsecond_precision_is_preserved",
+			now:      time.Date(2026, time.April, 23, 8, 0, 59, 999_000_000, time.UTC),
+			interval: 30 * time.Second,
+			expected: time.Millisecond,
+		},
+		{
+			name:     "invalid_interval_returns_zero",
+			now:      time.Date(2026, time.April, 23, 8, 0, 0, 0, time.UTC),
+			interval: 0,
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, timeUntilNextIntervalBoundary(tc.now, tc.interval))
+		})
+	}
+}
+
+func TestCreateDefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := createDefaultConfig().(*Config)
+	require.False(t, cfg.AlignToWallClock)
+}


### PR DESCRIPTION
#### Description
This updates `intervalprocessor` to support wall-clock-aligned flush scheduling behind an opt-in config flag.

When enabled, startup waits until the next interval boundary before first export, then continues with regular interval ticks. Example with `interval: 30s`: `:00`, `:30`, `:00`, `:30` across replicas.

Why:
- Reduces cross-replica phase drift caused by pod restart time.
- Avoids abrupt phase jumps when ownership moves between replicas.
- Keeps rollout risk low by making behavior opt-in.

Implementation details:
- Added `align_to_wall_clock` config option (default: `false`).
- Existing behavior remains unchanged unless flag is enabled.
- With flag enabled:
  - first flush waits until `now.Truncate(interval).Add(interval)`
  - subsequent flushes use normal `time.Ticker(interval)` cadence
- Shutdown semantics are unchanged (still flushes buffered metrics on shutdown).

#### Link to tracking issue
N/A

#### Documentation
- Updated `processor/intervalprocessor/README.md` configuration docs.
- Updated `processor/intervalprocessor/config.schema.yaml` with `align_to_wall_clock`.
