### PR TITLE
add include_all_containers option to dockerobserver

### DIFF
--- a/.chloggen/dockerobserver-include-all-containers.yaml
+++ b/.chloggen/dockerobserver-include-all-containers.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/dockerobserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `include_all_containers` option to emit a port-less endpoint for every running container, including those with no exposed ports.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When enabled, the observer emits a `container` endpoint with no port
+  information for every running container, alongside any per-port endpoints.
+  This allows `receiver_creator` rules of `type == "container"` to attach
+  receivers to every container regardless of whether it exposes ports.
+  Defaults to `false` for backwards compatibility.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dockerobserver-include-all-containers.yaml
+++ b/.chloggen/dockerobserver-include-all-containers.yaml
@@ -4,13 +4,13 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/dockerobserver
+component: extension/docker_observer
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add `include_all_containers` option to emit a port-less endpoint for every running container, including those with no exposed ports.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48252]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/extension/observer/dockerobserver/README.md
+++ b/extension/observer/dockerobserver/README.md
@@ -99,6 +99,18 @@ to an instance of the collector running outside of the docker network stack.
 
 default: `false`
 
+### `include_all_containers`
+
+If true, the observer emits a port-less endpoint for every running container,
+alongside any per-port endpoints. This makes every container, including those
+without exposed ports, discoverable by `receiver_creator` rules of
+`type == "container"`. The port-less endpoint has no port information
+(`port` and `alternate_port` are `0`, `transport` is `unknown`). To get exactly
+one logging receiver per container, scope with 
+`rule: type == "container" and port == 0`.
+
+default: `false`
+
 ### `cache_sync_interval`
 
 The time to wait before resyncing the list of containers the observer maintains

--- a/extension/observer/dockerobserver/config.go
+++ b/extension/observer/dockerobserver/config.go
@@ -33,6 +33,12 @@ type Config struct {
 	// to an instance of the agent running outside of the docker network stack.
 	IgnoreNonHostBindings bool `mapstructure:"ignore_non_host_bindings"`
 
+	// If true, the observer will emit a port-less endpoint for every running container,
+	// alongside any per-port endpoints. This makes every container, including those
+	// without exposed ports, discoverable by receiver_creator rules matching
+	// `type == "container"`.
+	IncludeAllContainers bool `mapstructure:"include_all_containers"`
+
 	// The time to wait before resyncing the list of containers the observer maintains
 	// through the docker event listener example: cache_sync_interval: "20m"
 	// Default: "60m"

--- a/extension/observer/dockerobserver/config_test.go
+++ b/extension/observer/dockerobserver/config_test.go
@@ -46,6 +46,7 @@ func TestLoadConfig(t *testing.T) {
 				UseHostnameIfPresent:  true,
 				UseHostBindings:       true,
 				IgnoreNonHostBindings: true,
+				IncludeAllContainers:  true,
 			},
 		},
 	}

--- a/extension/observer/dockerobserver/extension.go
+++ b/extension/observer/dockerobserver/extension.go
@@ -135,7 +135,58 @@ func (d *dockerObserver) containerEndpoints(c *ctypes.InspectResponse) []observe
 		endpoints = append(endpoints, *endpoint)
 	}
 
+	if d.config.IncludeAllContainers {
+		if endpoint := d.endpointForContainer(c); endpoint != nil {
+			endpoints = append(endpoints, *endpoint)
+		}
+	}
+
 	return endpoints
+}
+
+// endpointForContainer creates a port-less observer.Endpoint for the container itself.
+// It is emitted when IncludeAllContainers is enabled so that receiver_creator rules
+// matching `type == "container"` can attach receivers to every running container,
+// including those that expose no ports.
+func (d *dockerObserver) endpointForContainer(c *ctypes.InspectResponse) *observer.Endpoint {
+	imageRef, err := dcommon.ParseImageName(c.Config.Image)
+	if err != nil {
+		d.logger.Error("could not parse container image name", zap.Error(err))
+	}
+
+	details := &observer.Container{
+		Name:        strings.TrimPrefix(c.Name, "/"),
+		Image:       imageRef.Repository,
+		Tag:         imageRef.Tag,
+		Command:     strings.Join(c.Config.Cmd, " "),
+		ContainerID: c.ID,
+		Transport:   observer.ProtocolUnknown,
+		Labels:      c.Config.Labels,
+		Host:        d.containerHost(c),
+	}
+
+	return &observer.Endpoint{
+		ID:      observer.EndpointID(c.ID),
+		Target:  details.Host,
+		Details: details,
+	}
+}
+
+// containerHost resolves a host string for a container without considering port bindings.
+func (d *dockerObserver) containerHost(c *ctypes.InspectResponse) string {
+	if d.config.UseHostnameIfPresent && c.Config.Hostname != "" {
+		return c.Config.Hostname
+	}
+	for _, n := range c.NetworkSettings.Networks {
+		if n.IPAddress.IsValid() {
+			return n.IPAddress.String()
+		}
+		break
+	}
+	if d.config.UseHostBindings {
+		return "127.0.0.1"
+	}
+	return ""
 }
 
 // endpointForPort creates an observer.Endpoint for a given port that is exposed in a Docker container.

--- a/extension/observer/dockerobserver/extension_test.go
+++ b/extension/observer/dockerobserver/extension_test.go
@@ -122,6 +122,24 @@ func TestCollectEndpointsAllConfigSettings(t *testing.T) {
 				Host:          "127.0.0.1",
 			},
 		},
+		{
+			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
+			Target: "babc5a6d7af2",
+			Details: &observer.Container{
+				Name:        "agitated_wu",
+				Image:       "nginx",
+				Tag:         "1.17",
+				Command:     "nginx -g daemon off;",
+				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
+				Transport:   observer.ProtocolUnknown,
+				Labels: map[string]string{
+					"hello":      "world",
+					"maintainer": "NGINX Docker Maintainers",
+					"mstumpf":    "",
+				},
+				Host: "babc5a6d7af2",
+			},
+		},
 	}
 
 	require.Equal(t, want, cEndpoints)
@@ -194,6 +212,61 @@ func TestCollectEndpointsUseHostBindings(t *testing.T) {
 				Port:          8080,
 				AlternatePort: 80,
 				Host:          "127.0.0.1",
+			},
+		},
+	}
+
+	require.Equal(t, want, cEndpoints)
+}
+
+func TestCollectEndpointsIncludeAllContainers(t *testing.T) {
+	extIncludeAll := loadConfig(t, component.NewIDWithName(metadata.Type, "include_all_containers"))
+	ext, err := newObserver(zap.NewNop(), extIncludeAll)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	obvs := ext.(*dockerObserver)
+
+	c := containerJSON(t)
+	cEndpoints := obvs.containerEndpoints(&c)
+
+	want := []observer.Endpoint{
+		{
+			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
+			Target: "172.17.0.2:80",
+			Details: &observer.Container{
+				Name:        "agitated_wu",
+				Image:       "nginx",
+				Tag:         "1.17",
+				Command:     "nginx -g daemon off;",
+				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
+				Transport:   observer.ProtocolTCP,
+				Labels: map[string]string{
+					"hello":      "world",
+					"maintainer": "NGINX Docker Maintainers",
+					"mstumpf":    "",
+				},
+				Port:          80,
+				AlternatePort: 8080,
+				Host:          "172.17.0.2",
+			},
+		},
+		{
+			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
+			Target: "172.17.0.2",
+			Details: &observer.Container{
+				Name:        "agitated_wu",
+				Image:       "nginx",
+				Tag:         "1.17",
+				Command:     "nginx -g daemon off;",
+				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
+				Transport:   observer.ProtocolUnknown,
+				Labels: map[string]string{
+					"hello":      "world",
+					"maintainer": "NGINX Docker Maintainers",
+					"mstumpf":    "",
+				},
+				Host: "172.17.0.2",
 			},
 		},
 	}

--- a/extension/observer/dockerobserver/testdata/config.yaml
+++ b/extension/observer/dockerobserver/testdata/config.yaml
@@ -6,8 +6,11 @@ docker_observer/all_settings:
   use_hostname_if_present: true
   use_host_bindings: true
   ignore_non_host_bindings: true
+  include_all_containers: true
   cache_sync_interval: 5m
   api_version: '1.45'
+docker_observer/include_all_containers:
+  include_all_containers: true
 docker_observer/use_hostname_if_present:
   use_hostname_if_present: true
 docker_observer/use_host_bindings:


### PR DESCRIPTION
#### Description

Adds a new `include_all_containers` option (default `false`) to the dockerobserver extension. When enabled, the observer emits a port-less endpoint for every running, non-paused container, alongside the existing per-port endpoints. This makes containers without exposed ports discoverable by `receiver_creator` rules matching `type == "container" and port == 0`, allowing attaching log receivers (or any other per-container receiver) to every container regardless of whether it exposes ports.

The change is purely additive: with the flag off, behavior is byte-identical to the current implementation. The new endpoint has `ID = <containerID>`, `Target = <host>` (no port), `Port` and `AlternatePort` of `0`, and `Transport` of unknown. To attach exactly one receiver per container, rules should scope with `port == 0`; the README documents this to avoid duplicate-receiver footguns when mixing with existing port-based rules.

#### Link to tracking issue

N/A

#### Testing

- New `TestCollectEndpointsIncludeAllContainers` exercising the flag in isolation against the existing `testdata/container.json` fixture.
- `TestCollectEndpointsAllConfigSettings` updated to expect the additional port-less endpoint when `include_all_containers` is enabled in
the `all_settings` fixture.
- `TestLoadConfig` updated to cover the new field.
- `go test ./...` and `go vet ./...` pass under `extension/observer/dockerobserver`.
- Built/deployed manually into our testing environment

#### Documentation

- New `include_all_containers` section in `extension/observer/dockerobserver/README.md` describing the behavior, the shape of the emitted
endpoint, and the recommended `rule: type == "container" and port == 0` scoping for one-receiver-per-container use cases (e.g. logging).
- Changelog entry at `.chloggen/dockerobserver-include-all-containers.yaml` (`change_type: enhancement`).