### PR TITLE
[DO_NOT_MERGE] check e2e tests

### DIFF
--- a/processor/k8sattributesprocessor/e2e_test.go
+++ b/processor/k8sattributesprocessor/e2e_test.go
@@ -1985,6 +1985,7 @@ func TestE2E_SharedProcessor(t *testing.T) {
 
 	k8sClient, err := k8stest.NewK8sClient(testKubeConfig)
 	require.NoError(t, err)
+	// wip
 
 	nsFile := filepath.Join(testDir, "namespace.yaml")
 	buf, err := os.ReadFile(nsFile)


### PR DESCRIPTION
Checking k8s e2e test failures: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/25380327038/job/74574396237?pr=47431