### PR TITLE
[chore] Document not to use Co-authored-by for AI disclosure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,8 @@ Examples:
 Assisted-by: ChatGPT 5.2
 Assisted-by: Claude Opus 4.5
 ```
+
+Do NOT use a `Co-authored-by:` trailer to disclose AI assistance. Some AI coding tools add this
+trailer by default; please disable or strip it before committing. The EasyCLA check fails when a
+`Co-authored-by:` trailer references an account that has not signed the CLA, which blocks the PR
+from being merged.


### PR DESCRIPTION
#### Description

Some AI coding tools (notably Claude Code) inject a `Co-authored-by:` trailer into commit messages by default. When that trailer references an account that has not signed the CLA, EasyCLA fails and blocks the PR from being merged. Make the existing `Assisted-by:` guidance in `AGENTS.md` explicit about this so contributors know to disable or strip the `Co-authored-by:` trailer before committing.