### PR TITLE
[connector/service_graph] Fix client exponential histogram emitted with zero timestamp

### DIFF
--- a/.chloggen/fix-servicegraph-client-exp-histogram-timestamp.yaml
+++ b/.chloggen/fix-servicegraph-client-exp-histogram-timestamp.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: connector/service_graph
+
+note: Fix client-side exponential histograms being emitted with a zero timestamp, causing backends like Grafana Cloud Mimir to reject them.
+
+issues: [48049]
+
+subtext: |
+  collectClientLatencyMetrics omitted SetTimestamp on the exponential-histogram data point, so the
+  zero-value timestamp leaked through. The server-side function and the client-side explicit-bucket
+  branch were already correct.
+
+change_logs: [user]

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -585,6 +585,7 @@ func (p *serviceGraphConnector) collectLatencyMetrics(ilm pmetric.ScopeMetrics) 
 }
 
 func (p *serviceGraphConnector) collectClientLatencyMetrics(ilm pmetric.ScopeMetrics) error {
+	timestamp := pcommon.NewTimestampFromTime(p.nowWithOffset())
 	mDuration := pmetric.NewMetric()
 	mDuration.SetName("traces_service_graph_request_client")
 	mDuration.SetUnit(secondsUnit)
@@ -596,6 +597,7 @@ func (p *serviceGraphConnector) collectClientLatencyMetrics(ilm pmetric.ScopeMet
 		mDuration.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 		for key, expHistogram := range p.reqClientDurationExpHistogram {
 			dpDuration := mDuration.ExponentialHistogram().DataPoints().AppendEmpty()
+			dpDuration.SetTimestamp(timestamp)
 			dpDuration.SetStartTimestamp(pcommon.NewTimestampFromTime(p.startTime))
 			dimensions, ok := p.dimensionsForSeries(key)
 			if !ok {

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -852,6 +852,9 @@ func verifyExpDuration(t *testing.T, m pmetric.Metric, expectedDp pmetric.Expone
 	assert.Equal(t, 1, dps.Len())
 	dp := dps.At(0)
 
+	assert.NotZero(t, dp.Timestamp(), "timestamp must be set")
+	assert.NotZero(t, dp.StartTimestamp(), "start timestamp must be set")
+
 	// ignore time
 	dp.SetTimestamp(pcommon.Timestamp(0))
 	dp.SetStartTimestamp(pcommon.Timestamp(0))


### PR DESCRIPTION
#### Description

I've been trying out native histograms, and hit an issue with the service graph's client metric. The setup was otelcol-contrib sending to Grafana Cloud.

My config was:

```yaml
  service_graph:
    exponential_histogram_max_size: 160
    virtual_node_peer_attributes:
      - peer.service
      - db.system.name
      - server.address
    virtual_node_extra_label: true
```

The `collectClientLatencyMetrics` method does not call `SetTimestamp` on the exponential histogram data point, leaving Timestamp at zero.

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/83112925aa74330db39368ca78cd714ca3fda515/connector/servicegraphconnector/connector.go#L587-L610

Backends like Mimir reject the resulting `traces_service_graph_request_client_` series with err-mimir-too-far-in-past, timestamp: 0.

Logs of the resulting error:

```
1777537131460	2026-04-30T08:18:51.460Z	Exporting failed. Dropping data. code_file_path=go.opentelemetry.io/collector/exporter/exporterhelper@v0.151.0/internal/queue_sender.go code_function_name=go.opentelemetry.io/collector/exporter/exporterhelper/internal.NewQueueSender.func1 code_line_number=50 code_stacktrace=go.opentelemetry.io/collector/exporter/exporterhelper/internal.NewQueueSender.func1
	go.opentelemetry.io/collector/exporter/exporterhelper@v0.151.0/internal/queue_sender.go:50
go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch.(*disabledBatcher[...]).Consume
	go.opentelemetry.io/collector/exporter/exporterhelper@v0.151.0/internal/queuebatch/disabled_batcher.go:23
go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue.(*asyncQueue[...]).Start.func1
	go.opentelemetry.io/collector/exporter/exporterhelper@v0.151.0/internal/queue/async_queue.go:47
sync.(*WaitGroup).Go.func1
	sync/waitgroup.go:258 dropped_items=72 error=not retryable error: Permanent error: rpc error: code = InvalidArgument desc = error exporting items, request to https://otlp-gateway-prod-eu-west-2.grafana.net/otlp/v1/metrics responded with HTTP Status Code 400, Message=received a sample whose timestamp is too far in the past, timestamp: 0 series: 'traces_service_graph_request_client_seconds' (err-mimir-too-far-in-past). To adjust the related per-tenant limit, configure -validation.past-grace-period, or contact your service administrator., Details=[] otelcol_component_id=otlp_http/grafanacloud otelcol_component_kind=exporter otelcol_signal=metrics scope_name=go.opentelemetry.io/collector/service
```

This change sets the timestamp using `nowWithOffset`, to match the client explicit-bucket branch.

As a comparison, here's the server metric:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/83112925aa74330db39368ca78cd714ca3fda515/connector/servicegraphconnector/connector.go#L638-L663

(An aside, the server metric method uses a mix of `time.Now()` and `nowWithOffset()`. Maybe a bug on the server metric side?)

#### Link to tracking issue

Bug was introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39951. No tracking issue for this that I could find.

#### Testing

I'm relying on improvements to the tests covering this method to validate the fix for this one.

Assertions have been added to ensure the timestamp is not zero.
