### PR TITLE
[chore][receiver/hostmetrics] remove forbidigo exclusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -161,9 +161,6 @@ linters:
       - linters:
           - forbidigo
         path: receiver/datadogreceiver/
-      - linters:
-          - forbidigo
-        path: receiver/hostmetricsreceiver/
 
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47586
       - linters:


### PR DESCRIPTION
#### Description
- #47336 migrated feature gates to metadata, so the linter rule is no longer required

### Link to tracking issue
Part of #46116

### Testing
- `make lint` in the component directory