### PR TITLE
[receiver/prometheus] Remove statefulness warning in README

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -31,7 +31,9 @@ and please don't use it if the following limitations are a concern:
   scrape the targets multiple times.
 * Users need to configure each replica with different scraping configuration
   if they want to manually shard the scraping.
-* The Prometheus receiver is a stateful component.
+* The receiver does not support persistent state. The embedded Prometheus
+  scrape manager keeps in-memory caches, for example staleness tracking and
+  service discovery metadata, that are rebuilt on restart.
 
 ## Unsupported features
 The Prometheus receiver is meant to minimally be a drop-in replacement for Prometheus. However,

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -31,10 +31,6 @@ and please don't use it if the following limitations are a concern:
   scrape the targets multiple times.
 * Users need to configure each replica with different scraping configuration
   if they want to manually shard the scraping.
-* The receiver does not support persistent state. The embedded Prometheus
-  scrape manager keeps in-memory caches, for example staleness tracking and
-  service discovery metadata, that are rebuilt on restart.
-
 ## Unsupported features
 The Prometheus receiver is meant to minimally be a drop-in replacement for Prometheus. However,
 there are advanced features of Prometheus that we don't support and thus explicitly will return


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removes the Prometheus receiver's statefulness warning in the README.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Addresses https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44169.

<!--Describe the documentation added.-->
#### Documentation

Updates `Warning` section in Prometheus receiver README.

<!--Please delete paragraphs that you did not use before submitting.-->
