### PR TITLE
[receiver/prometheusremotewrite] Add warning logging for invalid histogram schemas

### DIFF
--- a/.chloggen/prometheusremotewrite-invalid-schema-logging.yaml
+++ b/.chloggen/prometheusremotewrite-invalid-schema-logging.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/prometheusremotewrite
+component: receiver/prometheus_remote_write
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add warning logging when dropping histograms with invalid schema values

--- a/.chloggen/prometheusremotewrite-invalid-schema-logging.yaml
+++ b/.chloggen/prometheusremotewrite-invalid-schema-logging.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add warning logging when dropping histograms with invalid schema values
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48027]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/prometheusremotewrite-invalid-schema-logging.yaml
+++ b/.chloggen/prometheusremotewrite-invalid-schema-logging.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/prometheus_remote_write
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add warning logging when dropping histograms with invalid schema values
+note: Add debug logging when dropping histograms with invalid schema values
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [48027]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -492,8 +492,8 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		case -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8:
 			histogramType = "exponential"
 		default:
-			// Skip invalid schema - log warning for visibility
-			prw.settings.Logger.Warn(
+			// Skip invalid schema - log at debug level for details
+			prw.settings.Logger.Debug(
 				"Dropping histogram with invalid schema",
 				zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
 				zapcore.Field{Key: "schema", Type: zapcore.Int32Type, Integer: int64(histogram.Schema)},

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -492,7 +492,15 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		case -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8:
 			histogramType = "exponential"
 		default:
-			// Skip invalid schema
+			// Skip invalid schema - log warning for visibility
+			prw.settings.Logger.Warn(
+				"Dropping histogram with invalid schema",
+				zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
+				zapcore.Field{Key: "schema", Type: zapcore.Int32Type, Integer: int64(histogram.Schema)},
+				zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
+				zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
+				zapcore.Field{Key: "timestamp", Type: zapcore.Int64Type, Integer: histogram.Timestamp},
+			)
 			continue
 		}
 		// Create resource if needed (only for the first valid histogram)

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -2516,40 +2516,25 @@ func TestInvalidSchemaLogging(t *testing.T) {
 						},
 						PositiveDeltas: []int64{10, 15},
 					},
-					{
-						Timestamp: 123456790,
-						Schema:    99, // Invalid schema
-						Sum:       200.0,
-						Count:     &writev2.Histogram_CountInt{CountInt: 100},
-					},
 				},
 			},
 		},
 	}
 
-	ctx := context.Background()
-	metrics, stats, err := writeReceiver.translateV2(ctx, request)
+	metrics, stats, err := writeReceiver.translateV2(t.Context(), request)
 	require.NoError(t, err)
 	assert.Equal(t, 0, metrics.MetricCount())
 	assert.Equal(t, 0, stats.Histograms)
 
-	// Verify that warning logs were emitted for both invalid schemas
+	// Verify that warning log was emitted for the invalid schema
 	logs := obs.All()
-	require.Len(t, logs, 2, "Expected 2 warning logs for 2 invalid schemas")
+	require.Len(t, logs, 1, "Expected 1 warning log for invalid schema")
 
-	// Check first log entry
+	// Check log entry
 	assert.Equal(t, "Dropping histogram with invalid schema", logs[0].Message)
 	assert.Equal(t, "test_invalid_histogram", logs[0].ContextMap()["metric_name"])
 	assert.Equal(t, int32(-10), logs[0].ContextMap()["schema"])
 	assert.Equal(t, "test_job", logs[0].ContextMap()["job"])
 	assert.Equal(t, "test_instance", logs[0].ContextMap()["instance"])
 	assert.Equal(t, int64(123456789), logs[0].ContextMap()["timestamp"])
-
-	// Check second log entry
-	assert.Equal(t, "Dropping histogram with invalid schema", logs[1].Message)
-	assert.Equal(t, "test_invalid_histogram", logs[1].ContextMap()["metric_name"])
-	assert.Equal(t, int32(99), logs[1].ContextMap()["schema"])
-	assert.Equal(t, "test_job", logs[1].ContextMap()["job"])
-	assert.Equal(t, "test_instance", logs[1].ContextMap()["instance"])
-	assert.Equal(t, int64(123456790), logs[1].ContextMap()["timestamp"])
 }

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -2463,9 +2463,9 @@ func TestHandlePRWConsumerResponse(t *testing.T) {
 	})
 }
 
-// TestInvalidSchemaLogging verifies that invalid histogram schemas trigger warning logs
+// TestInvalidSchemaLogging verifies that invalid histogram schemas trigger debug logs
 func TestInvalidSchemaLogging(t *testing.T) {
-	core, obs := observer.New(zapcore.WarnLevel)
+	core, obs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
 	factory := NewFactory()
@@ -2526,9 +2526,9 @@ func TestInvalidSchemaLogging(t *testing.T) {
 	assert.Equal(t, 0, metrics.MetricCount())
 	assert.Equal(t, 0, stats.Histograms)
 
-	// Verify that warning log was emitted for the invalid schema
+	// Verify that debug log was emitted for the invalid schema
 	logs := obs.All()
-	require.Len(t, logs, 1, "Expected 1 warning log for invalid schema")
+	require.Len(t, logs, 1, "Expected 1 debug log for invalid schema")
 
 	// Check log entry
 	assert.Equal(t, "Dropping histogram with invalid schema", logs[0].Message)

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -34,6 +34,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
@@ -2458,4 +2461,95 @@ func TestHandlePRWConsumerResponse(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(body), "permanent failure")
 	})
+}
+
+// TestInvalidSchemaLogging verifies that invalid histogram schemas trigger warning logs
+func TestInvalidSchemaLogging(t *testing.T) {
+	core, obs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = logger
+
+	prwReceiver, err := factory.CreateMetrics(t.Context(), settings, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, prwReceiver)
+
+	receiverID := component.MustNewID("test")
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             receiverID,
+		Transport:              "http",
+		ReceiverCreateSettings: settings,
+	})
+	require.NoError(t, err)
+
+	prwReceiver.(*prometheusRemoteWriteReceiver).obsrecv = obsrecv
+	writeReceiver := prwReceiver.(*prometheusRemoteWriteReceiver)
+	t.Cleanup(func() {
+		writeReceiver.rmCache.Purge()
+	})
+
+	request := &writev2.Request{
+		Symbols: []string{
+			"",
+			"__name__", "test_invalid_histogram",
+			"job", "test_job",
+			"instance", "test_instance",
+		},
+		Timeseries: []writev2.TimeSeries{
+			{
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Metadata: writev2.Metadata{
+					Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+				},
+				Histograms: []writev2.Histogram{
+					{
+						Timestamp: 123456789,
+						Schema:    -10, // Invalid schema
+						Sum:       100.5,
+						Count:     &writev2.Histogram_CountInt{CountInt: 50},
+						PositiveSpans: []writev2.BucketSpan{
+							{Offset: 0, Length: 2},
+						},
+						PositiveDeltas: []int64{10, 15},
+					},
+					{
+						Timestamp: 123456790,
+						Schema:    99, // Invalid schema
+						Sum:       200.0,
+						Count:     &writev2.Histogram_CountInt{CountInt: 100},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	metrics, stats, err := writeReceiver.translateV2(ctx, request)
+	require.NoError(t, err)
+	assert.Equal(t, 0, metrics.MetricCount())
+	assert.Equal(t, 0, stats.Histograms)
+
+	// Verify that warning logs were emitted for both invalid schemas
+	logs := obs.All()
+	require.Len(t, logs, 2, "Expected 2 warning logs for 2 invalid schemas")
+
+	// Check first log entry
+	assert.Equal(t, "Dropping histogram with invalid schema", logs[0].Message)
+	assert.Equal(t, "test_invalid_histogram", logs[0].ContextMap()["metric_name"])
+	assert.Equal(t, int32(-10), logs[0].ContextMap()["schema"])
+	assert.Equal(t, "test_job", logs[0].ContextMap()["job"])
+	assert.Equal(t, "test_instance", logs[0].ContextMap()["instance"])
+	assert.Equal(t, int64(123456789), logs[0].ContextMap()["timestamp"])
+
+	// Check second log entry
+	assert.Equal(t, "Dropping histogram with invalid schema", logs[1].Message)
+	assert.Equal(t, "test_invalid_histogram", logs[1].ContextMap()["metric_name"])
+	assert.Equal(t, int32(99), logs[1].ContextMap()["schema"])
+	assert.Equal(t, "test_job", logs[1].ContextMap()["job"])
+	assert.Equal(t, "test_instance", logs[1].ContextMap()["instance"])
+	assert.Equal(t, int64(123456790), logs[1].ContextMap()["timestamp"])
 }


### PR DESCRIPTION
 This change adds visibility when histograms with invalid schema values
   are dropped during processing. Previously, invalid schemas were silently
   skipped without any logging, making it difficult for users to diagnose
   missing histogram data.

   Changes:
   - Add warning log when encountering invalid histogram schemas
   - Include metric name, schema value, job, instance, and timestamp in log
   - Add test case to verify logging behavior

   The warning log includes contextual information to help users:
   - Identify which metrics are affected
   - Determine the invalid schema value
   - Trace back to the source (job/instance)
   - Correlate with other logs using timestamp

   Fixes #48027