### PR TITLE
[extension/storage/dbstorage] quote generated table identifiers

### DIFF
--- a/.chloggen/fix_48030.yaml
+++ b/.chloggen/fix_48030.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: extension/storage/dbstorage
+note: Quote generated table identifiers for PostgreSQL/SQLite so valid component names containing `-` do not break SQL statements.
+issues: [48030]
+subtext:
+change_logs: [user]

--- a/extension/storage/dbstorage/client_queries.go
+++ b/extension/storage/dbstorage/client_queries.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -116,6 +117,7 @@ func (d *dbDialect) Close() error {
 
 // newDBDialect creates a new DB dialect which is just a set of DB-specific queries/prepared statements
 func newDBDialect(driverName, tableName string) *dbDialect {
+	quotedTableName := quoteTableIdentifier(driverName, tableName)
 	queries := getDialectQueries(driverName)
 
 	var aggSize int
@@ -129,14 +131,24 @@ func newDBDialect(driverName, tableName string) *dbDialect {
 	}
 	return &dbDialect{
 		Queries: sqlQuerySet{
-			QueryCreateTable:     fmt.Sprintf(queries.QueryCreateTable, tableName),
-			QueryGetRow:          fmt.Sprintf(queries.QueryGetRow, tableName),
-			QuerySetRow:          fmt.Sprintf(queries.QuerySetRow, tableName),
-			QueryDeleteRow:       fmt.Sprintf(queries.QueryDeleteRow, tableName),
-			QueryGetMultiRows:    fmt.Sprintf(queries.QueryGetMultiRows, tableName),
-			QuerySetMultiRows:    fmt.Sprintf(queries.QuerySetMultiRows, tableName),
-			QueryDeleteMultiRows: fmt.Sprintf(queries.QueryDeleteMultiRows, tableName),
+			QueryCreateTable:     fmt.Sprintf(queries.QueryCreateTable, quotedTableName),
+			QueryGetRow:          fmt.Sprintf(queries.QueryGetRow, quotedTableName),
+			QuerySetRow:          fmt.Sprintf(queries.QuerySetRow, quotedTableName),
+			QueryDeleteRow:       fmt.Sprintf(queries.QueryDeleteRow, quotedTableName),
+			QueryGetMultiRows:    fmt.Sprintf(queries.QueryGetMultiRows, quotedTableName),
+			QuerySetMultiRows:    fmt.Sprintf(queries.QuerySetMultiRows, quotedTableName),
+			QueryDeleteMultiRows: fmt.Sprintf(queries.QueryDeleteMultiRows, quotedTableName),
 		},
 		MaxAggregationSize: aggSize,
+	}
+}
+
+func quoteTableIdentifier(driverName, tableName string) string {
+	switch driverName {
+	case driverPostgreSQL, driverSQLite:
+		escaped := strings.ReplaceAll(tableName, `"`, `""`)
+		return `"` + escaped + `"`
+	default:
+		return tableName
 	}
 }

--- a/extension/storage/dbstorage/client_queries_test.go
+++ b/extension/storage/dbstorage/client_queries_test.go
@@ -46,12 +46,25 @@ func Test_dbDialect_Prepare(t *testing.T) {
 func Test_newDBDialect(t *testing.T) {
 	t.Run("Should substitute table name on Dialect creation", func(t *testing.T) {
 		got := newDBDialect(driverPostgreSQL, testTableName)
-		assert.Contains(t, got.Queries.QueryCreateTable, testTableName)
-		assert.Contains(t, got.Queries.QueryGetRow, testTableName)
-		assert.Contains(t, got.Queries.QuerySetRow, testTableName)
-		assert.Contains(t, got.Queries.QueryDeleteRow, testTableName)
-		assert.Contains(t, got.Queries.QueryGetMultiRows, testTableName)
-		assert.Contains(t, got.Queries.QuerySetMultiRows, testTableName)
-		assert.Contains(t, got.Queries.QueryDeleteMultiRows, testTableName)
+		assert.Contains(t, got.Queries.QueryCreateTable, `"`+testTableName+`"`)
+		assert.Contains(t, got.Queries.QueryGetRow, `"`+testTableName+`"`)
+		assert.Contains(t, got.Queries.QuerySetRow, `"`+testTableName+`"`)
+		assert.Contains(t, got.Queries.QueryDeleteRow, `"`+testTableName+`"`)
+		assert.Contains(t, got.Queries.QueryGetMultiRows, `"`+testTableName+`"`)
+		assert.Contains(t, got.Queries.QuerySetMultiRows, `"`+testTableName+`"`)
+		assert.Contains(t, got.Queries.QueryDeleteMultiRows, `"`+testTableName+`"`)
 	})
+
+	t.Run("Should keep table name unquoted for generic driver", func(t *testing.T) {
+		got := newDBDialect("unknown", testTableName)
+		assert.Contains(t, got.Queries.QueryCreateTable, testTableName)
+		assert.NotContains(t, got.Queries.QueryCreateTable, `"`+testTableName+`"`)
+	})
+}
+
+func Test_quoteTableIdentifier(t *testing.T) {
+	assert.Equal(t, `"receiver_a"`, quoteTableIdentifier(driverPostgreSQL, "receiver_a"))
+	assert.Equal(t, `"receiver_a"`, quoteTableIdentifier(driverSQLite, "receiver_a"))
+	assert.Equal(t, "receiver_a", quoteTableIdentifier("unknown", "receiver_a"))
+	assert.Equal(t, `"with""quote"`, quoteTableIdentifier(driverPostgreSQL, `with"quote`))
 }

--- a/extension/storage/dbstorage/client_test.go
+++ b/extension/storage/dbstorage/client_test.go
@@ -25,12 +25,13 @@ func Test_newClient(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 		queries := getDialectQueries(driverPostgreSQL)
+		tableName := quoteTableIdentifier(driverPostgreSQL, testTableName)
 
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryCreateTable, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryCreateTable, tableName))).
 			WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName)))
-		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName)))
-		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName)))
+		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName)))
+		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName)))
+		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName)))
 
 		_, err = newClient(t.Context(), zap.L(), db, driverPostgreSQL, testTableName)
 		assert.NoError(t, err)
@@ -40,12 +41,13 @@ func Test_newClient(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 		queries := getDialectQueries(driverSQLite)
+		tableName := quoteTableIdentifier(driverSQLite, testTableName)
 
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryCreateTable, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryCreateTable, tableName))).
 			WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName)))
-		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName)))
-		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName)))
+		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName)))
+		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName)))
+		mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName)))
 
 		_, err = newClient(t.Context(), zap.L(), db, driverSQLite, testTableName)
 		assert.NoError(t, err)
@@ -54,12 +56,13 @@ func Test_newClient(t *testing.T) {
 
 func Test_dbStorageClient_Get(t *testing.T) {
 	queries := getDialectQueries(driverSQLite)
+	tableName := quoteTableIdentifier(driverSQLite, testTableName)
 
 	t.Run("Should get a row without transaction", func(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
-		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName))).
+		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName))).
 			WithArgs("test").
 			WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow([]byte("value")))
 
@@ -72,7 +75,7 @@ func Test_dbStorageClient_Get(t *testing.T) {
 		defer client.db.Close()
 
 		mock.ExpectBegin()
-		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName))).
+		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName))).
 			WithArgs("test").
 			WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow([]byte("value")))
 		mock.ExpectCommit()
@@ -89,7 +92,7 @@ func Test_dbStorageClient_Get(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
-		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName))).
+		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName))).
 			WithArgs("test").
 			WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow([]byte("first")).AddRow([]byte("second")))
 
@@ -101,7 +104,7 @@ func Test_dbStorageClient_Get(t *testing.T) {
 		client, mock := newTestClient(t, driverPostgreSQL)
 		defer client.db.Close()
 
-		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName))).
+		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName))).
 			WithArgs("test").
 			WillReturnRows(sqlmock.NewRows([]string{"value"}))
 
@@ -113,12 +116,13 @@ func Test_dbStorageClient_Get(t *testing.T) {
 
 func Test_dbStorageClient_Set(t *testing.T) {
 	queries := getDialectQueries(driverSQLite)
+	tableName := quoteTableIdentifier(driverSQLite, testTableName)
 
 	t.Run("Should delete a row without transaction", func(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName))).
 			WithArgs("test", []byte("value")).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -129,7 +133,7 @@ func Test_dbStorageClient_Set(t *testing.T) {
 		defer client.db.Close()
 
 		mock.ExpectBegin()
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName))).
 			WithArgs("test", []byte("value")).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectCommit()
@@ -144,7 +148,7 @@ func Test_dbStorageClient_Set(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName))).
 			WithArgs("test", []byte("value")).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -154,12 +158,13 @@ func Test_dbStorageClient_Set(t *testing.T) {
 
 func Test_dbStorageClient_Delete(t *testing.T) {
 	queries := getDialectQueries(driverSQLite)
+	tableName := quoteTableIdentifier(driverSQLite, testTableName)
 
 	t.Run("Should delete a row without transaction", func(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName))).
 			WithArgs("test").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -170,7 +175,7 @@ func Test_dbStorageClient_Delete(t *testing.T) {
 		defer client.db.Close()
 
 		mock.ExpectBegin()
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName))).
 			WithArgs("test").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectCommit()
@@ -185,7 +190,7 @@ func Test_dbStorageClient_Delete(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName))).
 			WithArgs("test").
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -195,22 +200,23 @@ func Test_dbStorageClient_Delete(t *testing.T) {
 
 func Test_dbStorageClient_Batch(t *testing.T) {
 	queries := getDialectQueries(driverSQLite)
+	tableName := quoteTableIdentifier(driverSQLite, testTableName)
 
 	t.Run("Should run set of operations in a single transaction per call", func(t *testing.T) {
 		client, mock := newTestClient(t, driverSQLite)
 		defer client.db.Close()
 
 		mock.ExpectBegin()
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName))).
 			WithArgs("test", []byte("value")).
 			WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName))).
 			WithArgs("test").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectCommit()
 
 		mock.ExpectBegin()
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName))).
 			WithArgs("test").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectCommit()
@@ -227,13 +233,13 @@ func Test_dbStorageClient_Batch(t *testing.T) {
 		defer client.db.Close()
 
 		mock.ExpectBegin()
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName))).
 			WithArgs("test", []byte("value")).
 			WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName))).
+		mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName))).
 			WithArgs("test").
 			WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName))).
+		mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName))).
 			WithArgs("test").
 			WillReturnError(sql.ErrConnDone)
 		mock.ExpectRollback()
@@ -254,7 +260,7 @@ func Test_dbStorageClient_Batch(t *testing.T) {
 			storage.GetOperation("test2"),
 			storage.GetOperation("test3"),
 		}
-		q := fmt.Sprintf(queries.QueryGetMultiRows, testTableName)
+		q := fmt.Sprintf(queries.QueryGetMultiRows, tableName)
 		q1 := strings.Replace(q, "$1", generatePlaceholders(2, 0), 1)
 		q2 := strings.Replace(q, "$1", generatePlaceholders(1, 0), 1)
 
@@ -290,7 +296,7 @@ func Test_dbStorageClient_Batch(t *testing.T) {
 			storage.SetOperation("test2", []byte("second")),
 			storage.SetOperation("test3", []byte("third")),
 		}
-		q := fmt.Sprintf(queries.QuerySetMultiRows, testTableName)
+		q := fmt.Sprintf(queries.QuerySetMultiRows, tableName)
 		q = strings.Replace(q, "$1", generatePlaceholders(len(ops), 2), 1)
 
 		mock.ExpectBegin()
@@ -311,7 +317,7 @@ func Test_dbStorageClient_Batch(t *testing.T) {
 			storage.DeleteOperation("test2"),
 			storage.DeleteOperation("test3"),
 		}
-		q := fmt.Sprintf(queries.QueryDeleteMultiRows, testTableName)
+		q := fmt.Sprintf(queries.QueryDeleteMultiRows, tableName)
 		q = strings.Replace(q, "$1", generatePlaceholders(len(ops), 0), 1)
 
 		mock.ExpectBegin()
@@ -425,10 +431,11 @@ func newTestClient(t *testing.T, driverName string) (*dbStorageClient, sqlmock.S
 	require.NoError(t, err)
 
 	queries := getDialectQueries(driverName)
+	tableName := quoteTableIdentifier(driverName, testTableName)
 
-	mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, testTableName)))
-	mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, testTableName)))
-	mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, testTableName)))
+	mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryGetRow, tableName)))
+	mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QuerySetRow, tableName)))
+	mock.ExpectPrepare(regexp.QuoteMeta(fmt.Sprintf(queries.QueryDeleteRow, tableName)))
 
 	dialect := newDBDialect(driverName, testTableName)
 	err = dialect.Prepare(t.Context(), db)


### PR DESCRIPTION
## Description

Fixes SQL identifier handling in `extension/storage/dbstorage` for component IDs containing `-`.

Generated table names are now quoted for PostgreSQL and SQLite before being injected into all SQL templates (`CREATE`, `SELECT`, `INSERT`, `DELETE`, and batch variants). This preserves full component ID compatibility (including hyphens) without lossy name rewriting.

## Link to tracking issue

Fixes #48030

## Testing

From `extension/storage/dbstorage`:
- `go test ./... -run "Test_(newClient|dbStorageClient|wrapTx|generatePlaceholders|getDialectQueries|newDBDialect|quoteTableIdentifier)"`

Also updated sqlmock expectations to reflect quoted identifiers and added identifier-quoting coverage in `client_queries_test.go`.

## Checklist

- [x] Tests updated
- [x] Changelog entry added