### PR TITLE
[k8sattributes] Fix container.image.tags config check

### DIFF
--- a/.chloggen/fix_k8sattr_containerimagetags.yaml
+++ b/.chloggen/fix_k8sattr_containerimagetags.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/k8s_attributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix container.image.tags config check
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47113]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -90,7 +90,7 @@ func (cfg *Config) Validate() error {
 			string(conventions.K8SCronJobNameKey), string(conventions.K8SCronJobUIDKey),
 			string(conventions.K8SNodeNameKey), string(conventions.K8SNodeUIDKey),
 			string(conventions.K8SContainerNameKey), string(conventions.ContainerIDKey),
-			string(conventions.ContainerImageNameKey), containerImageTag,
+			string(conventions.ContainerImageNameKey), containerImageTag, string(conventions.ContainerImageTagsKey),
 			string(conventions.ServiceNamespaceKey), string(conventions.ServiceNameKey),
 			string(conventions.ServiceVersionKey), string(conventions.ServiceInstanceIDKey),
 			string(conventions.ContainerImageRepoDigestsKey), string(conventions.K8SClusterUIDKey):

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -345,6 +345,19 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "both_container_image_tags"),
+			expected: &Config{
+				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
+				Extract: ExtractConfig{
+					Metadata: []string{
+						"container.image.tag", "container.image.tags",
+					},
+				},
+				Exclude:                defaultExcludes,
+				WaitForMetadataTimeout: 10 * time.Second,
+			},
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "bad_metadata_field"),
 		},
 	}

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -269,6 +269,12 @@ k8s_attributes/all_metadata_fields:
       - service.instance.id
       - k8s.cluster.uid
 
+k8s_attributes/both_container_image_tags:
+  extract:
+    metadata:
+      - container.image.tag
+      - container.image.tags
+
 k8s_attributes/bad_metadata_field:
   extract:
     metadata:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Ensures that `container.image.tags` is allowed as an extracted field.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47113

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a unit-test

<!--Describe the documentation added.-->
#### Documentation
~

<!--Please delete paragraphs that you did not use before submitting.-->
