### PR TITLE
[exporter/honeycombmarker]: update code owners to VinozzZ and codeboten

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@ exporter/googlecloudpubsubexporter/                              @open-telemetry
 exporter/googlecloudstorageexporter/                             @open-telemetry/collector-contrib-approvers @constanca-m @braydonk
 exporter/googlemanagedprometheusexporter/                        @open-telemetry/collector-contrib-approvers @aabmass @dashpole @braydonk @jsuereth @psx95 @ridwanmsharif
 exporter/googlesecopsexporter/                                   @open-telemetry/collector-contrib-approvers @braydonk @colelaven @dpaasman00 @mrsillydog
-exporter/honeycombmarkerexporter/                                @open-telemetry/collector-contrib-approvers @TylerHelmuth @fchikwekwe
+exporter/honeycombmarkerexporter/                                @open-telemetry/collector-contrib-approvers @VinozzZ @codeboten
 exporter/influxdbexporter/                                       @open-telemetry/collector-contrib-approvers @jacobmarble
 exporter/kafkaexporter/                                          @open-telemetry/collector-contrib-approvers @pavolloffay @MovieStoreGuy @axw @paulojmdias
 exporter/loadbalancingexporter/                                  @open-telemetry/collector-contrib-approvers @rlankfo

--- a/exporter/honeycombmarkerexporter/README.md
+++ b/exporter/honeycombmarkerexporter/README.md
@@ -6,7 +6,8 @@
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fhoneycombmarker%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Fhoneycombmarker) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fhoneycombmarker%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Fhoneycombmarker) |
 | Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=exporter_honeycombmarker)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=exporter_honeycombmarker&displayType=list) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@TylerHelmuth](https://www.github.com/TylerHelmuth), [@fchikwekwe](https://www.github.com/fchikwekwe) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@VinozzZ](https://www.github.com/VinozzZ), [@codeboten](https://www.github.com/codeboten) |
+| Emeritus      | [@TylerHelmuth](https://www.github.com/TylerHelmuth), [@fchikwekwe](https://www.github.com/fchikwekwe) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/honeycombmarkerexporter/metadata.yaml
+++ b/exporter/honeycombmarkerexporter/metadata.yaml
@@ -9,6 +9,7 @@ status:
   distributions: [contrib]
   codeowners:
     active: [VinozzZ, codeboten]
+    emeritus: [TylerHelmuth, fchikwekwe]
 
 tests:
   expect_consumer_error: true

--- a/exporter/honeycombmarkerexporter/metadata.yaml
+++ b/exporter/honeycombmarkerexporter/metadata.yaml
@@ -8,7 +8,7 @@ status:
     alpha: [logs]
   distributions: [contrib]
   codeowners:
-    active: [TylerHelmuth, fchikwekwe]
+    active: [VinozzZ, codeboten]
 
 tests:
   expect_consumer_error: true


### PR DESCRIPTION
#### Description

Update the code owner for honeycombmarkerexporter to @VinozzZ and @codeboten

#### Link to tracking issue
N/A

#### Testing

N/A

#### Documentation

N/A
