### PR TITLE
[processor/deltatocumulative] refactor: add Storage interface

### DIFF
--- a/.chloggen/cumulativeprocessor-storage-interface.yaml
+++ b/.chloggen/cumulativeprocessor-storage-interface.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/deltatocumulative
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: introduce a Storage interface for the cumulative state map
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47380, 47086, 48249]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Abstracts the per-stream cumulative state behind a generic Storage interface so
+  that storage-extension-backed implementations can be plugged in. Behavior is
+  unchanged: the in-memory map remains the only implementation.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -41,16 +41,10 @@ type deltaToCumulativeProcessor struct {
 func newProcessor(cfg *Config, tel telemetry.Metrics, next consumer.Metrics) *deltaToCumulativeProcessor {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	limit := maps.Limit(int64(cfg.MaxStreams))
 	proc := deltaToCumulativeProcessor{
-		next: next,
-		cfg:  *cfg,
-		last: state{
-			ctx:  limit,
-			nums: maps.New[identity.Stream, *mutex[pmetric.NumberDataPoint]](limit),
-			hist: maps.New[identity.Stream, *mutex[pmetric.HistogramDataPoint]](limit),
-			expo: maps.New[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]](limit),
-		},
+		next:   next,
+		cfg:    *cfg,
+		last:   newState(int64(cfg.MaxStreams)),
 		aggr:   delta.Aggregator{Aggregator: new(data.Adder)},
 		ctx:    ctx,
 		cancel: cancel,
@@ -71,6 +65,14 @@ type vals struct {
 	expo *mutex[pmetric.ExponentialHistogramDataPoint]
 }
 
+func newVals() vals {
+	return vals{
+		nums: guard(pmetric.NewNumberDataPoint()),
+		hist: guard(pmetric.NewHistogramDataPoint()),
+		expo: guard(pmetric.NewExponentialHistogramDataPoint()),
+	}
+}
+
 func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	now := time.Now()
 
@@ -79,11 +81,7 @@ func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmet
 		drop = false
 	)
 
-	zero := vals{
-		nums: guard(pmetric.NewNumberDataPoint()),
-		hist: guard(pmetric.NewHistogramDataPoint()),
-		expo: guard(pmetric.NewExponentialHistogramDataPoint()),
-	}
+	zero := newVals()
 
 	metrics.Filter(md, func(m metrics.Metric) bool {
 		if m.AggregationTemporality() != pmetric.AggregationTemporalityDelta {
@@ -222,12 +220,30 @@ func (*deltaToCumulativeProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
+// Storage is the per-stream backing store for cumulative state. The in-memory
+// implementation ([maps.Parallel]) is used by default; storage-backed
+// implementations can be plugged in to persist state across restarts.
+type Storage[K comparable, V any] interface {
+	LoadOrStore(key K, value V) (actual V, loaded bool)
+	LoadAndDelete(key K) (value V, loaded bool)
+}
+
 // state keeps a cumulative value, aggregated over time, per stream
 type state struct {
 	ctx  maps.Context
-	nums *maps.Parallel[identity.Stream, *mutex[pmetric.NumberDataPoint]]
-	hist *maps.Parallel[identity.Stream, *mutex[pmetric.HistogramDataPoint]]
-	expo *maps.Parallel[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]
+	nums Storage[identity.Stream, *mutex[pmetric.NumberDataPoint]]
+	hist Storage[identity.Stream, *mutex[pmetric.HistogramDataPoint]]
+	expo Storage[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]
+}
+
+func newState(maxStreams int64) state {
+	limit := maps.Limit(maxStreams)
+	return state{
+		ctx:  limit,
+		nums: maps.New[identity.Stream, *mutex[pmetric.NumberDataPoint]](limit),
+		hist: maps.New[identity.Stream, *mutex[pmetric.HistogramDataPoint]](limit),
+		expo: maps.New[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]](limit),
+	}
 }
 
 func (s state) Size() int {


### PR DESCRIPTION
#### Description
- For adding persistent storage support for state recovery (
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47380).
- make `Storage` interface
- To support storage extension, I think we have to make it as an interface.

PR series:
- 1. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48249
- 2. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48250
- 3. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48251


#### Link to tracking issue
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47086

#### Testing
- No test

#### Documentation
