### PR TITLE
[processor/deltatocumulative] feat: add write-through flag for performance

### DIFF
--- a/.chloggen/cumulativeprocessor-storage-interface.yaml
+++ b/.chloggen/cumulativeprocessor-storage-interface.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/deltatocumulative
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: introduce a Storage interface for the cumulative state map
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47380, 47086, 48249]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Abstracts the per-stream cumulative state behind a generic Storage interface so
+  that storage-extension-backed implementations can be plugged in. Behavior is
+  unchanged: the in-memory map remains the only implementation.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/cumulativeprocessor-storage-persisted.yaml
+++ b/.chloggen/cumulativeprocessor-storage-persisted.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/deltatocumulative
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: persist cumulative state across collector restarts via a storage extension
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47380, 47086, 48249, 48250]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds an optional `storage` configuration that references a storage extension.
+  When set, accumulated stream state is loaded from storage on first access and
+  flushed in the background (write-back), so cumulative values survive collector
+  restarts. Orphaned entries from previous sessions are cleaned up after MaxStale.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/deltatocumulativeprocessor/README.md
+++ b/processor/deltatocumulativeprocessor/README.md
@@ -32,9 +32,51 @@ processors:
         # will be dropped
         [ max_streams: <int> | default = 9223372036854775807 (max int) ]
 
+        # optional: reference to a storage extension for persistent state.
+        # when set, accumulated stream state survives collector restarts.
+        [ storage: <component.ID> ]
+
 ```
 
 There is no further configuration required. All delta samples are converted to cumulative.
+
+### Persistent storage
+
+By default, all accumulated state is held in memory and lost on restart.
+Setting `storage` to a [storage extension](https://opentelemetry.io/docs/collector/configuration/#storage-extension) ID
+enables the processor to persist stream state across collector restarts.
+
+State is loaded from storage on first access and periodically flushed in the
+background (write-back), keeping I/O overhead low.
+
+#### Example: write-back with Redis storage
+
+``` yaml
+extensions:
+    redis_storage:
+        endpoint: localhost:6379
+
+processors:
+    deltatocumulative:
+        storage: redis_storage
+
+service:
+    extensions: [redis_storage]
+    pipelines:
+        metrics:
+            processors: [deltatocumulative]
+```
+
+## Warnings
+
+### Statefulness
+
+This processor **accumulates state** in memory (or in a configured storage extension). 
+The amount of state scales linearly with the number of unique metric streams.
+
+When no `storage` extension is configured, all state is lost on collector restart, which
+causes a gap in cumulative series until the next delta sample arrives.
+Configuring persistent storage eliminates this gap at the cost of I/O overhead.
 
 ## Troubleshooting
 

--- a/processor/deltatocumulativeprocessor/README.md
+++ b/processor/deltatocumulativeprocessor/README.md
@@ -36,6 +36,11 @@ processors:
         # when set, accumulated stream state survives collector restarts.
         [ storage: <component.ID> ]
 
+        # write every update to storage immediately instead of batching.
+        # requires storage to be set. provides stronger durability at the
+        # cost of higher I/O.
+        [ write_through: <bool> | default = false ]
+
 ```
 
 There is no further configuration required. All delta samples are converted to cumulative.
@@ -46,8 +51,12 @@ By default, all accumulated state is held in memory and lost on restart.
 Setting `storage` to a [storage extension](https://opentelemetry.io/docs/collector/configuration/#storage-extension) ID
 enables the processor to persist stream state across collector restarts.
 
-State is loaded from storage on first access and periodically flushed in the
-background (write-back), keeping I/O overhead low.
+Two persistence modes are available:
+
+| Mode | Config | Behavior |
+|------|--------|----------|
+| **Write-back** (default) | `storage: <id>` | State is loaded from storage on first access and periodically flushed in the background. Low I/O overhead. |
+| **Write-through** | `storage: <id>` + `write_through: true` | Every update is written to storage immediately. Stronger durability guarantees at the cost of higher I/O. |
 
 #### Example: write-back with Redis storage
 
@@ -62,6 +71,25 @@ processors:
 
 service:
     extensions: [redis_storage]
+    pipelines:
+        metrics:
+            processors: [deltatocumulative]
+```
+
+#### Example: write-through with file storage
+
+``` yaml
+extensions:
+    file_storage:
+        directory: /var/lib/otelcol/delta_state
+
+processors:
+    deltatocumulative:
+        storage: file_storage
+        write_through: true
+
+service:
+    extensions: [file_storage]
     pipelines:
         metrics:
             processors: [deltatocumulative]

--- a/processor/deltatocumulativeprocessor/codec.go
+++ b/processor/deltatocumulativeprocessor/codec.go
@@ -1,0 +1,154 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+)
+
+// streamHashKey returns a hex-encoded hash string for an identity.Stream,
+// suitable for use as a storage key.
+//
+// Uses the 64-bit FNV-1a hash of the stream identity. Collision probability is
+// negligible for realistic stream counts (~5e-10 at 100k streams). A fuller key
+// is not possible because identity.Stream fields are unexported.
+func streamHashKey(s identity.Stream) string {
+	return strconv.FormatUint(s.Hash().Sum64(), 16)
+}
+
+var errMalformedData = errors.New("malformed persisted datapoint")
+
+// marshalNumberDP wraps a single NumberDataPoint into a minimal pmetric.Metrics
+// and serializes it to protobuf bytes. The mutex is only held during the copy;
+// the expensive proto marshal runs lock-free.
+func marshalNumberDP(v *mutex[pmetric.NumberDataPoint]) ([]byte, error) {
+	md := pmetric.NewMetrics()
+	target := md.ResourceMetrics().AppendEmpty().
+		ScopeMetrics().AppendEmpty().
+		Metrics().AppendEmpty().
+		SetEmptySum().DataPoints().AppendEmpty()
+	v.use(func(dp pmetric.NumberDataPoint) {
+		dp.CopyTo(target)
+	})
+	return protoMarshaler.MarshalMetrics(md)
+}
+
+// unmarshalNumberDP deserializes protobuf bytes into a *mutex[NumberDataPoint].
+func unmarshalNumberDP(data []byte) (*mutex[pmetric.NumberDataPoint], error) {
+	md, err := protoUnmarshaler.UnmarshalMetrics(data)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal number datapoint: %w", err)
+	}
+	if err := validateSingleDP(md); err != nil {
+		return nil, err
+	}
+	dp := md.ResourceMetrics().At(0).
+		ScopeMetrics().At(0).
+		Metrics().At(0).
+		Sum().DataPoints().At(0)
+	return guard(dp), nil
+}
+
+// marshalHistogramDP wraps a single HistogramDataPoint and serializes it.
+func marshalHistogramDP(v *mutex[pmetric.HistogramDataPoint]) ([]byte, error) {
+	md := pmetric.NewMetrics()
+	target := md.ResourceMetrics().AppendEmpty().
+		ScopeMetrics().AppendEmpty().
+		Metrics().AppendEmpty().
+		SetEmptyHistogram().DataPoints().AppendEmpty()
+	v.use(func(dp pmetric.HistogramDataPoint) {
+		dp.CopyTo(target)
+	})
+	return protoMarshaler.MarshalMetrics(md)
+}
+
+// unmarshalHistogramDP deserializes protobuf bytes into a *mutex[HistogramDataPoint].
+func unmarshalHistogramDP(data []byte) (*mutex[pmetric.HistogramDataPoint], error) {
+	md, err := protoUnmarshaler.UnmarshalMetrics(data)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal histogram datapoint: %w", err)
+	}
+	if err := validateSingleDP(md); err != nil {
+		return nil, err
+	}
+	dp := md.ResourceMetrics().At(0).
+		ScopeMetrics().At(0).
+		Metrics().At(0).
+		Histogram().DataPoints().At(0)
+	return guard(dp), nil
+}
+
+// marshalExpoDP wraps a single ExponentialHistogramDataPoint and serializes it.
+func marshalExpoDP(v *mutex[pmetric.ExponentialHistogramDataPoint]) ([]byte, error) {
+	md := pmetric.NewMetrics()
+	target := md.ResourceMetrics().AppendEmpty().
+		ScopeMetrics().AppendEmpty().
+		Metrics().AppendEmpty().
+		SetEmptyExponentialHistogram().DataPoints().AppendEmpty()
+	v.use(func(dp pmetric.ExponentialHistogramDataPoint) {
+		dp.CopyTo(target)
+	})
+	return protoMarshaler.MarshalMetrics(md)
+}
+
+// unmarshalExpoDP deserializes protobuf bytes into a *mutex[ExponentialHistogramDataPoint].
+func unmarshalExpoDP(data []byte) (*mutex[pmetric.ExponentialHistogramDataPoint], error) {
+	md, err := protoUnmarshaler.UnmarshalMetrics(data)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal exponential histogram datapoint: %w", err)
+	}
+	if err := validateSingleDP(md); err != nil {
+		return nil, err
+	}
+	dp := md.ResourceMetrics().At(0).
+		ScopeMetrics().At(0).
+		Metrics().At(0).
+		ExponentialHistogram().DataPoints().At(0)
+	return guard(dp), nil
+}
+
+// validateSingleDP checks that a pmetric.Metrics contains exactly one metric
+// with at least the expected nesting depth. Prevents panics on corrupted data.
+func validateSingleDP(md pmetric.Metrics) error {
+	if md.ResourceMetrics().Len() == 0 {
+		return errMalformedData
+	}
+	rm := md.ResourceMetrics().At(0)
+	if rm.ScopeMetrics().Len() == 0 {
+		return errMalformedData
+	}
+	sm := rm.ScopeMetrics().At(0)
+	if sm.Metrics().Len() == 0 {
+		return errMalformedData
+	}
+	m := sm.Metrics().At(0)
+	switch m.Type() {
+	case pmetric.MetricTypeSum:
+		if m.Sum().DataPoints().Len() == 0 {
+			return errMalformedData
+		}
+	case pmetric.MetricTypeHistogram:
+		if m.Histogram().DataPoints().Len() == 0 {
+			return errMalformedData
+		}
+	case pmetric.MetricTypeExponentialHistogram:
+		if m.ExponentialHistogram().DataPoints().Len() == 0 {
+			return errMalformedData
+		}
+	default:
+		return errMalformedData
+	}
+	return nil
+}
+
+var (
+	protoMarshaler   = &pmetric.ProtoMarshaler{}
+	protoUnmarshaler = &pmetric.ProtoUnmarshaler{}
+)

--- a/processor/deltatocumulativeprocessor/config.go
+++ b/processor/deltatocumulativeprocessor/config.go
@@ -20,6 +20,8 @@ var _ xconfmap.Validator = (*Config)(nil)
 type Config struct {
 	MaxStale   time.Duration `mapstructure:"max_stale"`
 	MaxStreams int           `mapstructure:"max_streams"`
+
+	StorageID *component.ID `mapstructure:"storage"`
 }
 
 func (c *Config) Validate() error {

--- a/processor/deltatocumulativeprocessor/config.go
+++ b/processor/deltatocumulativeprocessor/config.go
@@ -5,6 +5,7 @@ package deltatocumulativeprocessor // import "github.com/open-telemetry/opentele
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -21,7 +22,8 @@ type Config struct {
 	MaxStale   time.Duration `mapstructure:"max_stale"`
 	MaxStreams int           `mapstructure:"max_streams"`
 
-	StorageID *component.ID `mapstructure:"storage"`
+	StorageID    *component.ID `mapstructure:"storage"`
+	WriteThrough bool          `mapstructure:"write_through"`
 }
 
 func (c *Config) Validate() error {
@@ -30,6 +32,9 @@ func (c *Config) Validate() error {
 	}
 	if c.MaxStreams < 0 {
 		return fmt.Errorf("max_streams must be a positive number (got %d)", c.MaxStreams)
+	}
+	if c.WriteThrough && c.StorageID == nil {
+		return errors.New("write_through requires storage to be configured")
 	}
 	return nil
 }

--- a/processor/deltatocumulativeprocessor/config_test.go
+++ b/processor/deltatocumulativeprocessor/config_test.go
@@ -65,3 +65,17 @@ func TestLoadConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_WriteThroughRequiresStorage(t *testing.T) {
+	cfg := &Config{
+		MaxStale:     5 * time.Minute,
+		MaxStreams:   1000,
+		WriteThrough: true,
+		StorageID:    nil, // no storage configured
+	}
+	assert.Error(t, cfg.Validate())
+
+	storageID := component.MustNewID("file_storage")
+	cfg.StorageID = &storageID
+	assert.NoError(t, cfg.Validate())
+}

--- a/processor/deltatocumulativeprocessor/factory.go
+++ b/processor/deltatocumulativeprocessor/factory.go
@@ -34,5 +34,5 @@ func createMetricsProcessor(_ context.Context, set processor.Settings, cfg compo
 		return nil, err
 	}
 
-	return newProcessor(pcfg, tel, next), nil
+	return newProcessor(pcfg, set.ID, tel, next), nil
 }

--- a/processor/deltatocumulativeprocessor/go.mod
+++ b/processor/deltatocumulativeprocessor/go.mod
@@ -13,7 +13,9 @@ require (
 	go.opentelemetry.io/collector/confmap/xconfmap v0.151.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/consumer v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/consumer/consumertest v0.151.1-0.20260501001745-24aecacf1c04
+	go.opentelemetry.io/collector/extension/xextension v0.151.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/pdata v1.57.1-0.20260501001745-24aecacf1c04
+	go.opentelemetry.io/collector/pipeline v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/processor v1.57.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/collector/processor/processortest v0.151.1-0.20260501001745-24aecacf1c04
 	go.opentelemetry.io/otel v1.43.0
@@ -47,11 +49,11 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.151.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.151.1-0.20260501001745-24aecacf1c04 // indirect
+	go.opentelemetry.io/collector/extension v1.57.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.57.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.151.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.151.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.151.1-0.20260501001745-24aecacf1c04 // indirect
-	go.opentelemetry.io/collector/pipeline v1.57.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.151.1-0.20260501001745-24aecacf1c04 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/processor/deltatocumulativeprocessor/go.sum
+++ b/processor/deltatocumulativeprocessor/go.sum
@@ -69,6 +69,10 @@ go.opentelemetry.io/collector/consumer/consumertest v0.151.1-0.20260501001745-24
 go.opentelemetry.io/collector/consumer/consumertest v0.151.1-0.20260501001745-24aecacf1c04/go.mod h1:eAGCGxkq+aABLmlr3PvMOqz3ZJbmn/lUqCbbffabSi4=
 go.opentelemetry.io/collector/consumer/xconsumer v0.151.1-0.20260501001745-24aecacf1c04 h1:KFnUzGruixLmgxT1yb5qgsc4ItxjB5WdtC6VCQzAYLo=
 go.opentelemetry.io/collector/consumer/xconsumer v0.151.1-0.20260501001745-24aecacf1c04/go.mod h1:9K97TkCN7XYfwKzPzktozrWc3Qw/4A1T4XgMn9TnG0c=
+go.opentelemetry.io/collector/extension v1.57.0 h1:xrKqf2CK8AjEJFtxky84l7PkzbDrFv5jomfsRDgeW80=
+go.opentelemetry.io/collector/extension v1.57.0/go.mod h1:jwIanPruVtNwWbkXOi8ikfWj0mIl4m7vZdGQPDvUJcE=
+go.opentelemetry.io/collector/extension/xextension v0.151.1-0.20260501001745-24aecacf1c04 h1:O9pP+pZA7mLTdmsNuYna8AMDS12M6nGRo6yU9j17HW8=
+go.opentelemetry.io/collector/extension/xextension v0.151.1-0.20260501001745-24aecacf1c04/go.mod h1:DXK1pzPdH5zQpKfTYW7eFBUf3ES/RkLxJUnSxco/ZrA=
 go.opentelemetry.io/collector/featuregate v1.57.1-0.20260501001745-24aecacf1c04 h1:IfqXdbqi14+K8ztsFp5LVYm/x2aKy2gLttkpyzApQPk=
 go.opentelemetry.io/collector/featuregate v1.57.1-0.20260501001745-24aecacf1c04/go.mod h1:4ga1QBMPEejXXmpyJS8lmaRpknJ3Lb9Bvk6e420bUFU=
 go.opentelemetry.io/collector/internal/componentalias v0.151.1-0.20260501001745-24aecacf1c04 h1:hbATIXYyPC+lx6X6UhA5qgqSFoHUcOIGnj2fiL/Y2Hc=

--- a/processor/deltatocumulativeprocessor/internal/maps/helpers_test.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/helpers_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package maps_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+)
+
+// memClient is a minimal in-memory storage.Client for testing.
+type memClient struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newMemClient() *memClient {
+	return &memClient{data: make(map[string][]byte)}
+}
+
+func (c *memClient) Get(_ context.Context, key string) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.data[key], nil
+}
+
+func (c *memClient) Set(_ context.Context, key string, value []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = value
+	return nil
+}
+
+func (c *memClient) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.data, key)
+	return nil
+}
+
+func (c *memClient) Batch(_ context.Context, ops ...*storage.Operation) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, op := range ops {
+		switch op.Type {
+		case storage.Get:
+			op.Value = c.data[op.Key]
+		case storage.Set:
+			c.data[op.Key] = op.Value
+		case storage.Delete:
+			delete(c.data, op.Key)
+		}
+	}
+	return nil
+}
+
+func (*memClient) Close(_ context.Context) error { return nil }
+
+func (c *memClient) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.data)
+}
+
+// intEncode is a trivial encode for int values in tests.
+func intEncode(v int) ([]byte, error) {
+	return []byte(strconv.Itoa(v)), nil
+}
+
+// intDecode is a trivial decode for int values in tests.
+func intDecode(data []byte) (int, error) {
+	return strconv.Atoi(string(data))
+}
+
+func intHashKey(k int) string {
+	return strconv.Itoa(k)
+}
+
+// countClient wraps memClient and counts Set operations via Batch.
+type countClient struct {
+	*memClient
+	batchSets atomic.Int64
+}
+
+func (c *countClient) Batch(ctx context.Context, ops ...*storage.Operation) error {
+	for _, op := range ops {
+		if op.Type == storage.Set {
+			c.batchSets.Add(1)
+		}
+	}
+	return c.memClient.Batch(ctx, ops...)
+}
+
+// failGetClient wraps memClient and makes all Get calls return an error.
+type failGetClient struct {
+	*memClient
+}
+
+func (*failGetClient) Get(_ context.Context, _ string) ([]byte, error) {
+	return nil, errors.New("simulated storage failure")
+}

--- a/processor/deltatocumulativeprocessor/internal/maps/map.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/map.go
@@ -110,6 +110,12 @@ func (ctx Context) Size() int64 {
 	return ctx.total.Load()
 }
 
+// Range iterates all entries in the map, calling fn for each key-value pair.
+// If fn returns false, iteration stops.
+func (m *Parallel[K, V]) Range(fn func(K, V) bool) {
+	m.elems.Range(fn)
+}
+
 // Exceeded reports whether a [Limited.LoadOrStore] failed due to the limit being exceeded.
 func Exceeded[T comparable](v T, loaded bool) bool {
 	return !loaded && v == *new(T)

--- a/processor/deltatocumulativeprocessor/internal/maps/map.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/map.go
@@ -110,6 +110,10 @@ func (ctx Context) Size() int64 {
 	return ctx.total.Load()
 }
 
+// Store is a no-op for in-memory maps. The value is already in the map via
+// the mutable reference returned by LoadOrStore.
+func (*Parallel[K, V]) Store(_ K, _ V) {}
+
 // Range iterates all entries in the map, calling fn for each key-value pair.
 // If fn returns false, iteration stops.
 func (m *Parallel[K, V]) Range(fn func(K, V) bool) {

--- a/processor/deltatocumulativeprocessor/internal/maps/persisted.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/persisted.go
@@ -1,0 +1,196 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package maps // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/maps"
+
+import (
+	"context"
+	"errors"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+)
+
+// Persisted wraps a lock-free [Parallel] map with a [storage.Client] backing
+// store. The in-memory cache remains the hot path (lock-free reads), while the
+// backing store provides durability across restarts.
+//
+// On cache miss, Persisted performs a read-through from storage so that
+// previously persisted state is recovered transparently. Updated values are
+// written back lazily via [Persisted.Flush].
+//
+// Only entries that have been accessed (and thus potentially mutated) since the
+// last flush are re-serialized, avoiding redundant I/O for unchanged streams.
+type Persisted[K comparable, V any] struct {
+	cache   *Parallel[K, V]
+	store   storage.Client
+	prefix  string
+	hashKey func(K) string
+	encode  func(V) ([]byte, error)
+	decode  func([]byte) (V, error)
+
+	// dirty tracks keys that were accessed (and potentially mutated) since the
+	// last Flush. Only these entries are re-serialized on the next flush.
+	dirty *xsync.Map[K, struct{}]
+}
+
+// NewPersisted creates a [Persisted] map backed by a [storage.Client].
+//
+// Parameters:
+//   - hashKey converts a map key to a unique storage-friendly string.
+//   - encode serializes a value to bytes for storage.
+//   - decode deserializes bytes back into a value.
+func NewPersisted[K comparable, V any](
+	client storage.Client,
+	prefix string,
+	limit Context,
+	hashKey func(K) string,
+	encode func(V) ([]byte, error),
+	decode func([]byte) (V, error),
+) *Persisted[K, V] {
+	return &Persisted[K, V]{
+		cache:   New[K, V](limit),
+		store:   client,
+		prefix:  prefix,
+		hashKey: hashKey,
+		encode:  encode,
+		decode:  decode,
+		dirty:   xsync.NewMap[K, struct{}](),
+	}
+}
+
+// LoadOrStore returns the existing value for k if present in the cache.
+// On a cache miss it performs a read-through from the backing storage. If a
+// persisted value is found it is loaded into the cache and returned. Otherwise
+// def is stored in the cache (subject to the size limit).
+//
+// Every successful access marks the key as dirty because the caller is expected
+// to mutate the returned value (e.g. aggregation). Only dirty entries are
+// flushed to storage.
+//
+// The return semantics match [Parallel.LoadOrStore]: use [Exceeded] to check
+// whether the store was rejected due to the size limit.
+func (m *Persisted[K, V]) LoadOrStore(ctx context.Context, k K, def V) (V, bool) {
+	// Fast path: lock-free cache lookup
+	if v, ok := m.cache.elems.Load(k); ok {
+		m.dirty.Store(k, struct{}{})
+		return v, true
+	}
+
+	// Cold path: read-through from storage.
+	data, getErr := m.store.Get(ctx, m.storageKey(k))
+	if getErr != nil {
+		// Transient storage failure on a new key. Return the Exceeded
+		// sentinel so the caller safely drops this data point rather than
+		// caching a zero default that would overwrite the real persisted
+		// cumulative value on the next Flush.
+		var zero V
+		return zero, false
+	}
+
+	if len(data) > 0 {
+		if recovered, err := m.decode(data); err == nil {
+			// Use recovered value as the default so that the cache stores
+			// the previously persisted state rather than a zero value.
+			def = recovered
+		}
+		// Decode failure on existing data: proceed with original def.
+		// The corrupt entry will be overwritten on the next Flush.
+	}
+
+	v, loaded := m.cache.LoadOrStore(k, def)
+	// Mark dirty unconditionally. In the exceeded case the key won't be in
+	// the cache, so the phantom dirty entry is harmlessly ignored by Flush.
+	m.dirty.Store(k, struct{}{})
+	return v, loaded
+}
+
+// LoadAndDelete removes k from both the in-memory cache and the backing
+// storage. The returned value and loaded flag match [Parallel.LoadAndDelete].
+func (m *Persisted[K, V]) LoadAndDelete(ctx context.Context, k K) (V, bool) {
+	v, loaded := m.cache.LoadAndDelete(k)
+	if loaded {
+		m.dirty.Delete(k)
+		_ = m.store.Delete(ctx, m.storageKey(k))
+	}
+	return v, loaded
+}
+
+// FlushResult contains the outcome of a [Persisted.Flush] operation.
+type FlushResult struct {
+	// Keys holds the hash keys of all entries currently in the cache,
+	// collected during the flush iteration at no extra cost.
+	Keys []string
+	// Err is the combined error from encoding and batch storage operations.
+	Err error
+}
+
+// Flush writes dirty cached entries to the backing storage. Only entries that
+// were accessed since the last Flush are re-serialized, significantly reducing
+// I/O when only a fraction of streams are active per flush period.
+//
+// It also returns all current cache keys (collected in the same iteration) so
+// callers can persist the stale index without an additional full scan.
+func (m *Persisted[K, V]) Flush(ctx context.Context) FlushResult {
+	var (
+		ops     []*storage.Operation
+		encErrs []error
+		keys    []string
+	)
+
+	// Collect all cache keys for the stale index, and encode only dirty ones.
+	m.cache.Range(func(k K, v V) bool {
+		hk := m.hashKey(k)
+		keys = append(keys, hk)
+
+		if _, isDirty := m.dirty.LoadAndDelete(k); !isDirty {
+			return true
+		}
+		data, err := m.encode(v)
+		if err != nil {
+			encErrs = append(encErrs, err)
+			return true
+		}
+		ops = append(ops, storage.SetOperation(m.prefix+"/"+hk, data))
+		return true
+	})
+
+	var batchErr error
+	if len(ops) > 0 {
+		batchErr = m.store.Batch(ctx, ops...)
+	}
+
+	// Clean up phantom dirty entries left by exceeded stores. These keys
+	// are in the dirty set but not in the cache, so Flush never drains them.
+	m.dirty.Range(func(k K, _ struct{}) bool {
+		if _, ok := m.cache.elems.Load(k); !ok {
+			m.dirty.Delete(k)
+		}
+		return true
+	})
+
+	return FlushResult{
+		Keys: keys,
+		Err:  errors.Join(append(encErrs, batchErr)...),
+	}
+}
+
+// Keys returns the hash keys of all entries currently in the cache.
+func (m *Persisted[K, V]) Keys() []string {
+	var keys []string
+	m.cache.Range(func(k K, _ V) bool {
+		keys = append(keys, m.hashKey(k))
+		return true
+	})
+	return keys
+}
+
+// DeleteByHashKey removes an entry from storage by its hash key. This is used
+// to clean up orphaned entries whose original map key cannot be reconstructed.
+func (m *Persisted[K, V]) DeleteByHashKey(ctx context.Context, hashKey string) error {
+	return m.store.Delete(ctx, m.prefix+"/"+hashKey)
+}
+
+func (m *Persisted[K, V]) storageKey(k K) string {
+	return m.prefix + "/" + m.hashKey(k)
+}

--- a/processor/deltatocumulativeprocessor/internal/maps/persisted_test.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/persisted_test.go
@@ -1,0 +1,282 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package maps_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/maps"
+)
+
+func TestPersisted_LoadOrStore_CacheHit(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store a new value
+	v, loaded := m.LoadOrStore(ctx, 1, 42)
+	assert.False(t, loaded)
+	assert.Equal(t, 42, v)
+
+	// Hit the cache
+	v, loaded = m.LoadOrStore(ctx, 1, 99)
+	assert.True(t, loaded)
+	assert.Equal(t, 42, v) // original value, not 99
+}
+
+func TestPersisted_LoadOrStore_ReadThrough(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	// Pre-populate storage to simulate a previous session
+	_ = client.Set(ctx, "test/"+intHashKey(1), []byte("42"))
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Should read-through from storage
+	v, loaded := m.LoadOrStore(ctx, 1, 0)
+	assert.False(t, loaded) // stored recovered value in cache (not "loaded" from cache)
+	assert.Equal(t, 42, v)  // recovered from storage, not the default 0
+}
+
+func TestPersisted_LoadOrStore_StorageMiss(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Nothing in cache or storage — should store the default
+	v, loaded := m.LoadOrStore(ctx, 1, 42)
+	assert.False(t, loaded)
+	assert.Equal(t, 42, v)
+}
+
+func TestPersisted_LoadAndDelete(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store, then flush to storage
+	m.LoadOrStore(ctx, 1, 42)
+	require.NoError(t, m.Flush(ctx).Err)
+	require.Equal(t, 1, client.Len())
+
+	// Delete
+	v, loaded := m.LoadAndDelete(ctx, 1)
+	assert.True(t, loaded)
+	assert.Equal(t, 42, v)
+
+	// Storage should also be cleaned up
+	assert.Equal(t, 0, client.Len())
+
+	// Should not be in cache anymore
+	_, loaded = m.LoadAndDelete(ctx, 1)
+	assert.False(t, loaded)
+}
+
+func TestPersisted_Flush(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store several entries
+	for i := range 5 {
+		m.LoadOrStore(ctx, i, i*10)
+	}
+
+	// Storage should be empty before flush
+	assert.Equal(t, 0, client.Len())
+
+	// Flush
+	result := m.Flush(ctx)
+	require.NoError(t, result.Err)
+
+	// All 5 entries should be in storage
+	assert.Equal(t, 5, client.Len())
+
+	// Flush should also return all keys
+	assert.Len(t, result.Keys, 5)
+
+	// Verify values
+	for i := range 5 {
+		data, err := client.Get(ctx, "test/"+intHashKey(i))
+		require.NoError(t, err)
+		v, err := intDecode(data)
+		require.NoError(t, err)
+		assert.Equal(t, i*10, v)
+	}
+}
+
+func TestPersisted_Exceeded(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(2)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Fill to capacity
+	v1, loaded := m.LoadOrStore(ctx, 1, 10)
+	assert.False(t, loaded)
+	assert.Equal(t, 10, v1)
+
+	v2, loaded := m.LoadOrStore(ctx, 2, 20)
+	assert.False(t, loaded)
+	assert.Equal(t, 20, v2)
+
+	// Third entry should be rejected
+	v3, loaded := m.LoadOrStore(ctx, 3, 30)
+	assert.True(t, maps.Exceeded(v3, loaded))
+}
+
+func TestPersisted_Concurrent(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	var (
+		stores = new(atomic.Int64)
+		loads  = new(atomic.Int64)
+	)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			for i := range 100 {
+				_, loaded := m.LoadOrStore(ctx, i, i*10)
+				if loaded {
+					loads.Add(1)
+				} else {
+					stores.Add(1)
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(100), stores.Load())
+	assert.Equal(t, int64(900), loads.Load())
+}
+
+func TestPersisted_FlushThenRecover(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	// Session 1: store values and flush
+	limit1 := maps.Limit(100)
+	m1 := maps.NewPersisted(client, "test", limit1, intHashKey, intEncode, intDecode)
+	m1.LoadOrStore(ctx, 1, 100)
+	m1.LoadOrStore(ctx, 2, 200)
+	require.NoError(t, m1.Flush(ctx).Err)
+
+	// Session 2: new map against the same storage client (simulates restart)
+	limit2 := maps.Limit(100)
+	m2 := maps.NewPersisted(client, "test", limit2, intHashKey, intEncode, intDecode)
+
+	// Should recover values via read-through
+	v, loaded := m2.LoadOrStore(ctx, 1, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 100, v)
+
+	v, loaded = m2.LoadOrStore(ctx, 2, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 200, v)
+
+	// Key 3 was never stored — should use default
+	v, loaded = m2.LoadOrStore(ctx, 3, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 0, v)
+}
+
+func TestPersisted_DeleteByHashKey(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store and flush
+	m.LoadOrStore(ctx, 1, 42)
+	require.NoError(t, m.Flush(ctx).Err)
+	require.Equal(t, 1, client.Len())
+
+	// Delete by hash key (simulates orphan cleanup)
+	require.NoError(t, m.DeleteByHashKey(ctx, intHashKey(1)))
+
+	// Storage entry should be gone
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}
+
+func TestPersisted_DirtyTracking(t *testing.T) {
+	ctx := t.Context()
+	client := &countClient{memClient: newMemClient()}
+	limit := maps.Limit(100)
+
+	m := maps.NewPersisted[int, int](client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store 5 entries and flush — all 5 are dirty
+	for i := range 5 {
+		m.LoadOrStore(ctx, i, i*10)
+	}
+	r1 := m.Flush(ctx)
+	require.NoError(t, r1.Err)
+	assert.Equal(t, int64(5), client.batchSets.Load())
+
+	// Flush again without touching anything — 0 batch ops expected
+	client.batchSets.Store(0)
+	r2 := m.Flush(ctx)
+	require.NoError(t, r2.Err)
+	assert.Equal(t, int64(0), client.batchSets.Load())
+	// Keys should still be returned even though nothing was dirty
+	assert.Len(t, r2.Keys, 5)
+
+	// Touch only 2 entries — only 2 should be flushed
+	client.batchSets.Store(0)
+	m.LoadOrStore(ctx, 0, 0) // cache hit, marks dirty
+	m.LoadOrStore(ctx, 3, 0) // cache hit, marks dirty
+	r3 := m.Flush(ctx)
+	require.NoError(t, r3.Err)
+	assert.Equal(t, int64(2), client.batchSets.Load())
+}
+
+func TestPersisted_LoadOrStore_GetErrorReturnsExceeded(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	// Pre-populate storage with an existing value
+	_ = client.Set(ctx, "test/"+intHashKey(1), []byte("100"))
+
+	// Wrap with a client that fails on Get
+	failing := &failGetClient{memClient: client}
+	m := maps.NewPersisted(failing, "test", limit, intHashKey, intEncode, intDecode)
+
+	// LoadOrStore should return the Exceeded sentinel because Get failed and
+	// we cannot safely distinguish "key missing" from "transient failure".
+	v, loaded := m.LoadOrStore(ctx, 1, 0)
+	assert.True(t, maps.Exceeded(v, loaded), "should signal exceeded on Get failure")
+
+	// The original value in storage must be preserved (not overwritten)
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	got, err := intDecode(data)
+	require.NoError(t, err)
+	assert.Equal(t, 100, got, "storage value must not be overwritten when Get fails")
+}

--- a/processor/deltatocumulativeprocessor/internal/maps/writethrough.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/writethrough.go
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package maps // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/maps"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+)
+
+// WriteThrough wraps a lock-free [Parallel] map with a [storage.Client] that
+// is written on every [WriteThrough.Store] call. The in-memory cache ensures
+// concurrent callers within the same process receive the same pointer (required
+// for mutex-based aggregation safety), while the immediate write-through
+// guarantees persistence without waiting for a periodic flush.
+//
+// On a cache miss, WriteThrough performs a read-through from storage so that
+// previously persisted state is recovered transparently — identical to
+// [Persisted]. The key difference is that mutated values must be persisted via
+// an explicit [WriteThrough.Store] call rather than a lazy batch flush.
+type WriteThrough[K comparable, V any] struct {
+	cache   *Parallel[K, V]
+	store   storage.Client
+	prefix  string
+	hashKey func(K) string
+	encode  func(V) ([]byte, error)
+	decode  func([]byte) (V, error)
+}
+
+// NewWriteThrough creates a [WriteThrough] map backed by a [storage.Client].
+// Values are cached in memory for concurrent safety (same pointer to all
+// goroutines). Every mutation must be followed by [WriteThrough.Store] to
+// persist the update.
+func NewWriteThrough[K comparable, V any](
+	client storage.Client,
+	prefix string,
+	limit Context,
+	hashKey func(K) string,
+	encode func(V) ([]byte, error),
+	decode func([]byte) (V, error),
+) *WriteThrough[K, V] {
+	return &WriteThrough[K, V]{
+		cache:   New[K, V](limit),
+		store:   client,
+		prefix:  prefix,
+		hashKey: hashKey,
+		encode:  encode,
+		decode:  decode,
+	}
+}
+
+// LoadOrStore returns the existing value for k if present in the cache.
+// On a cache miss it performs a read-through from the backing storage. If a
+// persisted value is found it is loaded into the cache and returned. Otherwise
+// def is stored in the cache (subject to the size limit).
+//
+// The return semantics match [Parallel.LoadOrStore]: use [Exceeded] to check
+// whether the store was rejected due to the size limit.
+//
+// If a storage read fails for a new key (not yet cached), LoadOrStore returns
+// the [Exceeded] sentinel to safely drop the data point rather than risk
+// overwriting existing cumulative state with a zero default.
+func (m *WriteThrough[K, V]) LoadOrStore(ctx context.Context, k K, def V) (V, bool) {
+	// Fast path: cache hit — return existing pointer for concurrent safety.
+	if v, ok := m.cache.elems.Load(k); ok {
+		return v, true
+	}
+
+	// Cold path: read-through from storage.
+	sk := m.storageKey(k)
+	data, getErr := m.store.Get(ctx, sk)
+
+	if getErr != nil {
+		// Transient storage failure on a new key. We cannot distinguish
+		// between "key doesn't exist" and "key exists but Get failed".
+		// Return the Exceeded sentinel so the caller safely drops this
+		// data point rather than aggregating on a zero default and
+		// overwriting existing cumulative state via Store.
+		var zero V
+		return zero, false
+	}
+
+	if len(data) > 0 {
+		if recovered, err := m.decode(data); err == nil {
+			def = recovered
+		}
+		// Decode failure on existing data: proceed with original def.
+		// The corrupt entry will be overwritten on the next Store.
+	}
+
+	// Write the default to storage only when the key is truly new.
+	if len(data) == 0 {
+		if encoded, err := m.encode(def); err == nil {
+			_ = m.store.Set(ctx, sk, encoded)
+		}
+	}
+
+	v, loaded := m.cache.LoadOrStore(k, def)
+	return v, loaded
+}
+
+// Store writes v to the backing storage immediately. This must be called after
+// mutating a value returned by [WriteThrough.LoadOrStore] to persist the update.
+func (m *WriteThrough[K, V]) Store(ctx context.Context, k K, v V) error {
+	data, err := m.encode(v)
+	if err != nil {
+		return err
+	}
+	return m.store.Set(ctx, m.storageKey(k), data)
+}
+
+// LoadAndDelete removes k from both the in-memory cache and the backing
+// storage. The returned value and loaded flag match [Parallel.LoadAndDelete].
+func (m *WriteThrough[K, V]) LoadAndDelete(ctx context.Context, k K) (V, bool) {
+	v, loaded := m.cache.LoadAndDelete(k)
+	if loaded {
+		_ = m.store.Delete(ctx, m.storageKey(k))
+	}
+	return v, loaded
+}
+
+// Keys returns the hash keys of all entries currently managed by this instance.
+func (m *WriteThrough[K, V]) Keys() []string {
+	var keys []string
+	m.cache.Range(func(k K, _ V) bool {
+		keys = append(keys, m.hashKey(k))
+		return true
+	})
+	return keys
+}
+
+// DeleteByHashKey removes an entry from storage by its hash key. This is used
+// to clean up orphaned entries whose original map key cannot be reconstructed.
+func (m *WriteThrough[K, V]) DeleteByHashKey(ctx context.Context, hashKey string) error {
+	return m.store.Delete(ctx, m.prefix+"/"+hashKey)
+}
+
+func (m *WriteThrough[K, V]) storageKey(k K) string {
+	return m.prefix + "/" + m.hashKey(k)
+}

--- a/processor/deltatocumulativeprocessor/internal/maps/writethrough_test.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/writethrough_test.go
@@ -1,0 +1,328 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package maps_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/maps"
+)
+
+func TestWriteThrough_LoadOrStore_ReadFromStorage(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	// Pre-populate storage (simulates another collector instance writing)
+	_ = client.Set(ctx, "test/"+intHashKey(1), []byte("42"))
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// First access: cache miss → read-through from storage → store in cache.
+	// loaded=false because the value was stored into the cache (not loaded
+	// from an existing cache entry). Same semantics as Persisted.
+	v, loaded := m.LoadOrStore(ctx, 1, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 42, v) // recovered from storage, not the default 0
+}
+
+func TestWriteThrough_LoadOrStore_NewEntry(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Not in storage — should store default
+	v, loaded := m.LoadOrStore(ctx, 1, 42)
+	assert.False(t, loaded)
+	assert.Equal(t, 42, v)
+
+	// Verify it was written to storage
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	got, err := intDecode(data)
+	require.NoError(t, err)
+	assert.Equal(t, 42, got)
+}
+
+func TestWriteThrough_CacheTakesPrecedence(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store initial value
+	m.LoadOrStore(ctx, 1, 10)
+
+	// Externally update storage (simulates another collector instance)
+	_ = client.Set(ctx, "test/"+intHashKey(1), []byte("99"))
+
+	// WriteThrough caches values for concurrent safety within a process.
+	// External updates are NOT visible once cached — this is the expected
+	// tradeoff for safe intra-process concurrency.
+	v, loaded := m.LoadOrStore(ctx, 1, 0)
+	assert.True(t, loaded)
+	assert.Equal(t, 10, v) // cached value, not external update
+}
+
+func TestWriteThrough_Store(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Create entry
+	m.LoadOrStore(ctx, 1, 10)
+
+	// Update via Store (simulates mutation after aggregation)
+	require.NoError(t, m.Store(ctx, 1, 42))
+
+	// Verify storage was updated
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	got, err := intDecode(data)
+	require.NoError(t, err)
+	assert.Equal(t, 42, got)
+}
+
+func TestWriteThrough_LoadAndDelete(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store and verify
+	m.LoadOrStore(ctx, 1, 42)
+	assert.Equal(t, 1, client.Len())
+
+	// Delete — returns the cached value
+	v, loaded := m.LoadAndDelete(ctx, 1)
+	assert.True(t, loaded)
+	assert.Equal(t, 42, v)
+
+	// Storage should be empty
+	assert.Equal(t, 0, client.Len())
+
+	// Double delete returns false
+	_, loaded = m.LoadAndDelete(ctx, 1)
+	assert.False(t, loaded)
+}
+
+func TestWriteThrough_Exceeded(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(2)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Fill to capacity
+	m.LoadOrStore(ctx, 1, 10)
+	m.LoadOrStore(ctx, 2, 20)
+
+	// Third entry should be rejected
+	v, loaded := m.LoadOrStore(ctx, 3, 30)
+	assert.True(t, maps.Exceeded(v, loaded))
+
+	// Existing entries still accessible
+	v, loaded = m.LoadOrStore(ctx, 1, 0)
+	assert.True(t, loaded)
+	assert.Equal(t, 10, v)
+}
+
+func TestWriteThrough_Keys(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	m.LoadOrStore(ctx, 1, 10)
+	m.LoadOrStore(ctx, 2, 20)
+	m.LoadOrStore(ctx, 3, 30)
+
+	keys := m.Keys()
+	assert.Len(t, keys, 3)
+
+	expected := map[string]struct{}{
+		intHashKey(1): {},
+		intHashKey(2): {},
+		intHashKey(3): {},
+	}
+	for _, k := range keys {
+		_, ok := expected[k]
+		assert.True(t, ok, "unexpected key: %s", k)
+	}
+}
+
+func TestWriteThrough_LoadOrStore_GetErrorReturnsExceeded(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	// Pre-populate storage with an existing value
+	_ = client.Set(ctx, "test/"+intHashKey(1), []byte("100"))
+
+	// Wrap with a client that fails on Get
+	failing := &failGetClient{memClient: client}
+	m := maps.NewWriteThrough(failing, "test", limit, intHashKey, intEncode, intDecode)
+
+	// LoadOrStore should return the Exceeded sentinel because Get failed and
+	// we cannot safely distinguish "key missing" from "transient failure".
+	v, loaded := m.LoadOrStore(ctx, 1, 0)
+	assert.True(t, maps.Exceeded(v, loaded), "should signal exceeded on Get failure")
+
+	// The original value in storage must be preserved (not overwritten with "0")
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	got, err := intDecode(data)
+	require.NoError(t, err)
+	assert.Equal(t, 100, got, "storage value must not be overwritten when Get fails")
+}
+
+func TestWriteThrough_LoadOrStore_DecodeErrorPreservesStorage(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	// Pre-populate storage with corrupted data (not decodable as int)
+	_ = client.Set(ctx, "test/"+intHashKey(1), []byte("not-a-number"))
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// LoadOrStore should return default because decode failed.
+	// The value is cached so subsequent calls return the same default.
+	v, loaded := m.LoadOrStore(ctx, 1, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 0, v)
+
+	// Corrupted data in storage is NOT overwritten by LoadOrStore (data was
+	// non-empty, so the "write default" branch is skipped). It will be
+	// overwritten on the next explicit Store call after aggregation.
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("not-a-number"), data, "corrupted storage must not be overwritten by LoadOrStore")
+}
+
+func TestWriteThrough_DeleteByHashKey(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store and verify
+	m.LoadOrStore(ctx, 1, 42)
+	assert.Equal(t, 1, client.Len())
+
+	// Delete by hash key (simulates orphan cleanup)
+	require.NoError(t, m.DeleteByHashKey(ctx, intHashKey(1)))
+
+	// Storage should be empty
+	data, err := client.Get(ctx, "test/"+intHashKey(1))
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}
+
+func TestWriteThrough_Concurrent(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	var (
+		stores = new(atomic.Int64)
+		loads  = new(atomic.Int64)
+	)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			for i := range 100 {
+				_, loaded := m.LoadOrStore(ctx, i, i*10)
+				if loaded {
+					loads.Add(1)
+				} else {
+					stores.Add(1)
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// Exactly 100 unique keys should be stored, 900 loads
+	assert.Equal(t, int64(100), stores.Load())
+	assert.Equal(t, int64(900), loads.Load())
+}
+
+func TestWriteThrough_ConcurrentSamePointer(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+	limit := maps.Limit(100)
+
+	m := maps.NewWriteThrough(client, "test", limit, intHashKey, intEncode, intDecode)
+
+	// Store a key first
+	first, _ := m.LoadOrStore(ctx, 1, 42)
+
+	// Concurrent LoadOrStore calls must all return the same pointer
+	ptrs := make([]int, 10)
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Go(func() {
+			v, loaded := m.LoadOrStore(ctx, 1, 0)
+			assert.True(t, loaded)
+			ptrs[i] = v
+		})
+	}
+	wg.Wait()
+
+	for i := range 10 {
+		assert.Equal(t, first, ptrs[i], "goroutine %d got different value", i)
+	}
+}
+
+func TestWriteThrough_FlushThenRecover(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	// Session 1: store values via write-through
+	limit1 := maps.Limit(100)
+	m1 := maps.NewWriteThrough(client, "test", limit1, intHashKey, intEncode, intDecode)
+	m1.LoadOrStore(ctx, 1, 100)
+	m1.LoadOrStore(ctx, 2, 200)
+
+	// Write-through: values are already in storage immediately
+	assert.Equal(t, 2, client.Len())
+
+	// Update via Store (simulates aggregation mutation)
+	require.NoError(t, m1.Store(ctx, 1, 150))
+
+	// Session 2: new map against the same storage client (simulates restart)
+	limit2 := maps.Limit(100)
+	m2 := maps.NewWriteThrough(client, "test", limit2, intHashKey, intEncode, intDecode)
+
+	// Should recover values via read-through
+	v, loaded := m2.LoadOrStore(ctx, 1, 0)
+	assert.False(t, loaded) // first access in this session
+	assert.Equal(t, 150, v) // recovered the updated value
+
+	v, loaded = m2.LoadOrStore(ctx, 2, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 200, v)
+
+	// Key 3 was never stored — should use default
+	v, loaded = m2.LoadOrStore(ctx, 3, 0)
+	assert.False(t, loaded)
+	assert.Equal(t, 0, v)
+}

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -41,16 +41,10 @@ type deltaToCumulativeProcessor struct {
 func newProcessor(cfg *Config, tel telemetry.Metrics, next consumer.Metrics) *deltaToCumulativeProcessor {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	limit := maps.Limit(int64(cfg.MaxStreams))
 	proc := deltaToCumulativeProcessor{
-		next: next,
-		cfg:  *cfg,
-		last: state{
-			ctx:  limit,
-			nums: maps.New[identity.Stream, *mutex[pmetric.NumberDataPoint]](limit),
-			hist: maps.New[identity.Stream, *mutex[pmetric.HistogramDataPoint]](limit),
-			expo: maps.New[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]](limit),
-		},
+		next:   next,
+		cfg:    *cfg,
+		last:   newState(int64(cfg.MaxStreams)),
 		aggr:   delta.Aggregator{Aggregator: new(data.Adder)},
 		ctx:    ctx,
 		cancel: cancel,
@@ -71,6 +65,14 @@ type vals struct {
 	expo *mutex[pmetric.ExponentialHistogramDataPoint]
 }
 
+func newVals() vals {
+	return vals{
+		nums: guard(pmetric.NewNumberDataPoint()),
+		hist: guard(pmetric.NewHistogramDataPoint()),
+		expo: guard(pmetric.NewExponentialHistogramDataPoint()),
+	}
+}
+
 func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	now := time.Now()
 
@@ -79,11 +81,7 @@ func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmet
 		drop = false
 	)
 
-	zero := vals{
-		nums: guard(pmetric.NewNumberDataPoint()),
-		hist: guard(pmetric.NewHistogramDataPoint()),
-		expo: guard(pmetric.NewExponentialHistogramDataPoint()),
-	}
+	zero := newVals()
 
 	metrics.Filter(md, func(m metrics.Metric) bool {
 		if m.AggregationTemporality() != pmetric.AggregationTemporalityDelta {
@@ -222,12 +220,30 @@ func (*deltaToCumulativeProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
+// Storage is the per-stream backing store for cumulative state. The in-memory
+// implementation ([maps.Parallel]) is used by default; storage-backed
+// implementations can be plugged in to persist state across restarts.
+type Storage[K comparable, V any] interface {
+	LoadOrStore(key K, value V) (actual V, loaded bool)
+	LoadAndDelete(key K) (value V, loaded bool)
+}
+
 // state keeps a cumulative value, aggregated over time, per stream
 type state struct {
 	ctx  maps.Context
-	nums *maps.Parallel[identity.Stream, *mutex[pmetric.NumberDataPoint]]
-	hist *maps.Parallel[identity.Stream, *mutex[pmetric.HistogramDataPoint]]
-	expo *maps.Parallel[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]
+	nums Storage[identity.Stream, *mutex[pmetric.NumberDataPoint]]
+	hist Storage[identity.Stream, *mutex[pmetric.HistogramDataPoint]]
+	expo Storage[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]
+}
+
+func newState(maxStreams int64) state {
+	limit := maps.Limit(maxStreams)
+	return state{
+		ctx:  limit,
+		nums: maps.New[identity.Stream, *mutex[pmetric.NumberDataPoint]](limit),
+		hist: maps.New[identity.Stream, *mutex[pmetric.HistogramDataPoint]](limit),
+		expo: maps.New[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]](limit),
+	}
 }
 
 func (s state) Size() int {

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -137,6 +137,7 @@ func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmet
 					err = p.aggr.Numbers(last, dp)
 					last.CopyTo(dp)
 				})
+				p.last.nums.Store(id, last)
 			case pmetric.HistogramDataPoint:
 				last, loaded := p.last.hist.LoadOrStore(id, zero.hist)
 				if maps.Exceeded(last, loaded) {
@@ -157,6 +158,7 @@ func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmet
 					err = p.aggr.Histograms(last, dp)
 					last.CopyTo(dp)
 				})
+				p.last.hist.Store(id, last)
 			case pmetric.ExponentialHistogramDataPoint:
 				last, loaded := p.last.expo.LoadOrStore(id, zero.expo)
 				if maps.Exceeded(last, loaded) {
@@ -177,6 +179,7 @@ func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmet
 					err = p.aggr.Exponential(last, dp)
 					last.CopyTo(dp)
 				})
+				p.last.expo.Store(id, last)
 			}
 
 			if err != nil {
@@ -209,7 +212,12 @@ func (p *deltaToCumulativeProcessor) Start(ctx context.Context, host component.H
 		if err != nil {
 			return fmt.Errorf("getting storage client: %w", err)
 		}
-		p.last = newPersistedState(client, int64(p.cfg.MaxStreams), p.cfg.MaxStale, p.bgDone)
+		switch {
+		case p.cfg.WriteThrough:
+			p.last = newWriteThroughState(client, int64(p.cfg.MaxStreams), p.cfg.MaxStale, p.bgDone)
+		default:
+			p.last = newPersistedState(client, int64(p.cfg.MaxStreams), p.cfg.MaxStale, p.bgDone)
+		}
 	}
 
 	go func() {

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -290,6 +290,30 @@ func (ps *persistedStorage[K, V]) LoadAndDelete(key K) (V, bool) {
 	return ps.m.LoadAndDelete(ps.ctx, key)
 }
 
+// Store is a no-op for write-back mode. Dirty tracking in LoadOrStore
+// already ensures changed values are flushed.
+func (*persistedStorage[K, V]) Store(_ K, _ V) {}
+
+// writeThroughStorage adapts a [maps.WriteThrough] to the [Storage] interface
+// by capturing a context.Context. Unlike [persistedStorage], every Store call
+// writes directly to the backing storage.
+type writeThroughStorage[K comparable, V any] struct {
+	ctx context.Context
+	m   *maps.WriteThrough[K, V]
+}
+
+func (ws *writeThroughStorage[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	return ws.m.LoadOrStore(ws.ctx, key, value)
+}
+
+func (ws *writeThroughStorage[K, V]) LoadAndDelete(key K) (V, bool) {
+	return ws.m.LoadAndDelete(ws.ctx, key)
+}
+
+func (ws *writeThroughStorage[K, V]) Store(key K, value V) {
+	_ = ws.m.Store(ws.ctx, key, value)
+}
+
 // state keeps a cumulative value, aggregated over time, per stream
 type state struct {
 	ctx   maps.Context
@@ -343,6 +367,29 @@ func newPersistedState(client storage.Client, maxStreams int64, maxStale time.Du
 			flushErr := errors.Join(numsR.Err, histR.Err, expoR.Err)
 			indexErr := persistStaleIndex(ctx, client, numsR.Keys, histR.Keys, expoR.Keys)
 			return errors.Join(flushErr, indexErr)
+		},
+	}
+}
+
+func newWriteThroughState(client storage.Client, maxStreams int64, maxStale time.Duration, done <-chan struct{}) state {
+	limit := maps.Limit(maxStreams)
+	storageCtx := context.Background()
+
+	nums := maps.NewWriteThrough(client, "nums", limit, streamHashKey, marshalNumberDP, unmarshalNumberDP)
+	hist := maps.NewWriteThrough(client, "hist", limit, streamHashKey, marshalHistogramDP, unmarshalHistogramDP)
+	expo := maps.NewWriteThrough(client, "expo", limit, streamHashKey, marshalExpoDP, unmarshalExpoDP)
+
+	scheduleOrphanCleanup(storageCtx, client, done, maxStale, nums, hist, expo)
+
+	return state{
+		ctx:  limit,
+		nums: &writeThroughStorage[identity.Stream, *mutex[pmetric.NumberDataPoint]]{ctx: storageCtx, m: nums},
+		hist: &writeThroughStorage[identity.Stream, *mutex[pmetric.HistogramDataPoint]]{ctx: storageCtx, m: hist},
+		expo: &writeThroughStorage[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]{ctx: storageCtx, m: expo},
+		flush: func(ctx context.Context) error {
+			// Write-through: values are already persisted via Store.
+			// Only persist the stale index for orphan cleanup.
+			return persistStaleIndex(ctx, client, nums.Keys(), hist.Keys(), expo.Keys())
 		},
 	}
 }

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -4,14 +4,19 @@
 package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/puzpuzpuz/xsync/v4"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
@@ -24,27 +29,40 @@ import (
 
 var _ processor.Metrics = (*deltaToCumulativeProcessor)(nil)
 
+var (
+	errNoStorageClient    = errors.New("storage client not found")
+	errWrongExtensionType = errors.New("extension is not a storage extension")
+)
+
 type deltaToCumulativeProcessor struct {
 	next consumer.Metrics
 	cfg  Config
+	id   component.ID
 
 	last state
 	aggr data.Aggregator
 
 	ctx    context.Context
 	cancel context.CancelFunc
+	bgDone chan struct{} // closed when background goroutine exits
 
 	stale *xsync.Map[identity.Stream, time.Time]
 	tel   telemetry.Metrics
 }
 
-func newProcessor(cfg *Config, tel telemetry.Metrics, next consumer.Metrics) *deltaToCumulativeProcessor {
+func newProcessor(
+	cfg *Config,
+	componentID component.ID,
+	tel telemetry.Metrics,
+	next consumer.Metrics,
+) *deltaToCumulativeProcessor {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	proc := deltaToCumulativeProcessor{
 		next:   next,
 		cfg:    *cfg,
-		last:   newState(int64(cfg.MaxStreams)),
+		id:     componentID,
+		last:   newState(ctx, int64(cfg.MaxStreams)),
 		aggr:   delta.Aggregator{Aggregator: new(data.Adder)},
 		ctx:    ctx,
 		cancel: cancel,
@@ -182,37 +200,68 @@ func (p *deltaToCumulativeProcessor) ConsumeMetrics(ctx context.Context, md pmet
 	return p.next.ConsumeMetrics(ctx, md)
 }
 
-func (p *deltaToCumulativeProcessor) Start(_ context.Context, _ component.Host) error {
-	if p.cfg.MaxStale != 0 {
-		// delete stale streams once per minute
-		go func() {
-			tick := time.NewTicker(time.Minute)
-			defer tick.Stop()
-			for {
-				select {
-				case <-p.ctx.Done():
-					return
-				case <-tick.C:
+func (p *deltaToCumulativeProcessor) Start(ctx context.Context, host component.Host) error {
+	// background goroutine: stale cleanup + lazy flush
+	p.bgDone = make(chan struct{})
+
+	if p.cfg.StorageID != nil && host != nil {
+		client, err := toStorageClient(ctx, *p.cfg.StorageID, host, p.id, pipeline.SignalMetrics)
+		if err != nil {
+			return fmt.Errorf("getting storage client: %w", err)
+		}
+		p.last = newPersistedState(client, int64(p.cfg.MaxStreams), p.cfg.MaxStale, p.bgDone)
+	}
+
+	go func() {
+		defer close(p.bgDone)
+		tick := time.NewTicker(time.Minute)
+		defer tick.Stop()
+		for {
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-tick.C:
+				if p.cfg.MaxStale != 0 {
 					now := time.Now()
 					p.stale.Range(func(id identity.Stream, last time.Time) bool {
 						if now.Sub(last) > p.cfg.MaxStale {
-							p.last.nums.LoadAndDelete(id)
-							p.last.hist.LoadAndDelete(id)
-							p.last.expo.LoadAndDelete(id)
-							p.stale.Delete(id)
+							// Re-check: ConsumeMetrics may have refreshed
+							// the timestamp concurrently during iteration.
+							if cur, ok := p.stale.Load(id); ok && now.Sub(cur) > p.cfg.MaxStale {
+								p.last.nums.LoadAndDelete(id)
+								p.last.hist.LoadAndDelete(id)
+								p.last.expo.LoadAndDelete(id)
+								p.stale.Delete(id)
+							}
 						}
 						return true
 					})
 				}
+
+				// lazy flush to persistent storage — intentionally uses
+				// background context because the processor's ctx may be cancelled.
+				if p.last.flush != nil {
+					_ = p.last.flush(context.Background())
+				}
 			}
-		}()
-	}
+		}
+	}()
 
 	return nil
 }
 
-func (p *deltaToCumulativeProcessor) Shutdown(_ context.Context) error {
+func (p *deltaToCumulativeProcessor) Shutdown(ctx context.Context) error {
+	// stop background goroutine first and wait for it to exit,
+	// ensuring no concurrent flush can happen
 	p.cancel()
+	if p.bgDone != nil {
+		<-p.bgDone
+	}
+
+	// final flush after background goroutine is gone
+	if p.last.flush != nil {
+		return p.last.flush(ctx)
+	}
 	return nil
 }
 
@@ -220,23 +269,37 @@ func (*deltaToCumulativeProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
-// Storage is the per-stream backing store for cumulative state. The in-memory
-// implementation ([maps.Parallel]) is used by default; storage-backed
-// implementations can be plugged in to persist state across restarts.
 type Storage[K comparable, V any] interface {
 	LoadOrStore(key K, value V) (actual V, loaded bool)
 	LoadAndDelete(key K) (value V, loaded bool)
 }
 
-// state keeps a cumulative value, aggregated over time, per stream
-type state struct {
-	ctx  maps.Context
-	nums Storage[identity.Stream, *mutex[pmetric.NumberDataPoint]]
-	hist Storage[identity.Stream, *mutex[pmetric.HistogramDataPoint]]
-	expo Storage[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]
+// persistedStorage adapts a [maps.Persisted] to the [Storage] interface by
+// capturing a context.Context. The context should outlive storage operations
+// and must NOT be the processor's cancellable lifecycle context.
+type persistedStorage[K comparable, V any] struct {
+	ctx context.Context
+	m   *maps.Persisted[K, V]
 }
 
-func newState(maxStreams int64) state {
+func (ps *persistedStorage[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	return ps.m.LoadOrStore(ps.ctx, key, value)
+}
+
+func (ps *persistedStorage[K, V]) LoadAndDelete(key K) (V, bool) {
+	return ps.m.LoadAndDelete(ps.ctx, key)
+}
+
+// state keeps a cumulative value, aggregated over time, per stream
+type state struct {
+	ctx   maps.Context
+	nums  Storage[identity.Stream, *mutex[pmetric.NumberDataPoint]]
+	hist  Storage[identity.Stream, *mutex[pmetric.HistogramDataPoint]]
+	expo  Storage[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]
+	flush func(ctx context.Context) error // optional: called periodically and on shutdown to persist state
+}
+
+func newState(_ context.Context, maxStreams int64) state {
 	limit := maps.Limit(maxStreams)
 	return state{
 		ctx:  limit,
@@ -248,6 +311,121 @@ func newState(maxStreams int64) state {
 
 func (s state) Size() int {
 	return int(s.ctx.Size())
+}
+
+const staleIndexKey = "_index/stale_keys"
+
+func newPersistedState(client storage.Client, maxStreams int64, maxStale time.Duration, done <-chan struct{}) state {
+	limit := maps.Limit(maxStreams)
+
+	// Use a background context for storage operations — must not be tied
+	// to the processor's cancellable lifecycle context so that the final
+	// shutdown flush can succeed.
+	storageCtx := context.Background()
+
+	nums := maps.NewPersisted(client, "nums", limit, streamHashKey, marshalNumberDP, unmarshalNumberDP)
+	hist := maps.NewPersisted(client, "hist", limit, streamHashKey, marshalHistogramDP, unmarshalHistogramDP)
+	expo := maps.NewPersisted(client, "expo", limit, streamHashKey, marshalExpoDP, unmarshalExpoDP)
+
+	// Load the stale index from the previous session and schedule cleanup
+	// for orphaned storage entries after MaxStale.
+	scheduleOrphanCleanup(storageCtx, client, done, maxStale, nums, hist, expo)
+
+	return state{
+		ctx:  limit,
+		nums: &persistedStorage[identity.Stream, *mutex[pmetric.NumberDataPoint]]{ctx: storageCtx, m: nums},
+		hist: &persistedStorage[identity.Stream, *mutex[pmetric.HistogramDataPoint]]{ctx: storageCtx, m: hist},
+		expo: &persistedStorage[identity.Stream, *mutex[pmetric.ExponentialHistogramDataPoint]]{ctx: storageCtx, m: expo},
+		flush: func(ctx context.Context) error {
+			numsR := nums.Flush(ctx)
+			histR := hist.Flush(ctx)
+			expoR := expo.Flush(ctx)
+			flushErr := errors.Join(numsR.Err, histR.Err, expoR.Err)
+			indexErr := persistStaleIndex(ctx, client, numsR.Keys, histR.Keys, expoR.Keys)
+			return errors.Join(flushErr, indexErr)
+		},
+	}
+}
+
+// persistStaleIndex saves the union of all active stream hash keys so that a
+// future session can identify and clean up orphaned storage entries.
+// The keysets come from different metric types (nums, hist, expo) and never
+// overlap, so no deduplication is needed.
+func persistStaleIndex(ctx context.Context, client storage.Client, keysets ...[]string) error {
+	var size int
+	for _, keys := range keysets {
+		for _, k := range keys {
+			size += len(k) + 1 // +1 for newline
+		}
+	}
+	buf := make([]byte, 0, size)
+	for _, keys := range keysets {
+		for _, k := range keys {
+			buf = append(buf, k...)
+			buf = append(buf, '\n')
+		}
+	}
+	return client.Set(ctx, staleIndexKey, buf)
+}
+
+// loadStaleIndex reads the previously persisted stream hash keys.
+func loadStaleIndex(ctx context.Context, client storage.Client) map[string]struct{} {
+	data, err := client.Get(ctx, staleIndexKey)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	keys := make(map[string]struct{})
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
+		if k := string(line); k != "" {
+			keys[k] = struct{}{}
+		}
+	}
+	return keys
+}
+
+type deletableByHash interface {
+	Keys() []string
+	DeleteByHashKey(ctx context.Context, hashKey string) error
+}
+
+// scheduleOrphanCleanup loads the stale index from the previous session and
+// starts a one-shot goroutine that, after MaxStale elapses, deletes any
+// storage entries that were NOT accessed (and thus not loaded into cache) since
+// startup. This prevents orphaned streams from accumulating in storage across
+// restarts.
+func scheduleOrphanCleanup(ctx context.Context, client storage.Client, done <-chan struct{}, maxStale time.Duration, persisted ...deletableByHash) {
+	prevKeys := loadStaleIndex(ctx, client)
+	if len(prevKeys) == 0 || maxStale == 0 {
+		return
+	}
+
+	go func() {
+		timer := time.NewTimer(maxStale)
+		defer timer.Stop()
+		select {
+		case <-done:
+			return
+		case <-timer.C:
+		}
+
+		// Collect currently active keys across all persisted maps
+		active := make(map[string]struct{})
+		for _, p := range persisted {
+			for _, k := range p.Keys() {
+				active[k] = struct{}{}
+			}
+		}
+
+		// Delete orphans: keys from previous session that are not active now
+		for k := range prevKeys {
+			if _, ok := active[k]; ok {
+				continue
+			}
+			for _, p := range persisted {
+				_ = p.DeleteByHashKey(ctx, k)
+			}
+		}
+	}()
 }
 
 type mutex[T any] struct {
@@ -263,4 +441,18 @@ func (mtx *mutex[T]) use(do func(T)) {
 
 func guard[T any](v T) *mutex[T] {
 	return &mutex[T]{v: v}
+}
+
+func toStorageClient(ctx context.Context, storageID component.ID, host component.Host, ownerID component.ID, signal pipeline.Signal) (storage.Client, error) {
+	ext, found := host.GetExtensions()[storageID]
+	if !found {
+		return nil, errNoStorageClient
+	}
+
+	storageExt, ok := ext.(storage.Extension)
+	if !ok {
+		return nil, errWrongExtensionType
+	}
+
+	return storageExt.GetClient(ctx, component.KindProcessor, ownerID, signal.String())
 }

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -272,6 +272,7 @@ func (*deltaToCumulativeProcessor) Capabilities() consumer.Capabilities {
 type Storage[K comparable, V any] interface {
 	LoadOrStore(key K, value V) (actual V, loaded bool)
 	LoadAndDelete(key K) (value V, loaded bool)
+	Store(key K, value V) // Persist after mutation. No-op for in-memory and write-back maps.
 }
 
 // persistedStorage adapts a [maps.Persisted] to the [Storage] interface by

--- a/processor/deltatocumulativeprocessor/storage_test.go
+++ b/processor/deltatocumulativeprocessor/storage_test.go
@@ -1,0 +1,221 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deltatocumulativeprocessor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+)
+
+// memClient is a minimal in-memory storage.Client for testing.
+type memClient struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newMemClient() *memClient {
+	return &memClient{data: make(map[string][]byte)}
+}
+
+func (c *memClient) Get(_ context.Context, key string) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.data[key], nil
+}
+
+func (c *memClient) Set(_ context.Context, key string, value []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = value
+	return nil
+}
+
+func (c *memClient) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.data, key)
+	return nil
+}
+
+func (c *memClient) Batch(_ context.Context, ops ...*storage.Operation) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, op := range ops {
+		switch op.Type {
+		case storage.Get:
+			op.Value = c.data[op.Key]
+		case storage.Set:
+			c.data[op.Key] = op.Value
+		case storage.Delete:
+			delete(c.data, op.Key)
+		}
+	}
+	return nil
+}
+
+func (*memClient) Close(_ context.Context) error { return nil }
+
+func TestPersistStaleIndex_RoundTrip(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	// Persist keys from 3 maps
+	err := persistStaleIndex(ctx, client, []string{"aaa", "bbb"}, []string{"ccc"}, []string{"ddd", "eee"})
+	require.NoError(t, err)
+
+	// Load them back
+	loaded := loadStaleIndex(ctx, client)
+	require.Len(t, loaded, 5)
+	for _, k := range []string{"aaa", "bbb", "ccc", "ddd", "eee"} {
+		_, ok := loaded[k]
+		assert.True(t, ok, "expected key %q in loaded index", k)
+	}
+}
+
+func TestLoadStaleIndex_Empty(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	loaded := loadStaleIndex(ctx, client)
+	assert.Nil(t, loaded)
+}
+
+func TestPersistStaleIndex_EmptyKeys(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	err := persistStaleIndex(ctx, client, nil, nil, nil)
+	require.NoError(t, err)
+
+	// Empty buffer is written — loadStaleIndex should return nil
+	loaded := loadStaleIndex(ctx, client)
+	assert.Nil(t, loaded)
+}
+
+// fakePersisted implements deletableByHash for testing scheduleOrphanCleanup.
+type fakePersisted struct {
+	mu      sync.Mutex
+	active  []string
+	deleted []string
+}
+
+func (f *fakePersisted) Keys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.active...)
+}
+
+func (f *fakePersisted) DeleteByHashKey(_ context.Context, hashKey string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, hashKey)
+	return nil
+}
+
+func (f *fakePersisted) getDeleted() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.deleted...)
+}
+
+func TestScheduleOrphanCleanup_DeletesOrphans(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	// Simulate previous session: persisted 5 keys in the stale index
+	require.NoError(t, persistStaleIndex(ctx, client, []string{"a", "b", "c", "d", "e"}))
+
+	// Current session: only keys "a" and "c" are still active
+	p := &fakePersisted{active: []string{"a", "c"}}
+
+	done := make(chan struct{})
+	scheduleOrphanCleanup(ctx, client, done, 10*time.Millisecond, p)
+
+	require.Eventually(t, func() bool {
+		return len(p.getDeleted()) == 3
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ElementsMatch(t, []string{"b", "d", "e"}, p.getDeleted())
+}
+
+func TestScheduleOrphanCleanup_NoPreviousIndex(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	// No stale index in storage — scheduleOrphanCleanup returns immediately
+	// without spawning a goroutine, so no deletions will ever happen.
+	p := &fakePersisted{active: []string{"x"}}
+
+	done := make(chan struct{})
+	scheduleOrphanCleanup(ctx, client, done, 10*time.Millisecond, p)
+
+	// Give extra time to confirm nothing happens
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, p.getDeleted())
+}
+
+func TestScheduleOrphanCleanup_AllKeysActive(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	require.NoError(t, persistStaleIndex(ctx, client, []string{"a", "b"}))
+
+	// All previous keys are still active — nothing to delete
+	p := &fakePersisted{active: []string{"a", "b"}}
+
+	done := make(chan struct{})
+	scheduleOrphanCleanup(ctx, client, done, 10*time.Millisecond, p)
+
+	// The goroutine must fire and complete with 0 deletions. We wait long
+	// enough for it to run, then verify nothing was deleted.
+	time.Sleep(100 * time.Millisecond)
+	assert.Empty(t, p.getDeleted())
+}
+
+func TestScheduleOrphanCleanup_CancelledBeforeTimer(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	require.NoError(t, persistStaleIndex(ctx, client, []string{"a", "b", "c"}))
+
+	p := &fakePersisted{active: []string{}}
+
+	done := make(chan struct{})
+	// Long maxStale — goroutine should be waiting on timer
+	scheduleOrphanCleanup(ctx, client, done, time.Hour, p)
+
+	// Close done channel before timer fires — goroutine should exit
+	close(done)
+	time.Sleep(50 * time.Millisecond)
+
+	deleted := p.getDeleted()
+	assert.Empty(t, deleted, "cleanup should not have run because done was closed before timer")
+}
+
+func TestScheduleOrphanCleanup_MultiplePersistedMaps(t *testing.T) {
+	ctx := t.Context()
+	client := newMemClient()
+
+	// Previous session had keys from 2 maps
+	require.NoError(t, persistStaleIndex(ctx, client, []string{"a", "b", "c"}))
+
+	// 2 persisted maps: map1 has "a" active, map2 has "c" active
+	p1 := &fakePersisted{active: []string{"a"}}
+	p2 := &fakePersisted{active: []string{"c"}}
+
+	done := make(chan struct{})
+	scheduleOrphanCleanup(ctx, client, done, 10*time.Millisecond, p1, p2)
+
+	// "b" is orphaned — should be deleted from both maps
+	require.Eventually(t, func() bool {
+		return len(p1.getDeleted()) == 1 && len(p2.getDeleted()) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ElementsMatch(t, []string{"b"}, p1.getDeleted())
+	assert.ElementsMatch(t, []string{"b"}, p2.getDeleted())
+}


### PR DESCRIPTION
#### Description
For adding persistent storage support for state recovery (
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47380),

PR series:
- 1. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48249
- 2. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48250
- 3. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48251

#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
