### PR TITLE
[exporter/elasticsearch] Fix _doc_count always being 1 for Number (sum/gauge) metrics

### DIFF
--- a/.chloggen/elasticsearchexporter_doc-count-aggregation.yaml
+++ b/.chloggen/elasticsearchexporter_doc-count-aggregation.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix _doc_count always being 1 for Number datapoint metrics by reading from elasticsearch.doc_count attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48108]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  To support pre-aggregated data (such as composite spans), this change adds support to read the _doc_count value from the
+  `elasticsearch.doc_count` attribute. This will occur when the datapoint is a sum or gauge and the _doc_count mapping hint is present.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -443,6 +443,16 @@ The index template must define dynamic templates whose names match the values se
 - **OTel**: Each metric is written under the `metrics` object; the bulk action maps full field names (e.g. `metrics.my_metric`) to one of the OTel template names above based on metric type (histogram, summary, gauge, or counter) and value type.
 - **ECS**: Each metric is written as a top-level field `metric.<name>`; the bulk action maps that field name to one of the ECS/APM template names (`histogram_metrics`, `summary_metrics`, or `double_metrics` for gauges and counters).
 
+### Metrics special attributes
+
+The following are transient attributes. They are consumed by the exporter to control document-level Elasticsearch behaviour but are not written to the documents themselves:
+
+- **`elasticsearch.mapping.hints`** (metrics): A list of hints that influence how the metric document is written. Supported values:
+  - `_doc_count` — instructs the exporter to write a [_doc_count](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-doc-count-field.html) field indicating the document represents multiple source events.
+  - `aggregate_metric_double` — instructs the exporter to use the `aggregate_metric_double` dynamic template.
+
+- **`elasticsearch.doc_count`** (metrics, traces): An integer indicating how many source events this datapoint represents. When present alongside the `_doc_count` mapping hint, its value is used to populate `_doc_count` in the Elasticsearch document. For `Histogram` and `ExponentialHistogram` datapoints the built-in count field is used instead.
+
 ## Exporting profiles
 
 Profiles support is currently in development, and should not be used in

--- a/exporter/elasticsearchexporter/internal/datapoints/number.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/number.go
@@ -78,7 +78,10 @@ func (dp Number) DynamicTemplate(metric pmetric.Metric, mode DynamicTemplateMode
 	}
 }
 
-func (Number) DocCount() uint64 {
+func (dp Number) DocCount() uint64 {
+	if v, ok := dp.Attributes().Get("elasticsearch.doc_count"); ok && v.Type() == pcommon.ValueTypeInt && v.Int() > 0 {
+		return uint64(v.Int())
+	}
 	return 1
 }
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -110,6 +110,12 @@ var (
 		string(conventions.DBNamespaceKey):          {to: "span.db.instance"},
 		string(conventions.DBQueryTextKey):          {to: "span.db.statement"},
 		string(conventions.HTTPResponseBodySizeKey): {to: "http.response.encoded_body_size"},
+		"elasticsearch.doc_count":                   {skip: true},
+	}
+
+	datapointAttrsConversionMap = map[string]conversionEntry{
+		"elasticsearch.doc_count":         {skip: true},
+		elasticsearch.MappingHintsAttrKey: {skip: true},
 	}
 
 	// Precomputed protected fields for performance
@@ -477,7 +483,7 @@ func (ecsDataPointsEncoder) encodeMetrics(
 
 	encodeAttributesECSMode(&document, ec.resource.Attributes(), resourceAttrsConversionMap)
 	document.AddTimestamp("@timestamp", dp0.Timestamp())
-	document.AddAttributes("", dp0.Attributes())
+	encodeAttributesECSMode(&document, dp0.Attributes(), datapointAttrsConversionMap)
 	addDataStreamAttributes(&document, "", idx)
 	var docCount uint64
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -317,6 +317,56 @@ func TestEncodeMetricDocCountHint(t *testing.T) {
 			wantDocCountInDoc: true,
 			wantDocCountValue: 1,
 		},
+		{
+			name: "doc count hint with elasticsearch.doc_count attribute",
+			buildDataPoints: func() []datapoints.DataPoint {
+				m := pmetric.NewMetric()
+				m.SetName("sum")
+				dp := m.SetEmptySum().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+				dp.SetIntValue(5)
+
+				hints := dp.Attributes().PutEmptySlice(elasticsearch.MappingHintsAttrKey)
+				hints.AppendEmpty().SetStr(string(elasticsearch.HintDocCount))
+				dp.Attributes().PutInt("elasticsearch.doc_count", 5)
+
+				return []datapoints.DataPoint{datapoints.NewNumber(m, dp)}
+			},
+			wantDocCountInDoc: true,
+			wantDocCountValue: 5,
+		},
+		{
+			name: "doc count hint with elasticsearch.doc_count zero falls back to default",
+			buildDataPoints: func() []datapoints.DataPoint {
+				m := pmetric.NewMetric()
+				m.SetName("sum")
+				dp := m.SetEmptySum().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+				dp.SetIntValue(5)
+
+				hints := dp.Attributes().PutEmptySlice(elasticsearch.MappingHintsAttrKey)
+				hints.AppendEmpty().SetStr(string(elasticsearch.HintDocCount))
+				dp.Attributes().PutInt("elasticsearch.doc_count", 0)
+
+				return []datapoints.DataPoint{datapoints.NewNumber(m, dp)}
+			},
+			wantDocCountInDoc: true,
+			wantDocCountValue: 1,
+		},
+		{
+			name: "elasticsearch.doc_count attribute ignored without hint",
+			buildDataPoints: func() []datapoints.DataPoint {
+				m := pmetric.NewMetric()
+				m.SetName("sum")
+				dp := m.SetEmptySum().DataPoints().AppendEmpty()
+				dp.SetTimestamp(ts)
+				dp.SetIntValue(5)
+				dp.Attributes().PutInt("elasticsearch.doc_count", 5)
+
+				return []datapoints.DataPoint{datapoints.NewNumber(m, dp)}
+			},
+			wantDocCountInDoc: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add support for reading _doc_count from the elasticsearch.doc_count attribute on sum and gauge datapoints when the _doc_count mapping hint is present. This allows pre-aggregated data such as composite spans to correctly reflect their source event count in Elasticsearch. The elasticsearch.doc_count attribute is not written to the indexed document

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48108

<!--Describe what testing was performed and which tests were added.-->
#### Testing

#### Unit test 
I added coverage for the new use cases

#### Testing with collector config

a) run elasticsearch e.g. docker image

```
  docker run --name es01 -p 9200:9200 -it -m 1GB \
    docker.elastic.co/elasticsearch/elasticsearch:9.3.4
```

b) To make the test easy we are going to use user:password auth. To do that I needed to reset the password to get the new one

```
docker exec -it es01 /usr/share/elasticsearch/bin/elasticsearch-reset-password -u elastic
```
Copy your password from the output

c) Setup the collector config
```
  receivers:
    otlp:
      protocols:
        grpc:
          endpoint: 0.0.0.0:4317 # using grpc out of convienience to use telemetrygen

  processors:
    transform/doc_count:
      metric_statements:
        - context: datapoint
          statements:
            - set(attributes["elasticsearch.mapping.hints"], ["_doc_count"]) # manuall setting the hint and the new doc count attribute
            - set(attributes["elasticsearch.doc_count"], 5)
  
  exporters:
    elasticsearch:
      endpoint: https://localhost:9200
      user: elastic
      password:<password>
      tls:
        insecure_skip_verify: true
      mapping:
        mode: ecs
  
  service:
    pipelines:
      metrics:
        receivers: [otlp]
        processors: [transform/doc_count]
        exporters: [elasticsearch]
```

d) send some metrics

```
telemetrygen metrics --otlp-insecure --metric-type Sum --duration 1s
```

e) search for the document and check the `_doc_count` attribute

```
curl -k -u elastic:<password>\
    "https://localhost:9200/metrics-*/_search?size=1&sort=@timestamp:desc" \
    | jq '.[].hits.hits[0]._source._doc_count'
```

you should see `5` since we setting manually in the config 

4. Testing with elasticapmconnector / elasticapmprocessor

In our production this will be used with the following two PRs to process and set the `elasticsearch.doc_count` and hint:

https://github.com/elastic/opentelemetry-collector-components/pull/1197
https://github.com/elastic/opentelemetry-collector-components/pull/1198

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
