### PR TITLE
[chore] fix check-codeowners workflow always passing

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -57,6 +57,6 @@ jobs:
       - name: Gen CODEOWNERS
         run: |
           GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=./pr" make codeowners
-          cd pr && git diff -s --exit-code || (echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1)
+          cd pr && if ! git diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1; fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -57,6 +57,6 @@ jobs:
       - name: Gen CODEOWNERS
         run: |
           GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=./pr" make codeowners
-          git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gencodeowners" or apply this diff and commit the changes in this PR.' && git diff && exit 1)
+          cd pr && git diff -s --exit-code || (echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1)
 
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The workflow is always passing now.

See this PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47918. The `metadata.yaml` got updated to add a new codeowner but did not update `.github/CODEOWNERS`.