### PR TITLE
[chore] [receiver/kafkametricsreceiver] expand franz-go scraper tests

### DIFF
--- a/receiver/kafkametricsreceiver/broker_scraper_franz_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_franz_test.go
@@ -4,13 +4,17 @@
 package kafkametricsreceiver
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper"
+	"go.opentelemetry.io/collector/scraper/scrapererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver/internal/metadata"
@@ -116,6 +120,128 @@ func TestBrokerScraperFranz_Start(t *testing.T) {
 
 	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, s.Shutdown(t.Context()))
+}
+
+func TestBrokerScraperFranz_ScrapeMetricValues(t *testing.T) {
+	setFranzGo(t, true)
+
+	const numBrokers = 3
+	const logRetentionHoursValue = 168
+	_, clientCfg := kafkatest.NewCluster(t,
+		kfake.SeedTopics(1, "meta-topic"),
+		kfake.NumBrokers(numBrokers),
+		kfake.BrokerConfigs(map[string]string{
+			logRetentionHours: "168",
+		}),
+	)
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		ClusterAlias:         "test-cluster",
+	}
+	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	cfg.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
+
+	s, err := createBrokerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	md, err := s.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, md.ResourceMetrics().Len())
+
+	rm := md.ResourceMetrics().At(0)
+	val, ok := rm.Resource().Attributes().Get("kafka.cluster.alias")
+	require.True(t, ok)
+	require.Equal(t, "test-cluster", val.Str())
+
+	ms := rm.ScopeMetrics().At(0).Metrics()
+	var sawBrokers, sawRetention bool
+	for i := 0; i < ms.Len(); i++ {
+		m := ms.At(i)
+		switch m.Name() {
+		case "kafka.brokers":
+			require.Equal(t, pmetric.MetricTypeSum, m.Type())
+			require.Equal(t, int64(numBrokers), m.Sum().DataPoints().At(0).IntValue())
+			sawBrokers = true
+		case "kafka.broker.log_retention_period":
+			require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+			dps := m.Gauge().DataPoints()
+			require.Equal(t, numBrokers, dps.Len())
+			for j := 0; j < dps.Len(); j++ {
+				require.Equal(t, int64(logRetentionHoursValue*3600), dps.At(j).IntValue())
+			}
+			sawRetention = true
+		}
+	}
+	require.True(t, sawBrokers, "kafka.brokers not emitted")
+	require.True(t, sawRetention, "kafka.broker.log_retention_period not emitted")
+}
+
+func TestBrokerScraperFranz_ScrapePartialError_UnparseableRetention(t *testing.T) {
+	setFranzGo(t, true)
+
+	const numBrokers = 2
+	_, clientCfg := kafkatest.NewCluster(t,
+		kfake.SeedTopics(1, "meta-topic"),
+		kfake.NumBrokers(numBrokers),
+		kfake.BrokerConfigs(map[string]string{
+			logRetentionHours: "not-a-number",
+		}),
+	)
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
+
+	s, err := createBrokerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	md, err := s.ScrapeMetrics(t.Context())
+	// Per-broker parse failure should produce a partial scrape error, not a hard error.
+	require.Error(t, err)
+	var partial scrapererror.PartialScrapeError
+	require.ErrorAs(t, err, &partial, "expected PartialScrapeError, got %T: %v", err, err)
+	require.Equal(t, numBrokers, partial.Failed)
+
+	ms := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	var sawBrokers, sawRetention bool
+	for i := 0; i < ms.Len(); i++ {
+		switch ms.At(i).Name() {
+		case "kafka.brokers":
+			sawBrokers = true
+		case "kafka.broker.log_retention_period":
+			sawRetention = true
+		}
+	}
+	require.True(t, sawBrokers)
+	require.False(t, sawRetention, "log retention metric should be skipped on parse failure")
+}
+
+func TestBrokerScraperFranz_ScrapeUnreachable(t *testing.T) {
+	setFranzGo(t, true)
+
+	cluster, clientCfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, "meta-topic"))
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+	}
+
+	s, err := createBrokerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	cluster.Close() // simulate unreachable cluster
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	_, err = s.ScrapeMetrics(ctx)
+	require.Error(t, err)
 }
 
 func TestBrokerScraperFranz_ShutdownWithoutStart_OK(t *testing.T) {

--- a/receiver/kafkametricsreceiver/consumer_scraper_franz_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_franz_test.go
@@ -4,11 +4,15 @@
 package kafkametricsreceiver
 
 import (
+	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper"
@@ -113,6 +117,137 @@ func TestConsumerScraperFranz_EmptyClusterAlias(t *testing.T) {
 	}
 
 	require.NoError(t, s.Shutdown(t.Context()))
+}
+
+func TestConsumerScraperFranz_ScrapeMetricValues(t *testing.T) {
+	setFranzGo(t, true)
+
+	const (
+		topic     = "topic-a"
+		group     = "test-group"
+		committed = int64(7)
+	)
+
+	cluster, clientCfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, topic))
+	cl, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	require.NoError(t, err)
+	t.Cleanup(cl.Close)
+
+	adm := kadm.NewClient(cl)
+
+	// Produce one record so the partition has an end offset.
+	produceResults := cl.ProduceSync(t.Context(), &kgo.Record{Topic: topic, Value: []byte("payload")})
+	require.NoError(t, produceResults.FirstErr())
+
+	// Commit an offset for the group at partition 0.
+	var os kadm.Offsets
+	os.AddOffset(topic, 0, committed, -1)
+	_, err = adm.CommitOffsets(t.Context(), group, os)
+	require.NoError(t, err)
+
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		ClusterAlias:         "test-cluster",
+		TopicMatch:           ".*",
+		GroupMatch:           ".*",
+	}
+	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+
+	s, err := createConsumerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	md, err := s.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, md.ResourceMetrics().Len())
+
+	rm := md.ResourceMetrics().At(0)
+	val, ok := rm.Resource().Attributes().Get("kafka.cluster.alias")
+	require.True(t, ok)
+	require.Equal(t, "test-cluster", val.Str())
+
+	// We produced 1 record at partition 0, and committed offset = 7. End offset is 1 (record offset 0 + 1),
+	// so lag = 1 - 7 = -6. The scraper records the raw difference; we just verify the metric is emitted
+	// with the committed offset and a deterministic lag.
+	const expectedEnd = int64(1)
+	const expectedLag = expectedEnd - committed
+
+	ms := rm.ScopeMetrics().At(0).Metrics()
+	seen := map[string]bool{}
+	for i := 0; i < ms.Len(); i++ {
+		m := ms.At(i)
+		seen[m.Name()] = true
+		switch m.Name() {
+		case "kafka.consumer_group.members":
+			// No active members for an offset-only commit.
+			require.Equal(t, int64(0), m.Sum().DataPoints().At(0).IntValue())
+		case "kafka.consumer_group.offset":
+			dps := m.Gauge().DataPoints()
+			var found bool
+			for j := 0; j < dps.Len(); j++ {
+				partition, _ := dps.At(j).Attributes().Get("partition")
+				if partition.Int() == 0 {
+					require.Equal(t, committed, dps.At(j).IntValue())
+					found = true
+				}
+			}
+			require.True(t, found, "expected offset for partition 0")
+		case "kafka.consumer_group.lag":
+			dps := m.Gauge().DataPoints()
+			var found bool
+			for j := 0; j < dps.Len(); j++ {
+				partition, _ := dps.At(j).Attributes().Get("partition")
+				if partition.Int() == 0 {
+					require.Equal(t, expectedLag, dps.At(j).IntValue())
+					found = true
+				}
+			}
+			require.True(t, found, "expected lag for partition 0")
+		case "kafka.consumer_group.offset_sum":
+			require.Equal(t, committed, m.Gauge().DataPoints().At(0).IntValue())
+		case "kafka.consumer_group.lag_sum":
+			require.Equal(t, expectedLag, m.Gauge().DataPoints().At(0).IntValue())
+		}
+	}
+	for _, name := range []string{
+		"kafka.consumer_group.members",
+		"kafka.consumer_group.offset",
+		"kafka.consumer_group.lag",
+		"kafka.consumer_group.offset_sum",
+		"kafka.consumer_group.lag_sum",
+	} {
+		require.True(t, seen[name], "metric %s not emitted", name)
+	}
+
+	// Clean up the group so the kfake goroutine exits.
+	_, err = adm.DeleteGroups(t.Context(), group)
+	require.NoError(t, err)
+}
+
+func TestConsumerScraperFranz_ScrapeUnreachable(t *testing.T) {
+	setFranzGo(t, true)
+
+	cluster, clientCfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, "topic-a"))
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		TopicMatch:           ".*",
+		GroupMatch:           ".*",
+	}
+
+	s, err := createConsumerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	cluster.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	_, err = s.ScrapeMetrics(ctx)
+	require.Error(t, err)
 }
 
 // (Optional) If you want a direct filter parity check like the Sarama unit did:

--- a/receiver/kafkametricsreceiver/topic_scraper_franz_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_franz_test.go
@@ -4,14 +4,18 @@
 package kafkametricsreceiver
 
 import (
+	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper"
+	"go.opentelemetry.io/collector/scraper/scrapererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver/internal/metadata"
@@ -88,6 +92,196 @@ func TestTopicScraperFranz_EmptyClusterAlias(t *testing.T) {
 	}
 
 	require.NoError(t, s.Shutdown(t.Context()))
+}
+
+func TestTopicScraperFranz_ScrapeMetricValues(t *testing.T) {
+	setFranzGo(t, true)
+
+	const (
+		topic         = "topic-a"
+		numPartitions = 3
+		numBrokers    = 2
+	)
+	_, clientCfg := kafkatest.NewCluster(t,
+		kfake.SeedTopics(numPartitions, topic),
+		kfake.NumBrokers(numBrokers),
+	)
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		ClusterAlias:         "franz-topics",
+		TopicMatch:           ".*",
+	}
+	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	cfg.Metrics.KafkaTopicLogRetentionPeriod.Enabled = true
+	cfg.Metrics.KafkaTopicLogRetentionSize.Enabled = true
+	cfg.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
+	cfg.Metrics.KafkaTopicReplicationFactor.Enabled = true
+
+	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	md, err := s.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, md.ResourceMetrics().Len())
+
+	rm := md.ResourceMetrics().At(0)
+	val, ok := rm.Resource().Attributes().Get("kafka.cluster.alias")
+	require.True(t, ok)
+	require.Equal(t, "franz-topics", val.Str())
+
+	// kfake topic config defaults
+	const (
+		expectedRetentionMs    = 604800000 // 7 days
+		expectedRetentionBytes = -1
+		expectedMinInsync      = 1
+	)
+
+	ms := rm.ScopeMetrics().At(0).Metrics()
+	seen := map[string]bool{}
+	for i := 0; i < ms.Len(); i++ {
+		m := ms.At(i)
+		seen[m.Name()] = true
+		switch m.Name() {
+		case "kafka.topic.partitions":
+			require.Equal(t, pmetric.MetricTypeSum, m.Type())
+			dps := m.Sum().DataPoints()
+			require.Equal(t, 1, dps.Len())
+			require.Equal(t, int64(numPartitions), dps.At(0).IntValue())
+		case "kafka.topic.replication_factor":
+			require.Equal(t, int64(numBrokers), m.Gauge().DataPoints().At(0).IntValue())
+		case "kafka.topic.min_insync_replicas":
+			require.Equal(t, int64(expectedMinInsync), m.Gauge().DataPoints().At(0).IntValue())
+		case "kafka.topic.log_retention_period":
+			require.Equal(t, int64(expectedRetentionMs/1000), m.Gauge().DataPoints().At(0).IntValue())
+		case "kafka.topic.log_retention_size":
+			require.Equal(t, int64(expectedRetentionBytes), m.Gauge().DataPoints().At(0).IntValue())
+		case "kafka.partition.replicas":
+			require.Equal(t, numPartitions, m.Sum().DataPoints().Len())
+			for j := 0; j < m.Sum().DataPoints().Len(); j++ {
+				require.Equal(t, int64(numBrokers), m.Sum().DataPoints().At(j).IntValue())
+			}
+		case "kafka.partition.replicas_in_sync":
+			require.Equal(t, numPartitions, m.Sum().DataPoints().Len())
+			for j := 0; j < m.Sum().DataPoints().Len(); j++ {
+				require.Equal(t, int64(numBrokers), m.Sum().DataPoints().At(j).IntValue())
+			}
+		}
+	}
+	for _, name := range []string{
+		"kafka.topic.partitions",
+		"kafka.topic.replication_factor",
+		"kafka.topic.min_insync_replicas",
+		"kafka.topic.log_retention_period",
+		"kafka.topic.log_retention_size",
+		"kafka.partition.replicas",
+		"kafka.partition.replicas_in_sync",
+	} {
+		require.True(t, seen[name], "metric %s not emitted", name)
+	}
+}
+
+func TestTopicScraperFranz_TopicFilterExcludes(t *testing.T) {
+	setFranzGo(t, true)
+
+	_, clientCfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, "include-me", "_internal"))
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		TopicMatch:           "include-.*",
+	}
+
+	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	md, err := s.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+
+	if md.ResourceMetrics().Len() == 0 {
+		return
+	}
+	ms := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < ms.Len(); i++ {
+		m := ms.At(i)
+		if m.Name() != "kafka.topic.partitions" {
+			continue
+		}
+		dps := m.Sum().DataPoints()
+		for j := 0; j < dps.Len(); j++ {
+			topic, _ := dps.At(j).Attributes().Get("topic")
+			require.Equal(t, "include-me", topic.Str())
+		}
+	}
+}
+
+func TestTopicScraperFranz_ScrapePartialError_UnparseableConfig(t *testing.T) {
+	setFranzGo(t, true)
+
+	const topic = "topic-a"
+	_, clientCfg := kafkatest.NewCluster(t,
+		kfake.SeedTopics(2, topic),
+		// kfake propagates min.insync.replicas from broker config into the topic config.
+		kfake.BrokerConfigs(map[string]string{
+			minInsyncReplicas: "not-a-number",
+		}),
+	)
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		TopicMatch:           ".*",
+	}
+	cfg.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
+
+	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	md, err := s.ScrapeMetrics(t.Context())
+	require.Error(t, err)
+	var partial scrapererror.PartialScrapeError
+	require.ErrorAs(t, err, &partial, "expected PartialScrapeError, got %T: %v", err, err)
+	require.Equal(t, 1, partial.Failed)
+
+	ms := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	var sawPartitions, sawMinInsync bool
+	for i := 0; i < ms.Len(); i++ {
+		switch ms.At(i).Name() {
+		case "kafka.topic.partitions":
+			sawPartitions = true
+		case "kafka.topic.min_insync_replicas":
+			sawMinInsync = true
+		}
+	}
+	require.True(t, sawPartitions)
+	require.False(t, sawMinInsync, "min_insync_replicas should be skipped on parse failure")
+}
+
+func TestTopicScraperFranz_ScrapeUnreachable(t *testing.T) {
+	setFranzGo(t, true)
+
+	cluster, clientCfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, "topic-a"))
+	cfg := Config{
+		ClientConfig:         clientCfg,
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		TopicMatch:           ".*",
+	}
+
+	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+	require.NoError(t, s.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, s.Shutdown(t.Context())) })
+
+	cluster.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	_, err = s.ScrapeMetrics(ctx)
+	require.Error(t, err)
 }
 
 // Optional parity check: default regex compiles (like Sarama test style)


### PR DESCRIPTION
#### Description

Improve test coverage of the franz-go based implementation. The tests now cover more functionality by manipulating a kfake cluster. This is a prelude to stabilising the feature gate and removing the Sarama implementation.

Assisted-by: Claude Opus 4.7