### PR TITLE
[exporter/azuremonitor] Migrate semconv RPC attributes to v1.40.0

### DIFF
--- a/.chloggen/fix_47546.yaml
+++ b/.chloggen/fix_47546.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Migrate RPC semconv attributes to v1.40.0 (`rpc.system` → `rpc.system.name`, `rpc.grpc.status_code` → `rpc.response.status_code`)
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47546]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventionsv138 "go.opentelemetry.io/otel/semconv/v1.38.0"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
@@ -231,14 +230,16 @@ type rpcAttributes struct {
 // MapAttribute attempts to map a Span attribute to one of the known types
 func (attrs *rpcAttributes) MapAttribute(k string, v pcommon.Value) bool {
 	switch k {
-	case string(conventionsv138.RPCSystemKey):
+	case string(conventions.RPCSystemNameKey):
 		attrs.RPCSystem = v.Str()
-	case string(conventionsv138.RPCServiceKey):
+	case "rpc.service":
 		attrs.RPCService = v.Str()
 	case string(conventions.RPCMethodKey):
 		attrs.RPCMethod = v.Str()
-	case string(conventionsv138.RPCGRPCStatusCodeKey):
-		attrs.RPCGRPCStatusCode = v.Int()
+	case string(conventions.RPCResponseStatusCodeKey):
+		if val, err := getAttributeValueAsInt(v); err == nil {
+			attrs.RPCGRPCStatusCode = val
+		}
 
 	case string(conventions.ServerAddressKey):
 		attrs.ServerAttributes.ServerAddress = v.Str()

--- a/exporter/azuremonitorexporter/conventions_test.go
+++ b/exporter/azuremonitorexporter/conventions_test.go
@@ -97,9 +97,10 @@ func TestHTTPAttributeMapping(t *testing.T) {
 
 func testRPCPAttributeMapping(t *testing.T, variant string) {
 	rpcAttributeValues := map[string]any{
-		"rpc.system":  "rpc.system",
-		"rpc.service": "rpc.service",
-		"rpc.method":  "rpc.method",
+		"rpc.system.name":          "rpc.system",
+		"rpc.service":              "rpc.service",
+		"rpc.method":               "rpc.method",
+		"rpc.response.status_code": int64(1),
 	}
 
 	attributeMap := pcommon.NewMap()
@@ -122,6 +123,7 @@ func testRPCPAttributeMapping(t *testing.T, variant string) {
 	assert.Equal(t, "rpc.system", rpcAttributes.RPCSystem)
 	assert.Equal(t, "rpc.service", rpcAttributes.RPCService)
 	assert.Equal(t, "rpc.method", rpcAttributes.RPCMethod)
+	assert.Equal(t, int64(1), rpcAttributes.RPCGRPCStatusCode)
 
 	networkAttributesValidations(t, rpcAttributes.NetworkAttributes)
 

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -16,7 +16,6 @@ import (
 	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventionsv138 "go.opentelemetry.io/otel/semconv/v1.38.0"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.uber.org/zap"
 
@@ -521,7 +520,6 @@ func fillRemoteDependencyDataRPC(span ptrace.Span, data *contracts.RemoteDepende
 
 // Returns the RPC status code as a string
 func getRPCStatusCodeAsString(rpcAttributes *rpcAttributes) (statusCodeAsString string) {
-	// Honor the attribute rpc.grpc.status_code if there
 	if rpcAttributes.RPCGRPCStatusCode != 0 {
 		return strconv.FormatInt(rpcAttributes.RPCGRPCStatusCode, 10)
 	}
@@ -676,7 +674,7 @@ func mapIncomingSpanToType(attributeMap pcommon.Map) spanType {
 	}
 
 	// RPC
-	if _, exists := attributeMap.Get(string(conventionsv138.RPCSystemKey)); exists {
+	if _, exists := attributeMap.Get(string(conventions.RPCSystemNameKey)); exists {
 		return rpcSpanType
 	}
 

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -85,8 +85,8 @@ var (
 
 	// Required attribute for any RPC Span
 	requiredRPCAttributes = map[string]any{
-		"rpc.system":     defaultRPCSystem,
-		"server.address": defaultServerAddress,
+		"rpc.system.name": defaultRPCSystem,
+		"server.address":  defaultServerAddress,
 	}
 
 	requiredDatabaseAttributes = map[string]any{
@@ -398,10 +398,10 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "127.0.0.1:81")
 
-	// test RPC error using the new rpc.grpc.status_code attribute
+	// test RPC error using the new rpc.response.status_code attribute
 	span.Status().SetCode(ptrace.StatusCodeError)
 	span.Status().SetMessage("Resource exhausted")
-	spanAttributes.PutInt("rpc.grpc.status_code", 8)
+	spanAttributes.PutInt("rpc.response.status_code", 8)
 
 	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
 	envelope = envelopes[0]


### PR DESCRIPTION
Updates `rpc.system`, `rpc.grpc.status_code`, and `rpc.service` attribute keys to their v1.40.0 equivalents. 
`rpc.service` is kept as a string literal since it was removed in v1.40.0 with no replacement.

Fixes #47546
