### PR TITLE
[receiver/oracledbreceiver] Add CDB/PDB detection and oracledb.pdb_name resource attribute

### DIFF
--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -508,4 +508,6 @@ Collection of event metrics for top N queries, filtered based on the highest CPU
 | ---- | ----------- | ------ | ------- | ------------------- |
 | host.name | The host name of Oracle Server | Any Str | true | - |
 | oracledb.instance.name | The name of the instance that data is coming from. | Any Str | true | - |
+| oracledb.pdb_name | The name of the Oracle Pluggable Database (PDB) that the monitoring user is connected to. Only set when the database is a Container Database (CDB) and the monitoring user is connected to a specific PDB rather than the CDB root. Empty for non-CDB (traditional) Oracle instances.
+ | Any Str | true | - |
 | service.instance.id | A unique identifier of the Oracle DB instance in the format host:port/serviceName. (defaults to 'unknown:1521', in case of error in generating this value) | Any Str | true | - |

--- a/receiver/oracledbreceiver/generated_package_test.go
+++ b/receiver/oracledbreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package oracledbreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/oracledbreceiver/instance_info.go
+++ b/receiver/oracledbreceiver/instance_info.go
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oracledbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver"
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// oracleInstanceInfo holds Oracle deployment metadata detected once at scraper
+// start time. All fields are best-effort: if a detection query fails (e.g.
+// insufficient privileges, older Oracle version), the field stays at its zero
+// value and the receiver continues with reduced metadata.
+type oracleInstanceInfo struct {
+	// dbVersion is the Oracle version string returned by v$instance, e.g.
+	// "19.0.0.0.0". Empty if version detection failed.
+	dbVersion string
+
+	// isCDB is true when the database is a Container Database (Oracle 12c+).
+	// false for non-CDB (traditional) instances or when detection failed.
+	isCDB bool
+
+	// connectedToPDB is true when the monitoring user is connected to a
+	// specific Pluggable Database rather than the CDB root.
+	connectedToPDB bool
+
+	// pdbName is the name of the PDB when connectedToPDB is true.
+	// Empty otherwise.
+	pdbName string
+}
+
+// isVersionGTE reports whether the detected Oracle major version is greater
+// than or equal to minMajor. Returns false if version detection failed.
+func (info oracleInstanceInfo) isVersionGTE(minMajor int) bool {
+	if info.dbVersion == "" {
+		return false
+	}
+	major, err := strconv.Atoi(strings.SplitN(info.dbVersion, ".", 2)[0])
+	if err != nil {
+		return false
+	}
+	return major >= minMajor
+}
+
+const (
+	// minMultitenantVersion is the Oracle major version that introduced
+	// multitenant (CDB/PDB) architecture.
+	minMultitenantVersion = 12
+
+	// instanceInfoDetectTimeout caps the total time spent on instance
+	// detection queries at startup. Detection is best-effort so a slow or
+	// blackholed endpoint must not stall the collector.
+	instanceInfoDetectTimeout = 5 * time.Second
+
+	instanceVersionSQL  = "SELECT version FROM v$instance"
+	instanceCDBSQL      = "SELECT cdb FROM v$database"
+	instanceConTypeSQL  = "SELECT decode(sys_context('USERENV','CON_ID'),1,'CDB','PDB') FROM dual"
+	instanceConNameSQL  = "SELECT sys_context('USERENV','CON_NAME') FROM dual"
+)
+
+// detectInstanceInfo runs a small set of read-only queries using the provided
+// dbClient instances to populate and return an oracleInstanceInfo. All queries
+// run within a single short timeout context. Any failure is logged at Warn
+// level and causes that field to retain its zero value; the receiver continues
+// normally.
+func detectInstanceInfo(
+	ctx context.Context,
+	versionClient dbClient,
+	cdbClient dbClient,
+	conTypeClient dbClient,
+	conNameClient dbClient,
+	logger *zap.Logger,
+) oracleInstanceInfo {
+	ctx, cancel := context.WithTimeout(ctx, instanceInfoDetectTimeout)
+	defer cancel()
+
+	info := oracleInstanceInfo{}
+
+	// Step 1 — Oracle version from v$instance.
+	rows, err := versionClient.metricRows(ctx)
+	if err != nil || len(rows) == 0 {
+		logger.Warn("oracledbreceiver: failed to detect Oracle version; pdb_name attribute will not be set",
+			zap.Error(err))
+		return info
+	}
+	info.dbVersion = rows[0]["VERSION"]
+	logger.Info("oracledbreceiver: detected Oracle version", zap.String("version", info.dbVersion))
+
+	// Remaining detection requires Oracle 12c+.
+	if !info.isVersionGTE(minMultitenantVersion) {
+		logger.Info("oracledbreceiver: Oracle version is pre-12c; multitenant detection skipped",
+			zap.String("version", info.dbVersion))
+		return info
+	}
+
+	// Step 2 — Is this a Container Database?
+	rows, err = cdbClient.metricRows(ctx)
+	if err != nil || len(rows) == 0 {
+		logger.Warn("oracledbreceiver: failed to detect CDB status; assuming non-CDB",
+			zap.Error(err))
+		return info
+	}
+	info.isCDB = strings.EqualFold(rows[0]["CDB"], "YES")
+
+	if !info.isCDB {
+		// Non-CDB instance: no further multitenant detection needed.
+		return info
+	}
+
+	// Step 3 — Is the monitoring user connected to a PDB or the CDB root?
+	// CON_ID = 1 means CDB root; any other value means a specific PDB.
+	rows, err = conTypeClient.metricRows(ctx)
+	if err != nil || len(rows) == 0 {
+		logger.Warn("oracledbreceiver: failed to detect connection type (CDB root vs PDB)",
+			zap.Error(err))
+		return info
+	}
+	// The decode() expression returns one unnamed column; the dbClient uppercases
+	// column names, so the key is the expression text — access by first value.
+	for _, v := range rows[0] {
+		info.connectedToPDB = v == "PDB"
+		break
+	}
+
+	if !info.connectedToPDB {
+		return info
+	}
+
+	// Step 4 — Name of the PDB the monitoring user is connected to.
+	rows, err = conNameClient.metricRows(ctx)
+	if err != nil || len(rows) == 0 {
+		logger.Warn("oracledbreceiver: failed to detect PDB name",
+			zap.Error(err))
+		return info
+	}
+	for _, v := range rows[0] {
+		info.pdbName = v
+		break
+	}
+	logger.Info("oracledbreceiver: connected to PDB", zap.String("pdb_name", info.pdbName))
+
+	return info
+}

--- a/receiver/oracledbreceiver/instance_info_test.go
+++ b/receiver/oracledbreceiver/instance_info_test.go
@@ -1,0 +1,338 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oracledbreceiver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
+)
+
+// errQuery is a sentinel error used to simulate a failed DB query.
+var errQuery = errors.New("ORA-00942: table or view does not exist")
+
+// versionRow builds the fakeDbClient response for the v$instance version query.
+func versionRow(v string) []metricRow {
+	return []metricRow{{"VERSION": v}}
+}
+
+// cdbRow builds the fakeDbClient response for the v$database CDB query.
+func cdbRow(cdb string) []metricRow {
+	return []metricRow{{"CDB": cdb}}
+}
+
+// conTypeRow builds the fakeDbClient response for the USERENV CON_ID query.
+// The decode() expression produces an unnamed column; the dbClient stores it
+// by whatever key the driver returns, so we use the same key the real driver
+// would produce — but in tests we use the first map value (see instance_info.go).
+func conTypeRow(t string) []metricRow {
+	return []metricRow{{"TYPE": t}}
+}
+
+// conNameRow builds the fakeDbClient response for the USERENV CON_NAME query.
+func conNameRow(name string) []metricRow {
+	return []metricRow{{"NAME": name}}
+}
+
+// noopClient returns a fakeDbClient that should never be called.
+// Use it for detection steps that must not run in a given test.
+func noopClient(t *testing.T) dbClient {
+	t.Helper()
+	return &fakeDbClient{
+		Err: errors.New("this client should not have been called"),
+	}
+}
+
+// errClient returns a fakeDbClient that always returns an error.
+func errClient() dbClient {
+	return &fakeDbClient{Err: errQuery}
+}
+
+// rowClient returns a fakeDbClient that returns the given rows once.
+func rowClient(rows []metricRow) dbClient {
+	return &fakeDbClient{Responses: [][]metricRow{rows}}
+}
+
+// -- isVersionGTE unit tests --------------------------------------------------
+
+func TestIsVersionGTE(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		minMajor int
+		expected bool
+	}{
+		{name: "empty version returns false", version: "", minMajor: 12, expected: false},
+		{name: "19 >= 12", version: "19.0.0.0.0", minMajor: 12, expected: true},
+		{name: "12 >= 12", version: "12.2.0.1.0", minMajor: 12, expected: true},
+		{name: "11 not >= 12", version: "11.2.0.4.0", minMajor: 12, expected: false},
+		{name: "19 >= 18", version: "19.0.0.0.0", minMajor: 18, expected: true},
+		{name: "18 >= 18", version: "18.0.0.0.0", minMajor: 18, expected: true},
+		{name: "12 not >= 18", version: "12.2.0.1.0", minMajor: 18, expected: false},
+		{name: "21 >= 12", version: "21.0.0.0.0", minMajor: 12, expected: true},
+		{name: "major-only version string", version: "19", minMajor: 12, expected: true},
+		{name: "malformed version returns false", version: "not-a-version", minMajor: 12, expected: false},
+		{name: "version with only dot returns false", version: ".", minMajor: 12, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := oracleInstanceInfo{dbVersion: tt.version}
+			assert.Equal(t, tt.expected, info.isVersionGTE(tt.minMajor))
+		})
+	}
+}
+
+// -- detectInstanceInfo tests -------------------------------------------------
+
+func TestDetectInstanceInfo_VersionQueryFails(t *testing.T) {
+	// When v$instance is inaccessible all fields stay at zero value and
+	// detection stops — the three subsequent clients must not be called.
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	info := detectInstanceInfo(context.Background(),
+		errClient(),
+		noopClient(t), noopClient(t), noopClient(t),
+		zap.New(core),
+	)
+
+	assert.Empty(t, info.dbVersion)
+	assert.False(t, info.isCDB)
+	assert.False(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+	assert.Equal(t, 1, logs.FilterMessage("oracledbreceiver: failed to detect Oracle version; pdb_name attribute will not be set").Len())
+}
+
+func TestDetectInstanceInfo_Pre12c(t *testing.T) {
+	// Oracle 11g: version is set, multitenant detection is skipped entirely.
+	core, logs := observer.New(zapcore.InfoLevel)
+
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("11.2.0.4.0")),
+		noopClient(t), noopClient(t), noopClient(t),
+		zap.New(core),
+	)
+
+	assert.Equal(t, "11.2.0.4.0", info.dbVersion)
+	assert.False(t, info.isCDB)
+	assert.False(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+	assert.Equal(t, 1, logs.FilterMessage("oracledbreceiver: Oracle version is pre-12c; multitenant detection skipped").Len())
+}
+
+func TestDetectInstanceInfo_NonCDB(t *testing.T) {
+	// Oracle 19c non-CDB: isCDB=false, no further steps run.
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("19.0.0.0.0")),
+		rowClient(cdbRow("NO")),
+		noopClient(t), noopClient(t),
+		zap.NewNop(),
+	)
+
+	assert.Equal(t, "19.0.0.0.0", info.dbVersion)
+	assert.False(t, info.isCDB)
+	assert.False(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+}
+
+func TestDetectInstanceInfo_CDBQueryFails(t *testing.T) {
+	// v$database query fails: isCDB stays false, no further steps run.
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("19.0.0.0.0")),
+		errClient(),
+		noopClient(t), noopClient(t),
+		zap.New(core),
+	)
+
+	assert.Equal(t, "19.0.0.0.0", info.dbVersion)
+	assert.False(t, info.isCDB)
+	assert.False(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+	assert.Equal(t, 1, logs.FilterMessage("oracledbreceiver: failed to detect CDB status; assuming non-CDB").Len())
+}
+
+func TestDetectInstanceInfo_CDBRootConnection(t *testing.T) {
+	// Oracle 19c CDB, monitoring user connected to CDB root (CON_ID=1).
+	// connectedToPDB=false, pdbName stays empty, conNameClient not called.
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("19.0.0.0.0")),
+		rowClient(cdbRow("YES")),
+		rowClient(conTypeRow("CDB")),
+		noopClient(t),
+		zap.NewNop(),
+	)
+
+	assert.Equal(t, "19.0.0.0.0", info.dbVersion)
+	assert.True(t, info.isCDB)
+	assert.False(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+}
+
+func TestDetectInstanceInfo_ConnTypeQueryFails(t *testing.T) {
+	// USERENV CON_ID query fails: connectedToPDB stays false, conNameClient not called.
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("19.0.0.0.0")),
+		rowClient(cdbRow("YES")),
+		errClient(),
+		noopClient(t),
+		zap.New(core),
+	)
+
+	assert.Equal(t, "19.0.0.0.0", info.dbVersion)
+	assert.True(t, info.isCDB)
+	assert.False(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+	assert.Equal(t, 1, logs.FilterMessage("oracledbreceiver: failed to detect connection type (CDB root vs PDB)").Len())
+}
+
+func TestDetectInstanceInfo_PDBConnection(t *testing.T) {
+	// All four steps succeed: all fields populated.
+	core, logs := observer.New(zapcore.InfoLevel)
+
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("19.0.0.0.0")),
+		rowClient(cdbRow("YES")),
+		rowClient(conTypeRow("PDB")),
+		rowClient(conNameRow("MYPDB")),
+		zap.New(core),
+	)
+
+	assert.Equal(t, "19.0.0.0.0", info.dbVersion)
+	assert.True(t, info.isCDB)
+	assert.True(t, info.connectedToPDB)
+	assert.Equal(t, "MYPDB", info.pdbName)
+	assert.Equal(t, 1, logs.FilterField(zap.String("pdb_name", "MYPDB")).Len())
+}
+
+func TestDetectInstanceInfo_PDBNameQueryFails(t *testing.T) {
+	// CON_NAME query fails: connectedToPDB=true but pdbName stays empty.
+	// Receiver still starts without the PDB name attribute.
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("19.0.0.0.0")),
+		rowClient(cdbRow("YES")),
+		rowClient(conTypeRow("PDB")),
+		errClient(),
+		zap.New(core),
+	)
+
+	assert.Equal(t, "19.0.0.0.0", info.dbVersion)
+	assert.True(t, info.isCDB)
+	assert.True(t, info.connectedToPDB)
+	assert.Empty(t, info.pdbName)
+	assert.Equal(t, 1, logs.FilterMessage("oracledbreceiver: failed to detect PDB name").Len())
+}
+
+func TestDetectInstanceInfo_CDBFlagCaseInsensitive(t *testing.T) {
+	// Oracle may return "YES", "Yes", or "yes" — all must set isCDB=true.
+	for _, cdbVal := range []string{"YES", "Yes", "yes"} {
+		t.Run("cdb="+cdbVal, func(t *testing.T) {
+			info := detectInstanceInfo(context.Background(),
+				rowClient(versionRow("19.0.0.0.0")),
+				rowClient(cdbRow(cdbVal)),
+				rowClient(conTypeRow("CDB")),
+				noopClient(t),
+				zap.NewNop(),
+			)
+			assert.True(t, info.isCDB, "expected isCDB=true for cdb=%q", cdbVal)
+		})
+	}
+}
+
+func TestDetectInstanceInfo_Oracle12c(t *testing.T) {
+	// Oracle 12c is the minimum multitenant version — full detection runs.
+	info := detectInstanceInfo(context.Background(),
+		rowClient(versionRow("12.2.0.1.0")),
+		rowClient(cdbRow("YES")),
+		rowClient(conTypeRow("PDB")),
+		rowClient(conNameRow("SALESPDB")),
+		zap.NewNop(),
+	)
+
+	assert.Equal(t, "12.2.0.1.0", info.dbVersion)
+	assert.True(t, info.isCDB)
+	assert.True(t, info.connectedToPDB)
+	assert.Equal(t, "SALESPDB", info.pdbName)
+}
+
+// -- setupResourceBuilder tests -----------------------------------------------
+
+func TestSetupResourceBuilder_NoPDB(t *testing.T) {
+	// When not connected to a PDB, oracledb.pdb_name must not appear in resource.
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	scrpr := oracleScraper{
+		mb:                   metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		metricsBuilderConfig: cfg,
+		instanceName:         "myinstance",
+		hostName:             "myhost",
+		instanceInfo:         oracleInstanceInfo{dbVersion: "19.0.0.0.0", isCDB: false},
+	}
+
+	res := scrpr.setupResourceBuilder(scrpr.mb.NewResourceBuilder()).Emit()
+
+	_, hasPDB := res.Attributes().Get("oracledb.pdb_name")
+	assert.False(t, hasPDB, "pdb_name should not be set for non-PDB connections")
+
+	name, _ := res.Attributes().Get("oracledb.instance.name")
+	assert.Equal(t, "myinstance", name.Str())
+	host, _ := res.Attributes().Get("host.name")
+	assert.Equal(t, "myhost", host.Str())
+}
+
+func TestSetupResourceBuilder_WithPDB(t *testing.T) {
+	// When connected to a PDB, oracledb.pdb_name must be set on the resource.
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	scrpr := oracleScraper{
+		mb:                   metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		metricsBuilderConfig: cfg,
+		instanceName:         "myinstance",
+		hostName:             "myhost",
+		instanceInfo: oracleInstanceInfo{
+			dbVersion:      "19.0.0.0.0",
+			isCDB:          true,
+			connectedToPDB: true,
+			pdbName:        "SALESPDB",
+		},
+	}
+
+	res := scrpr.setupResourceBuilder(scrpr.mb.NewResourceBuilder()).Emit()
+
+	pdbName, ok := res.Attributes().Get("oracledb.pdb_name")
+	require.True(t, ok, "oracledb.pdb_name should be set when connected to a PDB")
+	assert.Equal(t, "SALESPDB", pdbName.Str())
+}
+
+func TestSetupResourceBuilder_PDBConnectedButEmptyName(t *testing.T) {
+	// connectedToPDB=true but pdbName="" (name query failed): pdb_name must not
+	// be emitted as an empty string — it should simply be absent.
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	scrpr := oracleScraper{
+		mb:                   metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		metricsBuilderConfig: cfg,
+		instanceInfo: oracleInstanceInfo{
+			dbVersion:      "19.0.0.0.0",
+			isCDB:          true,
+			connectedToPDB: true,
+			pdbName:        "",
+		},
+	}
+
+	res := scrpr.setupResourceBuilder(scrpr.mb.NewResourceBuilder()).Emit()
+
+	_, hasPDB := res.Attributes().Get("oracledb.pdb_name")
+	assert.False(t, hasPDB, "pdb_name should not be emitted when name is empty")
+}

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -452,6 +452,33 @@ $defs:
             type: array
             items:
               $ref: go.opentelemetry.io/collector/filter.config
+      oracledb.pdb_name:
+        description: ResourceAttributeConfig provides common config for a oracledb.pdb_name resource attribute.
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          metrics_include:
+            description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          metrics_exclude:
+            description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          events_include:
+            description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          events_exclude:
+            description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
       service.instance.id:
         description: ResourceAttributeConfig provides common config for a service.instance.id resource attribute.
         type: object

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1286,6 +1286,7 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 type ResourceAttributesConfig struct {
 	HostName             ResourceAttributeConfig `mapstructure:"host.name"`
 	OracledbInstanceName ResourceAttributeConfig `mapstructure:"oracledb.instance.name"`
+	OracledbPdbName      ResourceAttributeConfig `mapstructure:"oracledb.pdb_name"`
 	ServiceInstanceID    ResourceAttributeConfig `mapstructure:"service.instance.id"`
 }
 
@@ -1295,6 +1296,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		OracledbInstanceName: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		OracledbPdbName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 		ServiceInstanceID: ResourceAttributeConfig{

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -174,6 +174,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					HostName:             ResourceAttributeConfig{Enabled: true},
 					OracledbInstanceName: ResourceAttributeConfig{Enabled: true},
+					OracledbPdbName:      ResourceAttributeConfig{Enabled: true},
 					ServiceInstanceID:    ResourceAttributeConfig{Enabled: true},
 				},
 			},
@@ -330,6 +331,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					HostName:             ResourceAttributeConfig{Enabled: false},
 					OracledbInstanceName: ResourceAttributeConfig{Enabled: false},
+					OracledbPdbName:      ResourceAttributeConfig{Enabled: false},
 					ServiceInstanceID:    ResourceAttributeConfig{Enabled: false},
 				},
 			},
@@ -378,6 +380,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				HostName:             ResourceAttributeConfig{Enabled: true},
 				OracledbInstanceName: ResourceAttributeConfig{Enabled: true},
+				OracledbPdbName:      ResourceAttributeConfig{Enabled: true},
 				ServiceInstanceID:    ResourceAttributeConfig{Enabled: true},
 			},
 		},
@@ -386,6 +389,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				HostName:             ResourceAttributeConfig{Enabled: false},
 				OracledbInstanceName: ResourceAttributeConfig{Enabled: false},
+				OracledbPdbName:      ResourceAttributeConfig{Enabled: false},
 				ServiceInstanceID:    ResourceAttributeConfig{Enabled: false},
 			},
 		},

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -178,6 +177,12 @@ func NewLogsBuilder(lbc LogsBuilderConfig, settings receiver.Settings) *LogsBuil
 	}
 	if lbc.ResourceAttributes.OracledbInstanceName.EventsExclude != nil {
 		lb.resourceAttributeExcludeFilter["oracledb.instance.name"] = filter.CreateFilter(lbc.ResourceAttributes.OracledbInstanceName.EventsExclude)
+	}
+	if lbc.ResourceAttributes.OracledbPdbName.EventsInclude != nil {
+		lb.resourceAttributeIncludeFilter["oracledb.pdb_name"] = filter.CreateFilter(lbc.ResourceAttributes.OracledbPdbName.EventsInclude)
+	}
+	if lbc.ResourceAttributes.OracledbPdbName.EventsExclude != nil {
+		lb.resourceAttributeExcludeFilter["oracledb.pdb_name"] = filter.CreateFilter(lbc.ResourceAttributes.OracledbPdbName.EventsExclude)
 	}
 	if lbc.ResourceAttributes.ServiceInstanceID.EventsInclude != nil {
 		lb.resourceAttributeIncludeFilter["service.instance.id"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceInstanceID.EventsInclude)

--- a/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_logs_test.go
@@ -4,9 +4,6 @@ package metadata
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -14,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"testing"
+	"time"
 )
 
 type eventsTestDataSet int
@@ -33,6 +32,7 @@ func TestLogsBuilderAppendLogRecord(t *testing.T) {
 	rb := lb.NewResourceBuilder()
 	rb.SetHostName("host.name-val")
 	rb.SetOracledbInstanceName("oracledb.instance.name-val")
+	rb.SetOracledbPdbName("oracledb.pdb_name-val")
 	rb.SetServiceInstanceID("service.instance.id-val")
 	res := rb.Emit()
 
@@ -139,6 +139,7 @@ func TestLogsBuilder(t *testing.T) {
 			rb := lb.NewResourceBuilder()
 			rb.SetHostName("host.name-val")
 			rb.SetOracledbInstanceName("oracledb.instance.name-val")
+			rb.SetOracledbPdbName("oracledb.pdb_name-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
 			res := rb.Emit()
 			logs := lb.Emit(WithLogsResource(res))

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -2834,6 +2834,12 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	if mbc.ResourceAttributes.OracledbInstanceName.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["oracledb.instance.name"] = filter.CreateFilter(mbc.ResourceAttributes.OracledbInstanceName.MetricsExclude)
 	}
+	if mbc.ResourceAttributes.OracledbPdbName.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["oracledb.pdb_name"] = filter.CreateFilter(mbc.ResourceAttributes.OracledbPdbName.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.OracledbPdbName.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["oracledb.pdb_name"] = filter.CreateFilter(mbc.ResourceAttributes.OracledbPdbName.MetricsExclude)
+	}
 	if mbc.ResourceAttributes.ServiceInstanceID.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["service.instance.id"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceInstanceID.MetricsInclude)
 	}

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -254,6 +254,7 @@ func TestMetricsBuilder(t *testing.T) {
 			rb := mb.NewResourceBuilder()
 			rb.SetHostName("host.name-val")
 			rb.SetOracledbInstanceName("oracledb.instance.name-val")
+			rb.SetOracledbPdbName("oracledb.pdb_name-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))

--- a/receiver/oracledbreceiver/internal/metadata/generated_resource.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_resource.go
@@ -35,6 +35,13 @@ func (rb *ResourceBuilder) SetOracledbInstanceName(val string) {
 	}
 }
 
+// SetOracledbPdbName sets provided value as "oracledb.pdb_name" attribute.
+func (rb *ResourceBuilder) SetOracledbPdbName(val string) {
+	if rb.config.OracledbPdbName.Enabled {
+		rb.res.Attributes().PutStr("oracledb.pdb_name", val)
+	}
+}
+
 // SetServiceInstanceID sets provided value as "service.instance.id" attribute.
 func (rb *ResourceBuilder) SetServiceInstanceID(val string) {
 	if rb.config.ServiceInstanceID.Enabled {

--- a/receiver/oracledbreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_resource_test.go
@@ -15,6 +15,7 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetHostName("host.name-val")
 			rb.SetOracledbInstanceName("oracledb.instance.name-val")
+			rb.SetOracledbPdbName("oracledb.pdb_name-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
 
 			res := rb.Emit()
@@ -22,9 +23,9 @@ func TestResourceBuilder(t *testing.T) {
 
 			switch tt {
 			case "default":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -40,6 +41,11 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, "oracledb.instance.name-val", oracledbInstanceNameAttrVal.Str())
+			}
+			oracledbPdbNameAttrVal, ok := res.Attributes().Get("oracledb.pdb_name")
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, "oracledb.pdb_name-val", oracledbPdbNameAttrVal.Str())
 			}
 			serviceInstanceIDAttrVal, ok := res.Attributes().Get("service.instance.id")
 			assert.True(t, ok)

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -106,6 +106,8 @@ all_set:
       enabled: true
     oracledb.instance.name:
       enabled: true
+    oracledb.pdb_name:
+      enabled: true
     service.instance.id:
       enabled: true
 reaggregate_set:
@@ -214,6 +216,8 @@ reaggregate_set:
     host.name:
       enabled: true
     oracledb.instance.name:
+      enabled: true
+    oracledb.pdb_name:
       enabled: true
     service.instance.id:
       enabled: true
@@ -324,6 +328,8 @@ none_set:
       enabled: false
     oracledb.instance.name:
       enabled: false
+    oracledb.pdb_name:
+      enabled: false
     service.instance.id:
       enabled: false
 filter_set_include:
@@ -335,6 +341,12 @@ filter_set_include:
       events_include:
         - regexp: ".*"
     oracledb.instance.name:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+      events_include:
+        - regexp: ".*"
+    oracledb.pdb_name:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -360,6 +372,12 @@ filter_set_exclude:
         - strict: "oracledb.instance.name-val"
       events_exclude:
         - strict: "oracledb.instance.name-val"
+    oracledb.pdb_name:
+      enabled: true
+      metrics_exclude:
+        - strict: "oracledb.pdb_name-val"
+      events_exclude:
+        - strict: "oracledb.pdb_name-val"
     service.instance.id:
       enabled: true
       metrics_exclude:

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -24,6 +24,14 @@ resource_attributes:
     description: The name of the instance that data is coming from.
     enabled: true
     type: string
+  oracledb.pdb_name:
+    description: >
+      The name of the Oracle Pluggable Database (PDB) that the monitoring user
+      is connected to. Only set when the database is a Container Database (CDB)
+      and the monitoring user is connected to a specific PDB rather than the
+      CDB root. Empty for non-CDB (traditional) Oracle instances.
+    enabled: true
+    type: string
   service.instance.id:
     description: A unique identifier of the Oracle DB instance in the format host:port/serviceName. (defaults to 'unknown:1521', in case of error in generating this value)
     enabled: true

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -153,6 +153,10 @@ type oracleScraper struct {
 	querySampleCfg             QuerySample
 	serviceInstanceID          string
 	lastExecutionTimestamp     time.Time
+	// instanceInfo holds Oracle deployment metadata detected once at start().
+	// All fields are best-effort: detection failures are logged and leave the
+	// field at its zero value; they never prevent the receiver from starting.
+	instanceInfo oracleInstanceInfo
 }
 
 func newScraper(metricsBuilder *metadata.MetricsBuilder, metricsBuilderConfig metadata.MetricsBuilderConfig, scrapeCfg scraperhelper.ControllerConfig, logger *zap.Logger, providerFunc dbProviderFunc, clientProviderFunc clientProviderFunc, instanceName, hostName string) (scraper.Metrics, error) {
@@ -192,12 +196,25 @@ func newLogsScraper(logsBuilder *metadata.LogsBuilder, logsBuilderConfig metadat
 	return scraper.NewLogs(s.scrapeLogs, scraper.WithShutdown(s.shutdown), scraper.WithStart(s.start))
 }
 
-func (s *oracleScraper) start(context.Context, component.Host) error {
+func (s *oracleScraper) start(ctx context.Context, _ component.Host) error {
 	s.startTime = pcommon.NewTimestampFromTime(time.Now())
 	var err error
 	s.db, err = s.dbProviderFunc()
 	if err != nil {
 		return fmt.Errorf("failed to open db connection: %w", err)
+	}
+	// Detect Oracle version and multitenant topology. This is best-effort:
+	// failures are logged and leave instanceInfo at its zero value without
+	// preventing the receiver from starting or collecting other metrics.
+	if s.db != nil {
+		s.instanceInfo = detectInstanceInfo(
+			ctx,
+			s.clientProviderFunc(s.db, instanceVersionSQL, s.logger),
+			s.clientProviderFunc(s.db, instanceCDBSQL, s.logger),
+			s.clientProviderFunc(s.db, instanceConTypeSQL, s.logger),
+			s.clientProviderFunc(s.db, instanceConNameSQL, s.logger),
+			s.logger,
+		)
 	}
 	s.statsClient = s.clientProviderFunc(s.db, statsSQL, s.logger)
 	s.sessionCountClient = s.clientProviderFunc(s.db, sessionCountSQL, s.logger)
@@ -963,6 +980,9 @@ func (s *oracleScraper) setupResourceBuilder(rb *metadata.ResourceBuilder) *meta
 	rb.SetOracledbInstanceName(s.instanceName)
 	rb.SetHostName(s.hostName)
 	rb.SetServiceInstanceID(s.serviceInstanceID)
+	if s.instanceInfo.connectedToPDB && s.instanceInfo.pdbName != "" {
+		rb.SetOracledbPdbName(s.instanceInfo.pdbName)
+	}
 	return rb
 }
 


### PR DESCRIPTION
- Detect Oracle deployment type at scraper startup using three lightweight read-only queries (v$instance, v$database, USERENV context).
- Detection is best-effort: failures are logged and never prevent the receiver from starting.
- Detected fields stored in oracleInstanceInfo:
  - dbVersion: Oracle version string (e.g. "19.0.0.0.0")
  - isCDB: true when connected to a Container Database (Oracle 12c+)
  - connectedToPDB: true when the monitoring user is connected to a specific PDB
  - pdbName: name of the PDB when connectedToPDB is true

When connected to a PDB, the pdb_name is exposed as a new oracledb.pdb_name resource attribute so metrics can be filtered and grouped by Pluggable Database.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
