### PR TITLE
[processor/tailsampling] Switch `rate_limiting` to a token bucket algorithm with `burst_capacity`

### DIFF
--- a/.chloggen/tailsampling-rate-limiting-burst-capacity.yaml
+++ b/.chloggen/tailsampling-rate-limiting-burst-capacity.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Switch the `rate_limiting` policy to a token bucket and add `burst_capacity` to allow short bursts of traffic above the sustained spans-per-second rate.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If `burst_capacity` is not set, it defaults to 2x `spans_per_second`, mirroring the `bytes_limiting` policy.
+
+  Existing configurations will see slightly different behavior: the bucket starts with a default burst of 2x
+  `spans_per_second` tokens. A trace whose span count equals `spans_per_second` can now be sampled (the previous
+  strict `<` comparison meant `spans_per_second: 1` would never sample).
+  Set `burst_capacity` explicitly to match the previous per-second cap if needed.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/tailsampling-rate-limiting-burst-capacity.yaml
+++ b/.chloggen/tailsampling-rate-limiting-burst-capacity.yaml
@@ -10,7 +10,7 @@ component: processor/tail_sampling
 note: Switch the `rate_limiting` policy to a token bucket and add `burst_capacity` to allow short bursts of traffic above the sustained spans-per-second rate.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [ ]
+issues: [48226]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -33,7 +33,7 @@ Multiple policies exist today and it is straight forward to add more. These incl
 - `string_attribute`: Sample based on string attributes (resource and record) value matches, both exact and regex value matches are supported
 - `trace_state`: Sample based on [TraceState](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracestate) value matches
 - `trace_flags`: Sample if the [sampled trace flag](https://www.w3.org/TR/trace-context-2/#sampled-flag) was set on any span in the trace
-- `rate_limiting`: Sample based on the rate of spans per second.
+- `rate_limiting`: Sample based on the rate of spans per second using a token bucket algorithm implemented by golang.org/x/time/rate. This allows for burst traffic up to a configurable capacity while maintaining the average rate over time. The bucket is refilled continuously at the specified rate and has a maximum capacity for burst handling.
 - `bytes_limiting`: Sample based on the rate of bytes per second using a token bucket algorithm implemented by golang.org/x/time/rate. This allows for burst traffic up to a configurable capacity while maintaining the average rate over time. The bucket is refilled continuously at the specified rate and has a maximum capacity for burst handling.
 - `span_count`: Sample based on the minimum and/or maximum number of spans, inclusive. If the sum of all spans in the trace is outside the range threshold, the trace will not be sampled.
 - `boolean_attribute`: Sample based on boolean attribute (resource and record).
@@ -146,7 +146,7 @@ processors:
           {
             name: test-policy-8,
             type: rate_limiting,
-            rate_limiting: {spans_per_second: 35}
+            rate_limiting: {spans_per_second: 35, burst_capacity: 70}
          },
          {
             name: test-policy-9,

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -250,6 +250,10 @@ type StringAttributeCfg struct {
 type RateLimitingCfg struct {
 	// SpansPerSecond sets the limit on the maximum number of spans that can be processed each second.
 	SpansPerSecond int64 `mapstructure:"spans_per_second"`
+	// BurstCapacity sets the maximum burst capacity in spans. If not specified, defaults to 2x SpansPerSecond.
+	// This allows for short bursts of traffic above the sustained rate. It also acts as a
+	// limit for individual trace span counts, a single trace with more spans than the burst size will not pass.
+	BurstCapacity int64 `mapstructure:"burst_capacity"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/processor/tailsamplingprocessor/config.schema.yaml
+++ b/processor/tailsamplingprocessor/config.schema.yaml
@@ -360,6 +360,10 @@ $defs:
     description: RateLimitingCfg holds the configurable settings to create a rate limiting sampling policy evaluator.
     type: object
     properties:
+      burst_capacity:
+        description: BurstCapacity sets the maximum burst capacity in spans. If not specified, defaults to 2x SpansPerSecond. This allows for short bursts of traffic above the sustained rate. It also acts as a limit for individual trace span counts, a single trace with more spans than the burst size will not pass.
+        type: integer
+        x-customType: int64
       spans_per_second:
         description: SpansPerSecond sets the limit on the maximum number of spans that can be processed each second.
         type: integer

--- a/processor/tailsamplingprocessor/config_test.go
+++ b/processor/tailsamplingprocessor/config_test.go
@@ -85,7 +85,7 @@ func TestLoadConfig(t *testing.T) {
 					sharedPolicyCfg: sharedPolicyCfg{
 						Name:            "test-policy-7",
 						Type:            RateLimiting,
-						RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 35},
+						RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 35, BurstCapacity: 70},
 					},
 				},
 				{

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
@@ -10,39 +10,41 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type rateLimiting struct {
-	currentSecond        int64
-	spansInCurrentSecond int64
-	spansPerSecond       int64
-	logger               *zap.Logger
+	// Rate limiter using golang.org/x/time/rate for efficient token bucket implementation.
+	limiter *rate.Limiter
+	logger  *zap.Logger
 }
 
 var _ samplingpolicy.Evaluator = (*rateLimiting)(nil)
 
-// NewRateLimiting creates a policy evaluator the samples all traces.
+// NewRateLimiting creates a policy evaluator that samples traces based on a span limit per second using a token bucket algorithm.
+// The bucket capacity defaults to 2x the spans per second to allow for reasonable burst traffic.
 func NewRateLimiting(settings component.TelemetrySettings, spansPerSecond int64) samplingpolicy.Evaluator {
+	return NewRateLimitingWithBurstCapacity(settings, spansPerSecond, spansPerSecond*2)
+}
+
+// NewRateLimitingWithBurstCapacity creates a rate limiting policy evaluator with a configurable
+// burst capacity, using a token bucket algorithm. Tokens (spans) refill continuously at
+// spansPerSecond and the bucket holds at most burstCapacity tokens. A single trace whose span
+// count exceeds the burst capacity will not pass.
+func NewRateLimitingWithBurstCapacity(settings component.TelemetrySettings, spansPerSecond, burstCapacity int64) samplingpolicy.Evaluator {
 	return &rateLimiting{
-		spansPerSecond: spansPerSecond,
-		logger:         settings.Logger,
+		limiter: rate.NewLimiter(rate.Limit(spansPerSecond), int(burstCapacity)),
+		logger:  settings.Logger,
 	}
 }
 
-// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision based on token bucket consumption.
 func (r *rateLimiting) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	r.logger.Debug("Evaluating spans in rate-limiting filter")
-	currSecond := time.Now().Unix()
-	if r.currentSecond != currSecond {
-		r.currentSecond = currSecond
-		r.spansInCurrentSecond = 0
-	}
 
-	spansInSecondIfSampled := r.spansInCurrentSecond + trace.SpanCount
-	if spansInSecondIfSampled < r.spansPerSecond {
-		r.spansInCurrentSecond = spansInSecondIfSampled
+	if r.limiter.AllowN(time.Now(), int(trace.SpanCount)) {
 		return samplingpolicy.Sampled, nil
 	}
 

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
@@ -5,40 +5,80 @@ package sampling
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func TestRateLimiter(t *testing.T) {
+func TestRateLimiterTokenBucket(t *testing.T) {
 	trace := newTraceStringAttrs(nil, "example", "value")
 	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
-	rateLimiter := NewRateLimiting(componenttest.NewNopTelemetrySettings(), 3)
+	rateLimiter := NewRateLimitingWithBurstCapacity(componenttest.NewNopTelemetrySettings(), 3, 3)
 
-	// Trace span count greater than spans per second
-	trace.SpanCount = 10
-	decision, err := rateLimiter.Evaluate(t.Context(), traceID, trace)
-	assert.NoError(t, err)
-	assert.Equal(t, samplingpolicy.NotSampled, decision)
-
-	// Trace span count equal to spans per second
+	// First trace consumes the entire burst.
 	trace.SpanCount = 3
-	decision, err = rateLimiter.Evaluate(t.Context(), traceID, trace)
-	assert.NoError(t, err)
-	assert.Equal(t, samplingpolicy.NotSampled, decision)
-
-	// Trace span count less than spans per second
-	trace.SpanCount = 2
-	decision, err = rateLimiter.Evaluate(t.Context(), traceID, trace)
-	assert.NoError(t, err)
+	decision, err := rateLimiter.Evaluate(t.Context(), traceID, trace)
+	require.NoError(t, err)
 	assert.Equal(t, samplingpolicy.Sampled, decision)
 
-	// Trace span count less than spans per second
-	trace.SpanCount = 0
+	// No tokens remain in the same window.
+	trace.SpanCount = 1
 	decision, err = rateLimiter.Evaluate(t.Context(), traceID, trace)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
+}
+
+func TestRateLimiterBurstCapacityRejectsLargeTrace(t *testing.T) {
+	trace := newTraceStringAttrs(nil, "example", "value")
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	rateLimiter := NewRateLimitingWithBurstCapacity(componenttest.NewNopTelemetrySettings(), 3, 2)
+
+	// A single trace exceeding burst capacity is rejected.
+	trace.SpanCount = 3
+	decision, err := rateLimiter.Evaluate(t.Context(), traceID, trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
+}
+
+func TestRateLimiterDefaultConstructorBurst(t *testing.T) {
+	trace := newTraceStringAttrs(nil, "example", "value")
+	rateLimiter := NewRateLimiting(componenttest.NewNopTelemetrySettings(), 2)
+
+	// Default burst is 2x spans_per_second, so the first 4 single-span traces are sampled.
+	trace.SpanCount = 1
+	for i := range 4 {
+		decision, err := rateLimiter.Evaluate(t.Context(), pcommon.TraceID([16]byte{byte(i + 1)}), trace)
+		require.NoError(t, err)
+		assert.Equal(t, samplingpolicy.Sampled, decision)
+	}
+
+	decision, err := rateLimiter.Evaluate(t.Context(), pcommon.TraceID([16]byte{5}), trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
+}
+
+func TestRateLimiterTokenRefill(t *testing.T) {
+	trace := newTraceStringAttrs(nil, "example", "value")
+	rateLimiter := NewRateLimitingWithBurstCapacity(componenttest.NewNopTelemetrySettings(), 4, 2)
+
+	trace.SpanCount = 2
+	decision, err := rateLimiter.Evaluate(t.Context(), pcommon.TraceID([16]byte{1}), trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
+
+	decision, err = rateLimiter.Evaluate(t.Context(), pcommon.TraceID([16]byte{2}), trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
+
+	// Refill happens at 4 tokens per second; wait long enough for the bucket to refill.
+	time.Sleep(600 * time.Millisecond)
+
+	decision, err = rateLimiter.Evaluate(t.Context(), pcommon.TraceID([16]byte{3}), trace)
+	require.NoError(t, err)
 	assert.Equal(t, samplingpolicy.Sampled, decision)
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -429,6 +429,9 @@ func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedP
 		return sampling.NewStatusCodeFilter(settings, scfCfg.StatusCodes)
 	case RateLimiting:
 		rlfCfg := cfg.RateLimitingCfg
+		if rlfCfg.BurstCapacity > 0 {
+			return sampling.NewRateLimitingWithBurstCapacity(settings, rlfCfg.SpansPerSecond, rlfCfg.BurstCapacity), nil
+		}
 		return sampling.NewRateLimiting(settings, rlfCfg.SpansPerSecond), nil
 	case BytesLimiting:
 		blfCfg := cfg.BytesLimitingCfg

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -1213,6 +1213,7 @@ func TestRateLimiter(t *testing.T) {
 					Type: "rate_limiting",
 					RateLimitingCfg: RateLimitingCfg{
 						SpansPerSecond: 2,
+						BurstCapacity:  2,
 					},
 				},
 			},

--- a/processor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
+++ b/processor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
@@ -39,7 +39,7 @@ tail_sampling:
         {
           name: test-policy-7,
           type: rate_limiting,
-          rate_limiting: {spans_per_second: 35}
+          rate_limiting: {spans_per_second: 35, burst_capacity: 70}
        },
        {
           name: test-policy-8,


### PR DESCRIPTION
#### Description

The `rate_limiting` policy has a strict `spans_per_second` limit enforced each second. This means traces larger than `spans_per_second` can never be ingested.
This PR changes the implementation to uses a token bucket algorithm from https://golang.org/x/time/rate. The rate limiter has a burst capacity which can sample a large trace at once.

This is almost identical to how the `bytes_limiting` policy works.

Note: this is a slight change in behaviour. Traces that were not sampled by the previous implementation might be sampled now using burst capacity. I think this is acceptable since the intention of the policy didn't change and over time it will still sample at a`spans_per_second` rate of spans.
If a user relied on never sampling more than `spans_per_second` each second, they can set `burst_capacity = spans_per_second`.

#### Testing

Updated/added new tests.

#### Documentation

Updated the README.