### PR TITLE
[chore]: fix check-codeowners

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -56,7 +56,8 @@ jobs:
 
       - name: Gen CODEOWNERS
         run: |
-          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=./pr" make codeowners
-          cd pr && if ! git diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1; fi
+          cd pr
+          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} make codeowners
+          if ! git diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1; fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
#### Description

check-codeowners is [failing](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/25525400708/job/74919681299) because the file paths are different. Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48191
