### PR TITLE
feat(resourcedetectionprocessor): add retry with backoff config to resource detector processor

### DIFF
--- a/.chloggen/res-detection-fix.yaml
+++ b/.chloggen/res-detection-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resource_detection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support global retry config for resource detection processor"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46546]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -23,6 +23,44 @@ override the resource value in telemetry data with this information.
 >
 > If a configured resource detector fails, the error will propagate and stop the collector from starting.
 
+## Retry configuration
+
+By default, every detector retries failed `Detect` calls with exponential
+backoff. The `retry` block uses the standard
+[`configretry.BackOffConfig`](https://pkg.go.dev/go.opentelemetry.io/collector/config/configretry)
+and applies to every detection attempt (including periodic refreshes when
+`refresh_interval > 0`).
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `retry.enabled` | `true` | Set to `false` to perform a single attempt per detector with no retries. |
+| `retry.initial_interval` | `1s` | Delay before the first retry. |
+| `retry.randomization_factor` | `0.5` | Jitter applied to each interval. |
+| `retry.multiplier` | `2` | Each interval is multiplied by this factor up to `max_interval`. |
+| `retry.max_interval` | `30s` | Upper bound on the backoff interval. |
+| `retry.max_elapsed_time` | `0` | Total retry budget. `0` means no explicit cap — the session is bounded by `timeout` (the HTTP client timeout) instead. Set to a positive duration to retry past `timeout`. |
+
+When `retry.max_elapsed_time` is `0`, the whole detection session is bounded by
+`timeout`. When it is greater than zero, `timeout` only bounds each individual
+attempt, and `max_elapsed_time` bounds the total. The processor rejects
+configurations with `retry.enabled: true`, `timeout: 0`, and
+`retry.max_elapsed_time: 0` — at least one of the two must be set so a hung
+detector cannot block startup indefinitely.
+
+Example: wait up to two minutes for a slow metadata server to come up.
+
+```yaml
+processors:
+  resource_detection/wait_for_metadata:
+    detectors: [gcp]
+    timeout: 5s
+    retry:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 10s
+      max_elapsed_time: 2m
+```
+
 ## Supported detectors
 
 ### Environment Variable

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -4,9 +4,11 @@
 package resourcedetectionprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 
 import (
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configretry"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai"
@@ -63,6 +65,19 @@ type Config struct {
 	// Supersedes the per-detector fail_on_missing_metadata fields (now deprecated).
 	// Default: false (backward compatible).
 	FailOnMissingMetadata bool `mapstructure:"fail_on_missing_metadata"`
+	// Retry controls retry/backoff for each detection attempt. Set Enabled=false
+	// to perform a single attempt per detector with no retries.
+	Retry configretry.BackOffConfig `mapstructure:"retry"`
+}
+
+// Validate rejects configurations that would let a hung detector block the
+// pipeline forever: with retry enabled, at least one of the HTTP client timeout
+// or the retry budget must be finite so detection always terminates.
+func (cfg *Config) Validate() error {
+	if cfg.Retry.Enabled && cfg.ClientConfig.Timeout == 0 && cfg.Retry.MaxElapsedTime == 0 {
+		return errors.New("retry.enabled requires either timeout > 0 or retry.max_elapsed_time > 0 to bound detection")
+	}
+	return nil
 }
 
 // DetectorConfig contains user-specified configurations unique to all individual detectors

--- a/processor/resourcedetectionprocessor/config.schema.yaml
+++ b/processor/resourcedetectionprocessor/config.schema.yaml
@@ -108,6 +108,9 @@ properties:
     description: If > 0, periodically re-run detection for all configured detectors. When 0 (default), no periodic refresh occurs.
     type: string
     format: duration
+  retry:
+    description: Retry controls retry/backoff for each detection attempt. Set Enabled=false to perform a single attempt per detector with no retries.
+    $ref: go.opentelemetry.io/collector/config/configretry.back_off_config
 allOf:
   - $ref: detector_config
   - $ref: go.opentelemetry.io/collector/config/confighttp.client_config

--- a/processor/resourcedetectionprocessor/config_test.go
+++ b/processor/resourcedetectionprocessor/config_test.go
@@ -76,6 +76,7 @@ func TestLoadConfig(t *testing.T) {
 				Override:       true,
 				DetectorConfig: detectorCreateDefaultConfig(),
 				ClientConfig:   defaultClientConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -85,6 +86,7 @@ func TestLoadConfig(t *testing.T) {
 				DetectorConfig: openshiftConfig,
 				ClientConfig:   cfg,
 				Override:       false,
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -94,6 +96,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -103,6 +106,7 @@ func TestLoadConfig(t *testing.T) {
 				DetectorConfig: ec2Config,
 				ClientConfig:   cfg,
 				Override:       false,
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -112,6 +116,7 @@ func TestLoadConfig(t *testing.T) {
 				DetectorConfig: systemConfig,
 				ClientConfig:   cfg,
 				Override:       false,
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -121,6 +126,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -130,6 +136,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -139,6 +146,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -148,6 +156,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -157,6 +166,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -166,6 +176,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: detectorCreateDefaultConfig(),
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -175,6 +186,7 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:   cfg,
 				Override:       false,
 				DetectorConfig: resourceAttributesConfig,
+				Retry:          defaultRetryConfig(),
 			},
 		},
 		{
@@ -185,6 +197,7 @@ func TestLoadConfig(t *testing.T) {
 				Override:        false,
 				DetectorConfig:  detectorCreateDefaultConfig(),
 				RefreshInterval: 5 * time.Second,
+				Retry:           defaultRetryConfig(),
 			},
 		},
 		{
@@ -199,6 +212,7 @@ func TestLoadConfig(t *testing.T) {
 				Override:              false,
 				FailOnMissingMetadata: true,
 				DetectorConfig:        detectorCreateDefaultConfig(),
+				Retry:                 defaultRetryConfig(),
 			},
 		},
 		{
@@ -359,4 +373,63 @@ func TestDetectorCreateDefaultConfig(t *testing.T) {
 	assert.NotNil(t, config.UpcloudConfig)
 	assert.NotNil(t, config.VultrConfig)
 	assert.NotNil(t, config.AlibabaECSConfig)
+}
+
+func TestDefaultConfig_RetryDefaults(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	assert.True(t, cfg.Retry.Enabled, "retry must be enabled by default")
+	assert.Equal(t, 1*time.Second, cfg.Retry.InitialInterval)
+	assert.InDelta(t, 0.5, cfg.Retry.RandomizationFactor, 1e-9)
+	assert.InDelta(t, 2.0, cfg.Retry.Multiplier, 1e-9)
+	assert.Equal(t, 30*time.Second, cfg.Retry.MaxInterval)
+	assert.Equal(t, time.Duration(0), cfg.Retry.MaxElapsedTime, "no explicit retry budget by default (session bounded by client.Timeout)")
+}
+
+func TestConfig_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:   "defaults are valid",
+			mutate: func(*Config) {},
+		},
+		{
+			name: "retry enabled with timeout=0 and max_elapsed_time=0 is rejected",
+			mutate: func(c *Config) {
+				c.ClientConfig.Timeout = 0
+				c.Retry.MaxElapsedTime = 0
+			},
+			wantErr: "retry.enabled requires either timeout > 0 or retry.max_elapsed_time > 0",
+		},
+		{
+			name: "retry enabled with timeout=0 but max_elapsed_time>0 is valid",
+			mutate: func(c *Config) {
+				c.ClientConfig.Timeout = 0
+				c.Retry.MaxElapsedTime = 30 * time.Second
+			},
+		},
+		{
+			name: "retry disabled with timeout=0 is valid",
+			mutate: func(c *Config) {
+				c.ClientConfig.Timeout = 0
+				c.Retry.Enabled = false
+				c.Retry.MaxElapsedTime = 0
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewFactory().CreateDefaultConfig().(*Config)
+			tc.mutate(cfg)
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }

--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/processor"
@@ -128,8 +129,20 @@ func createDefaultConfig() component.Config {
 		Override:        true,
 		DetectorConfig:  detectorCreateDefaultConfig(),
 		RefreshInterval: 0,
+		Retry:           defaultRetryConfig(),
 		// TODO: Once issue(https://github.com/open-telemetry/opentelemetry-collector/issues/4001) gets resolved,
 		//		 Set the default value of 'hostname_source' here instead of 'system' detector
+	}
+}
+
+func defaultRetryConfig() configretry.BackOffConfig {
+	return configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     1 * time.Second,
+		RandomizationFactor: 0.5,
+		Multiplier:          2,
+		MaxInterval:         30 * time.Second,
+		MaxElapsedTime:      0,
 	}
 }
 
@@ -241,7 +254,7 @@ func (f *factory) getResourceDetectionProcessor(
 
 	// The deprecated per-detector fail_on_missing_metadata fields are OR'd with this
 	// top-level flag inside each affected detector, preserving per-detector scope.
-	provider, err := f.getResourceProvider(params, oCfg.ClientConfig.Timeout, oCfg.Detectors, oCfg.DetectorConfig, oCfg.FailOnMissingMetadata)
+	provider, err := f.getResourceProvider(params, oCfg.Retry, oCfg.Detectors, oCfg.DetectorConfig, oCfg.FailOnMissingMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +300,7 @@ func warnDeprecatedPerDetectorFlags(logger *zap.Logger, oCfg *Config) {
 
 func (f *factory) getResourceProvider(
 	params processor.Settings,
-	timeout time.Duration,
+	backoffConfig configretry.BackOffConfig,
 	configuredDetectors []string,
 	detectorConfigs DetectorConfig,
 	failOnMissingMetadata bool,
@@ -304,7 +317,7 @@ func (f *factory) getResourceProvider(
 		detectorTypes = append(detectorTypes, internal.DetectorType(strings.TrimSpace(key)))
 	}
 
-	provider, err := f.resourceProviderFactory.CreateResourceProvider(params, timeout, failOnMissingMetadata, &detectorConfigs, detectorTypes...)
+	provider, err := f.resourceProviderFactory.CreateResourceProvider(params, backoffConfig, failOnMissingMetadata, &detectorConfigs, detectorTypes...)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.158.1-0.20260805181402-19664a7b14af
 	go.opentelemetry.io/collector/config/configopaque v1.64.1-0.20260805181402-19664a7b14af
 	go.opentelemetry.io/collector/config/configoptional v1.64.1-0.20260805181402-19664a7b14af
+	go.opentelemetry.io/collector/config/configretry v1.64.1-0.20260805181402-19664a7b14af
 	go.opentelemetry.io/collector/config/configtls v1.64.1-0.20260805181402-19664a7b14af
 	go.opentelemetry.io/collector/confmap v1.64.1-0.20260805181402-19664a7b14af
 	go.opentelemetry.io/collector/consumer v1.64.1-0.20260805181402-19664a7b14af

--- a/processor/resourcedetectionprocessor/go.sum
+++ b/processor/resourcedetectionprocessor/go.sum
@@ -414,6 +414,8 @@ go.opentelemetry.io/collector/config/configopaque v1.64.1-0.20260805181402-19664
 go.opentelemetry.io/collector/config/configopaque v1.64.1-0.20260805181402-19664a7b14af/go.mod h1:U1lq3Rq5UEmXsGNp3/KCSiI5hPJj8v4jJB6DQq0ld3Y=
 go.opentelemetry.io/collector/config/configoptional v1.64.1-0.20260805181402-19664a7b14af h1:9GHZ19genj4J2dgKKlA2J859xzjrf9YePR7/CYsofpk=
 go.opentelemetry.io/collector/config/configoptional v1.64.1-0.20260805181402-19664a7b14af/go.mod h1:AEERYrYh5HRQtaf0XhpZ4Z6+bLTv/mPGMqTSFYcCzRU=
+go.opentelemetry.io/collector/config/configretry v1.64.1-0.20260805181402-19664a7b14af h1:KALGIEDSWs79n8ZMYjdON2C+eDNXiaViVrWEL/xo++c=
+go.opentelemetry.io/collector/config/configretry v1.64.1-0.20260805181402-19664a7b14af/go.mod h1:6aRt0eEIeqBN314h7gU4IMMyzqHL82mKKo8jBDSGpik=
 go.opentelemetry.io/collector/config/configtls v1.64.1-0.20260805181402-19664a7b14af h1:8KNBR9z9uR8wsqcm+y6UgMWNH0666oHX+KcmLM8uw9Q=
 go.opentelemetry.io/collector/config/configtls v1.64.1-0.20260805181402-19664a7b14af/go.mod h1:XeREGtiJtPziGtlz+SQpNuhkXdaS0JDhjiROYKDq758=
 go.opentelemetry.io/collector/confmap v1.64.1-0.20260805181402-19664a7b14af h1:vRN9/ZezGJS+HF5rZ3+vQPQ88LRYmT+sMU+doK42Ado=

--- a/processor/resourcedetectionprocessor/internal/benchmark_test.go
+++ b/processor/resourcedetectionprocessor/internal/benchmark_test.go
@@ -112,7 +112,7 @@ func BenchmarkResourceProvider(b *testing.B) {
 	d1 := &benchDetector{res: generateResource(b, 0, 10)}
 	d2 := &benchDetector{res: generateResource(b, 0, 10)}
 	d3 := &benchDetector{res: generateResource(b, 0, 10)}
-	provider, err := newTestResourceProvider(0, d1, d2, d3)
+	provider, err := newTestResourceProvider(fastRetryConfig, d1, d2, d3)
 	require.NoError(b, err)
 	ctx := b.Context()
 	client := &http.Client{}

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	backoff "github.com/cenkalti/backoff/v5"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/otel/attribute"
@@ -57,7 +58,7 @@ func NewProviderFactory(detectors map[DetectorType]DetectorFactory) *ResourcePro
 
 func (f *ResourceProviderFactory) CreateResourceProvider(
 	params processor.Settings,
-	timeout time.Duration,
+	backoffConfig configretry.BackOffConfig,
 	failOnMissingMetadata bool,
 	detectorConfigs ResourceDetectorConfig,
 	detectorTypes ...DetectorType,
@@ -72,7 +73,7 @@ func (f *ResourceProviderFactory) CreateResourceProvider(
 		return nil, err
 	}
 
-	provider := NewResourceProvider(params.Logger, telemetryBuilder, timeout, detectors...)
+	provider := NewResourceProvider(params.Logger, telemetryBuilder, backoffConfig, detectors...)
 
 	// Register observer for the detected-attribute count.
 	if err := telemetryBuilder.RegisterResourcedetectionAttributesDetectedCallback(func(_ context.Context, o metric.Int64Observer) error {
@@ -110,7 +111,7 @@ func (f *ResourceProviderFactory) getDetectors(params processor.Settings, detect
 type ResourceProvider struct {
 	logger           *zap.Logger
 	telemetry        *metadata.TelemetryBuilder
-	timeout          time.Duration
+	backoffConfig    configretry.BackOffConfig
 	detectors        []detectorEntry
 	detectedResource atomic.Pointer[resourceResult]
 
@@ -129,11 +130,11 @@ type resourceResult struct {
 	err       error
 }
 
-func NewResourceProvider(logger *zap.Logger, telemetry *metadata.TelemetryBuilder, timeout time.Duration, detectors ...detectorEntry) *ResourceProvider {
+func NewResourceProvider(logger *zap.Logger, telemetry *metadata.TelemetryBuilder, backoffConfig configretry.BackOffConfig, detectors ...detectorEntry) *ResourceProvider {
 	return &ResourceProvider{
 		logger:          logger,
 		telemetry:       telemetry,
-		timeout:         timeout,
+		backoffConfig:   backoffConfig,
 		detectors:       detectors,
 		refreshInterval: 0, // No periodic refresh by default
 	}
@@ -149,10 +150,21 @@ func (p *ResourceProvider) Get(_ context.Context, _ *http.Client) (pcommon.Resou
 
 // Refresh recomputes the resource, replacing any previous result.
 func (p *ResourceProvider) Refresh(ctx context.Context, client *http.Client) error {
-	ctx, cancel := context.WithTimeout(ctx, client.Timeout)
-	defer cancel()
+	// Bound the session with a ctx deadline whenever something else doesn't
+	// already bound it: client.Timeout when there's no retry budget, or
+	// MaxElapsedTime when there's a budget but no per-attempt cap.
+	switch {
+	case p.backoffConfig.MaxElapsedTime == 0 && client.Timeout > 0:
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, client.Timeout)
+		defer cancel()
+	case p.backoffConfig.MaxElapsedTime > 0 && client.Timeout == 0:
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.backoffConfig.MaxElapsedTime)
+		defer cancel()
+	}
 
-	res, schemaURL, err := p.detectResource(ctx)
+	res, schemaURL, err := p.detectResource(ctx, client)
 	prev := p.detectedResource.Load()
 
 	// Check if we have a previous successful snapshot
@@ -177,7 +189,7 @@ func (p *ResourceProvider) Refresh(ctx context.Context, client *http.Client) err
 	return err
 }
 
-func (p *ResourceProvider) detectResource(ctx context.Context) (pcommon.Resource, string, error) {
+func (p *ResourceProvider) detectResource(ctx context.Context, client *http.Client) (pcommon.Resource, string, error) {
 	res := pcommon.NewResource()
 	mergedSchemaURL := ""
 	var joinedErr error
@@ -191,63 +203,7 @@ func (p *ResourceProvider) detectResource(ctx context.Context) (pcommon.Resource
 		resultsChan[i] = ch
 
 		go func(entry detectorEntry, ch chan resourceResult) {
-			startTime := time.Now()
-			detectorAttr := attribute.String("detector", string(entry.detectorType))
-
-			// record emits the per-detector result and duration. On failure, failErr
-			// classifies the error.type on the results counter.
-			record := func(outcome string, failErr error) {
-				base := []attribute.KeyValue{detectorAttr, attribute.String("outcome", outcome)}
-				p.telemetry.ResourcedetectionDetectorDuration.Record(ctx, time.Since(startTime).Seconds(), metric.WithAttributes(base...))
-				if failErr != nil {
-					base = append(base, semconv.ErrorType(failErr))
-				}
-				p.telemetry.ResourcedetectionDetectorResults.Add(ctx, 1, metric.WithAttributes(base...))
-			}
-
-			sleep := backoff.ExponentialBackOff{
-				InitialInterval:     1 * time.Second,
-				RandomizationFactor: 1.5,
-				Multiplier:          2,
-			}
-			sleep.Reset()
-
-			// Classify error.type from the first attempt's error: it's the deterministic
-			// root cause, whereas the last attempt's error often just reflects the context
-			// deadline firing rather than why the detector actually failed.
-			var firstErr error
-			for {
-				r, schemaURL, err := entry.detector.Detect(ctx)
-				if err == nil {
-					record("success", nil)
-					ch <- resourceResult{resource: r, schemaURL: schemaURL}
-					return
-				}
-				if firstErr == nil {
-					firstErr = err
-				}
-
-				p.logger.Warn("failed to detect resource", zap.String("detector", string(entry.detectorType)), zap.Error(err))
-
-				next := sleep.NextBackOff()
-				if next == backoff.Stop {
-					record("failure", firstErr)
-					ch <- resourceResult{err: err}
-					return
-				}
-
-				timer := time.NewTimer(next)
-				select {
-				case <-ctx.Done():
-					p.logger.Warn("context was cancelled", zap.Error(ctx.Err()))
-					timer.Stop()
-					record("failure", firstErr)
-					ch <- resourceResult{err: err}
-					return
-				case <-timer.C:
-					// retry
-				}
-			}
+			p.detectWithRetry(ctx, client, entry, ch)
 		}(entry, ch)
 	}
 
@@ -278,6 +234,109 @@ func (p *ResourceProvider) detectResource(ctx context.Context) (pcommon.Resource
 
 	// Partial or full success: return merged resources.
 	return res, mergedSchemaURL, returnErr
+}
+
+func attemptContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return ctx, func() {}
+}
+
+// detectWithRetry runs a detector with backoff. With Enabled=false it makes one
+// attempt. With MaxElapsedTime > 0 each attempt is capped at client.Timeout so
+// one hanging attempt can't eat the whole retry budget. Every attempt records
+// per-detector result and duration telemetry.
+func (p *ResourceProvider) detectWithRetry(ctx context.Context, client *http.Client, entry detectorEntry, ch chan resourceResult) {
+	startTime := time.Now()
+	detectorAttr := attribute.String("detector", string(entry.detectorType))
+
+	// record emits the per-detector result and duration. On failure, failErr
+	// classifies the error.type on the results counter.
+	record := func(outcome string, failErr error) {
+		base := []attribute.KeyValue{detectorAttr, attribute.String("outcome", outcome)}
+		p.telemetry.ResourcedetectionDetectorDuration.Record(ctx, time.Since(startTime).Seconds(), metric.WithAttributes(base...))
+		if failErr != nil {
+			base = append(base, semconv.ErrorType(failErr))
+		}
+		p.telemetry.ResourcedetectionDetectorResults.Add(ctx, 1, metric.WithAttributes(base...))
+	}
+
+	if !p.backoffConfig.Enabled {
+		attemptCtx, cancel := attemptContext(ctx, client.Timeout)
+		defer cancel()
+		r, schemaURL, err := entry.detector.Detect(attemptCtx)
+		if err != nil {
+			p.logger.Warn("failed to detect resource", zap.String("detector", string(entry.detectorType)), zap.Error(err))
+			record("failure", err)
+			ch <- resourceResult{err: err}
+			return
+		}
+		record("success", nil)
+		ch <- resourceResult{resource: r, schemaURL: schemaURL}
+		return
+	}
+
+	sleep := &backoff.ExponentialBackOff{
+		InitialInterval:     p.backoffConfig.InitialInterval,
+		RandomizationFactor: p.backoffConfig.RandomizationFactor,
+		Multiplier:          p.backoffConfig.Multiplier,
+		MaxInterval:         p.backoffConfig.MaxInterval,
+	}
+
+	opts := []backoff.RetryOption{
+		backoff.WithBackOff(sleep),
+	}
+	// MaxElapsedTime == 0 disables the default 15-minute cap, enabling "retry forever".
+	opts = append(opts, backoff.WithMaxElapsedTime(p.backoffConfig.MaxElapsedTime))
+
+	type detectResult struct {
+		resource  pcommon.Resource
+		schemaURL string
+	}
+
+	perAttemptTimeout := time.Duration(0)
+	if p.backoffConfig.MaxElapsedTime > 0 {
+		perAttemptTimeout = client.Timeout
+	}
+
+	// Classify error.type from the first attempt's error: it's the deterministic
+	// root cause, whereas the last attempt's error often just reflects the context
+	// deadline firing rather than why the detector actually failed.
+	var firstErr, lastDetErr error
+	result, err := backoff.Retry(ctx, func() (detectResult, error) {
+		attemptCtx, cancel := attemptContext(ctx, perAttemptTimeout)
+		defer cancel()
+
+		r, schemaURL, detErr := entry.detector.Detect(attemptCtx)
+		if detErr != nil {
+			lastDetErr = detErr
+			if firstErr == nil {
+				firstErr = detErr
+			}
+			p.logger.Warn("failed to detect resource, will retry", zap.String("detector", string(entry.detectorType)), zap.Error(detErr))
+			return detectResult{}, detErr
+		}
+		return detectResult{resource: r, schemaURL: schemaURL}, nil
+	}, opts...)
+	if err != nil {
+		// Preserve the underlying detector error so callers see the real cause,
+		// not just bare context.DeadlineExceeded / backoff.PermanentError wrappers.
+		if lastDetErr != nil && !errors.Is(err, lastDetErr) {
+			err = errors.Join(lastDetErr, err)
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			p.logger.Warn("resource detection cancelled", zap.String("detector", string(entry.detectorType)), zap.Error(err))
+		} else {
+			p.logger.Error("resource detection retry budget exhausted", zap.String("detector", string(entry.detectorType)), zap.Error(err))
+		}
+		record("failure", firstErr)
+		ch <- resourceResult{err: err}
+		return
+	}
+
+	record("success", nil)
+	ch <- resourceResult{resource: result.resource, schemaURL: result.schemaURL}
 }
 
 func MergeSchemaURL(currentSchemaURL, newSchemaURL string) string {

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -150,17 +150,20 @@ func (p *ResourceProvider) Get(_ context.Context, _ *http.Client) (pcommon.Resou
 
 // Refresh recomputes the resource, replacing any previous result.
 func (p *ResourceProvider) Refresh(ctx context.Context, client *http.Client) error {
-	// Bound the session with a ctx deadline whenever something else doesn't
-	// already bound it: client.Timeout when there's no retry budget, or
-	// MaxElapsedTime when there's a budget but no per-attempt cap.
+	// MaxElapsedTime, when set, is the definitive bound on the whole retry
+	// session: apply it regardless of client.Timeout, since backoff.Retry only
+	// checks elapsed time between attempts, not during one — a per-attempt cap
+	// larger than MaxElapsedTime would otherwise let a single attempt overrun
+	// the budget. Otherwise fall back to client.Timeout so a single-shot or
+	// unbounded-retry session still can't hang forever.
 	switch {
-	case p.backoffConfig.MaxElapsedTime == 0 && client.Timeout > 0:
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, client.Timeout)
-		defer cancel()
-	case p.backoffConfig.MaxElapsedTime > 0 && client.Timeout == 0:
+	case p.backoffConfig.MaxElapsedTime > 0:
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, p.backoffConfig.MaxElapsedTime)
+		defer cancel()
+	case client.Timeout > 0:
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, client.Timeout)
 		defer cancel()
 	}
 

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -725,6 +725,26 @@ func TestDetectRetryBudgetBoundsHungAttemptWithNoClientTimeout(t *testing.T) {
 	assert.Less(t, time.Since(start), 5*time.Second, "hung attempt should have been bounded by MaxElapsedTime, not left to run forever")
 }
 
+func TestDetectRetryBudgetBoundsAttemptEvenWithLargerClientTimeout(t *testing.T) {
+	retryConfig := configretry.BackOffConfig{
+		Enabled:         true,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     10 * time.Millisecond,
+		MaxElapsedTime:  50 * time.Millisecond,
+	}
+	p, err := newTestResourceProvider(retryConfig, hangingDetector{})
+	require.NoError(t, err)
+
+	start := time.Now()
+	// client.Timeout is far larger than MaxElapsedTime; the session must still
+	// be bounded by MaxElapsedTime, not left to run for the full client.Timeout.
+	err = p.Refresh(t.Context(), &http.Client{Timeout: 5 * time.Second})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 1*time.Second, "attempt should have been bounded by MaxElapsedTime, not by the larger client.Timeout")
+}
+
 // newTestResourceProvider builds a provider with a nop telemetry builder, assigning
 // each detector a synthetic type.
 func newTestResourceProvider(backoffConfig configretry.BackOffConfig, detectors ...Detector) (*ResourceProvider, error) {

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
@@ -27,6 +28,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/metadatatest"
 )
+
+// fastRetryConfig: small intervals, no budget cap (bounded by test ctx).
+var fastRetryConfig = configretry.BackOffConfig{
+	Enabled:             true,
+	InitialInterval:     1 * time.Millisecond,
+	RandomizationFactor: 0,
+	Multiplier:          2,
+	MaxInterval:         10 * time.Millisecond,
+	MaxElapsedTime:      0,
+}
 
 type mockDetector struct {
 	mock.Mock
@@ -95,7 +106,7 @@ func TestDetect(t *testing.T) {
 			}
 
 			f := NewProviderFactory(mockDetectors)
-			p, err := f.CreateResourceProvider(processortest.NewNopSettings(metadata.Type), time.Second, false, &mockDetectorConfig{}, mockDetectorTypes...)
+			p, err := f.CreateResourceProvider(processortest.NewNopSettings(metadata.Type), fastRetryConfig, false, &mockDetectorConfig{}, mockDetectorTypes...)
 			require.NoError(t, err)
 
 			// Perform initial detection
@@ -114,7 +125,7 @@ func TestDetect(t *testing.T) {
 func TestDetectResource_InvalidDetectorType(t *testing.T) {
 	mockDetectorKey := DetectorType("mock")
 	p := NewProviderFactory(map[DetectorType]DetectorFactory{})
-	_, err := p.CreateResourceProvider(processortest.NewNopSettings(metadata.Type), time.Second, false, &mockDetectorConfig{}, mockDetectorKey)
+	_, err := p.CreateResourceProvider(processortest.NewNopSettings(metadata.Type), fastRetryConfig, false, &mockDetectorConfig{}, mockDetectorKey)
 	require.EqualError(t, err, fmt.Sprintf("invalid detector key: %v", mockDetectorKey))
 }
 
@@ -125,7 +136,7 @@ func TestDetectResource_DetectorFactoryError(t *testing.T) {
 			return nil, errors.New("creation failed")
 		},
 	})
-	_, err := p.CreateResourceProvider(processortest.NewNopSettings(metadata.Type), time.Second, false, &mockDetectorConfig{}, mockDetectorKey)
+	_, err := p.CreateResourceProvider(processortest.NewNopSettings(metadata.Type), fastRetryConfig, false, &mockDetectorConfig{}, mockDetectorKey)
 	require.EqualError(t, err, fmt.Sprintf("failed creating detector type %q: %v", mockDetectorKey, "creation failed"))
 }
 
@@ -136,21 +147,21 @@ func TestDetectResource_Error_ContextDeadline(t *testing.T) {
 	md2 := &mockDetector{}
 	md2.On("Detect").Return(pcommon.NewResource(), "", errors.New("err2"))
 
-	p, err := newTestResourceProvider(time.Second, md1, md2)
+	p, err := newTestResourceProvider(fastRetryConfig, md1, md2)
 	require.NoError(t, err)
 
-	var cancel context.CancelFunc
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	err = p.Refresh(ctx, &http.Client{Timeout: 10 * time.Second})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "err1")
-	require.Contains(t, err.Error(), "err2")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "err1")
+	assert.Contains(t, err.Error(), "err2")
 }
 
 func TestDetectResource_NoDetectors(t *testing.T) {
-	p, err := newTestResourceProvider(time.Second)
+	p, err := newTestResourceProvider(fastRetryConfig)
 	require.NoError(t, err)
 
 	err = p.Refresh(t.Context(), &http.Client{Timeout: 10 * time.Second})
@@ -168,7 +179,7 @@ func TestDetectResource_RecordsTelemetry(t *testing.T) {
 	f := NewProviderFactory(map[DetectorType]DetectorFactory{
 		"ec2": func(processor.Settings, DetectorConfig, bool) (Detector, error) { return md, nil },
 	})
-	p, err := f.CreateResourceProvider(metadatatest.NewSettings(tt), time.Second, false, &mockDetectorConfig{}, "ec2")
+	p, err := f.CreateResourceProvider(metadatatest.NewSettings(tt), fastRetryConfig, false, &mockDetectorConfig{}, "ec2")
 	require.NoError(t, err)
 
 	require.NoError(t, p.Refresh(t.Context(), &http.Client{Timeout: 10 * time.Second}))
@@ -195,7 +206,7 @@ func TestDetectResource_RecordsFailureTelemetry(t *testing.T) {
 	f := NewProviderFactory(map[DetectorType]DetectorFactory{
 		"ec2": func(processor.Settings, DetectorConfig, bool) (Detector, error) { return md, nil },
 	})
-	p, err := f.CreateResourceProvider(metadatatest.NewSettings(tt), time.Second, false, &mockDetectorConfig{}, "ec2")
+	p, err := f.CreateResourceProvider(metadatatest.NewSettings(tt), fastRetryConfig, false, &mockDetectorConfig{}, "ec2")
 	require.NoError(t, err)
 
 	// Short timeout cuts the inter-retry backoff short via context cancellation.
@@ -303,7 +314,7 @@ func TestDetectResource_Parallel(t *testing.T) {
 
 	expectedResourceAttrs := map[string]any{"a": "1", "b": "2", "c": "3"}
 
-	p, err := newTestResourceProvider(time.Second, md1, md2)
+	p, err := newTestResourceProvider(fastRetryConfig, md1, md2)
 	require.NoError(t, err)
 
 	// Perform initial detection
@@ -359,7 +370,7 @@ func TestDetectResource_Reconnect(t *testing.T) {
 
 	expectedResourceAttrs := map[string]any{"a": "1", "b": "2", "c": "3"}
 
-	p, err := newTestResourceProvider(time.Second, md1, md2)
+	p, err := newTestResourceProvider(fastRetryConfig, md1, md2)
 	require.NoError(t, err)
 
 	err = p.Refresh(t.Context(), &http.Client{Timeout: 15 * time.Second})
@@ -385,7 +396,7 @@ func TestResourceProvider_RefreshInterval(t *testing.T) {
 	md.On("Detect").Return(res1, "", nil).Once()
 	md.On("Detect").Return(res2, "", nil).Once()
 
-	p, err := newTestResourceProvider(1*time.Second, md)
+	p, err := newTestResourceProvider(fastRetryConfig, md)
 	require.NoError(t, err)
 
 	// Initial detection
@@ -481,7 +492,7 @@ func TestStartStopRefreshing(t *testing.T) {
 		md.On("Detect").Return(res1, "", nil).Once()
 		md.On("Detect").Return(res2, "", nil)
 
-		p, err := newTestResourceProvider(time.Second, md)
+		p, err := newTestResourceProvider(fastRetryConfig, md)
 		require.NoError(t, err)
 
 		// Initial detection
@@ -516,7 +527,7 @@ func TestStartStopRefreshing(t *testing.T) {
 		require.NoError(t, res.Attributes().FromRaw(map[string]any{"a": "1"}))
 		md.On("Detect").Return(res, "", nil).Once()
 
-		p, err := newTestResourceProvider(time.Second, md)
+		p, err := newTestResourceProvider(fastRetryConfig, md)
 		require.NoError(t, err)
 
 		// Initial detection
@@ -542,7 +553,7 @@ func TestStartStopRefreshing(t *testing.T) {
 		require.NoError(t, res.Attributes().FromRaw(map[string]any{"a": "1"}))
 		md.On("Detect").Return(res, "", nil).Once()
 
-		p, err := newTestResourceProvider(time.Second, md)
+		p, err := newTestResourceProvider(fastRetryConfig, md)
 		require.NoError(t, err)
 
 		// Initial detection
@@ -558,7 +569,7 @@ func TestStartStopRefreshing(t *testing.T) {
 }
 
 func TestStartRefreshing_CalledMultipleTimes(t *testing.T) {
-	provider, err := newTestResourceProvider(5 * time.Second)
+	provider, err := newTestResourceProvider(fastRetryConfig)
 	require.NoError(t, err)
 	client := &http.Client{Timeout: 5 * time.Second}
 
@@ -589,9 +600,134 @@ func TestStartRefreshing_CalledMultipleTimes(t *testing.T) {
 	}
 }
 
+func TestDetectWithRetry(t *testing.T) {
+	md := &mockDetector{}
+	res := pcommon.NewResource()
+	require.NoError(t, res.Attributes().FromRaw(map[string]any{"cloud": "gcp"}))
+
+	// Fail twice, then succeed.
+	md.On("Detect").Return(pcommon.NewResource(), "", errors.New("metadata unavailable")).Twice()
+	md.On("Detect").Return(res, "", nil)
+
+	retryConfig := configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     10 * time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          2,
+		MaxInterval:         50 * time.Millisecond,
+		MaxElapsedTime:      0, // retry forever
+	}
+	p, err := newTestResourceProvider(retryConfig, md)
+	require.NoError(t, err)
+
+	err = p.Refresh(t.Context(), &http.Client{Timeout: 5 * time.Second})
+	require.NoError(t, err)
+
+	got, _, err := p.Get(t.Context(), &http.Client{Timeout: 5 * time.Second})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"cloud": "gcp"}, got.Attributes().AsRaw())
+	md.AssertNumberOfCalls(t, "Detect", 3)
+}
+
+func TestDetectRetryBudgetExhausted(t *testing.T) {
+	md := &mockDetector{}
+	md.On("Detect").Return(pcommon.NewResource(), "", errors.New("still unavailable"))
+
+	retryConfig := configretry.BackOffConfig{
+		Enabled:         true,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     10 * time.Millisecond,
+		MaxElapsedTime:  60 * time.Millisecond,
+	}
+	p, err := newTestResourceProvider(retryConfig, md)
+	require.NoError(t, err)
+
+	err = p.Refresh(t.Context(), &http.Client{Timeout: 5 * time.Second})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still unavailable")
+}
+
+func TestDetectRetryDisabled(t *testing.T) {
+	md := &mockDetector{}
+	md.On("Detect").Return(pcommon.NewResource(), "", errors.New("boom")).Once()
+
+	disabledRetry := configretry.BackOffConfig{Enabled: false}
+	p, err := newTestResourceProvider(disabledRetry, md)
+	require.NoError(t, err)
+
+	err = p.Refresh(t.Context(), &http.Client{Timeout: 5 * time.Second})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+	md.AssertNumberOfCalls(t, "Detect", 1)
+}
+
+func TestDetectResource_JoinedErrors(t *testing.T) {
+	md1 := &mockDetector{}
+	md1.On("Detect").Return(pcommon.NewResource(), "", errors.New("err1")).Once()
+
+	md2 := &mockDetector{}
+	md2.On("Detect").Return(pcommon.NewResource(), "", errors.New("err2")).Once()
+
+	disabledRetry := configretry.BackOffConfig{Enabled: false}
+	p, err := newTestResourceProvider(disabledRetry, md1, md2)
+	require.NoError(t, err)
+
+	err = p.Refresh(t.Context(), &http.Client{Timeout: 5 * time.Second})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "err1")
+	assert.Contains(t, err.Error(), "err2")
+}
+
+func TestDetectRetryContextCancellation(t *testing.T) {
+	md := &mockDetector{}
+	md.On("Detect").Return(pcommon.NewResource(), "", errors.New("not ready"))
+
+	retryConfig := configretry.BackOffConfig{
+		Enabled:         true,
+		InitialInterval: 50 * time.Millisecond,
+		MaxInterval:     50 * time.Millisecond,
+		MaxElapsedTime:  0, // would retry forever if not cancelled
+	}
+	p, err := newTestResourceProvider(retryConfig, md)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 80*time.Millisecond)
+	defer cancel()
+
+	err = p.Refresh(ctx, &http.Client{Timeout: 5 * time.Second})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// hangingDetector blocks until its context is done, simulating a detector
+// attempt that never returns on its own.
+type hangingDetector struct{}
+
+func (hangingDetector) Detect(ctx context.Context) (pcommon.Resource, string, error) {
+	<-ctx.Done()
+	return pcommon.NewResource(), "", ctx.Err()
+}
+
+func TestDetectRetryBudgetBoundsHungAttemptWithNoClientTimeout(t *testing.T) {
+	retryConfig := configretry.BackOffConfig{
+		Enabled:         true,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     10 * time.Millisecond,
+		MaxElapsedTime:  50 * time.Millisecond,
+	}
+	p, err := newTestResourceProvider(retryConfig, hangingDetector{})
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = p.Refresh(t.Context(), &http.Client{Timeout: 0})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second, "hung attempt should have been bounded by MaxElapsedTime, not left to run forever")
+}
+
 // newTestResourceProvider builds a provider with a nop telemetry builder, assigning
 // each detector a synthetic type.
-func newTestResourceProvider(timeout time.Duration, detectors ...Detector) (*ResourceProvider, error) {
+func newTestResourceProvider(backoffConfig configretry.BackOffConfig, detectors ...Detector) (*ResourceProvider, error) {
 	tb, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
 	if err != nil {
 		return nil, err
@@ -600,5 +736,5 @@ func newTestResourceProvider(timeout time.Duration, detectors ...Detector) (*Res
 	for i, d := range detectors {
 		entries[i] = detectorEntry{detectorType: DetectorType(fmt.Sprintf("mock%d", i)), detector: d}
 	}
-	return NewResourceProvider(zap.NewNop(), tb, timeout, entries...), nil
+	return NewResourceProvider(zap.NewNop(), tb, backoffConfig, entries...), nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a retry config to resource detection processor, this retry affects all detectors, this comes as a replacement to detector specific retry config (such as the EC2 one_ 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46546

<!--Describe what testing was performed and which tests were added.-->
#### Testing


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
