### PR TITLE
[processor/k8sattributesprocessor] Add pod_delete_grace_period configuration option

### DIFF
--- a/.chloggen/add-pod-delete-grace-period.yaml
+++ b/.chloggen/add-pod-delete-grace-period.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: processor/k8s_attributes
+note: Add `pod_delete_grace_period` config option to configure pod metadata cache deletion grace period.
+issues: [48127]
+subtext: The `pod_delete_grace_period` config option defaults to `120s` to match the previously hardcoded behavior.
+change_logs: [user]

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -234,6 +234,12 @@ Because resource state modifications are already pushed immediately via Kubernet
 
 - `watch_sync_period` (`default: 5m`): The resync period for K8s informers. You may set this to `0s` to disable resyncing completely (recommended for large clusters).
 
+## Pod Deletion Grace Period
+
+After receiving a pod deletion event, the processor can keep the pod's metadata in its lookup cache for a short period before eviction. This grace window ensures that delayed spans, metrics, or logs that belong to the deleted pod can still be correctly enriched.
+
+- `pod_delete_grace_period` (`default: 120s`): The grace period to wait before deleting a pod's metadata from the lookup cache after a deletion event.
+
 
 ## Extracting attributes from pod labels and annotations
 
@@ -719,6 +725,10 @@ k8s_attributes:
   # Default: 5m
   watch_sync_period: 5m
   
+  # Grace period to wait before removing deleted pods from the cache.
+  # Default: 120s
+  pod_delete_grace_period: 120s
+  
   # Extract configuration - defines what metadata to extract
   extract:
     # Metadata fields to extract as resource attributes
@@ -891,6 +901,7 @@ k8s_attributes:
 | `wait_for_metadata` | bool | `false` | Block collector startup until metadata is synced |
 | `wait_for_metadata_timeout` | duration | `10s` | Max wait time for metadata sync on startup |
 | `watch_sync_period` | duration | `5m` | Resync period for K8s informers (`0s` disables resync completely) |
+| `pod_delete_grace_period` | duration | `120s` | Grace period to wait before deleting pod metadata from the cache on deletion |
 
 #### Extract Options
 

--- a/processor/k8sattributesprocessor/client_test.go
+++ b/processor/k8sattributesprocessor/client_test.go
@@ -45,7 +45,7 @@ func selectors() (labels.Selector, fields.Selector) {
 }
 
 // newFakeClient instantiates a new FakeClient object and satisfies the ClientProvider type
-func newFakeClient(_ component.TelemetrySettings, _ k8sconfig.APIConfig, rules kube.ExtractionRules, filters kube.Filters, associations []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformersFactoryList, _ bool, _, _ time.Duration) (kube.Client, error) {
+func newFakeClient(_ component.TelemetrySettings, _ k8sconfig.APIConfig, rules kube.ExtractionRules, filters kube.Filters, associations []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformersFactoryList, _ bool, _, _, _ time.Duration) (kube.Client, error) {
 	cs := fake.NewClientset()
 
 	ls, fs := selectors()

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -52,6 +52,9 @@ type Config struct {
 	// Reprocessing the informer cache periodically can cause significant memory churn and CPU spikes.
 	// Setting this to 0 disables resync.
 	WatchSyncPeriod time.Duration `mapstructure:"watch_sync_period"`
+
+	// PodDeleteGracePeriod is the duration to wait before deleting a pod from the cache after receiving a delete event.
+	PodDeleteGracePeriod time.Duration `mapstructure:"pod_delete_grace_period"`
 }
 
 func (cfg *Config) Validate() error {
@@ -61,6 +64,9 @@ func (cfg *Config) Validate() error {
 
 	if cfg.WatchSyncPeriod < 0 {
 		return errors.New("watch_sync_period must be greater than or equal to 0")
+	}
+	if cfg.PodDeleteGracePeriod < 0 {
+		return errors.New("pod_delete_grace_period must be greater than or equal to 0")
 	}
 
 	for _, assoc := range cfg.Association {

--- a/processor/k8sattributesprocessor/config.schema.yaml
+++ b/processor/k8sattributesprocessor/config.schema.yaml
@@ -128,6 +128,10 @@ properties:
     type: array
     items:
       $ref: pod_association_config
+  pod_delete_grace_period:
+    description: PodDeleteGracePeriod is the duration to wait before deleting a pod from the cache after receiving a delete event.
+    type: string
+    format: duration
   wait_for_metadata:
     description: WaitForMetadata is a flag that determines if the processor should wait k8s metadata to be synced when starting.
     type: boolean

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -35,6 +35,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -109,6 +110,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -134,6 +136,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -147,6 +150,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -160,6 +164,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -201,6 +206,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -215,6 +221,7 @@ func TestLoadConfig(t *testing.T) {
 				WaitForMetadata:        true,
 				WaitForMetadataTimeout: 30 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -229,6 +236,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -247,6 +255,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -265,6 +274,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -284,6 +294,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -300,6 +311,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -316,6 +328,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -332,6 +345,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -348,6 +362,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -364,6 +379,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -386,6 +402,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -401,6 +418,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
 		},
 		{
@@ -417,6 +435,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        20 * time.Second,
+				PodDeleteGracePeriod:   30 * time.Second,
 			},
 		},
 		{
@@ -433,7 +452,11 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        0,
+				PodDeleteGracePeriod:   120 * time.Second,
 			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "bad_pod_delete_grace_period"),
 		},
 	}
 

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -52,6 +52,7 @@ func createDefaultConfig() component.Config {
 		},
 		WaitForMetadataTimeout: 10 * time.Second,
 		WatchSyncPeriod:        5 * time.Minute,
+		PodDeleteGracePeriod:   120 * time.Second,
 	}
 }
 
@@ -281,7 +282,8 @@ func createProcessorOpts(cfg component.Config) []option {
 		withExtractPodAssociations(oCfg.Association...),
 		withExcludes(oCfg.Exclude),
 		withWaitForMetadataTimeout(oCfg.WaitForMetadataTimeout),
-		withWatchSyncPeriod(oCfg.WatchSyncPeriod))
+		withWatchSyncPeriod(oCfg.WatchSyncPeriod),
+		withPodDeleteGracePeriod(oCfg.PodDeleteGracePeriod))
 
 	if oCfg.WaitForMetadata {
 		opts = append(opts, withWaitForMetadata(true))

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -54,6 +54,7 @@ type WatchClient struct {
 	waitForMetadata        bool
 	waitForMetadataTimeout time.Duration
 	watchSyncPeriod        time.Duration
+	podDeleteGracePeriod   time.Duration
 
 	// A map containing Pod related data, used to associate them with resources.
 	// Key can be either an IP address or Pod UID
@@ -135,6 +136,7 @@ func New(
 	waitForMetadata bool,
 	waitForMetadataTimeout time.Duration,
 	watchSyncPeriod time.Duration,
+	podDeleteGracePeriod time.Duration,
 ) (Client, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(set)
 	if err != nil {
@@ -153,6 +155,7 @@ func New(
 		waitForMetadata:        waitForMetadata,
 		waitForMetadataTimeout: waitForMetadataTimeout,
 		watchSyncPeriod:        watchSyncPeriod,
+		podDeleteGracePeriod:   podDeleteGracePeriod,
 	}
 
 	c.Pods = map[PodIdentifier]*Pod{}
@@ -272,7 +275,7 @@ func New(
 // Start registers pod event handlers and starts watching the kubernetes cluster for pod changes.
 func (c *WatchClient) Start() error {
 	// Start the delete loop for cleaning up old pods from cache
-	go c.deleteLoop(time.Second*30, defaultPodDeleteGracePeriod)
+	go c.deleteLoop(time.Second*30, c.podDeleteGracePeriod)
 
 	synced := make([]cache.InformerSynced, 0)
 	// start the replicaSet informer first, as the replica sets need to be

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -154,11 +154,11 @@ func nodeAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 }
 
 func TestDefaultClientset(t *testing.T) {
-	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, InformersFactoryList{}, false, 10*time.Second, 0)
+	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, InformersFactoryList{}, false, 10*time.Second, 0, 120*time.Second)
 	require.EqualError(t, err, "invalid authType for kubernetes: ")
 	assert.Nil(t, c)
 
-	c, err = New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, InformersFactoryList{}, false, 10*time.Second, 0)
+	c, err = New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, InformersFactoryList{}, false, 10*time.Second, 0, 120*time.Second)
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
 }
@@ -169,7 +169,7 @@ func TestBadFilters(t *testing.T) {
 		newNamespaceInformer:  NewFakeNamespaceInformer,
 		newReplicaSetInformer: NewFakeReplicaSetInformer,
 	}
-	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{Fields: []FieldFilter{{Op: selection.Exists}}}, []Association{}, Excludes{}, newFakeAPIClientset, factory, false, 10*time.Second, 0)
+	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{Fields: []FieldFilter{{Op: selection.Exists}}}, []Association{}, Excludes{}, newFakeAPIClientset, factory, false, 10*time.Second, 0, 120*time.Second)
 	assert.Error(t, err)
 	assert.Nil(t, c)
 }
@@ -209,7 +209,7 @@ func TestConstructorErrors(t *testing.T) {
 			newInformer:          NewFakeInformer,
 			newNamespaceInformer: NewFakeNamespaceInformer,
 		}
-		c, err := New(componenttest.NewNopTelemetrySettings(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, factory, false, 10*time.Second, 0)
+		c, err := New(componenttest.NewNopTelemetrySettings(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, factory, false, 10*time.Second, 0, 120*time.Second)
 		assert.Nil(t, c)
 		require.EqualError(t, err, "error creating k8s client")
 		assert.Equal(t, apiCfg, gotAPIConfig)
@@ -3645,7 +3645,7 @@ func newTestClientWithRulesAndFilters(t *testing.T, f Filters) (*WatchClient, *o
 		newReplicaSetInformer: NewFakeReplicaSetInformer,
 	}
 
-	c, err := New(set, k8sconfig.APIConfig{}, ExtractionRules{}, f, associations, exclude, newFakeAPIClientset, factory, false, 10*time.Second, 0)
+	c, err := New(set, k8sconfig.APIConfig{}, ExtractionRules{}, f, associations, exclude, newFakeAPIClientset, factory, false, 10*time.Second, 0, 120*time.Second)
 	require.NoError(t, err)
 	return c.(*WatchClient), logs
 }
@@ -3693,7 +3693,7 @@ func TestWaitForMetadata(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, InformersFactoryList{newInformer: tc.informerProvider}, true, 1*time.Second, 0)
+			c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, InformersFactoryList{newInformer: tc.informerProvider}, true, 1*time.Second, 0, 120*time.Second)
 			require.NoError(t, err)
 
 			err = c.Start()
@@ -4306,7 +4306,7 @@ func TestReplicaSetInformerConditionalStart(t *testing.T) {
 				newReplicaSetInformer: newTrackableInformer,
 			}
 
-			c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, tt.rules, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, factory, false, 10*time.Second, 0)
+			c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, tt.rules, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, factory, false, 10*time.Second, 0, 120*time.Second)
 			require.NoError(t, err)
 			wc := c.(*WatchClient)
 
@@ -4711,6 +4711,7 @@ func TestCreateRestConfigFailure(t *testing.T) {
 		false,
 		10*time.Second,
 		0,
+		120*time.Second,
 	)
 
 	// Assert that the client is nil and an error is returned
@@ -4739,6 +4740,7 @@ func TestMetadataNewForConfigFailure(t *testing.T) {
 		false,
 		10*time.Second,
 		0,
+		120*time.Second,
 	)
 	assert.Nil(t, c)
 	assert.Error(t, err)

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -81,9 +81,6 @@ func PodIdentifierAttributeFromResourceAttribute(key, value string) PodIdentifie
 	)
 }
 
-// TODO: move this to config with default values
-var defaultPodDeleteGracePeriod = time.Second * 120
-
 // Client defines the main interface that allows querying pods by metadata.
 type Client interface {
 	GetPod(PodIdentifier) (*Pod, bool)
@@ -98,7 +95,7 @@ type Client interface {
 }
 
 // ClientProvider defines a func type that returns a new Client.
-type ClientProvider func(component.TelemetrySettings, k8sconfig.APIConfig, ExtractionRules, Filters, []Association, Excludes, APIClientsetProvider, InformersFactoryList, bool, time.Duration, time.Duration) (Client, error)
+type ClientProvider func(component.TelemetrySettings, k8sconfig.APIConfig, ExtractionRules, Filters, []Association, Excludes, APIClientsetProvider, InformersFactoryList, bool, time.Duration, time.Duration, time.Duration) (Client, error)
 
 // APIClientsetProvider defines a func type that initializes and return a new kubernetes
 // Clientset object.

--- a/processor/k8sattributesprocessor/internal/kube/partialmetadata_benchmark_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/partialmetadata_benchmark_test.go
@@ -95,7 +95,7 @@ func Benchmark_RS_ResourceSweep_InProcess(b *testing.B) {
 					return k8sconfig.ClientBundle{K8s: fc}, nil
 				}
 
-				c, err := New(set, k8sconfig.APIConfig{}, rules, filters, nil, Excludes{}, newClientSet, factory, false, 0, 0)
+				c, err := New(set, k8sconfig.APIConfig{}, rules, filters, nil, Excludes{}, newClientSet, factory, false, 0, 0, time.Second)
 				if err != nil {
 					b.Fatalf("New: %v", err)
 				}

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -434,3 +434,11 @@ func withWatchSyncPeriod(duration time.Duration) option {
 		return nil
 	}
 }
+
+// withPodDeleteGracePeriod allows specifying the grace period for pod deletion.
+func withPodDeleteGracePeriod(duration time.Duration) option {
+	return func(p *kubernetesprocessor) error {
+		p.podDeleteGracePeriod = duration
+		return nil
+	}
+}

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -47,6 +47,7 @@ type kubernetesprocessor struct {
 	waitForMetadata        bool
 	waitForMetadataTimeout time.Duration
 	watchSyncPeriod        time.Duration
+	podDeleteGracePeriod   time.Duration
 }
 
 func (kp *kubernetesprocessor) initKubeClient(set component.TelemetrySettings, kubeClient kube.ClientProvider) error {
@@ -54,7 +55,7 @@ func (kp *kubernetesprocessor) initKubeClient(set component.TelemetrySettings, k
 		kubeClient = kube.New
 	}
 	if !kp.passthroughMode {
-		kc, err := kubeClient(set, kp.apiConfig, kp.rules, kp.filters, kp.podAssociations, kp.podIgnore, nil, kube.InformersFactoryList{}, kp.waitForMetadata, kp.waitForMetadataTimeout, kp.watchSyncPeriod)
+		kc, err := kubeClient(set, kp.apiConfig, kp.rules, kp.filters, kp.podAssociations, kp.podIgnore, nil, kube.InformersFactoryList{}, kp.waitForMetadata, kp.waitForMetadataTimeout, kp.watchSyncPeriod, kp.podDeleteGracePeriod)
 		if err != nil {
 			return err
 		}

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -290,7 +290,7 @@ func TestNewProcessor(t *testing.T) {
 }
 
 func TestProcessorBadClientProvider(t *testing.T) {
-	clientProvider := func(_ component.TelemetrySettings, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformersFactoryList, _ bool, _, _ time.Duration) (kube.Client, error) {
+	clientProvider := func(_ component.TelemetrySettings, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformersFactoryList, _ bool, _, _, _ time.Duration) (kube.Client, error) {
 		return nil, errors.New("bad client error")
 	}
 

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -285,9 +285,13 @@ k8s_attributes/bad_metadata_field:
 
 k8s_attributes/custom_intervals:
   watch_sync_period: 20s
+  pod_delete_grace_period: 30s
 
 k8s_attributes/bad_watch_sync_period:
   watch_sync_period: -20s
 
 k8s_attributes/disable_watch_sync:
   watch_sync_period: 0s
+
+k8s_attributes/bad_pod_delete_grace_period:
+  pod_delete_grace_period: -30s


### PR DESCRIPTION
### Description

This PR adds the `pod_delete_grace_period` configuration option to the `k8sattributes` processor, making the cache eviction grace window for deleted pods configurable. 

By default, after receiving a pod deletion event, the processor keeps the pod's metadata in its lookup cache for a short duration (`120s`) before eviction. This ensures that delayed spans, metrics, or logs originating from the pod can still be correctly enriched. With this change, users can tune this duration to match their environment's constraints (e.g. reducing memory overhead by lowering the duration, or setting it to `0s` to evict immediately).

> [!IMPORTANT]
> **Stacked PR:** This PR is stacked on top of [**[processor/k8sattributesprocessor] Add watch_sync_period config option**](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48111). Only the changes in the second commit (`Add pod_delete_grace_period config option...`) are new to this PR.

---

### Link to tracking Issue
The issue of configurability (and its longstanding TODO) are brought up in #48110.

---

### Testing & Verification

#### Automated Tests
- Added unit test coverage in [config_test.go](file:///usr/local/google/home/giulianosider/repos/opentelemetry-collector-contrib/processor/k8sattributesprocessor/config_test.go) ensuring custom `pod_delete_grace_period` values (e.g., `30s`) are successfully loaded, parsed, and validated.
- Added unit test coverage verifying that negative durations (e.g., `-30s`) correctly fail configuration validation.
- All tests compiled and passed successfully:
  ```bash
  go test -v ./...
  ```

---

### Documentation

- Added a description of the config in the README.
- Added an entry to the user changelog.