### PR TITLE
Update elasticsearchexporter README.md default for block_on_overflow

### DIFF
--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -356,7 +356,7 @@ The behaviour of this bulk indexing can be configured with the following setting
   - `enabled` (default=true): Enable queueing and batching behaviour.
   - `num_consumers` (default=10): Number of consumers that dequeue batches.
   - `wait_for_result` (default=false): If `true`, blocks incoming requests until processed.
-  - `block_on_overflow` (default=false): If `true`, blocks the request until the queue has space.
+  - `block_on_overflow` (default=true): If `true`, blocks the request until the queue has space.
   - `sizer` (default=requests): Measure queueing by requests.
   - `queue_size` (default=10): Maximum size the queue can accept.
   - `batch`:


### PR DESCRIPTION
#### Description

According to the below, the default for the `elasticsearchexporter`'s `sending_queue::block_on_overflow` is currently `true`.
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/818298d81b278c1152b1ec209d87fc1bf31f11ec/exporter/elasticsearchexporter/factory.go#L43

<!--Describe the documentation added.-->
#### Documentation
* Changed the default value for `elasticsearchexporter`'s `sending_queue::block_on_overflow` to `true`.
