### PR TITLE
[receiver/googlecloudmonitoring] Allow overriding default monitoring endpoint

### DIFF
--- a/.chloggen/allow-overriding-default-endpoint-for-googlecloudmonitoringreceiver.yaml
+++ b/.chloggen/allow-overriding-default-endpoint-for-googlecloudmonitoringreceiver.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudmonitoring
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow overriding default endpoint for googlecloudmonitoringreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47984]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds an endpoint property which overrides the default monitoring.googleapis.com:443 endpoint.
+  This is needed when targeting non-standard universe domains (e.g. S3NS: https://docs.cloud.google.com/sovereign-controls-by-partners/docs/data-boundaries/france-data-boundary-s3ns)
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudmonitoringreceiver/README.md
+++ b/receiver/googlecloudmonitoringreceiver/README.md
@@ -41,6 +41,7 @@ receivers:
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `timeout`: (default = `1m`) The timeout of running commands against the GCP Monitoring REST API.
 - `project_id` (Required): The GCP project ID.
+- `endpoint` (Optional): Overrides the default `monitoring.googleapis.com:443` endpoint. Use this when targeting non-standard universe domains.
 - `metrics_list` (Required): A list of services metrics to monitor.
 
 Each single metric can have the following configuration:

--- a/receiver/googlecloudmonitoringreceiver/config.go
+++ b/receiver/googlecloudmonitoringreceiver/config.go
@@ -20,7 +20,10 @@ const (
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 
-	ProjectID   string         `mapstructure:"project_id"`
+	ProjectID string `mapstructure:"project_id"`
+	// Endpoint overrides the default monitoring.googleapis.com:443 endpoint.
+	// Use this when targeting non-standard universe domains.
+	Endpoint    string         `mapstructure:"endpoint"`
 	MetricsList []MetricConfig `mapstructure:"metrics_list"`
 }
 

--- a/receiver/googlecloudmonitoringreceiver/config.go
+++ b/receiver/googlecloudmonitoringreceiver/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 
 	ProjectID string `mapstructure:"project_id"`
-	// Endpoint overrides the default monitoring.googleapis.com:443 endpoint.
+	// Overrides the default monitoring.googleapis.com:443 endpoint.
 	// Use this when targeting non-standard universe domains.
 	Endpoint    string         `mapstructure:"endpoint"`
 	MetricsList []MetricConfig `mapstructure:"metrics_list"`

--- a/receiver/googlecloudmonitoringreceiver/config.schema.yaml
+++ b/receiver/googlecloudmonitoringreceiver/config.schema.yaml
@@ -9,6 +9,9 @@ $defs:
         type: string
 type: object
 properties:
+  endpoint:
+    description: Overrides the default monitoring.googleapis.com:443 endpoint. Use this when targeting non-standard universe domains.
+    type: string
   metrics_list:
     type: array
     items:

--- a/receiver/googlecloudmonitoringreceiver/config_test.go
+++ b/receiver/googlecloudmonitoringreceiver/config_test.go
@@ -21,33 +21,51 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
-	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(cfg))
-
-	assert.Equal(t,
-		&Config{
-			ControllerConfig: scraperhelper.ControllerConfig{
-				CollectionInterval: 120 * time.Second,
-				InitialDelay:       1 * time.Second,
-			},
-			ProjectID: "my-project-id",
-			MetricsList: []MetricConfig{
-				{
-					MetricName: "compute.googleapis.com/instance/cpu/usage_time",
+	tests := []struct {
+		id       component.ID
+		expected *Config
+	}{
+		{
+			id: component.NewIDWithName(metadata.Type, ""),
+			expected: &Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: 120 * time.Second,
+					InitialDelay:       1 * time.Second,
 				},
-				{
-					MetricName: "connectors.googleapis.com/flex/instance/cpu/usage_time",
-				},
-				{
-					MetricDescriptorFilter: "metric.type = starts_with(\"compute.googleapis.com\")",
+				ProjectID: "my-project-id",
+				MetricsList: []MetricConfig{
+					{MetricName: "compute.googleapis.com/instance/cpu/usage_time"},
+					{MetricName: "connectors.googleapis.com/flex/instance/cpu/usage_time"},
+					{MetricDescriptorFilter: "metric.type = starts_with(\"compute.googleapis.com\")"},
 				},
 			},
 		},
-		cfg,
-	)
+		{
+			id: component.NewIDWithName(metadata.Type, "endpoint"),
+			expected: &Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: 120 * time.Second,
+					InitialDelay:       1 * time.Second,
+				},
+				ProjectID: "my-project-id",
+				Endpoint:  "monitoring.example.com:443",
+				MetricsList: []MetricConfig{
+					{MetricName: "compute.googleapis.com/instance/cpu/usage_time"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			cfg := factory.CreateDefaultConfig()
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, sub.Unmarshal(cfg))
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
 }
 
 func TestValidateService(t *testing.T) {

--- a/receiver/googlecloudmonitoringreceiver/receiver.go
+++ b/receiver/googlecloudmonitoringreceiver/receiver.go
@@ -154,8 +154,13 @@ func (mr *monitoringReceiver) initializeClient(ctx context.Context) error {
 		return fmt.Errorf("failed to find default credentials: %w", err)
 	}
 
+	opts := []option.ClientOption{option.WithCredentials(creds)}
+	if mr.config.Endpoint != "" {
+		opts = append(opts, option.WithEndpoint(mr.config.Endpoint))
+	}
+
 	// Attempt to create the monitoring client
-	client, err := monitoring.NewMetricClient(ctx, option.WithCredentials(creds))
+	client, err := monitoring.NewMetricClient(ctx, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create a monitoring client: %w", err)
 	}

--- a/receiver/googlecloudmonitoringreceiver/testdata/config.yaml
+++ b/receiver/googlecloudmonitoringreceiver/testdata/config.yaml
@@ -5,3 +5,10 @@ googlecloudmonitoring:
     - metric_name: "compute.googleapis.com/instance/cpu/usage_time"
     - metric_name: "connectors.googleapis.com/flex/instance/cpu/usage_time"
     - metric_descriptor_filter: "metric.type = starts_with(\"compute.googleapis.com\")"
+
+googlecloudmonitoring/endpoint:
+  collection_interval: 2m
+  project_id: my-project-id
+  endpoint: monitoring.example.com:443
+  metrics_list:
+    - metric_name: "compute.googleapis.com/instance/cpu/usage_time"


### PR DESCRIPTION
Adds an `endpoint` property which overrides the default `monitoring.googleapis.com:443`.

This is needed when targeting non-standard universe domains. (e.g. S3NS: https://docs.cloud.google.com/sovereign-controls-by-partners/docs/data-boundaries/france-data-boundary-s3ns)