### PR TITLE
[receiver/k8sevents] add exclude_namespaces config

### DIFF
--- a/.chloggen/feat_k8sevents-exclude-namespaces.yaml
+++ b/.chloggen/feat_k8sevents-exclude-namespaces.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/k8s_events
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `exclude_namespaces` config to skip events from selected namespaces. Entries are matched against the namespace name as `filter.Config` (regex via `regexp:`). Cannot be combined with `namespaces`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23991]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8seventsreceiver/README.md
+++ b/receiver/k8seventsreceiver/README.md
@@ -32,6 +32,9 @@ the K8s API server. This can be one of `none` (for no auth), `serviceAccount`
 - `namespaces` (default = `all`): An array of `namespaces` to collect events from.
 This receiver will continuously watch all the `namespaces` mentioned in the array for
 new events.
+- `exclude_namespaces`: allows excluding namespaces from being watched. Cannot
+be combined with `namespaces`. (NOTE: if a new namespace that matches the regex
+is added, the collector will need to be restarted.)
 - `kube_api_qps` (default = `5`): Maximum number of queries per second to the Kubernetes API. Increase this if you see `client-side throttling` warnings in the collector logs.
 - `kube_api_burst` (default = `10`): Maximum burst size for requests to the Kubernetes API. Increase this alongside `kube_api_qps` if you see `client-side throttling` warnings.
 - `k8s_leader_elector` (default: none): if specified, will enable Leader Election by using `k8sleaderelector` extension
@@ -49,6 +52,12 @@ Examples:
     storage: file_storage
     k8s_leader_elector: k8s_leader_elector
     namespaces: [default, my_namespace]
+
+  k8s_events/exclude_noisy:
+    auth_type: kubeConfig
+    exclude_namespaces:
+      - regexp: kube-.*
+      - regexp: istio-system
 ```
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go)

--- a/receiver/k8seventsreceiver/config.go
+++ b/receiver/k8seventsreceiver/config.go
@@ -4,7 +4,10 @@
 package k8seventsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver"
 
 import (
+	"errors"
+
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/filter"
 	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
 
@@ -17,6 +20,12 @@ type Config struct {
 
 	// List of ‘namespaces’ to collect events from.
 	Namespaces []string `mapstructure:"namespaces"`
+
+	// ExcludeNamespaces lists namespaces whose events should be skipped.
+	// Each entry is a filter.Config matched against the namespace name; the
+	// receiver lists the cluster's namespaces at startup, drops the ones that
+	// match, and watches only the survivors. Cannot be combined with Namespaces.
+	ExcludeNamespaces []filter.Config `mapstructure:"exclude_namespaces"`
 
 	// Storage is the ID of the storage extension to use for resource version persistence.
 	// When set, the receiver will persist the latest resource version and resume from it on restart,
@@ -31,7 +40,13 @@ type Config struct {
 }
 
 func (cfg *Config) Validate() error {
-	return cfg.APIConfig.Validate()
+	if err := cfg.APIConfig.Validate(); err != nil {
+		return err
+	}
+	if len(cfg.Namespaces) != 0 && len(cfg.ExcludeNamespaces) != 0 {
+		return errors.New("namespaces and exclude_namespaces cannot both be set at the same time")
+	}
+	return nil
 }
 
 func (cfg *Config) getK8sClient() (k8s.Interface, error) {

--- a/receiver/k8seventsreceiver/config.schema.yaml
+++ b/receiver/k8seventsreceiver/config.schema.yaml
@@ -1,6 +1,11 @@
 description: Config defines configuration for kubernetes events receiver.
 type: object
 properties:
+  exclude_namespaces:
+    description: ExcludeNamespaces lists namespaces whose events should be skipped. Each entry is a filter.Config matched against the namespace name; the receiver lists the cluster's namespaces at startup, drops the ones that match, and watches only the survivors. Cannot be combined with Namespaces.
+    type: array
+    items:
+      $ref: go.opentelemetry.io/collector/filter.config
   k8s_leader_elector:
     x-pointer: true
     type: string

--- a/receiver/k8seventsreceiver/config_test.go
+++ b/receiver/k8seventsreceiver/config_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
+	"go.opentelemetry.io/collector/filter"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver/internal/metadata"
@@ -44,6 +45,15 @@ func TestConfigValidationAPIRateLimit(t *testing.T) {
 			cfg: &Config{
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount, KubeAPIQPS: 100, KubeAPIBurst: 200},
 			},
+		},
+		{
+			desc: "namespaces and exclude_namespaces both set is invalid",
+			cfg: &Config{
+				APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
+				Namespaces:        []string{"default"},
+				ExcludeNamespaces: []filter.Config{{Regex: "kube-.*"}},
+			},
+			expectedErr: "namespaces and exclude_namespaces cannot both be set at the same time",
 		},
 	}
 
@@ -78,6 +88,20 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "all_settings"),
 			expected: &Config{
 				Namespaces: []string{"default", "my_namespace"},
+				APIConfig: k8sconfig.APIConfig{
+					AuthType:     k8sconfig.AuthTypeServiceAccount,
+					KubeAPIQPS:   k8sconfig.DefaultKubeAPIQPS,
+					KubeAPIBurst: k8sconfig.DefaultKubeAPIBurst,
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "exclude_namespaces"),
+			expected: &Config{
+				ExcludeNamespaces: []filter.Config{
+					{Regex: "kube-.*"},
+					{Regex: "istio-system"},
+				},
 				APIConfig: k8sconfig.APIConfig{
 					AuthType:     k8sconfig.AuthTypeServiceAccount,
 					KubeAPIQPS:   k8sconfig.DefaultKubeAPIQPS,

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/consumer v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/consumer/consumertest v0.151.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/extension/xextension v0.151.1-0.20260501001745-24aecacf1c04
+	go.opentelemetry.io/collector/filter v0.151.0
 	go.opentelemetry.io/collector/pdata v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/receiver v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.151.1-0.20260501001745-24aecacf1c04

--- a/receiver/k8seventsreceiver/go.sum
+++ b/receiver/k8seventsreceiver/go.sum
@@ -134,6 +134,8 @@ go.opentelemetry.io/collector/extension/xextension v0.151.1-0.20260501001745-24a
 go.opentelemetry.io/collector/extension/xextension v0.151.1-0.20260501001745-24aecacf1c04/go.mod h1:DXK1pzPdH5zQpKfTYW7eFBUf3ES/RkLxJUnSxco/ZrA=
 go.opentelemetry.io/collector/featuregate v1.57.1-0.20260501001745-24aecacf1c04 h1:IfqXdbqi14+K8ztsFp5LVYm/x2aKy2gLttkpyzApQPk=
 go.opentelemetry.io/collector/featuregate v1.57.1-0.20260501001745-24aecacf1c04/go.mod h1:4ga1QBMPEejXXmpyJS8lmaRpknJ3Lb9Bvk6e420bUFU=
+go.opentelemetry.io/collector/filter v0.151.0 h1:acMfpuJbF7tucpd1jU/4UDUSEg7HalgcudCxTow/e6E=
+go.opentelemetry.io/collector/filter v0.151.0/go.mod h1:3LnA3tS8Z2EzVdkHveeP9RTu7YZybWegwij5Tr4T398=
 go.opentelemetry.io/collector/internal/componentalias v0.151.1-0.20260501001745-24aecacf1c04 h1:hbATIXYyPC+lx6X6UhA5qgqSFoHUcOIGnj2fiL/Y2Hc=
 go.opentelemetry.io/collector/internal/componentalias v0.151.1-0.20260501001745-24aecacf1c04/go.mod h1:c70sQuXHQZWSYCyc0y/VynqJdmEeBunSmEy3xfLQPWE=
 go.opentelemetry.io/collector/internal/testutil v0.151.0 h1:CFjDItLuqzblItOsnK6IPSdrsOaZCaDjYpB8qWG+XHI=

--- a/receiver/k8seventsreceiver/receiver.go
+++ b/receiver/k8seventsreceiver/receiver.go
@@ -6,6 +6,7 @@ package k8seventsreceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,19 +31,22 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver/internal/metadata"
 )
 
+var namespacesGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+
 type k8seventsReceiver struct {
-	config          *Config
-	settings        receiver.Settings
-	logsConsumer    consumer.Logs
-	stopperChanList []chan struct{}
-	startTime       time.Time
-	ctx             context.Context
-	cancel          context.CancelFunc
-	obsrecv         *receiverhelper.ObsReport
-	mu              sync.Mutex
-	client          dynamic.Interface
-	storageClient   storage.Client
-	wg              sync.WaitGroup
+	config            *Config
+	settings          receiver.Settings
+	logsConsumer      consumer.Logs
+	stopperChanList   []chan struct{}
+	startTime         time.Time
+	namespacesToWatch []string
+	ctx               context.Context
+	cancel            context.CancelFunc
+	obsrecv           *receiverhelper.ObsReport
+	mu                sync.Mutex
+	client            dynamic.Interface
+	storageClient     storage.Client
+	wg                sync.WaitGroup
 }
 
 // newReceiver creates the Kubernetes events receiver with the given configuration.
@@ -86,6 +91,20 @@ func (kr *k8seventsReceiver) Start(ctx context.Context, host component.Host) err
 			return fmt.Errorf("failed to get storage client: %w", storageErr)
 		}
 		kr.storageClient = storageClient
+	}
+
+	// Resolve the watch list. With exclude_namespaces, list the cluster's namespaces
+	// once and watch only the survivors. Without it, fall back to the configured
+	// allowlist (or all namespaces if neither is set). New namespaces created after
+	// startup are not picked up — restart the collector to refresh the list.
+	if len(kr.config.ExcludeNamespaces) > 0 {
+		included, listErr := kr.resolveNamespaces(ctx)
+		if listErr != nil {
+			return fmt.Errorf("failed to resolve namespaces for exclude_namespaces: %w", listErr)
+		}
+		kr.namespacesToWatch = included
+	} else {
+		kr.namespacesToWatch = kr.config.Namespaces
 	}
 
 	if kr.config.K8sLeaderElector != nil {
@@ -152,6 +171,46 @@ func (kr *k8seventsReceiver) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// resolveNamespaces lists the cluster's namespaces and returns the ones not
+// matched by any entry in cfg.ExcludeNamespaces. Regex compile errors on
+// individual entries are logged and skipped, mirroring k8sobjectsreceiver.
+func (kr *k8seventsReceiver) resolveNamespaces(ctx context.Context) ([]string, error) {
+	allNamespaces, err := kr.client.Resource(namespacesGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	compiled := make([]*regexp.Regexp, 0, len(kr.config.ExcludeNamespaces))
+	for _, pattern := range kr.config.ExcludeNamespaces {
+		re, compErr := regexp.Compile(pattern.Regex)
+		if compErr != nil {
+			kr.settings.Logger.Error("failed to compile exclude_namespaces regex",
+				zap.String("regex", pattern.Regex), zap.Error(compErr))
+			continue
+		}
+		compiled = append(compiled, re)
+	}
+
+	included := make([]string, 0, len(allNamespaces.Items))
+	for _, ns := range allNamespaces.Items {
+		name := ns.GetName()
+		excluded := false
+		for _, re := range compiled {
+			if re.MatchString(name) {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			included = append(included, name)
+		}
+	}
+
+	kr.settings.Logger.Info("Watching namespaces after exclude_namespaces filter",
+		zap.Strings("namespaces", included))
+	return included, nil
+}
+
 // startWatchers creates and starts the k8sinventory watch observer
 func (kr *k8seventsReceiver) startWatchers() {
 	// Events GVR (GroupVersionResource)
@@ -161,7 +220,7 @@ func (kr *k8seventsReceiver) startWatchers() {
 		Resource: "events",
 	}
 
-	namespaces := kr.config.Namespaces
+	namespaces := kr.namespacesToWatch
 	if len(namespaces) == 0 {
 		namespaces = []string{""} // Empty string means all namespaces
 	}

--- a/receiver/k8seventsreceiver/receiver_test.go
+++ b/receiver/k8seventsreceiver/receiver_test.go
@@ -4,6 +4,7 @@
 package k8seventsreceiver
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -12,10 +13,13 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -450,4 +454,130 @@ func TestStartWatchersMultipleNamespaces(t *testing.T) {
 	// Should have at least 1 watcher started
 	assert.GreaterOrEqual(t, watcherCount, 1)
 	require.NoError(t, r.Shutdown(t.Context()))
+}
+
+// TestExcludeNamespacesResolution verifies that exclude_namespaces filters out
+// matching namespaces at startup so that only the survivors are watched.
+func TestExcludeNamespacesResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		clusterNamespaces []string
+		exclude           []filter.Config
+		want              []string
+	}{
+		{
+			name:              "regex matches subset",
+			clusterNamespaces: []string{"default", "kube-system", "kube-public", "app"},
+			exclude:           []filter.Config{{Regex: "kube-.*"}},
+			want:              []string{"default", "app"},
+		},
+		{
+			name:              "multiple regexes",
+			clusterNamespaces: []string{"default", "kube-system", "istio-system", "app"},
+			exclude:           []filter.Config{{Regex: "kube-.*"}, {Regex: "istio-system"}},
+			want:              []string{"default", "app"},
+		},
+		{
+			name:              "no match keeps all",
+			clusterNamespaces: []string{"default", "app"},
+			exclude:           []filter.Config{{Regex: "no-such-namespace"}},
+			want:              []string{"default", "app"},
+		},
+		{
+			name:              "all excluded leaves empty list",
+			clusterNamespaces: []string{"kube-system", "kube-public"},
+			exclude:           []filter.Config{{Regex: "kube-.*"}},
+			want:              []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := newFakeDynamicClientWithNamespaces(t, tc.clusterNamespaces...)
+
+			rCfg := createDefaultConfig().(*Config)
+			rCfg.ExcludeNamespaces = tc.exclude
+			rCfg.makeClient = func(k8sconfig.APIConfig) (k8s.Interface, error) {
+				return fake.NewClientset(), nil
+			}
+			rCfg.makeDynamicClient = func(k8sconfig.APIConfig) (dynamic.Interface, error) {
+				return fakeClient, nil
+			}
+
+			r, err := newReceiver(
+				receivertest.NewNopSettings(metadata.Type),
+				rCfg,
+				consumertest.NewNop(),
+			)
+			require.NoError(t, err)
+
+			require.NoError(t, r.Start(t.Context(), componenttest.NewNopHost()))
+			recv := r.(*k8seventsReceiver)
+			assert.ElementsMatch(t, tc.want, recv.namespacesToWatch)
+			require.NoError(t, r.Shutdown(t.Context()))
+		})
+	}
+}
+
+// TestExcludeNamespacesInvalidRegexSkipped verifies that an entry with an
+// uncompilable regex is logged and skipped rather than failing startup.
+func TestExcludeNamespacesInvalidRegexSkipped(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeDynamicClientWithNamespaces(t, "default", "kube-system")
+
+	rCfg := createDefaultConfig().(*Config)
+	rCfg.ExcludeNamespaces = []filter.Config{
+		{Regex: "[invalid"}, // bad regex
+		{Regex: "kube-.*"},
+	}
+	rCfg.makeClient = func(k8sconfig.APIConfig) (k8s.Interface, error) {
+		return fake.NewClientset(), nil
+	}
+	rCfg.makeDynamicClient = func(k8sconfig.APIConfig) (dynamic.Interface, error) {
+		return fakeClient, nil
+	}
+
+	r, err := newReceiver(
+		receivertest.NewNopSettings(metadata.Type),
+		rCfg,
+		consumertest.NewNop(),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Start(t.Context(), componenttest.NewNopHost()))
+	recv := r.(*k8seventsReceiver)
+	assert.ElementsMatch(t, []string{"default"}, recv.namespacesToWatch)
+	require.NoError(t, r.Shutdown(t.Context()))
+}
+
+// newFakeDynamicClientWithNamespaces returns a fake dynamic client pre-loaded
+// with the given namespace names so that List(namespacesGVR) returns them.
+func newFakeDynamicClientWithNamespaces(t *testing.T, names ...string) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "namespaces"}: "NamespaceList",
+		{Group: "", Version: "v1", Resource: "events"}:     "EventList",
+	}
+	fc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+
+	nsResource := fc.Resource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"})
+	for i, name := range names {
+		ns := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]any{
+					"name": name,
+				},
+			},
+		}
+		ns.SetResourceVersion(strconv.Itoa(i + 1))
+		_, err := nsResource.Create(t.Context(), ns, v1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	return fc
 }

--- a/receiver/k8seventsreceiver/testdata/config.yaml
+++ b/receiver/k8seventsreceiver/testdata/config.yaml
@@ -1,3 +1,7 @@
 k8s_events:
 k8s_events/all_settings:
   namespaces: [ default, my_namespace ]
+k8s_events/exclude_namespaces:
+  exclude_namespaces:
+    - regexp: kube-.*
+    - regexp: istio-system


### PR DESCRIPTION
#### Description

Adds an `exclude_namespaces` config field to the `k8s_events` receiver. Entries are Go regular expressions (matching `k8sobjectsreceiver`'s `exclude_namespaces` shape via `filter.Config`). At startup the receiver lists all namespaces via the dynamic client, drops any whose name matches an entry, and starts one watch per surviving namespace via the existing `internal/k8sinventory/watch` observer. Useful for ignoring noisy infrastructure namespaces (e.g. `kube-system`, `istio-system`) without enumerating every other namespace in `namespaces`.

```yaml
k8s_events:
  exclude_namespaces:
    - regexp: kube-.*
    - regexp: istio-system
```

`namespaces` and `exclude_namespaces` are mutually exclusive — `Validate()` returns an error if both are set.

#### Implementation notes

- Mirrors `receiver/k8sobjectsreceiver` end-to-end (config field shape, mutex validation, pre-watch resolution, regex semantics, restart caveat).
- `Start()` calls `Resource(namespacesGVR).List(...)` once, compiles each entry's `Regex`, builds the inclusion list, and stores it on the receiver. Invalid regexes are logged and skipped (same as `k8sobjects`).
- The k8sinventory watch observer is unchanged — it already supports a per-namespace watch fan-out, so the inclusion list flows in unmodified.
- **Caveat:** namespaces created after the receiver starts are not picked up — a restart is required to pick them up. Same trade-off `k8sobjects` documents today; called out in the README.

#### Link to tracking issue

Fixes #23991

#### Testing

- `go test -race ./...` in `receiver/k8seventsreceiver` passes.
- New tests:
  - `TestExcludeNamespacesResolution` — table-driven (4 cases): regex matches a subset, multiple regexes, no match keeps all, all-excluded leaves the watch list empty. Parallels `k8sobjects`' `TestNamespaceDenyListWatchObject`.
  - `TestExcludeNamespacesInvalidRegexSkipped` — uncompilable regex is logged and skipped, same as `k8sobjects`.
  - `config_test.go` case asserting `Validate()` rejects setting both `namespaces` and `exclude_namespaces`.
- `golangci-lint run`, `go vet`, `gofmt -l` clean (golangci-lint v2.6.0 in `golang:1.25.9`).

#### Documentation

README updated with the new field, the mutex rule, the regex semantics, and the restart-on-new-namespace caveat (matches `k8sobjects`' phrasing).

#### Backward compatibility

Defaults preserve current behavior. Empty/nil list → no filtering, identical to today.
