### PR TITLE
[exporter/honeycombmarker] derive dataset slug from service.name resource attribute

### DIFF
--- a/.chloggen/feat_honeycombmarker-dataset-from-service-name.yaml
+++ b/.chloggen/feat_honeycombmarker-dataset-from-service-name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/honeycombmarker
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `use_service_name_as_dataset_slug` marker config to derive the dataset slug from the log's resource `service.name` attribute at send-time.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29407]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/honeycombmarkerexporter/README.md
+++ b/exporter/honeycombmarkerexporter/README.md
@@ -28,6 +28,7 @@ The following configuration options are supported:
   * `rules` (Required): This is a list of [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl) rules that determine when to create an event marker. 
     * `log_conditions` (Required): A list of [OTTL log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog) conditions that determine a match. The marker will be created if **ANY** condition matches.
   * `dataset_slug` (Optional): The dataset in which to create the marker. If not set, will default to `__all__`.
+  * `use_service_name_as_dataset_slug` (Optional, default `false`): When `true`, the marker is sent to the dataset named after the log's resource `service.name` attribute. If `service.name` is missing, the marker falls back to `dataset_slug`, then to `__all__`. Useful for fanning a single marker rule out to per-service Honeycomb datasets.
   * `message_key` (Optional): The key of the attribute whose value will be used as the marker's message. If necessary the value will be converted to a string.
   * `url_key` (Optional): The key of the attribute whose value will be used as the marker's url. If necessary the value will be converted to a string.
 

--- a/exporter/honeycombmarkerexporter/config.go
+++ b/exporter/honeycombmarkerexporter/config.go
@@ -52,6 +52,11 @@ type Marker struct {
 
 	// DatasetSlug is the endpoint that specifies the Honeycomb environment
 	DatasetSlug string `mapstructure:"dataset_slug"`
+
+	// UseServiceNameAsDatasetSlug, when true, derives the dataset slug at send-time
+	// from the log's resource service.name attribute. If service.name is missing,
+	// the marker falls back to DatasetSlug, then to the default "__all__" slug.
+	UseServiceNameAsDatasetSlug bool `mapstructure:"use_service_name_as_dataset_slug"`
 }
 
 type Rules struct {

--- a/exporter/honeycombmarkerexporter/config_test.go
+++ b/exporter/honeycombmarkerexporter/config_test.go
@@ -73,6 +73,24 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "use_service_name"),
+			expected: &Config{
+				APIKey: "test-apikey",
+				APIURL: "https://api.testhost.io",
+				Markers: []Marker{
+					{
+						Type:                        "fooType",
+						UseServiceNameAsDatasetSlug: true,
+						Rules: Rules{
+							LogConditions: []string{
+								`body == "test"`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "bad_syntax_log"),
 		},
 		{

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -78,6 +78,10 @@ func newHoneycombLogsExporter(set exporter.Settings, config *Config) (*honeycomb
 func (e *honeycombLogsExporter) exportMarkers(ctx context.Context, ld plog.Logs) error {
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rlogs := ld.ResourceLogs().At(i)
+		serviceName := ""
+		if v, ok := rlogs.Resource().Attributes().Get("service.name"); ok {
+			serviceName = v.AsString()
+		}
 		for j := 0; j < rlogs.ScopeLogs().Len(); j++ {
 			slogs := rlogs.ScopeLogs().At(j)
 			logs := slogs.LogRecords()
@@ -91,7 +95,7 @@ func (e *honeycombLogsExporter) exportMarkers(ctx context.Context, ld plog.Logs)
 						return err
 					}
 					if match {
-						err = e.sendMarker(ctx, m, logRecord)
+						err = e.sendMarker(ctx, m, logRecord, serviceName)
 						if err != nil {
 							tCtx.Close()
 							return err
@@ -105,7 +109,7 @@ func (e *honeycombLogsExporter) exportMarkers(ctx context.Context, ld plog.Logs)
 	return nil
 }
 
-func (e *honeycombLogsExporter) sendMarker(ctx context.Context, m marker, logRecord plog.LogRecord) error {
+func (e *honeycombLogsExporter) sendMarker(ctx context.Context, m marker, logRecord plog.LogRecord, serviceName string) error {
 	requestMap := map[string]string{
 		"type": m.Type,
 	}
@@ -125,10 +129,7 @@ func (e *honeycombLogsExporter) sendMarker(ctx context.Context, m marker, logRec
 		return err
 	}
 
-	datasetSlug := m.DatasetSlug
-	if datasetSlug == "" {
-		datasetSlug = defaultDatasetSlug
-	}
+	datasetSlug := resolveDatasetSlug(m.Marker, serviceName)
 
 	url := fmt.Sprintf("%s/1/markers/%s", strings.TrimRight(e.apiURL, "/"), datasetSlug)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(request))
@@ -158,6 +159,19 @@ func (e *honeycombLogsExporter) sendMarker(ctx context.Context, m marker, logRec
 	}
 
 	return nil
+}
+
+// resolveDatasetSlug picks the slug to send a marker to, in priority order:
+// resource service.name (when use_service_name_as_dataset_slug is enabled), then
+// the configured DatasetSlug, then the default "__all__".
+func resolveDatasetSlug(m Marker, serviceName string) string {
+	if m.UseServiceNameAsDatasetSlug && serviceName != "" {
+		return serviceName
+	}
+	if m.DatasetSlug != "" {
+		return m.DatasetSlug
+	}
+	return defaultDatasetSlug
 }
 
 func (e *honeycombLogsExporter) start(ctx context.Context, host component.Host) (err error) {

--- a/exporter/honeycombmarkerexporter/logs_exporter_test.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter_test.go
@@ -162,8 +162,15 @@ func TestExportMarkers(t *testing.T) {
 }
 
 func constructLogs(attributes map[string]string) plog.Logs {
+	return constructLogsWithResource(attributes, nil)
+}
+
+func constructLogsWithResource(attributes, resourceAttributes map[string]string) plog.Logs {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
+	for k, v := range resourceAttributes {
+		rl.Resource().Attributes().PutStr(k, v)
+	}
 	sl := rl.ScopeLogs().AppendEmpty()
 	l := sl.LogRecords().AppendEmpty()
 
@@ -298,4 +305,103 @@ func TestExportMarkers_NoAPICall(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestResolveDatasetSlug(t *testing.T) {
+	tests := []struct {
+		name        string
+		marker      Marker
+		serviceName string
+		want        string
+	}{
+		{name: "default falls back to __all__", marker: Marker{}, want: "__all__"},
+		{name: "configured slug used when flag off", marker: Marker{DatasetSlug: "billing"}, want: "billing"},
+		{name: "service name used when flag on", marker: Marker{UseServiceNameAsDatasetSlug: true}, serviceName: "billing", want: "billing"},
+		{name: "service name preferred over configured slug", marker: Marker{UseServiceNameAsDatasetSlug: true, DatasetSlug: "fallback"}, serviceName: "billing", want: "billing"},
+		{name: "missing service name falls back to configured slug", marker: Marker{UseServiceNameAsDatasetSlug: true, DatasetSlug: "fallback"}, want: "fallback"},
+		{name: "missing service name and missing slug falls back to default", marker: Marker{UseServiceNameAsDatasetSlug: true}, want: "__all__"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDatasetSlug(tt.marker, tt.serviceName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestExportMarkers_UseServiceNameAsDatasetSlug verifies the end-to-end path:
+// when use_service_name_as_dataset_slug is true and the resource has a service.name,
+// the marker request is sent to /1/markers/<service.name>.
+func TestExportMarkers_UseServiceNameAsDatasetSlug(t *testing.T) {
+	cfg := Config{
+		APIKey: "test-apikey",
+		Markers: []Marker{
+			{
+				Type:                        "test-type",
+				DatasetSlug:                 "should-be-overridden",
+				UseServiceNameAsDatasetSlug: true,
+				Rules: Rules{
+					LogConditions: []string{`body == "test"`},
+				},
+			},
+		},
+	}
+
+	var gotPath string
+	markerServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+	defer markerServer.Close()
+
+	cfg.APIURL = markerServer.URL
+
+	f := NewFactory()
+	exp, err := f.CreateLogs(t.Context(), exportertest.NewNopSettings(metadata.Type), &cfg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+
+	logs := constructLogsWithResource(nil, map[string]string{"service.name": "billing"})
+	require.NoError(t, exp.ConsumeLogs(t.Context(), logs))
+
+	assert.Equal(t, "/1/markers/billing", gotPath)
+}
+
+// TestExportMarkers_UseServiceNameMissingFallsBackToSlug verifies the fallback when
+// the flag is on but the resource is missing service.name: the marker still goes to
+// the configured DatasetSlug rather than silently dropping or sending to /__all__.
+func TestExportMarkers_UseServiceNameMissingFallsBackToSlug(t *testing.T) {
+	cfg := Config{
+		APIKey: "test-apikey",
+		Markers: []Marker{
+			{
+				Type:                        "test-type",
+				DatasetSlug:                 "fallback-dataset",
+				UseServiceNameAsDatasetSlug: true,
+				Rules: Rules{
+					LogConditions: []string{`body == "test"`},
+				},
+			},
+		},
+	}
+
+	var gotPath string
+	markerServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+	defer markerServer.Close()
+
+	cfg.APIURL = markerServer.URL
+
+	f := NewFactory()
+	exp, err := f.CreateLogs(t.Context(), exportertest.NewNopSettings(metadata.Type), &cfg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+
+	// No resource attributes — service.name is missing.
+	logs := constructLogs(nil)
+	require.NoError(t, exp.ConsumeLogs(t.Context(), logs))
+
+	assert.Equal(t, "/1/markers/fallback-dataset", gotPath)
 }

--- a/exporter/honeycombmarkerexporter/testdata/config.yaml
+++ b/exporter/honeycombmarkerexporter/testdata/config.yaml
@@ -80,3 +80,13 @@ honeycomb_marker/no_dataset_slug:
         log_conditions:
           - body == "test"
 
+honeycomb_marker/use_service_name:
+  api_key: "test-apikey"
+  api_url: "https://api.testhost.io"
+  markers:
+    - type: "fooType"
+      use_service_name_as_dataset_slug: true
+      rules:
+        log_conditions:
+          - body == "test"
+


### PR DESCRIPTION
#### Description

Adds a `use_service_name_as_dataset_slug: bool` field on `Marker` (default `false`). When enabled, the dataset slug used to create the Honeycomb marker is taken at send-time from the log's resource `service.name` attribute. This lets a single marker rule fan out to per-service datasets without duplicating the marker definition.

```yaml
exporters:
  honeycomb_marker:
    api_key: ${env:HONEYCOMB_API_KEY}
    markers:
      - type: k8s-backoff-events
        use_service_name_as_dataset_slug: true
        rules:
          log_conditions:
            - IsMap(body) and IsMap(body["object"]) and body["object"]["reason"] == "Backoff"
```

#### Implementation notes

- Slug resolution is extracted to an unexported `resolveDatasetSlug(m Marker, serviceName string) string` so the precedence rules are unit-testable in isolation.
- Precedence: resource `service.name` (when flag is on and present) -> configured `DatasetSlug` -> default `__all__`. The flag never silently sends to `__all__` when `service.name` is missing if `dataset_slug` is set.
- `service.name` is read once per `ResourceLogs` iteration in `exportMarkers` and passed as a string to `sendMarker`, rather than threading the full `pcommon.Resource`. Keeps `sendMarker` decoupled from pdata and the test fixtures simple.
- Field default is the zero value (`false`), so existing configs are unchanged.

#### Link to tracking issue

Fixes #29407

#### Testing

- `go test -race ./...` passes (existing tests + 3 new):
  - `TestResolveDatasetSlug` — table-driven on the helper covering all 6 precedence paths.
  - `TestExportMarkers_UseServiceNameAsDatasetSlug` — end-to-end with an `httptest` recorder.
  - `TestExportMarkers_UseServiceNameMissingFallsBackToSlug` — flag on but no `service.name`.
- `TestLoadConfig` extended with `honeycomb_marker/use_service_name` block.
- `golangci-lint run` (v2.7.2), `go vet`, `gofmt -l` clean.

#### Documentation

README updated.

#### Backward compatibility

Defaults preserve current behavior bit-for-bit. New field is purely additive.

---

Marked draft because PR #48086 is the requester's first non-draft PR awaiting CODEOWNERS review (welcome-bot first-time-contributor rule). Will move to ready-for-review once that lands.