### PR TITLE
[receiver/vcenter] Add batching for QueryPerf requests

### DIFF
--- a/.chloggen/fix_47941.yaml
+++ b/.chloggen/fix_47941.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: receiver/vcenter
+note: Add max_query_metrics option to batch QueryPerf requests, preventing vCenter resource exhaustion in large deployments.
+issues: [47941]

--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -36,6 +36,7 @@ A “Read Only” user assigned to a vSphere with permissions to the vCenter ser
 | tls                 |         | TLSClientSetting | Not Required. Will use defaults for [configtls.ClientConfig](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md). By default insecure settings are rejected and certificate verification is on. |
 | collection_interval | 2m      | Duration         | This receiver collects metrics on an interval. If the vCenter is fairly large, this value may need to be increased. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`                                                              |
 | initial_delay       | 1s      | Duration         | Defines how long this receiver waits before starting.                                                                                                                                                                                           |
+| max_query_metrics   | 256     | int              | Maximum number of metric IDs per `QueryPerf` API call. Should match or be lower than your vCenter's `vpxd.stats.maxQueryMetrics` setting (default 256). Set to `0` to disable batching. See [VMware KB 301449](https://knowledge.broadcom.com/external/article?articleNumber=301449). |
 
 ### Example Configuration
 

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -326,22 +327,41 @@ func (vc *vcenterClient) PerfMetricsQuery(
 		return &perfMetricsQueryResult{}, nil
 	}
 	vc.pm.Sort = true
-	sample, err := vc.pm.SampleByName(ctx, spec, names, objs)
-	if err != nil {
-		return nil, err
-	}
-	result, err := vc.pm.ToMetricSeries(ctx, sample)
-	if err != nil {
-		return nil, err
+
+	batchSize := vc.batchSizeForMetrics(len(names))
+	if batchSize <= 0 || batchSize >= len(objs) {
+		batchSize = max(len(objs), 1)
 	}
 
 	resultsByRef := map[string]*performance.EntityMetric{}
-	for i := range result {
-		resultsByRef[result[i].Entity.Value] = &result[i]
+	for batch := range slices.Chunk(objs, batchSize) {
+		sample, err := vc.pm.SampleByName(ctx, spec, names, batch)
+		if err != nil {
+			return nil, err
+		}
+		result, err := vc.pm.ToMetricSeries(ctx, sample)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range result {
+			resultsByRef[result[i].Entity.Value] = &result[i]
+		}
 	}
 	return &perfMetricsQueryResult{
 		resultsByRef: resultsByRef,
 	}, nil
+}
+
+func (vc *vcenterClient) batchSizeForMetrics(numMetrics int) int {
+	if vc.cfg == nil {
+		return 0
+	}
+	limit := vc.cfg.MaxQueryMetrics
+	if limit <= 0 || numMetrics == 0 {
+		return 0
+	}
+	return limit / numMetrics
 }
 
 // vSANQueryResults contains all returned vSAN metric related data

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -218,6 +218,42 @@ func TestPerfMetricsQuery(t *testing.T) {
 	}, esx)
 }
 
+func TestPerfMetricsQueryBatching(t *testing.T) {
+	vpx := simulator.VPX()
+	vpx.Host = 10
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		pm := performance.NewManager(c)
+		m := view.NewManager(c)
+		finder := find.NewFinder(c)
+		client := vcenterClient{
+			vimDriver: c,
+			vm:        m,
+			pm:        pm,
+			finder:    finder,
+			cfg: &Config{
+				MaxQueryMetrics: len(hostPerfMetricList) * 3,
+			},
+		}
+
+		dc, err := finder.DefaultDatacenter(ctx)
+		require.NoError(t, err)
+
+		hss, err := client.HostSystems(ctx, dc.Reference())
+		require.NoError(t, err)
+		require.NotEmpty(t, hss)
+
+		var refs []types.ManagedObjectReference
+		for _, hs := range hss {
+			refs = append(refs, hs.Reference())
+		}
+
+		spec := types.PerfQuerySpec{Format: string(types.PerfFormatNormal), IntervalId: int32(20)}
+		metrics, err := client.PerfMetricsQuery(ctx, spec, hostPerfMetricList, refs)
+		require.NoError(t, err)
+		require.Len(t, metrics.resultsByRef, len(hss))
+	}, vpx)
+}
+
 func TestDatacenterInventoryListObjects(t *testing.T) {
 	vpx := simulator.VPX()
 	vpx.Datacenter = 2

--- a/receiver/vcenterreceiver/config.go
+++ b/receiver/vcenterreceiver/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Endpoint                       string              `mapstructure:"endpoint"`
 	Username                       string              `mapstructure:"username"`
 	Password                       configopaque.String `mapstructure:"password"`
+	MaxQueryMetrics                int                 `mapstructure:"max_query_metrics"`
 }
 
 // Validate checks to see if the supplied config will work for the receiver

--- a/receiver/vcenterreceiver/config.schema.yaml
+++ b/receiver/vcenterreceiver/config.schema.yaml
@@ -3,6 +3,8 @@ type: object
 properties:
   endpoint:
     type: string
+  max_query_metrics:
+    type: integer
   password:
     $ref: go.opentelemetry.io/collector/config/configopaque.string
   username:

--- a/receiver/vcenterreceiver/config_test.go
+++ b/receiver/vcenterreceiver/config_test.go
@@ -103,6 +103,7 @@ func TestLoadConfig(t *testing.T) {
 	expected.Endpoint = "http://vcsa.host.localnet"
 	expected.Username = "otelu"
 	expected.Password = "${env:VCENTER_PASSWORD}"
+	expected.MaxQueryMetrics = 128
 	expected.MetricsBuilderConfig = metadata.NewDefaultMetricsBuilderConfig()
 	expected.Metrics.VcenterHostCPUUtilization.Enabled = false
 	expected.CollectionInterval = 5 * time.Minute

--- a/receiver/vcenterreceiver/factory.go
+++ b/receiver/vcenterreceiver/factory.go
@@ -35,6 +35,7 @@ func createDefaultConfig() component.Config {
 		ControllerConfig:     cfg,
 		ClientConfig:         configtls.ClientConfig{},
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		MaxQueryMetrics:      256,
 	}
 }
 

--- a/receiver/vcenterreceiver/testdata/config.yaml
+++ b/receiver/vcenterreceiver/testdata/config.yaml
@@ -3,6 +3,7 @@ vcenter:
   username: otelu
   password: ${env:VCENTER_PASSWORD}
   collection_interval: 5m
+  max_query_metrics: 128
   metrics:
     vcenter.host.cpu.utilization:
       enabled: false


### PR DESCRIPTION
Adds `max_query_metrics` to chunk large `QueryPerf` calls. 
This avoids HTTP 500 errors on large vCenter deployments where the number of metrics requested exceeds the server's internal limit. 
Batching can be disabled by setting it to 0.

Fixes #47941
