### PR TITLE
[chore][exporter/faro] drop headers from example, document app-key URL

### DIFF
--- a/exporter/faroexporter/README.md
+++ b/exporter/faroexporter/README.md
@@ -42,13 +42,11 @@ Example:
 ```yaml
 exporters:
   faro:
-    endpoint: https://faro.example.com/collect
+    endpoint: https://faro.example.com/collect/<app-key>
     timeout: 10s
-    headers:
-      X-Custom-Header: "custom-value"
 ```
 
-> **Note:** A Faro collector endpoint identifies the application via the app key in the URL path (e.g. `https://faro.example.com/collect/<app-key>`). It does **not** authenticate requests via an `X-API-Key` header, so do not set one for that purpose. The `headers` block is provided for passing any additional HTTP headers your deployment may require (e.g. via an intermediate proxy).
+> **Note:** The app key in the URL path identifies the application sending telemetry to the Faro endpoint.
 
 The full list of settings exposed for this exporter are documented [here](./config.go) with detailed sample configurations [here](./testdata/config.yaml).
 

--- a/exporter/faroexporter/README.md
+++ b/exporter/faroexporter/README.md
@@ -45,8 +45,10 @@ exporters:
     endpoint: https://faro.example.com/collect
     timeout: 10s
     headers:
-      X-API-Key: "my-api-key"
+      X-Custom-Header: "custom-value"
 ```
+
+> **Note:** A Faro collector endpoint identifies the application via the app key in the URL path (e.g. `https://faro.example.com/collect/<app-key>`). It does **not** authenticate requests via an `X-API-Key` header, so do not set one for that purpose. The `headers` block is provided for passing any additional HTTP headers your deployment may require (e.g. via an intermediate proxy).
 
 The full list of settings exposed for this exporter are documented [here](./config.go) with detailed sample configurations [here](./testdata/config.yaml).
 

--- a/exporter/faroexporter/testdata/config.yaml
+++ b/exporter/faroexporter/testdata/config.yaml
@@ -9,7 +9,7 @@ exporters:
     endpoint: https://faro.example.com/collect
     timeout: 10s
     headers:
-      X-API-Key: "my-api-key"
+      X-Custom-Header: "custom-value"
 
   faro/with_queue_settings:
     endpoint: https://faro.example.com/collect

--- a/exporter/faroexporter/testdata/config.yaml
+++ b/exporter/faroexporter/testdata/config.yaml
@@ -8,8 +8,6 @@ exporters:
   faro:
     endpoint: https://faro.example.com/collect
     timeout: 10s
-    headers:
-      X-Custom-Header: "custom-value"
 
   faro/with_queue_settings:
     endpoint: https://faro.example.com/collect


### PR DESCRIPTION
#### Description

The example config showed `X-API-Key: "my-api-key"` in a `headers`
block, implying the Faro endpoint authenticates via that header. It
doesn't:

- The Faro collector endpoint (Grafana Cloud) identifies
  the application via the **app key in the URL path**
  (`/collect/<app-key>`); it doesn't read `X-API-Key`.
- The Faro receiver in this repo only inspects `Content-Type` on
  incoming requests.

This PR removes the misleading `headers` block from the README example
and `testdata/config.yaml`, updates the example endpoint to include
`<app-key>`, and adds a short note. The `headers` config option itself
stays documented for users who need it (e.g. an intermediate proxy).

#### Testing

`go test ./exporter/faroexporter/...` passes.