### PR TITLE
[extension/awslogsencoding] Remove deprecated config

### DIFF
--- a/.chloggen/awslogsencoding-remove-deprecated-formats.yaml
+++ b/.chloggen/awslogsencoding-remove-deprecated-formats.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/aws_logs_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated format values and the `vpc_flow_log` config field.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42901]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The deprecated format values `vpc_flow_log`, `elb_access_log`, `s3_access_log`, `cloudtrail_log`,
+  `waf_log`, and `cloudwatch_logs_subscription_filter` are no longer supported. Use `vpcflow`,
+  `elbaccess`, `s3access`, `cloudtrail`, `waf`, and `cloudwatch` respectively. The deprecated
+  `vpc_flow_log` config field has been removed; use `vpcflow` instead.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/awslogsencodingextension/README.md
+++ b/extension/encoding/awslogsencodingextension/README.md
@@ -111,25 +111,6 @@ The following format values are supported in the `awslogsencodingextension` to i
 | CloudWatch Logs | `cloudwatch` | CloudWatch Logs Subscription Filter events |
 | Network Firewall Logs | `networkfirewall` | AWS Network Firewall event logs (Alert/Flow, TLS) |
 
-### Breaking Change Notice
-
-**Format values have been simplified in v0.137.0**
-
-**The old format values are deprecated and will be unsupported in v0.138.0.**
-
-| **AWS Log Type** | **Old Format Value (Deprecated)** | **New Format Value** |
-|------------------|-----------------------------------|---------------------|
-| VPC Flow Logs | `vpc_flow_log` | `vpcflow` |
-| ELB Access Logs | `elb_access_log` | `elbaccess` |
-| S3 Access Logs | `s3_access_log` | `s3access` |
-| CloudTrail Logs | `cloudtrail_log` | `cloudtrail` |
-| WAF Logs | `waf_log` | `waf` |
-| CloudWatch Logs | `cloudwatch_logs_subscription_filter` | `cloudwatch` |
-
-#### Migration Path
-
-If you're using the old format values you should update the encoding extension configuration with the new format values.
-
 ## Feature Gates
 
 Following feature gates are available to modify the behavior of the AWS Logs encoding extension.

--- a/extension/encoding/awslogsencodingextension/config.go
+++ b/extension/encoding/awslogsencodingextension/config.go
@@ -17,7 +17,6 @@ var _ xconfmap.Validator = (*Config)(nil)
 
 var (
 	supportedLogFormats = []string{
-		// New format values
 		constants.FormatCloudWatchLogsSubscriptionFilter,
 		constants.FormatVPCFlowLog,
 		constants.FormatS3AccessLog,
@@ -25,13 +24,6 @@ var (
 		constants.FormatCloudTrailLog,
 		constants.FormatELBAccessLog,
 		constants.FormatNetworkFirewallLog,
-		// Legacy format values (for backward compatibility)
-		constants.FormatCloudWatchLogsSubscriptionFilterV1,
-		constants.FormatVPCFlowLogV1,
-		constants.FormatS3AccessLogV1,
-		constants.FormatWAFLogV1,
-		constants.FormatCloudTrailLogV1,
-		constants.FormatELBAccessLogV1,
 	}
 	supportedVPCFlowLogFileFormat = []string{constants.FileFormatPlainText, constants.FileFormatParquet}
 )
@@ -51,8 +43,6 @@ type Config struct {
 	Format string `mapstructure:"format"`
 
 	VPCFlowLogConfig vpcflowlog.Config `mapstructure:"vpcflow"`
-	// Deprecated: use VPCFlowLogConfig instead. It will be removed in v0.138.0
-	VPCFlowLogConfigV1 vpcflowlog.Config `mapstructure:"vpc_flow_log"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -65,16 +55,10 @@ func (cfg *Config) Validate() error {
 	case "":
 		errs = append(errs, fmt.Errorf("format unspecified, expected one of %q", supportedLogFormats))
 	case constants.FormatCloudWatchLogsSubscriptionFilter: // valid
-	case constants.FormatCloudWatchLogsSubscriptionFilterV1: // valid
-	case constants.FormatVPCFlowLogV1: // valid
 	case constants.FormatVPCFlowLog: // valid
-	case constants.FormatS3AccessLogV1: // valid
 	case constants.FormatS3AccessLog: // valid
-	case constants.FormatWAFLogV1: // valid
 	case constants.FormatWAFLog: // valid
-	case constants.FormatCloudTrailLogV1: // valid
 	case constants.FormatCloudTrailLog: // valid
-	case constants.FormatELBAccessLogV1: // valid
 	case constants.FormatELBAccessLog: // valid
 	case constants.FormatNetworkFirewallLog: // valid
 	default:
@@ -88,18 +72,6 @@ func (cfg *Config) Validate() error {
 		errs = append(errs, fmt.Errorf(
 			"unsupported file format %q for VPC flow log, expected one of %q",
 			cfg.VPCFlowLogConfig.FileFormat,
-			supportedVPCFlowLogFileFormat,
-		))
-	}
-
-	// to be deprecated in v0.138.0
-	switch cfg.VPCFlowLogConfigV1.FileFormat {
-	case constants.FileFormatParquet: // valid
-	case constants.FileFormatPlainText: // valid
-	default:
-		errs = append(errs, fmt.Errorf(
-			"unsupported file format %q for VPC flow log, expected one of %q",
-			cfg.VPCFlowLogConfigV1.FileFormat,
 			supportedVPCFlowLogFileFormat,
 		))
 	}

--- a/extension/encoding/awslogsencodingextension/config_test.go
+++ b/extension/encoding/awslogsencodingextension/config_test.go
@@ -42,30 +42,12 @@ func TestLoadConfig(t *testing.T) {
 				VPCFlowLogConfig: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
 			},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "text_vpcflow"),
 			expected: &Config{
 				Format: constants.FormatVPCFlowLog,
-				VPCFlowLogConfig: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
-			},
-		},
-		{
-			id: component.NewIDWithName(metadata.Type, "text_vpc_flow_log"),
-			expected: &Config{
-				Format: constants.FormatVPCFlowLogV1,
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
 				VPCFlowLogConfig: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
@@ -78,20 +60,10 @@ func TestLoadConfig(t *testing.T) {
 				VPCFlowLogConfig: vpcflowlog.Config{
 					FileFormat: constants.FileFormatParquet,
 				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
 			},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "invalid_vpcflow"),
-			expectedErr: fmt.Sprintf(
-				`unsupported file format "invalid" for VPC flow log, expected one of %q`,
-				supportedVPCFlowLogFileFormat,
-			),
-		},
-		{
-			id: component.NewIDWithName(metadata.Type, "invalid_vpc_flow_log"),
 			expectedErr: fmt.Sprintf(
 				`unsupported file format "invalid" for VPC flow log, expected one of %q`,
 				supportedVPCFlowLogFileFormat,
@@ -104,9 +76,6 @@ func TestLoadConfig(t *testing.T) {
 				VPCFlowLogConfig: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
 			},
 		},
 		{
@@ -114,9 +83,6 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				Format: constants.FormatWAFLog,
 				VPCFlowLogConfig: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
 			},
@@ -128,9 +94,6 @@ func TestLoadConfig(t *testing.T) {
 				VPCFlowLogConfig: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
 			},
 		},
 		{
@@ -140,9 +103,6 @@ func TestLoadConfig(t *testing.T) {
 				VPCFlowLogConfig: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
 			},
 		},
 		{
@@ -150,9 +110,6 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				Format: constants.FormatNetworkFirewallLog,
 				VPCFlowLogConfig: vpcflowlog.Config{
-					FileFormat: constants.FileFormatPlainText,
-				},
-				VPCFlowLogConfigV1: vpcflowlog.Config{
 					FileFormat: constants.FileFormatPlainText,
 				},
 			},

--- a/extension/encoding/awslogsencodingextension/extension.go
+++ b/extension/encoding/awslogsencodingextension/extension.go
@@ -74,25 +74,13 @@ type encodingExtension struct {
 
 func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension, error) {
 	switch cfg.Format {
-	case constants.FormatCloudWatchLogsSubscriptionFilter, constants.FormatCloudWatchLogsSubscriptionFilterV1:
-		if cfg.Format == constants.FormatCloudWatchLogsSubscriptionFilterV1 {
-			settings.Logger.Warn("using old format value. This format will be removed in version 0.138.0.",
-				zap.String("old_format", constants.FormatCloudWatchLogsSubscriptionFilterV1),
-				zap.String("new_format", constants.FormatCloudWatchLogsSubscriptionFilter),
-			)
-		}
+	case constants.FormatCloudWatchLogsSubscriptionFilter:
 		return &encodingExtension{
 			unmarshaler: subscriptionfilter.NewSubscriptionFilterUnmarshaler(settings.BuildInfo),
 			format:      constants.FormatCloudWatchLogsSubscriptionFilter,
 			logger:      settings.Logger,
 		}, nil
-	case constants.FormatVPCFlowLog, constants.FormatVPCFlowLogV1:
-		if cfg.Format == constants.FormatVPCFlowLogV1 {
-			settings.Logger.Warn("using old format value. This format will be removed in version 0.138.0.",
-				zap.String("old_format", constants.FormatVPCFlowLogV1),
-				zap.String("new_format", constants.FormatVPCFlowLog),
-			)
-		}
+	case constants.FormatVPCFlowLog:
 		unmarshaler, err := vpcflowlog.NewVPCFlowLogUnmarshaler(
 			cfg.VPCFlowLogConfig,
 			settings.BuildInfo,
@@ -105,37 +93,19 @@ func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension,
 			format:      constants.FormatVPCFlowLog,
 			logger:      settings.Logger,
 		}, err
-	case constants.FormatS3AccessLog, constants.FormatS3AccessLogV1:
-		if cfg.Format == constants.FormatS3AccessLogV1 {
-			settings.Logger.Warn("using old format value. This format will be removed in version 0.138.0.",
-				zap.String("old_format", constants.FormatS3AccessLogV1),
-				zap.String("new_format", constants.FormatS3AccessLog),
-			)
-		}
+	case constants.FormatS3AccessLog:
 		return &encodingExtension{
 			unmarshaler: s3accesslog.NewS3AccessLogUnmarshaler(settings.BuildInfo),
 			format:      constants.FormatS3AccessLog,
 			logger:      settings.Logger,
 		}, nil
-	case constants.FormatWAFLog, constants.FormatWAFLogV1:
-		if cfg.Format == constants.FormatWAFLogV1 {
-			settings.Logger.Warn("using old format value. This format will be removed in version 0.138.0.",
-				zap.String("old_format", constants.FormatWAFLogV1),
-				zap.String("new_format", constants.FormatWAFLog),
-			)
-		}
+	case constants.FormatWAFLog:
 		return &encodingExtension{
 			unmarshaler: waf.NewWAFLogUnmarshaler(settings.BuildInfo),
 			format:      constants.FormatWAFLog,
 			logger:      settings.Logger,
 		}, nil
-	case constants.FormatCloudTrailLog, constants.FormatCloudTrailLogV1:
-		if cfg.Format == constants.FormatCloudTrailLogV1 {
-			settings.Logger.Warn("using old format value. This format will be removed in version 0.138.0.",
-				zap.String("old_format", constants.FormatCloudTrailLogV1),
-				zap.String("new_format", constants.FormatCloudTrailLog),
-			)
-		}
+	case constants.FormatCloudTrailLog:
 		if metadata.ExtensionEncodingAwslogsencodingDontEmitV0RPCConventionsFeatureGate.IsEnabled() &&
 			!metadata.ExtensionEncodingAwslogsencodingEmitV1RPCConventionsFeatureGate.IsEnabled() {
 			return nil, errors.New("extension.encoding.awslogsencoding.DontEmitV0RPCConventions requires extension.encoding.awslogsencoding.EmitV1RPCConventions to be enabled")
@@ -147,13 +117,7 @@ func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension,
 			format: constants.FormatCloudTrailLog,
 			logger: settings.Logger,
 		}, nil
-	case constants.FormatELBAccessLog, constants.FormatELBAccessLogV1:
-		if cfg.Format == constants.FormatELBAccessLogV1 {
-			settings.Logger.Warn("using old format value. This format will be removed in version 0.138.0.",
-				zap.String("old_format", constants.FormatELBAccessLogV1),
-				zap.String("new_format", constants.FormatELBAccessLog),
-			)
-		}
+	case constants.FormatELBAccessLog:
 		return &encodingExtension{
 			unmarshaler: elbaccesslogs.NewELBAccessLogUnmarshaler(
 				settings.BuildInfo,

--- a/extension/encoding/awslogsencodingextension/extension_test.go
+++ b/extension/encoding/awslogsencodingextension/extension_test.go
@@ -30,26 +30,8 @@ func TestNew_CloudWatchLogsSubscriptionFilter(t *testing.T) {
 	require.ErrorContains(t, err, `failed to unmarshal logs as "cloudwatch" format`)
 }
 
-func TestNew_CloudWatchLogsSubscriptionFilterV1(t *testing.T) {
-	e, err := newExtension(&Config{Format: constants.FormatCloudWatchLogsSubscriptionFilterV1}, extensiontest.NewNopSettings(extensiontest.NopType))
-	require.NoError(t, err)
-	require.NotNil(t, e)
-
-	_, err = e.UnmarshalLogs([]byte("invalid"))
-	require.ErrorContains(t, err, `failed to unmarshal logs as "cloudwatch" format`)
-}
-
 func TestNew_CloudTrailLog(t *testing.T) {
 	e, err := newExtension(&Config{Format: constants.FormatCloudTrailLog}, extensiontest.NewNopSettings(extensiontest.NopType))
-	require.NoError(t, err)
-	require.NotNil(t, e)
-
-	_, err = e.UnmarshalLogs([]byte("invalid"))
-	require.ErrorContains(t, err, `failed to unmarshal logs as "cloudtrail" format`)
-}
-
-func TestNew_CloudTrailLogV1(t *testing.T) {
-	e, err := newExtension(&Config{Format: constants.FormatCloudTrailLogV1}, extensiontest.NewNopSettings(extensiontest.NopType))
 	require.NoError(t, err)
 	require.NotNil(t, e)
 
@@ -68,14 +50,6 @@ func TestNew_VPCFlowLog(t *testing.T) {
 	require.ErrorContains(t, err, "failed to read first line of VPC logs from S3")
 }
 
-func TestNew_VPCFlowLogV1(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.Format = constants.FormatVPCFlowLogV1
-	e, err := newExtension(cfg, extensiontest.NewNopSettings(extensiontest.NopType))
-	require.NoError(t, err)
-	require.NotNil(t, e)
-}
-
 func TestNew_S3AccessLog(t *testing.T) {
 	e, err := newExtension(&Config{Format: constants.FormatS3AccessLog}, extensiontest.NewNopSettings(extensiontest.NopType))
 	require.NoError(t, err)
@@ -83,14 +57,6 @@ func TestNew_S3AccessLog(t *testing.T) {
 
 	_, err = e.UnmarshalLogs([]byte("invalid"))
 	require.ErrorContains(t, err, `failed to unmarshal logs as "s3access" format`)
-}
-
-func TestNew_S3AccessLogV1(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.Format = constants.FormatS3AccessLogV1
-	e, err := newExtension(cfg, extensiontest.NewNopSettings(extensiontest.NopType))
-	require.NoError(t, err)
-	require.NotNil(t, e)
 }
 
 func TestNew_WAFLog(t *testing.T) {
@@ -102,14 +68,6 @@ func TestNew_WAFLog(t *testing.T) {
 	require.ErrorContains(t, err, `failed to unmarshal logs as "waf" format`)
 }
 
-func TestNew_WAFLogV1(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.Format = constants.FormatWAFLogV1
-	e, err := newExtension(cfg, extensiontest.NewNopSettings(extensiontest.NopType))
-	require.NoError(t, err)
-	require.NotNil(t, e)
-}
-
 func TestNew_ELBAcessLog(t *testing.T) {
 	e, err := newExtension(&Config{Format: constants.FormatELBAccessLog}, extensiontest.NewNopSettings(extensiontest.NopType))
 	require.NoError(t, err)
@@ -117,14 +75,6 @@ func TestNew_ELBAcessLog(t *testing.T) {
 
 	_, err = e.UnmarshalLogs([]byte("invalid"))
 	require.ErrorContains(t, err, `failed to unmarshal logs as "elbaccess" format`)
-}
-
-func TestNew_ELBAcessLogV1(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.Format = constants.FormatELBAccessLogV1
-	e, err := newExtension(cfg, extensiontest.NewNopSettings(extensiontest.NopType))
-	require.NoError(t, err)
-	require.NotNil(t, e)
 }
 
 func TestNew_Unimplemented(t *testing.T) {

--- a/extension/encoding/awslogsencodingextension/factory.go
+++ b/extension/encoding/awslogsencodingextension/factory.go
@@ -34,8 +34,5 @@ func createDefaultConfig() component.Config {
 		VPCFlowLogConfig: vpcflowlog.Config{
 			FileFormat: constants.FileFormatPlainText,
 		},
-		VPCFlowLogConfigV1: vpcflowlog.Config{
-			FileFormat: constants.FileFormatPlainText,
-		},
 	}
 }

--- a/extension/encoding/awslogsencodingextension/internal/constants/format.go
+++ b/extension/encoding/awslogsencodingextension/internal/constants/format.go
@@ -12,14 +12,6 @@ const (
 	FormatELBAccessLog                     = "elbaccess"
 	FormatNetworkFirewallLog               = "networkfirewall"
 
-	// Legacy format values (v1) - kept for backward compatibility
-	FormatVPCFlowLogV1                       = "vpc_flow_log"
-	FormatELBAccessLogV1                     = "elb_access_log"
-	FormatS3AccessLogV1                      = "s3_access_log"
-	FormatCloudTrailLogV1                    = "cloudtrail_log"
-	FormatWAFLogV1                           = "waf_log"
-	FormatCloudWatchLogsSubscriptionFilterV1 = "cloudwatch_logs_subscription_filter"
-
 	FileFormatPlainText     = "plain-text"
 	FileFormatParquet       = "parquet"
 	FormatIdentificationTag = "encoding.format"

--- a/extension/encoding/awslogsencodingextension/testdata/config.yaml
+++ b/extension/encoding/awslogsencodingextension/testdata/config.yaml
@@ -8,11 +8,6 @@ aws_logs_encoding/text_vpcflow:
   vpcflow:
     file_format: plain-text
 
-aws_logs_encoding/text_vpc_flow_log:
-  format: vpc_flow_log
-  vpc_flow_log:
-    file_format: plain-text
-
 aws_logs_encoding/parquet_vpcflow:
   format: vpcflow
   vpcflow:
@@ -21,11 +16,6 @@ aws_logs_encoding/parquet_vpcflow:
 aws_logs_encoding/invalid_vpcflow:
   format: vpcflow
   vpcflow:
-    file_format: invalid
-
-aws_logs_encoding/invalid_vpc_flow_log:
-  format: vpc_flow_log
-  vpc_flow_log:
     file_format: invalid
 
 aws_logs_encoding/s3access:


### PR DESCRIPTION
#### Description

Remove the deprecated `vpc_flow_log`, `elb_access_log`, `s3_access_log`, `cloudtrail_log`, `waf_log`, and `cloudwatch_logs_subscription_filter` format values, along with the deprecated `vpc_flow_log` config field.

Assisted-by: Claude Opus 4.7

#### Link to tracking issue

Relates to #42901

#### Testing

N/A

#### Documentation

Updated README