### PR TITLE
[processor/tailsampling]: support ottl context inference

### DIFF
--- a/.chloggen/tailsampling-ottl-path-context.yaml
+++ b/.chloggen/tailsampling-ottl-path-context.yaml
@@ -10,7 +10,7 @@ component: processor/tail_sampling
 note: Support OTTL path-context names (e.g. `span.attributes["foo"]`, `resource.attributes["bar"]`, `spanevent.name`) in the `ottl_condition` policy.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48330]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/tailsampling-ottl-path-context.yaml
+++ b/.chloggen/tailsampling-ottl-path-context.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support OTTL path-context names (e.g. `span.attributes["foo"]`, `resource.attributes["bar"]`, `spanevent.name`) in the `ottl_condition` policy.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Un-prefixed paths continue to work for now. If you are using un-prefixed paths, the updated statements will be printed on startup. It is highly recommended to switch to the new syntax to avoid breaking changes in the future.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -37,7 +37,7 @@ Multiple policies exist today and it is straight forward to add more. These incl
 - `bytes_limiting`: Sample based on the rate of bytes per second using a token bucket algorithm implemented by golang.org/x/time/rate. This allows for burst traffic up to a configurable capacity while maintaining the average rate over time. The bucket is refilled continuously at the specified rate and has a maximum capacity for burst handling.
 - `span_count`: Sample based on the minimum and/or maximum number of spans, inclusive. If the sum of all spans in the trace is outside the range threshold, the trace will not be sampled.
 - `boolean_attribute`: Sample based on boolean attribute (resource and record).
-- `ottl_condition`: Sample based on given boolean OTTL condition (span and span event).
+- `ottl_condition`: Sample based on given boolean OTTL condition (span and span event). Conditions may use OTTL path-based context names (e.g. `span.attributes["http.status_code"]`, `resource.attributes["service.name"]`, `spanevent.name`, `scope.name`). It is highly recommended to use this new syntax to avoid breaking changes in the future.
 - `and`: Sample based on multiple policies, creates an AND policy
 - `not`: Sample based on the opposite result a single policy, creates a NOT policy
 - `drop`: Drop (not sample) based on multiple policies, creates a DROP policy
@@ -180,6 +180,20 @@ processors:
                    spanevent: [
                         "name != \"test_span_event_name\"",
                         "attributes[\"test_event_attr_key_2\"] != \"test_event_attr_val_1\"",
+                   ]
+              }
+         },
+         {
+              name: test-policy-14,
+              type: ottl_condition,
+              ottl_condition: {
+                   error_mode: ignore,
+                   span: [
+                        "resource.attributes[\"service.name\"] == \"checkout\"",
+                        "span.attributes[\"http.status_code\"] >= 500",
+                   ],
+                   spanevent: [
+                        "spanevent.name == \"exception\"",
                    ]
               }
          },

--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -41,13 +41,13 @@ func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions
 	}
 
 	if len(spanConditions) > 0 {
-		if filter.sampleSpanExpr, err = filterottl.NewBoolExprForSpan(spanConditions, filterottl.StandardSpanFuncs(), errMode, settings); err != nil {
+		if filter.sampleSpanExpr, err = filterottl.NewBoolExprForSpanWithPathContextNames(spanConditions, filterottl.StandardSpanFuncs(), errMode, settings); err != nil {
 			return nil, err
 		}
 	}
 
 	if len(spanEventConditions) > 0 {
-		if filter.sampleSpanEventExpr, err = filterottl.NewBoolExprForSpanEvent(spanEventConditions, filterottl.StandardSpanEventFuncs(), errMode, settings); err != nil {
+		if filter.sampleSpanEventExpr, err = filterottl.NewBoolExprForSpanEventWithPathContextNames(spanEventConditions, filterottl.StandardSpanEventFuncs(), errMode, settings); err != nil {
 			return nil, err
 		}
 	}

--- a/processor/tailsamplingprocessor/internal/sampling/ottl_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl_test.go
@@ -83,6 +83,54 @@ func TestEvaluate_OTTL(t *testing.T) {
 			false,
 			samplingpolicy.NotSampled,
 		},
+		{
+			"OTTL conditions with span context prefix",
+			[]string{"span.attributes[\"attr_k_1\"] == \"attr_v_1\""},
+			[]string{},
+			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_1"}}},
+			false,
+			samplingpolicy.Sampled,
+		},
+		{
+			"OTTL conditions inverse match with span context prefix",
+			[]string{"span.attributes[\"attr_k_1\"] != \"attr_v_1\""},
+			[]string{},
+			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_2"}}},
+			false,
+			samplingpolicy.Sampled,
+		},
+		{
+			"OTTL conditions with spanevent context prefix on attributes",
+			[]string{},
+			[]string{"spanevent.attributes[\"event_attr_k_1\"] == \"event_attr_v_1\""},
+			[]spanWithAttributes{{SpanEventAttributes: map[string]string{"event_attr_k_1": "event_attr_v_1"}}},
+			false,
+			samplingpolicy.Sampled,
+		},
+		{
+			"OTTL conditions with spanevent context prefix on name",
+			[]string{},
+			[]string{"spanevent.name != \"incorrect event name\""},
+			[]spanWithAttributes{{SpanEventAttributes: nil}},
+			false,
+			samplingpolicy.Sampled,
+		},
+		{
+			"OTTL conditions mixed prefixed and unprefixed in same span list",
+			[]string{"attributes[\"attr_k_1\"] == \"attr_v_1\"", "span.attributes[\"attr_k_2\"] == \"attr_v_2\""},
+			[]string{},
+			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_2": "attr_v_2"}}},
+			false,
+			samplingpolicy.Sampled,
+		},
+		{
+			"OTTL conditions with invalid context prefix",
+			[]string{"badcontext.attributes[\"x\"] == \"y\""},
+			[]string{},
+			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_1"}}},
+			true,
+			samplingpolicy.NotSampled,
+		},
 	}
 
 	for _, c := range cases {
@@ -99,6 +147,64 @@ func TestEvaluate_OTTL(t *testing.T) {
 	}
 }
 
+func TestEvaluate_OTTL_PathContextNames(t *testing.T) {
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	cases := []struct {
+		Desc                string
+		SpanConditions      []string
+		SpanEventConditions []string
+		ResourceAttributes  map[string]string
+		ScopeName           string
+		ScopeAttributes     map[string]string
+		Spans               []spanWithAttributes
+		WantErr             bool
+		Decision            samplingpolicy.Decision
+	}{
+		{
+			Desc:               "Resource attribute match using resource context prefix on span",
+			SpanConditions:     []string{"resource.attributes[\"service.name\"] == \"checkout\""},
+			ResourceAttributes: map[string]string{"service.name": "checkout"},
+			Spans:              []spanWithAttributes{{}},
+			Decision:           samplingpolicy.Sampled,
+		},
+		{
+			Desc:                "Resource attribute match using resource context prefix on spanevent",
+			SpanEventConditions: []string{"resource.attributes[\"service.name\"] == \"checkout\""},
+			ResourceAttributes:  map[string]string{"service.name": "checkout"},
+			Spans:               []spanWithAttributes{{}},
+			Decision:            samplingpolicy.Sampled,
+		},
+		{
+			Desc:           "Scope name match using scope context prefix on span",
+			SpanConditions: []string{"scope.name == \"my-scope\""},
+			ScopeName:      "my-scope",
+			Spans:          []spanWithAttributes{{}},
+			Decision:       samplingpolicy.Sampled,
+		},
+		{
+			Desc:           "Scope name match using instrumentation_scope context prefix on span",
+			SpanConditions: []string{"instrumentation_scope.name == \"my-scope\""},
+			ScopeName:      "my-scope",
+			Spans:          []spanWithAttributes{{}},
+			Decision:       samplingpolicy.Sampled,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			filter, err := NewOTTLConditionFilter(componenttest.NewNopTelemetrySettings(), c.SpanConditions, c.SpanEventConditions, ottl.IgnoreError)
+			assert.Equal(t, err != nil, c.WantErr)
+
+			if err == nil {
+				decision, err := filter.Evaluate(t.Context(), traceID, newTraceWithResourceAndScope(c.ResourceAttributes, c.ScopeName, c.ScopeAttributes, c.Spans))
+				assert.Equal(t, err != nil, c.WantErr)
+				assert.Equal(t, decision, c.Decision)
+			}
+		})
+	}
+}
+
 type spanWithAttributes struct {
 	SpanAttributes      map[string]string
 	SpanEventAttributes map[string]string
@@ -108,6 +214,39 @@ func newTraceWithSpansAttributes(spans []spanWithAttributes) *samplingpolicy.Tra
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ils := rs.ScopeSpans().AppendEmpty()
+
+	for _, s := range spans {
+		span := ils.Spans().AppendEmpty()
+		span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		for k, v := range s.SpanAttributes {
+			span.Attributes().PutStr(k, v)
+		}
+		spanEvent := span.Events().AppendEmpty()
+		spanEvent.SetName("test event")
+		for k, v := range s.SpanEventAttributes {
+			spanEvent.Attributes().PutStr(k, v)
+		}
+	}
+
+	return &samplingpolicy.TraceData{
+		ReceivedBatches: traces,
+	}
+}
+
+func newTraceWithResourceAndScope(resourceAttrs map[string]string, scopeName string, scopeAttrs map[string]string, spans []spanWithAttributes) *samplingpolicy.TraceData {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	for k, v := range resourceAttrs {
+		rs.Resource().Attributes().PutStr(k, v)
+	}
+	ils := rs.ScopeSpans().AppendEmpty()
+	if scopeName != "" {
+		ils.Scope().SetName(scopeName)
+	}
+	for k, v := range scopeAttrs {
+		ils.Scope().Attributes().PutStr(k, v)
+	}
 
 	for _, s := range spans {
 		span := ils.Spans().AppendEmpty()


### PR DESCRIPTION
#### Description

Add support for context inference to the tail sampling processor

#### Testing

added unit tests

#### Documentation

updated readme
