### PR TITLE
[chore][exporter/datadogexporter] fix instrumentation_scope_metadata_as_tags default in example

### DIFF
--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -260,10 +260,10 @@ exporters:
       #
       # resource_attributes_as_tags: false
 
-      ## @param instrumentation_scope_metadata_as_tags - string - optional - default: false
-      ## Set to true to add metadata about the instrumentation scope that created a metric.
+      ## @param instrumentation_scope_metadata_as_tags - string - optional - default: true
+      ## Adds metadata about the instrumentation scope that created a metric. Set to false to disable.
       #
-      # instrumentation_scope_metadata_as_tags: false
+      # instrumentation_scope_metadata_as_tags: true
 
       ## @param histograms - custom object - optional
       ## Histograms specific configuration.


### PR DESCRIPTION
## Description

The example `collector.yaml` for the Datadog exporter documents the default value of `metrics::instrumentation_scope_metadata_as_tags` as `false`:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml#L263-L266

```yaml
## @param instrumentation_scope_metadata_as_tags - string - optional - default: false
## Set to true to add metadata about the instrumentation scope that created a metric.
#
# instrumentation_scope_metadata_as_tags: false
```

However, the real default in `pkg/datadog/config` is `true`:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/datadog/config/config.go#L371

```go
ExporterConfig: MetricsExporterConfig{
    ResourceAttributesAsTags:           false,
    InstrumentationScopeMetadataAsTags: true,
},
```

The default was flipped to `true` in #39767 (see CHANGELOG: "Enable instrumentation_scope_metadata_as_tags by default in datadogexporter"), but the example file was missed. This PR updates the `@param` annotation, the description, and the commented-out example value to reflect the real default.

## Link to tracking issue

N/A — small docs-only fix.

## Testing

Documentation only — no code changes.

## Documentation

This PR _is_ the documentation update.

Made with [Cursor](https://cursor.com)