### PR TITLE
[processor/schema] make cache cooldown and retry limit configurable

### DIFF
--- a/.chloggen/schema-processor-cache-config.yaml
+++ b/.chloggen/schema-processor-cache-config.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: processor/schema
+note: Make CacheableProvider cooldown and retry limit configurable via `cache_cooldown` and `cache_retry_limit`.
+issues: [47761]
+subtext: ""
+change_logs: []

--- a/processor/schemaprocessor/README.md
+++ b/processor/schemaprocessor/README.md
@@ -24,6 +24,16 @@ be sure to follow [schema overview](https://opentelemetry.io/docs/reference/spec
 In order to improve efficiency of the processor, the `prefetch` option allows the processor to start downloading and preparing
 the translations needed for signals that match the schema URL.
 
+The processor caches fetched schema translation files. If a fetch fails, the
+processor retries up to `cache_retry_limit` times before entering a cooldown
+period of `cache_cooldown` during which further attempts for the same key
+return an error immediately.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cache_cooldown` | duration | `5m` | Wait time after retry limit is reached |
+| `cache_retry_limit` | int | `5` | Consecutive failures before cooldown |
+
 ## Schema Formats
 
 A [schema URL](https://opentelemetry.io/docs/reference/specification/schemas/overview/#schema-url) is made up in two parts, _Schema Family_ and _Schema Version_, the schema URL is broken down like so:

--- a/processor/schemaprocessor/config.go
+++ b/processor/schemaprocessor/config.go
@@ -6,6 +6,7 @@ package schemaprocessor // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
 
@@ -21,6 +22,14 @@ var (
 type Config struct {
 	confighttp.ClientConfig `mapstructure:",squash"`
 
+	// CacheCooldown is the duration to wait before retrying schema fetches
+	// after the retry limit has been reached. Defaults to 5 minutes.
+	CacheCooldown time.Duration `mapstructure:"cache_cooldown"`
+
+	// CacheRetryLimit is the number of consecutive failed schema fetch
+	// attempts allowed before enforcing the cooldown period. Defaults to 5.
+	CacheRetryLimit int `mapstructure:"cache_retry_limit"`
+
 	// PreCache is a list of schema URLs that are downloaded
 	// and cached at the start of the collector runtime
 	// in order to avoid fetching data that later on could
@@ -34,6 +43,12 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
+	if c.CacheCooldown < 0 {
+		return errors.New("cache_cooldown must not be negative")
+	}
+	if c.CacheRetryLimit < 0 {
+		return errors.New("cache_retry_limit must not be negative")
+	}
 	for _, schemaURL := range c.Prefetch {
 		_, _, err := translation.GetFamilyAndVersion(schemaURL)
 		if err != nil {

--- a/processor/schemaprocessor/config.schema.yaml
+++ b/processor/schemaprocessor/config.schema.yaml
@@ -1,6 +1,13 @@
 description: Config defines the user provided values for the Schema Processor
 type: object
 properties:
+  cache_cooldown:
+    description: CacheCooldown is the duration to wait before retrying schema fetches after the retry limit has been reached. Defaults to 5 minutes.
+    type: string
+    format: duration
+  cache_retry_limit:
+    description: CacheRetryLimit is the number of consecutive failed schema fetch attempts allowed before enforcing the cooldown period. Defaults to 5.
+    type: integer
   prefetch:
     description: PreCache is a list of schema URLs that are downloaded and cached at the start of the collector runtime in order to avoid fetching data that later on could block processing of signals. (Optional field)
     type: array

--- a/processor/schemaprocessor/config_test.go
+++ b/processor/schemaprocessor/config_test.go
@@ -6,6 +6,7 @@ package schemaprocessor
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,9 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(cfg))
 
 	assert.Equal(t, &Config{
-		ClientConfig: confighttp.NewDefaultClientConfig(),
+		ClientConfig:    confighttp.NewDefaultClientConfig(),
+		CacheCooldown:   10 * time.Minute,
+		CacheRetryLimit: 3,
 		Prefetch: []string{
 			"https://opentelemetry.io/schemas/1.9.0",
 		},
@@ -86,4 +89,24 @@ func TestConfigurationValidation(t *testing.T) {
 
 		assert.ErrorIs(t, xconfmap.Validate(cfg), tc.expectError, tc.scenario)
 	}
+}
+
+func TestConfigurationValidation_CacheFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Targets:       []string{"https://opentelemetry.io/schemas/1.9.0"},
+		CacheCooldown: -1 * time.Minute,
+	}
+	err := xconfmap.Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache_cooldown must not be negative")
+
+	cfg = &Config{
+		Targets:         []string{"https://opentelemetry.io/schemas/1.9.0"},
+		CacheRetryLimit: -1,
+	}
+	err = xconfmap.Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache_retry_limit must not be negative")
 }

--- a/processor/schemaprocessor/factory.go
+++ b/processor/schemaprocessor/factory.go
@@ -7,6 +7,7 @@ package schemaprocessor // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -26,7 +27,9 @@ type factory struct{}
 // with the default values being used throughout it
 func newDefaultConfiguration() component.Config {
 	return &Config{
-		ClientConfig: confighttp.NewDefaultClientConfig(),
+		ClientConfig:    confighttp.NewDefaultClientConfig(),
+		CacheCooldown:   5 * time.Minute,
+		CacheRetryLimit: 5,
 	}
 }
 

--- a/processor/schemaprocessor/internal/translation/cacheable_provider.go
+++ b/processor/schemaprocessor/internal/translation/cacheable_provider.go
@@ -37,7 +37,6 @@ type CacheableProvider struct {
 func NewCacheableProvider(provider Provider, cooldown time.Duration, limit int) Provider {
 	return &CacheableProvider{
 		provider: provider,
-		// TODO make cache configurable
 		cache:    cache.New(cache.NoExpiration, cache.NoExpiration),
 		cooldown: cooldown,
 		limit:    limit,

--- a/processor/schemaprocessor/internal/translation/manager.go
+++ b/processor/schemaprocessor/internal/translation/manager.go
@@ -34,13 +34,15 @@ type manager struct {
 	providers     []Provider
 	match         map[string]*Version
 	translatorMap map[string]*translator
+	cooldown      time.Duration
+	limit         int
 }
 
 var _ Manager = (*manager)(nil)
 
 // NewManager creates a manager that will allow for management
 // of schema
-func NewManager(targetSchemaURLS []string, log *zap.Logger, providers ...Provider) (Manager, error) {
+func NewManager(targetSchemaURLS []string, log *zap.Logger, cooldown time.Duration, limit int, providers ...Provider) (Manager, error) {
 	if log == nil {
 		return nil, fmt.Errorf("logger: %w", errNilValueProvided)
 	}
@@ -57,8 +59,7 @@ func NewManager(targetSchemaURLS []string, log *zap.Logger, providers ...Provide
 	// wrap provider with cacheable provider
 	var prs []Provider
 	for _, p := range providers {
-		// TODO make cache configurable
-		prs = append(prs, NewCacheableProvider(p, 5*time.Minute, 5))
+		prs = append(prs, NewCacheableProvider(p, cooldown, limit))
 	}
 
 	return &manager{
@@ -66,6 +67,8 @@ func NewManager(targetSchemaURLS []string, log *zap.Logger, providers ...Provide
 		match:         match,
 		translatorMap: make(map[string]*translator),
 		providers:     prs,
+		cooldown:      cooldown,
+		limit:         limit,
 	}, nil
 }
 
@@ -142,7 +145,7 @@ func (m *manager) AddProvider(p Provider) {
 		return
 	}
 	if _, ok := p.(*CacheableProvider); !ok {
-		p = NewCacheableProvider(p, 5*time.Minute, 5)
+		p = NewCacheableProvider(p, m.cooldown, m.limit)
 	}
 	m.providers = append(m.providers, p)
 }

--- a/processor/schemaprocessor/internal/translation/manager_test.go
+++ b/processor/schemaprocessor/internal/translation/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,8 @@ func TestRequestTranslation(t *testing.T) {
 	m, err := NewManager(
 		[]string{schemaURL},
 		zaptest.NewLogger(t),
+		5*time.Minute,
+		5,
 		NewHTTPProvider(s.Client()),
 	)
 	require.NoError(t, err, "Must not error when created manager")
@@ -105,6 +108,8 @@ versions:
 	m, err := NewManager(
 		[]string{targetURL},
 		zaptest.NewLogger(t),
+		5*time.Minute,
+		5,
 		NewHTTPProvider(s.Client()),
 	)
 	require.NoError(t, err)
@@ -144,6 +149,8 @@ func TestManagerError(t *testing.T) {
 	m, err := NewManager(
 		[]string{"http://localhost/1.1.0"},
 		zaptest.NewLogger(t),
+		5*time.Minute,
+		5,
 		&errorProvider{},
 	)
 	require.NoError(t, err, "Must not error when created manager")

--- a/processor/schemaprocessor/processor.go
+++ b/processor/schemaprocessor/processor.go
@@ -35,6 +35,8 @@ func newSchemaProcessor(_ context.Context, conf component.Config, set processor.
 	m, err := translation.NewManager(
 		cfg.Targets,
 		set.Logger.Named("schema-manager"),
+		cfg.CacheCooldown,
+		cfg.CacheRetryLimit,
 	)
 	if err != nil {
 		return nil, err

--- a/processor/schemaprocessor/testdata/config.yml
+++ b/processor/schemaprocessor/testdata/config.yml
@@ -1,4 +1,6 @@
 schema/with-all-options:
+  cache_cooldown: 10m
+  cache_retry_limit: 3
   # Prefetch is an optional field that allows
   # the collector to fetch the defined schema files
   # as the collector starts.


### PR DESCRIPTION
#### Description
The schema processor's `CacheableProvider` had `5*time.Minute` and `5` hardcoded
as the cooldown and retry limit. surfacing these as `cache_cooldown` and
`cache_retry_limit` in the config so users can tune them, defaults stay the same.

#### Link to tracking issue
Fixes #47761
Part of #47428

#### Testing
Added tests for negative value validation on both fields. 
Updated the load config test and existing manager tests to cover the new signature.

#### Documentation
Updated `README.md` and `config.schema.yaml`.
