### PR TITLE
[receiver/ntp] Enable dynamic metric reaggregation

### DIFF
--- a/.chloggen/ntpreceiver-reaggregation.yaml
+++ b/.chloggen/ntpreceiver-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/ntp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable scraper reaggregation for the NTP receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46370]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/ntpreceiver/internal/metadata/generated_config.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_config.go
@@ -7,13 +7,13 @@ import (
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// NtpOffsetMetricConfig provides config for the ntp.offset metric.
+type NtpOffsetMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *NtpOffsetMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,12 +29,12 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for ntp metrics.
 type MetricsConfig struct {
-	NtpOffset MetricConfig `mapstructure:"ntp.offset"`
+	NtpOffset NtpOffsetMetricConfig `mapstructure:"ntp.offset"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		NtpOffset: MetricConfig{
+		NtpOffset: NtpOffsetMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/ntpreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_config_test.go
@@ -26,7 +26,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NtpOffset: MetricConfig{
+					NtpOffset: NtpOffsetMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -39,7 +39,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NtpOffset: MetricConfig{
+					NtpOffset: NtpOffsetMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -52,7 +52,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(NtpOffsetMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/ntpreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_metrics.go
@@ -12,6 +12,13 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
+)
+
 var MetricsInfo = metricsInfo{
 	NtpOffset: metricInfo{
 		Name: "ntp.offset",
@@ -27,9 +34,9 @@ type metricInfo struct {
 }
 
 type metricNtpOffset struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric        // data buffer for generated metric.
+	config   NtpOffsetMetricConfig // metric config provided by user.
+	capacity int                   // max observed number of data points added to the metric.
 }
 
 // init fills ntp.offset metric with initial data.
@@ -66,7 +73,7 @@ func (m *metricNtpOffset) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricNtpOffset(cfg MetricConfig) metricNtpOffset {
+func newMetricNtpOffset(cfg NtpOffsetMetricConfig) metricNtpOffset {
 	m := metricNtpOffset{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/ntpreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -62,7 +68,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -75,6 +83,8 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetNtpHost("ntp.host-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())

--- a/receiver/ntpreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/ntpreceiver/internal/metadata/testdata/config.yaml
@@ -6,6 +6,13 @@ all_set:
   resource_attributes:
     ntp.host:
       enabled: true
+reaggregate_set:
+  metrics:
+    ntp.offset:
+      enabled: true
+  resource_attributes:
+    ntp.host:
+      enabled: true
 none_set:
   metrics:
     ntp.offset:

--- a/receiver/ntpreceiver/metadata.yaml
+++ b/receiver/ntpreceiver/metadata.yaml
@@ -1,5 +1,6 @@
 display_name: NTP Receiver
 type: ntp
+reaggregation_enabled: true
 
 description: |
   This receiver periodically retrieves the clock offset from a NTP server.


### PR DESCRIPTION
  #### Description
Enable dynamic metric reaggregation for the NTP receiver by setting `reaggregation_enabled` in metadata and also regenerated the receiver metadata package

  #### Link to tracking issue
  Fixes #46370

  #### Testing
  - `make test` in `receiver/ntpreceiver`
  - `make lint` in `receiver/ntpreceiver`
  - `make chlog-validate`