### PR TITLE
[processor/filter] Deprecate custom functions options suffixed with `New`

### DIFF
--- a/.chloggen/change-filter-api-func-opts-use-pointers.yaml
+++ b/.chloggen/change-filter-api-func-opts-use-pointers.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/filter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change `With*Functions` and `Default*Functions` to use pointer-based transform context signatures
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |  
+  The filter processor function options `With*Functions` and `Default*Functions` now use pointer-based transform context signatures
+  and are no longer deprecated. As a result, they are not compatible with older non-pointer signatures anymore and must be updated to 
+  use the new signature.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/change-filter-api-func-opts-use-pointers.yaml
+++ b/.chloggen/change-filter-api-func-opts-use-pointers.yaml
@@ -10,7 +10,7 @@ component: processor/filter
 note: Change `With*Functions` and `Default*Functions` to use pointer-based transform context signatures
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47975]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/deprecate-ilter-api-func-opt-with-new.yaml
+++ b/.chloggen/deprecate-ilter-api-func-opt-with-new.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/filter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate custom function options suffixed with `New` in favor of the existing pointer-based options
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |    
+  The `With*FunctionsNew` and `Default*FunctionsNew` variants are now deprecated and will be removed in a future release.
+  If you register custom filter processor functions, migrate:
+    - `With*FunctionsNew` -> `With*Functions`
+    - `Default*FunctionsNew` -> `Default*Functions`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/deprecate-ilter-api-func-opt-with-new.yaml
+++ b/.chloggen/deprecate-ilter-api-func-opt-with-new.yaml
@@ -10,7 +10,7 @@ component: processor/filter
 note: Deprecate custom function options suffixed with `New` in favor of the existing pointer-based options
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [47975]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -66,23 +66,6 @@ type hasAttributeOnDatapointArguments struct {
 	ExpectedVal string
 }
 
-// TODO: Remove when deprecated DefaultMetricFunctions is removed.
-func NewHasAttributeOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
-	return ottl.NewFactory("HasAttrOnDatapoint", &hasAttributeOnDatapointArguments{}, createHasAttributeOnDatapointFunctionLegacy)
-}
-
-func createHasAttributeOnDatapointFunctionLegacy(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	args, ok := oArgs.(*hasAttributeOnDatapointArguments)
-
-	if !ok {
-		return nil, errors.New("hasAttributeOnDatapointFactory args must be of type *hasAttributeOnDatapointArguments")
-	}
-
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
-		return checkDataPoints(&tCtx, args.Key, &args.ExpectedVal)
-	}, nil
-}
-
 func newHasAttributeOnDatapointFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("HasAttrOnDatapoint", &hasAttributeOnDatapointArguments{}, createHasAttributeOnDatapointFunction)
 }
@@ -105,23 +88,6 @@ func hasAttributeOnDatapoint(key, expectedVal string) (ottl.ExprFunc[*ottlmetric
 
 type hasAttributeKeyOnDatapointArguments struct {
 	Key string
-}
-
-// TODO: Remove when deprecated DefaultMetricFunctions is removed.
-func NewHasAttributeKeyOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
-	return ottl.NewFactory("HasAttrKeyOnDatapoint", &hasAttributeKeyOnDatapointArguments{}, createHasAttributeKeyOnDatapointFunctionLegacy)
-}
-
-func createHasAttributeKeyOnDatapointFunctionLegacy(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	args, ok := oArgs.(*hasAttributeKeyOnDatapointArguments)
-
-	if !ok {
-		return nil, errors.New("hasAttributeKeyOnDatapointFactory args must be of type *hasAttributeOnDatapointArguments")
-	}
-
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
-		return checkDataPoints(&tCtx, args.Key, nil)
-	}, nil
 }
 
 func newHasAttributeKeyOnDatapointFactory() ottl.Factory[*ottlmetric.TransformContext] {

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -26,19 +26,19 @@ import (
 
 func assertConfigContainsDefaultFunctions(t *testing.T, config Config) {
 	t.Helper()
-	for _, f := range DefaultLogFunctionsNew() {
+	for _, f := range DefaultLogFunctions() {
 		assert.Contains(t, config.logFunctions, f.Name(), "missing log function %v", f.Name())
 	}
-	for _, f := range DefaultDataPointFunctionsNew() {
+	for _, f := range DefaultDataPointFunctions() {
 		assert.Contains(t, config.dataPointFunctions, f.Name(), "missing data point function %v", f.Name())
 	}
-	for _, f := range DefaultMetricFunctionsNew() {
+	for _, f := range DefaultMetricFunctions() {
 		assert.Contains(t, config.metricFunctions, f.Name(), "missing metric function %v", f.Name())
 	}
-	for _, f := range DefaultSpanFunctionsNew() {
+	for _, f := range DefaultSpanFunctions() {
 		assert.Contains(t, config.spanFunctions, f.Name(), "missing span function %v", f.Name())
 	}
-	for _, f := range DefaultSpanEventFunctionsNew() {
+	for _, f := range DefaultSpanEventFunctions() {
 		assert.Contains(t, config.spanEventFunctions, f.Name(), "missing span event function %v", f.Name())
 	}
 	for _, f := range DefaultProfileFunctions() {

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -48,18 +48,9 @@ type filterProcessorFactory struct {
 // FactoryOption applies changes to filterProcessorFactory.
 type FactoryOption func(factory *filterProcessorFactory)
 
-// Deprecated: [v0.142.0] Use WithResourceFunctionsNew.
-func WithResourceFunctions(resourceFunctions []ottl.Factory[ottlresource.TransformContext]) FactoryOption {
-	newResourceFunctions := make([]ottl.Factory[*ottlresource.TransformContext], 0, len(resourceFunctions))
-	for _, resourceFunction := range resourceFunctions {
-		newResourceFunctions = append(newResourceFunctions, ottl.NewFactory[*ottlresource.TransformContext](resourceFunction.Name(), resourceFunction.CreateDefaultArguments(), fromNonPointerFunction(resourceFunction.CreateFunction)))
-	}
-	return WithResourceFunctionsNew(newResourceFunctions)
-}
-
-// WithResourceFunctionsNew will override the default OTTL resource context functions with the provided resourceFunctions in resulting processor.
-// Subsequent uses of WithResourceFunctionsNew will merge the provided resourceFunctions with the previously registered functions.
-func WithResourceFunctionsNew(resourceFunctions []ottl.Factory[*ottlresource.TransformContext]) FactoryOption {
+// WithResourceFunctions will override the default OTTL resource context functions with the provided resourceFunctions in resulting processor.
+// Subsequent uses of WithResourceFunctions will merge the provided resourceFunctions with the previously registered functions.
+func WithResourceFunctions(resourceFunctions []ottl.Factory[*ottlresource.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultResourceFunctionsOverridden {
 			factory.resourceFunctions = map[string]ottl.Factory[*ottlresource.TransformContext]{}
@@ -69,18 +60,14 @@ func WithResourceFunctionsNew(resourceFunctions []ottl.Factory[*ottlresource.Tra
 	}
 }
 
-// Deprecated: [v0.142.0] Use WithDataPointFunctionsNew.
-func WithDataPointFunctions(dataPointFunctions []ottl.Factory[ottldatapoint.TransformContext]) FactoryOption {
-	newDataPointFunctions := make([]ottl.Factory[*ottldatapoint.TransformContext], 0, len(dataPointFunctions))
-	for _, dataPointFunction := range dataPointFunctions {
-		newDataPointFunctions = append(newDataPointFunctions, ottl.NewFactory[*ottldatapoint.TransformContext](dataPointFunction.Name(), dataPointFunction.CreateDefaultArguments(), fromNonPointerFunction(dataPointFunction.CreateFunction)))
-	}
-	return WithDataPointFunctionsNew(newDataPointFunctions)
+// Deprecated: [v0.152.0] Use WithResourceFunctions.
+func WithResourceFunctionsNew(resourceFunctions []ottl.Factory[*ottlresource.TransformContext]) FactoryOption {
+	return WithResourceFunctions(resourceFunctions)
 }
 
-// WithDataPointFunctionsNew will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
-// Subsequent uses of WithDataPointFunctionsNew will merge the provided dataPointFunctions with the previously registered functions.
-func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
+// WithDataPointFunctions will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
+// Subsequent uses of WithDataPointFunctions will merge the provided dataPointFunctions with the previously registered functions.
+func WithDataPointFunctions(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultDataPointFunctionsOverridden {
 			factory.dataPointFunctions = map[string]ottl.Factory[*ottldatapoint.TransformContext]{}
@@ -90,18 +77,14 @@ func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.
 	}
 }
 
-// Deprecated: [v0.142.0] Use WithLogFunctionsNew.
-func WithLogFunctions(logFunctions []ottl.Factory[ottllog.TransformContext]) FactoryOption {
-	newLogFunctions := make([]ottl.Factory[*ottllog.TransformContext], 0, len(logFunctions))
-	for _, logFunction := range logFunctions {
-		newLogFunctions = append(newLogFunctions, ottl.NewFactory[*ottllog.TransformContext](logFunction.Name(), logFunction.CreateDefaultArguments(), fromNonPointerFunction(logFunction.CreateFunction)))
-	}
-	return WithLogFunctionsNew(newLogFunctions)
+// Deprecated: [v0.152.0] Use WithDataPointFunctions.
+func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
+	return WithDataPointFunctions(dataPointFunctions)
 }
 
-// WithLogFunctionsNew will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
-// Subsequent uses of WithLogFunctionsNew will merge the provided logFunctions with the previously registered functions.
-func WithLogFunctionsNew(logFunctions []ottl.Factory[*ottllog.TransformContext]) FactoryOption {
+// WithLogFunctions will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
+// Subsequent uses of WithLogFunctions will merge the provided logFunctions with the previously registered functions.
+func WithLogFunctions(logFunctions []ottl.Factory[*ottllog.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultLogFunctionsOverridden {
 			factory.logFunctions = map[string]ottl.Factory[*ottllog.TransformContext]{}
@@ -111,18 +94,14 @@ func WithLogFunctionsNew(logFunctions []ottl.Factory[*ottllog.TransformContext])
 	}
 }
 
-// Deprecated: [v0.142.0] Use WithMetricFunctionsNew.
-func WithMetricFunctions(metricFunctions []ottl.Factory[ottlmetric.TransformContext]) FactoryOption {
-	newMetricFunctions := make([]ottl.Factory[*ottlmetric.TransformContext], 0, len(metricFunctions))
-	for _, metricFunction := range metricFunctions {
-		newMetricFunctions = append(newMetricFunctions, ottl.NewFactory[*ottlmetric.TransformContext](metricFunction.Name(), metricFunction.CreateDefaultArguments(), fromNonPointerFunction(metricFunction.CreateFunction)))
-	}
-	return WithMetricFunctionsNew(newMetricFunctions)
+// Deprecated: [v0.152.0] Use WithLogFunctions.
+func WithLogFunctionsNew(logFunctions []ottl.Factory[*ottllog.TransformContext]) FactoryOption {
+	return WithLogFunctions(logFunctions)
 }
 
-// WithMetricFunctionsNew will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
-// Subsequent uses of WithMetricFunctionsNew will merge the provided metricFunctions with the previously registered functions.
-func WithMetricFunctionsNew(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
+// WithMetricFunctions will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
+// Subsequent uses of WithMetricFunctions will merge the provided metricFunctions with the previously registered functions.
+func WithMetricFunctions(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultMetricFunctionsOverridden {
 			factory.metricFunctions = map[string]ottl.Factory[*ottlmetric.TransformContext]{}
@@ -132,18 +111,14 @@ func WithMetricFunctionsNew(metricFunctions []ottl.Factory[*ottlmetric.Transform
 	}
 }
 
-// Deprecated: [v0.142.0] Use WithSpanEventFunctionsNew.
-func WithSpanEventFunctions(spanEventFunctions []ottl.Factory[ottlspanevent.TransformContext]) FactoryOption {
-	newSpanFunctions := make([]ottl.Factory[*ottlspanevent.TransformContext], 0, len(spanEventFunctions))
-	for _, spanEventFunction := range spanEventFunctions {
-		newSpanFunctions = append(newSpanFunctions, ottl.NewFactory[*ottlspanevent.TransformContext](spanEventFunction.Name(), spanEventFunction.CreateDefaultArguments(), fromNonPointerFunction(spanEventFunction.CreateFunction)))
-	}
-	return WithSpanEventFunctionsNew(newSpanFunctions)
+// Deprecated: [v0.152.0] Use WithMetricFunctions.
+func WithMetricFunctionsNew(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
+	return WithMetricFunctions(metricFunctions)
 }
 
-// WithSpanEventFunctionsNew will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
-// Subsequent uses of WithSpanEventFunctionsNew will merge the provided spanEventFunctions with the previously registered functions.
-func WithSpanEventFunctionsNew(spanEventFunctions []ottl.Factory[*ottlspanevent.TransformContext]) FactoryOption {
+// WithSpanEventFunctions will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
+// Subsequent uses of WithSpanEventFunctions will merge the provided spanEventFunctions with the previously registered functions.
+func WithSpanEventFunctions(spanEventFunctions []ottl.Factory[*ottlspanevent.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultSpanEventFunctionsOverridden {
 			factory.spanEventFunctions = map[string]ottl.Factory[*ottlspanevent.TransformContext]{}
@@ -153,18 +128,14 @@ func WithSpanEventFunctionsNew(spanEventFunctions []ottl.Factory[*ottlspanevent.
 	}
 }
 
-// Deprecated: [v0.142.0] use WithSpanFunctionsNew.
-func WithSpanFunctions(spanFunctions []ottl.Factory[ottlspan.TransformContext]) FactoryOption {
-	newSpanFunctions := make([]ottl.Factory[*ottlspan.TransformContext], 0, len(spanFunctions))
-	for _, spanFunction := range spanFunctions {
-		newSpanFunctions = append(newSpanFunctions, ottl.NewFactory[*ottlspan.TransformContext](spanFunction.Name(), spanFunction.CreateDefaultArguments(), fromNonPointerFunction(spanFunction.CreateFunction)))
-	}
-	return WithSpanFunctionsNew(newSpanFunctions)
+// Deprecated: [v0.152.0] Use WithSpanEventFunctions.
+func WithSpanEventFunctionsNew(spanEventFunctions []ottl.Factory[*ottlspanevent.TransformContext]) FactoryOption {
+	return WithSpanEventFunctions(spanEventFunctions)
 }
 
-// WithSpanFunctionsNew will override the default OTTL span context functions with the provided spanFunctions in the resulting processor.
+// WithSpanFunctions will override the default OTTL span context functions with the provided spanFunctions in the resulting processor.
 // Subsequent uses of WithSpanFunctions will merge the provided spanFunctions with the previously registered functions.
-func WithSpanFunctionsNew(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
+func WithSpanFunctions(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultSpanFunctionsOverridden {
 			factory.spanFunctions = map[string]ottl.Factory[*ottlspan.TransformContext]{}
@@ -174,18 +145,14 @@ func WithSpanFunctionsNew(spanFunctions []ottl.Factory[*ottlspan.TransformContex
 	}
 }
 
-// Deprecated: [v0.145.0] use WithProfileFunctionsNew.
-func WithProfileFunctions(profileFunctions []ottl.Factory[ottlprofile.TransformContext]) FactoryOption {
-	newProfileFunctions := make([]ottl.Factory[*ottlprofile.TransformContext], 0, len(profileFunctions))
-	for _, profileFunction := range profileFunctions {
-		newProfileFunctions = append(newProfileFunctions, ottl.NewFactory[*ottlprofile.TransformContext](profileFunction.Name(), profileFunction.CreateDefaultArguments(), fromNonPointerFunction(profileFunction.CreateFunction)))
-	}
-	return WithProfileFunctionsNew(newProfileFunctions)
+// Deprecated: [v0.152.0] use WithSpanFunctions.
+func WithSpanFunctionsNew(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
+	return WithSpanFunctions(spanFunctions)
 }
 
-// WithProfileFunctionsNew will override the default OTTL profile context functions with the provided profileFunctions in the resulting processor.
-// Subsequent uses of WithProfileFunctionsNew will merge the provided profileFunctions with the previously registered functions.
-func WithProfileFunctionsNew(profileFunctions []ottl.Factory[*ottlprofile.TransformContext]) FactoryOption {
+// WithProfileFunctions will override the default OTTL profile context functions with the provided profileFunctions in the resulting processor.
+// Subsequent uses of WithProfileFunctions will merge the provided profileFunctions with the previously registered functions.
+func WithProfileFunctions(profileFunctions []ottl.Factory[*ottlprofile.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultProfileFunctionsOverridden {
 			factory.profileFunctions = map[string]ottl.Factory[*ottlprofile.TransformContext]{}
@@ -193,6 +160,11 @@ func WithProfileFunctionsNew(profileFunctions []ottl.Factory[*ottlprofile.Transf
 		}
 		factory.profileFunctions = mergeFunctionsToMap(factory.profileFunctions, profileFunctions)
 	}
+}
+
+// Deprecated: [v0.152.0] use WithProfileFunctions.
+func WithProfileFunctionsNew(profileFunctions []ottl.Factory[*ottlprofile.TransformContext]) FactoryOption {
+	return WithProfileFunctions(profileFunctions)
 }
 
 // NewFactory returns a new factory for the Filter processor.
@@ -342,16 +314,4 @@ func (f *filterProcessorFactory) createProfilesProcessor(
 		nextConsumer,
 		fp.processProfiles,
 		xprocessorhelper.WithCapabilities(processorCapabilities))
-}
-
-func fromNonPointerFunction[K any](legacy func(fCtx ottl.FunctionContext, args ottl.Arguments) (ottl.ExprFunc[K], error)) func(fCtx ottl.FunctionContext, args ottl.Arguments) (ottl.ExprFunc[*K], error) {
-	return func(fCtx ottl.FunctionContext, args ottl.Arguments) (ottl.ExprFunc[*K], error) {
-		legacyExpr, err := legacy(fCtx, args)
-		if err != nil {
-			return nil, err
-		}
-		return func(ctx context.Context, tCtx *K) (any, error) {
-			return legacyExpr(ctx, *tCtx)
-		}, nil
-	}
 }

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -168,8 +168,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -181,7 +181,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctions(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -192,7 +192,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -204,7 +204,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -215,9 +215,9 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
-				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
+				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctions([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
 		{
@@ -229,8 +229,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestSpanFunc"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
+				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
 		{
@@ -241,7 +241,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctions([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 			},
 		},
 		{
@@ -253,7 +253,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctions([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 			},
 		},
 		{
@@ -264,9 +264,9 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
-				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctions([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 		{
@@ -278,8 +278,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestSpanEventFunc"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
+				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
 		{
@@ -290,7 +290,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctions([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 		{
@@ -302,7 +302,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctions([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 	}
@@ -341,8 +341,8 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -354,7 +354,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctions(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -365,7 +365,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -377,7 +377,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithLogFunctionsNew(DefaultLogFunctionsNew()),
-				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctions(DefaultLogFunctions()),
+				WithLogFunctions([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 		{
@@ -401,7 +401,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestLogFunc"`,
 			factoryOptions: []FactoryOption{
-				WithLogFunctionsNew(DefaultLogFunctionsNew()),
+				WithLogFunctions(DefaultLogFunctions()),
 			},
 		},
 		{
@@ -412,7 +412,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctions([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 		{
@@ -424,7 +424,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctions([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 	}
@@ -464,8 +464,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -477,7 +477,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctions(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -488,7 +488,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -500,7 +500,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -511,9 +511,9 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
-				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
-				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
+				WithMetricFunctions(DefaultMetricFunctions()),
+				WithMetricFunctions([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithDataPointFunctions(DefaultDataPointFunctions()),
 			},
 		},
 		{
@@ -525,8 +525,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestMetricFunc"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
-				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
+				WithMetricFunctions(DefaultMetricFunctions()),
+				WithDataPointFunctions(DefaultDataPointFunctions()),
 			},
 		},
 		{
@@ -537,7 +537,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithMetricFunctions([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
 			},
 		},
 		{
@@ -549,7 +549,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithMetricFunctions([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
 			},
 		},
 		{
@@ -560,9 +560,9 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
-				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
-				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithMetricFunctions(DefaultMetricFunctions()),
+				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithDataPointFunctions([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 		{
@@ -574,8 +574,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestDataPointFunc"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
-				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
+				WithMetricFunctions(DefaultMetricFunctions()),
+				WithDataPointFunctions(DefaultDataPointFunctions()),
 			},
 		},
 		{
@@ -586,7 +586,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithDataPointFunctions([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 		{
@@ -598,7 +598,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithDataPointFunctions([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 	}
@@ -637,8 +637,8 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -650,7 +650,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctions(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -661,7 +661,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -673,7 +673,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctions([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -684,8 +684,8 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithProfileFunctionsNew(DefaultProfileFunctionsNew()),
-				WithProfileFunctionsNew([]ottl.Factory[*ottlprofile.TransformContext]{createTestFuncFactory[*ottlprofile.TransformContext]("TestProfileFunc")}),
+				WithProfileFunctions(DefaultProfileFunctions()),
+				WithProfileFunctions([]ottl.Factory[*ottlprofile.TransformContext]{createTestFuncFactory[*ottlprofile.TransformContext]("TestProfileFunc")}),
 			},
 		},
 		{
@@ -697,7 +697,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestProfileFunc"`,
 			factoryOptions: []FactoryOption{
-				WithProfileFunctionsNew(DefaultProfileFunctionsNew()),
+				WithProfileFunctions(DefaultProfileFunctions()),
 			},
 		},
 		{
@@ -708,7 +708,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithProfileFunctionsNew([]ottl.Factory[*ottlprofile.TransformContext]{createTestFuncFactory[*ottlprofile.TransformContext]("TestProfileFunc")}),
+				WithProfileFunctions([]ottl.Factory[*ottlprofile.TransformContext]{createTestFuncFactory[*ottlprofile.TransformContext]("TestProfileFunc")}),
 			},
 		},
 		{
@@ -720,7 +720,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithProfileFunctionsNew([]ottl.Factory[*ottlprofile.TransformContext]{createTestFuncFactory[*ottlprofile.TransformContext]("TestProfileFunc")}),
+				WithProfileFunctions([]ottl.Factory[*ottlprofile.TransformContext]{createTestFuncFactory[*ottlprofile.TransformContext]("TestProfileFunc")}),
 			},
 		},
 	}

--- a/processor/filterprocessor/functions.go
+++ b/processor/filterprocessor/functions.go
@@ -16,73 +16,64 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
 func DefaultResourceFunctions() []ottl.Factory[*ottlresource.TransformContext] {
 	return slices.Collect(maps.Values(defaultResourceFunctionsMap()))
 }
 
-// Deprecated: [v0.142.0] use DefaultLogFunctionsNew.
-func DefaultLogFunctions() []ottl.Factory[ottllog.TransformContext] {
-	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[ottllog.TransformContext]()))
-}
-
-func DefaultLogFunctionsNew() []ottl.Factory[*ottllog.TransformContext] {
+func DefaultLogFunctions() []ottl.Factory[*ottllog.TransformContext] {
 	return slices.Collect(maps.Values(defaultLogFunctionsMap()))
 }
 
-// Deprecated: [v0.142.0] use DefaultMetricFunctionsNew.
-func DefaultMetricFunctions() []ottl.Factory[ottlmetric.TransformContext] {
-	m := ottlfuncs.StandardConverters[ottlmetric.TransformContext]()
-	hasAttributeOnDatapointFactory := filterottl.NewHasAttributeOnDatapointFactory()
-	hasAttributeKeyOnDatapointFactory := filterottl.NewHasAttributeKeyOnDatapointFactory()
-	m[hasAttributeOnDatapointFactory.Name()] = hasAttributeOnDatapointFactory
-	m[hasAttributeKeyOnDatapointFactory.Name()] = hasAttributeKeyOnDatapointFactory
-	return slices.Collect(maps.Values(m))
+// Deprecated: [v0.152.0] use DefaultLogFunctions.
+func DefaultLogFunctionsNew() []ottl.Factory[*ottllog.TransformContext] {
+	return DefaultLogFunctions()
 }
 
-func DefaultMetricFunctionsNew() []ottl.Factory[*ottlmetric.TransformContext] {
+func DefaultMetricFunctions() []ottl.Factory[*ottlmetric.TransformContext] {
 	return slices.Collect(maps.Values(defaultMetricFunctionsMap()))
 }
 
-// Deprecated: [v0.142.0] use DefaultDataPointFunctionsNew.
-func DefaultDataPointFunctions() []ottl.Factory[ottldatapoint.TransformContext] {
-	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[ottldatapoint.TransformContext]()))
+// Deprecated: [v0.152.0] use DefaultMetricFunctions.
+func DefaultMetricFunctionsNew() []ottl.Factory[*ottlmetric.TransformContext] {
+	return DefaultMetricFunctions()
 }
 
-func DefaultDataPointFunctionsNew() []ottl.Factory[*ottldatapoint.TransformContext] {
+func DefaultDataPointFunctions() []ottl.Factory[*ottldatapoint.TransformContext] {
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
-// Deprecated: [v0.142.0] use DefaultSpanFunctionsNew.
-func DefaultSpanFunctions() []ottl.Factory[ottlspan.TransformContext] {
-	funcs := ottlfuncs.StandardConverters[ottlspan.TransformContext]()
-	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactory()
-	funcs[isRootSpanFactory.Name()] = isRootSpanFactory
-	return slices.Collect(maps.Values(funcs))
+// Deprecated: [v0.152.0] use DefaultDataPointFunctions.
+func DefaultDataPointFunctionsNew() []ottl.Factory[*ottldatapoint.TransformContext] {
+	return DefaultDataPointFunctions()
 }
 
-func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
+func DefaultSpanFunctions() []ottl.Factory[*ottlspan.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanFunctionsMap()))
 }
 
-// Deprecated: [v0.142.0] use DefaultSpanEventFunctionsNew.
-func DefaultSpanEventFunctions() []ottl.Factory[*ottlspanevent.TransformContext] {
-	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[*ottlspanevent.TransformContext]()))
+// Deprecated: [v0.152.0] use DefaultSpanFunctions.
+func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
+	return DefaultSpanFunctions()
 }
 
-func DefaultSpanEventFunctionsNew() []ottl.Factory[*ottlspanevent.TransformContext] {
+func DefaultSpanEventFunctions() []ottl.Factory[*ottlspanevent.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanEventFunctionsMap()))
 }
 
-// Deprecated: [v0.145.0] use DefaultProfileFunctionsNew.
-func DefaultProfileFunctions() []ottl.Factory[ottlprofile.TransformContext] {
-	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[ottlprofile.TransformContext]()))
+// Deprecated: [v0.152.0] use DefaultSpanEventFunctions.
+func DefaultSpanEventFunctionsNew() []ottl.Factory[*ottlspanevent.TransformContext] {
+	return DefaultSpanEventFunctions()
 }
 
-func DefaultProfileFunctionsNew() []ottl.Factory[*ottlprofile.TransformContext] {
+func DefaultProfileFunctions() []ottl.Factory[*ottlprofile.TransformContext] {
 	return slices.Collect(maps.Values(defaultProfileFunctionsMap()))
+}
+
+// Deprecated: [v0.152.0] use DefaultProfileFunctions.
+func DefaultProfileFunctionsNew() []ottl.Factory[*ottlprofile.TransformContext] {
+	return DefaultProfileFunctions()
 }
 
 func defaultResourceFunctionsMap() map[string]ottl.Factory[*ottlresource.TransformContext] {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Change deprecated `With*Functions` and `Default*Functions` to use pointer-based transform context signatures, and mark them as non-deprecated.
- Deprecate custom function options suffixed with `New` in favor of the existing pointer-based options.

<!--Please delete paragraphs that you did not use before submitting.-->
