### PR TITLE
[cmd/telemetrygen] Fix --allow-export-failures ignored in batch mode

### DIFF
--- a/.chloggen/fix-telemetrygen-allow-export-failures.yaml
+++ b/.chloggen/fix-telemetrygen-allow-export-failures.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix --allow-export-failures flag being ignored in batch mode for logs and metrics."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47215]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext:
+
+change_logs: [user]

--- a/cmd/telemetrygen/pkg/logs/worker.go
+++ b/cmd/telemetrygen/pkg/logs/worker.go
@@ -139,7 +139,11 @@ func (w *worker) flushBuffer(exporter sdklog.Exporter) {
 	}
 
 	if err := exporter.Export(context.Background(), w.batchBuffer); err != nil {
-		w.logger.Error("failed to export batched logs", zap.Error(err))
+		if w.allowFailures {
+			w.logger.Error("exporter failed, continuing due to --allow-export-failures", zap.Error(err))
+		} else {
+			w.logger.Fatal("failed to export batched logs", zap.Error(err))
+		}
 	} else {
 		w.logger.Debug("exported batched logs", zap.Int("count", len(w.batchBuffer)))
 	}

--- a/cmd/telemetrygen/pkg/metrics/worker.go
+++ b/cmd/telemetrygen/pkg/metrics/worker.go
@@ -268,7 +268,11 @@ func (w *worker) flushBuffer(exporter sdkmetric.Exporter) {
 	}
 
 	if err := exporter.Export(context.Background(), &merged); err != nil {
-		w.logger.Error("failed to export batch", zap.Error(err), zap.Int("count", len(w.metricBuffer)))
+		if w.allowFailures {
+			w.logger.Error("exporter failed, continuing due to --allow-export-failures", zap.Error(err), zap.Int("count", len(w.metricBuffer)))
+		} else {
+			w.logger.Fatal("failed to export batch", zap.Error(err), zap.Int("count", len(w.metricBuffer)))
+		}
 	} else {
 		w.logger.Debug("exported batch", zap.Int("count", len(w.metricBuffer)))
 	}


### PR DESCRIPTION
## Summary

Fix `--allow-export-failures` flag being silently ignored when using batch mode for logs and metrics in telemetrygen.

Fixes #47215

## Problem

In batch mode, `flushBuffer()` for both logs and metrics always:
1. Logs the error at ERROR level
2. Continues execution regardless

This ignores the `--allow-export-failures` flag entirely. In non-batch mode, the same worker correctly calls `logger.Fatal` when the flag is not set.

## Fix

Updated `flushBuffer()` in both `pkg/logs/worker.go` and `pkg/metrics/worker.go` to:
- Call `logger.Fatal` when `allowFailures` is false (default) — process crashes on export failure
- Call `logger.Error` when `allowFailures` is true — continues running

This makes batch mode behavior consistent with non-batch mode.

## Test Plan

- [x] All telemetrygen tests pass (logs, metrics, traces)
- [x] Code builds cleanly
- [x] Behavior matches non-batch mode error handling pattern (lines 98-105 in logs/worker.go)