### PR TITLE
Drop conflicting Scope attributes name, version and schema_url

### DIFF
--- a/.chloggen/prometheusexporter-drop-reserved-scope-attrs.yaml
+++ b/.chloggen/prometheusexporter-drop-reserved-scope-attrs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop reserved instrumentation scope attributes from Prometheus exporter labels to avoid conflicts with scope metadata labels.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47924]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -317,6 +317,9 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 
 	if !c.withoutScopeInfo {
 		for k, v := range scopeAttributes.All() {
+			if isReservedScopeAttribute(k) {
+				continue
+			}
 			labelName, err := c.labelNamer.Build("otel_scope_" + k)
 			if err != nil {
 				multiErrs = multierr.Append(multiErrs, err)
@@ -346,6 +349,15 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 		return nil, nil, multiErrs
 	}
 	return prometheus.NewDesc(name, help, keys, c.constLabels), values, nil
+}
+
+func isReservedScopeAttribute(k string) bool {
+	switch k {
+	case "name", "version", "schema_url":
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *collector) convertGauge(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -493,6 +493,40 @@ func TestWithoutScopeInfoFlag(t *testing.T) {
 	require.Empty(t, loggerCore.errorMessages, "collector unexpectedly returned an error")
 }
 
+func TestScopeAttributeConflictsDropped(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("test_metric")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(42)
+	dp.Attributes().PutStr("somelabel", "1")
+
+	scopeAttributes := pcommon.NewMap()
+	scopeAttributes.PutStr("name", "should-be-dropped")
+	scopeAttributes.PutStr("version", "should-be-dropped")
+	scopeAttributes.PutStr("schema_url", "should-be-dropped")
+	scopeAttributes.PutStr("custom", "should-be-kept")
+
+	c := newCollector(&Config{}, zap.NewNop())
+	m, err := c.convertMetric(metric, pcommon.NewMap(), "test.scope", "1.0.0", "https://opentelemetry.io/schemas/1.7.0", scopeAttributes)
+	require.NoError(t, err)
+
+	pbMetric := io_prometheus_client.Metric{}
+	require.NoError(t, m.Write(&pbMetric))
+
+	labels := make(map[string]string, len(pbMetric.Label))
+	for _, l := range pbMetric.Label {
+		labels[l.GetName()] = l.GetValue()
+	}
+
+	require.Equal(t, map[string]string{
+		"somelabel":             "1",
+		"otel_scope_name":       "test.scope",
+		"otel_scope_version":    "1.0.0",
+		"otel_scope_schema_url": "https://opentelemetry.io/schemas/1.7.0",
+		"otel_scope_custom":     "should-be-kept",
+	}, labels)
+}
+
 func TestCollectMetrics(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

While working on https://github.com/open-telemetry/opentelemetry-specification/pull/5052, I've realized the Prometheus exporter doesn't handle conflicting scope attributes