### PR TITLE
[exporter/kafka] fixed MaxMessageBytes not respect in kafka exporter

### DIFF
--- a/.chloggen/kafkaexporter-split-oversized-messages.yaml
+++ b/.chloggen/kafkaexporter-split-oversized-messages.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Automatically split payloads that exceed `max_message_bytes` into multiple smaller messages instead of failing permanently with a MessageTooLarge error.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36982]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Splitting is attempted at three granularity levels (Resource → Scope → individual record/span/metric/profile).
+  If a single atomic item cannot be split further it is forwarded as-is, preserving the existing permanent
+  MessageTooLarge error only for truly unsplittable payloads.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/internal/splitter/splitter.go
+++ b/exporter/kafkaexporter/internal/splitter/splitter.go
@@ -1,0 +1,418 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package splitter provides size-aware splitting of pdata signal types so that
+// each resulting chunk marshals to no more than a given byte limit.  It is used
+// by the Kafka exporter to automatically split payloads that would otherwise
+// exceed the producer MaxMessageBytes limit.
+package splitter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/splitter"
+
+import (
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/marshaler"
+)
+
+// SplitTraces splits td into chunks such that every chunk marshals to at most
+// maxBytes.  Splitting is attempted at three levels: ResourceSpans →
+// ScopeSpans → individual Span.  If a single Span still exceeds maxBytes it
+// is returned as-is; the caller must handle that case (the broker will reject
+// it with MessageTooLarge).
+func SplitTraces(td ptrace.Traces, m marshaler.TracesMarshaler, maxBytes int) ([]ptrace.Traces, error) {
+	msgs, err := m.MarshalTraces(td)
+	if err != nil {
+		return nil, err
+	}
+	if fitsInLimit(msgs, maxBytes) {
+		return []ptrace.Traces{td}, nil
+	}
+
+	// Split at ResourceSpans level.
+	n := td.ResourceSpans().Len()
+	if n > 1 {
+		mid := n / 2
+		left, right := ptrace.NewTraces(), ptrace.NewTraces()
+		for i := range mid {
+			td.ResourceSpans().At(i).CopyTo(left.ResourceSpans().AppendEmpty())
+		}
+		for i := mid; i < n; i++ {
+			td.ResourceSpans().At(i).CopyTo(right.ResourceSpans().AppendEmpty())
+		}
+		lc, err := SplitTraces(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitTraces(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	// Single ResourceSpans — split at ScopeSpans level.
+	rs := td.ResourceSpans().At(0)
+	nSS := rs.ScopeSpans().Len()
+	if nSS > 1 {
+		mid := nSS / 2
+		left, right := ptrace.NewTraces(), ptrace.NewTraces()
+		lRS, rRS := left.ResourceSpans().AppendEmpty(), right.ResourceSpans().AppendEmpty()
+		rs.Resource().CopyTo(lRS.Resource())
+		rs.Resource().CopyTo(rRS.Resource())
+		lRS.SetSchemaUrl(rs.SchemaUrl())
+		rRS.SetSchemaUrl(rs.SchemaUrl())
+		for i := range mid {
+			rs.ScopeSpans().At(i).CopyTo(lRS.ScopeSpans().AppendEmpty())
+		}
+		for i := mid; i < nSS; i++ {
+			rs.ScopeSpans().At(i).CopyTo(rRS.ScopeSpans().AppendEmpty())
+		}
+		lc, err := SplitTraces(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitTraces(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	// Single ScopeSpans — split at Span level.
+	ss := rs.ScopeSpans().At(0)
+	nSpans := ss.Spans().Len()
+	if nSpans > 1 {
+		mid := nSpans / 2
+		left, right := ptrace.NewTraces(), ptrace.NewTraces()
+		lRS, rRS := left.ResourceSpans().AppendEmpty(), right.ResourceSpans().AppendEmpty()
+		rs.Resource().CopyTo(lRS.Resource())
+		rs.Resource().CopyTo(rRS.Resource())
+		lRS.SetSchemaUrl(rs.SchemaUrl())
+		rRS.SetSchemaUrl(rs.SchemaUrl())
+		lSS, rSS := lRS.ScopeSpans().AppendEmpty(), rRS.ScopeSpans().AppendEmpty()
+		ss.Scope().CopyTo(lSS.Scope())
+		ss.Scope().CopyTo(rSS.Scope())
+		lSS.SetSchemaUrl(ss.SchemaUrl())
+		rSS.SetSchemaUrl(ss.SchemaUrl())
+		for i := range mid {
+			ss.Spans().At(i).CopyTo(lSS.Spans().AppendEmpty())
+		}
+		for i := mid; i < nSpans; i++ {
+			ss.Spans().At(i).CopyTo(rSS.Spans().AppendEmpty())
+		}
+		lc, err := SplitTraces(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitTraces(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	// Single Span — cannot split further.
+	return []ptrace.Traces{td}, nil
+}
+
+// SplitLogs splits ld into chunks such that every chunk marshals to at most
+// maxBytes.  Splitting is attempted at three levels: ResourceLogs →
+// ScopeLogs → individual LogRecord.  If a single LogRecord still exceeds
+// maxBytes it is returned as-is.
+func SplitLogs(ld plog.Logs, m marshaler.LogsMarshaler, maxBytes int) ([]plog.Logs, error) {
+	msgs, err := m.MarshalLogs(ld)
+	if err != nil {
+		return nil, err
+	}
+	if fitsInLimit(msgs, maxBytes) {
+		return []plog.Logs{ld}, nil
+	}
+
+	n := ld.ResourceLogs().Len()
+	if n > 1 {
+		mid := n / 2
+		left, right := plog.NewLogs(), plog.NewLogs()
+		for i := range mid {
+			ld.ResourceLogs().At(i).CopyTo(left.ResourceLogs().AppendEmpty())
+		}
+		for i := mid; i < n; i++ {
+			ld.ResourceLogs().At(i).CopyTo(right.ResourceLogs().AppendEmpty())
+		}
+		lc, err := SplitLogs(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitLogs(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	rl := ld.ResourceLogs().At(0)
+	nSL := rl.ScopeLogs().Len()
+	if nSL > 1 {
+		mid := nSL / 2
+		left, right := plog.NewLogs(), plog.NewLogs()
+		lRL, rRL := left.ResourceLogs().AppendEmpty(), right.ResourceLogs().AppendEmpty()
+		rl.Resource().CopyTo(lRL.Resource())
+		rl.Resource().CopyTo(rRL.Resource())
+		lRL.SetSchemaUrl(rl.SchemaUrl())
+		rRL.SetSchemaUrl(rl.SchemaUrl())
+		for i := range mid {
+			rl.ScopeLogs().At(i).CopyTo(lRL.ScopeLogs().AppendEmpty())
+		}
+		for i := mid; i < nSL; i++ {
+			rl.ScopeLogs().At(i).CopyTo(rRL.ScopeLogs().AppendEmpty())
+		}
+		lc, err := SplitLogs(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitLogs(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	sl := rl.ScopeLogs().At(0)
+	nLR := sl.LogRecords().Len()
+	if nLR > 1 {
+		mid := nLR / 2
+		left, right := plog.NewLogs(), plog.NewLogs()
+		lRL, rRL := left.ResourceLogs().AppendEmpty(), right.ResourceLogs().AppendEmpty()
+		rl.Resource().CopyTo(lRL.Resource())
+		rl.Resource().CopyTo(rRL.Resource())
+		lRL.SetSchemaUrl(rl.SchemaUrl())
+		rRL.SetSchemaUrl(rl.SchemaUrl())
+		lSL, rSL := lRL.ScopeLogs().AppendEmpty(), rRL.ScopeLogs().AppendEmpty()
+		sl.Scope().CopyTo(lSL.Scope())
+		sl.Scope().CopyTo(rSL.Scope())
+		lSL.SetSchemaUrl(sl.SchemaUrl())
+		rSL.SetSchemaUrl(sl.SchemaUrl())
+		for i := range mid {
+			sl.LogRecords().At(i).CopyTo(lSL.LogRecords().AppendEmpty())
+		}
+		for i := mid; i < nLR; i++ {
+			sl.LogRecords().At(i).CopyTo(rSL.LogRecords().AppendEmpty())
+		}
+		lc, err := SplitLogs(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitLogs(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	// Single LogRecord — cannot split further.
+	return []plog.Logs{ld}, nil
+}
+
+// SplitMetrics splits md into chunks such that every chunk marshals to at
+// most maxBytes.  Splitting is attempted at three levels: ResourceMetrics →
+// ScopeMetrics → individual Metric.  If a single Metric still exceeds
+// maxBytes it is returned as-is.
+func SplitMetrics(md pmetric.Metrics, m marshaler.MetricsMarshaler, maxBytes int) ([]pmetric.Metrics, error) {
+	msgs, err := m.MarshalMetrics(md)
+	if err != nil {
+		return nil, err
+	}
+	if fitsInLimit(msgs, maxBytes) {
+		return []pmetric.Metrics{md}, nil
+	}
+
+	n := md.ResourceMetrics().Len()
+	if n > 1 {
+		mid := n / 2
+		left, right := pmetric.NewMetrics(), pmetric.NewMetrics()
+		for i := range mid {
+			md.ResourceMetrics().At(i).CopyTo(left.ResourceMetrics().AppendEmpty())
+		}
+		for i := mid; i < n; i++ {
+			md.ResourceMetrics().At(i).CopyTo(right.ResourceMetrics().AppendEmpty())
+		}
+		lc, err := SplitMetrics(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitMetrics(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	rm := md.ResourceMetrics().At(0)
+	nSM := rm.ScopeMetrics().Len()
+	if nSM > 1 {
+		mid := nSM / 2
+		left, right := pmetric.NewMetrics(), pmetric.NewMetrics()
+		lRM, rRM := left.ResourceMetrics().AppendEmpty(), right.ResourceMetrics().AppendEmpty()
+		rm.Resource().CopyTo(lRM.Resource())
+		rm.Resource().CopyTo(rRM.Resource())
+		lRM.SetSchemaUrl(rm.SchemaUrl())
+		rRM.SetSchemaUrl(rm.SchemaUrl())
+		for i := range mid {
+			rm.ScopeMetrics().At(i).CopyTo(lRM.ScopeMetrics().AppendEmpty())
+		}
+		for i := mid; i < nSM; i++ {
+			rm.ScopeMetrics().At(i).CopyTo(rRM.ScopeMetrics().AppendEmpty())
+		}
+		lc, err := SplitMetrics(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitMetrics(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	sm := rm.ScopeMetrics().At(0)
+	nM := sm.Metrics().Len()
+	if nM > 1 {
+		mid := nM / 2
+		left, right := pmetric.NewMetrics(), pmetric.NewMetrics()
+		lRM, rRM := left.ResourceMetrics().AppendEmpty(), right.ResourceMetrics().AppendEmpty()
+		rm.Resource().CopyTo(lRM.Resource())
+		rm.Resource().CopyTo(rRM.Resource())
+		lRM.SetSchemaUrl(rm.SchemaUrl())
+		rRM.SetSchemaUrl(rm.SchemaUrl())
+		lSM, rSM := lRM.ScopeMetrics().AppendEmpty(), rRM.ScopeMetrics().AppendEmpty()
+		sm.Scope().CopyTo(lSM.Scope())
+		sm.Scope().CopyTo(rSM.Scope())
+		lSM.SetSchemaUrl(sm.SchemaUrl())
+		rSM.SetSchemaUrl(sm.SchemaUrl())
+		for i := range mid {
+			sm.Metrics().At(i).CopyTo(lSM.Metrics().AppendEmpty())
+		}
+		for i := mid; i < nM; i++ {
+			sm.Metrics().At(i).CopyTo(rSM.Metrics().AppendEmpty())
+		}
+		lc, err := SplitMetrics(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitMetrics(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	// Single Metric — cannot split further.
+	return []pmetric.Metrics{md}, nil
+}
+
+// SplitProfiles splits pd into chunks such that every chunk marshals to at
+// most maxBytes.  Splitting is attempted at three levels: ResourceProfiles →
+// ScopeProfiles → individual Profile.  If a single Profile still exceeds
+// maxBytes it is returned as-is.
+func SplitProfiles(pd pprofile.Profiles, m marshaler.ProfilesMarshaler, maxBytes int) ([]pprofile.Profiles, error) {
+	msgs, err := m.MarshalProfiles(pd)
+	if err != nil {
+		return nil, err
+	}
+	if fitsInLimit(msgs, maxBytes) {
+		return []pprofile.Profiles{pd}, nil
+	}
+
+	n := pd.ResourceProfiles().Len()
+	if n > 1 {
+		mid := n / 2
+		left, right := pprofile.NewProfiles(), pprofile.NewProfiles()
+		for i := range mid {
+			pd.ResourceProfiles().At(i).CopyTo(left.ResourceProfiles().AppendEmpty())
+		}
+		for i := mid; i < n; i++ {
+			pd.ResourceProfiles().At(i).CopyTo(right.ResourceProfiles().AppendEmpty())
+		}
+		lc, err := SplitProfiles(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitProfiles(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	rp := pd.ResourceProfiles().At(0)
+	nSP := rp.ScopeProfiles().Len()
+	if nSP > 1 {
+		mid := nSP / 2
+		left, right := pprofile.NewProfiles(), pprofile.NewProfiles()
+		lRP, rRP := left.ResourceProfiles().AppendEmpty(), right.ResourceProfiles().AppendEmpty()
+		rp.Resource().CopyTo(lRP.Resource())
+		rp.Resource().CopyTo(rRP.Resource())
+		lRP.SetSchemaUrl(rp.SchemaUrl())
+		rRP.SetSchemaUrl(rp.SchemaUrl())
+		for i := range mid {
+			rp.ScopeProfiles().At(i).CopyTo(lRP.ScopeProfiles().AppendEmpty())
+		}
+		for i := mid; i < nSP; i++ {
+			rp.ScopeProfiles().At(i).CopyTo(rRP.ScopeProfiles().AppendEmpty())
+		}
+		lc, err := SplitProfiles(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitProfiles(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	sp := rp.ScopeProfiles().At(0)
+	nP := sp.Profiles().Len()
+	if nP > 1 {
+		mid := nP / 2
+		left, right := pprofile.NewProfiles(), pprofile.NewProfiles()
+		lRP, rRP := left.ResourceProfiles().AppendEmpty(), right.ResourceProfiles().AppendEmpty()
+		rp.Resource().CopyTo(lRP.Resource())
+		rp.Resource().CopyTo(rRP.Resource())
+		lRP.SetSchemaUrl(rp.SchemaUrl())
+		rRP.SetSchemaUrl(rp.SchemaUrl())
+		lSP, rSP := lRP.ScopeProfiles().AppendEmpty(), rRP.ScopeProfiles().AppendEmpty()
+		sp.Scope().CopyTo(lSP.Scope())
+		sp.Scope().CopyTo(rSP.Scope())
+		lSP.SetSchemaUrl(sp.SchemaUrl())
+		rSP.SetSchemaUrl(sp.SchemaUrl())
+		for i := range mid {
+			sp.Profiles().At(i).CopyTo(lSP.Profiles().AppendEmpty())
+		}
+		for i := mid; i < nP; i++ {
+			sp.Profiles().At(i).CopyTo(rSP.Profiles().AppendEmpty())
+		}
+		lc, err := SplitProfiles(left, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		rc, err := SplitProfiles(right, m, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return append(lc, rc...), nil
+	}
+
+	// Single Profile — cannot split further.
+	return []pprofile.Profiles{pd}, nil
+}
+
+func fitsInLimit(msgs []marshaler.Message, maxBytes int) bool {
+	for _, msg := range msgs {
+		if len(msg.Value) > maxBytes {
+			return false
+		}
+	}
+	return true
+}

--- a/exporter/kafkaexporter/internal/splitter/splitter_test.go
+++ b/exporter/kafkaexporter/internal/splitter/splitter_test.go
@@ -1,0 +1,361 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package splitter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/marshaler"
+)
+
+// ---- helper marshalers ----
+
+type tracesMarshaler struct{ m ptrace.ProtoMarshaler }
+
+func (t tracesMarshaler) MarshalTraces(td ptrace.Traces) ([]marshaler.Message, error) {
+	b, err := t.m.MarshalTraces(td)
+	if err != nil {
+		return nil, err
+	}
+	return []marshaler.Message{{Value: b}}, nil
+}
+
+type logsMarshaler struct{ m plog.ProtoMarshaler }
+
+func (l logsMarshaler) MarshalLogs(ld plog.Logs) ([]marshaler.Message, error) {
+	b, err := l.m.MarshalLogs(ld)
+	if err != nil {
+		return nil, err
+	}
+	return []marshaler.Message{{Value: b}}, nil
+}
+
+type metricsMarshaler struct{ m pmetric.ProtoMarshaler }
+
+func (m metricsMarshaler) MarshalMetrics(md pmetric.Metrics) ([]marshaler.Message, error) {
+	b, err := m.m.MarshalMetrics(md)
+	if err != nil {
+		return nil, err
+	}
+	return []marshaler.Message{{Value: b}}, nil
+}
+
+type profilesMarshaler struct{ m pprofile.ProtoMarshaler }
+
+func (p profilesMarshaler) MarshalProfiles(pd pprofile.Profiles) ([]marshaler.Message, error) {
+	b, err := p.m.MarshalProfiles(pd)
+	if err != nil {
+		return nil, err
+	}
+	return []marshaler.Message{{Value: b}}, nil
+}
+
+// ---- traces tests ----
+
+func TestSplitTraces_FitsInLimit(t *testing.T) {
+	td := makeTraces(4, 1, 1)
+	m := tracesMarshaler{}
+
+	msgs, _ := m.MarshalTraces(td)
+	limit := len(msgs[0].Value) + 100 // well above actual size
+
+	chunks, err := SplitTraces(td, m, limit)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1, "no split expected when payload fits")
+	assert.Equal(t, td.ResourceSpans().Len(), chunks[0].ResourceSpans().Len())
+}
+
+func TestSplitTraces_SplitsAtResourceLevel(t *testing.T) {
+	// 8 resource spans; marshal the first one to find its per-resource size.
+	td := makeTraces(8, 1, 1)
+	m := tracesMarshaler{}
+
+	// Pick a limit that fits 1 resource span but not all 8.
+	single := makeTraces(1, 1, 1)
+	singleMsgs, _ := m.MarshalTraces(single)
+	limit := len(singleMsgs[0].Value) + 20
+
+	chunks, err := SplitTraces(td, m, limit)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1, "expected multiple chunks")
+
+	// Verify every chunk fits in the limit.
+	for _, c := range chunks {
+		msgs, _ := m.MarshalTraces(c)
+		assert.LessOrEqual(t, len(msgs[0].Value), limit)
+	}
+
+	// Verify all spans are preserved.
+	total := 0
+	for _, c := range chunks {
+		for _, rs := range c.ResourceSpans().All() {
+			for _, ss := range rs.ScopeSpans().All() {
+				total += ss.Spans().Len()
+			}
+		}
+	}
+	assert.Equal(t, 8, total)
+}
+
+func TestSplitTraces_SplitsAtScopeLevel(t *testing.T) {
+	// 1 resource span with 8 scope spans, each with 1 span.
+	td := makeTraces(1, 8, 1)
+	m := tracesMarshaler{}
+
+	single := makeTraces(1, 1, 1)
+	singleMsgs, _ := m.MarshalTraces(single)
+	limit := len(singleMsgs[0].Value) + 20
+
+	chunks, err := SplitTraces(td, m, limit)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+
+	for _, c := range chunks {
+		msgs, _ := m.MarshalTraces(c)
+		assert.LessOrEqual(t, len(msgs[0].Value), limit)
+	}
+}
+
+func TestSplitTraces_SplitsAtSpanLevel(t *testing.T) {
+	// 1 resource span, 1 scope span, 8 spans.
+	td := makeTraces(1, 1, 8)
+	m := tracesMarshaler{}
+
+	single := makeTraces(1, 1, 1)
+	singleMsgs, _ := m.MarshalTraces(single)
+	limit := len(singleMsgs[0].Value) + 20
+
+	chunks, err := SplitTraces(td, m, limit)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+
+	for _, c := range chunks {
+		msgs, _ := m.MarshalTraces(c)
+		assert.LessOrEqual(t, len(msgs[0].Value), limit)
+	}
+}
+
+func TestSplitTraces_UnsplittableSingleSpan(t *testing.T) {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	sp := ss.Spans().AppendEmpty()
+	sp.Attributes().PutStr("large", strings.Repeat("x", 500))
+
+	m := tracesMarshaler{}
+	msgs, _ := m.MarshalTraces(td)
+	// Set limit well below the actual size so it can never fit.
+	limit := len(msgs[0].Value) / 2
+
+	chunks, err := SplitTraces(td, m, limit)
+	require.NoError(t, err)
+	// Cannot split further — must be returned as-is.
+	require.Len(t, chunks, 1)
+}
+
+// ---- logs tests ----
+
+func TestSplitLogs_FitsInLimit(t *testing.T) {
+	ld := makeLogs(4, 1, 1)
+	m := logsMarshaler{}
+
+	msgs, _ := m.MarshalLogs(ld)
+	limit := len(msgs[0].Value) + 100
+
+	chunks, err := SplitLogs(ld, m, limit)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+}
+
+func TestSplitLogs_SplitsAtResourceLevel(t *testing.T) {
+	ld := makeLogs(8, 1, 1)
+	m := logsMarshaler{}
+
+	single := makeLogs(1, 1, 1)
+	singleMsgs, _ := m.MarshalLogs(single)
+	limit := len(singleMsgs[0].Value) + 20
+
+	chunks, err := SplitLogs(ld, m, limit)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+
+	total := 0
+	for _, c := range chunks {
+		msgs, _ := m.MarshalLogs(c)
+		assert.LessOrEqual(t, len(msgs[0].Value), limit)
+		for _, rl := range c.ResourceLogs().All() {
+			for _, sl := range rl.ScopeLogs().All() {
+				total += sl.LogRecords().Len()
+			}
+		}
+	}
+	assert.Equal(t, 8, total)
+}
+
+func TestSplitLogs_UnsplittableSingleRecord(t *testing.T) {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr(strings.Repeat("x", 500))
+
+	m := logsMarshaler{}
+	msgs, _ := m.MarshalLogs(ld)
+	limit := len(msgs[0].Value) / 2
+
+	chunks, err := SplitLogs(ld, m, limit)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+}
+
+// ---- metrics tests ----
+
+func TestSplitMetrics_FitsInLimit(t *testing.T) {
+	md := makeMetrics(4, 1, 1)
+	m := metricsMarshaler{}
+
+	msgs, _ := m.MarshalMetrics(md)
+	limit := len(msgs[0].Value) + 100
+
+	chunks, err := SplitMetrics(md, m, limit)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+}
+
+func TestSplitMetrics_SplitsAtResourceLevel(t *testing.T) {
+	md := makeMetrics(8, 1, 1)
+	m := metricsMarshaler{}
+
+	single := makeMetrics(1, 1, 1)
+	singleMsgs, _ := m.MarshalMetrics(single)
+	limit := len(singleMsgs[0].Value) + 20
+
+	chunks, err := SplitMetrics(md, m, limit)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+
+	for _, c := range chunks {
+		msgs, _ := m.MarshalMetrics(c)
+		assert.LessOrEqual(t, len(msgs[0].Value), limit)
+	}
+}
+
+// ---- profiles tests ----
+
+func TestSplitProfiles_FitsInLimit(t *testing.T) {
+	pd := makeProfiles(4, 1, 1)
+	m := profilesMarshaler{}
+
+	msgs, _ := m.MarshalProfiles(pd)
+	limit := len(msgs[0].Value) + 100
+
+	chunks, err := SplitProfiles(pd, m, limit)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+}
+
+func TestSplitProfiles_SplitsAtResourceLevel(t *testing.T) {
+	pd := makeProfiles(8, 1, 1)
+	m := profilesMarshaler{}
+
+	single := makeProfiles(1, 1, 1)
+	singleMsgs, _ := m.MarshalProfiles(single)
+	limit := len(singleMsgs[0].Value) + 20
+
+	chunks, err := SplitProfiles(pd, m, limit)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+
+	for _, c := range chunks {
+		msgs, _ := m.MarshalProfiles(c)
+		assert.LessOrEqual(t, len(msgs[0].Value), limit)
+	}
+}
+
+// ---- pdata builders ----
+
+// makeTraces creates a ptrace.Traces with nRS ResourceSpans, each containing
+// nSS ScopeSpans, each containing nSpans Spans.
+func makeTraces(nRS, nSS, nSpans int) ptrace.Traces {
+	td := ptrace.NewTraces()
+	for range nRS {
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("res", "val")
+		for range nSS {
+			ss := rs.ScopeSpans().AppendEmpty()
+			ss.Scope().SetName("scope")
+			for range nSpans {
+				sp := ss.Spans().AppendEmpty()
+				sp.SetName("span")
+				sp.Attributes().PutStr("k", "v")
+			}
+		}
+	}
+	return td
+}
+
+// makeLogs creates a plog.Logs with nRL ResourceLogs, nSL ScopeLogs, nLR LogRecords.
+func makeLogs(nRL, nSL, nLR int) plog.Logs {
+	ld := plog.NewLogs()
+	for range nRL {
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("res", "val")
+		for range nSL {
+			sl := rl.ScopeLogs().AppendEmpty()
+			sl.Scope().SetName("scope")
+			for range nLR {
+				lr := sl.LogRecords().AppendEmpty()
+				lr.Body().SetStr("log body")
+				lr.Attributes().PutStr("k", "v")
+			}
+		}
+	}
+	return ld
+}
+
+// makeMetrics creates a pmetric.Metrics with nRM ResourceMetrics, nSM ScopeMetrics,
+// nM Metrics (each a gauge with one data point).
+func makeMetrics(nRM, nSM, nM int) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	for range nRM {
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("res", "val")
+		for range nSM {
+			sm := rm.ScopeMetrics().AppendEmpty()
+			sm.Scope().SetName("scope")
+			for range nM {
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("metric")
+				m.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(1.0)
+			}
+		}
+	}
+	return md
+}
+
+// makeProfiles creates a pprofile.Profiles with nRP ResourceProfiles, nSP ScopeProfiles,
+// nP Profiles.
+func makeProfiles(nRP, nSP, nP int) pprofile.Profiles {
+	pd := pprofile.NewProfiles()
+	for range nRP {
+		rp := pd.ResourceProfiles().AppendEmpty()
+		rp.Resource().Attributes().PutStr("res", "val")
+		for range nSP {
+			sp := rp.ScopeProfiles().AppendEmpty()
+			sp.Scope().SetName("scope")
+			for range nP {
+				sp.Profiles().AppendEmpty()
+			}
+		}
+	}
+	return pd
+}

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/kafkaclient"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/marshaler"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/splitter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal"
@@ -50,6 +51,11 @@ type messenger[T any] interface {
 
 	// getTopic returns the topic name for the given context and data.
 	getTopic(context.Context, T) string
+
+	// splitData splits data into sub-chunks such that each chunk marshals to
+	// at most maxBytes.  If an atomic item (span, log record, etc.) still
+	// exceeds maxBytes it is returned as-is.
+	splitData(data T, maxBytes int) ([]T, error)
 }
 
 type kafkaExporter[T any] struct {
@@ -127,6 +133,7 @@ func (e *kafkaExporter[T]) Close(context.Context) (err error) {
 
 func (e *kafkaExporter[T]) exportData(ctx context.Context, data T) error {
 	var m kafkaclient.Messages
+	maxBytes := e.cfg.Producer.MaxMessageBytes
 	for key, data := range e.messenger.partitionData(data) {
 		topic := e.messenger.getTopic(ctx, data)
 		partitionMessages, err := e.messenger.marshalData(data)
@@ -137,6 +144,14 @@ func (e *kafkaExporter[T]) exportData(ctx context.Context, data T) error {
 				zap.Error(err),
 			)
 			return consumererror.NewPermanent(err)
+		}
+		// If any message exceeds the limit, split the pdata into smaller
+		// chunks and re-marshal each one.
+		if anyMessageExceedsLimit(partitionMessages, maxBytes) {
+			partitionMessages, err = e.splitAndMarshal(topic, data, maxBytes)
+			if err != nil {
+				return err
+			}
 		}
 		for i := range partitionMessages {
 			// Marshalers may set the Key, so don't override
@@ -180,6 +195,37 @@ func (e *kafkaExporter[T]) exportData(ctx context.Context, data T) error {
 	return err
 }
 
+// splitAndMarshal splits oversized data into sub-chunks and marshals each one.
+func (e *kafkaExporter[T]) splitAndMarshal(topic string, data T, maxBytes int) ([]marshaler.Message, error) {
+	subChunks, err := e.messenger.splitData(data, maxBytes)
+	if err != nil {
+		return nil, consumererror.NewPermanent(fmt.Errorf("error splitting oversized message for topic %q: %w", topic, err))
+	}
+	var msgs []marshaler.Message
+	for _, sub := range subChunks {
+		subMsgs, marshalErr := e.messenger.marshalData(sub)
+		if marshalErr != nil {
+			marshalErr = fmt.Errorf("error exporting to topic %q: %w", topic, marshalErr)
+			e.logger.Error("kafka records marshal data failed after split",
+				zap.String("topic", topic),
+				zap.Error(marshalErr),
+			)
+			return nil, consumererror.NewPermanent(marshalErr)
+		}
+		msgs = append(msgs, subMsgs...)
+	}
+	return msgs, nil
+}
+
+func anyMessageExceedsLimit(msgs []marshaler.Message, maxBytes int) bool {
+	for _, msg := range msgs {
+		if len(msg.Value) > maxBytes {
+			return true
+		}
+	}
+	return false
+}
+
 func newTracesExporter(config Config, set exporter.Settings) *kafkaExporter[ptrace.Traces] {
 	// Jaeger encodings do their own partitioning, so disable trace ID
 	// partitioning when they are configured.
@@ -206,6 +252,10 @@ type kafkaTracesMessenger struct {
 
 func (e *kafkaTracesMessenger) marshalData(td ptrace.Traces) ([]marshaler.Message, error) {
 	return e.marshaler.MarshalTraces(td)
+}
+
+func (e *kafkaTracesMessenger) splitData(td ptrace.Traces, maxBytes int) ([]ptrace.Traces, error) {
+	return splitter.SplitTraces(td, e.marshaler, maxBytes)
 }
 
 func (e *kafkaTracesMessenger) getTopic(ctx context.Context, td ptrace.Traces) string {
@@ -265,6 +315,10 @@ type kafkaLogsMessenger struct {
 
 func (e *kafkaLogsMessenger) marshalData(ld plog.Logs) ([]marshaler.Message, error) {
 	return e.marshaler.MarshalLogs(ld)
+}
+
+func (e *kafkaLogsMessenger) splitData(ld plog.Logs, maxBytes int) ([]plog.Logs, error) {
+	return splitter.SplitLogs(ld, e.marshaler, maxBytes)
 }
 
 func (e *kafkaLogsMessenger) getTopic(ctx context.Context, ld plog.Logs) string {
@@ -333,6 +387,10 @@ func (e *kafkaMetricsMessenger) marshalData(md pmetric.Metrics) ([]marshaler.Mes
 	return e.marshaler.MarshalMetrics(md)
 }
 
+func (e *kafkaMetricsMessenger) splitData(md pmetric.Metrics, maxBytes int) ([]pmetric.Metrics, error) {
+	return splitter.SplitMetrics(md, e.marshaler, maxBytes)
+}
+
 func (e *kafkaMetricsMessenger) getTopic(ctx context.Context, md pmetric.Metrics) string {
 	return getTopic[pmetric.ResourceMetrics](ctx, e.config.Metrics, e.config.TopicFromAttribute, md.ResourceMetrics())
 }
@@ -384,6 +442,10 @@ type kafkaProfilesMessenger struct {
 
 func (e *kafkaProfilesMessenger) marshalData(ld pprofile.Profiles) ([]marshaler.Message, error) {
 	return e.marshaler.MarshalProfiles(ld)
+}
+
+func (e *kafkaProfilesMessenger) splitData(pd pprofile.Profiles, maxBytes int) ([]pprofile.Profiles, error) {
+	return splitter.SplitProfiles(pd, e.marshaler, maxBytes)
 }
 
 func (e *kafkaProfilesMessenger) getTopic(ctx context.Context, ld pprofile.Profiles) string {

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -6,6 +6,7 @@ package kafkaexporter
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -508,8 +509,9 @@ func TestLogsDataPusher_ctx_Kgo(t *testing.T) {
 		assert.ElementsMatch(t, expectedHeaders, record.Headers, "message headers mismatch")
 	})
 
-	// Produce message that exceeds MaxMessageBytes to trigger a permanent non-retriable error.
-	t.Run("WithNonRetriableError", func(t *testing.T) {
+	// A batch that exceeds MaxMessageBytes should be automatically split and
+	// delivered as multiple smaller messages without error.
+	t.Run("LargePayloadIsAutoSplit", func(t *testing.T) {
 		config := createDefaultConfig().(*Config)
 		config.Producer.MaxMessageBytes = 512
 		exp, fakeCluster := newKgoMockLogsExporter(t, *config,
@@ -517,10 +519,36 @@ func TestLogsDataPusher_ctx_Kgo(t *testing.T) {
 		)
 		defer fakeCluster.Close()
 
-		// ensure we have a big payload to trigger the error
+		// 20 resource logs totalling well above 512 bytes.
 		logs := testdata.GenerateLogs(20)
 
 		err := exp.exportData(t.Context(), logs)
+		require.NoError(t, err, "large payload should be split and delivered")
+
+		records := fetchKgoRecords(t, fakeCluster.ListenAddrs(), config.Logs.Topic, 20)
+		assert.Greater(t, len(records), 1, "expected multiple records after auto-split")
+	})
+
+	// A single log record whose serialized size exceeds MaxMessageBytes cannot
+	// be split further; the broker rejects it with a permanent MessageTooLarge error.
+	// Note: franz-go enforces a minimum of 512 bytes for ProducerBatchMaxBytes.
+	t.Run("UnsplittablePayload", func(t *testing.T) {
+		config := createDefaultConfig().(*Config)
+		config.Producer.MaxMessageBytes = 512
+		exp, fakeCluster := newKgoMockLogsExporter(t, *config,
+			componenttest.NewNopHost(), config.Logs.Topic,
+		)
+		defer fakeCluster.Close()
+
+		// A single log record with a large body: ~750 bytes serialized > 512 limit.
+		// It has only 1 resource → 1 scope → 1 record, so the splitter cannot
+		// divide it further and returns it as-is.
+		logs := plog.NewLogs()
+		lr := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		lr.Body().SetStr(strings.Repeat("x", 700))
+
+		err := exp.exportData(t.Context(), logs)
+		require.Error(t, err)
 		require.ErrorAs(t, err, &kerr.MessageTooLarge, "expected MessageTooLarge error")
 		assert.True(t, consumererror.IsPermanent(err), "expected permanent error")
 	})


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- The Kafka exporter failed permanently with a MessageTooLarge error whenever a serialized payload exceeded max_message_bytes (default 1 MB). Instead of attempting to split the payload, the exporter passed the full batch directly to the Kafka producer, which then rejected it. This meant any collector instance that received a large burst of telemetry would be stuck in an infinite retry loop and never deliver the data.

- Fixed: splitting oversized payloads into smaller messages before sending. When any marshaled message exceeds max_message_bytes, the exporter recursively halves the pdata batch at three granularity levels — Resource → Scope → individual record/span/metric/profile until each chunk fits within the limit. If a single atomic item (e.g. one span with a huge attribute) still cannot fit, it is forwarded as-is and the existing permanent `MessageTooLarge` error is preserved for that specific record only.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36982 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added exporter/kafkaexporter/internal/splitter package with 12-unit tests covering: payload that already fits (no split), splitting at resource/scope/span levels, and the unsplittable single-item edge case for all four signal types.
 - Updated `TestLogsDataPusher_ctx_Kgo/LargePayloadIsAutoSplit`: a 20-resource-log batch with `max_message_bytes=512` now succeeds and produces multiple Kafka records instead of returning an error.
 - Added `TestLogsDataPusher_ctx_Kgo/UnsplittablePayload`: a single log record whose serialized size exceeds the limit returns a permanent `MessageTooLarge` error, preserving the previous behavior for truly unsplittable payloads.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
