### PR TITLE
[receiver/prometheus] Document external dependencies

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -44,6 +44,22 @@ an error for if the receiver's configuration YAML/code contains any of the follo
 - [x] remote_write
 - [x] rule_files
 
+## External Dependencies
+
+This receiver uses the scrape manager and parser implementation from
+[`prometheus/prometheus`](https://github.com/prometheus/prometheus). Compatibility with Prometheus scrape behavior follows the version pinned in [`go.mod`](./go.mod).
+
+Supported scrape protocol and exposition formats are those accepted by the Prometheus scrape configuration:
+
+- `PrometheusProto`
+- `OpenMetricsText1.0.0`
+- `OpenMetricsText0.0.1`
+- `PrometheusText1.0.0`
+- `PrometheusText0.0.4`
+
+If `fallback_scrape_protocol` is not set, the receiver defaults it to `PrometheusText0.0.4` for compatibility with targets that do not return a proper content type.
+
+For native histogram details and protocol requirements, see [Prometheus native histograms](#prometheus-native-histograms).
 
 ## Getting Started
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds an External Dependencies section to the Prometheus receiver README to document compatibility expectations with Prometheus.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Addresses https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44169.

<!--Describe the documentation added.-->
#### Documentation
Adds an `External Dependencies` section to the README.

<!--Please delete paragraphs that you did not use before submitting.-->
