### PR TITLE
[exporter/honeycombmarker]: add support for OTTL context inference

### DIFF
--- a/.chloggen/honeycombmarker-path-context-names.yaml
+++ b/.chloggen/honeycombmarker-path-context-names.yaml
@@ -10,7 +10,7 @@ component: exporter/honeycombmarker
 note: Support OTTL path-context names (e.g. `log.body == "x"`, `resource.attributes["service.name"] == "y"`) in `markers[].rules.log_conditions`.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48325]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/honeycombmarker-path-context-names.yaml
+++ b/.chloggen/honeycombmarker-path-context-names.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/honeycombmarker
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support OTTL path-context names (e.g. `log.body == "x"`, `resource.attributes["service.name"] == "y"`) in `markers[].rules.log_conditions`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Un-prefixed paths continue to work for now. If you are using un-prefixed paths, the updated statements will be printed on startup. It is highly recommended to switch to the new syntax to avoid breaking changes in the future.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/honeycombmarker-path-context-names.yaml
+++ b/.chloggen/honeycombmarker-path-context-names.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: exporter/honeycombmarker
+component: exporter/honeycomb_marker
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support OTTL path-context names (e.g. `log.body == "x"`, `resource.attributes["service.name"] == "y"`) in `markers[].rules.log_conditions`.

--- a/exporter/honeycombmarkerexporter/README.md
+++ b/exporter/honeycombmarkerexporter/README.md
@@ -32,6 +32,8 @@ The following configuration options are supported:
   * `message_key` (Optional): The key of the attribute whose value will be used as the marker's message. If necessary the value will be converted to a string.
   * `url_key` (Optional): The key of the attribute whose value will be used as the marker's url. If necessary the value will be converted to a string.
 
+`log_conditions` accept both the legacy un-prefixed form (`body == "x"`) and the new OTTL path-context form (`log.body == "x"`). Resource and scope paths are also reachable via `resource.attributes["..."]`, `scope.name`, etc. Un-prefixed paths continue to work for now; the parser logs the rewritten statements on startup. It is recommended to switch to the new syntax to avoid breaking changes in the future.
+
 Example:
 ```yaml
 exporters:
@@ -42,5 +44,10 @@ exporters:
       - type: k8s-backoff-events
         rules:
           log_conditions:
-            - IsMap(body) and IsMap(body["object"]) and body["object"]["reason"] == "Backoff"
+            - IsMap(log.body) and IsMap(log.body["object"]) and log.body["object"]["reason"] == "Backoff"
+      # Path-context syntax allows referencing resource and scope fields directly
+      - type: deployment-events
+        rules:
+          log_conditions:
+            - log.body["event"] == "deploy" and resource.attributes["service.name"] == "checkout"
 ```

--- a/exporter/honeycombmarkerexporter/config.go
+++ b/exporter/honeycombmarkerexporter/config.go
@@ -81,7 +81,7 @@ func (cfg *Config) Validate() error {
 			return fmt.Errorf("marker must have rules %v", m)
 		}
 
-		_, err := filterottl.NewBoolExprForLog(m.Rules.LogConditions, filterottl.StandardLogFuncs(), ottl.PropagateError, component.TelemetrySettings{Logger: zap.NewNop()})
+		_, err := filterottl.NewBoolExprForLogWithPathContextNames(m.Rules.LogConditions, filterottl.StandardLogFuncs(), ottl.PropagateError, component.TelemetrySettings{Logger: zap.NewNop()})
 		if err != nil {
 			return err
 		}

--- a/exporter/honeycombmarkerexporter/config_test.go
+++ b/exporter/honeycombmarkerexporter/config_test.go
@@ -84,6 +84,45 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "no_markers_supplied"),
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "path_context_log"),
+			expected: &Config{
+				APIKey: "test-apikey",
+				APIURL: "https://api.honeycomb.io",
+				Markers: []Marker{
+					{
+						Type: "fooType",
+						Rules: Rules{
+							LogConditions: []string{
+								`log.body == "test"`,
+								`log.attributes["level"] == "ERROR"`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "path_context_mixed"),
+			expected: &Config{
+				APIKey: "test-apikey",
+				APIURL: "https://api.honeycomb.io",
+				Markers: []Marker{
+					{
+						Type: "fooType",
+						Rules: Rules{
+							LogConditions: []string{
+								`body == "test"`,
+								`resource.attributes["service.name"] == "checkout"`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "path_context_invalid"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -55,7 +55,7 @@ func newHoneycombLogsExporter(set exporter.Settings, config *Config) (*honeycomb
 	telemetrySettings := set.TelemetrySettings
 	markers := make([]marker, len(config.Markers))
 	for i, m := range config.Markers {
-		matchLogConditions, err := filterottl.NewBoolExprForLog(m.Rules.LogConditions, filterottl.StandardLogFuncs(), ottl.PropagateError, telemetrySettings)
+		matchLogConditions, err := filterottl.NewBoolExprForLogWithPathContextNames(m.Rules.LogConditions, filterottl.StandardLogFuncs(), ottl.PropagateError, telemetrySettings)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse log conditions: %w", err)
 		}

--- a/exporter/honeycombmarkerexporter/logs_exporter_test.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter_test.go
@@ -116,6 +116,31 @@ func TestExportMarkers(t *testing.T) {
 			},
 			expectedURL: "/1/markers/__all__",
 		},
+		{
+			name: "path context syntax",
+			config: Config{
+				APIKey: "test-apikey",
+				Markers: []Marker{
+					{
+						Type:        "test-type",
+						MessageKey:  "message",
+						URLKey:      "url",
+						DatasetSlug: "test-dataset",
+						Rules: Rules{
+							LogConditions: []string{
+								`log.body == "test"`,
+							},
+						},
+					},
+				},
+			},
+			attributeMap: map[string]string{
+				"message": "this is a test message",
+				"url":     "https://api.testhost.io",
+				"type":    "test-type",
+			},
+			expectedURL: "/1/markers/test-dataset",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/honeycombmarkerexporter/testdata/config.yaml
+++ b/exporter/honeycombmarkerexporter/testdata/config.yaml
@@ -80,3 +80,29 @@ honeycomb_marker/no_dataset_slug:
         log_conditions:
           - body == "test"
 
+honeycomb_marker/path_context_log:
+  api_key: "test-apikey"
+  markers:
+    - type: "fooType"
+      rules:
+        log_conditions:
+          - log.body == "test"
+          - log.attributes["level"] == "ERROR"
+
+honeycomb_marker/path_context_mixed:
+  api_key: "test-apikey"
+  markers:
+    - type: "fooType"
+      rules:
+        log_conditions:
+          - body == "test"
+          - resource.attributes["service.name"] == "checkout"
+
+honeycomb_marker/path_context_invalid:
+  api_key: "test-apikey"
+  markers:
+    - type: "fooType"
+      rules:
+        log_conditions:
+          - metric.name == "foo"
+


### PR DESCRIPTION
#### Description

add support for OTTL context inference

#### Testing

unit tests

#### Documentation

updated readme
