### PR TITLE
[receiver/hostmetrics] Add cputicks package for raw CPU tick reading

### DIFF
--- a/.chloggen/fix_hostmetrics-cpu-ticks-package.yaml
+++ b/.chloggen/fix_hostmetrics-cpu-ticks-package.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/hostmetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add cputicks package and integrate with CPU scraper behind feature gate
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46177]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+    New internal package that reads raw uint64 CPU ticks directly from /proc/stat
+    on Linux, avoiding the precision loss from gopsutil's float64 seconds conversion.
+    Enabled via the receiver.hostmetricsreceiver.UseCPUTicks feature gate (alpha).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/config.go
@@ -10,4 +10,9 @@ import (
 // Config relating to CPU Metric Scraper.
 type Config struct {
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	rootPath                      string
+}
+
+func (cfg *Config) SetRootPath(rootPath string) {
+	cfg.rootPath = rootPath
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -30,12 +30,11 @@ type cpuScraper struct {
 	settings scraper.Settings
 	config   *Config
 	mb       *metadata.MetricsBuilder
-	ucal     *ucal.CPUUtilizationCalculator
 
 	// for mocking
-	bootTime func(context.Context) (uint64, error)
-	times    func(context.Context, bool) ([]cpu.TimesStat, error)
-	now      func() time.Time
+	bootTime       func(context.Context) (uint64, error)
+	emitCPUMetrics func(context.Context, pcommon.Timestamp, *metadata.MetricsBuilder) error
+	now            func() time.Time
 }
 
 type cpuInfo struct {
@@ -45,7 +44,29 @@ type cpuInfo struct {
 
 // newCPUScraper creates a set of CPU related metrics
 func newCPUScraper(_ context.Context, settings scraper.Settings, cfg *Config) *cpuScraper {
-	return &cpuScraper{settings: settings, config: cfg, bootTime: host.BootTimeWithContext, times: cpu.TimesWithContext, ucal: &ucal.CPUUtilizationCalculator{}, now: time.Now}
+	return &cpuScraper{
+		settings:       settings,
+		config:         cfg,
+		bootTime:       host.BootTimeWithContext,
+		emitCPUMetrics: newCPUEmitter(cfg),
+		now:            time.Now,
+	}
+}
+
+func newGopsutilEmitter(times func(context.Context, bool) ([]cpu.TimesStat, error)) func(context.Context, pcommon.Timestamp, *metadata.MetricsBuilder) error {
+	calc := &ucal.CPUUtilizationCalculator{}
+	return func(ctx context.Context, now pcommon.Timestamp, mb *metadata.MetricsBuilder) error {
+		cpuTimes, err := times(ctx, true)
+		if err != nil {
+			return err
+		}
+		for _, cpuTime := range cpuTimes {
+			recordCPUTimeStateDataPoints(now, cpuTime, mb)
+		}
+		return calc.CalculateAndRecord(now, cpuTimes, func(now pcommon.Timestamp, u ucal.CPUUtilization) {
+			recordCPUUtilization(now, u, mb)
+		})
+	}
 }
 
 func (s *cpuScraper) start(ctx context.Context, _ component.Host) error {
@@ -59,17 +80,8 @@ func (s *cpuScraper) start(ctx context.Context, _ component.Host) error {
 
 func (s *cpuScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	now := pcommon.NewTimestampFromTime(s.now())
-	cpuTimes, err := s.times(ctx, true /*percpu=*/)
-	if err != nil {
-		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
-	}
 
-	for _, cpuTime := range cpuTimes {
-		s.recordCPUTimeStateDataPoints(now, cpuTime)
-	}
-
-	err = s.ucal.CalculateAndRecord(now, cpuTimes, s.recordCPUUtilization)
-	if err != nil {
+	if err := s.emitCPUMetrics(ctx, now, s.mb); err != nil {
 		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -6,35 +6,151 @@
 package cpuscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/tklauser/go-sysconf"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/scraper/scrapererror"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/precision"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal"
 )
 
-func (s *cpuScraper) recordCPUTimeStateDataPoints(now pcommon.Timestamp, cpuTime cpu.TimesStat) {
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.User, cpuTime.CPU, metadata.AttributeStateUser)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.System, cpuTime.CPU, metadata.AttributeStateSystem)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Idle, cpuTime.CPU, metadata.AttributeStateIdle)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Irq, cpuTime.CPU, metadata.AttributeStateInterrupt)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Nice, cpuTime.CPU, metadata.AttributeStateNice)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Softirq, cpuTime.CPU, metadata.AttributeStateSoftirq)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Steal, cpuTime.CPU, metadata.AttributeStateSteal)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Iowait, cpuTime.CPU, metadata.AttributeStateWait)
+var useCPUTicks = featuregate.GlobalRegistry().MustRegister(
+	"receiver.hostmetricsreceiver.UseCPUTicks",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Use raw uint64 CPU tick counts from /proc/stat instead of gopsutil for improved precision in CPU time and utilization metrics."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177"),
+	featuregate.WithRegisterFromVersion("v0.152.0"),
+)
+
+const defaultTicksPerSecond = 100
+
+// tickReader reads per-CPU tick counts from the operating system.
+// Defined at the consumer for testability.
+type tickReader interface {
+	ReadAll(ctx context.Context) ([]cputicks.Stat, error)
+	TicksPerSecond() uint64
 }
 
-func (s *cpuScraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.User, cpuUtilization.CPU, metadata.AttributeStateUser)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.System, cpuUtilization.CPU, metadata.AttributeStateSystem)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Idle, cpuUtilization.CPU, metadata.AttributeStateIdle)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Irq, cpuUtilization.CPU, metadata.AttributeStateInterrupt)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Nice, cpuUtilization.CPU, metadata.AttributeStateNice)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Softirq, cpuUtilization.CPU, metadata.AttributeStateSoftirq)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Steal, cpuUtilization.CPU, metadata.AttributeStateSteal)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Iowait, cpuUtilization.CPU, metadata.AttributeStateWait)
+func clockTicksPerSecond() uint64 {
+	clkTck, err := sysconf.Sysconf(sysconf.SC_CLK_TCK)
+	if err != nil || clkTck <= 0 {
+		return defaultTicksPerSecond
+	}
+	return uint64(clkTck)
+}
+
+func newCPUEmitter(cfg *Config) func(context.Context, pcommon.Timestamp, *metadata.MetricsBuilder) error {
+	if useCPUTicks.IsEnabled() {
+		return newCputicksEmitter(cputicks.NewReader(cfg.rootPath, clockTicksPerSecond()))
+	}
+	return newGopsutilEmitter(cpu.TimesWithContext)
+}
+
+func newCputicksEmitter(reader tickReader) func(context.Context, pcommon.Timestamp, *metadata.MetricsBuilder) error {
+	tickDuration := time.Second / time.Duration(reader.TicksPerSecond())
+	var prevTicks map[string]cputicks.Stat
+	return func(ctx context.Context, now pcommon.Timestamp, mb *metadata.MetricsBuilder) error {
+		ticks, err := reader.ReadAll(ctx)
+		if err != nil {
+			return err
+		}
+
+		recordTickTimes(now, ticks, tickDuration, mb)
+
+		if prevTicks != nil {
+			currTicks := make(map[string]cputicks.Stat, len(ticks))
+			for _, t := range ticks {
+				currTicks[t.CPU] = t
+			}
+			for _, prev := range prevTicks {
+				curr, ok := currTicks[prev.CPU]
+				if !ok {
+					return fmt.Errorf("getting ticks for cpu %s: %w", prev.CPU, ucal.ErrTimeStatNotFound)
+				}
+				recordTickUtilization(now, prev, curr, mb)
+			}
+		}
+		prevTicks = make(map[string]cputicks.Stat, len(ticks))
+		for _, t := range ticks {
+			prevTicks[t.CPU] = t
+		}
+		return nil
+	}
+}
+
+func recordTickTimes(now pcommon.Timestamp, ticks []cputicks.Stat, tickDuration time.Duration, mb *metadata.MetricsBuilder) {
+	for _, t := range ticks {
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.User, tickDuration), t.CPU, metadata.AttributeStateUser)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.System, tickDuration), t.CPU, metadata.AttributeStateSystem)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.Idle, tickDuration), t.CPU, metadata.AttributeStateIdle)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.Irq, tickDuration), t.CPU, metadata.AttributeStateInterrupt)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.Nice, tickDuration), t.CPU, metadata.AttributeStateNice)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.Softirq, tickDuration), t.CPU, metadata.AttributeStateSoftirq)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.Steal, tickDuration), t.CPU, metadata.AttributeStateSteal)
+		mb.RecordSystemCPUTimeDataPoint(now, precision.Scale(t.Iowait, tickDuration), t.CPU, metadata.AttributeStateWait)
+	}
+}
+
+func recordTickUtilization(now pcommon.Timestamp, prev, curr cputicks.Stat, mb *metadata.MetricsBuilder) {
+	deltaTotal := curr.Total() - prev.Total()
+	if deltaTotal == 0 {
+		recordZeroUtilization(now, curr.CPU, mb)
+		return
+	}
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.User-prev.User, deltaTotal), curr.CPU, metadata.AttributeStateUser)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.System-prev.System, deltaTotal), curr.CPU, metadata.AttributeStateSystem)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.Idle-prev.Idle, deltaTotal), curr.CPU, metadata.AttributeStateIdle)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.Irq-prev.Irq, deltaTotal), curr.CPU, metadata.AttributeStateInterrupt)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.Nice-prev.Nice, deltaTotal), curr.CPU, metadata.AttributeStateNice)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.Softirq-prev.Softirq, deltaTotal), curr.CPU, metadata.AttributeStateSoftirq)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.Steal-prev.Steal, deltaTotal), curr.CPU, metadata.AttributeStateSteal)
+	mb.RecordSystemCPUUtilizationDataPoint(now, precision.Ratio(curr.Iowait-prev.Iowait, deltaTotal), curr.CPU, metadata.AttributeStateWait)
+}
+
+func recordZeroUtilization(now pcommon.Timestamp, cpuName string, mb *metadata.MetricsBuilder) {
+	for _, state := range []metadata.AttributeState{
+		metadata.AttributeStateUser,
+		metadata.AttributeStateSystem,
+		metadata.AttributeStateIdle,
+		metadata.AttributeStateInterrupt,
+		metadata.AttributeStateNice,
+		metadata.AttributeStateSoftirq,
+		metadata.AttributeStateSteal,
+		metadata.AttributeStateWait,
+	} {
+		mb.RecordSystemCPUUtilizationDataPoint(now, 0, cpuName, state)
+	}
+}
+
+func recordCPUTimeStateDataPoints(now pcommon.Timestamp, cpuTime cpu.TimesStat, mb *metadata.MetricsBuilder) {
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.User, cpuTime.CPU, metadata.AttributeStateUser)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.System, cpuTime.CPU, metadata.AttributeStateSystem)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Idle, cpuTime.CPU, metadata.AttributeStateIdle)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Irq, cpuTime.CPU, metadata.AttributeStateInterrupt)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Nice, cpuTime.CPU, metadata.AttributeStateNice)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Softirq, cpuTime.CPU, metadata.AttributeStateSoftirq)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Steal, cpuTime.CPU, metadata.AttributeStateSteal)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Iowait, cpuTime.CPU, metadata.AttributeStateWait)
+}
+
+func recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization, mb *metadata.MetricsBuilder) {
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.User, cpuUtilization.CPU, metadata.AttributeStateUser)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.System, cpuUtilization.CPU, metadata.AttributeStateSystem)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Idle, cpuUtilization.CPU, metadata.AttributeStateIdle)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Irq, cpuUtilization.CPU, metadata.AttributeStateInterrupt)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Nice, cpuUtilization.CPU, metadata.AttributeStateNice)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Softirq, cpuUtilization.CPU, metadata.AttributeStateSoftirq)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Steal, cpuUtilization.CPU, metadata.AttributeStateSteal)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Iowait, cpuUtilization.CPU, metadata.AttributeStateWait)
 }
 
 func (*cpuScraper) getCPUInfo() ([]cpuInfo, error) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
@@ -6,16 +6,24 @@
 package cpuscraper
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/scraper/scrapererror"
 	"go.opentelemetry.io/collector/scraper/scrapertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal"
 )
 
 func TestScrape_CpuFrequency(t *testing.T) {
@@ -93,3 +101,265 @@ func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric) {
 		require.GreaterOrEqual(t, dp.DoubleValue(), 0.0, "CPU frequency should be non-negative")
 	}
 }
+
+func TestCputicksEmitter(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	require.NoError(t, os.MkdirAll(procDir, 0o755))
+
+	scrape1 := "cpu  100 200 300 400 50 60 70 80 0 0\ncpu0 50 100 150 200 25 30 35 40 0 0\ncpu1 50 100 150 200 25 30 35 40 0 0\n"
+	scrape2 := "cpu  200 400 600 800 100 120 140 160 0 0\ncpu0 110 120 170 220 35 40 45 50 0 0\ncpu1 90 280 430 580 65 80 95 110 0 0\n"
+
+	cfg := metadata.DefaultMetricsBuilderConfig()
+	cfg.Metrics.SystemCPUUtilization.Enabled = true
+
+	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
+		&Config{MetricsBuilderConfig: cfg, rootPath: root})
+	scraper.emitCPUMetrics = newCputicksEmitter(cputicks.NewReader(root, defaultTicksPerSecond))
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape1), 0o600))
+	md, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, md.MetricCount(), "first scrape should only have cpu.time (no utilization yet)")
+
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape2), 0o600))
+	md, err = scraper.scrape(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, md.MetricCount(), "second scrape should have cpu.time and cpu.utilization")
+
+	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	var utilMetric pmetric.Metric
+	for _, m := range metrics.All() {
+		if m.Name() == "system.cpu.utilization" {
+			utilMetric = m
+			break
+		}
+	}
+	require.NotEqual(t, pmetric.Metric{}, utilMetric, "utilization metric not found")
+
+	dp := utilMetric.Gauge().DataPoints()
+	require.Equal(t, 16, dp.Len(), "expected 8 states * 2 CPUs")
+
+	for i := range dp.Len() {
+		val := dp.At(i).DoubleValue()
+		assert.GreaterOrEqual(t, val, 0.0, "utilization should be >= 0")
+		assert.LessOrEqual(t, val, 1.0, "utilization should be <= 1")
+	}
+}
+
+func TestCputicksEmitter_Utilization(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	require.NoError(t, os.MkdirAll(procDir, 0o755))
+
+	scrape1 := "cpu  100 25 50 200 25 25 25 50 0 0\ncpu0 100 25 50 200 25 25 25 50 0 0\n"
+	scrape2 := "cpu  300 75 150 600 75 75 75 150 0 0\ncpu0 300 75 150 600 75 75 75 150 0 0\n"
+
+	cfg := metadata.DefaultMetricsBuilderConfig()
+	cfg.Metrics.SystemCPUUtilization.Enabled = true
+
+	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
+		&Config{MetricsBuilderConfig: cfg, rootPath: root})
+	scraper.emitCPUMetrics = newCputicksEmitter(cputicks.NewReader(root, defaultTicksPerSecond))
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape1), 0o600))
+	_, err = scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape2), 0o600))
+	md, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, 2, md.MetricCount())
+	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+
+	findMetric := func(name string) pmetric.Metric {
+		for _, m := range metrics.All() {
+			if m.Name() == name {
+				return m
+			}
+		}
+		t.Fatalf("metric not found: %s", name)
+		return pmetric.Metric{}
+	}
+
+	findDP := func(metric pmetric.Metric, cpuName, state string) float64 {
+		var dp pmetric.NumberDataPointSlice
+		switch metric.Type() {
+		case pmetric.MetricTypeSum:
+			dp = metric.Sum().DataPoints()
+		case pmetric.MetricTypeGauge:
+			dp = metric.Gauge().DataPoints()
+		}
+		for i := range dp.Len() {
+			p := dp.At(i)
+			cpuAttr, _ := p.Attributes().Get("cpu")
+			stateAttr, _ := p.Attributes().Get("state")
+			if cpuAttr.Str() == cpuName && stateAttr.Str() == state {
+				return p.DoubleValue()
+			}
+		}
+		t.Fatalf("datapoint not found: metric=%s cpu=%s state=%s", metric.Name(), cpuName, state)
+		return 0
+	}
+
+	timeMetric := findMetric("system.cpu.time")
+	assert.InDelta(t, 3.0, findDP(timeMetric, "cpu0", "user"), 0.001)
+	assert.InDelta(t, 0.75, findDP(timeMetric, "cpu0", "nice"), 0.001)
+	assert.InDelta(t, 1.5, findDP(timeMetric, "cpu0", "system"), 0.001)
+	assert.InDelta(t, 6.0, findDP(timeMetric, "cpu0", "idle"), 0.001)
+	assert.InDelta(t, 0.75, findDP(timeMetric, "cpu0", "wait"), 0.001)
+	assert.InDelta(t, 0.75, findDP(timeMetric, "cpu0", "interrupt"), 0.001)
+	assert.InDelta(t, 0.75, findDP(timeMetric, "cpu0", "softirq"), 0.001)
+	assert.InDelta(t, 1.5, findDP(timeMetric, "cpu0", "steal"), 0.001)
+
+	utilMetric := findMetric("system.cpu.utilization")
+	assert.InDelta(t, 0.2, findDP(utilMetric, "cpu0", "user"), 0.001)
+	assert.InDelta(t, 0.05, findDP(utilMetric, "cpu0", "nice"), 0.001)
+	assert.InDelta(t, 0.1, findDP(utilMetric, "cpu0", "system"), 0.001)
+	assert.InDelta(t, 0.4, findDP(utilMetric, "cpu0", "idle"), 0.001)
+	assert.InDelta(t, 0.05, findDP(utilMetric, "cpu0", "wait"), 0.001)
+	assert.InDelta(t, 0.05, findDP(utilMetric, "cpu0", "interrupt"), 0.001)
+	assert.InDelta(t, 0.05, findDP(utilMetric, "cpu0", "softirq"), 0.001)
+	assert.InDelta(t, 0.1, findDP(utilMetric, "cpu0", "steal"), 0.001)
+}
+
+func TestCputicksEmitter_NewCPUAppears(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	require.NoError(t, os.MkdirAll(procDir, 0o755))
+
+	scrape1 := "cpu  100 25 50 200 25 25 25 50 0 0\ncpu0 100 25 50 200 25 25 25 50 0 0\n"
+	scrape2 := "cpu  300 75 150 600 75 75 75 150 0 0\ncpu0 200 50 100 400 50 50 50 100 0 0\ncpu1 100 25 50 200 25 25 25 50 0 0\n"
+
+	cfg := metadata.DefaultMetricsBuilderConfig()
+	cfg.Metrics.SystemCPUUtilization.Enabled = true
+
+	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
+		&Config{MetricsBuilderConfig: cfg, rootPath: root})
+	scraper.emitCPUMetrics = newCputicksEmitter(cputicks.NewReader(root, defaultTicksPerSecond))
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape1), 0o600))
+	_, err = scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	// New CPU appears. Should be silently skipped for utilization.
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape2), 0o600))
+	_, err = scraper.scrape(t.Context())
+	require.NoError(t, err)
+}
+
+func TestCputicksEmitter_CPUDisappears(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	require.NoError(t, os.MkdirAll(procDir, 0o755))
+
+	scrape1 := "cpu  200 50 100 400 50 50 50 100 0 0\ncpu0 100 25 50 200 25 25 25 50 0 0\ncpu1 100 25 50 200 25 25 25 50 0 0\n"
+	scrape2 := "cpu  300 75 150 600 75 75 75 150 0 0\ncpu0 300 75 150 600 75 75 75 150 0 0\n"
+
+	cfg := metadata.DefaultMetricsBuilderConfig()
+	cfg.Metrics.SystemCPUUtilization.Enabled = true
+
+	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
+		&Config{MetricsBuilderConfig: cfg, rootPath: root})
+	scraper.emitCPUMetrics = newCputicksEmitter(cputicks.NewReader(root, defaultTicksPerSecond))
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape1), 0o600))
+	_, err = scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	// CPU disappears. Should return error.
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(scrape2), 0o600))
+	_, err = scraper.scrape(t.Context())
+	var partialErr scrapererror.PartialScrapeError
+	require.ErrorAs(t, err, &partialErr)
+	assert.ErrorContains(t, partialErr, ucal.ErrTimeStatNotFound.Error())
+}
+
+// mockTickReader implements tickReader for testing.
+type mockTickReader struct {
+	readAll        func(context.Context) ([]cputicks.Stat, error)
+	ticksPerSecond uint64
+}
+
+func (m *mockTickReader) ReadAll(ctx context.Context) ([]cputicks.Stat, error) {
+	return m.readAll(ctx)
+}
+
+func (m *mockTickReader) TicksPerSecond() uint64 { return m.ticksPerSecond }
+
+func TestCputicksEmitter_ReadError(t *testing.T) {
+	readErr := errors.New("disk I/O error")
+	reader := &mockTickReader{
+		readAll:        func(context.Context) ([]cputicks.Stat, error) { return nil, readErr },
+		ticksPerSecond: 100,
+	}
+
+	cfg := metadata.DefaultMetricsBuilderConfig()
+	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
+		&Config{MetricsBuilderConfig: cfg})
+	scraper.emitCPUMetrics = newCputicksEmitter(reader)
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	_, err = scraper.scrape(t.Context())
+	var partialErr scrapererror.PartialScrapeError
+	require.ErrorAs(t, err, &partialErr)
+	assert.ErrorContains(t, partialErr, "disk I/O error")
+}
+
+func TestCputicksEmitter_ZeroDelta(t *testing.T) {
+	sameTicks := []cputicks.Stat{
+		{CPU: "cpu0", User: 100, Nice: 25, System: 50, Idle: 200, Iowait: 25, Irq: 25, Softirq: 25, Steal: 50},
+	}
+	reader := &mockTickReader{
+		readAll:        func(context.Context) ([]cputicks.Stat, error) { return sameTicks, nil },
+		ticksPerSecond: 100,
+	}
+
+	cfg := metadata.DefaultMetricsBuilderConfig()
+	cfg.Metrics.SystemCPUUtilization.Enabled = true
+
+	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
+		&Config{MetricsBuilderConfig: cfg})
+	scraper.emitCPUMetrics = newCputicksEmitter(reader)
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	_, err = scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	md, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 2, md.MetricCount())
+
+	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for _, m := range metrics.All() {
+		if m.Name() == "system.cpu.utilization" {
+			dp := m.Gauge().DataPoints()
+			require.Equal(t, 8, dp.Len(), "expected 8 states for 1 CPU")
+			for i := range dp.Len() {
+				assert.Equal(t, 0.0, dp.At(i).DoubleValue(), "all utilization should be 0 when delta is 0")
+			}
+			return
+		}
+	}
+	t.Fatal("system.cpu.utilization metric not found")
+}
+
+
+

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -6,6 +6,8 @@
 package cpuscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
 
 import (
+	"context"
+
 	"github.com/shirou/gopsutil/v4/cpu"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
@@ -13,18 +15,22 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal"
 )
 
-func (s *cpuScraper) recordCPUTimeStateDataPoints(now pcommon.Timestamp, cpuTime cpu.TimesStat) {
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.User, cpuTime.CPU, metadata.AttributeStateUser)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.System, cpuTime.CPU, metadata.AttributeStateSystem)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Idle, cpuTime.CPU, metadata.AttributeStateIdle)
-	s.mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Irq, cpuTime.CPU, metadata.AttributeStateInterrupt)
+func newCPUEmitter(_ *Config) func(context.Context, pcommon.Timestamp, *metadata.MetricsBuilder) error {
+	return newGopsutilEmitter(cpu.TimesWithContext)
 }
 
-func (s *cpuScraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization) {
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.User, cpuUtilization.CPU, metadata.AttributeStateUser)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.System, cpuUtilization.CPU, metadata.AttributeStateSystem)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Idle, cpuUtilization.CPU, metadata.AttributeStateIdle)
-	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Irq, cpuUtilization.CPU, metadata.AttributeStateInterrupt)
+func recordCPUTimeStateDataPoints(now pcommon.Timestamp, cpuTime cpu.TimesStat, mb *metadata.MetricsBuilder) {
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.User, cpuTime.CPU, metadata.AttributeStateUser)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.System, cpuTime.CPU, metadata.AttributeStateSystem)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Idle, cpuTime.CPU, metadata.AttributeStateIdle)
+	mb.RecordSystemCPUTimeDataPoint(now, cpuTime.Irq, cpuTime.CPU, metadata.AttributeStateInterrupt)
+}
+
+func recordCPUUtilization(now pcommon.Timestamp, cpuUtilization ucal.CPUUtilization, mb *metadata.MetricsBuilder) {
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.User, cpuUtilization.CPU, metadata.AttributeStateUser)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.System, cpuUtilization.CPU, metadata.AttributeStateSystem)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Idle, cpuUtilization.CPU, metadata.AttributeStateIdle)
+	mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Irq, cpuUtilization.CPU, metadata.AttributeStateInterrupt)
 }
 
 func (*cpuScraper) getCPUInfo() ([]cpuInfo, error) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -79,7 +79,7 @@ func TestScrape(t *testing.T) {
 				scraper.bootTime = test.bootTimeFunc
 			}
 			if test.timesFunc != nil {
-				scraper.times = test.timesFunc
+				scraper.emitCPUMetrics = newGopsutilEmitter(test.timesFunc)
 			}
 
 			err := scraper.start(t.Context(), componenttest.NewNopHost())
@@ -305,21 +305,20 @@ func TestScrape_CpuUtilization(t *testing.T) {
 
 // Error in calculation should be returned as PartialScrapeError
 func TestScrape_CpuUtilizationError(t *testing.T) {
+	var currentTimes []cpu.TimesStat
 	scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()})
-	// mock times function to force an error in next scrape
-	scraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
-		return []cpu.TimesStat{{CPU: "1", System: 1, User: 2}}, nil
-	}
+	scraper.emitCPUMetrics = newGopsutilEmitter(func(_ context.Context, _ bool) ([]cpu.TimesStat, error) {
+		return currentTimes, nil
+	})
+
 	err := scraper.start(t.Context(), componenttest.NewNopHost())
 	require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
 
+	currentTimes = []cpu.TimesStat{{CPU: "1", System: 1, User: 2}}
 	_, err = scraper.scrape(t.Context())
-	// Force error not finding CPU info
-	scraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
-		return []cpu.TimesStat{}, nil
-	}
 	require.NoError(t, err, "Failed to scrape metrics: %v", err)
-	// 2nd scrape will trigger utilization metrics calculation
+
+	currentTimes = []cpu.TimesStat{}
 	md, err := scraper.scrape(t.Context())
 	var partialScrapeErr scrapererror.PartialScrapeError
 	assert.ErrorAs(t, err, &partialScrapeErr)
@@ -373,12 +372,14 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 		},
 	}
 
+	var currentTimes []cpu.TimesStat
 	cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: overriddenMetricsSettings})
+	cpuScraper.emitCPUMetrics = newGopsutilEmitter(func(_ context.Context, _ bool) ([]cpu.TimesStat, error) {
+		return currentTimes, nil
+	})
+
 	for _, scrapeData := range scrapesData {
-		// mock TimeStats and Now
-		cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
-			return scrapeData.times, nil
-		}
+		currentTimes = scrapeData.times
 		cpuScraper.now = func() time.Time {
 			now, _ := time.Parse(time.RFC3339, scrapeData.scrapeTime)
 			return now

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/cputicks.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/cputicks.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package cputicks // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks"
+
+// Stat stores raw CPU tick counts for a single logical CPU.
+// Field order matches /proc/stat columns.
+type Stat struct {
+	CPU       string
+	User      uint64
+	Nice      uint64
+	System    uint64
+	Idle      uint64
+	Iowait    uint64
+	Irq       uint64
+	Softirq   uint64
+	Steal     uint64
+	Guest     uint64
+	GuestNice uint64
+}
+
+func (s Stat) Total() uint64 {
+	return s.User + s.Nice + s.System + s.Idle + s.Iowait +
+		s.Irq + s.Softirq + s.Steal + s.Guest + s.GuestNice
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/cputicks_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/cputicks_others.go
@@ -1,0 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package cputicks // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/cputicks_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/cputicks_test.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package cputicks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTotal(t *testing.T) {
+	tick := Stat{
+		User: 10, Nice: 20, System: 30, Idle: 40, Iowait: 5,
+		Irq: 6, Softirq: 7, Steal: 8, Guest: 9, GuestNice: 1,
+	}
+	assert.Equal(t, uint64(136), tick.Total())
+}
+
+func TestTotal_Zero(t *testing.T) {
+	assert.Equal(t, uint64(0), Stat{}.Total())
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/reader_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/reader_linux.go
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package cputicks // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks"
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Reader parses /proc/stat for per-CPU tick counts.
+type Reader struct {
+	path           string
+	ticksPerSecond uint64
+}
+
+// NewReader returns a Reader that parses /proc/stat.
+// rootPath is the host root directory (e.g. "/host" for container environments);
+// pass "" to use the default /proc/stat.
+// ticksPerSecond is the OS timer resolution (USER_HZ, typically 100 on Linux).
+func NewReader(rootPath string, ticksPerSecond uint64) *Reader {
+	if rootPath == "" {
+		rootPath = "/"
+	}
+	return &Reader{path: filepath.Join(rootPath, "proc", "stat"), ticksPerSecond: ticksPerSecond}
+}
+
+func (r *Reader) TicksPerSecond() uint64 { return r.ticksPerSecond }
+
+func (r *Reader) ReadAll(_ context.Context) ([]Stat, error) {
+	f, err := os.Open(r.path)
+	if err != nil {
+		return nil, fmt.Errorf("cputicks: %w", err)
+	}
+	defer f.Close()
+
+	result := []Stat{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "cpu") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Skip the aggregate "cpu" line (no digit after "cpu").
+		if fields[0] == "cpu" {
+			continue
+		}
+		t, err := parseLine(fields)
+		if err != nil {
+			return nil, fmt.Errorf("cputicks: %w", err)
+		}
+		result = append(result, t)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cputicks: %w", err)
+	}
+	return result, nil
+}
+
+// parseLine converts a split /proc/stat "cpuN" line into a Stat value.
+// Minimum 5 fields: cpuN user nice system idle. Extra fields are optional.
+func parseLine(fields []string) (Stat, error) {
+	if len(fields) < 5 {
+		return Stat{}, fmt.Errorf("too few fields in line: %q", strings.Join(fields, " "))
+	}
+	t := Stat{CPU: fields[0]}
+
+	dests := []*uint64{
+		&t.User, &t.Nice, &t.System, &t.Idle, &t.Iowait,
+		&t.Irq, &t.Softirq, &t.Steal, &t.Guest, &t.GuestNice,
+	}
+	for i, dest := range dests {
+		col := i + 1
+		if col >= len(fields) {
+			break
+		}
+		v, err := strconv.ParseUint(fields[col], 10, 64)
+		if err != nil {
+			return Stat{}, fmt.Errorf("column %d (%q): %w", col, fields[col], err)
+		}
+		*dest = v
+	}
+	return t, nil
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/reader_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/cputicks/reader_linux_test.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package cputicks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAll(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []Stat
+		wantErr string
+	}{
+		{
+			name: "standard multi-cpu",
+			content: `cpu  100 200 300 400 50 60 70 80 90 10
+cpu0 10 20 30 40 5 6 7 8 9 1
+cpu1 90 180 270 360 45 54 63 72 81 9
+`,
+			want: []Stat{
+				{CPU: "cpu0", User: 10, Nice: 20, System: 30, Idle: 40, Iowait: 5, Irq: 6, Softirq: 7, Steal: 8, Guest: 9, GuestNice: 1},
+				{CPU: "cpu1", User: 90, Nice: 180, System: 270, Idle: 360, Iowait: 45, Irq: 54, Softirq: 63, Steal: 72, Guest: 81, GuestNice: 9},
+			},
+		},
+		{
+			name: "minimal four columns (old kernel)",
+			content: `cpu  100 200 300 400
+cpu0 10 20 30 40
+`,
+			want: []Stat{
+				{CPU: "cpu0", User: 10, Nice: 20, System: 30, Idle: 40},
+			},
+		},
+		{
+			name: "full ten columns",
+			content: `cpu  1 2 3 4 5 6 7 8 9 10
+cpu0 1 2 3 4 5 6 7 8 9 10
+`,
+			want: []Stat{
+				{CPU: "cpu0", User: 1, Nice: 2, System: 3, Idle: 4, Iowait: 5, Irq: 6, Softirq: 7, Steal: 8, Guest: 9, GuestNice: 10},
+			},
+		},
+		{
+			name:    "aggregate cpu line skipped",
+			content: "cpu  100 200 300 400 50 60 70 80 90 10\nintr 123 456\n",
+			want:    []Stat{},
+		},
+		{
+			name:    "malformed non-numeric field",
+			content: "cpu  100 200 300 400\ncpu0 10 abc 30 40\n",
+			wantErr: `column 2 ("abc")`,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    []Stat{},
+		},
+		{
+			name: "non-cpu lines interspersed",
+			content: `cpu  100 200 300 400 50 60 70 80 90 10
+intr 1234 56 78
+cpu0 10 20 30 40 5 6 7 8 9 1
+ctxt 9876543
+cpu1 90 180 270 360 45 54 63 72 81 9
+processes 12345
+`,
+			want: []Stat{
+				{CPU: "cpu0", User: 10, Nice: 20, System: 30, Idle: 40, Iowait: 5, Irq: 6, Softirq: 7, Steal: 8, Guest: 9, GuestNice: 1},
+				{CPU: "cpu1", User: 90, Nice: 180, System: 270, Idle: 360, Iowait: 45, Irq: 54, Softirq: 63, Steal: 72, Guest: 81, GuestNice: 9},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "stat")
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0o600))
+
+			r := &Reader{path: path, ticksPerSecond: 100}
+			actual, err := r.ReadAll(t.Context())
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}
+
+func TestReadAll_FileNotFound(t *testing.T) {
+	r := &Reader{path: "/nonexistent/stat", ticksPerSecond: 100}
+	_, err := r.ReadAll(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cputicks:")
+}
+
+func TestNewReader_RootPath(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	require.NoError(t, os.MkdirAll(procDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(
+		"cpu  100 200 300 400 50 60 70 80 90 10\ncpu0 10 20 30 40 5 6 7 8 9 1\n",
+	), 0o600))
+
+	r := NewReader(root, 100)
+	assert.Equal(t, uint64(100), r.TicksPerSecond())
+	ticks, err := r.ReadAll(t.Context())
+	require.NoError(t, err)
+	require.Len(t, ticks, 1)
+	assert.Equal(t, Stat{CPU: "cpu0", User: 10, Nice: 20, System: 30, Idle: 40, Iowait: 5, Irq: 6, Softirq: 7, Steal: 8, Guest: 9, GuestNice: 1}, ticks[0])
+}
+
+func TestReadAll_RealProcStat(t *testing.T) {
+	if _, err := os.Stat("/proc/stat"); err != nil {
+		t.Skip("/proc/stat not available")
+	}
+	r := NewReader("", 100)
+	ticks, err := r.ReadAll(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, ticks, "expected at least one CPU")
+	for _, tick := range ticks {
+		assert.NotEmpty(t, tick.CPU)
+		assert.NotZero(t, tick.Total(), "expected non-zero total for %s", tick.CPU)
+	}
+}
+
+func BenchmarkReadAll(b *testing.B) {
+	if _, err := os.Stat("/proc/stat"); err != nil {
+		b.Skip("/proc/stat not available")
+	}
+	r := NewReader("", 100)
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := r.ReadAll(b.Context())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReadAll_Gopsutil(b *testing.B) {
+	if _, err := os.Stat("/proc/stat"); err != nil {
+		b.Skip("/proc/stat not available")
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := cpu.TimesWithContext(b.Context(), true)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to [#46153](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46153) (precision improvements for memory, disk, and filesystem scrapers) and the approach discussed in [#46177](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177). The CPU scraper was excluded from [#46153](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46153) because gopsutil converts raw integer jiffies from `/proc/stat` to `float64` seconds before the scraper sees them. This shrinks operand magnitudes so that `precision.Ratio` rounds too aggressively; a 1-CPU/10s-interval machine gets only 1 significant digit, rounding 3% utilization to 0%.

As discussed in [#46177](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177), a gopsutil upstream fix wouldn't help here since the consumer still computes `delta_user / delta_total` as `float64 / float64`, producing 15-17 digits again. The fix needs to keep the data as `uint64` throughout the pipeline. The new path is behind an alpha feature gate for opt-in testing before becoming the default.

This PR adds a Linux-only `cputicks` package and integrates it into the CPU scraper, combining the infrastructure and wiring proposed in [#46177](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177) into a single PR. The package is scoped to `cpuscraper/internal/cputicks/` since it is only used by the CPU scraper. Linux-only is pragmatic: the vast majority of OTel collectors in production run on Linux, and macOS/Windows native readers can follow in separate PRs if needed.

The `cputicks.Reader` parses `/proc/stat` directly using `bufio.Scanner` + `strconv.ParseUint`, returning `[]Stat` with raw `uint64` fields. It handles variable column counts across kernel versions and supports `rootPath` for container environments where the host procfs is mounted at a non-default location.

To wire the new reader in without breaking existing behavior, the scraper's direct `times` + `ucal` fields are replaced with a single `emitCPUMetrics` function field that encapsulates the full read+record cycle. `newGopsutilEmitter` wraps the existing gopsutil+ucal logic unchanged; `newCputicksEmitter` uses `cputicks.Reader` with `precision.Scale` for tick-to-seconds conversion and `precision.Ratio` for utilization, preserving the true precision of the source data instead of producing 15-17 digit float64 artifacts.

The `receiver.hostmetricsreceiver.UseCPUTicks` alpha feature gate selects between the two emitters at construction time. When disabled (default) or on non-Linux platforms, behavior is unchanged and `newGopsutilEmitter` is used. Non-Linux platforms continue using gopsutil as noted in [#46177](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177) since reconstructing integer ticks from gopsutil's `float64` output would be a lossy round-trip.

## Testing

```bash
cd receiver/hostmetricsreceiver
go test ./internal/scraper/cpuscraper/...
```

## Benchmarks

Reading `/proc/stat` directly does not introduce a performance penalty compared to gopsutil:

```
BenchmarkReadAll-8            147184    8216 ns/op    7992 B/op    33 allocs/op
BenchmarkReadAll_Gopsutil-8   130821    9200 ns/op    8737 B/op    46 allocs/op
```

```bash
cd receiver/hostmetricsreceiver
go test ./internal/scraper/cpuscraper/internal/cputicks/... -bench=. -benchmem
```

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177