### PR TITLE
[kafkatopics_observer] Switch to franz-go

### DIFF
--- a/.chloggen/kafkatopicsobserver-franzgo.yaml
+++ b/.chloggen/kafkatopicsobserver-franzgo.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/kafkatopics_observer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Switch to the franz-go client.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48169]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is another step towards consolidating on franz-go for all Kafka components.
+  We have already switched the receiver and exporter, and they are working well.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/observer/kafkatopicsobserver/README.md
+++ b/extension/observer/kafkatopicsobserver/README.md
@@ -51,7 +51,4 @@ The following settings can be optionally configured:
         - `keytab_file`: Path to keytab file. i.e /etc/security/kafka.keytab
         - `disable_fast_negotiation`: Disable PA-FX-FAST negotiation (Pre-Authentication Framework - Fast). Some common Kerberos implementations do not support PA-FX-FAST negotiation. This is set to `false` by default.
 - `metadata`
-  - `full` (default = true): Whether to maintain a full set of metadata. When disabled, the client does not make the initial request to broker at the startup.
-  - `retry`
-    - `max` (default = 3): The number of retries to get metadata
-    - `backoff` (default = 250ms): How long to wait between metadata retries
+  - `refresh_interval` (default = 10m): How often to refresh Kafka topic/partition metadata

--- a/extension/observer/kafkatopicsobserver/extension.go
+++ b/extension/observer/kafkatopicsobserver/extension.go
@@ -8,14 +8,15 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/IBM/sarama"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/endpointswatcher"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
 )
 
 var (
@@ -28,32 +29,18 @@ type kafkaTopicsObserver struct {
 	logger *zap.Logger
 	config *Config
 
-	adminClient      sarama.ClusterAdmin
-	cancelKafkaAdmin func()
+	client *kadm.Client
 }
 
-func newObserver(
-	logger *zap.Logger,
-	config *Config,
-	newAdminClusterClient func(context.Context, configkafka.ClientConfig) (sarama.ClusterAdmin, error),
-) (extension.Extension, error) {
+func newObserver(logger *zap.Logger, config *Config) (extension.Extension, error) {
 	topicRegexp, err := regexp.Compile(config.TopicRegex)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile topic regex: %w", err)
 	}
 
-	kCtx, cancel := context.WithCancel(context.Background())
-	adminClient, err := newAdminClusterClient(kCtx, config.ClientConfig)
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not create kafka cluster admin: %w", err)
-	}
-
 	o := &kafkaTopicsObserver{
-		logger:           logger,
-		config:           config,
-		cancelKafkaAdmin: cancel,
-		adminClient:      adminClient,
+		logger: logger,
+		config: config,
 	}
 	o.EndpointsWatcher = endpointswatcher.New(
 		&kafkaTopicsEndpointsLister{o: o, topicRegexp: topicRegexp},
@@ -63,18 +50,25 @@ func newObserver(
 	return o, nil
 }
 
-func (*kafkaTopicsObserver) Start(context.Context, component.Host) error {
+func (k *kafkaTopicsObserver) Start(ctx context.Context, host component.Host) error {
+	client, _, err := kafka.NewFranzClusterAdminClient(
+		ctx, host, k.config.ClientConfig, k.logger,
+		// Set metadata min age below the sync interval
+		// so each sync sees a fresh topic list.
+		kgo.MetadataMinAge(k.config.TopicsSyncInterval/2),
+	)
+	if err != nil {
+		return fmt.Errorf("could not create kafka cluster admin client: %w", err)
+	}
+	k.client = client
 	return nil
 }
 
 func (k *kafkaTopicsObserver) Shutdown(context.Context) error {
 	k.StopListAndWatch()
-	k.cancelKafkaAdmin()
-	err := k.adminClient.Close()
-	if err != nil {
-		return fmt.Errorf("failed to close kafka cluster admin client: %w", err)
+	if k.client != nil {
+		k.client.Close()
 	}
-	k.logger.Info("kafka cluster admin client closed")
 	return nil
 }
 
@@ -87,7 +81,7 @@ type kafkaTopicsEndpointsLister struct {
 }
 
 func (k *kafkaTopicsEndpointsLister) ListEndpoints() []observer.Endpoint {
-	topics, err := k.listMatchingTopics()
+	topics, err := k.listMatchingTopics(context.Background())
 	if err != nil {
 		k.o.logger.Error("failed to list topics, using cached list", zap.Error(err))
 		// Use the previously cached list of topics.
@@ -112,18 +106,15 @@ func (k *kafkaTopicsEndpointsLister) ListEndpoints() []observer.Endpoint {
 	return endpoints
 }
 
-func (k *kafkaTopicsEndpointsLister) listMatchingTopics() ([]string, error) {
-	// Collect all available topics
-	topics, err := k.o.adminClient.ListTopics()
+func (k *kafkaTopicsEndpointsLister) listMatchingTopics(ctx context.Context) ([]string, error) {
+	td, err := k.o.client.ListTopics(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// Filter topics
 	var matchingTopics []string
-	for topic := range topics {
-		if k.topicRegexp.MatchString(topic) {
-			matchingTopics = append(matchingTopics, topic)
+	for name := range td {
+		if k.topicRegexp.MatchString(name) {
+			matchingTopics = append(matchingTopics, name)
 		}
 	}
 	return matchingTopics, nil

--- a/extension/observer/kafkatopicsobserver/extension_test.go
+++ b/extension/observer/kafkatopicsobserver/extension_test.go
@@ -5,104 +5,60 @@ package kafkatopicsobserver
 
 import (
 	"cmp"
-	"context"
 	"slices"
 	"testing"
+	"time"
 
-	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
 )
 
-type mockClusterAdmin struct {
-	sarama.ClusterAdmin
-	mock.Mock
-}
+func TestStartShutdown(t *testing.T) {
+	_, clientCfg := kafkatest.NewCluster(t)
 
-func (m *mockClusterAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
-	args := m.Called()
-	return args.Get(0).(map[string]sarama.TopicDetail), args.Error(1)
-}
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cfg.ClientConfig = clientCfg
+	cfg.TopicRegex = ".*"
 
-func (m *mockClusterAdmin) Close() error {
-	return m.Called().Error(0)
-}
-
-func TestCollectEndpointsDefaultConfig(t *testing.T) {
-	factory := NewFactory()
-	mockAdmin := &mockClusterAdmin{}
-	mockAdmin.On("ListTopics").Return(map[string]sarama.TopicDetail{"abc": {}, "def": {}}, nil)
-	mockAdmin.On("Close").Return(nil).Once()
-
-	ext, err := newObserver(
-		zap.NewNop(),
-		factory.CreateDefaultConfig().(*Config),
-		func(context.Context, configkafka.ClientConfig) (sarama.ClusterAdmin, error) {
-			return mockAdmin, nil
-		},
-	)
+	ext, err := newObserver(zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)
 
-	err = ext.Start(t.Context(), componenttest.NewNopHost())
-	assert.NoError(t, err)
-
-	err = ext.Shutdown(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
+	require.NoError(t, ext.Shutdown(t.Context()))
 }
 
-func TestCollectEndpointsAllConfigSettings(t *testing.T) {
-	mockAdmin := &mockClusterAdmin{}
-
-	// During first check new topics matching the regex are detected
-	mockAdmin.On("ListTopics").Return(map[string]sarama.TopicDetail{
-		"topic1": {},
-		"topic2": {},
-	}, nil).Once()
-
-	// During the second check only one new topic which doesn't match a regex is detected
-	mockAdmin.On("ListTopics").Return(map[string]sarama.TopicDetail{
-		"topic1": {},
-		"topic2": {},
-		"topics": {},
-	}, nil).Once()
-
-	// During the third check one topic matching a regex is detected
-	mockAdmin.On("ListTopics").Return(map[string]sarama.TopicDetail{
-		"topic1": {},
-		"topics": {},
-	}, nil)
-	mockAdmin.On("Close").Return(nil).Once()
-
-	// Override the createKafkaClusterAdmin function to return the mock admin
-	extAllSettings := loadConfig(t, component.NewIDWithName(metadata.Type, "all_settings"))
-	ext, err := newObserver(
-		zap.NewNop(), extAllSettings,
-		func(context.Context, configkafka.ClientConfig) (sarama.ClusterAdmin, error) {
-			return mockAdmin, nil
-		},
+func TestObserveTopics(t *testing.T) {
+	cluster, clientCfg := kafkatest.NewCluster(t,
+		kfake.SeedTopics(1, "topic1", "topic2", "topics"),
 	)
+
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cfg.ClientConfig = clientCfg
+	cfg.TopicRegex = "^topic[0-9]$"
+	cfg.TopicsSyncInterval = 100 * time.Millisecond
+
+	ext, err := newObserver(zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)
 
-	err = ext.Start(t.Context(), componenttest.NewNopHost())
-	require.NoError(t, err)
-	defer func() {
-		err := ext.Shutdown(t.Context())
-		assert.NoError(t, err)
-	}()
+	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, ext.Shutdown(t.Context()))
+	})
 
 	ops := make(channelNotifier, 1) // buffer for the initial op
 	ext.(*kafkaTopicsObserver).ListAndWatch(ops)
 
+	// First sync detects the two seeded topics matching the regex.
 	assert.Equal(t, notifyOp{
 		op: "add",
 		endpoints: []observer.Endpoint{{
@@ -115,6 +71,13 @@ func TestCollectEndpointsAllConfigSettings(t *testing.T) {
 			Details: &observer.KafkaTopic{},
 		}},
 	}, <-ops)
+
+	// Delete topic2 from the cluster; the next sync should report its removal.
+	adminCl, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	require.NoError(t, err)
+	t.Cleanup(adminCl.Close)
+	_, err = kadm.NewClient(adminCl).DeleteTopics(t.Context(), "topic2")
+	require.NoError(t, err)
 
 	assert.Equal(t, notifyOp{
 		op: "remove",

--- a/extension/observer/kafkatopicsobserver/factory.go
+++ b/extension/observer/kafkatopicsobserver/factory.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 )
 
@@ -36,11 +35,6 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createExtension(
-	_ context.Context,
-	settings extension.Settings,
-	cfg component.Config,
-) (extension.Extension, error) {
-	config := cfg.(*Config)
-	return newObserver(settings.Logger, config, kafka.NewSaramaClusterAdminClient)
+func createExtension(_ context.Context, settings extension.Settings, cfg component.Config) (extension.Extension, error) {
+	return newObserver(settings.Logger, cfg.(*Config))
 }

--- a/extension/observer/kafkatopicsobserver/go.mod
+++ b/extension/observer/kafkatopicsobserver/go.mod
@@ -3,11 +3,13 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/obser
 go 1.25.0
 
 require (
-	github.com/IBM/sarama v1.48.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.151.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.151.0
 	github.com/stretchr/testify v1.11.1
+	github.com/twmb/franz-go v1.21.1
+	github.com/twmb/franz-go/pkg/kadm v1.18.0
+	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260421215025-4e7a1e1569ac
 	go.opentelemetry.io/collector/component v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/component/componenttest v0.151.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/confmap v1.57.1-0.20260501001745-24aecacf1c04
@@ -19,6 +21,7 @@ require (
 )
 
 require (
+	github.com/IBM/sarama v1.48.0 // indirect
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.36.4 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.16 // indirect
@@ -64,9 +67,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/twmb/franz-go v1.21.1 // indirect
-	github.com/twmb/franz-go/pkg/kadm v1.18.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
 	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 // indirect
 	github.com/twmb/franz-go/plugin/kzap v1.1.2 // indirect


### PR DESCRIPTION
#### Description

Update the kafkatopics_observer extension to use franz-go instead of Sarama.

#### Link to tracking issue

N/A

#### Testing

Unit tests updated to use kfake, so the tests now exercise the client against a real (fake) Kafka cluster.

#### Documentation

Removed config attributes from README that are not honoured by the franz-go client; added the refresh interval attribute.