### PR TITLE
[connector/failover] add failover mode abstraction

### DIFF
--- a/.chloggen/failoverconnector-multiple-mode.yaml
+++ b/.chloggen/failoverconnector-multiple-mode.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/failover
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Refactors failoverconnector to create failover mode interface.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42657]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/failoverconnector/README.md
+++ b/connector/failoverconnector/README.md
@@ -33,6 +33,7 @@ If you are not already familiar with connectors, you may find it helpful to firs
 The following settings are available:
 
 - `priority_levels (required)`: list of pipeline level priorities in a 1 - n configuration, multiple pipelines can sit at a single priority level.
+- `failover_mode (optional)`: the failover strategy to use. Currently only `standard` is supported. Default value is `standard`.
 - `retry_interval (optional)`: the frequency at which the pipeline levels will attempt to reestablish connection with all higher priority levels. Default value is 10 minutes. (See Example below for further explanation)
 - `retry_gap (optional)`: * **Deprecated** * the amount of time between trying two separate priority levels in a single retry_interval timeframe. Default value is 30 seconds. (See Example below for further explanation)
 - `max_retries (optional)`: **Deprecated** * the maximum retries per level. Default value is 10. Set to 0 to allow unlimited retries.

--- a/connector/failoverconnector/README.md
+++ b/connector/failoverconnector/README.md
@@ -33,10 +33,9 @@ If you are not already familiar with connectors, you may find it helpful to firs
 The following settings are available:
 
 - `priority_levels (required)`: list of pipeline level priorities in a 1 - n configuration, multiple pipelines can sit at a single priority level.
-- `strategy (optional)`: the failover strategy to use. Currently only `standard` is supported. Default value is `standard`.
-- `standard (optional)`: configuration that applies when `strategy` is `standard`. Fields:
-  - `retry_interval (optional)`: the frequency at which the pipeline levels will attempt to reestablish connection with all higher priority levels. Default value is 10 minutes. (See Example below for further explanation)
-- `retry_interval (optional)`: * **Deprecated** * use `standard.retry_interval` instead. If both are set, `standard.retry_interval` takes precedence.
+- `strategy (optional)`: a block selecting the failover strategy and holding its options. Exactly one variant sub-block may be set; omitting `strategy` is equivalent to selecting `standard` with default options. Currently only `standard` is supported.
+  - `strategy.standard.retry_interval (optional)`: the frequency at which the pipeline levels will attempt to reestablish connection with all higher priority levels. Default value is 10 minutes. (See Example below for further explanation)
+- `retry_interval (optional)`: * **Deprecated** * use `strategy.standard.retry_interval` instead. If both are set, `strategy.standard.retry_interval` takes precedence.
 - `retry_gap (optional)`: * **Deprecated** * the amount of time between trying two separate priority levels in a single retry_interval timeframe. Default value is 30 seconds. (See Example below for further explanation)
 - `max_retries (optional)`: **Deprecated** * the maximum retries per level. Default value is 10. Set to 0 to allow unlimited retries.
 
@@ -54,7 +53,9 @@ connectors:
       - [traces/first, traces/also_first]
       - [traces/second]
       - [traces/third]
-    retry_interval: 10s
+    strategy:
+      standard:
+        retry_interval: 10s
 
 service:
   pipelines:

--- a/connector/failoverconnector/README.md
+++ b/connector/failoverconnector/README.md
@@ -33,8 +33,10 @@ If you are not already familiar with connectors, you may find it helpful to firs
 The following settings are available:
 
 - `priority_levels (required)`: list of pipeline level priorities in a 1 - n configuration, multiple pipelines can sit at a single priority level.
-- `failover_mode (optional)`: the failover strategy to use. Currently only `standard` is supported. Default value is `standard`.
-- `retry_interval (optional)`: the frequency at which the pipeline levels will attempt to reestablish connection with all higher priority levels. Default value is 10 minutes. (See Example below for further explanation)
+- `strategy (optional)`: the failover strategy to use. Currently only `standard` is supported. Default value is `standard`.
+- `standard (optional)`: configuration that applies when `strategy` is `standard`. Fields:
+  - `retry_interval (optional)`: the frequency at which the pipeline levels will attempt to reestablish connection with all higher priority levels. Default value is 10 minutes. (See Example below for further explanation)
+- `retry_interval (optional)`: * **Deprecated** * use `standard.retry_interval` instead. If both are set, `standard.retry_interval` takes precedence.
 - `retry_gap (optional)`: * **Deprecated** * the amount of time between trying two separate priority levels in a single retry_interval timeframe. Default value is 30 seconds. (See Example below for further explanation)
 - `max_retries (optional)`: **Deprecated** * the maximum retries per level. Default value is 10. Set to 0 to allow unlimited retries.
 

--- a/connector/failoverconnector/config.go
+++ b/connector/failoverconnector/config.go
@@ -16,10 +16,14 @@ import (
 var (
 	errNoPipelinePriority    = errors.New("No pipelines are defined in the priority list")
 	errInvalidRetryIntervals = errors.New("Retry interval must be positive")
-	errInvalidFailoverMode   = errors.New("failover mode is invalid")
+	errInvalidStrategy       = errors.New("strategy is invalid")
 )
 
-var validFailoverModes = []FailoverMode{FailoverModeStandard}
+var validStrategies = []Strategy{StrategyStandard}
+
+const defaultRetryInterval = 10 * time.Minute
+
+func durationPtr(d time.Duration) *time.Duration { return &d }
 
 type Config struct {
 	// QueueSettings use the exporterhelper sending_queue to move the queue to the connector to avoid data being stuck
@@ -31,12 +35,15 @@ type Config struct {
 	// level is considered unhealthy
 	PipelinePriority [][]pipeline.ID `mapstructure:"priority_levels"`
 
-	// FailoverMode determines the failover strategy to use. Options: "standard".
-	FailoverMode FailoverMode `mapstructure:"failover_mode"`
+	// Strategy determines the failover strategy to use. Options: "standard".
+	Strategy Strategy `mapstructure:"strategy"`
+
+	// Standard holds configuration that applies when Strategy is "standard".
+	Standard StandardConfig `mapstructure:"standard"`
 
 	// RetryInterval is the frequency at which the pipeline levels will attempt to recover by going over
 	// all levels below the current
-	RetryInterval time.Duration `mapstructure:"retry_interval"`
+	RetryInterval *time.Duration `mapstructure:"retry_interval"` // **Deprecated**
 
 	// RetryGap is how much time will pass between trying two separate priority levels in a single RetryInterval
 	// If the priority list has 3 levels, the RetryInterval is 5m, and the retryGap is 1m, within the 5m RetryInterval,
@@ -50,16 +57,41 @@ type Config struct {
 	_ struct{}
 }
 
+type StandardConfig struct {
+	RetryInterval *time.Duration `mapstructure:"retry_interval"`
+}
+
+// effectiveRetryInterval returns the standard.retry_interval if set, otherwise
+// the deprecated top-level retry_interval, otherwise defaultRetryInterval.
+//
+// TODO(strategy-config): the top-level retry_interval fallback is temporary.
+// When that field is removed in a future release, this resolver collapses to a
+// direct read of c.Standard.RetryInterval (with defaultRetryInterval as the
+// only fallback).
+func (c *Config) effectiveRetryInterval() time.Duration {
+	switch {
+	case c.Standard.RetryInterval != nil:
+		return *c.Standard.RetryInterval
+	case c.RetryInterval != nil:
+		return *c.RetryInterval
+	default:
+		return defaultRetryInterval
+	}
+}
+
 // Validate needs to ensure RetryInterval > # elements in PriorityList * RetryGap
 func (c *Config) Validate() error {
 	if len(c.PipelinePriority) == 0 {
 		return errNoPipelinePriority
 	}
-	if c.RetryInterval <= 0 {
+	if c.RetryInterval != nil && *c.RetryInterval <= 0 {
 		return errInvalidRetryIntervals
 	}
-	if !slices.Contains(validFailoverModes, c.FailoverMode) {
-		return errInvalidFailoverMode
+	if c.Standard.RetryInterval != nil && *c.Standard.RetryInterval <= 0 {
+		return errInvalidRetryIntervals
+	}
+	if !slices.Contains(validStrategies, c.Strategy) {
+		return errInvalidStrategy
 	}
 	return nil
 }

--- a/connector/failoverconnector/config.go
+++ b/connector/failoverconnector/config.go
@@ -5,6 +5,7 @@ package failoverconnector // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"errors"
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -15,7 +16,10 @@ import (
 var (
 	errNoPipelinePriority    = errors.New("No pipelines are defined in the priority list")
 	errInvalidRetryIntervals = errors.New("Retry interval must be positive")
+	errInvalidFailoverMode   = errors.New("failover mode is invalid")
 )
+
+var validFailoverModes = []FailoverMode{FailoverModeStandard}
 
 type Config struct {
 	// QueueSettings use the exporterhelper sending_queue to move the queue to the connector to avoid data being stuck
@@ -26,6 +30,9 @@ type Config struct {
 	// sit at a single priority level and will be routed in a fanout. If any pipeline at a level fails, the
 	// level is considered unhealthy
 	PipelinePriority [][]pipeline.ID `mapstructure:"priority_levels"`
+
+	// FailoverMode determines the failover strategy to use. Options: "standard".
+	FailoverMode FailoverMode `mapstructure:"failover_mode"`
 
 	// RetryInterval is the frequency at which the pipeline levels will attempt to recover by going over
 	// all levels below the current
@@ -50,6 +57,9 @@ func (c *Config) Validate() error {
 	}
 	if c.RetryInterval <= 0 {
 		return errInvalidRetryIntervals
+	}
+	if !slices.Contains(validFailoverModes, c.FailoverMode) {
+		return errInvalidFailoverMode
 	}
 	return nil
 }

--- a/connector/failoverconnector/config.go
+++ b/connector/failoverconnector/config.go
@@ -5,7 +5,6 @@ package failoverconnector // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"errors"
-	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -16,10 +15,7 @@ import (
 var (
 	errNoPipelinePriority    = errors.New("No pipelines are defined in the priority list")
 	errInvalidRetryIntervals = errors.New("Retry interval must be positive")
-	errInvalidStrategy       = errors.New("strategy is invalid")
 )
-
-var validStrategies = []Strategy{StrategyStandard}
 
 const defaultRetryInterval = 10 * time.Minute
 
@@ -35,11 +31,10 @@ type Config struct {
 	// level is considered unhealthy
 	PipelinePriority [][]pipeline.ID `mapstructure:"priority_levels"`
 
-	// Strategy determines the failover strategy to use. Options: "standard".
+	// Strategy selects the failover strategy and holds its options. Exactly one
+	// variant sub-block (e.g. Standard) may be set; the absence of any variant
+	// is equivalent to selecting the standard variant with default options.
 	Strategy Strategy `mapstructure:"strategy"`
-
-	// Standard holds configuration that applies when Strategy is "standard".
-	Standard StandardConfig `mapstructure:"standard"`
 
 	// RetryInterval is the frequency at which the pipeline levels will attempt to recover by going over
 	// all levels below the current
@@ -57,21 +52,29 @@ type Config struct {
 	_ struct{}
 }
 
+// Strategy is a discriminated union of failover-strategy variants. Exactly one
+// of its sub-block fields may be non-nil; the empty value selects the standard
+// variant with default options.
+type Strategy struct {
+	Standard *StandardConfig `mapstructure:"standard"`
+	_        struct{}
+}
+
 type StandardConfig struct {
 	RetryInterval *time.Duration `mapstructure:"retry_interval"`
 }
 
-// effectiveRetryInterval returns the standard.retry_interval if set, otherwise
-// the deprecated top-level retry_interval, otherwise defaultRetryInterval.
+// effectiveRetryInterval returns the strategy.standard.retry_interval if set,
+// otherwise the deprecated top-level retry_interval, otherwise defaultRetryInterval.
 //
 // TODO(strategy-config): the top-level retry_interval fallback is temporary.
 // When that field is removed in a future release, this resolver collapses to a
-// direct read of c.Standard.RetryInterval (with defaultRetryInterval as the
-// only fallback).
+// direct read of c.Strategy.Standard.RetryInterval (with defaultRetryInterval
+// as the only fallback).
 func (c *Config) effectiveRetryInterval() time.Duration {
 	switch {
-	case c.Standard.RetryInterval != nil:
-		return *c.Standard.RetryInterval
+	case c.Strategy.Standard != nil && c.Strategy.Standard.RetryInterval != nil:
+		return *c.Strategy.Standard.RetryInterval
 	case c.RetryInterval != nil:
 		return *c.RetryInterval
 	default:
@@ -87,11 +90,8 @@ func (c *Config) Validate() error {
 	if c.RetryInterval != nil && *c.RetryInterval <= 0 {
 		return errInvalidRetryIntervals
 	}
-	if c.Standard.RetryInterval != nil && *c.Standard.RetryInterval <= 0 {
+	if c.Strategy.Standard != nil && c.Strategy.Standard.RetryInterval != nil && *c.Strategy.Standard.RetryInterval <= 0 {
 		return errInvalidRetryIntervals
-	}
-	if !slices.Contains(validStrategies, c.Strategy) {
-		return errInvalidStrategy
 	}
 	return nil
 }

--- a/connector/failoverconnector/config.schema.yaml
+++ b/connector/failoverconnector/config.schema.yaml
@@ -7,8 +7,12 @@ $defs:
         type: string
         format: duration
   strategy:
-    description: Strategy defines the interface for different failover strategies
-    type: string
+    description: Strategy is a discriminated union of failover-strategy variants. Exactly one of its sub-block fields may be non-nil; the empty value selects the standard variant with default options.
+    type: object
+    properties:
+      standard:
+        x-pointer: true
+        $ref: standard_config
 type: object
 properties:
   max_retries:
@@ -34,9 +38,6 @@ properties:
     description: QueueSettings use the exporterhelper sending_queue to move the queue to the connector to avoid data being stuck in the queue of an unhealthy exporter
     x-optional: true
     $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config
-  standard:
-    description: Standard holds configuration that applies when Strategy is "standard".
-    $ref: standard_config
   strategy:
-    description: 'Strategy determines the failover strategy to use. Options: "standard".'
+    description: Strategy selects the failover strategy and holds its options. Exactly one variant sub-block (e.g. Standard) may be set; the absence of any variant is equivalent to selecting the standard variant with default options.
     $ref: strategy

--- a/connector/failoverconnector/config.schema.yaml
+++ b/connector/failoverconnector/config.schema.yaml
@@ -1,5 +1,12 @@
+$defs:
+  failover_mode:
+    description: FailoverMode defines the interface for different failover strategies
+    type: string
 type: object
 properties:
+  failover_mode:
+    description: 'FailoverMode determines the failover strategy to use. Options: "standard".'
+    $ref: failover_mode
   max_retries:
     description: MaxRetry is the maximum retries per level, once this limit is hit for a level, even if the next pipeline level fails, it will not try to recover the level that exceeded the maximum retries
     type: integer

--- a/connector/failoverconnector/config.schema.yaml
+++ b/connector/failoverconnector/config.schema.yaml
@@ -1,12 +1,16 @@
 $defs:
-  failover_mode:
-    description: FailoverMode defines the interface for different failover strategies
+  standard_config:
+    type: object
+    properties:
+      retry_interval:
+        x-pointer: true
+        type: string
+        format: duration
+  strategy:
+    description: Strategy defines the interface for different failover strategies
     type: string
 type: object
 properties:
-  failover_mode:
-    description: 'FailoverMode determines the failover strategy to use. Options: "standard".'
-    $ref: failover_mode
   max_retries:
     description: MaxRetry is the maximum retries per level, once this limit is hit for a level, even if the next pipeline level fails, it will not try to recover the level that exceeded the maximum retries
     type: integer
@@ -23,9 +27,16 @@ properties:
     format: duration
   retry_interval:
     description: RetryInterval is the frequency at which the pipeline levels will attempt to recover by going over all levels below the current
+    x-pointer: true
     type: string
     format: duration
   sending_queue:
     description: QueueSettings use the exporterhelper sending_queue to move the queue to the connector to avoid data being stuck in the queue of an unhealthy exporter
     x-optional: true
     $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config
+  standard:
+    description: Standard holds configuration that applies when Strategy is "standard".
+    $ref: standard_config
+  strategy:
+    description: 'Strategy determines the failover strategy to use. Options: "standard".'
+    $ref: strategy

--- a/connector/failoverconnector/config_test.go
+++ b/connector/failoverconnector/config_test.go
@@ -34,7 +34,6 @@ func TestLoadConfig(t *testing.T) {
 						pipeline.NewIDWithName(pipeline.SignalTraces, ""),
 					},
 				},
-				Strategy: StrategyStandard,
 			},
 		},
 		{
@@ -56,7 +55,6 @@ func TestLoadConfig(t *testing.T) {
 						pipeline.NewIDWithName(pipeline.SignalTraces, "fourth"),
 					},
 				},
-				Strategy:      StrategyStandard,
 				RetryInterval: durationPtr(5 * time.Minute),
 			},
 		},
@@ -68,8 +66,7 @@ func TestLoadConfig(t *testing.T) {
 					{pipeline.NewIDWithName(pipeline.SignalTraces, "first")},
 					{pipeline.NewIDWithName(pipeline.SignalTraces, "second")},
 				},
-				Strategy: StrategyStandard,
-				Standard: StandardConfig{RetryInterval: durationPtr(5 * time.Minute)},
+				Strategy: Strategy{Standard: &StandardConfig{RetryInterval: durationPtr(5 * time.Minute)}},
 			},
 		},
 	}
@@ -107,11 +104,6 @@ func TestValidateConfig(t *testing.T) {
 			name: "invalid retry_interval",
 			id:   component.NewIDWithName(metadata.Type, "invalid"),
 			err:  errInvalidRetryIntervals,
-		},
-		{
-			name: "invalid strategy",
-			id:   component.NewIDWithName(metadata.Type, "invalid_strategy"),
-			err:  errInvalidStrategy,
 		},
 	}
 

--- a/connector/failoverconnector/config_test.go
+++ b/connector/failoverconnector/config_test.go
@@ -34,8 +34,7 @@ func TestLoadConfig(t *testing.T) {
 						pipeline.NewIDWithName(pipeline.SignalTraces, ""),
 					},
 				},
-				FailoverMode:  FailoverModeStandard,
-				RetryInterval: 10 * time.Minute,
+				Strategy: StrategyStandard,
 			},
 		},
 		{
@@ -57,8 +56,20 @@ func TestLoadConfig(t *testing.T) {
 						pipeline.NewIDWithName(pipeline.SignalTraces, "fourth"),
 					},
 				},
-				FailoverMode:  FailoverModeStandard,
-				RetryInterval: 5 * time.Minute,
+				Strategy:      StrategyStandard,
+				RetryInterval: durationPtr(5 * time.Minute),
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "standard_retry_interval"),
+			expected: &Config{
+				QueueSettings: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+				PipelinePriority: [][]pipeline.ID{
+					{pipeline.NewIDWithName(pipeline.SignalTraces, "first")},
+					{pipeline.NewIDWithName(pipeline.SignalTraces, "second")},
+				},
+				Strategy: StrategyStandard,
+				Standard: StandardConfig{RetryInterval: durationPtr(5 * time.Minute)},
 			},
 		},
 	}
@@ -98,9 +109,9 @@ func TestValidateConfig(t *testing.T) {
 			err:  errInvalidRetryIntervals,
 		},
 		{
-			name: "invalid failover_mode",
-			id:   component.NewIDWithName(metadata.Type, "invalid_mode"),
-			err:  errInvalidFailoverMode,
+			name: "invalid strategy",
+			id:   component.NewIDWithName(metadata.Type, "invalid_strategy"),
+			err:  errInvalidStrategy,
 		},
 	}
 

--- a/connector/failoverconnector/config_test.go
+++ b/connector/failoverconnector/config_test.go
@@ -34,6 +34,7 @@ func TestLoadConfig(t *testing.T) {
 						pipeline.NewIDWithName(pipeline.SignalTraces, ""),
 					},
 				},
+				FailoverMode:  FailoverModeStandard,
 				RetryInterval: 10 * time.Minute,
 			},
 		},
@@ -56,6 +57,7 @@ func TestLoadConfig(t *testing.T) {
 						pipeline.NewIDWithName(pipeline.SignalTraces, "fourth"),
 					},
 				},
+				FailoverMode:  FailoverModeStandard,
 				RetryInterval: 5 * time.Minute,
 			},
 		},
@@ -94,6 +96,11 @@ func TestValidateConfig(t *testing.T) {
 			name: "invalid retry_interval",
 			id:   component.NewIDWithName(metadata.Type, "invalid"),
 			err:  errInvalidRetryIntervals,
+		},
+		{
+			name: "invalid failover_mode",
+			id:   component.NewIDWithName(metadata.Type, "invalid_mode"),
+			err:  errInvalidFailoverMode,
 		},
 	}
 

--- a/connector/failoverconnector/factory.go
+++ b/connector/failoverconnector/factory.go
@@ -29,9 +29,6 @@ func NewFactory() connector.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		QueueSettings: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
-		Strategy:      StrategyStandard,
-		RetryGap:      0,
-		MaxRetries:    0,
 	}
 }
 

--- a/connector/failoverconnector/factory.go
+++ b/connector/failoverconnector/factory.go
@@ -30,6 +30,7 @@ func NewFactory() connector.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		QueueSettings: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+		FailoverMode:  FailoverModeStandard,
 		RetryInterval: 10 * time.Minute,
 		RetryGap:      0,
 		MaxRetries:    0,

--- a/connector/failoverconnector/factory.go
+++ b/connector/failoverconnector/factory.go
@@ -5,7 +5,6 @@ package failoverconnector // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -30,8 +29,7 @@ func NewFactory() connector.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		QueueSettings: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
-		FailoverMode:  FailoverModeStandard,
-		RetryInterval: 10 * time.Minute,
+		Strategy:      StrategyStandard,
 		RetryGap:      0,
 		MaxRetries:    0,
 	}

--- a/connector/failoverconnector/factory_test.go
+++ b/connector/failoverconnector/factory_test.go
@@ -23,7 +23,7 @@ func TestNewFactory(t *testing.T) {
 	traces2 := pipeline.NewIDWithName(pipeline.SignalTraces, "2")
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{traces0, traces1}, {traces2}},
-		RetryInterval:    5 * time.Minute,
+		RetryInterval:    durationPtr(5 * time.Minute),
 	}
 
 	router := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{

--- a/connector/failoverconnector/failover.go
+++ b/connector/failoverconnector/failover.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/pipeline"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector/internal/state"
 )
 
 var (
@@ -21,22 +19,7 @@ type consumerProvider[C any] func(...pipeline.ID) (C, error)
 // baseFailoverRouter provides the common infrastructure for failover routing
 type baseFailoverRouter[C any] struct {
 	cfg       *Config
-	pS        *state.PipelineSelector
 	consumers []C
-
-	errTryLock  *state.TryLock
-	notifyRetry chan struct{}
-	done        chan struct{}
-}
-
-// getCurrentConsumer returns the consumer for the current healthy level
-func (f *baseFailoverRouter[C]) getCurrentConsumer() (C, int) {
-	var nilConsumer C
-	pl := f.pS.CurrentPipeline()
-	if pl >= len(f.cfg.PipelinePriority) {
-		return nilConsumer, pl
-	}
-	return f.consumers[pl], pl
 }
 
 // getConsumerAtIndex returns the consumer at a specific index
@@ -44,28 +27,7 @@ func (f *baseFailoverRouter[C]) getConsumerAtIndex(idx int) C {
 	return f.consumers[idx]
 }
 
-// reportConsumerError ensures only one consumer is reporting an error at a time to avoid multiple failovers
-func (f *baseFailoverRouter[C]) reportConsumerError(idx int) {
-	f.errTryLock.TryExecute(f.pS.HandleError, idx)
-}
-
-func (f *baseFailoverRouter[C]) Shutdown() {
-	select {
-	case <-f.done:
-	default:
-		close(f.done)
-	}
-}
-
 func newBaseFailoverRouter[C any](provider consumerProvider[C], cfg *Config) (*baseFailoverRouter[C], error) {
-	done := make(chan struct{})
-	notifyRetry := make(chan struct{}, 1)
-	pSConstants := state.PSConstants{
-		RetryInterval: cfg.RetryInterval,
-		RetryGap:      cfg.RetryGap,
-		MaxRetries:    cfg.MaxRetries,
-	}
-
 	consumers := make([]C, 0)
 	for _, pipelines := range cfg.PipelinePriority {
 		baseConsumer, err := provider(pipelines...)
@@ -75,28 +37,15 @@ func newBaseFailoverRouter[C any](provider consumerProvider[C], cfg *Config) (*b
 		consumers = append(consumers, baseConsumer)
 	}
 
-	selector := state.NewPipelineSelector(notifyRetry, done, pSConstants)
 	return &baseFailoverRouter[C]{
-		consumers:   consumers,
-		cfg:         cfg,
-		pS:          selector,
-		errTryLock:  state.NewTryLock(),
-		done:        done,
-		notifyRetry: notifyRetry,
+		consumers: consumers,
+		cfg:       cfg,
 	}, nil
 }
 
 // For Testing
 func (f *baseFailoverRouter[C]) ModifyConsumerAtIndex(idx int, c C) {
 	f.consumers[idx] = c
-}
-
-func (f *baseFailoverRouter[C]) TestGetCurrentConsumerIndex() int {
-	return f.pS.CurrentPipeline()
-}
-
-func (f *baseFailoverRouter[C]) TestSetStableConsumerIndex(idx int) {
-	f.pS.TestSetCurrentPipeline(idx)
 }
 
 func (f *baseFailoverRouter[C]) TestGetConsumerAtIndex(idx int) C {

--- a/connector/failoverconnector/failover_test.go
+++ b/connector/failoverconnector/failover_test.go
@@ -43,6 +43,7 @@ func TestFailoverRecovery(t *testing.T) {
 
 	failoverConnector := conn.(*tracesFailover)
 	tRouter := failoverConnector.failover
+	strategy := tRouter.strategy.(*standardTracesStrategy)
 
 	tr := sampleTrace()
 
@@ -54,13 +55,13 @@ func TestFailoverRecovery(t *testing.T) {
 		defer func() {
 			resetConsumers(tRouter, &sinkFirst, &sinkSecond, &sinkThird, &sinkFourth)
 		}()
-		failoverConnector.failover.ModifyConsumerAtIndex(0, consumertest.NewErr(errTracesConsumer))
 
+		tRouter.ModifyConsumerAtIndex(0, consumertest.NewErr(errTracesConsumer))
 		require.NoError(t, conn.ConsumeTraces(t.Context(), tr))
-		idx := failoverConnector.failover.TestGetCurrentConsumerIndex()
+		idx := strategy.TestGetCurrentConsumerIndex()
 		require.Equal(t, 1, idx)
 
-		failoverConnector.failover.ModifyConsumerAtIndex(0, &sinkFirst)
+		tRouter.ModifyConsumerAtIndex(0, &sinkFirst)
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 0, tr)
@@ -71,21 +72,22 @@ func TestFailoverRecovery(t *testing.T) {
 		defer func() {
 			resetConsumers(tRouter, &sinkFirst, &sinkSecond, &sinkThird, &sinkFourth)
 		}()
-		failoverConnector.failover.ModifyConsumerAtIndex(0, consumertest.NewErr(errTracesConsumer))
-		failoverConnector.failover.ModifyConsumerAtIndex(1, consumertest.NewErr(errTracesConsumer))
+
+		tRouter.ModifyConsumerAtIndex(0, consumertest.NewErr(errTracesConsumer))
+		tRouter.ModifyConsumerAtIndex(1, consumertest.NewErr(errTracesConsumer))
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 2, tr)
 		}, 3*time.Second, 5*time.Millisecond)
 
 		// Simulate recovery of exporter
-		failoverConnector.failover.ModifyConsumerAtIndex(1, &sinkSecond)
+		tRouter.ModifyConsumerAtIndex(1, &sinkSecond)
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 1, tr)
 		}, 3*time.Second, 5*time.Millisecond)
 
-		failoverConnector.failover.ModifyConsumerAtIndex(0, &sinkFirst)
+		tRouter.ModifyConsumerAtIndex(0, &sinkFirst)
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 0, tr)
@@ -96,34 +98,35 @@ func TestFailoverRecovery(t *testing.T) {
 		defer func() {
 			resetConsumers(tRouter, &sinkFirst, &sinkSecond, &sinkThird, &sinkFourth)
 		}()
-		failoverConnector.failover.ModifyConsumerAtIndex(0, consumertest.NewErr(errTracesConsumer))
-		failoverConnector.failover.ModifyConsumerAtIndex(1, consumertest.NewErr(errTracesConsumer))
+
+		tRouter.ModifyConsumerAtIndex(0, consumertest.NewErr(errTracesConsumer))
+		tRouter.ModifyConsumerAtIndex(1, consumertest.NewErr(errTracesConsumer))
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 2, tr)
 		}, 3*time.Second, 5*time.Millisecond)
 
 		// Simulate recovery of exporter
-		failoverConnector.failover.ModifyConsumerAtIndex(1, &sinkSecond)
+		tRouter.ModifyConsumerAtIndex(1, &sinkSecond)
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 1, tr)
 		}, 3*time.Second, 5*time.Millisecond)
 
-		failoverConnector.failover.ModifyConsumerAtIndex(2, consumertest.NewErr(errTracesConsumer))
-		failoverConnector.failover.ModifyConsumerAtIndex(1, consumertest.NewErr(errTracesConsumer))
+		tRouter.ModifyConsumerAtIndex(2, consumertest.NewErr(errTracesConsumer))
+		tRouter.ModifyConsumerAtIndex(1, consumertest.NewErr(errTracesConsumer))
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 3, tr)
 		}, 3*time.Second, 5*time.Millisecond)
 
-		failoverConnector.failover.ModifyConsumerAtIndex(2, &sinkThird)
+		tRouter.ModifyConsumerAtIndex(2, &sinkThird)
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 2, tr)
 		}, 3*time.Second, 5*time.Millisecond)
 
-		failoverConnector.failover.ModifyConsumerAtIndex(0, &sinkThird)
+		tRouter.ModifyConsumerAtIndex(0, &sinkThird)
 
 		require.Eventually(t, func() bool {
 			return consumeTracesAndCheckStable(tRouter, 0, tr)
@@ -135,5 +138,6 @@ func resetConsumers(router *tracesRouter, consumers ...consumer.Traces) {
 	for i, sink := range consumers {
 		router.ModifyConsumerAtIndex(i, sink)
 	}
-	router.TestSetStableConsumerIndex(0)
+	strategy := router.strategy.(*standardTracesStrategy)
+	strategy.TestSetStableConsumerIndex(0)
 }

--- a/connector/failoverconnector/failover_test.go
+++ b/connector/failoverconnector/failover_test.go
@@ -26,7 +26,7 @@ func TestFailoverRecovery(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{tracesFirst}, {tracesSecond}, {tracesThird}, {tracesFourth}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{

--- a/connector/failoverconnector/logs.go
+++ b/connector/failoverconnector/logs.go
@@ -15,6 +15,7 @@ import (
 
 type logsRouter struct {
 	*baseFailoverRouter[consumer.Logs]
+	strategy LogsFailoverStrategy
 }
 
 func newLogsRouter(provider consumerProvider[consumer.Logs], cfg *Config) (*logsRouter, error) {
@@ -22,51 +23,20 @@ func newLogsRouter(provider consumerProvider[consumer.Logs], cfg *Config) (*logs
 	if err != nil {
 		return nil, err
 	}
-	return &logsRouter{baseFailoverRouter: failover}, nil
+
+	// Create the appropriate strategy based on the failover mode
+	factory := getFailoverStrategyFactory(cfg.FailoverMode)
+	strategy := factory.CreateLogsStrategy(failover)
+
+	return &logsRouter{
+		baseFailoverRouter: failover,
+		strategy:           strategy,
+	}, nil
 }
 
 // Consume is the logs-specific consumption method
 func (f *logsRouter) Consume(ctx context.Context, ld plog.Logs) error {
-	select {
-	case <-f.notifyRetry:
-		if !f.sampleRetryConsumers(ctx, ld) {
-			return f.consumeByHealthyPipeline(ctx, ld)
-		}
-		return nil
-	default:
-		return f.consumeByHealthyPipeline(ctx, ld)
-	}
-}
-
-// consumeByHealthyPipeline will consume the logs by the current healthy level
-func (f *logsRouter) consumeByHealthyPipeline(ctx context.Context, ld plog.Logs) error {
-	for {
-		tc, idx := f.getCurrentConsumer()
-		if idx >= len(f.cfg.PipelinePriority) {
-			return errNoValidPipeline
-		}
-
-		if err := tc.ConsumeLogs(ctx, ld); err != nil {
-			f.reportConsumerError(idx)
-			continue
-		}
-
-		return nil
-	}
-}
-
-// sampleRetryConsumers iterates through all unhealthy consumers to re-establish a healthy connection
-func (f *logsRouter) sampleRetryConsumers(ctx context.Context, ld plog.Logs) bool {
-	stableIndex := f.pS.CurrentPipeline()
-	for i := range stableIndex {
-		consumer := f.getConsumerAtIndex(i)
-		err := consumer.ConsumeLogs(ctx, ld)
-		if err == nil {
-			f.pS.ResetHealthyPipeline(i)
-			return true
-		}
-	}
-	return false
+	return f.strategy.ConsumeLogs(ctx, ld)
 }
 
 type logsFailover struct {
@@ -88,8 +58,8 @@ func (f *logsFailover) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 }
 
 func (f *logsFailover) Shutdown(context.Context) error {
-	if f.failover != nil {
-		f.failover.Shutdown()
+	if f.failover != nil && f.failover.strategy != nil {
+		f.failover.strategy.Shutdown()
 	}
 	return nil
 }

--- a/connector/failoverconnector/logs.go
+++ b/connector/failoverconnector/logs.go
@@ -15,7 +15,7 @@ import (
 
 type logsRouter struct {
 	*baseFailoverRouter[consumer.Logs]
-	strategy LogsFailoverStrategy
+	strategy logsFailoverStrategy
 }
 
 func newLogsRouter(provider consumerProvider[consumer.Logs], cfg *Config) (*logsRouter, error) {
@@ -25,7 +25,7 @@ func newLogsRouter(provider consumerProvider[consumer.Logs], cfg *Config) (*logs
 	}
 
 	// Create the appropriate strategy based on the failover mode
-	factory := getFailoverStrategyFactory(cfg.FailoverMode)
+	factory := getFailoverStrategyFactory(cfg.Strategy)
 	strategy := factory.CreateLogsStrategy(failover)
 
 	return &logsRouter{

--- a/connector/failoverconnector/logs.go
+++ b/connector/failoverconnector/logs.go
@@ -25,7 +25,7 @@ func newLogsRouter(provider consumerProvider[consumer.Logs], cfg *Config) (*logs
 	}
 
 	// Create the appropriate strategy based on the failover mode
-	factory := getFailoverStrategyFactory(cfg.Strategy)
+	factory := cfg.Strategy.selectFactory()
 	strategy := factory.CreateLogsStrategy(failover)
 
 	return &logsRouter{

--- a/connector/failoverconnector/logs_test.go
+++ b/connector/failoverconnector/logs_test.go
@@ -86,7 +86,10 @@ func TestLogsWithValidFailover(t *testing.T) {
 	require.NoError(t, err)
 
 	failoverConnector := conn.(*logsFailover)
-	failoverConnector.failover.ModifyConsumerAtIndex(0, consumertest.NewErr(errLogsConsumer))
+	lRouter := failoverConnector.failover
+	strategy := lRouter.strategy.(*standardLogsStrategy)
+
+	strategy.router.ModifyConsumerAtIndex(0, consumertest.NewErr(errLogsConsumer))
 	defer func() {
 		assert.NoError(t, failoverConnector.Shutdown(t.Context()))
 	}()
@@ -94,7 +97,7 @@ func TestLogsWithValidFailover(t *testing.T) {
 	ld := sampleLog()
 
 	require.Eventually(t, func() bool {
-		return consumeLogsAndCheckStable(failoverConnector, 1, ld)
+		return consumeLogsAndCheckStable(lRouter, 1, ld)
 	}, 3*time.Second, 5*time.Millisecond)
 }
 
@@ -170,9 +173,10 @@ func TestLogsWithQueue(t *testing.T) {
 	assert.NoError(t, conn.ConsumeLogs(t.Context(), ld))
 }
 
-func consumeLogsAndCheckStable(conn *logsFailover, idx int, lr plog.Logs) bool {
-	_ = conn.ConsumeLogs(context.Background(), lr)
-	stableIndex := conn.failover.pS.CurrentPipeline()
+func consumeLogsAndCheckStable(router *logsRouter, idx int, lr plog.Logs) bool {
+	strategy := router.strategy.(*standardLogsStrategy)
+	_ = router.Consume(context.Background(), lr)
+	stableIndex := strategy.TestGetCurrentConsumerIndex()
 	return stableIndex == idx
 }
 

--- a/connector/failoverconnector/logs_test.go
+++ b/connector/failoverconnector/logs_test.go
@@ -32,7 +32,7 @@ func TestLogsRegisterConsumers(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{logsFirst}, {logsSecond}, {logsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 	}
 
@@ -71,7 +71,7 @@ func TestLogsWithValidFailover(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{logsFirst}, {logsSecond}, {logsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
@@ -109,7 +109,7 @@ func TestLogsWithFailoverError(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{logsFirst}, {logsSecond}, {logsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
@@ -144,7 +144,7 @@ func TestLogsWithQueue(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{logsFirst}, {logsSecond}, {logsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 	}
 

--- a/connector/failoverconnector/metrics.go
+++ b/connector/failoverconnector/metrics.go
@@ -15,6 +15,7 @@ import (
 
 type metricsRouter struct {
 	*baseFailoverRouter[consumer.Metrics]
+	strategy MetricsFailoverStrategy
 }
 
 func newMetricsRouter(provider consumerProvider[consumer.Metrics], cfg *Config) (*metricsRouter, error) {
@@ -22,51 +23,20 @@ func newMetricsRouter(provider consumerProvider[consumer.Metrics], cfg *Config) 
 	if err != nil {
 		return nil, err
 	}
-	return &metricsRouter{baseFailoverRouter: failover}, nil
+
+	// Create the appropriate strategy based on the failover mode
+	factory := getFailoverStrategyFactory(cfg.FailoverMode)
+	strategy := factory.CreateMetricsStrategy(failover)
+
+	return &metricsRouter{
+		baseFailoverRouter: failover,
+		strategy:           strategy,
+	}, nil
 }
 
 // Consume is the metrics-specific consumption method
 func (f *metricsRouter) Consume(ctx context.Context, md pmetric.Metrics) error {
-	select {
-	case <-f.notifyRetry:
-		if !f.sampleRetryConsumers(ctx, md) {
-			return f.consumeByHealthyPipeline(ctx, md)
-		}
-		return nil
-	default:
-		return f.consumeByHealthyPipeline(ctx, md)
-	}
-}
-
-// consumeByHealthyPipeline will consume the metrics by the current healthy level
-func (f *metricsRouter) consumeByHealthyPipeline(ctx context.Context, md pmetric.Metrics) error {
-	for {
-		tc, idx := f.getCurrentConsumer()
-		if idx >= len(f.cfg.PipelinePriority) {
-			return errNoValidPipeline
-		}
-
-		if err := tc.ConsumeMetrics(ctx, md); err != nil {
-			f.reportConsumerError(idx)
-			continue
-		}
-
-		return nil
-	}
-}
-
-// sampleRetryConsumers iterates through all unhealthy consumers to re-establish a healthy connection
-func (f *metricsRouter) sampleRetryConsumers(ctx context.Context, md pmetric.Metrics) bool {
-	stableIndex := f.pS.CurrentPipeline()
-	for i := range stableIndex {
-		consumer := f.getConsumerAtIndex(i)
-		err := consumer.ConsumeMetrics(ctx, md)
-		if err == nil {
-			f.pS.ResetHealthyPipeline(i)
-			return true
-		}
-	}
-	return false
+	return f.strategy.ConsumeMetrics(ctx, md)
 }
 
 type metricsFailover struct {
@@ -88,8 +58,8 @@ func (f *metricsFailover) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 }
 
 func (f *metricsFailover) Shutdown(context.Context) error {
-	if f.failover != nil {
-		f.failover.Shutdown()
+	if f.failover != nil && f.failover.strategy != nil {
+		f.failover.strategy.Shutdown()
 	}
 	return nil
 }

--- a/connector/failoverconnector/metrics.go
+++ b/connector/failoverconnector/metrics.go
@@ -15,7 +15,7 @@ import (
 
 type metricsRouter struct {
 	*baseFailoverRouter[consumer.Metrics]
-	strategy MetricsFailoverStrategy
+	strategy metricsFailoverStrategy
 }
 
 func newMetricsRouter(provider consumerProvider[consumer.Metrics], cfg *Config) (*metricsRouter, error) {
@@ -25,7 +25,7 @@ func newMetricsRouter(provider consumerProvider[consumer.Metrics], cfg *Config) 
 	}
 
 	// Create the appropriate strategy based on the failover mode
-	factory := getFailoverStrategyFactory(cfg.FailoverMode)
+	factory := getFailoverStrategyFactory(cfg.Strategy)
 	strategy := factory.CreateMetricsStrategy(failover)
 
 	return &metricsRouter{

--- a/connector/failoverconnector/metrics.go
+++ b/connector/failoverconnector/metrics.go
@@ -25,7 +25,7 @@ func newMetricsRouter(provider consumerProvider[consumer.Metrics], cfg *Config) 
 	}
 
 	// Create the appropriate strategy based on the failover mode
-	factory := getFailoverStrategyFactory(cfg.Strategy)
+	factory := cfg.Strategy.selectFactory()
 	strategy := factory.CreateMetricsStrategy(failover)
 
 	return &metricsRouter{

--- a/connector/failoverconnector/metrics_test.go
+++ b/connector/failoverconnector/metrics_test.go
@@ -32,7 +32,7 @@ func TestMetricsRegisterConsumers(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{metricsFirst}, {metricsSecond}, {metricsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
@@ -69,7 +69,7 @@ func TestMetricsWithValidFailover(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{metricsFirst}, {metricsSecond}, {metricsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
@@ -106,7 +106,7 @@ func TestMetricsWithFailoverError(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{metricsFirst}, {metricsSecond}, {metricsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
@@ -141,7 +141,7 @@ func TestMetricsWithQueue(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{metricsFirst}, {metricsSecond}, {metricsThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 	}
 

--- a/connector/failoverconnector/metrics_test.go
+++ b/connector/failoverconnector/metrics_test.go
@@ -84,7 +84,9 @@ func TestMetricsWithValidFailover(t *testing.T) {
 	require.NoError(t, err)
 
 	failoverConnector := conn.(*metricsFailover)
-	failoverConnector.failover.ModifyConsumerAtIndex(0, consumertest.NewErr(errMetricsConsumer))
+	mRouter := failoverConnector.failover
+
+	mRouter.ModifyConsumerAtIndex(0, consumertest.NewErr(errMetricsConsumer))
 	defer func() {
 		assert.NoError(t, failoverConnector.Shutdown(t.Context()))
 	}()
@@ -92,7 +94,7 @@ func TestMetricsWithValidFailover(t *testing.T) {
 	md := sampleMetric()
 
 	require.Eventually(t, func() bool {
-		return consumeMetricsAndCheckStable(failoverConnector, 1, md)
+		return consumeMetricsAndCheckStable(mRouter, 1, md)
 	}, 3*time.Second, 5*time.Millisecond)
 }
 
@@ -168,9 +170,10 @@ func TestMetricsWithQueue(t *testing.T) {
 	assert.NoError(t, conn.ConsumeMetrics(t.Context(), md))
 }
 
-func consumeMetricsAndCheckStable(conn *metricsFailover, idx int, mr pmetric.Metrics) bool {
-	_ = conn.ConsumeMetrics(context.Background(), mr)
-	stableIndex := conn.failover.pS.CurrentPipeline()
+func consumeMetricsAndCheckStable(router *metricsRouter, idx int, mr pmetric.Metrics) bool {
+	strategy := router.strategy.(*standardMetricsStrategy)
+	_ = router.Consume(context.Background(), mr)
+	stableIndex := strategy.TestGetCurrentConsumerIndex()
 	return stableIndex == idx
 }
 

--- a/connector/failoverconnector/mode.go
+++ b/connector/failoverconnector/mode.go
@@ -12,44 +12,44 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-// FailoverMode defines the interface for different failover strategies
-type FailoverMode string
+// Strategy defines the interface for different failover strategies
+type Strategy string
 
 const (
-	FailoverModeStandard FailoverMode = "standard"
+	StrategyStandard Strategy = "standard"
 )
 
-// TracesFailoverStrategy defines the interface for traces failover strategies
-type TracesFailoverStrategy interface {
+// tracesFailoverStrategy defines the interface for traces failover strategies
+type tracesFailoverStrategy interface {
 	ConsumeTraces(ctx context.Context, td ptrace.Traces) error
 	Shutdown()
 }
 
-// MetricsFailoverStrategy defines the interface for metrics failover strategies
-type MetricsFailoverStrategy interface {
+// metricsFailoverStrategy defines the interface for metrics failover strategies
+type metricsFailoverStrategy interface {
 	ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error
 	Shutdown()
 }
 
-// LogsFailoverStrategy defines the interface for logs failover strategies
-type LogsFailoverStrategy interface {
+// logsFailoverStrategy defines the interface for logs failover strategies
+type logsFailoverStrategy interface {
 	ConsumeLogs(ctx context.Context, ld plog.Logs) error
 	Shutdown()
 }
 
-// FailoverStrategyFactory creates failover strategies based on mode
-type FailoverStrategyFactory interface {
-	CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) TracesFailoverStrategy
-	CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) MetricsFailoverStrategy
-	CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) LogsFailoverStrategy
+// failoverStrategyFactory creates failover strategies based on mode
+type failoverStrategyFactory interface {
+	CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) tracesFailoverStrategy
+	CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) metricsFailoverStrategy
+	CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) logsFailoverStrategy
 }
 
-// GetFailoverStrategyFactory returns the appropriate factory for the given mode
-func getFailoverStrategyFactory(mode FailoverMode) FailoverStrategyFactory {
-	switch mode {
-	case FailoverModeStandard, "":
+// GetFailoverStrategyFactory returns the appropriate factory for the given strategy
+func getFailoverStrategyFactory(strategy Strategy) failoverStrategyFactory {
+	switch strategy {
+	case StrategyStandard, "":
 		return &standardFailoverFactory{}
 	default:
-		panic("failoverconnector: unrecognized failover mode " + string(mode) + " (Validate should have rejected it)")
+		panic("failoverconnector: unrecognized strategy " + string(strategy) + " (Validate should have rejected it)")
 	}
 }

--- a/connector/failoverconnector/mode.go
+++ b/connector/failoverconnector/mode.go
@@ -12,44 +12,30 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-// Strategy defines the interface for different failover strategies
-type Strategy string
-
-const (
-	StrategyStandard Strategy = "standard"
-)
-
-// tracesFailoverStrategy defines the interface for traces failover strategies
 type tracesFailoverStrategy interface {
 	ConsumeTraces(ctx context.Context, td ptrace.Traces) error
 	Shutdown()
 }
 
-// metricsFailoverStrategy defines the interface for metrics failover strategies
 type metricsFailoverStrategy interface {
 	ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error
 	Shutdown()
 }
 
-// logsFailoverStrategy defines the interface for logs failover strategies
 type logsFailoverStrategy interface {
 	ConsumeLogs(ctx context.Context, ld plog.Logs) error
 	Shutdown()
 }
 
-// failoverStrategyFactory creates failover strategies based on mode
 type failoverStrategyFactory interface {
 	CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) tracesFailoverStrategy
 	CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) metricsFailoverStrategy
 	CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) logsFailoverStrategy
 }
 
-// GetFailoverStrategyFactory returns the appropriate factory for the given strategy
-func getFailoverStrategyFactory(strategy Strategy) failoverStrategyFactory {
-	switch strategy {
-	case StrategyStandard, "":
-		return &standardFailoverFactory{}
-	default:
-		panic("failoverconnector: unrecognized strategy " + string(strategy) + " (Validate should have rejected it)")
-	}
+// selectFactory dispatches on which variant of the discriminated Strategy union
+// is set. The empty Strategy value selects the standard variant with defaults,
+// matching the documented zero-config behavior.
+func (Strategy) selectFactory() failoverStrategyFactory {
+	return &standardFailoverFactory{}
 }

--- a/connector/failoverconnector/mode.go
+++ b/connector/failoverconnector/mode.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package failoverconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// FailoverMode defines the interface for different failover strategies
+type FailoverMode string
+
+const (
+	FailoverModeStandard FailoverMode = "standard"
+)
+
+// TracesFailoverStrategy defines the interface for traces failover strategies
+type TracesFailoverStrategy interface {
+	ConsumeTraces(ctx context.Context, td ptrace.Traces) error
+	Shutdown()
+}
+
+// MetricsFailoverStrategy defines the interface for metrics failover strategies
+type MetricsFailoverStrategy interface {
+	ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error
+	Shutdown()
+}
+
+// LogsFailoverStrategy defines the interface for logs failover strategies
+type LogsFailoverStrategy interface {
+	ConsumeLogs(ctx context.Context, ld plog.Logs) error
+	Shutdown()
+}
+
+// FailoverStrategyFactory creates failover strategies based on mode
+type FailoverStrategyFactory interface {
+	CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) TracesFailoverStrategy
+	CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) MetricsFailoverStrategy
+	CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) LogsFailoverStrategy
+}
+
+// GetFailoverStrategyFactory returns the appropriate factory for the given mode
+func getFailoverStrategyFactory(mode FailoverMode) FailoverStrategyFactory {
+	switch mode {
+	case FailoverModeStandard, "":
+		return &standardFailoverFactory{}
+	default:
+		panic("failoverconnector: unrecognized failover mode " + string(mode) + " (Validate should have rejected it)")
+	}
+}

--- a/connector/failoverconnector/mode_test.go
+++ b/connector/failoverconnector/mode_test.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package failoverconnector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/connector/connectortest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pipeline"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector/internal/metadata"
+)
+
+func TestFailoverModes(t *testing.T) {
+	modes := []struct {
+		name string
+		mode FailoverMode
+	}{
+		{name: "standard_mode", mode: FailoverModeStandard},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			t.Run("traces", func(t *testing.T) { runTracesFailoverModeTest(t, m.mode) })
+			t.Run("metrics", func(t *testing.T) { runMetricsFailoverModeTest(t, m.mode) })
+			t.Run("logs", func(t *testing.T) { runLogsFailoverModeTest(t, m.mode) })
+		})
+	}
+}
+
+func runTracesFailoverModeTest(t *testing.T, mode FailoverMode) {
+	t.Helper()
+
+	var sinkFirst, sinkSecond consumertest.TracesSink
+	first := pipeline.NewIDWithName(pipeline.SignalTraces, "first")
+	second := pipeline.NewIDWithName(pipeline.SignalTraces, "second")
+
+	cfg := &Config{
+		PipelinePriority: [][]pipeline.ID{{first}, {second}},
+		FailoverMode:     mode,
+		RetryInterval:    50 * time.Millisecond,
+	}
+
+	router := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{
+		first:  &sinkFirst,
+		second: &sinkSecond,
+	})
+
+	conn, err := NewFactory().CreateTracesToTraces(t.Context(),
+		connectortest.NewNopSettings(metadata.Type), cfg, router.(consumer.Traces))
+	require.NoError(t, err)
+	defer shutdown(t, conn)
+
+	tr := sampleTrace()
+	require.NoError(t, conn.ConsumeTraces(t.Context(), tr))
+	assert.Len(t, sinkFirst.AllTraces(), 1)
+	assert.Empty(t, sinkSecond.AllTraces())
+
+	sinkFirst.Reset()
+	sinkSecond.Reset()
+
+	conn.(*tracesFailover).failover.ModifyConsumerAtIndex(0, consumertest.NewErr(assert.AnError))
+	require.NoError(t, conn.ConsumeTraces(t.Context(), tr))
+	assert.Empty(t, sinkFirst.AllTraces())
+	assert.Len(t, sinkSecond.AllTraces(), 1)
+}
+
+func runMetricsFailoverModeTest(t *testing.T, mode FailoverMode) {
+	t.Helper()
+
+	var sinkFirst, sinkSecond consumertest.MetricsSink
+	first := pipeline.NewIDWithName(pipeline.SignalMetrics, "first")
+	second := pipeline.NewIDWithName(pipeline.SignalMetrics, "second")
+
+	cfg := &Config{
+		PipelinePriority: [][]pipeline.ID{{first}, {second}},
+		FailoverMode:     mode,
+		RetryInterval:    50 * time.Millisecond,
+	}
+
+	router := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
+		first:  &sinkFirst,
+		second: &sinkSecond,
+	})
+
+	conn, err := NewFactory().CreateMetricsToMetrics(t.Context(),
+		connectortest.NewNopSettings(metadata.Type), cfg, router.(consumer.Metrics))
+	require.NoError(t, err)
+	defer shutdown(t, conn)
+
+	md := sampleMetric()
+	require.NoError(t, conn.ConsumeMetrics(t.Context(), md))
+	assert.Len(t, sinkFirst.AllMetrics(), 1)
+	assert.Empty(t, sinkSecond.AllMetrics())
+
+	sinkFirst.Reset()
+	sinkSecond.Reset()
+
+	conn.(*metricsFailover).failover.ModifyConsumerAtIndex(0, consumertest.NewErr(assert.AnError))
+	require.NoError(t, conn.ConsumeMetrics(t.Context(), md))
+	assert.Empty(t, sinkFirst.AllMetrics())
+	assert.Len(t, sinkSecond.AllMetrics(), 1)
+}
+
+func runLogsFailoverModeTest(t *testing.T, mode FailoverMode) {
+	t.Helper()
+
+	var sinkFirst, sinkSecond consumertest.LogsSink
+	first := pipeline.NewIDWithName(pipeline.SignalLogs, "first")
+	second := pipeline.NewIDWithName(pipeline.SignalLogs, "second")
+
+	cfg := &Config{
+		PipelinePriority: [][]pipeline.ID{{first}, {second}},
+		FailoverMode:     mode,
+		RetryInterval:    50 * time.Millisecond,
+	}
+
+	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
+		first:  &sinkFirst,
+		second: &sinkSecond,
+	})
+
+	conn, err := NewFactory().CreateLogsToLogs(t.Context(),
+		connectortest.NewNopSettings(metadata.Type), cfg, router.(consumer.Logs))
+	require.NoError(t, err)
+	defer shutdown(t, conn)
+
+	ld := sampleLog()
+	require.NoError(t, conn.ConsumeLogs(t.Context(), ld))
+	assert.Len(t, sinkFirst.AllLogs(), 1)
+	assert.Empty(t, sinkSecond.AllLogs())
+
+	sinkFirst.Reset()
+	sinkSecond.Reset()
+
+	conn.(*logsFailover).failover.ModifyConsumerAtIndex(0, consumertest.NewErr(assert.AnError))
+	require.NoError(t, conn.ConsumeLogs(t.Context(), ld))
+	assert.Empty(t, sinkFirst.AllLogs())
+	assert.Len(t, sinkSecond.AllLogs(), 1)
+}
+
+func shutdown(t *testing.T, c component.Component) {
+	t.Helper()
+	assert.NoError(t, c.Shutdown(t.Context()))
+}

--- a/connector/failoverconnector/mode_test.go
+++ b/connector/failoverconnector/mode_test.go
@@ -24,7 +24,8 @@ func TestStrategies(t *testing.T) {
 		name     string
 		strategy Strategy
 	}{
-		{name: "standard", strategy: StrategyStandard},
+		{name: "default", strategy: Strategy{}},
+		{name: "standard", strategy: Strategy{Standard: &StandardConfig{}}},
 	}
 
 	for _, s := range strategies {

--- a/connector/failoverconnector/mode_test.go
+++ b/connector/failoverconnector/mode_test.go
@@ -19,24 +19,24 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector/internal/metadata"
 )
 
-func TestFailoverModes(t *testing.T) {
-	modes := []struct {
-		name string
-		mode FailoverMode
+func TestStrategies(t *testing.T) {
+	strategies := []struct {
+		name     string
+		strategy Strategy
 	}{
-		{name: "standard_mode", mode: FailoverModeStandard},
+		{name: "standard", strategy: StrategyStandard},
 	}
 
-	for _, m := range modes {
-		t.Run(m.name, func(t *testing.T) {
-			t.Run("traces", func(t *testing.T) { runTracesFailoverModeTest(t, m.mode) })
-			t.Run("metrics", func(t *testing.T) { runMetricsFailoverModeTest(t, m.mode) })
-			t.Run("logs", func(t *testing.T) { runLogsFailoverModeTest(t, m.mode) })
+	for _, s := range strategies {
+		t.Run(s.name, func(t *testing.T) {
+			t.Run("traces", func(t *testing.T) { runTracesStrategyTest(t, s.strategy) })
+			t.Run("metrics", func(t *testing.T) { runMetricsStrategyTest(t, s.strategy) })
+			t.Run("logs", func(t *testing.T) { runLogsStrategyTest(t, s.strategy) })
 		})
 	}
 }
 
-func runTracesFailoverModeTest(t *testing.T, mode FailoverMode) {
+func runTracesStrategyTest(t *testing.T, strategy Strategy) {
 	t.Helper()
 
 	var sinkFirst, sinkSecond consumertest.TracesSink
@@ -45,8 +45,8 @@ func runTracesFailoverModeTest(t *testing.T, mode FailoverMode) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{first}, {second}},
-		FailoverMode:     mode,
-		RetryInterval:    50 * time.Millisecond,
+		Strategy:         strategy,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{
@@ -73,7 +73,7 @@ func runTracesFailoverModeTest(t *testing.T, mode FailoverMode) {
 	assert.Len(t, sinkSecond.AllTraces(), 1)
 }
 
-func runMetricsFailoverModeTest(t *testing.T, mode FailoverMode) {
+func runMetricsStrategyTest(t *testing.T, strategy Strategy) {
 	t.Helper()
 
 	var sinkFirst, sinkSecond consumertest.MetricsSink
@@ -82,8 +82,8 @@ func runMetricsFailoverModeTest(t *testing.T, mode FailoverMode) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{first}, {second}},
-		FailoverMode:     mode,
-		RetryInterval:    50 * time.Millisecond,
+		Strategy:         strategy,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
@@ -110,7 +110,7 @@ func runMetricsFailoverModeTest(t *testing.T, mode FailoverMode) {
 	assert.Len(t, sinkSecond.AllMetrics(), 1)
 }
 
-func runLogsFailoverModeTest(t *testing.T, mode FailoverMode) {
+func runLogsStrategyTest(t *testing.T, strategy Strategy) {
 	t.Helper()
 
 	var sinkFirst, sinkSecond consumertest.LogsSink
@@ -119,8 +119,8 @@ func runLogsFailoverModeTest(t *testing.T, mode FailoverMode) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{first}, {second}},
-		FailoverMode:     mode,
-		RetryInterval:    50 * time.Millisecond,
+		Strategy:         strategy,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{

--- a/connector/failoverconnector/standard_mode.go
+++ b/connector/failoverconnector/standard_mode.go
@@ -18,15 +18,15 @@ import (
 // standardFailoverFactory creates standard failover strategies
 type standardFailoverFactory struct{}
 
-func (*standardFailoverFactory) CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) TracesFailoverStrategy {
+func (*standardFailoverFactory) CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) tracesFailoverStrategy {
 	return &standardTracesStrategy{newStandardStrategy(router)}
 }
 
-func (*standardFailoverFactory) CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) MetricsFailoverStrategy {
+func (*standardFailoverFactory) CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) metricsFailoverStrategy {
 	return &standardMetricsStrategy{newStandardStrategy(router)}
 }
 
-func (*standardFailoverFactory) CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) LogsFailoverStrategy {
+func (*standardFailoverFactory) CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) logsFailoverStrategy {
 	return &standardLogsStrategy{newStandardStrategy(router)}
 }
 
@@ -45,7 +45,7 @@ func newStandardStrategy[C any](router *baseFailoverRouter[C]) *standardStrategy
 	done := make(chan struct{})
 	notifyRetry := make(chan struct{}, 1)
 	pSConstants := state.PSConstants{
-		RetryInterval: cfg.RetryInterval,
+		RetryInterval: cfg.effectiveRetryInterval(),
 		RetryGap:      cfg.RetryGap,
 		MaxRetries:    cfg.MaxRetries,
 	}

--- a/connector/failoverconnector/standard_mode.go
+++ b/connector/failoverconnector/standard_mode.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package failoverconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector"
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector/internal/state"
+)
+
+// standardFailoverFactory creates standard failover strategies
+type standardFailoverFactory struct{}
+
+func (*standardFailoverFactory) CreateTracesStrategy(router *baseFailoverRouter[consumer.Traces]) TracesFailoverStrategy {
+	return &standardTracesStrategy{newStandardStrategy(router)}
+}
+
+func (*standardFailoverFactory) CreateMetricsStrategy(router *baseFailoverRouter[consumer.Metrics]) MetricsFailoverStrategy {
+	return &standardMetricsStrategy{newStandardStrategy(router)}
+}
+
+func (*standardFailoverFactory) CreateLogsStrategy(router *baseFailoverRouter[consumer.Logs]) LogsFailoverStrategy {
+	return &standardLogsStrategy{newStandardStrategy(router)}
+}
+
+type standardStrategy[C any] struct {
+	router *baseFailoverRouter[C]
+
+	selector     *state.PipelineSelector
+	errTryLock   *state.TryLock
+	notifyRetry  chan struct{}
+	done         chan struct{}
+	shutdownOnce sync.Once
+}
+
+func newStandardStrategy[C any](router *baseFailoverRouter[C]) *standardStrategy[C] {
+	cfg := router.cfg
+	done := make(chan struct{})
+	notifyRetry := make(chan struct{}, 1)
+	pSConstants := state.PSConstants{
+		RetryInterval: cfg.RetryInterval,
+		RetryGap:      cfg.RetryGap,
+		MaxRetries:    cfg.MaxRetries,
+	}
+	return &standardStrategy[C]{
+		router:      router,
+		done:        done,
+		notifyRetry: notifyRetry,
+		selector:    state.NewPipelineSelector(notifyRetry, done, pSConstants),
+		errTryLock:  state.NewTryLock(),
+	}
+}
+
+// getCurrentConsumer returns the consumer for the current healthy level
+func (s *standardStrategy[C]) getCurrentConsumer() (C, int) {
+	var nilConsumer C
+	pl := s.selector.CurrentPipeline()
+	if pl >= len(s.router.cfg.PipelinePriority) {
+		return nilConsumer, pl
+	}
+	return s.router.consumers[pl], pl
+}
+
+// reportConsumerError ensures only one consumer is reporting an error at a time to avoid multiple failovers
+func (s *standardStrategy[C]) reportConsumerError(idx int) {
+	s.errTryLock.TryExecute(s.selector.HandleError, idx)
+}
+
+func (s *standardStrategy[C]) Shutdown() {
+	s.shutdownOnce.Do(func() { close(s.done) })
+}
+
+// For Testing
+
+func (s *standardStrategy[C]) TestGetCurrentConsumerIndex() int {
+	return s.selector.CurrentPipeline()
+}
+
+func (s *standardStrategy[C]) TestSetStableConsumerIndex(idx int) {
+	s.selector.TestSetCurrentPipeline(idx)
+}
+
+func consume[C, D any](ctx context.Context, s *standardStrategy[C], data D, fn func(C, context.Context, D) error) error {
+	select {
+	case <-s.notifyRetry:
+		if !sampleRetryConsumers(ctx, s, data, fn) {
+			return consumeByHealthyPipeline(ctx, s, data, fn)
+		}
+		return nil
+	default:
+		return consumeByHealthyPipeline(ctx, s, data, fn)
+	}
+}
+
+func consumeByHealthyPipeline[C, D any](ctx context.Context, s *standardStrategy[C], data D, fn func(C, context.Context, D) error) error {
+	for {
+		c, idx := s.getCurrentConsumer()
+		if idx >= len(s.router.cfg.PipelinePriority) {
+			return errNoValidPipeline
+		}
+
+		if err := fn(c, ctx, data); err != nil {
+			s.reportConsumerError(idx)
+			continue
+		}
+
+		return nil
+	}
+}
+
+func sampleRetryConsumers[C, D any](ctx context.Context, s *standardStrategy[C], data D, fn func(C, context.Context, D) error) bool {
+	stableIndex := s.selector.CurrentPipeline()
+	for i := range stableIndex {
+		c := s.router.getConsumerAtIndex(i)
+		if err := fn(c, ctx, data); err == nil {
+			s.selector.ResetHealthyPipeline(i)
+			return true
+		}
+	}
+	return false
+}
+
+type standardTracesStrategy struct {
+	*standardStrategy[consumer.Traces]
+}
+
+func (s *standardTracesStrategy) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	return consume(ctx, s.standardStrategy, td, consumer.Traces.ConsumeTraces)
+}
+
+type standardMetricsStrategy struct {
+	*standardStrategy[consumer.Metrics]
+}
+
+func (s *standardMetricsStrategy) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	return consume(ctx, s.standardStrategy, md, consumer.Metrics.ConsumeMetrics)
+}
+
+type standardLogsStrategy struct {
+	*standardStrategy[consumer.Logs]
+}
+
+func (s *standardLogsStrategy) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	return consume(ctx, s.standardStrategy, ld, consumer.Logs.ConsumeLogs)
+}

--- a/connector/failoverconnector/testdata/config.yaml
+++ b/connector/failoverconnector/testdata/config.yaml
@@ -3,7 +3,6 @@ failover:
 failover/default:
   priority_levels:
     - [traces]
-  strategy: standard
 
 failover/full:
   priority_levels:
@@ -11,16 +10,15 @@ failover/full:
     - [ traces/second ]
     - [ traces/third ]
     - [ traces/fourth ]
-  strategy: standard
   retry_interval: 5m
 
 failover/standard_retry_interval:
   priority_levels:
     - [ traces/first ]
     - [ traces/second ]
-  strategy: standard
-  standard:
-    retry_interval: 5m
+  strategy:
+    standard:
+      retry_interval: 5m
 
 failover/queue:
   priority_levels:
@@ -28,7 +26,6 @@ failover/queue:
     - [ traces/second ]
     - [ traces/third ]
     - [ traces/fourth ]
-  strategy: standard
   sending_queue:
     enabled: true
 
@@ -36,11 +33,4 @@ failover/invalid:
   priority_levels:
     - [ traces/first ]
     - [ traces/second ]
-  strategy: standard
   retry_interval: 0m
-
-failover/invalid_strategy:
-  priority_levels:
-    - [ traces/first ]
-    - [ traces/second ]
-  strategy: bogus

--- a/connector/failoverconnector/testdata/config.yaml
+++ b/connector/failoverconnector/testdata/config.yaml
@@ -3,6 +3,7 @@ failover:
 failover/default:
   priority_levels:
     - [traces]
+  failover_mode: standard
 
 failover/full:
   priority_levels:
@@ -10,6 +11,7 @@ failover/full:
     - [ traces/second ]
     - [ traces/third ]
     - [ traces/fourth ]
+  failover_mode: standard
   retry_interval: 5m
 
 failover/queue:
@@ -18,11 +20,19 @@ failover/queue:
     - [ traces/second ]
     - [ traces/third ]
     - [ traces/fourth ]
+  failover_mode: standard
   sending_queue:
     enabled: true
-    
+
 failover/invalid:
   priority_levels:
     - [ traces/first ]
     - [ traces/second ]
+  failover_mode: standard
   retry_interval: 0m
+
+failover/invalid_mode:
+  priority_levels:
+    - [ traces/first ]
+    - [ traces/second ]
+  failover_mode: bogus

--- a/connector/failoverconnector/testdata/config.yaml
+++ b/connector/failoverconnector/testdata/config.yaml
@@ -3,7 +3,7 @@ failover:
 failover/default:
   priority_levels:
     - [traces]
-  failover_mode: standard
+  strategy: standard
 
 failover/full:
   priority_levels:
@@ -11,8 +11,16 @@ failover/full:
     - [ traces/second ]
     - [ traces/third ]
     - [ traces/fourth ]
-  failover_mode: standard
+  strategy: standard
   retry_interval: 5m
+
+failover/standard_retry_interval:
+  priority_levels:
+    - [ traces/first ]
+    - [ traces/second ]
+  strategy: standard
+  standard:
+    retry_interval: 5m
 
 failover/queue:
   priority_levels:
@@ -20,7 +28,7 @@ failover/queue:
     - [ traces/second ]
     - [ traces/third ]
     - [ traces/fourth ]
-  failover_mode: standard
+  strategy: standard
   sending_queue:
     enabled: true
 
@@ -28,11 +36,11 @@ failover/invalid:
   priority_levels:
     - [ traces/first ]
     - [ traces/second ]
-  failover_mode: standard
+  strategy: standard
   retry_interval: 0m
 
-failover/invalid_mode:
+failover/invalid_strategy:
   priority_levels:
     - [ traces/first ]
     - [ traces/second ]
-  failover_mode: bogus
+  strategy: bogus

--- a/connector/failoverconnector/traces.go
+++ b/connector/failoverconnector/traces.go
@@ -16,6 +16,7 @@ import (
 
 type tracesRouter struct {
 	*baseFailoverRouter[consumer.Traces]
+	strategy TracesFailoverStrategy
 }
 
 func newTracesRouter(provider consumerProvider[consumer.Traces], cfg *Config) (*tracesRouter, error) {
@@ -23,51 +24,20 @@ func newTracesRouter(provider consumerProvider[consumer.Traces], cfg *Config) (*
 	if err != nil {
 		return nil, err
 	}
-	return &tracesRouter{baseFailoverRouter: failover}, nil
+
+	// Create the appropriate strategy based on the failover mode
+	factory := getFailoverStrategyFactory(cfg.FailoverMode)
+	strategy := factory.CreateTracesStrategy(failover)
+
+	return &tracesRouter{
+		baseFailoverRouter: failover,
+		strategy:           strategy,
+	}, nil
 }
 
 // Consume is the traces-specific consumption method
 func (f *tracesRouter) Consume(ctx context.Context, td ptrace.Traces) error {
-	select {
-	case <-f.notifyRetry:
-		if !f.sampleRetryConsumers(ctx, td) {
-			return f.consumeByHealthyPipeline(ctx, td)
-		}
-		return nil
-	default:
-		return f.consumeByHealthyPipeline(ctx, td)
-	}
-}
-
-// consumeByHealthyPipeline will consume the traces by the current healthy level
-func (f *tracesRouter) consumeByHealthyPipeline(ctx context.Context, td ptrace.Traces) error {
-	for {
-		tc, idx := f.getCurrentConsumer()
-		if idx >= len(f.cfg.PipelinePriority) {
-			return errNoValidPipeline
-		}
-
-		if err := tc.ConsumeTraces(ctx, td); err != nil {
-			f.reportConsumerError(idx)
-			continue
-		}
-
-		return nil
-	}
-}
-
-// sampleRetryConsumers iterates through all unhealthy consumers to re-establish a healthy connection
-func (f *tracesRouter) sampleRetryConsumers(ctx context.Context, td ptrace.Traces) bool {
-	stableIndex := f.pS.CurrentPipeline()
-	for i := range stableIndex {
-		consumer := f.getConsumerAtIndex(i)
-		err := consumer.ConsumeTraces(ctx, td)
-		if err == nil {
-			f.pS.ResetHealthyPipeline(i)
-			return true
-		}
-	}
-	return false
+	return f.strategy.ConsumeTraces(ctx, td)
 }
 
 type tracesFailover struct {
@@ -89,8 +59,8 @@ func (f *tracesFailover) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 }
 
 func (f *tracesFailover) Shutdown(context.Context) error {
-	if f.failover != nil {
-		f.failover.Shutdown()
+	if f.failover != nil && f.failover.strategy != nil {
+		f.failover.strategy.Shutdown()
 	}
 	return nil
 }

--- a/connector/failoverconnector/traces.go
+++ b/connector/failoverconnector/traces.go
@@ -26,7 +26,7 @@ func newTracesRouter(provider consumerProvider[consumer.Traces], cfg *Config) (*
 	}
 
 	// Create the appropriate strategy based on the failover mode
-	factory := getFailoverStrategyFactory(cfg.Strategy)
+	factory := cfg.Strategy.selectFactory()
 	strategy := factory.CreateTracesStrategy(failover)
 
 	return &tracesRouter{

--- a/connector/failoverconnector/traces.go
+++ b/connector/failoverconnector/traces.go
@@ -16,7 +16,7 @@ import (
 
 type tracesRouter struct {
 	*baseFailoverRouter[consumer.Traces]
-	strategy TracesFailoverStrategy
+	strategy tracesFailoverStrategy
 }
 
 func newTracesRouter(provider consumerProvider[consumer.Traces], cfg *Config) (*tracesRouter, error) {
@@ -26,7 +26,7 @@ func newTracesRouter(provider consumerProvider[consumer.Traces], cfg *Config) (*
 	}
 
 	// Create the appropriate strategy based on the failover mode
-	factory := getFailoverStrategyFactory(cfg.FailoverMode)
+	factory := getFailoverStrategyFactory(cfg.Strategy)
 	strategy := factory.CreateTracesStrategy(failover)
 
 	return &tracesRouter{

--- a/connector/failoverconnector/traces_test.go
+++ b/connector/failoverconnector/traces_test.go
@@ -174,8 +174,9 @@ func TestTracesWithQueue(t *testing.T) {
 }
 
 func consumeTracesAndCheckStable(router *tracesRouter, idx int, tr ptrace.Traces) bool {
+	strategy := router.strategy.(*standardTracesStrategy)
 	_ = router.Consume(context.Background(), tr)
-	stableIndex := router.pS.CurrentPipeline()
+	stableIndex := strategy.TestGetCurrentConsumerIndex()
 	return stableIndex == idx
 }
 

--- a/connector/failoverconnector/traces_test.go
+++ b/connector/failoverconnector/traces_test.go
@@ -32,7 +32,7 @@ func TestTracesRegisterConsumers(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{tracesFirst}, {tracesSecond}, {tracesThird}},
-		RetryInterval:    25 * time.Millisecond,
+		RetryInterval:    durationPtr(25 * time.Millisecond),
 		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 	}
 
@@ -72,7 +72,7 @@ func TestTracesWithValidFailover(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{tracesFirst}, {tracesSecond}, {tracesThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 	}
 
@@ -109,7 +109,7 @@ func TestTracesWithFailoverError(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{tracesFirst}, {tracesSecond}, {tracesThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 	}
 
 	router := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{
@@ -144,7 +144,7 @@ func TestTracesWithQueue(t *testing.T) {
 
 	cfg := &Config{
 		PipelinePriority: [][]pipeline.ID{{tracesFirst}, {tracesSecond}, {tracesThird}},
-		RetryInterval:    50 * time.Millisecond,
+		RetryInterval:    durationPtr(50 * time.Millisecond),
 		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 	}
 

--- a/connector/failoverconnector/wrapper.go
+++ b/connector/failoverconnector/wrapper.go
@@ -90,7 +90,7 @@ func (w *wrappedTracesConnector) Shutdown(ctx context.Context) error {
 	if shutdowner, ok := w.consumer.(interface{ Shutdown(context.Context) error }); ok {
 		err = shutdowner.Shutdown(ctx)
 	}
-	w.failoverCore.failover.Shutdown()
+	w.failoverCore.failover.strategy.Shutdown()
 	return err
 }
 
@@ -99,7 +99,7 @@ func (w *wrappedMetricsConnector) Shutdown(ctx context.Context) error {
 	if shutdowner, ok := w.consumer.(interface{ Shutdown(context.Context) error }); ok {
 		err = shutdowner.Shutdown(ctx)
 	}
-	w.failoverCore.failover.Shutdown()
+	w.failoverCore.failover.strategy.Shutdown()
 	return err
 }
 
@@ -108,7 +108,7 @@ func (w *wrappedLogsConnector) Shutdown(ctx context.Context) error {
 	if shutdowner, ok := w.consumer.(interface{ Shutdown(context.Context) error }); ok {
 		err = shutdowner.Shutdown(ctx)
 	}
-	w.failoverCore.failover.Shutdown()
+	w.failoverCore.failover.strategy.Shutdown()
 	return err
 }
 


### PR DESCRIPTION
#### Description
                                                                                             
Adds a failover_mode config option and refactors the connector internals into a strategy pattern so
additional failover modes can be plugged in without touching the per-signal routers. This PR establishes the required interfaces and the subsequent modes will be created in the next PRs.
                                                                                                     
                                  
*clean-up item*: Shutdown is now backed by sync.Once. The previous select { case <-done: default: close(done) } pattern could race two concurrent shutdowners into a double-close.                                 
                                                                  
#### Testing
- New TestFailoverModes exercises the standard mode end-to-end across traces, metrics, and logs.   
- TestValidateConfig gets a case for an invalid failover_mode value.
- Existing failover tests still pass; one small adjustment so they use the existing TestGetCurrentConsumerIndex helper instead of reaching into a renamed field.
- go test ./... -race is clean.                                                                    
                                                                                                     
#### Documentation                                                 

Added failover_mode to the settings list in the README