### PR TITLE
[chore][receiver/azure_monitor] Refactor internal data model to facilitate deduplication later

### DIFF
--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -60,29 +60,63 @@ const (
 	storageAccountType     = "Microsoft.Storage/storageAccounts"
 )
 
+// updatedMap is used internally to decorate each loaded data with a timestamp to do some cache.
+type updatedMap[K comparable, V any] struct {
+	LastUpdated time.Time
+	Data        map[K]V
+}
+
+func newUpdatedMap[K comparable, V any]() *updatedMap[K, V] {
+	return &updatedMap[K, V]{
+		Data: map[K]V{},
+	}
+}
+
 // azureSubscription is an extract of armsubscriptions.Subscription.
 // It designates a common structure between complex structures retrieved from the AP
 // and simple subscriptions ids that you can find in config.
 type azureSubscription struct {
-	SubscriptionID   string
-	DisplayName      string
-	resourcesUpdated time.Time
+	SubscriptionID string
+	DisplayName    string
 }
 
+// azureResource is an extract of armresources.GenericResourceExpanded.
+// It contains only the necessary information for our use case:
+//   - attributes are the labels that will appear in the resulting timeseries prefixed with metadataPrefix.
+//     Directly collected from the Azure resource metadata like name, resource group, resource type, ...
+//   - tags are the labels that will appear in the resulting timeseries prefixed with tagPrefix.
+//     Directly collected from the Azure resource's tags.
+//   - resourceType is a reference to the resource type, needed internally.
 type azureResource struct {
-	attributes                map[string]*string
-	metricsByCompositeKey     map[metricsCompositeKey]*azureResourceMetrics
-	metricsDefinitionsUpdated time.Time
-	tags                      map[string]*string
-	resourceType              *string
+	attributes   map[string]*string
+	tags         map[string]*string
+	resourceType *string
 }
 
+// metricsCompositeKey is a key used to uniquely identify a set of metrics.
+// This is used to group the queries that will be done and typically to build the request option.
+// It is composed of:
+//   - dimensions: a sorted list of dimensions, used to group metrics.
+//   - aggregations: a sorted list of aggregations, used to group metrics.
+//   - timeGrain: the time grain of the metrics.
+//
+// Example:
+//   - dimensions: "api_name,status_code"
+//   - aggregations: "Average,Count"
+//   - timeGrain: "PT1M"
 type metricsCompositeKey struct {
 	dimensions   string // comma separated sorted dimensions
 	aggregations string // comma separated sorted aggregations
 	timeGrain    string
 }
 
+// azureResourceMetrics is used in a map of metricsCompositeKey to store the metrics on which we'll query values for a given resource (armmonitor API) or resource type (AzBatch API)
+//   - metrics: the list of metrics to query.
+//   - metricsValuesUpdated: the last time the metrics values were updated.
+//     This is used to avoid querying the same metrics multiple times.
+//     It is updated when the metrics values are updated.
+//     It is also used to avoid querying metrics that are not supported by the Azure API.
+//     It is updated when the metrics definitions are updated.
 type azureResourceMetrics struct {
 	metrics              []string
 	metricsValuesUpdated time.Time
@@ -128,17 +162,27 @@ func newScraper(conf *Config, settings receiver.Settings) *azureScraper {
 	}
 }
 
-type azureScraper struct {
-	cred azcore.TokenCredential
+// azSubscriptionStore is a convenient alias for azureScraper.subscriptions and azureBatchScraper.subscriptions fields
+type azSubscriptionStore = *updatedMap[string, *azureSubscription]
 
+// azResourceStore is a convenient alias for azureScraper.resources and azureBatchScraper.resources fields
+type azResourceStore = map[string]*updatedMap[string, *azureResource]
+
+// azMetricsStore is a convenient alias for azureScraper.metrics and azureBatchScraper.metrics fields
+type azMetricsStore = map[string]map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics]
+
+type azureScraper struct {
+	cred     azcore.TokenCredential
 	cfg      *Config
 	settings component.TelemetrySettings
-	// resources on which we'll collect metrics. Stored by resource id and subscription id.
-	resources map[string]map[string]*azureResource
+	mb       *metadata.MetricsBuilder
+
 	// subscriptions on which we'll look up resources. Stored by subscription id.
-	subscriptions        map[string]*azureSubscription
-	subscriptionsUpdated time.Time
-	mb                   *metadata.MetricsBuilder
+	subscriptions azSubscriptionStore
+	// resources on which we'll look up metrics. Stored by subscription id and resource id.
+	resources azResourceStore
+	// metrics on which we'll collect values. Stored by subscription id, resource id, and metricsCompositeKey.
+	metrics azMetricsStore
 
 	mutex                        *sync.Mutex
 	time                         timeNowIface
@@ -151,36 +195,39 @@ func (s *azureScraper) start(_ context.Context, host component.Host) (err error)
 		return err
 	}
 
-	s.subscriptions = map[string]*azureSubscription{}
-	s.resources = map[string]map[string]*azureResource{}
+	s.subscriptions = newUpdatedMap[string, *azureSubscription]()
+	s.resources = azResourceStore{}
+	s.metrics = azMetricsStore{}
 
 	return err
 }
 
 func (s *azureScraper) loadSubscription(sub azureSubscription) {
-	s.resources[sub.SubscriptionID] = make(map[string]*azureResource)
-	s.subscriptions[sub.SubscriptionID] = &azureSubscription{
+	s.subscriptions.Data[sub.SubscriptionID] = &azureSubscription{
 		SubscriptionID: sub.SubscriptionID,
 		DisplayName:    sub.DisplayName,
 	}
+	s.resources[sub.SubscriptionID] = newUpdatedMap[string, *azureResource]()
+	s.metrics[sub.SubscriptionID] = make(map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics])
 }
 
 func (s *azureScraper) unloadSubscription(id string) {
 	s.settings.Logger.Debug("Unloading subscription", zap.String("subscription_id", id))
+	delete(s.subscriptions.Data, id)
 	delete(s.resources, id)
-	delete(s.subscriptions, id)
+	delete(s.metrics, id)
 }
 
 func (s *azureScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	s.loadSubscriptions(ctx)
 
-	for subscriptionID, subscription := range s.subscriptions {
+	for subscriptionID, subscription := range s.subscriptions.Data {
 		s.loadResources(ctx, subscriptionID)
 
 		resourcesIDsWithDefinitions := make(chan string)
 		go func(subscriptionID string) {
 			defer close(resourcesIDsWithDefinitions)
-			for resourceID := range s.resources[subscriptionID] {
+			for resourceID := range s.resources[subscriptionID].Data {
 				s.loadMetricsDefinitions(ctx, subscriptionID, resourceID)
 				resourcesIDsWithDefinitions <- resourceID
 			}
@@ -211,7 +258,7 @@ func (s *azureScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 func (s *azureScraper) loadSubscriptions(ctx context.Context) {
 	s.settings.Logger.Debug("Loading the list of Azure Subscriptions", zap.Bool("discover_subscriptions", s.cfg.DiscoverSubscriptions))
-	if time.Since(s.subscriptionsUpdated).Seconds() < s.cfg.CacheResources {
+	if time.Since(s.subscriptions.LastUpdated).Seconds() < s.cfg.CacheResources {
 		s.settings.Logger.Debug("Azure subscriptions are cached, skipping refresh")
 		return
 	}
@@ -255,15 +302,15 @@ func (s *azureScraper) loadSubscriptions(ctx context.Context) {
 				DisplayName:    *resp.DisplayName,
 			})
 		}
-		s.subscriptionsUpdated = time.Now()
+		s.subscriptions.LastUpdated = time.Now()
 		s.settings.Logger.Info("Loaded the list of Azure Subscriptions",
-			zap.Int("subscriptions_count", len(s.subscriptions)))
+			zap.Int("subscriptions_count", len(s.subscriptions.Data)))
 		return
 	}
 
 	// Prepare a map of existing subscriptions to detect removed ones later
 	existingSubscriptions := map[string]void{}
-	for id := range s.subscriptions {
+	for id := range s.subscriptions.Data {
 		existingSubscriptions[id] = void{}
 	}
 
@@ -298,16 +345,22 @@ func (s *azureScraper) loadSubscriptions(ctx context.Context) {
 		}
 	}
 
-	s.subscriptionsUpdated = time.Now()
+	s.subscriptions.LastUpdated = time.Now()
 	s.settings.Logger.Info("Loaded the list of Azure Subscriptions",
-		zap.Int("subscriptions_count", len(s.subscriptions)),
+		zap.Int("subscriptions_count", len(s.subscriptions.Data)),
 		zap.Int("deleted_subscriptions_count", len(existingSubscriptions)))
 }
 
 func (s *azureScraper) loadResources(ctx context.Context, subscriptionID string) {
 	s.settings.Logger.Debug("Loading the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID))
-	if time.Since(s.subscriptions[subscriptionID].resourcesUpdated).Seconds() < s.cfg.CacheResources {
+
+	// Ensure that the map for this subscription ID is initialized before trying to access it to avoid nil pointer dereference.
+	if s.resources[subscriptionID] == nil {
+		s.resources[subscriptionID] = newUpdatedMap[string, *azureResource]()
+	}
+
+	if time.Since(s.resources[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResources {
 		s.settings.Logger.Debug("Azure Resources are cached, skipping refresh",
 			zap.String("subscription_id", subscriptionID))
 		return
@@ -323,7 +376,7 @@ func (s *azureScraper) loadResources(ctx context.Context, subscriptionID string)
 
 	// Prepare a map of existing resources to detect removed ones later
 	existingResources := map[string]void{}
-	for id := range s.resources[subscriptionID] {
+	for id := range s.resources[subscriptionID].Data {
 		existingResources[id] = void{}
 	}
 
@@ -357,7 +410,7 @@ func (s *azureScraper) loadResources(ctx context.Context, subscriptionID string)
 		page++
 
 		for _, resource := range s.processResources(nextResult.Value) {
-			if _, ok := s.resources[subscriptionID][*resource.ID]; !ok {
+			if _, ok := s.resources[subscriptionID].Data[*resource.ID]; !ok {
 				resourceGroup := getResourceGroupFromID(*resource.ID)
 				attributes := map[string]*string{
 					attributeName:          resource.Name,
@@ -367,7 +420,7 @@ func (s *azureScraper) loadResources(ctx context.Context, subscriptionID string)
 				if resource.Location != nil {
 					attributes[attributeLocation] = resource.Location
 				}
-				s.resources[subscriptionID][*resource.ID] = &azureResource{
+				s.resources[subscriptionID].Data[*resource.ID] = &azureResource{
 					attributes:   attributes,
 					tags:         filterResourceTags(tagsFilterMap, resource.Tags),
 					resourceType: resource.Type,
@@ -380,14 +433,32 @@ func (s *azureScraper) loadResources(ctx context.Context, subscriptionID string)
 	// Unload resources that are no longer present
 	if len(existingResources) > 0 {
 		for idToDelete := range existingResources {
-			delete(s.resources[subscriptionID], idToDelete)
+			delete(s.resources[subscriptionID].Data, idToDelete)
 		}
 	}
 
-	s.subscriptions[subscriptionID].resourcesUpdated = time.Now()
+	s.resources[subscriptionID].LastUpdated = time.Now()
+
+	// Pre-allocate the per-resource metrics entries here, while we are still on the synchronous
+	// path of scrape() (no goroutine has been launched yet for this subscription). The
+	// producer (loadMetricsDefinitions) and the consumers (loadMetricsValues) will both access
+	// s.metrics[subscriptionID]; Go maps are not safe for concurrent read/write even on different
+	// keys (a write may trigger a rehash that invalidates concurrent reads). By inserting all
+	// entries up front, we guarantee that only inner-struct fields are mutated concurrently
+	// afterwards, never the outer map itself. Covered by TestAzureScraperBatchScrape_NoRaceWithManyResourceTypes
+	// and the equivalent test on the non-batch scraper.
+	if s.metrics[subscriptionID] == nil {
+		s.metrics[subscriptionID] = make(map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics])
+	}
+	for resourceID := range s.resources[subscriptionID].Data {
+		if s.metrics[subscriptionID][resourceID] == nil {
+			s.metrics[subscriptionID][resourceID] = newUpdatedMap[metricsCompositeKey, *azureResourceMetrics]()
+		}
+	}
+
 	s.settings.Logger.Info("Loaded the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID),
-		zap.Int("resources_count", len(s.resources[subscriptionID])),
+		zap.Int("resources_count", len(s.resources[subscriptionID].Data)),
 		zap.Int("deleted_resources_count", len(existingResources)))
 }
 
@@ -466,7 +537,8 @@ func (s *azureScraper) loadMetricsDefinitions(ctx context.Context, subscriptionI
 	s.settings.Logger.Debug("Loading the list of Azure Metrics Definitions",
 		zap.String("resource_id", resourceID),
 		zap.String("subscription_id", subscriptionID))
-	if time.Since(s.resources[subscriptionID][resourceID].metricsDefinitionsUpdated).Seconds() < s.cfg.CacheResourcesDefinitions {
+
+	if time.Since(s.metrics[subscriptionID][resourceID].LastUpdated).Seconds() < s.cfg.CacheResourcesDefinitions {
 		s.settings.Logger.Debug("Azure Metrics Definitions are cached, skipping refresh",
 			zap.String("resource_id", resourceID),
 			zap.String("subscription_id", subscriptionID))
@@ -474,7 +546,7 @@ func (s *azureScraper) loadMetricsDefinitions(ctx context.Context, subscriptionI
 	}
 
 	// Prepare the map of metrics by composite key.
-	s.resources[subscriptionID][resourceID].metricsByCompositeKey = map[metricsCompositeKey]*azureResourceMetrics{}
+	s.metrics[subscriptionID][resourceID].Data = map[metricsCompositeKey]*azureResourceMetrics{}
 
 	clientMetricsDefinitions, clientErr := armmonitor.NewMetricDefinitionsClient(subscriptionID, s.cred, s.clientOptionsResolver.GetArmMonitorClientOptions())
 	if clientErr != nil {
@@ -511,7 +583,7 @@ func (s *azureScraper) loadMetricsDefinitions(ctx context.Context, subscriptionI
 			}
 
 			timeGrain := *v.MetricAvailabilities[0].TimeGrain
-			dimensions := filterDimensions(v.Dimensions, s.cfg.Dimensions, *s.resources[subscriptionID][resourceID].resourceType, metricName)
+			dimensions := filterDimensions(v.Dimensions, s.cfg.Dimensions, *s.resources[subscriptionID].Data[resourceID].resourceType, metricName)
 			compositeKey := metricsCompositeKey{
 				timeGrain:    timeGrain,
 				dimensions:   serializeDimensions(dimensions),
@@ -521,9 +593,9 @@ func (s *azureScraper) loadMetricsDefinitions(ctx context.Context, subscriptionI
 		}
 	}
 
-	s.resources[subscriptionID][resourceID].metricsDefinitionsUpdated = time.Now()
+	s.metrics[subscriptionID][resourceID].LastUpdated = time.Now()
 	s.settings.Logger.Info("Loaded the list of Azure Metrics Definitions",
-		zap.Int("metrics_definitions_count", len(s.resources[subscriptionID][resourceID].metricsByCompositeKey)),
+		zap.Int("metrics_definitions_count", len(s.metrics[subscriptionID][resourceID].Data)),
 		zap.String("resource_id", resourceID),
 		zap.String("subscription_id", subscriptionID))
 }
@@ -536,12 +608,12 @@ func (s *azureScraper) loadMetricsDefinition(subscriptionID, resourceID, metricN
 		zap.String("metric", metricName),
 		zap.String("resource_id", resourceID),
 		zap.String("subscription_id", subscriptionID))
-	if _, ok := s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey]; ok {
-		s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey].metrics = append(
-			s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey].metrics, metricName,
+	if _, ok := s.metrics[subscriptionID][resourceID].Data[compositeKey]; ok {
+		s.metrics[subscriptionID][resourceID].Data[compositeKey].metrics = append(
+			s.metrics[subscriptionID][resourceID].Data[compositeKey].metrics, metricName,
 		)
 	} else {
-		s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey] = &azureResourceMetrics{metrics: []string{metricName}}
+		s.metrics[subscriptionID][resourceID].Data[compositeKey] = &azureResourceMetrics{metrics: []string{metricName}}
 	}
 }
 
@@ -549,7 +621,8 @@ func (s *azureScraper) loadMetricsValues(ctx context.Context, subscriptionID, re
 	s.settings.Logger.Debug("Loading the Azure Metrics",
 		zap.String("resource_id", resourceID),
 		zap.String("subscription_id", subscriptionID))
-	res := *s.resources[subscriptionID][resourceID]
+	res := *s.resources[subscriptionID].Data[resourceID]
+	metricsDef := s.metrics[subscriptionID][resourceID].Data
 	updatedAt := s.time.Now().Truncate(truncateTimeGrain)
 
 	clientMetricsValues, clientErr := armmonitor.NewMetricsClient(subscriptionID, s.cred, s.clientOptionsResolver.GetArmMonitorClientOptions())
@@ -561,7 +634,7 @@ func (s *azureScraper) loadMetricsValues(ctx context.Context, subscriptionID, re
 		return
 	}
 
-	for compositeKey, metricsByGrain := range res.metricsByCompositeKey {
+	for compositeKey, metricsByGrain := range metricsDef {
 		if updatedAt.Sub(metricsByGrain.metricsValuesUpdated).Seconds() < float64(timeGrains[compositeKey.timeGrain]) {
 			continue
 		}

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -355,11 +355,6 @@ func (s *azureScraper) loadResources(ctx context.Context, subscriptionID string)
 	s.settings.Logger.Debug("Loading the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID))
 
-	// Ensure that the map for this subscription ID is initialized before trying to access it to avoid nil pointer dereference.
-	if s.resources[subscriptionID] == nil {
-		s.resources[subscriptionID] = newUpdatedMap[string, *azureResource]()
-	}
-
 	if time.Since(s.resources[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResources {
 		s.settings.Logger.Debug("Azure Resources are cached, skipping refresh",
 			zap.String("subscription_id", subscriptionID))

--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -35,10 +35,10 @@ type azureType struct {
 }
 
 // azResourceTypeStore is a convenient alias for azureBatchScraper.resourceTypes field
-type azResourceTypeStore = map[string]*updatedMap[string, *azureType]
+type azResourceTypeStore = map[string]map[string]*azureType
 
 // azRegionStore is a convenient alias for azureBatchScraper.regions field
-type azRegionStore = map[string]*updatedMap[string, void]
+type azRegionStore = map[string]map[string]void
 
 func newBatchScraper(conf *Config, settings receiver.Settings) *azureBatchScraper {
 	return &azureBatchScraper{
@@ -62,10 +62,10 @@ type azureBatchScraper struct {
 
 	// subscriptions on which we'll look up resources. Stored by subscription id.
 	subscriptions azSubscriptionStore
-	// resourceTypes on which we'll look up metrics. Stored by subscription id and resource type.
-	resourceTypes azResourceTypeStore
 	// resources on which we'll look up metrics. Stored by subscription id and resource id.
 	resources azResourceStore
+	// resourceTypes on which we'll look up metrics. Stored by subscription id and resource type.
+	resourceTypes azResourceTypeStore
 	// regions on which we'll collect values. Stored by subscription id.
 	regions azRegionStore
 	// metrics on which we'll collect values. Stored by subscription id, resource id, and metricsCompositeKey.
@@ -103,8 +103,8 @@ func (s *azureBatchScraper) loadSubscription(sub azureSubscription) {
 		DisplayName:    sub.DisplayName,
 	}
 	s.resources[sub.SubscriptionID] = newUpdatedMap[string, *azureResource]()
-	s.resourceTypes[sub.SubscriptionID] = newUpdatedMap[string, *azureType]()
-	s.regions[sub.SubscriptionID] = newUpdatedMap[string, void]()
+	s.resourceTypes[sub.SubscriptionID] = make(map[string]*azureType)
+	s.regions[sub.SubscriptionID] = make(map[string]void)
 	s.metrics[sub.SubscriptionID] = make(map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics])
 }
 
@@ -133,7 +133,7 @@ func (s *azureBatchScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 			resourceTypesWithDefinitions := make(chan string)
 			go func() {
 				defer close(resourceTypesWithDefinitions)
-				for resourceType := range s.resourceTypes[subscriptionID].Data {
+				for resourceType := range s.resourceTypes[subscriptionID] {
 					s.loadResourceMetricsDefinitionsByType(ctx, subscriptionID, resourceType)
 					resourceTypesWithDefinitions <- resourceType
 				}
@@ -279,20 +279,7 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 	s.settings.Logger.Debug("Loading the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID))
 
-	// Ensure that the maps for this subscription ID are initialized before trying to access it to avoid nil pointer dereference.
-	if s.resources[subscriptionID] == nil {
-		s.resources[subscriptionID] = newUpdatedMap[string, *azureResource]()
-	}
-	if s.resourceTypes[subscriptionID] == nil {
-		s.resourceTypes[subscriptionID] = newUpdatedMap[string, *azureType]()
-	}
-	if s.regions[subscriptionID] == nil {
-		s.regions[subscriptionID] = newUpdatedMap[string, void]()
-	}
-
-	if time.Since(s.resources[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResources ||
-		time.Since(s.resourceTypes[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResourcesDefinitions ||
-		time.Since(s.regions[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResourcesDefinitions {
+	if time.Since(s.resources[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResources {
 		s.settings.Logger.Debug("Azure Resources are cached, skipping refresh",
 			zap.String("subscription_id", subscriptionID))
 		return
@@ -350,7 +337,7 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 					attributeResourceType:  resource.Type,
 				}
 				if resource.Location != nil {
-					s.regions[subscriptionID].Data[*resource.Location] = struct{}{}
+					s.regions[subscriptionID][*resource.Location] = struct{}{}
 					attributes[attributeLocation] = resource.Location
 				}
 				s.resources[subscriptionID].Data[*resource.ID] = &azureResource{
@@ -378,9 +365,7 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 	}
 
 	s.resources[subscriptionID].LastUpdated = time.Now()
-	s.resourceTypes[subscriptionID].LastUpdated = time.Now()
-	s.regions[subscriptionID].LastUpdated = time.Now()
-	maps.Copy(s.resourceTypes[subscriptionID].Data, resourceTypes)
+	maps.Copy(s.resourceTypes[subscriptionID], resourceTypes)
 
 	// Pre-allocate the per-resource-type metrics entries here, while we are still on the
 	// synchronous path of scrape() (no goroutine has been launched yet for this subscription).
@@ -393,7 +378,7 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 	if s.metrics[subscriptionID] == nil {
 		s.metrics[subscriptionID] = make(map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics])
 	}
-	for resourceType := range s.resourceTypes[subscriptionID].Data {
+	for resourceType := range s.resourceTypes[subscriptionID] {
 		if s.metrics[subscriptionID][resourceType] == nil {
 			s.metrics[subscriptionID][resourceType] = newUpdatedMap[metricsCompositeKey, *azureResourceMetrics]()
 		}
@@ -402,8 +387,8 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 	s.settings.Logger.Info("Loaded the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID),
 		zap.Int("resources_count", len(s.resources[subscriptionID].Data)),
-		zap.Int("regions_count", len(s.regions[subscriptionID].Data)),
-		zap.Int("resource_types_count", len(s.resourceTypes[subscriptionID].Data)),
+		zap.Int("regions_count", len(s.regions[subscriptionID])),
+		zap.Int("resource_types_count", len(s.resourceTypes[subscriptionID])),
 		zap.Int("deleted_resources_count", len(existingResources)))
 }
 
@@ -483,7 +468,7 @@ func (s *azureBatchScraper) loadResourceMetricsDefinitionsByType(ctx context.Con
 		return
 	}
 
-	resourceIDs := s.resourceTypes[subscriptionID].Data[resourceType].resourceIDs
+	resourceIDs := s.resourceTypes[subscriptionID][resourceType].resourceIDs
 	if len(resourceIDs) == 0 && resourceIDs[0] != "" {
 		return
 	}
@@ -552,7 +537,7 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 	s.settings.Logger.Debug("Loading the Azure Metrics",
 		zap.String("resource_type", resourceType),
 		zap.String("subscription_id", subscriptionID))
-	resType := *s.resourceTypes[subscriptionID].Data[resourceType]
+	resType := *s.resourceTypes[subscriptionID][resourceType]
 	metricsDef := s.metrics[subscriptionID][resourceType].Data
 	maxPerBatch := defaultMaximumResourcesPerBatch
 	if s.cfg.MaximumResourcesPerBatch > 0 {
@@ -582,7 +567,7 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 
 		startTime := now.Add(time.Duration(-timeGrains[compositeKey.timeGrain]) * time.Second * 4) // times 4 because for some resources, data are missing for the very latest timestamp. The processing will keep only the latest timestamp with data.
 
-		for region := range s.regions[subscriptionID].Data {
+		for region := range s.regions[subscriptionID] {
 			clientMetrics, clientErr := s.GetMetricsBatchValuesClient(region)
 			if clientErr != nil {
 				s.settings.Logger.Error("Failed to initialize the client for Azure Metrics",

--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -28,12 +28,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver/internal/metadata"
 )
 
+// azureType is built from the collected list of azureResource.
+// It is just a helper allowing us to easily find back the resourceIDs to provide to the AzBatch API.
 type azureType struct {
-	name                      *string
-	resourceIDs               []string
-	metricsByCompositeKey     map[metricsCompositeKey]*azureResourceMetrics
-	metricsDefinitionsUpdated time.Time
+	resourceIDs []string
 }
+
+// azResourceTypeStore is a convenient alias for azureBatchScraper.resourceTypes field
+type azResourceTypeStore = map[string]*updatedMap[string, *azureType]
+
+// azRegionStore is a convenient alias for azureBatchScraper.regions field
+type azRegionStore = map[string]*updatedMap[string, void]
 
 func newBatchScraper(conf *Config, settings receiver.Settings) *azureBatchScraper {
 	return &azureBatchScraper{
@@ -53,16 +58,18 @@ type azureBatchScraper struct {
 	cfg              *Config
 	receiverSettings receiver.Settings
 	settings         component.TelemetrySettings
-	// resources on which we'll get attributes. Stored by resource id and subscription id.
-	resources map[string]map[string]*azureResource
-	// resourceTypes on which we'll collect metrics. Stored by resource type and subscription id.
-	resourceTypes map[string]map[string]*azureType
+	mbs              concurrentMetricsBuilderMap[*metadata.MetricsBuilder]
+
 	// subscriptions on which we'll look up resources. Stored by subscription id.
-	subscriptions        map[string]*azureSubscription
-	subscriptionsUpdated time.Time
-	// regions on which we'll collect metrics. Stored by subscription id.
-	regions map[string]map[string]struct{}
-	mbs     concurrentMetricsBuilderMap[*metadata.MetricsBuilder]
+	subscriptions azSubscriptionStore
+	// resourceTypes on which we'll look up metrics. Stored by subscription id and resource type.
+	resourceTypes azResourceTypeStore
+	// resources on which we'll look up metrics. Stored by subscription id and resource id.
+	resources azResourceStore
+	// regions on which we'll collect values. Stored by subscription id.
+	regions azRegionStore
+	// metrics on which we'll collect values. Stored by subscription id, resource id, and metricsCompositeKey.
+	metrics azMetricsStore
 
 	mutex                        *sync.Mutex
 	time                         timeNowIface
@@ -81,31 +88,34 @@ func (s *azureBatchScraper) start(_ context.Context, host component.Host) (err e
 		return err
 	}
 
-	s.subscriptions = map[string]*azureSubscription{}
-	s.resourceTypes = map[string]map[string]*azureType{}
-	s.resources = map[string]map[string]*azureResource{}
-	s.regions = map[string]map[string]struct{}{}
+	s.subscriptions = newUpdatedMap[string, *azureSubscription]()
+	s.resourceTypes = azResourceTypeStore{}
+	s.resources = azResourceStore{}
+	s.regions = azRegionStore{}
+	s.metrics = azMetricsStore{}
 
 	return err
 }
 
 func (s *azureBatchScraper) loadSubscription(sub azureSubscription) {
-	s.resourceTypes[sub.SubscriptionID] = make(map[string]*azureType)
-	s.resources[sub.SubscriptionID] = make(map[string]*azureResource)
-	s.regions[sub.SubscriptionID] = make(map[string]struct{})
-	s.subscriptions[sub.SubscriptionID] = &azureSubscription{
+	s.subscriptions.Data[sub.SubscriptionID] = &azureSubscription{
 		SubscriptionID: sub.SubscriptionID,
 		DisplayName:    sub.DisplayName,
 	}
+	s.resources[sub.SubscriptionID] = newUpdatedMap[string, *azureResource]()
+	s.resourceTypes[sub.SubscriptionID] = newUpdatedMap[string, *azureType]()
+	s.regions[sub.SubscriptionID] = newUpdatedMap[string, void]()
+	s.metrics[sub.SubscriptionID] = make(map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics])
 }
 
 func (s *azureBatchScraper) unloadSubscription(id string) {
 	s.settings.Logger.Debug("Unloading subscription", zap.String("subscription_id", id))
 
-	delete(s.subscriptions, id)
+	delete(s.subscriptions.Data, id)
 	delete(s.resourceTypes, id)
 	delete(s.resources, id)
 	delete(s.regions, id)
+	delete(s.metrics, id)
 }
 
 func (s *azureBatchScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
@@ -113,7 +123,7 @@ func (s *azureBatchScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 
 	var subWG sync.WaitGroup
 
-	for subID, subscription := range s.subscriptions {
+	for subID, subscription := range s.subscriptions.Data {
 		s.mbs.Set(subID, metadata.NewMetricsBuilder(s.cfg.MetricsBuilderConfig, s.receiverSettings))
 		subWG.Add(1)
 		go func(subscriptionID string) {
@@ -123,7 +133,7 @@ func (s *azureBatchScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 			resourceTypesWithDefinitions := make(chan string)
 			go func() {
 				defer close(resourceTypesWithDefinitions)
-				for resourceType := range s.resourceTypes[subscriptionID] {
+				for resourceType := range s.resourceTypes[subscriptionID].Data {
 					s.loadResourceMetricsDefinitionsByType(ctx, subscriptionID, resourceType)
 					resourceTypesWithDefinitions <- resourceType
 				}
@@ -171,7 +181,7 @@ func (s *azureBatchScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 // TODO: duplicate
 func (s *azureBatchScraper) loadSubscriptions(ctx context.Context) {
 	s.settings.Logger.Debug("Loading the list of Azure Subscriptions", zap.Bool("discover_subscriptions", s.cfg.DiscoverSubscriptions))
-	if time.Since(s.subscriptionsUpdated).Seconds() < s.cfg.CacheResources {
+	if time.Since(s.subscriptions.LastUpdated).Seconds() < s.cfg.CacheResources {
 		s.settings.Logger.Debug("Azure subscriptions are cached, skipping refresh")
 		return
 	}
@@ -215,15 +225,15 @@ func (s *azureBatchScraper) loadSubscriptions(ctx context.Context) {
 				DisplayName:    *resp.DisplayName,
 			})
 		}
-		s.subscriptionsUpdated = time.Now()
+		s.subscriptions.LastUpdated = time.Now()
 		s.settings.Logger.Info("Loaded the list of Azure Subscriptions",
-			zap.Int("subscriptions_count", len(s.subscriptions)))
+			zap.Int("subscriptions_count", len(s.subscriptions.Data)))
 		return
 	}
 
 	// Prepare a map of existing subscriptions to detect removed ones later
 	existingSubscriptions := map[string]void{}
-	for id := range s.subscriptions {
+	for id := range s.subscriptions.Data {
 		existingSubscriptions[id] = void{}
 	}
 
@@ -258,9 +268,9 @@ func (s *azureBatchScraper) loadSubscriptions(ctx context.Context) {
 		}
 	}
 
-	s.subscriptionsUpdated = time.Now()
+	s.subscriptions.LastUpdated = time.Now()
 	s.settings.Logger.Info("Loaded the list of Azure Subscriptions",
-		zap.Int("subscriptions_count", len(s.subscriptions)),
+		zap.Int("subscriptions_count", len(s.subscriptions.Data)),
 		zap.Int("deleted_subscriptions_count", len(existingSubscriptions)))
 }
 
@@ -268,7 +278,21 @@ func (s *azureBatchScraper) loadSubscriptions(ctx context.Context) {
 func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscriptionID string) {
 	s.settings.Logger.Debug("Loading the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID))
-	if time.Since(s.subscriptions[subscriptionID].resourcesUpdated).Seconds() < s.cfg.CacheResources {
+
+	// Ensure that the maps for this subscription ID are initialized before trying to access it to avoid nil pointer dereference.
+	if s.resources[subscriptionID] == nil {
+		s.resources[subscriptionID] = newUpdatedMap[string, *azureResource]()
+	}
+	if s.resourceTypes[subscriptionID] == nil {
+		s.resourceTypes[subscriptionID] = newUpdatedMap[string, *azureType]()
+	}
+	if s.regions[subscriptionID] == nil {
+		s.regions[subscriptionID] = newUpdatedMap[string, void]()
+	}
+
+	if time.Since(s.resources[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResources ||
+		time.Since(s.resourceTypes[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResourcesDefinitions ||
+		time.Since(s.regions[subscriptionID].LastUpdated).Seconds() < s.cfg.CacheResourcesDefinitions {
 		s.settings.Logger.Debug("Azure Resources are cached, skipping refresh",
 			zap.String("subscription_id", subscriptionID))
 		return
@@ -283,7 +307,7 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 
 	// Prepare a map of existing resources to detect removed ones later
 	existingResources := map[string]void{}
-	for id := range s.resources[subscriptionID] {
+	for id := range s.resources[subscriptionID].Data {
 		existingResources[id] = void{}
 	}
 
@@ -318,7 +342,7 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 		page++
 
 		for _, resource := range s.processResources(nextResult.Value) {
-			if _, ok := s.resources[subscriptionID][*resource.ID]; !ok {
+			if _, ok := s.resources[subscriptionID].Data[*resource.ID]; !ok {
 				resourceGroup := getResourceGroupFromID(*resource.ID)
 				attributes := map[string]*string{
 					attributeName:          resource.Name,
@@ -326,17 +350,16 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 					attributeResourceType:  resource.Type,
 				}
 				if resource.Location != nil {
-					s.regions[subscriptionID][*resource.Location] = struct{}{}
+					s.regions[subscriptionID].Data[*resource.Location] = struct{}{}
 					attributes[attributeLocation] = resource.Location
 				}
-				s.resources[subscriptionID][*resource.ID] = &azureResource{
+				s.resources[subscriptionID].Data[*resource.ID] = &azureResource{
 					attributes:   attributes,
 					tags:         filterResourceTags(tagsFilterMap, resource.Tags),
 					resourceType: resource.Type,
 				}
 				if resourceTypes[*resource.Type] == nil {
 					resourceTypes[*resource.Type] = &azureType{
-						name:        resource.Type,
 						resourceIDs: []string{*resource.ID},
 					}
 				} else {
@@ -350,16 +373,38 @@ func (s *azureBatchScraper) loadResourcesAndTypes(ctx context.Context, subscript
 	// Unload resources that are no longer present
 	if len(existingResources) > 0 {
 		for idToDelete := range existingResources {
-			delete(s.resources[subscriptionID], idToDelete)
+			delete(s.resources[subscriptionID].Data, idToDelete)
 		}
 	}
 
-	s.subscriptions[subscriptionID].resourcesUpdated = time.Now()
+	s.resources[subscriptionID].LastUpdated = time.Now()
+	s.resourceTypes[subscriptionID].LastUpdated = time.Now()
+	s.regions[subscriptionID].LastUpdated = time.Now()
+	maps.Copy(s.resourceTypes[subscriptionID].Data, resourceTypes)
+
+	// Pre-allocate the per-resource-type metrics entries here, while we are still on the
+	// synchronous path of scrape() (no goroutine has been launched yet for this subscription).
+	// The producer (loadResourceMetricsDefinitionsByType) and the consumers
+	// (loadBatchMetricsValues) will both access s.metrics[subscriptionID]; Go maps are not safe
+	// for concurrent read/write even on different keys (a write may trigger a rehash that
+	// invalidates concurrent reads). By inserting all entries up front, we guarantee that only
+	// inner-struct fields are mutated concurrently afterwards, never the outer map itself.
+	// Covered by TestAzureScraperBatchScrape_NoRaceWithManyResourceTypes.
+	if s.metrics[subscriptionID] == nil {
+		s.metrics[subscriptionID] = make(map[string]*updatedMap[metricsCompositeKey, *azureResourceMetrics])
+	}
+	for resourceType := range s.resourceTypes[subscriptionID].Data {
+		if s.metrics[subscriptionID][resourceType] == nil {
+			s.metrics[subscriptionID][resourceType] = newUpdatedMap[metricsCompositeKey, *azureResourceMetrics]()
+		}
+	}
+
 	s.settings.Logger.Info("Loaded the list of Azure Resources",
 		zap.String("subscription_id", subscriptionID),
-		zap.Int("resources_count", len(s.resources[subscriptionID])),
+		zap.Int("resources_count", len(s.resources[subscriptionID].Data)),
+		zap.Int("regions_count", len(s.regions[subscriptionID].Data)),
+		zap.Int("resource_types_count", len(s.resourceTypes[subscriptionID].Data)),
 		zap.Int("deleted_resources_count", len(existingResources)))
-	maps.Copy(s.resourceTypes[subscriptionID], resourceTypes)
 }
 
 // processResources is a workaround specially done for the storageAccount metrics.
@@ -420,7 +465,8 @@ func (s *azureBatchScraper) loadResourceMetricsDefinitionsByType(ctx context.Con
 	s.settings.Logger.Debug("Loading the list of Azure Metrics Definitions",
 		zap.String("resource_type", resourceType),
 		zap.String("subscription_id", subscriptionID))
-	if time.Since(s.resourceTypes[subscriptionID][resourceType].metricsDefinitionsUpdated).Seconds() < s.cfg.CacheResourcesDefinitions {
+
+	if time.Since(s.metrics[subscriptionID][resourceType].LastUpdated).Seconds() < s.cfg.CacheResourcesDefinitions {
 		s.settings.Logger.Debug("Azure Metrics Definitions are cached, skipping refresh",
 			zap.String("resource_type", resourceType),
 			zap.String("subscription_id", subscriptionID))
@@ -428,7 +474,7 @@ func (s *azureBatchScraper) loadResourceMetricsDefinitionsByType(ctx context.Con
 	}
 
 	// Prepare the map of metrics by composite key.
-	s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey = map[metricsCompositeKey]*azureResourceMetrics{}
+	s.metrics[subscriptionID][resourceType].Data = map[metricsCompositeKey]*azureResourceMetrics{}
 
 	clientMetricsDefinitions, clientErr := armmonitor.NewMetricDefinitionsClient(subscriptionID, s.cred, s.clientOptionsResolver.GetArmMonitorClientOptions())
 	if clientErr != nil {
@@ -437,7 +483,7 @@ func (s *azureBatchScraper) loadResourceMetricsDefinitionsByType(ctx context.Con
 		return
 	}
 
-	resourceIDs := s.resourceTypes[subscriptionID][resourceType].resourceIDs
+	resourceIDs := s.resourceTypes[subscriptionID].Data[resourceType].resourceIDs
 	if len(resourceIDs) == 0 && resourceIDs[0] != "" {
 		return
 	}
@@ -477,9 +523,9 @@ func (s *azureBatchScraper) loadResourceMetricsDefinitionsByType(ctx context.Con
 			s.loadMetricsDefinitionByType(subscriptionID, resourceType, metricName, compositeKey)
 		}
 	}
-	s.resourceTypes[subscriptionID][resourceType].metricsDefinitionsUpdated = time.Now()
+	s.metrics[subscriptionID][resourceType].LastUpdated = time.Now()
 	s.settings.Logger.Info("Loaded the list of Azure Metrics Definitions",
-		zap.Int("metrics_definitions_count", len(s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey)),
+		zap.Int("metrics_definitions_count", len(s.metrics[subscriptionID][resourceType].Data)),
 		zap.String("resource_type", resourceType),
 		zap.String("subscription_id", subscriptionID))
 }
@@ -493,12 +539,12 @@ func (s *azureBatchScraper) loadMetricsDefinitionByType(subscriptionID, resource
 		zap.String("metric", metricName),
 		zap.String("resource_type", resourceType),
 		zap.String("subscription_id", subscriptionID))
-	if _, ok := s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey]; ok {
-		s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey].metrics = append(
-			s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey].metrics, metricName,
+	if _, ok := s.metrics[subscriptionID][resourceType].Data[compositeKey]; ok {
+		s.metrics[subscriptionID][resourceType].Data[compositeKey].metrics = append(
+			s.metrics[subscriptionID][resourceType].Data[compositeKey].metrics, metricName,
 		)
 	} else {
-		s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey] = &azureResourceMetrics{metrics: []string{metricName}}
+		s.metrics[subscriptionID][resourceType].Data[compositeKey] = &azureResourceMetrics{metrics: []string{metricName}}
 	}
 }
 
@@ -506,7 +552,8 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 	s.settings.Logger.Debug("Loading the Azure Metrics",
 		zap.String("resource_type", resourceType),
 		zap.String("subscription_id", subscriptionID))
-	resType := *s.resourceTypes[subscriptionID][resourceType]
+	resType := *s.resourceTypes[subscriptionID].Data[resourceType]
+	metricsDef := s.metrics[subscriptionID][resourceType].Data
 	maxPerBatch := defaultMaximumResourcesPerBatch
 	if s.cfg.MaximumResourcesPerBatch > 0 {
 		maxPerBatch = s.cfg.MaximumResourcesPerBatch
@@ -516,7 +563,7 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 		s.settings.Logger.Fatal("error: metrics builder not found for subscription")
 	}
 
-	for compositeKey, metricsByGrain := range resType.metricsByCompositeKey {
+	for compositeKey, metricsByGrain := range metricsDef {
 		now := time.Now().UTC()
 
 		// Anti-duplicate guard: do not re-scrape a (resourceType, compositeKey) pair more often
@@ -535,7 +582,7 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 
 		startTime := now.Add(time.Duration(-timeGrains[compositeKey.timeGrain]) * time.Second * 4) // times 4 because for some resources, data are missing for the very latest timestamp. The processing will keep only the latest timestamp with data.
 
-		for region := range s.regions[subscriptionID] {
+		for region := range s.regions[subscriptionID].Data {
 			clientMetrics, clientErr := s.GetMetricsBatchValuesClient(region)
 			if clientErr != nil {
 				s.settings.Logger.Error("Failed to initialize the client for Azure Metrics",
@@ -605,7 +652,8 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 						resID := *metricValues.ResourceID
 						for _, metric := range metricValues.Values {
 							for _, timeseriesElement := range metric.TimeSeries {
-								res := s.resources[subscriptionID][resID]
+								// TODO: move up
+								res := s.resources[subscriptionID].Data[resID]
 								if res == nil {
 									continue
 								}

--- a/receiver/azuremonitorreceiver/scraper_batch_test.go
+++ b/receiver/azuremonitorreceiver/scraper_batch_test.go
@@ -5,6 +5,7 @@ package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -232,11 +234,12 @@ func TestAzureScraperBatchScrape(t *testing.T) {
 				settings:                     settings.TelemetrySettings,
 				storageAccountSpecificConfig: newStorageAccountSpecificConfig(tt.fields.cfg.Services),
 
-				// From there, initialize everything that is normally initialized in start() func
-				subscriptions: map[string]*azureSubscription{},
-				resources:     map[string]map[string]*azureResource{},
-				regions:       map[string]map[string]struct{}{},
-				resourceTypes: map[string]map[string]*azureType{},
+				// From there, initialize everything normally initialized in start() func
+				subscriptions: newUpdatedMap[string, *azureSubscription](),
+				resourceTypes: azResourceTypeStore{},
+				resources:     azResourceStore{},
+				regions:       azRegionStore{},
+				metrics:       azMetricsStore{},
 			}
 
 			metrics, err := s.scrape(tt.args.ctx)
@@ -257,6 +260,118 @@ func TestAzureScraperBatchScrape(t *testing.T) {
 				pmetrictest.IgnoreResourceMetricsOrder(),
 			))
 		})
+	}
+}
+
+// TestAzureScraperBatchScrape_NoRaceWithManyResourceTypes ensures that the producer/consumer
+// pipeline in (*azureBatchScraper).scrape() does not race on the s.metrics[subscriptionID] map.
+//
+// The producer (loadResourceMetricsDefinitionsByType) and the consumers (loadBatchMetricsValues)
+// run concurrently and both touch s.metrics[subscriptionID]. Go maps are NOT safe for concurrent
+// read/write even on different keys: a write may trigger a rehash that invalidates concurrent
+// reads. To trigger this reliably, this test fans out across several distinct resourceTypes per
+// subscription so the producer keeps writing new entries while consumers iterate over previously
+// pushed ones, and runs scrape() many times to widen the race window.
+//
+// Run with `-race` to detect regressions: any future change that re-introduces a write to the
+// outer s.metrics[subscriptionID] map after the goroutines have started will fail this test.
+func TestAzureScraperBatchScrape_NoRaceWithManyResourceTypes(t *testing.T) {
+	const (
+		sub1     = "subRace1"
+		sub2     = "subRace2"
+		typeA    = "Microsoft.Race/typeA"
+		typeB    = "Microsoft.Race/typeB"
+		typeC    = "Microsoft.Race/typeC"
+		location = "westeurope"
+	)
+	id := func(sub, rt string) string {
+		return fmt.Sprintf("/subscriptions/%s/resourceGroups/rg/providers/%s/r", sub, rt)
+	}
+
+	cfg := createDefaultTestConfig()
+	cfg.SubscriptionIDs = []string{sub1, sub2}
+	cfg.AppendTagsAsAttributes = []string{}
+	cfg.MaximumNumberOfMetricsInACall = 2
+	cfg.Services = []string{typeA, typeB, typeC}
+
+	// One resource per (subscription, type). Multiple types per subscription is what
+	// triggers the race: the producer keeps inserting new keys in s.metrics[sub] while
+	// consumers iterate previously pushed ones.
+	resources := map[string][][]*armresources.GenericResourceExpanded{
+		sub1: {{
+			{ID: to.Ptr(id(sub1, typeA)), Location: to.Ptr(location), Name: to.Ptr("rA"), Type: to.Ptr(typeA)},
+			{ID: to.Ptr(id(sub1, typeB)), Location: to.Ptr(location), Name: to.Ptr("rB"), Type: to.Ptr(typeB)},
+			{ID: to.Ptr(id(sub1, typeC)), Location: to.Ptr(location), Name: to.Ptr("rC"), Type: to.Ptr(typeC)},
+		}},
+		sub2: {{
+			{ID: to.Ptr(id(sub2, typeA)), Location: to.Ptr(location), Name: to.Ptr("rA"), Type: to.Ptr(typeA)},
+			{ID: to.Ptr(id(sub2, typeB)), Location: to.Ptr(location), Name: to.Ptr("rB"), Type: to.Ptr(typeB)},
+			{ID: to.Ptr(id(sub2, typeC)), Location: to.Ptr(location), Name: to.Ptr("rC"), Type: to.Ptr(typeC)},
+		}},
+	}
+
+	// One trivial metric definition per resource so the scraper produces actual composite
+	// keys and therefore exercises loadBatchMetricsValues -> reads on s.metrics[sub][type].
+	metricsDefs := map[string][]metricsDefinitionMockInput{
+		id(sub1, typeA): {{namespace: typeA, name: "raceMetric", timeGrain: "PT1M"}},
+		id(sub1, typeB): {{namespace: typeB, name: "raceMetric", timeGrain: "PT1M"}},
+		id(sub1, typeC): {{namespace: typeC, name: "raceMetric", timeGrain: "PT1M"}},
+		id(sub2, typeA): {{namespace: typeA, name: "raceMetric", timeGrain: "PT1M"}},
+		id(sub2, typeB): {{namespace: typeB, name: "raceMetric", timeGrain: "PT1M"}},
+		id(sub2, typeC): {{namespace: typeC, name: "raceMetric", timeGrain: "PT1M"}},
+	}
+
+	// Empty-but-valid query response per (subscription, namespace). Values are irrelevant:
+	// the test only cares that consumers actually read s.metrics[sub][type].
+	mkQuery := func(sub, rt string) queryResourcesResponseMock {
+		return queryResourcesResponseMock{
+			params: queryResourcesResponseMockParams{
+				subscriptionID:  sub,
+				metricNamespace: rt,
+				metricNames:     []string{"raceMetric"},
+				resourceIDs:     []string{id(sub, rt)},
+			},
+			response: newQueryResourcesResponseMockData(nil),
+		}
+	}
+	queryMocks := []queryResourcesResponseMock{
+		mkQuery(sub1, typeA), mkQuery(sub1, typeB), mkQuery(sub1, typeC),
+		mkQuery(sub2, typeA), mkQuery(sub2, typeB), mkQuery(sub2, typeC),
+	}
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	optionsResolver := newMockClientOptionsResolver(
+		newSubscriptionsByIDMockData(map[string]string{sub1: sub1 + "-display", sub2: sub2 + "-display"}),
+		nil,
+		newResourcesMockData(resources),
+		newMetricsDefinitionMockData(metricsDefs),
+		nil,
+		queryMocks,
+	)
+
+	s := &azureBatchScraper{
+		cfg:                          cfg,
+		mbs:                          newConcurrentMapImpl[*metadata.MetricsBuilder](),
+		mutex:                        &sync.Mutex{},
+		time:                         getTimeMock(),
+		clientOptionsResolver:        optionsResolver,
+		receiverSettings:             settings,
+		settings:                     settings.TelemetrySettings,
+		storageAccountSpecificConfig: newStorageAccountSpecificConfig(cfg.Services),
+
+		subscriptions: newUpdatedMap[string, *azureSubscription](),
+		resourceTypes: azResourceTypeStore{},
+		resources:     azResourceStore{},
+		regions:       azRegionStore{},
+		metrics:       azMetricsStore{},
+	}
+
+	// We don't compare against a golden file: the value of this test is the race detector.
+	// Run several iterations to widen the race window (compensates for the small number
+	// of resource types).
+	for range 20 {
+		_, err := s.scrape(t.Context())
+		require.NoError(t, err)
 	}
 }
 

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -147,8 +147,9 @@ func TestAzureScraperScrape(t *testing.T) {
 				storageAccountSpecificConfig: newStorageAccountSpecificConfig(tt.fields.cfg.Services),
 
 				// From there, initialize everything that is normally initialized in start() func
-				subscriptions: map[string]*azureSubscription{},
-				resources:     map[string]map[string]*azureResource{},
+				subscriptions: newUpdatedMap[string, *azureSubscription](),
+				resources:     azResourceStore{},
+				metrics:       azMetricsStore{},
 			}
 
 			metrics, err := s.scrape(tt.args.ctx)
@@ -268,8 +269,9 @@ func TestAzureScraperScrapeFilterMetrics(t *testing.T) {
 			storageAccountSpecificConfig: newStorageAccountSpecificConfig(cfgLimitedMertics.Services),
 
 			// From there, initialize everything that is normally initialized in start() func
-			subscriptions: map[string]*azureSubscription{},
-			resources:     map[string]map[string]*azureResource{},
+			subscriptions: newUpdatedMap[string, *azureSubscription](),
+			resources:     azResourceStore{},
+			metrics:       azMetricsStore{},
 		}
 
 		metrics, err := s.scrape(t.Context())
@@ -327,19 +329,20 @@ func getNominalTestScraper() *azureScraper {
 		storageAccountSpecificConfig: newStorageAccountSpecificConfig(cfg.Services),
 
 		// From there, initialize everything that is normally initialized in start() func
-		subscriptions: map[string]*azureSubscription{},
-		resources:     map[string]map[string]*azureResource{},
+		subscriptions: newUpdatedMap[string, *azureSubscription](),
+		resources:     azResourceStore{},
+		metrics:       azMetricsStore{},
 	}
 }
 
 func TestAzureScraperGetResources(t *testing.T) {
 	s := getNominalTestScraper()
-	s.resources["subscriptionId1"] = map[string]*azureResource{}
-	s.subscriptions["subscriptionId1"] = &azureSubscription{}
+	s.resources["subscriptionId1"] = newUpdatedMap[string, *azureResource]()
+	s.subscriptions.Data["subscriptionId1"] = &azureSubscription{}
 	s.cfg.CacheResources = 0
 	s.loadResources(t.Context(), "subscriptionId1")
 	assert.Contains(t, s.resources, "subscriptionId1")
-	assert.Len(t, s.resources["subscriptionId1"], 3)
+	assert.Len(t, s.resources["subscriptionId1"].Data, 3)
 
 	s.clientOptionsResolver = newMockClientOptionsResolver(
 		getSubscriptionByIDMockData(),
@@ -357,7 +360,7 @@ func TestAzureScraperGetResources(t *testing.T) {
 	)
 	s.loadResources(t.Context(), "subscriptionId1")
 	assert.Contains(t, s.resources, "subscriptionId1")
-	assert.Empty(t, s.resources["subscriptionId1"])
+	assert.Empty(t, s.resources["subscriptionId1"].Data)
 }
 
 func TestAzureScraperProcessResources(t *testing.T) {
@@ -496,8 +499,9 @@ func TestAzureScraperProcessResources(t *testing.T) {
 				storageAccountSpecificConfig: newStorageAccountSpecificConfig(tt.cfg.Services),
 
 				// From there, initialize everything that is normally initialized in start() func
-				subscriptions: map[string]*azureSubscription{},
-				resources:     map[string]map[string]*azureResource{},
+				subscriptions: newUpdatedMap[string, *azureSubscription](),
+				resources:     azResourceStore{},
+				metrics:       azMetricsStore{},
 			}
 
 			assert.Equal(t, tt.expected, s.processResources(tt.resourcesArg))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`scraper.go` and `scraper_batch.go` suffer from a lot of duplication. This PR is a
step toward reunifying the two scrapers.

Before this change, metric definitions were stored either in the `resources` store
(`scraper.go`) or in the `resourceTypes` store (`scraper_batch.go`), with the
`lastUpdated` timestamp tracked separately on each map. With this change:

- A new generic helper type `updatedMap[K, V]` colocates a map with its
  `LastUpdated` timestamp, removing the need for parallel bookkeeping.
- Metric definitions are now stored in a dedicated `metrics` field of type
  `azMetricsStore`, used by both `scraper.go` and `scraper_batch.go`. This
  removes duplication and aligns the two scrapers on a common data model.
- Lifecycle of the `metrics` map entries is now owned by `loadResources()` /
  `loadResourcesAndTypes()` (single source of truth) instead of being lazily
  initialized from inside the producer goroutine.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
*No tracking issue*

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Existing unit tests still pass under `go test -race -count=1 ./...`.
- New regression test `TestAzureScraperBatchScrape_NoRaceWithManyResourceTypes`
  fans out across multiple `resourceType`s per subscription and runs `scrape()`
  several times to surface race conditions when the `metrics` pre-allocation is
  not done at the right place. This acts as a regression guard against future
  changes that would re-introduce a write to the outer `s.metrics[subscriptionID]`
  map after the producer/consumer goroutines have started.

<!--Describe the documentation added.-->
#### Documentation

*No user-facing changes; this is an internal refactor.*
<!--Please delete paragraphs that you did not use before submitting.-->
