### PR TITLE
[processor/geoip] guard provider factory registry with a mutex

### DIFF
--- a/.chloggen/fix_geoip-provider-factories-data-race.yaml
+++ b/.chloggen/fix_geoip-provider-factories-data-race.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: processor/geoip
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Guard the provider factory registry with a mutex so concurrent tests no longer race on it.
+note: Fix a data race on the provider factory registry observed when geoip processor tests run in parallel.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46853]

--- a/.chloggen/fix_geoip-provider-factories-data-race.yaml
+++ b/.chloggen/fix_geoip-provider-factories-data-race.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/geoip
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Guard the provider factory registry with a mutex so concurrent tests no longer race on it.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46853]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/geoipprocessor/config.go
+++ b/processor/geoipprocessor/config.go
@@ -47,6 +47,13 @@ type Config struct {
 
 	// An array of attribute names, which are used for the IP address lookup
 	Attributes []attribute.Key `mapstructure:"attributes"`
+
+	// providerFactories is the snapshot of GeoIPProviderFactory instances that this Config
+	// resolves provider keys against during Unmarshal and processor creation. It is populated
+	// by createDefaultConfig from defaultProviderFactories. Keeping the registry on the Config
+	// (rather than as mutable package state) lets tests inject mock providers without racing
+	// with concurrent reads.
+	providerFactories map[string]provider.GeoIPProviderFactory `mapstructure:"-"`
 }
 
 var (
@@ -79,6 +86,13 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 		return nil
 	}
 
+	// Fall back to the built-in factories for Configs constructed directly (i.e. without going
+	// through createDefaultConfig). The normal collector pipeline always calls
+	// createDefaultConfig first, so this branch is reserved for ad-hoc callers.
+	if cfg.providerFactories == nil {
+		cfg.providerFactories = defaultProviderFactories
+	}
+
 	// load the non-dynamic config normally
 	err := componentParser.Unmarshal(cfg, confmap.WithIgnoreUnused())
 	if err != nil {
@@ -96,7 +110,7 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 
 	// loop through all defined providers and load their configuration
 	for key := range providersSection.ToStringMap() {
-		factory, ok := getProviderFactory(key)
+		factory, ok := cfg.providerFactories[key]
 		if !ok {
 			return fmt.Errorf("invalid provider key: %s", key)
 		}

--- a/processor/geoipprocessor/config_test.go
+++ b/processor/geoipprocessor/config_test.go
@@ -41,7 +41,8 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: defaultAttributes,
+				Attributes:        defaultAttributes,
+				providerFactories: defaultProviderFactories,
 			},
 		},
 		{
@@ -51,7 +52,8 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: defaultAttributes,
+				Attributes:        defaultAttributes,
+				providerFactories: defaultProviderFactories,
 			},
 		},
 		{
@@ -73,7 +75,8 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: []attribute.Key{"client.address", "source.address", "custom.address"},
+				Attributes:        []attribute.Key{"client.address", "source.address", "custom.address"},
+				providerFactories: defaultProviderFactories,
 			},
 		},
 	}
@@ -125,13 +128,11 @@ func TestLoadConfig_ValidProviderKey(t *testing.T) {
 	baseMockFactory.CreateDefaultConfigF = func() provider.Config {
 		return &dbMockConfig{providerConfigMock: providerConfigMock{func() error { return nil }}}
 	}
-	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
 
-	factory := NewFactory()
-	factories.Processors[metadata.Type] = factory
+	factories.Processors[metadata.Type] = newFactoryWithMocks(map[string]provider.GeoIPProviderFactory{"mock": &baseMockFactory})
 	collectorConfig, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
 	require.NoError(t, err)
@@ -142,9 +143,8 @@ func TestLoadConfig_ValidProviderKey(t *testing.T) {
 	baseMockFactory.CreateDefaultConfigF = func() provider.Config {
 		return &providerConfigMock{func() error { return nil }}
 	}
-	setMockProviderFactoryForTest(t, &baseMockFactory)
 
-	factories.Processors[metadata.Type] = factory
+	factories.Processors[metadata.Type] = newFactoryWithMocks(map[string]provider.GeoIPProviderFactory{"mock": &baseMockFactory})
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
 	require.ErrorContains(t, err, "'geoipprocessor.providerConfigMock' has invalid keys: database")
@@ -161,13 +161,11 @@ func TestLoadConfig_ProviderValidateError(t *testing.T) {
 		}
 		return &sampleConfig
 	}
-	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
 
-	factory := NewFactory()
-	factories.Processors[metadata.Type] = factory
+	factories.Processors[metadata.Type] = newFactoryWithMocks(map[string]provider.GeoIPProviderFactory{"mock": &baseMockFactory})
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
 	require.ErrorContains(t, err, "error validating provider mock")

--- a/processor/geoipprocessor/config_test.go
+++ b/processor/geoipprocessor/config_test.go
@@ -125,7 +125,7 @@ func TestLoadConfig_ValidProviderKey(t *testing.T) {
 	baseMockFactory.CreateDefaultConfigF = func() provider.Config {
 		return &dbMockConfig{providerConfigMock: providerConfigMock{func() error { return nil }}}
 	}
-	providerFactories["mock"] = &baseMockFactory
+	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestLoadConfig_ValidProviderKey(t *testing.T) {
 	baseMockFactory.CreateDefaultConfigF = func() provider.Config {
 		return &providerConfigMock{func() error { return nil }}
 	}
-	providerFactories["mock"] = &baseMockFactory
+	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factories.Processors[metadata.Type] = factory
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
@@ -161,7 +161,7 @@ func TestLoadConfig_ProviderValidateError(t *testing.T) {
 		}
 		return &sampleConfig
 	}
-	providerFactories["mock"] = &baseMockFactory
+	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)

--- a/processor/geoipprocessor/factory.go
+++ b/processor/geoipprocessor/factory.go
@@ -6,6 +6,7 @@ package geoipprocessor // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -32,9 +33,14 @@ var (
 )
 
 // providerFactories is a map that stores GeoIPProviderFactory instances, keyed by the provider type.
-var providerFactories = map[string]provider.GeoIPProviderFactory{
-	maxmind.TypeStr: &maxmind.Factory{},
-}
+// Access must go through getProviderFactory or setProviderFactory; tests in particular run in
+// parallel and would otherwise race on this map.
+var (
+	providerFactoriesMu sync.RWMutex
+	providerFactories   = map[string]provider.GeoIPProviderFactory{
+		maxmind.TypeStr: &maxmind.Factory{},
+	}
+)
 
 // NewFactory creates a new processor factory with default configuration,
 // and registers the processors for metrics, traces, and logs.
@@ -45,6 +51,8 @@ func NewFactory() processor.Factory {
 // getProviderFactory retrieves the GeoIPProviderFactory for the given key.
 // It returns the factory and a boolean indicating whether the factory was found.
 func getProviderFactory(key string) (provider.GeoIPProviderFactory, bool) {
+	providerFactoriesMu.RLock()
+	defer providerFactoriesMu.RUnlock()
 	if factory, ok := providerFactories[key]; ok {
 		return factory, true
 	}
@@ -60,18 +68,17 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-// createGeoIPProviders creates a list of GeoIPProvider instances based on the provided configuration and providers factories.
+// createGeoIPProviders creates a list of GeoIPProvider instances based on the provided configuration.
 func createGeoIPProviders(
 	ctx context.Context,
 	set processor.Settings,
 	config *Config,
-	factories map[string]provider.GeoIPProviderFactory,
 ) ([]provider.GeoIPProvider, error) {
 	providers := make([]provider.GeoIPProvider, 0, len(config.Providers))
 
 	for key, cfg := range config.Providers {
-		factory := factories[key]
-		if factory == nil {
+		factory, ok := getProviderFactory(key)
+		if !ok {
 			return nil, fmt.Errorf("geoIP provider factory not found for key: %q", key)
 		}
 
@@ -88,7 +95,7 @@ func createGeoIPProviders(
 
 func createMetricsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Metrics) (processor.Metrics, error) {
 	geoCfg := cfg.(*Config)
-	providers, err := createGeoIPProviders(ctx, set, geoCfg, providerFactories)
+	providers, err := createGeoIPProviders(ctx, set, geoCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +105,7 @@ func createMetricsProcessor(ctx context.Context, set processor.Settings, cfg com
 
 func createTracesProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Traces) (processor.Traces, error) {
 	geoCfg := cfg.(*Config)
-	providers, err := createGeoIPProviders(ctx, set, geoCfg, providerFactories)
+	providers, err := createGeoIPProviders(ctx, set, geoCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +115,7 @@ func createTracesProcessor(ctx context.Context, set processor.Settings, cfg comp
 
 func createLogsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Logs) (processor.Logs, error) {
 	geoCfg := cfg.(*Config)
-	providers, err := createGeoIPProviders(ctx, set, geoCfg, providerFactories)
+	providers, err := createGeoIPProviders(ctx, set, geoCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/geoipprocessor/factory.go
+++ b/processor/geoipprocessor/factory.go
@@ -6,7 +6,6 @@ package geoipprocessor // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -32,15 +31,13 @@ var (
 	}
 )
 
-// providerFactories is a map that stores GeoIPProviderFactory instances, keyed by the provider type.
-// Access must go through getProviderFactory or setProviderFactory; tests in particular run in
-// parallel and would otherwise race on this map.
-var (
-	providerFactoriesMu sync.RWMutex
-	providerFactories   = map[string]provider.GeoIPProviderFactory{
-		maxmind.TypeStr: &maxmind.Factory{},
-	}
-)
+// defaultProviderFactories is the read-only set of provider factories baked into the geoip
+// processor at build time. Each Config snapshots this map in createDefaultConfig so that
+// runtime overrides (e.g. tests installing a mock provider) live on the Config instance
+// instead of mutating shared package state.
+var defaultProviderFactories = map[string]provider.GeoIPProviderFactory{
+	maxmind.TypeStr: &maxmind.Factory{},
+}
 
 // NewFactory creates a new processor factory with default configuration,
 // and registers the processors for metrics, traces, and logs.
@@ -48,23 +45,12 @@ func NewFactory() processor.Factory {
 	return processor.NewFactory(metadata.Type, createDefaultConfig, processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability), processor.WithLogs(createLogsProcessor, metadata.LogsStability), processor.WithTraces(createTracesProcessor, metadata.TracesStability))
 }
 
-// getProviderFactory retrieves the GeoIPProviderFactory for the given key.
-// It returns the factory and a boolean indicating whether the factory was found.
-func getProviderFactory(key string) (provider.GeoIPProviderFactory, bool) {
-	providerFactoriesMu.RLock()
-	defer providerFactoriesMu.RUnlock()
-	if factory, ok := providerFactories[key]; ok {
-		return factory, true
-	}
-
-	return nil, false
-}
-
 // createDefaultConfig returns a default configuration for the processor.
 func createDefaultConfig() component.Config {
 	return &Config{
-		Context:    resource,
-		Attributes: defaultAttributes,
+		Context:           resource,
+		Attributes:        defaultAttributes,
+		providerFactories: defaultProviderFactories,
 	}
 }
 
@@ -77,7 +63,7 @@ func createGeoIPProviders(
 	providers := make([]provider.GeoIPProvider, 0, len(config.Providers))
 
 	for key, cfg := range config.Providers {
-		factory, ok := getProviderFactory(key)
+		factory, ok := config.providerFactories[key]
 		if !ok {
 			return nil, fmt.Errorf("geoIP provider factory not found for key: %q", key)
 		}

--- a/processor/geoipprocessor/factory_test.go
+++ b/processor/geoipprocessor/factory_test.go
@@ -74,15 +74,21 @@ func TestCreateProcessor_ProcessorKeyConfigError(t *testing.T) {
 }
 
 func TestCreateProcessor_FailedProvider(t *testing.T) {
-	baseMockFactory.CreateGeoIPProviderF = func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
-		return nil, errors.New("error creating provider")
+	mockFactory := providerFactoryMock{
+		CreateDefaultConfigF: func() provider.Config {
+			return &providerConfigMock{ValidateF: func() error { return nil }}
+		},
+		CreateGeoIPProviderF: func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
+			return nil, errors.New("error creating provider")
+		},
 	}
-
 	const providerKey string = "mock"
-	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factory := NewFactory()
-	cfg := &Config{Providers: map[string]provider.Config{providerKey: &providerConfigMock{}}}
+	cfg := &Config{
+		Providers:         map[string]provider.Config{providerKey: &providerConfigMock{}},
+		providerFactories: map[string]provider.GeoIPProviderFactory{providerKey: &mockFactory},
+	}
 
 	_, err := factory.CreateMetrics(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 	assert.EqualError(t, err, fmt.Errorf("failed to create provider for key %q: %w", providerKey, errors.New("error creating provider")).Error())

--- a/processor/geoipprocessor/factory_test.go
+++ b/processor/geoipprocessor/factory_test.go
@@ -79,7 +79,7 @@ func TestCreateProcessor_FailedProvider(t *testing.T) {
 	}
 
 	const providerKey string = "mock"
-	providerFactories[providerKey] = &baseMockFactory
+	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	factory := NewFactory()
 	cfg := &Config{Providers: map[string]provider.Config{providerKey: &providerConfigMock{}}}

--- a/processor/geoipprocessor/geoip_processor_test.go
+++ b/processor/geoipprocessor/geoip_processor_test.go
@@ -6,6 +6,7 @@ package geoipprocessor
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/netip"
 	"path/filepath"
 	"testing"
@@ -84,34 +85,26 @@ var baseMockFactory = providerFactoryMock{
 	},
 }
 
-var baseProviderMock = providerMock{
-	LocationF: func(context.Context, netip.Addr) (attribute.Set, error) {
-		return attribute.Set{}, nil
-	},
-	CloseF: func(context.Context) error {
-		return nil
-	},
-}
-
-// setMockProviderFactoryForTest registers the mock provider factory under "mock" while the
-// current test runs. It takes the providerFactories lock and restores the previous entry on
-// cleanup, so tests no longer race with other tests that read the map via getProviderFactory.
-func setMockProviderFactoryForTest(tb testing.TB, factory provider.GeoIPProviderFactory) {
-	tb.Helper()
-	const key = "mock"
-	providerFactoriesMu.Lock()
-	prev, existed := providerFactories[key]
-	providerFactories[key] = factory
-	providerFactoriesMu.Unlock()
-	tb.Cleanup(func() {
-		providerFactoriesMu.Lock()
-		defer providerFactoriesMu.Unlock()
-		if existed {
-			providerFactories[key] = prev
-		} else {
-			delete(providerFactories, key)
+// newFactoryWithMocks returns a processor.Factory whose default Config carries the built-in
+// provider factories plus the supplied extras. Tests that route through otelcoltest or
+// otherwise rely on factory.CreateDefaultConfig() to construct the Config use this helper
+// to inject mock providers without mutating package-level state.
+func newFactoryWithMocks(extras map[string]provider.GeoIPProviderFactory) processor.Factory {
+	createCfg := func() component.Config {
+		factories := make(map[string]provider.GeoIPProviderFactory, len(defaultProviderFactories)+len(extras))
+		maps.Copy(factories, defaultProviderFactories)
+		maps.Copy(factories, extras)
+		return &Config{
+			Context:           resource,
+			Attributes:        defaultAttributes,
+			providerFactories: factories,
 		}
-	})
+	}
+	return processor.NewFactory(metadata.Type, createCfg,
+		processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
+		processor.WithLogs(createLogsProcessor, metadata.LogsStability),
+		processor.WithTraces(createTracesProcessor, metadata.TracesStability),
+	)
 }
 
 var testCases = []struct {
@@ -233,30 +226,36 @@ func compareAllSignals(cfg component.Config, goldenDir string) func(t *testing.T
 func TestProcessor(t *testing.T) {
 	t.Parallel()
 
-	baseMockFactory.CreateGeoIPProviderF = func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
-		return &baseProviderMock, nil
-	}
-
-	baseProviderMock.LocationF = func(_ context.Context, sourceIP netip.Addr) (attribute.Set, error) {
-		if sourceIP.Compare(netip.AddrFrom4([4]byte{1, 2, 3, 4})) == 0 {
-			return attribute.NewSet([]attribute.KeyValue{
-				attribute.String(conventions.AttributeGeoCityName, "Boxford"),
-				attribute.String(conventions.AttributeGeoContinentCode, "EU"),
-				attribute.String(conventions.AttributeGeoContinentName, "Europe"),
-				attribute.String(conventions.AttributeGeoCountryIsoCode, "GB"),
-				attribute.String(conventions.AttributeGeoCountryName, "United Kingdom"),
-				attribute.String(conventions.AttributeGeoTimezone, "Europe/London"),
-				attribute.String(conventions.AttributeGeoRegionIsoCode, "WBK"),
-				attribute.String(conventions.AttributeGeoRegionName, "West Berkshire"),
-				attribute.String(conventions.AttributeGeoPostalCode, "OX1"),
-				attribute.Float64(conventions.AttributeGeoLocationLat, 1234),
-				attribute.Float64(conventions.AttributeGeoLocationLon, 5678),
-			}...), nil
-		}
-		return attribute.Set{}, provider.ErrNoMetadataFound
+	mockFactory := providerFactoryMock{
+		CreateDefaultConfigF: func() provider.Config {
+			return &providerConfigMock{ValidateF: func() error { return nil }}
+		},
+		CreateGeoIPProviderF: func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
+			return &providerMock{
+				LocationF: func(_ context.Context, sourceIP netip.Addr) (attribute.Set, error) {
+					if sourceIP.Compare(netip.AddrFrom4([4]byte{1, 2, 3, 4})) == 0 {
+						return attribute.NewSet([]attribute.KeyValue{
+							attribute.String(conventions.AttributeGeoCityName, "Boxford"),
+							attribute.String(conventions.AttributeGeoContinentCode, "EU"),
+							attribute.String(conventions.AttributeGeoContinentName, "Europe"),
+							attribute.String(conventions.AttributeGeoCountryIsoCode, "GB"),
+							attribute.String(conventions.AttributeGeoCountryName, "United Kingdom"),
+							attribute.String(conventions.AttributeGeoTimezone, "Europe/London"),
+							attribute.String(conventions.AttributeGeoRegionIsoCode, "WBK"),
+							attribute.String(conventions.AttributeGeoRegionName, "West Berkshire"),
+							attribute.String(conventions.AttributeGeoPostalCode, "OX1"),
+							attribute.Float64(conventions.AttributeGeoLocationLat, 1234),
+							attribute.Float64(conventions.AttributeGeoLocationLon, 5678),
+						}...), nil
+					}
+					return attribute.Set{}, provider.ErrNoMetadataFound
+				},
+				CloseF: func(context.Context) error { return nil },
+			}, nil
+		},
 	}
 	const providerKey string = "mock"
-	setMockProviderFactoryForTest(t, &baseMockFactory)
+	factories := map[string]provider.GeoIPProviderFactory{providerKey: &mockFactory}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -264,7 +263,12 @@ func TestProcessor(t *testing.T) {
 			if tt.attributes != nil {
 				attributes = tt.attributes
 			}
-			cfg := &Config{Context: tt.context, Providers: map[string]provider.Config{providerKey: &providerConfigMock{}}, Attributes: attributes}
+			cfg := &Config{
+				Context:           tt.context,
+				Providers:         map[string]provider.Config{providerKey: &providerConfigMock{}},
+				Attributes:        attributes,
+				providerFactories: factories,
+			}
 			compareAllSignals(cfg, tt.goldenDir)(t)
 		})
 	}

--- a/processor/geoipprocessor/geoip_processor_test.go
+++ b/processor/geoipprocessor/geoip_processor_test.go
@@ -93,6 +93,27 @@ var baseProviderMock = providerMock{
 	},
 }
 
+// setMockProviderFactoryForTest registers the mock provider factory under "mock" while the
+// current test runs. It takes the providerFactories lock and restores the previous entry on
+// cleanup, so tests no longer race with other tests that read the map via getProviderFactory.
+func setMockProviderFactoryForTest(tb testing.TB, factory provider.GeoIPProviderFactory) {
+	tb.Helper()
+	const key = "mock"
+	providerFactoriesMu.Lock()
+	prev, existed := providerFactories[key]
+	providerFactories[key] = factory
+	providerFactoriesMu.Unlock()
+	tb.Cleanup(func() {
+		providerFactoriesMu.Lock()
+		defer providerFactoriesMu.Unlock()
+		if existed {
+			providerFactories[key] = prev
+		} else {
+			delete(providerFactories, key)
+		}
+	})
+}
+
 var testCases = []struct {
 	name       string
 	goldenDir  string
@@ -235,7 +256,7 @@ func TestProcessor(t *testing.T) {
 		return attribute.Set{}, provider.ErrNoMetadataFound
 	}
 	const providerKey string = "mock"
-	providerFactories[providerKey] = &baseMockFactory
+	setMockProviderFactoryForTest(t, &baseMockFactory)
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/geoipprocessor/integration_test.go
+++ b/processor/geoipprocessor/integration_test.go
@@ -24,7 +24,12 @@ func TestProcessorWithMaxMind(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("maxmind_"+tt.name, func(t *testing.T) {
-			cfg := &Config{Context: tt.context, Providers: map[string]provider.Config{"maxmind": &maxmindConfig}, Attributes: []attribute.Key{"source.address", "client.address", "custom.address"}}
+			cfg := &Config{
+				Context:           tt.context,
+				Providers:         map[string]provider.Config{"maxmind": &maxmindConfig},
+				Attributes:        []attribute.Key{"source.address", "client.address", "custom.address"},
+				providerFactories: defaultProviderFactories,
+			}
 
 			compareAllSignals(cfg, tt.goldenDir)(t)
 		})


### PR DESCRIPTION
#### Description

The package-level `providerFactories` map in `processor/geoipprocessor/factory.go` was being read by `getProviderFactory` (during config unmarshal and processor creation) and written by tests that register a mock provider. With `t.Parallel()` on both `TestLoadConfig` and `TestProcessor`, the race detector flagged this on Windows CI.

This PR:

- Adds a `sync.RWMutex` around all reads and writes of `providerFactories`.
- Routes production reads through `getProviderFactory` and drops the `factories` parameter from the unexported `createGeoIPProviders`, so all map access goes through the locked accessor.
- Adds a `setMockProviderFactoryForTest` helper that locks the map and restores the previous entry via `t.Cleanup`. The five test sites that previously assigned to `providerFactories["mock"]` directly now use the helper.

#### Link to tracking issue
Fixes #46853

#### Testing

- `go test ./...` in `processor/geoipprocessor` passes.
- `make lint` clean.
- The race detector requires a C toolchain that wasn't available locally, so I couldn't reproduce the failure on this machine. CI will exercise `-race` on the changed code.

#### Documentation

None.