### PR TITLE
[receiver/awss3] Fix zstd compressed files rejected as unsupported format

### DIFF
--- a/.chloggen/fix-awss3-receiver-zstd-suffix.yaml
+++ b/.chloggen/fix-awss3-receiver-zstd-suffix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awss3
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix zstd compressed files (.zst) being rejected with "Unsupported file format" by trimming the .zst suffix after decompression.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47802]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awss3receiver/receiver.go
+++ b/receiver/awss3receiver/receiver.go
@@ -153,6 +153,7 @@ func (r *awss3Receiver) receiveBytes(ctx context.Context, key string, data []byt
 				err = closeErr
 			}
 		}()
+		key = strings.TrimSuffix(key, ".zst")
 		data, err = io.ReadAll(decompressedReader)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

Fix a bug where the AWS S3 receiver rejects zstd-compressed files (`.binpb.zst`) with "Unsupported file format", causing silent data loss.

Fixes #47802

## Root Cause

When the receiver encounters a `.gz` file, it:
1. Decompresses the data
2. **Trims `.gz` from the key** (line 139)
3. Detects the format from the remaining extension (e.g. `.binpb`)

When it encounters a `.zst` file, it:
1. Decompresses the data
2. **Does NOT trim `.zst` from the key** (missing line)
3. Tries to detect format from `.binpb.zst` → fails → "Unsupported file format"

## Fix

Added `key = strings.TrimSuffix(key, ".zst")` to the zstd decompression block, mirroring the existing gzip handling.

**One line fix.**

## Impact

This bug causes **complete data loss** for any pipeline using `awss3exporter` with `compression: zstd` paired with `awss3receiver`. All telemetry is silently dropped. Switching to gzip works around the issue.

## Test Plan

- [x] All existing `awss3receiver` tests pass
- [x] Code builds cleanly
- [x] Fix mirrors the existing, proven gzip pattern (line 139)