### PR TITLE
[connector/spanmetrics] promote `includeCollectorInstanceID` feature-gate to beta

### DIFF
--- a/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
+++ b/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
@@ -10,7 +10,7 @@ component: "connector/spanmetrics"
 note: "Promote `connector.spanmetrics.includeCollectorInstanceID` feature gate to beta."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [40400]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
+++ b/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
@@ -4,7 +4,7 @@
 change_type: "breaking"
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: "connector/spanmetrics"
+component: "connector/span_metrics"
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Promote `connector.spanmetrics.includeCollectorInstanceID` feature gate to beta."

--- a/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
+++ b/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
@@ -15,7 +15,7 @@ issues: [40400]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: "This feature now in beta stage, user can disable it by feature-gate `--feature-gates=-connector.spanmetrics.includeCollectorInstanceID`"
+subtext: "Adds a `collector.instance.id` attribute to all metrics emitted by the spanmetrics connector."
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
+++ b/.chloggen/spanmetricsconnector-beta-collectorinstanceid.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "breaking"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "connector/spanmetrics"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Promote `connector.spanmetrics.includeCollectorInstanceID` feature gate to beta."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "This feature now in beta stage, user can disable it by feature-gate `--feature-gates=-connector.spanmetrics.includeCollectorInstanceID`"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -68,7 +68,7 @@ across all spans:
 
 The `collector.instance.id` dimension is intended to add a unique UUID to all metrics, ensuring that the spanmetrics connector
 does not violate the **Single Writer Principle** when spanmetrics is used in a multi-deployment model.
-Currently, `collector.instance.id` must be manually enabled via the feature gate: `connector.spanmetrics.includeCollectorInstanceID`.
+Currently, `collector.instance.id` can be manually disabled via the feature gate: `connector.spanmetrics.includeCollectorInstanceID`.
 More detail, please see [Known Limitation: the Single Writer Principle](#known-limitation-the-single-writer-principle)
 
 ## Span to Metrics processor to Span to metrics connector
@@ -289,7 +289,7 @@ connectors:
       - telemetry.sdk.language
       - telemetry.sdk.name
 ```
-* Manually enable the feature gate: `connector.spanmetrics.includeCollectorInstanceID` to produce uniquely identified metrics.
+* The feature gate `connector.spanmetrics.includeCollectorInstanceID` is enabled by default to produce uniquely identified metrics.
 * For exporters like Prometheus, which rely on the single writer assumption, use a dedicated pipeline with a single `spanmetricsconnector` instance
 
 More context is available in [GitHub issue #21101](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21101).

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -68,7 +68,15 @@ across all spans:
 
 The `collector.instance.id` dimension is intended to add a unique UUID to all metrics, ensuring that the spanmetrics connector
 does not violate the **Single Writer Principle** when spanmetrics is used in a multi-deployment model.
-Currently, `collector.instance.id` can be manually disabled via the feature gate: `connector.spanmetrics.includeCollectorInstanceID`.
+To disable, use `exclude_dimensions` setting:
+
+```yaml
+connectors:
+  spanmetrics:
+    exclude_dimensions: ['collector.instance.id']
+```
+
+Or, disable via the feature gate: `--feature-gates=-connector.spanmetrics.includeCollectorInstanceID`.
 More detail, please see [Known Limitation: the Single Writer Principle](#known-limitation-the-single-writer-principle)
 
 ## Span to Metrics processor to Span to metrics connector

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -38,10 +38,10 @@ type Dimension struct {
 type Config struct {
 	// Dimensions defines the list of additional dimensions on top of the provided:
 	// - service.name
-	// - span.kind
+	// - span.name
 	// - span.kind
 	// - status.code
-	// - collector.instance.id This dimensions never added unless enable feature-gate connector.spanmetrics.includeCollectorInstanceID
+	// - collector.instance.id
 	// The dimensions will be fetched from the span's attributes. Examples of some conventionally used attributes:
 	// https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go.
 	Dimensions        []Dimension `mapstructure:"dimensions"`

--- a/connector/spanmetricsconnector/config.schema.yaml
+++ b/connector/spanmetricsconnector/config.schema.yaml
@@ -73,7 +73,7 @@ properties:
     items:
       $ref: dimension
   dimensions:
-    description: 'Dimensions defines the list of additional dimensions on top of the provided: - service.name - span.kind - span.kind - status.code - collector.instance.id This dimensions never added unless enable feature-gate connector.spanmetrics.includeCollectorInstanceID The dimensions will be fetched from the span''s attributes. Examples of some conventionally used attributes: https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go.'
+    description: 'Dimensions defines the list of additional dimensions on top of the provided: - service.name - span.name - span.kind - status.code - collector.instance.id The dimensions will be fetched from the span''s attributes. Examples of some conventionally used attributes: https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go.'
     type: array
     items:
       $ref: dimension

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -56,11 +56,12 @@ const (
 
 // metricID represents the minimum attributes that uniquely identifies a metric in our tests.
 type metricID struct {
-	service        string
-	name           string
-	kind           string
-	statusCode     string
-	otelStatusCode string
+	service             string
+	name                string
+	kind                string
+	statusCode          string
+	collectorInstanceID string
+	otelStatusCode      string
 }
 
 type metricDataPoint interface {
@@ -373,6 +374,8 @@ func verifyMetricLabels(tb testing.TB, dp metricDataPoint, seenMetricIDs map[met
 			mID.kind = v.Str()
 		case statusCodeKey:
 			mID.statusCode = v.Str()
+		case collectorInstanceKey:
+			mID.collectorInstanceID = v.Str()
 		case otelStatusCodeKey:
 			mID.otelStatusCode = v.Str()
 		case metricAttrSamplingMethod:
@@ -2184,6 +2187,7 @@ func TestBuildAttributes_InstrumentationScope(t *testing.T) {
 				statusCodeKey:                  "STATUS_CODE_UNSET",
 				instrumentationScopeNameKey:    "express",
 				instrumentationScopeVersionKey: "1.0.0",
+				collectorInstanceKey:           instanceID,
 			},
 		},
 		{
@@ -2196,10 +2200,11 @@ func TestBuildAttributes_InstrumentationScope(t *testing.T) {
 			}(),
 			config: Config{EnableMetricsSamplingMethod: true},
 			want: map[string]string{
-				serviceNameKey: "test_service",
-				spanNameKey:    "test_span",
-				spanKindKey:    "SPAN_KIND_INTERNAL",
-				statusCodeKey:  "STATUS_CODE_UNSET",
+				serviceNameKey:       "test_service",
+				spanNameKey:          "test_span",
+				spanKindKey:          "SPAN_KIND_INTERNAL",
+				statusCodeKey:        "STATUS_CODE_UNSET",
+				collectorInstanceKey: instanceID,
 			},
 		},
 		{
@@ -2214,10 +2219,11 @@ func TestBuildAttributes_InstrumentationScope(t *testing.T) {
 				EnableMetricsSamplingMethod: true,
 			},
 			want: map[string]string{
-				serviceNameKey: "test_service",
-				spanNameKey:    "test_span",
-				spanKindKey:    "SPAN_KIND_INTERNAL",
-				statusCodeKey:  "STATUS_CODE_UNSET",
+				serviceNameKey:       "test_service",
+				spanNameKey:          "test_span",
+				spanKindKey:          "SPAN_KIND_INTERNAL",
+				statusCodeKey:        "STATUS_CODE_UNSET",
+				collectorInstanceKey: instanceID,
 			},
 		},
 
@@ -2238,13 +2244,14 @@ func TestBuildAttributes_InstrumentationScope(t *testing.T) {
 				spanKindKey:                 "SPAN_KIND_INTERNAL",
 				statusCodeKey:               "STATUS_CODE_UNSET",
 				instrumentationScopeNameKey: "express",
+				collectorInstanceKey:        instanceID,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &connectorImp{config: tt.config}
+			p := &connectorImp{config: tt.config, instanceID: instanceID}
 
 			span := ptrace.NewSpan()
 			span.SetName("test_span")
@@ -2524,6 +2531,7 @@ func TestBuildAttributesWithFeatureGate(t *testing.T) {
 				instrumentationScopeNameKey:    "express",
 				instrumentationScopeVersionKey: "1.0.0",
 			},
+			includeCollectorInstanceID: false,
 		},
 		{
 			name: "enable includeCollectorInstanceID feature-gate",
@@ -2553,11 +2561,11 @@ func TestBuildAttributesWithFeatureGate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &connectorImp{config: tt.config, instanceID: instanceID}
-			if tt.includeCollectorInstanceID {
-				require.NoError(t, featuregate.GlobalRegistry().Set(includeCollectorInstanceID.ID(), true))
+			if !tt.includeCollectorInstanceID {
+				require.NoError(t, featuregate.GlobalRegistry().Set(includeCollectorInstanceID.ID(), false))
 			}
 			defer func() {
-				require.NoError(t, featuregate.GlobalRegistry().Set(includeCollectorInstanceID.ID(), false))
+				require.NoError(t, featuregate.GlobalRegistry().Set(includeCollectorInstanceID.ID(), true))
 			}()
 
 			span := ptrace.NewSpan()

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -48,7 +48,7 @@ func init() {
 	)
 	includeCollectorInstanceID = featuregate.GlobalRegistry().MustRegister(
 		includeCollectorInstanceIDFeatureGateID,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, connector add collector.instance.id to default dimensions."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40400"),
 	)


### PR DESCRIPTION
#### Description
Feature-flag `includeCollectorInstanceID` is promoted from alpha to beta and enabled by default. This feature was added in v0.136.0, so it should be fine to move forward with it.

#### Link to tracking issue
Related to #40400 

#### Testing

Tests are updated to reflect new default dimension.

#### Documentation

Component docs are updated with info on the new default behavior.
