### PR TITLE
[exporter/elasticsearch] return permanent errors for `401 Unauthorized` and other non-retryable HTTP codes

### DIFF
--- a/.chloggen/fix_47870.yaml
+++ b/.chloggen/fix_47870.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/.chloggen/fix_47870.yaml
+++ b/.chloggen/fix_47870.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Return permanent errors for non-retryable HTTP responses to prevent unnecessary upstream retries.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47870]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/otel/attribute"
@@ -250,6 +252,7 @@ func (s *syncBulkIndexerSession) Flush(ctx context.Context) error {
 			ctx,
 			s.bi,
 			s.s.flushTimeout,
+			s.s.retryConfig.RetryOnStatus,
 			s.s.metadataKeys,
 			s.s.telemetryBuilder,
 			s.s.logger,
@@ -287,6 +290,7 @@ func flushBulkIndexer(
 	ctx context.Context,
 	bi *docappender.BulkIndexer,
 	timeout time.Duration,
+	retryOnStatus []int,
 	tMetaKeys []string,
 	tb *metadata.TelemetryBuilder,
 	logger *zap.Logger,
@@ -475,7 +479,15 @@ func flushBulkIndexer(
 			metric.WithAttributeSet(defaultAttrsSet),
 		)
 	}
+	var bulkFailedErr docappender.ErrorFlushFailed
+	if errors.As(err, &bulkFailedErr) && !retryableStatusCode(bulkFailedErr.StatusCode(), retryOnStatus) {
+		return consumererror.NewPermanent(err)
+	}
 	return err
+}
+
+func retryableStatusCode(statusCode int, retryOnStatus []int) bool {
+	return slices.Contains(retryOnStatus, statusCode)
 }
 
 func getAttributesFromMetadataKeys(ctx context.Context, keys []string) []attribute.KeyValue {

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -294,6 +295,73 @@ func TestSyncBulkIndexerRequestRetriesMetric(t *testing.T) {
 					),
 				},
 			}, metricdatatest.IgnoreTimestamp())
+		})
+	}
+}
+
+func TestSyncBulkIndexerFlushErrorPermanence(t *testing.T) {
+	tests := []struct {
+		name               string
+		responseStatusCode int
+		retryOnStatus      []int
+		wantPermanent      bool
+	}{
+		{
+			name:               "non-retryable status is permanent",
+			responseStatusCode: http.StatusUnauthorized,
+			retryOnStatus:      []int{http.StatusTooManyRequests},
+			wantPermanent:      true,
+		},
+		{
+			name:               "retryable status is not permanent",
+			responseStatusCode: http.StatusTooManyRequests,
+			retryOnStatus:      []int{http.StatusTooManyRequests},
+			wantPermanent:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				QueueBatchConfig: configoptional.Default(exporterhelper.QueueBatchConfig{NumConsumers: 1}),
+				Retry: RetrySettings{
+					Enabled:       false,
+					RetryOnStatus: tt.retryOnStatus,
+				},
+			}
+
+			esClient, err := elastictransport.New(elastictransport.Config{
+				URLs: []*url.URL{{Scheme: "http", Host: "localhost:9200"}},
+				Transport: &mockTransport{RoundTripFunc: func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+						Body:       io.NopCloser(strings.NewReader(`{"error":"boom"}`)),
+						StatusCode: tt.responseStatusCode,
+					}, nil
+				}},
+			})
+			require.NoError(t, err)
+
+			ct := componenttest.NewTelemetry()
+			tb, err := metadata.NewTelemetryBuilder(
+				metadatatest.NewSettings(ct).TelemetrySettings,
+			)
+			require.NoError(t, err)
+
+			bi := newSyncBulkIndexer(esClient, &cfg, false, tb, zap.NewNop(), nil)
+
+			session := bi.StartSession(t.Context())
+			require.NoError(t, session.Add(t.Context(), "foo", "", "", strings.NewReader(`{"foo":"bar"}`), nil, docappender.ActionCreate))
+
+			err = session.Flush(t.Context())
+			require.Error(t, err)
+			assert.Equal(t, tt.wantPermanent, consumererror.IsPermanent(err))
+
+			var flushErr docappender.ErrorFlushFailed
+			assert.ErrorAs(t, err, &flushErr)
+
+			session.End()
+			assert.NoError(t, bi.Close(t.Context()))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #47870