### PR TITLE
[ci]: allow /rerun command to triagers, approvers and maintainers

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -12,13 +12,20 @@ jobs:
     permissions:
       actions: write
       checks: read
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
       - name: Run rerun-failed-workflows.sh
         run: ./.github/workflows/scripts/rerun-failed-workflows.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT: ${{ github.event.comment.body }}
           SENDER: ${{ github.event.comment.user.login }}

--- a/.github/workflows/scripts/rerun-failed-workflows.sh
+++ b/.github/workflows/scripts/rerun-failed-workflows.sh
@@ -6,8 +6,8 @@
 
 set -euo pipefail
 
-if [[ -z "${PR_NUMBER:-}" || -z "${COMMENT:-}" || -z "${SENDER:-}" ]]; then
-    echo "PR_NUMBER, COMMENT, or SENDER not set"
+if [[ -z "${PR_NUMBER:-}" || -z "${COMMENT:-}" || -z "${SENDER:-}" || -z "${ORG_TOKEN:-}" ]]; then
+    echo "PR_NUMBER, COMMENT, SENDER or ORG_TOKEN not set"
     exit 0
 fi
 
@@ -20,8 +20,22 @@ PR_DATA=$(gh pr view "${PR_NUMBER}" --json headRefOid,author)
 HEAD_SHA=$(echo "${PR_DATA}" | jq -r '.headRefOid')
 PR_AUTHOR=$(echo "${PR_DATA}" | jq -r '.author.login')
 
-if [[ "${SENDER}" != "${PR_AUTHOR}" ]]; then
-    echo "Only PR author can rerun workflows"
+TEAMS=(
+    "collector-contrib-triagers"
+    "collector-contrib-approvers"
+    "collector-contrib-maintainers"
+)
+
+IS_AUTHORIZED="false"
+for TEAM in "${TEAMS[@]}"; do
+    if GH_TOKEN="${ORG_TOKEN}" gh api "orgs/open-telemetry/teams/${TEAM}/memberships/${SENDER}" --silent 2>/dev/null; then
+        IS_AUTHORIZED="true"
+        break
+    fi
+done
+
+if [[ "${SENDER}" != "${PR_AUTHOR}" && "${IS_AUTHORIZED}" != "true" ]]; then
+    echo "Only the PR author or a member of an authorized team can rerun workflows"
     exit 0
 fi
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The CI can fail due to a transient issue, and we can ask the PR author to `/rerun` the pipeline. But while we are reviewing PRs, I would like to help and ask myself for a `/rerun` to ensure I'm not missing anything on the review before approving.

This PR adds the ability for triagers, approvers, and maintainers to ask for a `/rerun` on the PRs that they are not the authors.
