### PR TITLE
  Add automated golden file tests that generate example indexed docum…

### DIFF
--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -259,6 +259,11 @@ Span events are stored in separate documents. They will be routed with `data_str
 
 Attribute `elasticsearch.index` will be removed from the final document if exists.
 
+Example indexed documents:
+[Log](testdata/docs/otel_log.json) |
+[Trace](testdata/docs/otel_trace.json) |
+[Metric](testdata/docs/otel_metric.json)
+
 | Signal    | Supported          |
 | --------- | ------------------ |
 | Logs      | :white_check_mark: |
@@ -274,6 +279,11 @@ Attribute `elasticsearch.index` will be removed from the final document if exist
 In `ecs` mapping mode, the Elasticsearch Exporter maps fields from
 [OpenTelemetry Semantic Conventions][SemConv] (version 1.22.0) to [Elastic Common Schema][ECS] where possible.
 This mode may be used for compatibility with existing dashboards that work with ECS.
+
+Example indexed documents:
+[Log](testdata/docs/ecs_log.json) |
+[Trace](testdata/docs/ecs_trace.json) |
+[Metric](testdata/docs/ecs_metric.json)
 
 | Signal    | `ecs`              |
 | --------- | ------------------ |
@@ -292,6 +302,9 @@ of a log record as the exact content of the Elasticsearch document without any t
 This mapping mode is intended for use cases where the client wishes to have complete control over
 the Elasticsearch document structure.
 
+Example indexed document:
+[Log](testdata/docs/bodymap_log.json)
+
 | Signal    | `bodymap`          |
 | --------- | ------------------ |
 | Logs      | :white_check_mark: |
@@ -303,6 +316,10 @@ the Elasticsearch document structure.
 
 In the `none` mapping mode the Elasticsearch Exporter produces documents with the original
 field names of from the OTLP data structures.
+
+Example indexed documents:
+[Log](testdata/docs/none_log.json) |
+[Trace](testdata/docs/none_trace.json)
 
 | Signal    | `none`             |
 | --------- | ------------------ |
@@ -319,6 +336,10 @@ The `raw` mapping mode is identical to `none`, except for two differences:
    while in `raw` mode they are not.
  - In `none` mode span events are mapped with an `Events.` prefix,
    while in `raw` mode they are not.
+
+Example indexed documents:
+[Log](testdata/docs/raw_log.json) |
+[Trace](testdata/docs/raw_trace.json)
 
 | Signal    | `raw `             |
 | --------- | ------------------ |

--- a/exporter/elasticsearchexporter/doc_examples_test.go
+++ b/exporter/elasticsearchexporter/doc_examples_test.go
@@ -1,0 +1,215 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearchexporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/datapoints"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
+)
+
+var update = flag.Bool("update", false, "update golden files in testdata/docs/")
+
+const goldenDir = "testdata/docs"
+
+func TestDocumentExamples(t *testing.T) {
+	tStart := time.Date(2024, 3, 12, 20, 0, 41, 123456789, time.UTC)
+	tEnd := time.Date(2024, 3, 12, 20, 0, 42, 123456789, time.UTC)
+
+	type testCase struct {
+		mode   MappingMode
+		signal string
+		encode func(t *testing.T, encoder documentEncoder) string
+	}
+
+	buildLog := func(t *testing.T, encoder documentEncoder) string {
+		t.Helper()
+		logs := plog.NewLogs()
+		resourceLogs := logs.ResourceLogs().AppendEmpty()
+		resource := resourceLogs.Resource()
+		resource.Attributes().PutStr("service.name", "my-service")
+		resource.Attributes().PutStr("host.name", "my-host")
+		resource.Attributes().PutStr("deployment.environment", "production")
+
+		scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+		scopeLogs.Scope().SetName("io.opentelemetry.example")
+		scopeLogs.Scope().SetVersion("1.0.0")
+
+		record := scopeLogs.LogRecords().AppendEmpty()
+		record.SetTimestamp(pcommon.NewTimestampFromTime(tStart))
+		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(tStart))
+		record.SetSeverityNumber(plog.SeverityNumberError)
+		record.SetSeverityText("ERROR")
+		record.Body().SetStr("User authentication failed")
+		record.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		record.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		record.Attributes().PutStr("user.id", "user-123")
+		record.Attributes().PutStr("event.name", "authentication.failure")
+
+		var buf bytes.Buffer
+		err := encoder.encodeLog(
+			encodingContext{resource: resource, scope: scopeLogs.Scope()},
+			record, elasticsearch.Index{}, &buf,
+		)
+		require.NoError(t, err)
+		return buf.String()
+	}
+
+	buildTrace := func(t *testing.T, encoder documentEncoder) string {
+		t.Helper()
+		traces := ptrace.NewTraces()
+		resourceSpans := traces.ResourceSpans().AppendEmpty()
+		resource := resourceSpans.Resource()
+		resource.Attributes().PutStr("service.name", "my-service")
+		resource.Attributes().PutStr("host.name", "my-host")
+		resource.Attributes().PutStr("deployment.environment", "production")
+
+		scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+		scopeSpans.Scope().SetName("io.opentelemetry.example")
+		scopeSpans.Scope().SetVersion("1.0.0")
+
+		span := scopeSpans.Spans().AppendEmpty()
+		span.SetName("GET /api/users")
+		span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		span.SetParentSpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
+		span.SetKind(ptrace.SpanKindServer)
+		span.SetStartTimestamp(pcommon.NewTimestampFromTime(tStart))
+		span.SetEndTimestamp(pcommon.NewTimestampFromTime(tEnd))
+		span.Status().SetCode(ptrace.StatusCodeOk)
+		span.Status().SetMessage("success")
+		span.Attributes().PutStr("http.method", "GET")
+		span.Attributes().PutStr("http.url", "/api/users")
+		span.Attributes().PutInt("http.status_code", 200)
+
+		var buf bytes.Buffer
+		err := encoder.encodeSpan(
+			encodingContext{resource: resource, scope: scopeSpans.Scope()},
+			span, elasticsearch.Index{}, &buf,
+		)
+		require.NoError(t, err)
+		return buf.String()
+	}
+
+	buildMetric := func(t *testing.T, encoder documentEncoder) string {
+		t.Helper()
+		metrics := pmetric.NewMetrics()
+		resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+		resource := resourceMetrics.Resource()
+		resource.Attributes().PutStr("service.name", "my-service")
+		resource.Attributes().PutStr("host.name", "my-host")
+
+		scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+		scopeMetrics.Scope().SetName("io.opentelemetry.example")
+		scopeMetrics.Scope().SetVersion("1.0.0")
+
+		metric := scopeMetrics.Metrics().AppendEmpty()
+		metric.SetName("http.server.request.duration")
+		metric.SetUnit("s")
+		gauge := metric.SetEmptyGauge()
+		dp := gauge.DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(tStart))
+		dp.SetDoubleValue(0.125)
+		dp.Attributes().PutStr("http.method", "GET")
+
+		dataPoint := datapoints.NewNumber(metric, dp)
+
+		var buf bytes.Buffer
+		var validationErrors []error
+		_, err := encoder.encodeMetrics(
+			encodingContext{resource: resource, scope: scopeMetrics.Scope()},
+			[]datapoints.DataPoint{dataPoint}, &validationErrors, elasticsearch.Index{}, &buf,
+		)
+		require.NoError(t, err)
+		require.Empty(t, validationErrors)
+		return buf.String()
+	}
+
+	buildBodymapLog := func(t *testing.T, encoder documentEncoder) string {
+		t.Helper()
+		logs := plog.NewLogs()
+		resourceLogs := logs.ResourceLogs().AppendEmpty()
+		scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+
+		record := scopeLogs.LogRecords().AppendEmpty()
+		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(tStart))
+
+		bodyMap := pcommon.NewMap()
+		bodyMap.PutStr("@timestamp", "2024-03-12T20:00:41.123456789Z")
+		bodyMap.PutStr("message", "User authentication failed")
+		bodyMap.PutStr("level", "error")
+		bodyMap.PutStr("service", "my-service")
+		bodyMap.PutInt("status_code", 401)
+		bodyMap.CopyTo(record.Body().SetEmptyMap())
+
+		var buf bytes.Buffer
+		err := encoder.encodeLog(
+			encodingContext{resource: resourceLogs.Resource(), scope: scopeLogs.Scope()},
+			record, elasticsearch.Index{}, &buf,
+		)
+		require.NoError(t, err)
+		return buf.String()
+	}
+
+	tests := []testCase{
+		// OTel mode
+		{mode: MappingOTel, signal: "log", encode: buildLog},
+		{mode: MappingOTel, signal: "trace", encode: buildTrace},
+		{mode: MappingOTel, signal: "metric", encode: buildMetric},
+		// ECS mode
+		{mode: MappingECS, signal: "log", encode: buildLog},
+		{mode: MappingECS, signal: "trace", encode: buildTrace},
+		{mode: MappingECS, signal: "metric", encode: buildMetric},
+		// None mode
+		{mode: MappingNone, signal: "log", encode: buildLog},
+		{mode: MappingNone, signal: "trace", encode: buildTrace},
+		// Raw mode
+		{mode: MappingRaw, signal: "log", encode: buildLog},
+		{mode: MappingRaw, signal: "trace", encode: buildTrace},
+		// Bodymap mode
+		{mode: MappingBodyMap, signal: "log", encode: buildBodymapLog},
+	}
+
+	for _, tt := range tests {
+		name := tt.mode.String() + "_" + tt.signal
+		t.Run(name, func(t *testing.T) {
+			encoder, err := newEncoder(tt.mode)
+			require.NoError(t, err)
+
+			raw := tt.encode(t, encoder)
+
+			// Pretty-print JSON
+			var pretty bytes.Buffer
+			err = json.Indent(&pretty, []byte(raw), "", "  ")
+			require.NoError(t, err)
+			prettyJSON := pretty.String() + "\n"
+
+			goldenFile := filepath.Join(goldenDir, name+".json")
+
+			if *update {
+				err = os.WriteFile(goldenFile, []byte(prettyJSON), 0600)
+				require.NoError(t, err)
+				return
+			}
+
+			expected, err := os.ReadFile(goldenFile)
+			require.NoError(t, err, "golden file %s not found, run with -update to generate", goldenFile)
+			assert.JSONEq(t, string(expected), prettyJSON)
+		})
+	}
+}

--- a/exporter/elasticsearchexporter/testdata/docs/bodymap_log.json
+++ b/exporter/elasticsearchexporter/testdata/docs/bodymap_log.json
@@ -1,0 +1,7 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "message": "User authentication failed",
+  "level": "error",
+  "service": "my-service",
+  "status_code": 401
+}

--- a/exporter/elasticsearchexporter/testdata/docs/ecs_log.json
+++ b/exporter/elasticsearchexporter/testdata/docs/ecs_log.json
@@ -1,0 +1,28 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "event": {
+    "action": "authentication.failure",
+    "severity": 17
+  },
+  "host": {
+    "hostname": "my-host",
+    "name": "my-host"
+  },
+  "log": {
+    "level": "ERROR"
+  },
+  "message": "User authentication failed",
+  "service": {
+    "environment": "production",
+    "name": "my-service"
+  },
+  "span": {
+    "id": "0102030405060708"
+  },
+  "trace": {
+    "id": "0102030405060708090a0b0c0d0e0f10"
+  },
+  "user": {
+    "id": "user-123"
+  }
+}

--- a/exporter/elasticsearchexporter/testdata/docs/ecs_metric.json
+++ b/exporter/elasticsearchexporter/testdata/docs/ecs_metric.json
@@ -1,0 +1,18 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "host": {
+    "hostname": "my-host",
+    "name": "my-host"
+  },
+  "http": {
+    "method": "GET",
+    "server": {
+      "request": {
+        "duration": 0.125
+      }
+    }
+  },
+  "service": {
+    "name": "my-service"
+  }
+}

--- a/exporter/elasticsearchexporter/testdata/docs/ecs_trace.json
+++ b/exporter/elasticsearchexporter/testdata/docs/ecs_trace.json
@@ -1,0 +1,30 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "event": {
+    "outcome": "success"
+  },
+  "host": {
+    "hostname": "my-host",
+    "name": "my-host"
+  },
+  "http": {
+    "method": "GET",
+    "status_code": 200,
+    "url": "/api/users"
+  },
+  "parent": {
+    "id": "0807060504030201"
+  },
+  "service": {
+    "environment": "production",
+    "name": "my-service"
+  },
+  "span": {
+    "id": "0102030405060708",
+    "kind": "SERVER",
+    "name": "GET /api/users"
+  },
+  "trace": {
+    "id": "0102030405060708090a0b0c0d0e0f10"
+  }
+}

--- a/exporter/elasticsearchexporter/testdata/docs/none_log.json
+++ b/exporter/elasticsearchexporter/testdata/docs/none_log.json
@@ -1,0 +1,16 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "Attributes.event.name": "authentication.failure",
+  "Attributes.user.id": "user-123",
+  "Body": "User authentication failed",
+  "Resource.deployment.environment": "production",
+  "Resource.host.name": "my-host",
+  "Resource.service.name": "my-service",
+  "Scope.name": "io.opentelemetry.example",
+  "Scope.version": "1.0.0",
+  "SeverityNumber": 17,
+  "SeverityText": "ERROR",
+  "SpanId": "0102030405060708",
+  "TraceFlags": 0,
+  "TraceId": "0102030405060708090a0b0c0d0e0f10"
+}

--- a/exporter/elasticsearchexporter/testdata/docs/none_trace.json
+++ b/exporter/elasticsearchexporter/testdata/docs/none_trace.json
@@ -1,0 +1,21 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "Attributes.http.method": "GET",
+  "Attributes.http.status_code": 200,
+  "Attributes.http.url": "/api/users",
+  "Duration": 1000000,
+  "EndTimestamp": "2024-03-12T20:00:42.123456789Z",
+  "Kind": "SPAN_KIND_SERVER",
+  "Link": "[]",
+  "Name": "GET /api/users",
+  "ParentSpanId": "0807060504030201",
+  "Resource.deployment.environment": "production",
+  "Resource.host.name": "my-host",
+  "Resource.service.name": "my-service",
+  "Scope.name": "io.opentelemetry.example",
+  "Scope.version": "1.0.0",
+  "SpanId": "0102030405060708",
+  "TraceId": "0102030405060708090a0b0c0d0e0f10",
+  "TraceStatus": 1,
+  "TraceStatusDescription": "success"
+}

--- a/exporter/elasticsearchexporter/testdata/docs/otel_log.json
+++ b/exporter/elasticsearchexporter/testdata/docs/otel_log.json
@@ -1,0 +1,27 @@
+{
+  "@timestamp": "1710273641123.456789",
+  "observed_timestamp": "1710273641123.456789",
+  "severity_text": "ERROR",
+  "severity_number": 17,
+  "trace_id": "0102030405060708090a0b0c0d0e0f10",
+  "span_id": "0102030405060708",
+  "attributes": {
+    "user.id": "user-123",
+    "event.name": "authentication.failure"
+  },
+  "event_name": "authentication.failure",
+  "resource": {
+    "attributes": {
+      "service.name": "my-service",
+      "host.name": "my-host",
+      "deployment.environment": "production"
+    }
+  },
+  "scope": {
+    "name": "io.opentelemetry.example",
+    "version": "1.0.0"
+  },
+  "body": {
+    "text": "User authentication failed"
+  }
+}

--- a/exporter/elasticsearchexporter/testdata/docs/otel_metric.json
+++ b/exporter/elasticsearchexporter/testdata/docs/otel_metric.json
@@ -1,0 +1,21 @@
+{
+  "@timestamp": 1710273641123,
+  "unit": "s",
+  "attributes": {
+    "http.method": "GET"
+  },
+  "resource": {
+    "attributes": {
+      "service.name": "my-service",
+      "host.name": "my-host"
+    }
+  },
+  "scope": {
+    "name": "io.opentelemetry.example",
+    "version": "1.0.0"
+  },
+  "metrics": {
+    "http.server.request.duration": 0.125
+  },
+  "_metric_names_hash": "30292700b84da900"
+}

--- a/exporter/elasticsearchexporter/testdata/docs/otel_trace.json
+++ b/exporter/elasticsearchexporter/testdata/docs/otel_trace.json
@@ -1,0 +1,30 @@
+{
+  "@timestamp": "1710273641123.456789",
+  "trace_id": "0102030405060708090a0b0c0d0e0f10",
+  "span_id": "0102030405060708",
+  "parent_span_id": "0807060504030201",
+  "name": "GET /api/users",
+  "kind": "Server",
+  "duration": 1000000000,
+  "attributes": {
+    "http.method": "GET",
+    "http.url": "/api/users",
+    "http.status_code": 200
+  },
+  "links": [],
+  "status": {
+    "message": "success",
+    "code": "Ok"
+  },
+  "resource": {
+    "attributes": {
+      "service.name": "my-service",
+      "host.name": "my-host",
+      "deployment.environment": "production"
+    }
+  },
+  "scope": {
+    "name": "io.opentelemetry.example",
+    "version": "1.0.0"
+  }
+}

--- a/exporter/elasticsearchexporter/testdata/docs/raw_log.json
+++ b/exporter/elasticsearchexporter/testdata/docs/raw_log.json
@@ -1,0 +1,16 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "Body": "User authentication failed",
+  "Resource.deployment.environment": "production",
+  "Resource.host.name": "my-host",
+  "Resource.service.name": "my-service",
+  "Scope.name": "io.opentelemetry.example",
+  "Scope.version": "1.0.0",
+  "SeverityNumber": 17,
+  "SeverityText": "ERROR",
+  "SpanId": "0102030405060708",
+  "TraceFlags": 0,
+  "TraceId": "0102030405060708090a0b0c0d0e0f10",
+  "event.name": "authentication.failure",
+  "user.id": "user-123"
+}

--- a/exporter/elasticsearchexporter/testdata/docs/raw_trace.json
+++ b/exporter/elasticsearchexporter/testdata/docs/raw_trace.json
@@ -1,0 +1,21 @@
+{
+  "@timestamp": "2024-03-12T20:00:41.123456789Z",
+  "Duration": 1000000,
+  "EndTimestamp": "2024-03-12T20:00:42.123456789Z",
+  "Kind": "SPAN_KIND_SERVER",
+  "Link": "[]",
+  "Name": "GET /api/users",
+  "ParentSpanId": "0807060504030201",
+  "Resource.deployment.environment": "production",
+  "Resource.host.name": "my-host",
+  "Resource.service.name": "my-service",
+  "Scope.name": "io.opentelemetry.example",
+  "Scope.version": "1.0.0",
+  "SpanId": "0102030405060708",
+  "TraceId": "0102030405060708090a0b0c0d0e0f10",
+  "TraceStatus": 1,
+  "TraceStatusDescription": "success",
+  "http.method": "GET",
+  "http.status_code": 200,
+  "http.url": "/api/users"
+}


### PR DESCRIPTION
#### Description

  Add automated golden file tests that generate example indexed documents
  for each mapping mode (otel, ecs, none, raw, bodymap) across supported
  signal types (logs, traces, metrics).

  for each mapping mode (otel, ecs, none, raw, bodymap) across supported
  signal types (logs, traces, metrics). Link examples from README.

  Fixes #39342

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add automated golden file tests that generate example indexed documents
for each mapping mode (otel, ecs, none, raw, bodymap) across supported signal
 types (logs, traces, metrics).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
  Fixes #39342

<!--Describe what testing was performed and which tests were added.-->
#### Testing

  Added `TestDocumentExamples` in `doc_examples_test.go` which verifies
  that encoder output matches the golden files for all 11 mode/signal
  combinations. All existing tests continue to pass.

<!--Describe the documentation added.-->
#### Documentation

  Added example indexed document links to each mapping mode section in
  the Elasticsearch exporter README, pointing to generated JSON files in
  `testdata/docs/`.

<!--Please delete paragraphs that you did not use before submitting.-->
