### PR TITLE
[exporter/loadbalancing] Replace log.Fatalf with proper error return and propagate context

### DIFF
--- a/exporter/loadbalancingexporter/resolver_aws_cloudmap.go
+++ b/exporter/loadbalancingexporter/resolver_aws_cloudmap.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"time"
@@ -37,9 +36,9 @@ var (
 	awsResolverFailureAttrSet = attribute.NewSet(awsResolverAttr, attribute.Bool("success", false))
 )
 
-func createDiscoveryFunction(client *servicediscovery.Client) func(params *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
-	return func(params *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
-		return client.DiscoverInstances(context.TODO(), params)
+func createDiscoveryFunction(client *servicediscovery.Client) func(ctx context.Context, params *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
+	return func(ctx context.Context, params *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
+		return client.DiscoverInstances(ctx, params)
 	}
 }
 
@@ -60,7 +59,7 @@ type cloudMapResolver struct {
 	updateLock         sync.Mutex
 	shutdownWg         sync.WaitGroup
 	changeCallbackLock sync.RWMutex
-	discoveryFn        func(params *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error)
+	discoveryFn        func(ctx context.Context, params *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error)
 	telemetry          *metadata.TelemetryBuilder
 }
 
@@ -76,10 +75,9 @@ func newCloudMapResolver(
 ) (*cloudMapResolver, error) { // Using the SDK's default configuration, loading additional config
 	// and credentials values from the environment variables, shared
 	// credentials, and shared configuration files
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithDefaultRegion("us-east-1"))
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithDefaultRegion("us-east-1"))
 	if err != nil {
-		log.Fatalf("unable to load SDK config, %v", err)
-		return nil, err
+		return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)
 	}
 
 	// Using the Config value, create the DynamoDB client
@@ -168,7 +166,7 @@ func (r *cloudMapResolver) resolve(ctx context.Context) ([]string, error) {
 	r.shutdownWg.Add(1)
 	defer r.shutdownWg.Done()
 
-	discoverInstancesOutput, err := r.discoveryFn(&servicediscovery.DiscoverInstancesInput{
+	discoverInstancesOutput, err := r.discoveryFn(ctx, &servicediscovery.DiscoverInstancesInput{
 		NamespaceName:      r.namespaceName,
 		ServiceName:        r.serviceName,
 		HealthStatus:       *r.healthStatus,

--- a/exporter/loadbalancingexporter/resolver_aws_cloudmap_test.go
+++ b/exporter/loadbalancingexporter/resolver_aws_cloudmap_test.go
@@ -4,6 +4,7 @@
 package loadbalancingexporter
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -104,7 +105,7 @@ func makeSummary(i int) types.HttpInstanceSummary {
 	}
 }
 
-func mockDiscovery(*servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
+func mockDiscovery(_ context.Context, _ *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
 	s := &servicediscovery.DiscoverInstancesOutput{
 		Instances: []types.HttpInstanceSummary{
 			makeSummary(1),


### PR DESCRIPTION
## Summary

Remove `log.Fatalf` from the load balancing exporter's AWS Cloud Map resolver and replace `context.TODO()` with proper context propagation.

## Problem

1. **`log.Fatalf` kills the entire collector process** — When the AWS SDK config fails to load, the resolver calls `log.Fatalf` which invokes `os.Exit(1)`. This prevents graceful shutdown, skips defer cleanup, and makes the error unrecoverable. Components should never call `log.Fatal` — they should return errors to the framework.

2. **`context.TODO()` used instead of proper context** — The `DiscoverInstances` API call used `context.TODO()` instead of propagating the caller's context. This means cancellation signals (shutdown, timeout) are not respected during service discovery.

## Fix

- Replaced `log.Fatalf` with `return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)` for proper error propagation
- Changed `createDiscoveryFunction` to accept and propagate `context.Context`
- Updated `discoveryFn` field type to include context parameter
- Replaced `context.TODO()` in SDK config loading with `context.Background()` (appropriate for one-time initialization)
- Removed unused `"log"` import

## Test Plan

- [x] All loadbalancing exporter tests pass
- [x] Updated mock function signature in tests