### PR TITLE
[exporter/azuremonitor] add config to mark HTTP status codes as Success

### DIFF
--- a/.chloggen/feat_azuremonitor-non-error-http-status.yaml
+++ b/.chloggen/feat_azuremonitor-non-error-http-status.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `non_error_http_status_codes` and `align_http_server_span_success_with_otel_spec` config to control which HTTP status codes are reported as `Success` on Application Insights envelopes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47691]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -44,6 +44,18 @@ The following settings can be optionally configured:
   - `storage` (default = `none`): When set, enables persistence and uses the component specified as a storage extension for the persistent queue
 - `shutdown_timeout` (default = 1s): Timeout to wait for graceful shutdown. Once exceeded, the component will shut down forcibly, dropping any element in queue.
 - `custom_events_enabled` (default = `false`): Enables export log record to custom events when there's attribute `microsoft.custom_event.name` or `APPLICATION_INSIGHTS_EVENT_MARKER_ATTRIBUTE`.
+- `non_error_http_status_codes` (default = `[]`): HTTP status codes that should be reported as `Success = true` on Application Insights `RequestData` (server spans) and `RemoteDependencyData` (client spans), regardless of the default 100-399 success range. Useful for hiding expected non-2xx responses (404 cache miss, 409 conflict, 412 precondition failed) from failure-rate dashboards and alerts. Codes must be in `[100, 599]`.
+- `align_http_server_span_success_with_otel_spec` (default = `false`): When `true`, any 4xx HTTP response on a server span is reported as `Success = true` on `RequestData`, matching the [OpenTelemetry HTTP semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status) which only flip server span status to `Error` on 5xx. Client spans (`RemoteDependencyData`) are unaffected; use `non_error_http_status_codes` to override individual client codes.
+
+Example:
+
+```yaml
+exporters:
+  azuremonitor:
+    connection_string: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/"
+    non_error_http_status_codes: [404, 409]
+    align_http_server_span_success_with_otel_spec: true
+```
 
 Example:
 

--- a/exporter/azuremonitorexporter/azuremonitor_exporter.go
+++ b/exporter/azuremonitorexporter/azuremonitor_exporter.go
@@ -102,9 +102,10 @@ func (exporter *azureMonitorExporter) consumeMetrics(_ context.Context, metricDa
 }
 
 type traceVisitor struct {
-	processed int
-	err       error
-	exporter  *azureMonitorExporter
+	processed  int
+	err        error
+	exporter   *azureMonitorExporter
+	httpPolicy httpStatusPolicy
 }
 
 // Called for each tuple of Resource, InstrumentationScope, and Span
@@ -113,7 +114,7 @@ func (v *traceVisitor) visit(
 	scope pcommon.InstrumentationScope,
 	span ptrace.Span,
 ) (ok bool) {
-	envelopes, err := spanToEnvelopes(resource, scope, span, v.exporter.config.SpanEventsEnabled, v.exporter.logger)
+	envelopes, err := spanToEnvelopes(resource, scope, span, v.exporter.config.SpanEventsEnabled, v.httpPolicy, v.exporter.logger)
 	if err != nil {
 		// record the error and short-circuit
 		v.err = consumererror.NewPermanent(err)
@@ -138,7 +139,7 @@ func (exporter *azureMonitorExporter) consumeTraces(_ context.Context, traceData
 		return nil
 	}
 
-	visitor := &traceVisitor{exporter: exporter}
+	visitor := &traceVisitor{exporter: exporter, httpPolicy: newHTTPStatusPolicy(exporter.config)}
 	accept(traceData, visitor)
 
 	// Flush the transport channel to force the telemetry to be sent

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -4,6 +4,7 @@
 package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 
 import (
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -23,5 +24,23 @@ type Config struct {
 	ShutdownTimeout        time.Duration                                            `mapstructure:"shutdown_timeout"`
 	CustomEventsEnabled    bool                                                     `mapstructure:"custom_events_enabled"`
 	ExceptionEventsEnabled bool                                                     `mapstructure:"exception_events_enabled"`
-	ClientConfig           confighttp.ClientConfig                                  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	// NonErrorHTTPStatusCodes lists HTTP status codes that should be reported as Success=true
+	// on Application Insights RequestData (server spans) and RemoteDependencyData (client spans),
+	// regardless of whether they fall outside the default 100-399 success range.
+	NonErrorHTTPStatusCodes []int `mapstructure:"non_error_http_status_codes"`
+	// AlignHTTPServerSpanSuccessWithOTelSpec, when true, marks any 4xx response on an HTTP
+	// server span as Success=true on RequestData. Aligns with the OpenTelemetry HTTP semantic
+	// conventions, which only flip server span status to Error on 5xx. Client spans are unaffected.
+	AlignHTTPServerSpanSuccessWithOTelSpec bool                    `mapstructure:"align_http_server_span_success_with_otel_spec"`
+	ClientConfig                           confighttp.ClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+}
+
+// Validate checks the configuration for invalid values.
+func (c *Config) Validate() error {
+	for _, code := range c.NonErrorHTTPStatusCodes {
+		if code < 100 || code > 599 {
+			return fmt.Errorf("non_error_http_status_codes: %d is not a valid HTTP status code (must be in [100, 599])", code)
+		}
+	}
+	return nil
 }

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -57,6 +57,18 @@ func TestLoadConfig(t *testing.T) {
 				ShutdownTimeout: 2 * time.Second,
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "3"),
+			expected: &Config{
+				ConnectionString:                       "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/",
+				MaxBatchSize:                           1024,
+				MaxBatchInterval:                       10 * time.Second,
+				ShutdownTimeout:                        1 * time.Second,
+				NonErrorHTTPStatusCodes:                []int{404, 409},
+				AlignHTTPServerSpanSuccessWithOTelSpec: true,
+				QueueSettings:                          configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -70,6 +82,34 @@ func TestLoadConfig(t *testing.T) {
 
 			assert.NoError(t, xconfmap.Validate(cfg))
 			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestConfigValidate_NonErrorHTTPStatusCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		codes   []int
+		wantErr string
+	}{
+		{name: "empty list ok", codes: nil},
+		{name: "valid range ok", codes: []int{100, 200, 404, 599}},
+		{name: "below 100 rejected", codes: []int{99}, wantErr: "99 is not a valid HTTP status code"},
+		{name: "above 599 rejected", codes: []int{600}, wantErr: "600 is not a valid HTTP status code"},
+		{name: "negative rejected", codes: []int{-1}, wantErr: "-1 is not a valid HTTP status code"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{NonErrorHTTPStatusCodes: tt.codes}
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }

--- a/exporter/azuremonitorexporter/testdata/config.yaml
+++ b/exporter/azuremonitorexporter/testdata/config.yaml
@@ -20,4 +20,9 @@ azuremonitor/2:
     num_consumers: 10
     storage: disk
 
+azuremonitor/3:
+  connection_string: InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/
+  non_error_http_status_codes: [404, 409]
+  align_http_server_span_success_with_otel_spec: true
+
 disk/3:

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -48,6 +48,37 @@ type msLink struct {
 	ID          string `json:"id"`
 }
 
+// httpStatusPolicy decides whether an HTTP status code on a span should be reported as
+// Success=true on Application Insights RequestData / RemoteDependencyData. The default
+// (zero value) preserves the historical behavior: any code in [100, 399] is success.
+type httpStatusPolicy struct {
+	nonErrorCodes               map[int64]struct{}
+	alignServerSpanWithOTelSpec bool
+}
+
+func newHTTPStatusPolicy(cfg *Config) httpStatusPolicy {
+	p := httpStatusPolicy{
+		alignServerSpanWithOTelSpec: cfg.AlignHTTPServerSpanSuccessWithOTelSpec,
+	}
+	if len(cfg.NonErrorHTTPStatusCodes) > 0 {
+		p.nonErrorCodes = make(map[int64]struct{}, len(cfg.NonErrorHTTPStatusCodes))
+		for _, code := range cfg.NonErrorHTTPStatusCodes {
+			p.nonErrorCodes[int64(code)] = struct{}{}
+		}
+	}
+	return p
+}
+
+func (p httpStatusPolicy) success(statusCode int64, isServer bool) bool {
+	if _, ok := p.nonErrorCodes[statusCode]; ok {
+		return true
+	}
+	if isServer && p.alignServerSpanWithOTelSpec && statusCode >= 400 && statusCode < 500 {
+		return true
+	}
+	return statusCode >= 100 && statusCode <= 399
+}
+
 // Transforms a tuple of pcommon.Resource, pcommon.InstrumentationScope, ptrace.Span into one or more of AppInsights contracts.Envelope
 // This is the only method that should be targeted in the unit tests
 func spanToEnvelopes(
@@ -55,6 +86,7 @@ func spanToEnvelopes(
 	instrumentationScope pcommon.InstrumentationScope,
 	span ptrace.Span,
 	spanEventsEnabled bool,
+	httpPolicy httpStatusPolicy,
 	logger *zap.Logger,
 ) ([]*contracts.Envelope, error) {
 	spanKind := span.Kind()
@@ -88,7 +120,7 @@ func spanToEnvelopes(
 
 	switch spanKind {
 	case ptrace.SpanKindServer, ptrace.SpanKindConsumer:
-		requestData := spanToRequestData(span, incomingSpanType)
+		requestData := spanToRequestData(span, incomingSpanType, httpPolicy)
 		dataProperties = requestData.Properties
 		dataSanitizeFunc = requestData.Sanitize
 		envelope.Name = requestData.EnvelopeName("")
@@ -96,7 +128,7 @@ func spanToEnvelopes(
 		data.BaseData = requestData
 		data.BaseType = requestData.BaseType()
 	case ptrace.SpanKindClient, ptrace.SpanKindProducer, ptrace.SpanKindInternal:
-		remoteDependencyData := spanToRemoteDependencyData(span, incomingSpanType)
+		remoteDependencyData := spanToRemoteDependencyData(span, incomingSpanType, httpPolicy)
 
 		// Regardless of the detected Span type, if the SpanKind is Internal we need to set data.Type to InProc
 		if spanKind == ptrace.SpanKindInternal {
@@ -222,7 +254,7 @@ func newEnvelope(span ptrace.Span, time string) *contracts.Envelope {
 }
 
 // Maps Server/Consumer Span to AppInsights RequestData
-func spanToRequestData(span ptrace.Span, incomingSpanType spanType) *contracts.RequestData {
+func spanToRequestData(span ptrace.Span, incomingSpanType spanType, httpPolicy httpStatusPolicy) *contracts.RequestData {
 	// See https://github.com/microsoft/ApplicationInsights-Go/blob/master/appinsights/contracts/requestdata.go
 	// Start with some reasonable default for server spans.
 	data := contracts.NewRequestData()
@@ -234,7 +266,7 @@ func spanToRequestData(span ptrace.Span, incomingSpanType spanType) *contracts.R
 
 	switch incomingSpanType {
 	case httpSpanType:
-		fillRequestDataHTTP(span, data)
+		fillRequestDataHTTP(span, data, httpPolicy)
 	case rpcSpanType:
 		fillRequestDataRPC(span, data)
 	case messagingSpanType:
@@ -247,7 +279,7 @@ func spanToRequestData(span ptrace.Span, incomingSpanType spanType) *contracts.R
 }
 
 // Maps Span to AppInsights RemoteDependencyData
-func spanToRemoteDependencyData(span ptrace.Span, incomingSpanType spanType) *contracts.RemoteDependencyData {
+func spanToRemoteDependencyData(span ptrace.Span, incomingSpanType spanType, httpPolicy httpStatusPolicy) *contracts.RemoteDependencyData {
 	// https://github.com/microsoft/ApplicationInsights-Go/blob/master/appinsights/contracts/remotedependencydata.go
 	// Start with some reasonable default for dependent spans.
 	data := contracts.NewRemoteDependencyData()
@@ -259,7 +291,7 @@ func spanToRemoteDependencyData(span ptrace.Span, incomingSpanType spanType) *co
 
 	switch incomingSpanType {
 	case httpSpanType:
-		fillRemoteDependencyDataHTTP(span, data)
+		fillRemoteDependencyDataHTTP(span, data, httpPolicy)
 	case rpcSpanType:
 		fillRemoteDependencyDataRPC(span, data)
 	case databaseSpanType:
@@ -302,18 +334,18 @@ func spanEventToMessageData(spanEvent ptrace.SpanEvent) *contracts.MessageData {
 	return data
 }
 
-func getFormattedHTTPStatusValues(statusCode int64) (statusAsString string, success bool) {
+func getFormattedHTTPStatusValues(statusCode int64, isServer bool, policy httpStatusPolicy) (statusAsString string, success bool) {
 	// see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status
-	return strconv.FormatInt(statusCode, 10), statusCode >= 100 && statusCode <= 399
+	return strconv.FormatInt(statusCode, 10), policy.success(statusCode, isServer)
 }
 
 // Maps HTTP Server Span to AppInsights RequestData
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#semantic-conventions-for-http-spans
-func fillRequestDataHTTP(span ptrace.Span, data *contracts.RequestData) {
+func fillRequestDataHTTP(span ptrace.Span, data *contracts.RequestData, httpPolicy httpStatusPolicy) {
 	attrs := copyAndExtractHTTPAttributes(span.Attributes(), data.Properties)
 
 	if attrs.HTTPResponseStatusCode != 0 {
-		data.ResponseCode, data.Success = getFormattedHTTPStatusValues(attrs.HTTPResponseStatusCode)
+		data.ResponseCode, data.Success = getFormattedHTTPStatusValues(attrs.HTTPResponseStatusCode, true, httpPolicy)
 	}
 
 	var sb strings.Builder
@@ -391,12 +423,12 @@ func fillRequestDataHTTP(span ptrace.Span, data *contracts.RequestData) {
 
 // Maps HTTP Client Span to AppInsights RemoteDependencyData
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
-func fillRemoteDependencyDataHTTP(span ptrace.Span, data *contracts.RemoteDependencyData) {
+func fillRemoteDependencyDataHTTP(span ptrace.Span, data *contracts.RemoteDependencyData, httpPolicy httpStatusPolicy) {
 	attrs := copyAndExtractHTTPAttributes(span.Attributes(), data.Properties)
 
 	data.Type = "HTTP"
 	if attrs.HTTPResponseStatusCode != 0 {
-		data.ResultCode, data.Success = getFormattedHTTPStatusValues(attrs.HTTPResponseStatusCode)
+		data.ResultCode, data.Success = getFormattedHTTPStatusValues(attrs.HTTPResponseStatusCode, false, httpPolicy)
 	}
 
 	var sb strings.Builder

--- a/exporter/azuremonitorexporter/trace_to_envelope_http_status_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_http_status_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuremonitorexporter
+
+import (
+	"testing"
+
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// TestHTTPServerSpan_NonErrorStatusCode_MarkedSuccess covers the case where a server span
+// returns a 4xx that the user has listed in non_error_http_status_codes. The resulting
+// RequestData.Success should be true even though 404 is outside the default 100-399 range.
+func TestHTTPServerSpan_NonErrorStatusCode_MarkedSuccess(t *testing.T) {
+	span := getDefaultHTTPServerSpan()
+	span.Attributes().PutInt("http.response.status_code", 404)
+
+	policy := newHTTPStatusPolicy(&Config{NonErrorHTTPStatusCodes: []int{404}})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	assert.Equal(t, "404", data.ResponseCode)
+	assert.True(t, data.Success)
+}
+
+// TestHTTPClientSpan_NonErrorStatusCode_MarkedSuccess mirrors the server-span test but
+// for a client span emitted as RemoteDependencyData. The non-error list applies to both.
+func TestHTTPClientSpan_NonErrorStatusCode_MarkedSuccess(t *testing.T) {
+	span := getDefaultHTTPClientSpan()
+	span.Attributes().PutInt("http.response.status_code", 404)
+
+	policy := newHTTPStatusPolicy(&Config{NonErrorHTTPStatusCodes: []int{404}})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	assert.Equal(t, "404", data.ResultCode)
+	assert.True(t, data.Success)
+}
+
+// TestHTTPServerSpan_OTelSpecAlignment_4xxIsSuccess verifies that with
+// align_http_server_span_success_with_otel_spec enabled, a 4xx server response is treated
+// as Success=true even when not in the non-error list.
+func TestHTTPServerSpan_OTelSpecAlignment_4xxIsSuccess(t *testing.T) {
+	span := getDefaultHTTPServerSpan()
+	span.Attributes().PutInt("http.response.status_code", 404)
+
+	policy := newHTTPStatusPolicy(&Config{AlignHTTPServerSpanSuccessWithOTelSpec: true})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	assert.Equal(t, "404", data.ResponseCode)
+	assert.True(t, data.Success)
+}
+
+// TestHTTPClientSpan_OTelSpecAlignment_4xxStillError verifies the alignment flag is
+// scoped to server spans only. Client spans keep the historical 4xx-as-error behavior,
+// matching OTel HTTP semantic conventions for client status (4xx is Error).
+func TestHTTPClientSpan_OTelSpecAlignment_4xxStillError(t *testing.T) {
+	span := getDefaultHTTPClientSpan()
+	span.Attributes().PutInt("http.response.status_code", 404)
+
+	policy := newHTTPStatusPolicy(&Config{AlignHTTPServerSpanSuccessWithOTelSpec: true})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	assert.Equal(t, "404", data.ResultCode)
+	assert.False(t, data.Success)
+}
+
+// TestHTTPServerSpan_OTelSpecAlignment_5xxStillError verifies the alignment flag does
+// not flip 5xx server responses to success; only 4xx is affected.
+func TestHTTPServerSpan_OTelSpecAlignment_5xxStillError(t *testing.T) {
+	span := getDefaultHTTPServerSpan()
+	span.Attributes().PutInt("http.response.status_code", 503)
+
+	policy := newHTTPStatusPolicy(&Config{AlignHTTPServerSpanSuccessWithOTelSpec: true})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	assert.Equal(t, "503", data.ResponseCode)
+	assert.False(t, data.Success)
+}
+
+// TestHTTPServerSpan_DefaultPolicy_4xxStillError pins the default behavior: with no
+// configuration, a 4xx server response is still reported as Success=false. Guards
+// against accidental change of the default during refactors.
+func TestHTTPServerSpan_DefaultPolicy_4xxStillError(t *testing.T) {
+	span := getDefaultHTTPServerSpan()
+	span.Attributes().PutInt("http.response.status_code", 404)
+
+	policy := newHTTPStatusPolicy(&Config{})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RequestData)
+	assert.Equal(t, "404", data.ResponseCode)
+	assert.False(t, data.Success)
+}
+
+// TestHTTPStatusPolicy_NonErrorOverridesAlignment verifies that a code in the non-error
+// list short-circuits to Success=true even on a client span where the alignment flag
+// would not apply. This is the only path that lets users mark client codes as success.
+func TestHTTPStatusPolicy_NonErrorOverridesAlignment(t *testing.T) {
+	span := getDefaultHTTPClientSpan()
+	span.Attributes().PutInt("http.response.status_code", 409)
+
+	policy := newHTTPStatusPolicy(&Config{
+		NonErrorHTTPStatusCodes:                []int{409},
+		AlignHTTPServerSpanSuccessWithOTelSpec: true,
+	})
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, policy, zap.NewNop())
+
+	data := envelopes[0].Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	assert.Equal(t, "409", data.ResultCode)
+	assert.True(t, data.Success)
+}

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -144,7 +144,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	spanAttributes.PutBool("somebool", false)
 	spanAttributes.PutDouble("somedouble", 0.1)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -177,7 +177,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet2(t *testing.T) {
 
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -205,7 +205,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet3(t *testing.T) {
 	spanAttributes.PutStr("client.address", "127.0.0.2")
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -223,7 +223,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet4(t *testing.T) {
 	spanAttributes.PutInt("http.response.status_code", defaultHTTPStatusCode)
 	spanAttributes.PutStr("url.full", "https://foo:81/bar?biz=baz")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -251,7 +251,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet1(t *testing.T) {
 	spanAttributes.PutStr("url.full", "https://foo:81/bar?biz=baz")
 	spanAttributes.PutInt("http.response.status_code", 400)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -285,7 +285,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet2(t *testing.T) {
 	// A specific http.route
 	spanAttributes.PutStr("http.route", "/bar/:baz_id")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -314,7 +314,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet3(t *testing.T) {
 	// Removing URL Full Key to test fallback although http client span requires url.full see https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/http/http-spans.md
 	spanAttributes.PutStr("url.full", "")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -339,7 +339,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	// Removing URL Full Key to test fallback although http client span requires url.full see https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/http/http-spans.md
 	spanAttributes.PutStr("url.full", "")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -358,7 +358,7 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -368,7 +368,7 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr("server.address", "")
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultRPCRequestDataValidations(t, span, data, "127.0.0.1:81")
@@ -383,7 +383,7 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutInt("client.port", 81)
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -393,7 +393,7 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("client.address", "")
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "127.0.0.1:81")
@@ -403,7 +403,7 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	span.Status().SetMessage("Resource exhausted")
 	spanAttributes.PutInt("rpc.grpc.status_code", 8)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
@@ -421,7 +421,7 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("client.address", "foo")
 	spanAttributes.PutInt("client.port", 81)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelopes[0], defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -434,7 +434,7 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("db.query.text", "")
 	spanAttributes.PutStr("db.query.text", defaultDBOperation)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	assert.Equal(t, defaultDBOperation, data.Data)
@@ -448,13 +448,13 @@ func TestMessagingConsumerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr("server.address", "foo")
 	spanAttributes.PutInt("server.port", 81)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultMessagingRequestDataValidations(t, span, data)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
@@ -469,13 +469,13 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr("client.address", "foo")
 	spanAttributes.PutInt("client.port", 81)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultMessagingRemoteDependencyDataValidations(t, span, data)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
@@ -490,7 +490,7 @@ func TestUnknownInternalSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("foo", "bar")
 	spanAttributes.PutStr("enduser.id", "4567")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -503,7 +503,7 @@ func TestUnspecifiedSpanToInProcRemoteDependencyData(t *testing.T) {
 	span := getDefaultInternalSpan()
 	span.SetKind(ptrace.SpanKindUnspecified)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -528,7 +528,7 @@ func TestSpanWithEventsToEnvelopes(t *testing.T) {
 
 	exceptionEvent.CopyTo(span.Events().AppendEmpty())
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, httpStatusPolicy{}, zap.NewNop())
 
 	assert.NotNil(t, envelopes)
 	assert.Len(t, envelopes, 3)


### PR DESCRIPTION
#### Description

Two opt-in config fields on the Azure Monitor exporter, both defaulting to the current behavior:

- `non_error_http_status_codes: []int` — HTTP status codes that should be reported as `Success = true` on `RequestData` (server) and `RemoteDependencyData` (client), regardless of the default 100-399 success range. Validated to `[100, 599]`.
- `align_http_server_span_success_with_otel_spec: bool` — when `true`, any 4xx response on an HTTP server span is reported as `Success = true` on `RequestData`, matching the [OTel HTTP semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status). Client spans are unaffected.

The two fields compose: a code in `non_error_http_status_codes` short-circuits to `Success = true` regardless of span kind, which is the only way to override individual client-span codes.

#### Implementation notes

- Introduces an unexported `httpStatusPolicy` value type with a `success(statusCode, isServer)` method. Built once per `traceVisitor` from the `Config` and threaded through `spanToEnvelopes` → `spanToRequestData` / `spanToRemoteDependencyData` → `fillRequestDataHTTP` / `fillRemoteDependencyDataHTTP` → `getFormattedHTTPStatusValues`.
- The `isServer` parameter is needed by `getFormattedHTTPStatusValues` because the alignment flag applies only to `RequestData`. Server vs client is already known at the fill-helper boundary; the bit is set there.
- Non-error list is held as `map[int64]struct{}` for clean lookup; the list is small in practice but the map handles duplicates and nil-safe lookup uniformly.
- `Config.Validate()` is new: the existing struct had none.

Default zero-value `httpStatusPolicy{}` preserves historical behavior exactly. The 22 existing test sites for `spanToEnvelopes` were updated mechanically to pass `httpStatusPolicy{}`.

#### Alternatives considered

- Hardcode 404 as success — rejected by the linked issue; users have other codes (401, 409, 412).
- Single boolean for full OTel-semconv alignment — does not let users mark individual client codes as success.
- Collector-wide feature gate — per-instance config is needed (e.g., one Azure Monitor exporter for billing dashboards, another for ops).
- Pass `*Config` through `spanToEnvelopes` — bloats the test signature and exposes more than the transform needs.

#### Link to tracking issue

Fixes #47691

#### Testing

- `go test -race ./...` in `exporter/azuremonitorexporter` passes.
- `go vet ./...`, `gofmt -l .`, and `golangci-lint run` are clean.
- New tests cover: non-error list on server/client spans, alignment flag for server 4xx, alignment-flag-does-not-touch client 4xx, alignment-flag-does-not-touch 5xx, default-policy regression guard, list overrides alignment for client codes.
- `Config.Validate` rejects codes outside `[100, 599]`.
- Existing `TestLoadConfig` extended with a third `azuremonitor/3` block exercising both new fields end-to-end through the YAML round-trip.

#### Documentation

- README updated with both fields and an example block under "Configuration Options".
- `.chloggen/feat_azuremonitor-non-error-http-status.yaml` added.

#### Backward compatibility

Defaults preserve current behavior bit-for-bit: empty list, alignment off, `Success` flag set exactly as before. No public API removed; the two unexported helpers (`spanToEnvelopes`, `getFormattedHTTPStatusValues`, etc.) gained a parameter but they are package-private.

---

Marked draft: it's the requester's second PR while #48086 (a separate `[processor/geoip]` fix) is awaiting CODEOWNERS review, per the first-time-contributor single-non-draft-PR convention. Will move to ready-for-review once that lands, or sooner if the design here is approved.