### PR TITLE
[exporter/clickhouse] remove deprecated clickhouse.json feature gate

### DIFF
--- a/.chloggen/clickhouse-remove-json-featuregate.yaml
+++ b/.chloggen/clickhouse-remove-json-featuregate.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/clickhouseexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `clickhouse.json` feature gate. Users should set `json: true` in the exporter config directly.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47888]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -11,18 +11,8 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/featuregate"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter/internal/metadata"
-)
-
-// Deprecated: Use the `json` config option instead. This feature gate will be removed in a future version.
-var featureGateJSON = featuregate.GlobalRegistry().MustRegister(
-	"clickhouse.json",
-	featuregate.StageDeprecated,
-	featuregate.WithRegisterDescription("Deprecated: Use the `json` config option instead."),
-	featuregate.WithRegisterToVersion("v0.149.0"),
 )
 
 // NewFactory creates a factory for the ClickHouse exporter.
@@ -45,7 +35,7 @@ func createLogsExporter(
 	c.collectorVersion = set.BuildInfo.Version
 
 	var exp anyLogsExporter
-	if useJSON(set.Logger, c) {
+	if c.JSON {
 		exp = newLogsJSONExporter(set.Logger, c)
 	} else {
 		exp = newLogsExporter(set.Logger, c)
@@ -73,7 +63,7 @@ func createTracesExporter(
 	c.collectorVersion = set.BuildInfo.Version
 
 	var exp anyTracesExporter
-	if useJSON(set.Logger, c) {
+	if c.JSON {
 		exp = newTracesJSONExporter(set.Logger, c)
 	} else {
 		exp = newTracesExporter(set.Logger, c)
@@ -90,14 +80,6 @@ func createTracesExporter(
 		exporterhelper.WithQueue(c.QueueSettings),
 		exporterhelper.WithRetry(c.BackOffConfig),
 	)
-}
-
-func useJSON(logger *zap.Logger, c *Config) bool {
-	if featureGateJSON.IsEnabled() {
-		logger.Warn("The clickhouse.json feature gate is deprecated. Use the `json` config option instead.")
-		return true
-	}
-	return c.JSON
 }
 
 func createMetricExporter(

--- a/exporter/clickhouseexporter/factory_test.go
+++ b/exporter/clickhouseexporter/factory_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter/internal/metadata"
 )
@@ -35,22 +34,6 @@ func TestFactory_CreateLogs(t *testing.T) {
 	require.NoError(t, exporter.Shutdown(t.Context()))
 }
 
-func TestFactory_CreateLogsJSON(t *testing.T) {
-	factory := NewFactory()
-	cfg := withDefaultConfig(func(cfg *Config) {
-		cfg.Endpoint = defaultEndpoint
-	})
-	gatePrev := featureGateJSON.IsEnabled()
-	_ = featuregate.GlobalRegistry().Set(featureGateJSON.ID(), true)
-	params := exportertest.NewNopSettings(metadata.Type)
-	exporter, err := factory.CreateLogs(t.Context(), params, cfg)
-	_ = featuregate.GlobalRegistry().Set(featureGateJSON.ID(), gatePrev)
-	require.NoError(t, err)
-	require.NotNil(t, exporter)
-
-	require.NoError(t, exporter.Shutdown(t.Context()))
-}
-
 func TestFactory_CreateTraces(t *testing.T) {
 	factory := NewFactory()
 	cfg := withDefaultConfig(func(cfg *Config) {
@@ -58,22 +41,6 @@ func TestFactory_CreateTraces(t *testing.T) {
 	})
 	params := exportertest.NewNopSettings(metadata.Type)
 	exporter, err := factory.CreateTraces(t.Context(), params, cfg)
-	require.NoError(t, err)
-	require.NotNil(t, exporter)
-
-	require.NoError(t, exporter.Shutdown(t.Context()))
-}
-
-func TestFactory_CreateTracesJSON(t *testing.T) {
-	factory := NewFactory()
-	cfg := withDefaultConfig(func(cfg *Config) {
-		cfg.Endpoint = defaultEndpoint
-	})
-	gatePrev := featureGateJSON.IsEnabled()
-	_ = featuregate.GlobalRegistry().Set(featureGateJSON.ID(), true)
-	params := exportertest.NewNopSettings(metadata.Type)
-	exporter, err := factory.CreateTraces(t.Context(), params, cfg)
-	_ = featuregate.GlobalRegistry().Set(featureGateJSON.ID(), gatePrev)
 	require.NoError(t, err)
 	require.NotNil(t, exporter)
 

--- a/exporter/clickhouseexporter/go.mod
+++ b/exporter/clickhouseexporter/go.mod
@@ -19,7 +19,6 @@ require (
 	go.opentelemetry.io/collector/exporter v1.58.1-0.20260514231715-e7f22744c28c
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.152.1-0.20260514231715-e7f22744c28c
 	go.opentelemetry.io/collector/exporter/exportertest v0.152.1-0.20260514231715-e7f22744c28c
-	go.opentelemetry.io/collector/featuregate v1.58.1-0.20260514231715-e7f22744c28c
 	go.opentelemetry.io/collector/pdata v1.58.1-0.20260514231715-e7f22744c28c
 	go.opentelemetry.io/otel v1.43.0
 	go.uber.org/goleak v1.3.0
@@ -100,6 +99,7 @@ require (
 	go.opentelemetry.io/collector/exporter/xexporter v0.152.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/extension v1.58.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.152.1-0.20260514231715-e7f22744c28c // indirect
+	go.opentelemetry.io/collector/featuregate v1.58.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.152.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.152.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.152.1-0.20260514231715-e7f22744c28c // indirect


### PR DESCRIPTION
#### Description

The `clickhouse.json` feature gate was marked for removal in v0.149.0 (we are currently on v0.150.0). This PR removes it along with the `useJSON` helper that wrapped it. Users should set `json: true` in the exporter config directly.

Removes the `forbidigo` lint exclusion for `exporter/clickhouseexporter/` from `.golangci.yml`.

#### Link to tracking issue

Part of #46116

#### Testing

No logic changes for users who already use `json: true`. `go test ./...` passes.

#### Documentation