### PR TITLE
[chore] fix check-codeowners workflow always passing

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -57,6 +57,6 @@ jobs:
       - name: Gen CODEOWNERS
         run: |
           GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=./pr" make codeowners
-          git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gencodeowners" or apply this diff and commit the changes in this PR.' && git diff && exit 1)
+          cd pr && git diff -s --exit-code || (echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1)
 
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
The `check-codeowners` workflow is supposed to fail when a PR changes `metadata.yaml` codeowners without also updating `.github/CODEOWNERS`. It has never worked.

The workflow runs:

```
GITHUBGEN_ARGS="-folder=./pr" make codeowners
git diff -s --exit-code || ...
```

`githubgen` uses the `-folder` value as both the root for reading `metadata.yaml` files and the root for writing the output. With `-folder=./pr`, it writes the regenerated CODEOWNERS to `./pr/.github/CODEOWNERS`, inside the PR's separate git checkout. The `git diff` then runs against the main checkout where nothing changed, so it always exits 0.

See PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47918. The `metadata.yaml` got updated to add a new codeowner but did not update `.github/CODEOWNERS`. The `check-codeowners` job reported success.