### PR TITLE
[exporter/clickhouse] Respect configured database when create_schema is false

### DIFF
--- a/.chloggen/clickhouse-respect-database-no-schema.yaml
+++ b/.chloggen/clickhouse-respect-database-no-schema.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Respect configured database when create_schema is false instead of always connecting to the default database.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48050]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -45,7 +45,7 @@ func (e *logsExporter) start(ctx context.Context, _ component.Host) error {
 		return err
 	}
 
-	e.db, err = internal.NewClickhouseClientFromOptions(opt)
+	e.db, err = internal.NewClickhouseClientFromOptions(opt, e.cfg.shouldCreateSchema())
 	if err != nil {
 		return err
 	}

--- a/exporter/clickhouseexporter/exporter_logs_json.go
+++ b/exporter/clickhouseexporter/exporter_logs_json.go
@@ -51,7 +51,7 @@ func (e *logsJSONExporter) start(ctx context.Context, _ component.Host) error {
 		return err
 	}
 
-	e.db, err = internal.NewClickhouseClientFromOptions(opt)
+	e.db, err = internal.NewClickhouseClientFromOptions(opt, e.cfg.shouldCreateSchema())
 	if err != nil {
 		return err
 	}

--- a/exporter/clickhouseexporter/exporter_metrics.go
+++ b/exporter/clickhouseexporter/exporter_metrics.go
@@ -42,7 +42,7 @@ func (e *metricsExporter) start(ctx context.Context, _ component.Host) error {
 		return err
 	}
 
-	e.db, err = internal.NewClickhouseClientFromOptions(opt)
+	e.db, err = internal.NewClickhouseClientFromOptions(opt, e.cfg.shouldCreateSchema())
 	if err != nil {
 		return err
 	}

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -41,7 +41,7 @@ func (e *tracesExporter) start(ctx context.Context, _ component.Host) error {
 		return err
 	}
 
-	e.db, err = internal.NewClickhouseClientFromOptions(opt)
+	e.db, err = internal.NewClickhouseClientFromOptions(opt, e.cfg.shouldCreateSchema())
 	if err != nil {
 		return err
 	}

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -49,7 +49,7 @@ func (e *tracesJSONExporter) start(ctx context.Context, _ component.Host) error 
 		return err
 	}
 
-	e.db, err = internal.NewClickhouseClientFromOptions(opt)
+	e.db, err = internal.NewClickhouseClientFromOptions(opt, e.cfg.shouldCreateSchema())
 	if err != nil {
 		return err
 	}

--- a/exporter/clickhouseexporter/integration_test.go
+++ b/exporter/clickhouseexporter/integration_test.go
@@ -246,7 +246,7 @@ func testIntegrationWithImage(t *testing.T, clickhouseImage string) {
 			t.Fatal(err)
 		}
 
-		db, err := internal.NewClickhouseClientFromOptions(opt)
+		db, err := internal.NewClickhouseClientFromOptions(opt, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/exporter/clickhouseexporter/internal/clickhouse.go
+++ b/exporter/clickhouseexporter/internal/clickhouse.go
@@ -25,10 +25,13 @@ func DatabaseFromDSN(dsn string) (string, error) {
 }
 
 // NewClickhouseClientFromOptions creates a new ClickHouse client from a clickhouse.Options struct.
-func NewClickhouseClientFromOptions(opt *clickhouse.Options) (driver.Conn, error) {
-	// Always connect to default database since configured database may not exist yet.
-	// TODO: only do this if createSchema is true
-	opt.Auth.Database = DefaultDatabase
+// When createSchema is true, connects to the default database since the configured database may
+// not exist yet (it will be created by the schema DDL). When false, connects directly to the
+// configured database.
+func NewClickhouseClientFromOptions(opt *clickhouse.Options, createSchema bool) (driver.Conn, error) {
+	if createSchema {
+		opt.Auth.Database = DefaultDatabase
+	}
 
 	conn, err := clickhouse.Open(opt)
 	if err != nil {


### PR DESCRIPTION
## Summary

When `create_schema: false`, connect directly to the configured database instead of always overriding to `default`.

## Problem

`NewClickhouseClientFromOptions` unconditionally sets `opt.Auth.Database = DefaultDatabase` regardless of the `create_schema` setting. This means:

- When `create_schema: true` — correct behavior, connects to `default` first then creates the target database
- When `create_schema: false` — **bug**: still connects to `default` even though the user manages their own schema and expects the configured database to be used directly

This is documented as a TODO in the code:
```go
// TODO: only do this if createSchema is true
opt.Auth.Database = DefaultDatabase
```

## Fix

Added a `createSchema bool` parameter to `NewClickhouseClientFromOptions`. When `false`, the configured database is preserved. All callers pass `e.cfg.shouldCreateSchema()`.

## Test Plan

- [x] All non-integration tests pass
- [x] Code builds cleanly
- [x] Integration test updated
- [x] Backward compatible — `create_schema: true` (default) retains existing behavior