### PR TITLE
[chore][exporter/splunk_hec] Fix README description of config option

### DIFF
--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -105,7 +105,7 @@ exporters:
     sourcetype: "otel"
     # Splunk index, optional name of the Splunk index targeted.
     index: "metrics"
-    # Maximum HTTP connections to use simultaneously when sending data. Defaults to 100.
+    # Maximum idle HTTP connections the client can keep open. Defaults to 100.
     max_idle_conns: 200
     # Whether to disable gzip compression over HTTP. Defaults to false.
     disable_compression: false


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The config option name in the example was updated from `max_connections` to `max_idle_conns` [when the former was deprecated](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16839), but the description was not updated.