### PR TITLE
[chore] Regenerate CODEOWNERS for isolationforestprocessor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -209,7 +209,7 @@ processor/geoipprocessor/                                        @open-telemetry
 processor/groupbyattrsprocessor/                                 @open-telemetry/collector-contrib-approvers @rnishtala-sumo @amdprophet
 processor/groupbytraceprocessor/                                 @open-telemetry/collector-contrib-approvers @iblancasa
 processor/intervalprocessor/                                     @open-telemetry/collector-contrib-approvers @RichieSams
-processor/isolationforestprocessor/                              @open-telemetry/collector-contrib-approvers @atoulme
+processor/isolationforestprocessor/                              @open-telemetry/collector-contrib-approvers @atoulme @aarvee11
 processor/k8sattributesprocessor/                                @open-telemetry/collector-contrib-approvers @dmitryax @fatsheep9146 @TylerHelmuth @ChrsMark @odubajDT
 processor/logdedupprocessor/                                     @open-telemetry/collector-contrib-approvers @MikeGoldsmith
 processor/logstransformprocessor/                                @open-telemetry/collector-contrib-approvers @dehaansa


### PR DESCRIPTION
## Description

The `metadata.yaml` for `processor/isolationforestprocessor` lists `@aarvee11` as a codeowner (added in #47918) but `.github/CODEOWNERS` was not regenerated at the time. This causes the `check-codeowners` workflow to fail on every PR opened against `main` until CODEOWNERS is brought back in sync.

This PR regenerates `.github/CODEOWNERS` via `make codeowners` so subsequent PRs can pass the check.

## Testing

- `make codeowners` produces no further diff after this change.

Assisted-by: Claude Opus 4.7