### PR TITLE
[exporter/Kafka] Allow record_headers to accept multiple headers with same key

### DIFF
--- a/.chloggen/fix-record-headers.yaml
+++ b/.chloggen/fix-record-headers.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: exporter/kafka
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Allow record_headers to set multiple headers with the same key. 
+note: Allow record_headers to accept multiple headers with the same key. 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [48092]

--- a/.chloggen/fix-record-headers.yaml
+++ b/.chloggen/fix-record-headers.yaml
@@ -10,7 +10,7 @@ component: exporter/kafka
 note: Allow record_headers to set multiple headers with the same key. 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48092]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-record-headers.yaml
+++ b/.chloggen/fix-record-headers.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: exporter/kafka

--- a/.chloggen/fix-record-headers.yaml
+++ b/.chloggen/fix-record-headers.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow record_headers to set multiple headers with the same key. 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -10,12 +10,12 @@ import (
 	"slices"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/kafkaclient"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 )
 
@@ -144,7 +144,7 @@ type Config struct {
 	IncludeMetadataKeys []string `mapstructure:"include_metadata_keys"`
 
 	// RecordHeaders sets static headers on every outgoing Kafka record.
-	RecordHeaders configopaque.MapList `mapstructure:"record_headers"`
+	RecordHeaders []kafkaclient.RecordHeader `mapstructure:"record_headers"`
 
 	// TopicFromAttribute is the name of the attribute to use as the topic name.
 	TopicFromAttribute string `mapstructure:"topic_from_attribute"`

--- a/exporter/kafkaexporter/config.schema.yaml
+++ b/exporter/kafkaexporter/config.schema.yaml
@@ -73,7 +73,9 @@ properties:
     $ref: signal_config
   record_headers:
     description: RecordHeaders sets static headers on every outgoing Kafka record.
-    $ref: go.opentelemetry.io/collector/config/configopaque.map_list
+    type: array
+    items:
+      $ref: ./internal/kafkaclient.record_header
   record_partitioner:
     description: RecordPartitioner configures how Kafka records are assigned to partitions. The default ("sarama_compatible") retains the legacy Sarama-compatible hashing behavior. Set to "sticky", "round_robin", or "least_backup" to use one of the built-in franz-go partitioners, or "extension" to delegate to a custom extension.
     $ref: record_partitioner_config

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/kafkaclient"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 )
@@ -267,6 +269,39 @@ func TestLoadConfig(t *testing.T) {
 					Encoding:             "otlp_proto",
 				},
 				IncludeMetadataKeys: []string{"metadata_key"},
+				RecordPartitioner: (RecordPartitionerConfig{
+					StickyKey: &StickyKeyPartitionerConfig{
+						Hasher: "sarama_compat",
+					},
+				}),
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "message_record_headers"),
+			expected: &Config{
+				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
+				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
+				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+				ClientConfig:     configkafka.NewDefaultClientConfig(),
+				Producer:         configkafka.NewDefaultProducerConfig(),
+				Logs:             SignalConfig{Topic: defaultLogsTopic, Encoding: defaultLogsEncoding},
+				Metrics:          SignalConfig{Topic: defaultMetricsTopic, Encoding: defaultMetricsEncoding},
+				Traces:           SignalConfig{Topic: defaultTracesTopic, Encoding: defaultTracesEncoding},
+				Profiles:         SignalConfig{Topic: defaultProfilesTopic, Encoding: defaultProfilesEncoding},
+				RecordHeaders: []kafkaclient.RecordHeader{
+					{
+						Name:  "some-key",
+						Value: configopaque.String("some-value"),
+					},
+					{
+						Name:  "some-key",
+						Value: configopaque.String("another-value"),
+					},
+					{
+						Name:  "new-key",
+						Value: configopaque.String("new-value"),
+					},
+				},
 				RecordPartitioner: (RecordPartitionerConfig{
 					StickyKey: &StickyKeyPartitionerConfig{
 						Hasher: "sarama_compat",

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -21,7 +21,6 @@ require (
 	go.opentelemetry.io/collector/client v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/component v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/component/componenttest v0.151.1-0.20260501001745-24aecacf1c04
-	go.opentelemetry.io/collector/config/configopaque v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/config/configoptional v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/config/configretry v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/confmap v1.57.1-0.20260501001745-24aecacf1c04
@@ -105,6 +104,7 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.57.1-0.20260501001745-24aecacf1c04 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.57.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.57.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.151.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.151.1-0.20260501001745-24aecacf1c04 // indirect

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/collector/client v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/component v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/component/componenttest v0.151.1-0.20260501001745-24aecacf1c04
+	go.opentelemetry.io/collector/config/configopaque v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/config/configoptional v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/config/configretry v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/confmap v1.57.1-0.20260501001745-24aecacf1c04
@@ -104,7 +105,6 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.57.1-0.20260501001745-24aecacf1c04 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.57.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.57.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.151.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.151.1-0.20260501001745-24aecacf1c04 // indirect

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
@@ -42,7 +42,7 @@ func recordUserSize(r *kgo.Record) int {
 // RecordHeader includes key-value pairs to be added as headers to Kafka records.
 type RecordHeader struct {
 	Name  string `mapstructure:"name"`
-	Value string `mapstructure:"value"`
+	Value configopaque.String `mapstructure:"value"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
@@ -40,6 +39,12 @@ func recordUserSize(r *kgo.Record) int {
 	return s
 }
 
+// RecordHeader includes key-value pairs to be added as headers to Kafka records.
+type RecordHeader struct {
+	Name  string `mapstructure:"name"`
+	Value string `mapstructure:"value"`
+}
+
 // FranzSyncProducer is a wrapper around the franz-go client that implements
 // the Producer interface. Allowing us to use the franz-go client while
 // maintaining compatibility with the existing Kafka exporter code.
@@ -53,7 +58,7 @@ type FranzSyncProducer struct {
 // NewFranzSyncProducer Franz-go producer from a kgo.Client and a Messenger.
 func NewFranzSyncProducer(client *kgo.Client,
 	metadataKeys []string,
-	recordHeaders configopaque.MapList,
+	recordHeaders []RecordHeader,
 	maxMessageBytes int,
 ) *FranzSyncProducer {
 	headers := make([]kgo.RecordHeader, 0, len(recordHeaders))

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
@@ -41,7 +42,7 @@ func recordUserSize(r *kgo.Record) int {
 
 // RecordHeader includes key-value pairs to be added as headers to Kafka records.
 type RecordHeader struct {
-	Name  string `mapstructure:"name"`
+	Name  string              `mapstructure:"name"`
 	Value configopaque.String `mapstructure:"value"`
 
 	// prevent unkeyed literal initialization

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo.go
@@ -43,6 +43,9 @@ func recordUserSize(r *kgo.Record) int {
 type RecordHeader struct {
 	Name  string `mapstructure:"name"`
 	Value string `mapstructure:"value"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // FranzSyncProducer is a wrapper around the franz-go client that implements

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_test.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/marshaler"
@@ -67,9 +68,9 @@ func TestExportData_MessageTooLarge(t *testing.T) {
 }
 
 func TestMakeFranzMessages_RecordHeaders(t *testing.T) {
-	recordHeaders := []kgo.RecordHeader{
-		{Key: "static-key-ONLY", Value: []byte("static-value")},
-		{Key: "shared-key", Value: []byte("static-value-override")},
+	recordHeaders := []RecordHeader{
+		{Name: "static-key-ONLY", Value: configopaque.String("static-value")},
+		{Name: "shared-key", Value: configopaque.String("static-value-override")},
 	}
 
 	md := client.NewMetadata(map[string][]string{
@@ -88,8 +89,11 @@ func TestMakeFranzMessages_RecordHeaders(t *testing.T) {
 		}},
 	}
 
+	// NewFranzSyncProducer will convert recordHeaders to kgo.RecordHeader and store them in the producer struct.
+	producer := NewFranzSyncProducer(nil, nil, recordHeaders, 0)
 	metadataHeaders := metadataToHeaders(ctx, []string{"dynamic-key-ONLY", "shared-key"})
-	records := makeFranzMessages(msgs, recordHeaders, metadataHeaders)
+
+	records := makeFranzMessages(msgs, producer.recordHeaders, metadataHeaders)
 
 	require.Len(t, records, 1, "expected exactly 1 record")
 	record := records[0]

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -89,3 +89,13 @@ kafka/metadata_batch_valid:
           - metadata_key
           - another_key
           - kafka_topic
+kafka/message_record_headers:
+  brokers:
+    - "localhost:9092"
+  record_headers:
+    - name: some-key
+      value: some-value
+    - name: some-key
+      value: another-value     
+    - name: new-key
+      value: new-value  


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Kafka allows multiple headers with same keys to exist. Newly added config parameter `record_headers` did not allow this and would error out with following message. 
```
exporters::kafka/_agent-component/default::record_headers: duplicate keys in map-style list: []
```

This PR fixes this bug. 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Use below config
```
receivers:
  filelog:
    include: ["/var/log/*.log"]

exporters:
  debug:
    use_internal_logger: false
    verbosity: detailed
  kafka:
    brokers:
      - localhost:9092
    record_headers:
      - name: "source"
        value: "otel-collector"
      - name: "source"
        value: "otel-collector-2"


service:
 telemetry:
    metrics:
      level: none
 pipelines:
    logs:
      receivers: [filelog]
      exporters: [debug, kafka]
```

<!--Describe the documentation added.-->
#### Documentation
None 

<!--Please delete paragraphs that you did not use before submitting.-->
