### PR TITLE
[receiver/kubeletstats] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46363-kubeletstats-enable-reaggregation.yaml
+++ b/.chloggen/46363-kubeletstats-enable-reaggregation.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/kubelet_stats
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enables dynamic metric reaggregation in the Kubelet Stats receiver. This does not break existing configuration files.
+note: Enables dynamic metric reaggregation capability
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46363]

--- a/.chloggen/46363-kubeletstats-enable-reaggregation.yaml
+++ b/.chloggen/46363-kubeletstats-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/kubelet_stats
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the Kubelet Stats receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46363]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -193,7 +193,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				MetricsBuilderConfig: metadata.MetricsBuilderConfig{
 					Metrics: metadata.MetricsConfig{
-						K8sContainerCPUNodeUtilization: metadata.MetricConfig{
+						K8sContainerCPUNodeUtilization: metadata.K8sContainerCPUNodeUtilizationMetricConfig{
 							Enabled: true,
 						},
 					},
@@ -221,7 +221,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				MetricsBuilderConfig: metadata.MetricsBuilderConfig{
 					Metrics: metadata.MetricsConfig{
-						K8sPodCPUNodeUtilization: metadata.MetricConfig{
+						K8sPodCPUNodeUtilization: metadata.K8sPodCPUNodeUtilizationMetricConfig{
 							Enabled: true,
 						},
 					},
@@ -249,7 +249,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				MetricsBuilderConfig: metadata.MetricsBuilderConfig{
 					Metrics: metadata.MetricsConfig{
-						K8sContainerMemoryNodeUtilization: metadata.MetricConfig{
+						K8sContainerMemoryNodeUtilization: metadata.K8sContainerMemoryNodeUtilizationMetricConfig{
 							Enabled: true,
 						},
 					},
@@ -277,7 +277,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				MetricsBuilderConfig: metadata.MetricsBuilderConfig{
 					Metrics: metadata.MetricsConfig{
-						K8sPodMemoryNodeUtilization: metadata.MetricConfig{
+						K8sPodMemoryNodeUtilization: metadata.K8sPodMemoryNodeUtilizationMetricConfig{
 							Enabled: true,
 						},
 					},

--- a/receiver/kubeletstatsreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/kubeletstatsreceiver/internal/metadata/config.schema.yaml
@@ -116,6 +116,22 @@ $defs:
           enabled:
             type: boolean
             default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "fs.type"
+            default:
+              - "fs.type"
       k8s.container.memory.node.utilization:
         description: "K8sContainerMemoryNodeUtilizationMetricConfig provides config for the k8s.container.memory.node.utilization metric."
         type: object
@@ -221,6 +237,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "interface"
+                - "direction"
+            default:
+              - "interface"
+              - "direction"
       k8s.node.network.io:
         description: "K8sNodeNetworkIoMetricConfig provides config for the k8s.node.network.io metric."
         type: object
@@ -228,6 +262,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "interface"
+                - "direction"
+            default:
+              - "interface"
+              - "direction"
       k8s.node.system_container.cpu.time:
         description: "K8sNodeSystemContainerCPUTimeMetricConfig provides config for the k8s.node.system_container.cpu.time metric."
         type: object
@@ -389,6 +441,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "interface"
+                - "direction"
+            default:
+              - "interface"
+              - "direction"
       k8s.pod.network.io:
         description: "K8sPodNetworkIoMetricConfig provides config for the k8s.pod.network.io metric."
         type: object
@@ -396,6 +466,24 @@ $defs:
           enabled:
             type: boolean
             default: true
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "sum"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "interface"
+                - "direction"
+            default:
+              - "interface"
+              - "direction"
       k8s.pod.uptime:
         description: "K8sPodUptimeMetricConfig provides config for the k8s.pod.uptime metric."
         type: object

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_config.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_config.go
@@ -3,17 +3,1403 @@
 package metadata
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
 
-// MetricConfig provides common config for a particular metric.
-type MetricConfig struct {
+// ContainerCPUTimeMetricConfig provides config for the container.cpu.time metric.
+type ContainerCPUTimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *ContainerCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerCPUUsageMetricConfig provides config for the container.cpu.usage metric.
+type ContainerCPUUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerCPUUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerFilesystemAvailableMetricConfig provides config for the container.filesystem.available metric.
+type ContainerFilesystemAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerFilesystemAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerFilesystemCapacityMetricConfig provides config for the container.filesystem.capacity metric.
+type ContainerFilesystemCapacityMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerFilesystemCapacityMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerFilesystemUsageMetricConfig provides config for the container.filesystem.usage metric.
+type ContainerFilesystemUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerFilesystemUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerMemoryAvailableMetricConfig provides config for the container.memory.available metric.
+type ContainerMemoryAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerMemoryAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerMemoryMajorPageFaultsMetricConfig provides config for the container.memory.major_page_faults metric.
+type ContainerMemoryMajorPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerMemoryMajorPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerMemoryPageFaultsMetricConfig provides config for the container.memory.page_faults metric.
+type ContainerMemoryPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerMemoryPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerMemoryRssMetricConfig provides config for the container.memory.rss metric.
+type ContainerMemoryRssMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerMemoryRssMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerMemoryUsageMetricConfig provides config for the container.memory.usage metric.
+type ContainerMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerMemoryWorkingSetMetricConfig provides config for the container.memory.working_set metric.
+type ContainerMemoryWorkingSetMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerMemoryWorkingSetMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ContainerUptimeMetricConfig provides config for the container.uptime metric.
+type ContainerUptimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ContainerUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerCPUNodeUtilizationMetricConfig provides config for the k8s.container.cpu.node.utilization metric.
+type K8sContainerCPUNodeUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerCPUNodeUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerCPULimitUtilizationMetricConfig provides config for the k8s.container.cpu_limit_utilization metric.
+type K8sContainerCPULimitUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerCPULimitUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerCPURequestUtilizationMetricConfig provides config for the k8s.container.cpu_request_utilization metric.
+type K8sContainerCPURequestUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerCPURequestUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerEphemeralStorageUsageMetricAttributeKey specifies the key of an attribute for the k8s.container.ephemeral_storage.usage metric.
+type K8sContainerEphemeralStorageUsageMetricAttributeKey string
+
+const (
+	K8sContainerEphemeralStorageUsageMetricAttributeKeyFsType K8sContainerEphemeralStorageUsageMetricAttributeKey = "fs.type"
+)
+
+// K8sContainerEphemeralStorageUsageMetricConfig provides config for the k8s.container.ephemeral_storage.usage metric.
+type K8sContainerEphemeralStorageUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sContainerEphemeralStorageUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sContainerEphemeralStorageUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sContainerEphemeralStorageUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sContainerEphemeralStorageUsageMetricAttributeKeyFsType:
+		default:
+			return fmt.Errorf("metric k8s.container.ephemeral_storage.usage doesn't have an attribute %v, valid attributes: [fs.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sContainerMemoryNodeUtilizationMetricConfig provides config for the k8s.container.memory.node.utilization metric.
+type K8sContainerMemoryNodeUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerMemoryNodeUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerMemoryLimitUtilizationMetricConfig provides config for the k8s.container.memory_limit_utilization metric.
+type K8sContainerMemoryLimitUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerMemoryLimitUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sContainerMemoryRequestUtilizationMetricConfig provides config for the k8s.container.memory_request_utilization metric.
+type K8sContainerMemoryRequestUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sContainerMemoryRequestUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeCPUTimeMetricConfig provides config for the k8s.node.cpu.time metric.
+type K8sNodeCPUTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeCPUUsageMetricConfig provides config for the k8s.node.cpu.usage metric.
+type K8sNodeCPUUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeCPUUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeFilesystemAvailableMetricConfig provides config for the k8s.node.filesystem.available metric.
+type K8sNodeFilesystemAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeFilesystemAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeFilesystemCapacityMetricConfig provides config for the k8s.node.filesystem.capacity metric.
+type K8sNodeFilesystemCapacityMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeFilesystemCapacityMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeFilesystemUsageMetricConfig provides config for the k8s.node.filesystem.usage metric.
+type K8sNodeFilesystemUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeFilesystemUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeMemoryAvailableMetricConfig provides config for the k8s.node.memory.available metric.
+type K8sNodeMemoryAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeMemoryAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeMemoryMajorPageFaultsMetricConfig provides config for the k8s.node.memory.major_page_faults metric.
+type K8sNodeMemoryMajorPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeMemoryMajorPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeMemoryPageFaultsMetricConfig provides config for the k8s.node.memory.page_faults metric.
+type K8sNodeMemoryPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeMemoryPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeMemoryRssMetricConfig provides config for the k8s.node.memory.rss metric.
+type K8sNodeMemoryRssMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeMemoryRssMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeMemoryUsageMetricConfig provides config for the k8s.node.memory.usage metric.
+type K8sNodeMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeMemoryWorkingSetMetricConfig provides config for the k8s.node.memory.working_set metric.
+type K8sNodeMemoryWorkingSetMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeMemoryWorkingSetMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeNetworkErrorsMetricAttributeKey specifies the key of an attribute for the k8s.node.network.errors metric.
+type K8sNodeNetworkErrorsMetricAttributeKey string
+
+const (
+	K8sNodeNetworkErrorsMetricAttributeKeyInterface K8sNodeNetworkErrorsMetricAttributeKey = "interface"
+	K8sNodeNetworkErrorsMetricAttributeKeyDirection K8sNodeNetworkErrorsMetricAttributeKey = "direction"
+)
+
+// K8sNodeNetworkErrorsMetricConfig provides config for the k8s.node.network.errors metric.
+type K8sNodeNetworkErrorsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sNodeNetworkErrorsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sNodeNetworkErrorsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sNodeNetworkErrorsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sNodeNetworkErrorsMetricAttributeKeyInterface, K8sNodeNetworkErrorsMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric k8s.node.network.errors doesn't have an attribute %v, valid attributes: [interface, direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sNodeNetworkIoMetricAttributeKey specifies the key of an attribute for the k8s.node.network.io metric.
+type K8sNodeNetworkIoMetricAttributeKey string
+
+const (
+	K8sNodeNetworkIoMetricAttributeKeyInterface K8sNodeNetworkIoMetricAttributeKey = "interface"
+	K8sNodeNetworkIoMetricAttributeKeyDirection K8sNodeNetworkIoMetricAttributeKey = "direction"
+)
+
+// K8sNodeNetworkIoMetricConfig provides config for the k8s.node.network.io metric.
+type K8sNodeNetworkIoMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sNodeNetworkIoMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sNodeNetworkIoMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sNodeNetworkIoMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sNodeNetworkIoMetricAttributeKeyInterface, K8sNodeNetworkIoMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric k8s.node.network.io doesn't have an attribute %v, valid attributes: [interface, direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sNodeSystemContainerCPUTimeMetricConfig provides config for the k8s.node.system_container.cpu.time metric.
+type K8sNodeSystemContainerCPUTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeSystemContainerCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeSystemContainerCPUUsageMetricConfig provides config for the k8s.node.system_container.cpu.usage metric.
+type K8sNodeSystemContainerCPUUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeSystemContainerCPUUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeSystemContainerMemoryUsageMetricConfig provides config for the k8s.node.system_container.memory.usage metric.
+type K8sNodeSystemContainerMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeSystemContainerMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeSystemContainerMemoryWorkingSetMetricConfig provides config for the k8s.node.system_container.memory.working_set metric.
+type K8sNodeSystemContainerMemoryWorkingSetMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeSystemContainerMemoryWorkingSetMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sNodeUptimeMetricConfig provides config for the k8s.node.uptime metric.
+type K8sNodeUptimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sNodeUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodCPUNodeUtilizationMetricConfig provides config for the k8s.pod.cpu.node.utilization metric.
+type K8sPodCPUNodeUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodCPUNodeUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodCPUTimeMetricConfig provides config for the k8s.pod.cpu.time metric.
+type K8sPodCPUTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodCPUUsageMetricConfig provides config for the k8s.pod.cpu.usage metric.
+type K8sPodCPUUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodCPUUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodCPULimitUtilizationMetricConfig provides config for the k8s.pod.cpu_limit_utilization metric.
+type K8sPodCPULimitUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodCPULimitUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodCPURequestUtilizationMetricConfig provides config for the k8s.pod.cpu_request_utilization metric.
+type K8sPodCPURequestUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodCPURequestUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodFilesystemAvailableMetricConfig provides config for the k8s.pod.filesystem.available metric.
+type K8sPodFilesystemAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodFilesystemAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodFilesystemCapacityMetricConfig provides config for the k8s.pod.filesystem.capacity metric.
+type K8sPodFilesystemCapacityMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodFilesystemCapacityMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodFilesystemUsageMetricConfig provides config for the k8s.pod.filesystem.usage metric.
+type K8sPodFilesystemUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodFilesystemUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryAvailableMetricConfig provides config for the k8s.pod.memory.available metric.
+type K8sPodMemoryAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryMajorPageFaultsMetricConfig provides config for the k8s.pod.memory.major_page_faults metric.
+type K8sPodMemoryMajorPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryMajorPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryNodeUtilizationMetricConfig provides config for the k8s.pod.memory.node.utilization metric.
+type K8sPodMemoryNodeUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryNodeUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryPageFaultsMetricConfig provides config for the k8s.pod.memory.page_faults metric.
+type K8sPodMemoryPageFaultsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryPageFaultsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryRssMetricConfig provides config for the k8s.pod.memory.rss metric.
+type K8sPodMemoryRssMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryRssMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryUsageMetricConfig provides config for the k8s.pod.memory.usage metric.
+type K8sPodMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryWorkingSetMetricConfig provides config for the k8s.pod.memory.working_set metric.
+type K8sPodMemoryWorkingSetMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryWorkingSetMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryLimitUtilizationMetricConfig provides config for the k8s.pod.memory_limit_utilization metric.
+type K8sPodMemoryLimitUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryLimitUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodMemoryRequestUtilizationMetricConfig provides config for the k8s.pod.memory_request_utilization metric.
+type K8sPodMemoryRequestUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodMemoryRequestUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodNetworkErrorsMetricAttributeKey specifies the key of an attribute for the k8s.pod.network.errors metric.
+type K8sPodNetworkErrorsMetricAttributeKey string
+
+const (
+	K8sPodNetworkErrorsMetricAttributeKeyInterface K8sPodNetworkErrorsMetricAttributeKey = "interface"
+	K8sPodNetworkErrorsMetricAttributeKeyDirection K8sPodNetworkErrorsMetricAttributeKey = "direction"
+)
+
+// K8sPodNetworkErrorsMetricConfig provides config for the k8s.pod.network.errors metric.
+type K8sPodNetworkErrorsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sPodNetworkErrorsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sPodNetworkErrorsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sPodNetworkErrorsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sPodNetworkErrorsMetricAttributeKeyInterface, K8sPodNetworkErrorsMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric k8s.pod.network.errors doesn't have an attribute %v, valid attributes: [interface, direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sPodNetworkIoMetricAttributeKey specifies the key of an attribute for the k8s.pod.network.io metric.
+type K8sPodNetworkIoMetricAttributeKey string
+
+const (
+	K8sPodNetworkIoMetricAttributeKeyInterface K8sPodNetworkIoMetricAttributeKey = "interface"
+	K8sPodNetworkIoMetricAttributeKeyDirection K8sPodNetworkIoMetricAttributeKey = "direction"
+)
+
+// K8sPodNetworkIoMetricConfig provides config for the k8s.pod.network.io metric.
+type K8sPodNetworkIoMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []K8sPodNetworkIoMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *K8sPodNetworkIoMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *K8sPodNetworkIoMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case K8sPodNetworkIoMetricAttributeKeyInterface, K8sPodNetworkIoMetricAttributeKeyDirection:
+		default:
+			return fmt.Errorf("metric k8s.pod.network.io doesn't have an attribute %v, valid attributes: [interface, direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// K8sPodUptimeMetricConfig provides config for the k8s.pod.uptime metric.
+type K8sPodUptimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sPodVolumeUsageMetricConfig provides config for the k8s.pod.volume.usage metric.
+type K8sPodVolumeUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sPodVolumeUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sVolumeAvailableMetricConfig provides config for the k8s.volume.available metric.
+type K8sVolumeAvailableMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sVolumeAvailableMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sVolumeCapacityMetricConfig provides config for the k8s.volume.capacity metric.
+type K8sVolumeCapacityMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sVolumeCapacityMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sVolumeInodesMetricConfig provides config for the k8s.volume.inodes metric.
+type K8sVolumeInodesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sVolumeInodesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sVolumeInodesFreeMetricConfig provides config for the k8s.volume.inodes.free metric.
+type K8sVolumeInodesFreeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sVolumeInodesFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// K8sVolumeInodesUsedMetricConfig provides config for the k8s.volume.inodes.used metric.
+type K8sVolumeInodesUsedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *K8sVolumeInodesUsedMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -29,260 +1415,270 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for kubelet_stats metrics.
 type MetricsConfig struct {
-	ContainerCPUTime                       MetricConfig `mapstructure:"container.cpu.time"`
-	ContainerCPUUsage                      MetricConfig `mapstructure:"container.cpu.usage"`
-	ContainerFilesystemAvailable           MetricConfig `mapstructure:"container.filesystem.available"`
-	ContainerFilesystemCapacity            MetricConfig `mapstructure:"container.filesystem.capacity"`
-	ContainerFilesystemUsage               MetricConfig `mapstructure:"container.filesystem.usage"`
-	ContainerMemoryAvailable               MetricConfig `mapstructure:"container.memory.available"`
-	ContainerMemoryMajorPageFaults         MetricConfig `mapstructure:"container.memory.major_page_faults"`
-	ContainerMemoryPageFaults              MetricConfig `mapstructure:"container.memory.page_faults"`
-	ContainerMemoryRss                     MetricConfig `mapstructure:"container.memory.rss"`
-	ContainerMemoryUsage                   MetricConfig `mapstructure:"container.memory.usage"`
-	ContainerMemoryWorkingSet              MetricConfig `mapstructure:"container.memory.working_set"`
-	ContainerUptime                        MetricConfig `mapstructure:"container.uptime"`
-	K8sContainerCPUNodeUtilization         MetricConfig `mapstructure:"k8s.container.cpu.node.utilization"`
-	K8sContainerCPULimitUtilization        MetricConfig `mapstructure:"k8s.container.cpu_limit_utilization"`
-	K8sContainerCPURequestUtilization      MetricConfig `mapstructure:"k8s.container.cpu_request_utilization"`
-	K8sContainerEphemeralStorageUsage      MetricConfig `mapstructure:"k8s.container.ephemeral_storage.usage"`
-	K8sContainerMemoryNodeUtilization      MetricConfig `mapstructure:"k8s.container.memory.node.utilization"`
-	K8sContainerMemoryLimitUtilization     MetricConfig `mapstructure:"k8s.container.memory_limit_utilization"`
-	K8sContainerMemoryRequestUtilization   MetricConfig `mapstructure:"k8s.container.memory_request_utilization"`
-	K8sNodeCPUTime                         MetricConfig `mapstructure:"k8s.node.cpu.time"`
-	K8sNodeCPUUsage                        MetricConfig `mapstructure:"k8s.node.cpu.usage"`
-	K8sNodeFilesystemAvailable             MetricConfig `mapstructure:"k8s.node.filesystem.available"`
-	K8sNodeFilesystemCapacity              MetricConfig `mapstructure:"k8s.node.filesystem.capacity"`
-	K8sNodeFilesystemUsage                 MetricConfig `mapstructure:"k8s.node.filesystem.usage"`
-	K8sNodeMemoryAvailable                 MetricConfig `mapstructure:"k8s.node.memory.available"`
-	K8sNodeMemoryMajorPageFaults           MetricConfig `mapstructure:"k8s.node.memory.major_page_faults"`
-	K8sNodeMemoryPageFaults                MetricConfig `mapstructure:"k8s.node.memory.page_faults"`
-	K8sNodeMemoryRss                       MetricConfig `mapstructure:"k8s.node.memory.rss"`
-	K8sNodeMemoryUsage                     MetricConfig `mapstructure:"k8s.node.memory.usage"`
-	K8sNodeMemoryWorkingSet                MetricConfig `mapstructure:"k8s.node.memory.working_set"`
-	K8sNodeNetworkErrors                   MetricConfig `mapstructure:"k8s.node.network.errors"`
-	K8sNodeNetworkIo                       MetricConfig `mapstructure:"k8s.node.network.io"`
-	K8sNodeSystemContainerCPUTime          MetricConfig `mapstructure:"k8s.node.system_container.cpu.time"`
-	K8sNodeSystemContainerCPUUsage         MetricConfig `mapstructure:"k8s.node.system_container.cpu.usage"`
-	K8sNodeSystemContainerMemoryUsage      MetricConfig `mapstructure:"k8s.node.system_container.memory.usage"`
-	K8sNodeSystemContainerMemoryWorkingSet MetricConfig `mapstructure:"k8s.node.system_container.memory.working_set"`
-	K8sNodeUptime                          MetricConfig `mapstructure:"k8s.node.uptime"`
-	K8sPodCPUNodeUtilization               MetricConfig `mapstructure:"k8s.pod.cpu.node.utilization"`
-	K8sPodCPUTime                          MetricConfig `mapstructure:"k8s.pod.cpu.time"`
-	K8sPodCPUUsage                         MetricConfig `mapstructure:"k8s.pod.cpu.usage"`
-	K8sPodCPULimitUtilization              MetricConfig `mapstructure:"k8s.pod.cpu_limit_utilization"`
-	K8sPodCPURequestUtilization            MetricConfig `mapstructure:"k8s.pod.cpu_request_utilization"`
-	K8sPodFilesystemAvailable              MetricConfig `mapstructure:"k8s.pod.filesystem.available"`
-	K8sPodFilesystemCapacity               MetricConfig `mapstructure:"k8s.pod.filesystem.capacity"`
-	K8sPodFilesystemUsage                  MetricConfig `mapstructure:"k8s.pod.filesystem.usage"`
-	K8sPodMemoryAvailable                  MetricConfig `mapstructure:"k8s.pod.memory.available"`
-	K8sPodMemoryMajorPageFaults            MetricConfig `mapstructure:"k8s.pod.memory.major_page_faults"`
-	K8sPodMemoryNodeUtilization            MetricConfig `mapstructure:"k8s.pod.memory.node.utilization"`
-	K8sPodMemoryPageFaults                 MetricConfig `mapstructure:"k8s.pod.memory.page_faults"`
-	K8sPodMemoryRss                        MetricConfig `mapstructure:"k8s.pod.memory.rss"`
-	K8sPodMemoryUsage                      MetricConfig `mapstructure:"k8s.pod.memory.usage"`
-	K8sPodMemoryWorkingSet                 MetricConfig `mapstructure:"k8s.pod.memory.working_set"`
-	K8sPodMemoryLimitUtilization           MetricConfig `mapstructure:"k8s.pod.memory_limit_utilization"`
-	K8sPodMemoryRequestUtilization         MetricConfig `mapstructure:"k8s.pod.memory_request_utilization"`
-	K8sPodNetworkErrors                    MetricConfig `mapstructure:"k8s.pod.network.errors"`
-	K8sPodNetworkIo                        MetricConfig `mapstructure:"k8s.pod.network.io"`
-	K8sPodUptime                           MetricConfig `mapstructure:"k8s.pod.uptime"`
-	K8sPodVolumeUsage                      MetricConfig `mapstructure:"k8s.pod.volume.usage"`
-	K8sVolumeAvailable                     MetricConfig `mapstructure:"k8s.volume.available"`
-	K8sVolumeCapacity                      MetricConfig `mapstructure:"k8s.volume.capacity"`
-	K8sVolumeInodes                        MetricConfig `mapstructure:"k8s.volume.inodes"`
-	K8sVolumeInodesFree                    MetricConfig `mapstructure:"k8s.volume.inodes.free"`
-	K8sVolumeInodesUsed                    MetricConfig `mapstructure:"k8s.volume.inodes.used"`
+	ContainerCPUTime                       ContainerCPUTimeMetricConfig                       `mapstructure:"container.cpu.time"`
+	ContainerCPUUsage                      ContainerCPUUsageMetricConfig                      `mapstructure:"container.cpu.usage"`
+	ContainerFilesystemAvailable           ContainerFilesystemAvailableMetricConfig           `mapstructure:"container.filesystem.available"`
+	ContainerFilesystemCapacity            ContainerFilesystemCapacityMetricConfig            `mapstructure:"container.filesystem.capacity"`
+	ContainerFilesystemUsage               ContainerFilesystemUsageMetricConfig               `mapstructure:"container.filesystem.usage"`
+	ContainerMemoryAvailable               ContainerMemoryAvailableMetricConfig               `mapstructure:"container.memory.available"`
+	ContainerMemoryMajorPageFaults         ContainerMemoryMajorPageFaultsMetricConfig         `mapstructure:"container.memory.major_page_faults"`
+	ContainerMemoryPageFaults              ContainerMemoryPageFaultsMetricConfig              `mapstructure:"container.memory.page_faults"`
+	ContainerMemoryRss                     ContainerMemoryRssMetricConfig                     `mapstructure:"container.memory.rss"`
+	ContainerMemoryUsage                   ContainerMemoryUsageMetricConfig                   `mapstructure:"container.memory.usage"`
+	ContainerMemoryWorkingSet              ContainerMemoryWorkingSetMetricConfig              `mapstructure:"container.memory.working_set"`
+	ContainerUptime                        ContainerUptimeMetricConfig                        `mapstructure:"container.uptime"`
+	K8sContainerCPUNodeUtilization         K8sContainerCPUNodeUtilizationMetricConfig         `mapstructure:"k8s.container.cpu.node.utilization"`
+	K8sContainerCPULimitUtilization        K8sContainerCPULimitUtilizationMetricConfig        `mapstructure:"k8s.container.cpu_limit_utilization"`
+	K8sContainerCPURequestUtilization      K8sContainerCPURequestUtilizationMetricConfig      `mapstructure:"k8s.container.cpu_request_utilization"`
+	K8sContainerEphemeralStorageUsage      K8sContainerEphemeralStorageUsageMetricConfig      `mapstructure:"k8s.container.ephemeral_storage.usage"`
+	K8sContainerMemoryNodeUtilization      K8sContainerMemoryNodeUtilizationMetricConfig      `mapstructure:"k8s.container.memory.node.utilization"`
+	K8sContainerMemoryLimitUtilization     K8sContainerMemoryLimitUtilizationMetricConfig     `mapstructure:"k8s.container.memory_limit_utilization"`
+	K8sContainerMemoryRequestUtilization   K8sContainerMemoryRequestUtilizationMetricConfig   `mapstructure:"k8s.container.memory_request_utilization"`
+	K8sNodeCPUTime                         K8sNodeCPUTimeMetricConfig                         `mapstructure:"k8s.node.cpu.time"`
+	K8sNodeCPUUsage                        K8sNodeCPUUsageMetricConfig                        `mapstructure:"k8s.node.cpu.usage"`
+	K8sNodeFilesystemAvailable             K8sNodeFilesystemAvailableMetricConfig             `mapstructure:"k8s.node.filesystem.available"`
+	K8sNodeFilesystemCapacity              K8sNodeFilesystemCapacityMetricConfig              `mapstructure:"k8s.node.filesystem.capacity"`
+	K8sNodeFilesystemUsage                 K8sNodeFilesystemUsageMetricConfig                 `mapstructure:"k8s.node.filesystem.usage"`
+	K8sNodeMemoryAvailable                 K8sNodeMemoryAvailableMetricConfig                 `mapstructure:"k8s.node.memory.available"`
+	K8sNodeMemoryMajorPageFaults           K8sNodeMemoryMajorPageFaultsMetricConfig           `mapstructure:"k8s.node.memory.major_page_faults"`
+	K8sNodeMemoryPageFaults                K8sNodeMemoryPageFaultsMetricConfig                `mapstructure:"k8s.node.memory.page_faults"`
+	K8sNodeMemoryRss                       K8sNodeMemoryRssMetricConfig                       `mapstructure:"k8s.node.memory.rss"`
+	K8sNodeMemoryUsage                     K8sNodeMemoryUsageMetricConfig                     `mapstructure:"k8s.node.memory.usage"`
+	K8sNodeMemoryWorkingSet                K8sNodeMemoryWorkingSetMetricConfig                `mapstructure:"k8s.node.memory.working_set"`
+	K8sNodeNetworkErrors                   K8sNodeNetworkErrorsMetricConfig                   `mapstructure:"k8s.node.network.errors"`
+	K8sNodeNetworkIo                       K8sNodeNetworkIoMetricConfig                       `mapstructure:"k8s.node.network.io"`
+	K8sNodeSystemContainerCPUTime          K8sNodeSystemContainerCPUTimeMetricConfig          `mapstructure:"k8s.node.system_container.cpu.time"`
+	K8sNodeSystemContainerCPUUsage         K8sNodeSystemContainerCPUUsageMetricConfig         `mapstructure:"k8s.node.system_container.cpu.usage"`
+	K8sNodeSystemContainerMemoryUsage      K8sNodeSystemContainerMemoryUsageMetricConfig      `mapstructure:"k8s.node.system_container.memory.usage"`
+	K8sNodeSystemContainerMemoryWorkingSet K8sNodeSystemContainerMemoryWorkingSetMetricConfig `mapstructure:"k8s.node.system_container.memory.working_set"`
+	K8sNodeUptime                          K8sNodeUptimeMetricConfig                          `mapstructure:"k8s.node.uptime"`
+	K8sPodCPUNodeUtilization               K8sPodCPUNodeUtilizationMetricConfig               `mapstructure:"k8s.pod.cpu.node.utilization"`
+	K8sPodCPUTime                          K8sPodCPUTimeMetricConfig                          `mapstructure:"k8s.pod.cpu.time"`
+	K8sPodCPUUsage                         K8sPodCPUUsageMetricConfig                         `mapstructure:"k8s.pod.cpu.usage"`
+	K8sPodCPULimitUtilization              K8sPodCPULimitUtilizationMetricConfig              `mapstructure:"k8s.pod.cpu_limit_utilization"`
+	K8sPodCPURequestUtilization            K8sPodCPURequestUtilizationMetricConfig            `mapstructure:"k8s.pod.cpu_request_utilization"`
+	K8sPodFilesystemAvailable              K8sPodFilesystemAvailableMetricConfig              `mapstructure:"k8s.pod.filesystem.available"`
+	K8sPodFilesystemCapacity               K8sPodFilesystemCapacityMetricConfig               `mapstructure:"k8s.pod.filesystem.capacity"`
+	K8sPodFilesystemUsage                  K8sPodFilesystemUsageMetricConfig                  `mapstructure:"k8s.pod.filesystem.usage"`
+	K8sPodMemoryAvailable                  K8sPodMemoryAvailableMetricConfig                  `mapstructure:"k8s.pod.memory.available"`
+	K8sPodMemoryMajorPageFaults            K8sPodMemoryMajorPageFaultsMetricConfig            `mapstructure:"k8s.pod.memory.major_page_faults"`
+	K8sPodMemoryNodeUtilization            K8sPodMemoryNodeUtilizationMetricConfig            `mapstructure:"k8s.pod.memory.node.utilization"`
+	K8sPodMemoryPageFaults                 K8sPodMemoryPageFaultsMetricConfig                 `mapstructure:"k8s.pod.memory.page_faults"`
+	K8sPodMemoryRss                        K8sPodMemoryRssMetricConfig                        `mapstructure:"k8s.pod.memory.rss"`
+	K8sPodMemoryUsage                      K8sPodMemoryUsageMetricConfig                      `mapstructure:"k8s.pod.memory.usage"`
+	K8sPodMemoryWorkingSet                 K8sPodMemoryWorkingSetMetricConfig                 `mapstructure:"k8s.pod.memory.working_set"`
+	K8sPodMemoryLimitUtilization           K8sPodMemoryLimitUtilizationMetricConfig           `mapstructure:"k8s.pod.memory_limit_utilization"`
+	K8sPodMemoryRequestUtilization         K8sPodMemoryRequestUtilizationMetricConfig         `mapstructure:"k8s.pod.memory_request_utilization"`
+	K8sPodNetworkErrors                    K8sPodNetworkErrorsMetricConfig                    `mapstructure:"k8s.pod.network.errors"`
+	K8sPodNetworkIo                        K8sPodNetworkIoMetricConfig                        `mapstructure:"k8s.pod.network.io"`
+	K8sPodUptime                           K8sPodUptimeMetricConfig                           `mapstructure:"k8s.pod.uptime"`
+	K8sPodVolumeUsage                      K8sPodVolumeUsageMetricConfig                      `mapstructure:"k8s.pod.volume.usage"`
+	K8sVolumeAvailable                     K8sVolumeAvailableMetricConfig                     `mapstructure:"k8s.volume.available"`
+	K8sVolumeCapacity                      K8sVolumeCapacityMetricConfig                      `mapstructure:"k8s.volume.capacity"`
+	K8sVolumeInodes                        K8sVolumeInodesMetricConfig                        `mapstructure:"k8s.volume.inodes"`
+	K8sVolumeInodesFree                    K8sVolumeInodesFreeMetricConfig                    `mapstructure:"k8s.volume.inodes.free"`
+	K8sVolumeInodesUsed                    K8sVolumeInodesUsedMetricConfig                    `mapstructure:"k8s.volume.inodes.used"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		ContainerCPUTime: MetricConfig{
+		ContainerCPUTime: ContainerCPUTimeMetricConfig{
 			Enabled: true,
 		},
-		ContainerCPUUsage: MetricConfig{
+		ContainerCPUUsage: ContainerCPUUsageMetricConfig{
 			Enabled: true,
 		},
-		ContainerFilesystemAvailable: MetricConfig{
+		ContainerFilesystemAvailable: ContainerFilesystemAvailableMetricConfig{
 			Enabled: true,
 		},
-		ContainerFilesystemCapacity: MetricConfig{
+		ContainerFilesystemCapacity: ContainerFilesystemCapacityMetricConfig{
 			Enabled: true,
 		},
-		ContainerFilesystemUsage: MetricConfig{
+		ContainerFilesystemUsage: ContainerFilesystemUsageMetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryAvailable: MetricConfig{
+		ContainerMemoryAvailable: ContainerMemoryAvailableMetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryMajorPageFaults: MetricConfig{
+		ContainerMemoryMajorPageFaults: ContainerMemoryMajorPageFaultsMetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryPageFaults: MetricConfig{
+		ContainerMemoryPageFaults: ContainerMemoryPageFaultsMetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryRss: MetricConfig{
+		ContainerMemoryRss: ContainerMemoryRssMetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryUsage: MetricConfig{
+		ContainerMemoryUsage: ContainerMemoryUsageMetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryWorkingSet: MetricConfig{
+		ContainerMemoryWorkingSet: ContainerMemoryWorkingSetMetricConfig{
 			Enabled: true,
 		},
-		ContainerUptime: MetricConfig{
+		ContainerUptime: ContainerUptimeMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerCPUNodeUtilization: MetricConfig{
+		K8sContainerCPUNodeUtilization: K8sContainerCPUNodeUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerCPULimitUtilization: MetricConfig{
+		K8sContainerCPULimitUtilization: K8sContainerCPULimitUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerCPURequestUtilization: MetricConfig{
+		K8sContainerCPURequestUtilization: K8sContainerCPURequestUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerEphemeralStorageUsage: MetricConfig{
+		K8sContainerEphemeralStorageUsage: K8sContainerEphemeralStorageUsageMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []K8sContainerEphemeralStorageUsageMetricAttributeKey{K8sContainerEphemeralStorageUsageMetricAttributeKeyFsType},
+		},
+		K8sContainerMemoryNodeUtilization: K8sContainerMemoryNodeUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerMemoryNodeUtilization: MetricConfig{
+		K8sContainerMemoryLimitUtilization: K8sContainerMemoryLimitUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerMemoryLimitUtilization: MetricConfig{
+		K8sContainerMemoryRequestUtilization: K8sContainerMemoryRequestUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sContainerMemoryRequestUtilization: MetricConfig{
+		K8sNodeCPUTime: K8sNodeCPUTimeMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeCPUUsage: K8sNodeCPUUsageMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeFilesystemAvailable: K8sNodeFilesystemAvailableMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeFilesystemCapacity: K8sNodeFilesystemCapacityMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeFilesystemUsage: K8sNodeFilesystemUsageMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeMemoryAvailable: K8sNodeMemoryAvailableMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeMemoryMajorPageFaults: K8sNodeMemoryMajorPageFaultsMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeMemoryPageFaults: K8sNodeMemoryPageFaultsMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeMemoryRss: K8sNodeMemoryRssMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeMemoryUsage: K8sNodeMemoryUsageMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeMemoryWorkingSet: K8sNodeMemoryWorkingSetMetricConfig{
+			Enabled: true,
+		},
+		K8sNodeNetworkErrors: K8sNodeNetworkErrorsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []K8sNodeNetworkErrorsMetricAttributeKey{K8sNodeNetworkErrorsMetricAttributeKeyInterface, K8sNodeNetworkErrorsMetricAttributeKeyDirection},
+		},
+		K8sNodeNetworkIo: K8sNodeNetworkIoMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []K8sNodeNetworkIoMetricAttributeKey{K8sNodeNetworkIoMetricAttributeKeyInterface, K8sNodeNetworkIoMetricAttributeKeyDirection},
+		},
+		K8sNodeSystemContainerCPUTime: K8sNodeSystemContainerCPUTimeMetricConfig{
 			Enabled: false,
 		},
-		K8sNodeCPUTime: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeCPUUsage: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeFilesystemAvailable: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeFilesystemCapacity: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeFilesystemUsage: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeMemoryAvailable: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeMemoryMajorPageFaults: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeMemoryPageFaults: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeMemoryRss: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeMemoryUsage: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeMemoryWorkingSet: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeNetworkErrors: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeNetworkIo: MetricConfig{
-			Enabled: true,
-		},
-		K8sNodeSystemContainerCPUTime: MetricConfig{
+		K8sNodeSystemContainerCPUUsage: K8sNodeSystemContainerCPUUsageMetricConfig{
 			Enabled: false,
 		},
-		K8sNodeSystemContainerCPUUsage: MetricConfig{
+		K8sNodeSystemContainerMemoryUsage: K8sNodeSystemContainerMemoryUsageMetricConfig{
 			Enabled: false,
 		},
-		K8sNodeSystemContainerMemoryUsage: MetricConfig{
+		K8sNodeSystemContainerMemoryWorkingSet: K8sNodeSystemContainerMemoryWorkingSetMetricConfig{
 			Enabled: false,
 		},
-		K8sNodeSystemContainerMemoryWorkingSet: MetricConfig{
+		K8sNodeUptime: K8sNodeUptimeMetricConfig{
 			Enabled: false,
 		},
-		K8sNodeUptime: MetricConfig{
+		K8sPodCPUNodeUtilization: K8sPodCPUNodeUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sPodCPUNodeUtilization: MetricConfig{
+		K8sPodCPUTime: K8sPodCPUTimeMetricConfig{
+			Enabled: true,
+		},
+		K8sPodCPUUsage: K8sPodCPUUsageMetricConfig{
+			Enabled: true,
+		},
+		K8sPodCPULimitUtilization: K8sPodCPULimitUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sPodCPUTime: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodCPUUsage: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodCPULimitUtilization: MetricConfig{
+		K8sPodCPURequestUtilization: K8sPodCPURequestUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sPodCPURequestUtilization: MetricConfig{
+		K8sPodFilesystemAvailable: K8sPodFilesystemAvailableMetricConfig{
+			Enabled: true,
+		},
+		K8sPodFilesystemCapacity: K8sPodFilesystemCapacityMetricConfig{
+			Enabled: true,
+		},
+		K8sPodFilesystemUsage: K8sPodFilesystemUsageMetricConfig{
+			Enabled: true,
+		},
+		K8sPodMemoryAvailable: K8sPodMemoryAvailableMetricConfig{
+			Enabled: true,
+		},
+		K8sPodMemoryMajorPageFaults: K8sPodMemoryMajorPageFaultsMetricConfig{
+			Enabled: true,
+		},
+		K8sPodMemoryNodeUtilization: K8sPodMemoryNodeUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sPodFilesystemAvailable: MetricConfig{
+		K8sPodMemoryPageFaults: K8sPodMemoryPageFaultsMetricConfig{
 			Enabled: true,
 		},
-		K8sPodFilesystemCapacity: MetricConfig{
+		K8sPodMemoryRss: K8sPodMemoryRssMetricConfig{
 			Enabled: true,
 		},
-		K8sPodFilesystemUsage: MetricConfig{
+		K8sPodMemoryUsage: K8sPodMemoryUsageMetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryAvailable: MetricConfig{
+		K8sPodMemoryWorkingSet: K8sPodMemoryWorkingSetMetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryMajorPageFaults: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodMemoryNodeUtilization: MetricConfig{
+		K8sPodMemoryLimitUtilization: K8sPodMemoryLimitUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sPodMemoryPageFaults: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodMemoryRss: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodMemoryUsage: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodMemoryWorkingSet: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodMemoryLimitUtilization: MetricConfig{
+		K8sPodMemoryRequestUtilization: K8sPodMemoryRequestUtilizationMetricConfig{
 			Enabled: false,
 		},
-		K8sPodMemoryRequestUtilization: MetricConfig{
+		K8sPodNetworkErrors: K8sPodNetworkErrorsMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []K8sPodNetworkErrorsMetricAttributeKey{K8sPodNetworkErrorsMetricAttributeKeyInterface, K8sPodNetworkErrorsMetricAttributeKeyDirection},
+		},
+		K8sPodNetworkIo: K8sPodNetworkIoMetricConfig{
+			Enabled:             true,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []K8sPodNetworkIoMetricAttributeKey{K8sPodNetworkIoMetricAttributeKeyInterface, K8sPodNetworkIoMetricAttributeKeyDirection},
+		},
+		K8sPodUptime: K8sPodUptimeMetricConfig{
 			Enabled: false,
 		},
-		K8sPodNetworkErrors: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodNetworkIo: MetricConfig{
-			Enabled: true,
-		},
-		K8sPodUptime: MetricConfig{
+		K8sPodVolumeUsage: K8sPodVolumeUsageMetricConfig{
 			Enabled: false,
 		},
-		K8sPodVolumeUsage: MetricConfig{
-			Enabled: false,
-		},
-		K8sVolumeAvailable: MetricConfig{
+		K8sVolumeAvailable: K8sVolumeAvailableMetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeCapacity: MetricConfig{
+		K8sVolumeCapacity: K8sVolumeCapacityMetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeInodes: MetricConfig{
+		K8sVolumeInodes: K8sVolumeInodesMetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeInodesFree: MetricConfig{
+		K8sVolumeInodesFree: K8sVolumeInodesFreeMetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeInodesUsed: MetricConfig{
+		K8sVolumeInodesUsed: K8sVolumeInodesUsedMetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_config_test.go
@@ -26,193 +26,203 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ContainerCPUTime: MetricConfig{
+					ContainerCPUTime: ContainerCPUTimeMetricConfig{
 						Enabled: true,
 					},
-					ContainerCPUUsage: MetricConfig{
+					ContainerCPUUsage: ContainerCPUUsageMetricConfig{
 						Enabled: true,
 					},
-					ContainerFilesystemAvailable: MetricConfig{
+					ContainerFilesystemAvailable: ContainerFilesystemAvailableMetricConfig{
 						Enabled: true,
 					},
-					ContainerFilesystemCapacity: MetricConfig{
+					ContainerFilesystemCapacity: ContainerFilesystemCapacityMetricConfig{
 						Enabled: true,
 					},
-					ContainerFilesystemUsage: MetricConfig{
+					ContainerFilesystemUsage: ContainerFilesystemUsageMetricConfig{
 						Enabled: true,
 					},
-					ContainerMemoryAvailable: MetricConfig{
+					ContainerMemoryAvailable: ContainerMemoryAvailableMetricConfig{
 						Enabled: true,
 					},
-					ContainerMemoryMajorPageFaults: MetricConfig{
+					ContainerMemoryMajorPageFaults: ContainerMemoryMajorPageFaultsMetricConfig{
 						Enabled: true,
 					},
-					ContainerMemoryPageFaults: MetricConfig{
+					ContainerMemoryPageFaults: ContainerMemoryPageFaultsMetricConfig{
 						Enabled: true,
 					},
-					ContainerMemoryRss: MetricConfig{
+					ContainerMemoryRss: ContainerMemoryRssMetricConfig{
 						Enabled: true,
 					},
-					ContainerMemoryUsage: MetricConfig{
+					ContainerMemoryUsage: ContainerMemoryUsageMetricConfig{
 						Enabled: true,
 					},
-					ContainerMemoryWorkingSet: MetricConfig{
+					ContainerMemoryWorkingSet: ContainerMemoryWorkingSetMetricConfig{
 						Enabled: true,
 					},
-					ContainerUptime: MetricConfig{
+					ContainerUptime: ContainerUptimeMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerCPUNodeUtilization: MetricConfig{
+					K8sContainerCPUNodeUtilization: K8sContainerCPUNodeUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerCPULimitUtilization: MetricConfig{
+					K8sContainerCPULimitUtilization: K8sContainerCPULimitUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerCPURequestUtilization: MetricConfig{
+					K8sContainerCPURequestUtilization: K8sContainerCPURequestUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerEphemeralStorageUsage: MetricConfig{
+					K8sContainerEphemeralStorageUsage: K8sContainerEphemeralStorageUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sContainerEphemeralStorageUsageMetricAttributeKey{K8sContainerEphemeralStorageUsageMetricAttributeKeyFsType},
+					},
+					K8sContainerMemoryNodeUtilization: K8sContainerMemoryNodeUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerMemoryNodeUtilization: MetricConfig{
+					K8sContainerMemoryLimitUtilization: K8sContainerMemoryLimitUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerMemoryLimitUtilization: MetricConfig{
+					K8sContainerMemoryRequestUtilization: K8sContainerMemoryRequestUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sContainerMemoryRequestUtilization: MetricConfig{
+					K8sNodeCPUTime: K8sNodeCPUTimeMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeCPUTime: MetricConfig{
+					K8sNodeCPUUsage: K8sNodeCPUUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeCPUUsage: MetricConfig{
+					K8sNodeFilesystemAvailable: K8sNodeFilesystemAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeFilesystemAvailable: MetricConfig{
+					K8sNodeFilesystemCapacity: K8sNodeFilesystemCapacityMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeFilesystemCapacity: MetricConfig{
+					K8sNodeFilesystemUsage: K8sNodeFilesystemUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeFilesystemUsage: MetricConfig{
+					K8sNodeMemoryAvailable: K8sNodeMemoryAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeMemoryAvailable: MetricConfig{
+					K8sNodeMemoryMajorPageFaults: K8sNodeMemoryMajorPageFaultsMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeMemoryMajorPageFaults: MetricConfig{
+					K8sNodeMemoryPageFaults: K8sNodeMemoryPageFaultsMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeMemoryPageFaults: MetricConfig{
+					K8sNodeMemoryRss: K8sNodeMemoryRssMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeMemoryRss: MetricConfig{
+					K8sNodeMemoryUsage: K8sNodeMemoryUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeMemoryUsage: MetricConfig{
+					K8sNodeMemoryWorkingSet: K8sNodeMemoryWorkingSetMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeMemoryWorkingSet: MetricConfig{
+					K8sNodeNetworkErrors: K8sNodeNetworkErrorsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sNodeNetworkErrorsMetricAttributeKey{K8sNodeNetworkErrorsMetricAttributeKeyInterface, K8sNodeNetworkErrorsMetricAttributeKeyDirection},
+					},
+					K8sNodeNetworkIo: K8sNodeNetworkIoMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sNodeNetworkIoMetricAttributeKey{K8sNodeNetworkIoMetricAttributeKeyInterface, K8sNodeNetworkIoMetricAttributeKeyDirection},
+					},
+					K8sNodeSystemContainerCPUTime: K8sNodeSystemContainerCPUTimeMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeNetworkErrors: MetricConfig{
+					K8sNodeSystemContainerCPUUsage: K8sNodeSystemContainerCPUUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeNetworkIo: MetricConfig{
+					K8sNodeSystemContainerMemoryUsage: K8sNodeSystemContainerMemoryUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeSystemContainerCPUTime: MetricConfig{
+					K8sNodeSystemContainerMemoryWorkingSet: K8sNodeSystemContainerMemoryWorkingSetMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeSystemContainerCPUUsage: MetricConfig{
+					K8sNodeUptime: K8sNodeUptimeMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeSystemContainerMemoryUsage: MetricConfig{
+					K8sPodCPUNodeUtilization: K8sPodCPUNodeUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeSystemContainerMemoryWorkingSet: MetricConfig{
+					K8sPodCPUTime: K8sPodCPUTimeMetricConfig{
 						Enabled: true,
 					},
-					K8sNodeUptime: MetricConfig{
+					K8sPodCPUUsage: K8sPodCPUUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sPodCPUNodeUtilization: MetricConfig{
+					K8sPodCPULimitUtilization: K8sPodCPULimitUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sPodCPUTime: MetricConfig{
+					K8sPodCPURequestUtilization: K8sPodCPURequestUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sPodCPUUsage: MetricConfig{
+					K8sPodFilesystemAvailable: K8sPodFilesystemAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sPodCPULimitUtilization: MetricConfig{
+					K8sPodFilesystemCapacity: K8sPodFilesystemCapacityMetricConfig{
 						Enabled: true,
 					},
-					K8sPodCPURequestUtilization: MetricConfig{
+					K8sPodFilesystemUsage: K8sPodFilesystemUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sPodFilesystemAvailable: MetricConfig{
+					K8sPodMemoryAvailable: K8sPodMemoryAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sPodFilesystemCapacity: MetricConfig{
+					K8sPodMemoryMajorPageFaults: K8sPodMemoryMajorPageFaultsMetricConfig{
 						Enabled: true,
 					},
-					K8sPodFilesystemUsage: MetricConfig{
+					K8sPodMemoryNodeUtilization: K8sPodMemoryNodeUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryAvailable: MetricConfig{
+					K8sPodMemoryPageFaults: K8sPodMemoryPageFaultsMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryMajorPageFaults: MetricConfig{
+					K8sPodMemoryRss: K8sPodMemoryRssMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryNodeUtilization: MetricConfig{
+					K8sPodMemoryUsage: K8sPodMemoryUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryPageFaults: MetricConfig{
+					K8sPodMemoryWorkingSet: K8sPodMemoryWorkingSetMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryRss: MetricConfig{
+					K8sPodMemoryLimitUtilization: K8sPodMemoryLimitUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryUsage: MetricConfig{
+					K8sPodMemoryRequestUtilization: K8sPodMemoryRequestUtilizationMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryWorkingSet: MetricConfig{
+					K8sPodNetworkErrors: K8sPodNetworkErrorsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sPodNetworkErrorsMetricAttributeKey{K8sPodNetworkErrorsMetricAttributeKeyInterface, K8sPodNetworkErrorsMetricAttributeKeyDirection},
+					},
+					K8sPodNetworkIo: K8sPodNetworkIoMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sPodNetworkIoMetricAttributeKey{K8sPodNetworkIoMetricAttributeKeyInterface, K8sPodNetworkIoMetricAttributeKeyDirection},
+					},
+					K8sPodUptime: K8sPodUptimeMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryLimitUtilization: MetricConfig{
+					K8sPodVolumeUsage: K8sPodVolumeUsageMetricConfig{
 						Enabled: true,
 					},
-					K8sPodMemoryRequestUtilization: MetricConfig{
+					K8sVolumeAvailable: K8sVolumeAvailableMetricConfig{
 						Enabled: true,
 					},
-					K8sPodNetworkErrors: MetricConfig{
+					K8sVolumeCapacity: K8sVolumeCapacityMetricConfig{
 						Enabled: true,
 					},
-					K8sPodNetworkIo: MetricConfig{
+					K8sVolumeInodes: K8sVolumeInodesMetricConfig{
 						Enabled: true,
 					},
-					K8sPodUptime: MetricConfig{
+					K8sVolumeInodesFree: K8sVolumeInodesFreeMetricConfig{
 						Enabled: true,
 					},
-					K8sPodVolumeUsage: MetricConfig{
-						Enabled: true,
-					},
-					K8sVolumeAvailable: MetricConfig{
-						Enabled: true,
-					},
-					K8sVolumeCapacity: MetricConfig{
-						Enabled: true,
-					},
-					K8sVolumeInodes: MetricConfig{
-						Enabled: true,
-					},
-					K8sVolumeInodesFree: MetricConfig{
-						Enabled: true,
-					},
-					K8sVolumeInodesUsed: MetricConfig{
+					K8sVolumeInodesUsed: K8sVolumeInodesUsedMetricConfig{
 						Enabled: true,
 					},
 				},
@@ -240,193 +250,203 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ContainerCPUTime: MetricConfig{
+					ContainerCPUTime: ContainerCPUTimeMetricConfig{
 						Enabled: false,
 					},
-					ContainerCPUUsage: MetricConfig{
+					ContainerCPUUsage: ContainerCPUUsageMetricConfig{
 						Enabled: false,
 					},
-					ContainerFilesystemAvailable: MetricConfig{
+					ContainerFilesystemAvailable: ContainerFilesystemAvailableMetricConfig{
 						Enabled: false,
 					},
-					ContainerFilesystemCapacity: MetricConfig{
+					ContainerFilesystemCapacity: ContainerFilesystemCapacityMetricConfig{
 						Enabled: false,
 					},
-					ContainerFilesystemUsage: MetricConfig{
+					ContainerFilesystemUsage: ContainerFilesystemUsageMetricConfig{
 						Enabled: false,
 					},
-					ContainerMemoryAvailable: MetricConfig{
+					ContainerMemoryAvailable: ContainerMemoryAvailableMetricConfig{
 						Enabled: false,
 					},
-					ContainerMemoryMajorPageFaults: MetricConfig{
+					ContainerMemoryMajorPageFaults: ContainerMemoryMajorPageFaultsMetricConfig{
 						Enabled: false,
 					},
-					ContainerMemoryPageFaults: MetricConfig{
+					ContainerMemoryPageFaults: ContainerMemoryPageFaultsMetricConfig{
 						Enabled: false,
 					},
-					ContainerMemoryRss: MetricConfig{
+					ContainerMemoryRss: ContainerMemoryRssMetricConfig{
 						Enabled: false,
 					},
-					ContainerMemoryUsage: MetricConfig{
+					ContainerMemoryUsage: ContainerMemoryUsageMetricConfig{
 						Enabled: false,
 					},
-					ContainerMemoryWorkingSet: MetricConfig{
+					ContainerMemoryWorkingSet: ContainerMemoryWorkingSetMetricConfig{
 						Enabled: false,
 					},
-					ContainerUptime: MetricConfig{
+					ContainerUptime: ContainerUptimeMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerCPUNodeUtilization: MetricConfig{
+					K8sContainerCPUNodeUtilization: K8sContainerCPUNodeUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerCPULimitUtilization: MetricConfig{
+					K8sContainerCPULimitUtilization: K8sContainerCPULimitUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerCPURequestUtilization: MetricConfig{
+					K8sContainerCPURequestUtilization: K8sContainerCPURequestUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerEphemeralStorageUsage: MetricConfig{
+					K8sContainerEphemeralStorageUsage: K8sContainerEphemeralStorageUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sContainerEphemeralStorageUsageMetricAttributeKey{K8sContainerEphemeralStorageUsageMetricAttributeKeyFsType},
+					},
+					K8sContainerMemoryNodeUtilization: K8sContainerMemoryNodeUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerMemoryNodeUtilization: MetricConfig{
+					K8sContainerMemoryLimitUtilization: K8sContainerMemoryLimitUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerMemoryLimitUtilization: MetricConfig{
+					K8sContainerMemoryRequestUtilization: K8sContainerMemoryRequestUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sContainerMemoryRequestUtilization: MetricConfig{
+					K8sNodeCPUTime: K8sNodeCPUTimeMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeCPUTime: MetricConfig{
+					K8sNodeCPUUsage: K8sNodeCPUUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeCPUUsage: MetricConfig{
+					K8sNodeFilesystemAvailable: K8sNodeFilesystemAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeFilesystemAvailable: MetricConfig{
+					K8sNodeFilesystemCapacity: K8sNodeFilesystemCapacityMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeFilesystemCapacity: MetricConfig{
+					K8sNodeFilesystemUsage: K8sNodeFilesystemUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeFilesystemUsage: MetricConfig{
+					K8sNodeMemoryAvailable: K8sNodeMemoryAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeMemoryAvailable: MetricConfig{
+					K8sNodeMemoryMajorPageFaults: K8sNodeMemoryMajorPageFaultsMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeMemoryMajorPageFaults: MetricConfig{
+					K8sNodeMemoryPageFaults: K8sNodeMemoryPageFaultsMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeMemoryPageFaults: MetricConfig{
+					K8sNodeMemoryRss: K8sNodeMemoryRssMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeMemoryRss: MetricConfig{
+					K8sNodeMemoryUsage: K8sNodeMemoryUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeMemoryUsage: MetricConfig{
+					K8sNodeMemoryWorkingSet: K8sNodeMemoryWorkingSetMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeMemoryWorkingSet: MetricConfig{
+					K8sNodeNetworkErrors: K8sNodeNetworkErrorsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sNodeNetworkErrorsMetricAttributeKey{K8sNodeNetworkErrorsMetricAttributeKeyInterface, K8sNodeNetworkErrorsMetricAttributeKeyDirection},
+					},
+					K8sNodeNetworkIo: K8sNodeNetworkIoMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sNodeNetworkIoMetricAttributeKey{K8sNodeNetworkIoMetricAttributeKeyInterface, K8sNodeNetworkIoMetricAttributeKeyDirection},
+					},
+					K8sNodeSystemContainerCPUTime: K8sNodeSystemContainerCPUTimeMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeNetworkErrors: MetricConfig{
+					K8sNodeSystemContainerCPUUsage: K8sNodeSystemContainerCPUUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeNetworkIo: MetricConfig{
+					K8sNodeSystemContainerMemoryUsage: K8sNodeSystemContainerMemoryUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeSystemContainerCPUTime: MetricConfig{
+					K8sNodeSystemContainerMemoryWorkingSet: K8sNodeSystemContainerMemoryWorkingSetMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeSystemContainerCPUUsage: MetricConfig{
+					K8sNodeUptime: K8sNodeUptimeMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeSystemContainerMemoryUsage: MetricConfig{
+					K8sPodCPUNodeUtilization: K8sPodCPUNodeUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeSystemContainerMemoryWorkingSet: MetricConfig{
+					K8sPodCPUTime: K8sPodCPUTimeMetricConfig{
 						Enabled: false,
 					},
-					K8sNodeUptime: MetricConfig{
+					K8sPodCPUUsage: K8sPodCPUUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sPodCPUNodeUtilization: MetricConfig{
+					K8sPodCPULimitUtilization: K8sPodCPULimitUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sPodCPUTime: MetricConfig{
+					K8sPodCPURequestUtilization: K8sPodCPURequestUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sPodCPUUsage: MetricConfig{
+					K8sPodFilesystemAvailable: K8sPodFilesystemAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sPodCPULimitUtilization: MetricConfig{
+					K8sPodFilesystemCapacity: K8sPodFilesystemCapacityMetricConfig{
 						Enabled: false,
 					},
-					K8sPodCPURequestUtilization: MetricConfig{
+					K8sPodFilesystemUsage: K8sPodFilesystemUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sPodFilesystemAvailable: MetricConfig{
+					K8sPodMemoryAvailable: K8sPodMemoryAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sPodFilesystemCapacity: MetricConfig{
+					K8sPodMemoryMajorPageFaults: K8sPodMemoryMajorPageFaultsMetricConfig{
 						Enabled: false,
 					},
-					K8sPodFilesystemUsage: MetricConfig{
+					K8sPodMemoryNodeUtilization: K8sPodMemoryNodeUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryAvailable: MetricConfig{
+					K8sPodMemoryPageFaults: K8sPodMemoryPageFaultsMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryMajorPageFaults: MetricConfig{
+					K8sPodMemoryRss: K8sPodMemoryRssMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryNodeUtilization: MetricConfig{
+					K8sPodMemoryUsage: K8sPodMemoryUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryPageFaults: MetricConfig{
+					K8sPodMemoryWorkingSet: K8sPodMemoryWorkingSetMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryRss: MetricConfig{
+					K8sPodMemoryLimitUtilization: K8sPodMemoryLimitUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryUsage: MetricConfig{
+					K8sPodMemoryRequestUtilization: K8sPodMemoryRequestUtilizationMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryWorkingSet: MetricConfig{
+					K8sPodNetworkErrors: K8sPodNetworkErrorsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sPodNetworkErrorsMetricAttributeKey{K8sPodNetworkErrorsMetricAttributeKeyInterface, K8sPodNetworkErrorsMetricAttributeKeyDirection},
+					},
+					K8sPodNetworkIo: K8sPodNetworkIoMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []K8sPodNetworkIoMetricAttributeKey{K8sPodNetworkIoMetricAttributeKeyInterface, K8sPodNetworkIoMetricAttributeKeyDirection},
+					},
+					K8sPodUptime: K8sPodUptimeMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryLimitUtilization: MetricConfig{
+					K8sPodVolumeUsage: K8sPodVolumeUsageMetricConfig{
 						Enabled: false,
 					},
-					K8sPodMemoryRequestUtilization: MetricConfig{
+					K8sVolumeAvailable: K8sVolumeAvailableMetricConfig{
 						Enabled: false,
 					},
-					K8sPodNetworkErrors: MetricConfig{
+					K8sVolumeCapacity: K8sVolumeCapacityMetricConfig{
 						Enabled: false,
 					},
-					K8sPodNetworkIo: MetricConfig{
+					K8sVolumeInodes: K8sVolumeInodesMetricConfig{
 						Enabled: false,
 					},
-					K8sPodUptime: MetricConfig{
+					K8sVolumeInodesFree: K8sVolumeInodesFreeMetricConfig{
 						Enabled: false,
 					},
-					K8sPodVolumeUsage: MetricConfig{
-						Enabled: false,
-					},
-					K8sVolumeAvailable: MetricConfig{
-						Enabled: false,
-					},
-					K8sVolumeCapacity: MetricConfig{
-						Enabled: false,
-					},
-					K8sVolumeInodes: MetricConfig{
-						Enabled: false,
-					},
-					K8sVolumeInodesFree: MetricConfig{
-						Enabled: false,
-					},
-					K8sVolumeInodesUsed: MetricConfig{
+					K8sVolumeInodesUsed: K8sVolumeInodesUsedMetricConfig{
 						Enabled: false,
 					},
 				},
@@ -454,7 +474,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ContainerCPUTimeMetricConfig{}, ContainerCPUUsageMetricConfig{}, ContainerFilesystemAvailableMetricConfig{}, ContainerFilesystemCapacityMetricConfig{}, ContainerFilesystemUsageMetricConfig{}, ContainerMemoryAvailableMetricConfig{}, ContainerMemoryMajorPageFaultsMetricConfig{}, ContainerMemoryPageFaultsMetricConfig{}, ContainerMemoryRssMetricConfig{}, ContainerMemoryUsageMetricConfig{}, ContainerMemoryWorkingSetMetricConfig{}, ContainerUptimeMetricConfig{}, K8sContainerCPUNodeUtilizationMetricConfig{}, K8sContainerCPULimitUtilizationMetricConfig{}, K8sContainerCPURequestUtilizationMetricConfig{}, K8sContainerEphemeralStorageUsageMetricConfig{}, K8sContainerMemoryNodeUtilizationMetricConfig{}, K8sContainerMemoryLimitUtilizationMetricConfig{}, K8sContainerMemoryRequestUtilizationMetricConfig{}, K8sNodeCPUTimeMetricConfig{}, K8sNodeCPUUsageMetricConfig{}, K8sNodeFilesystemAvailableMetricConfig{}, K8sNodeFilesystemCapacityMetricConfig{}, K8sNodeFilesystemUsageMetricConfig{}, K8sNodeMemoryAvailableMetricConfig{}, K8sNodeMemoryMajorPageFaultsMetricConfig{}, K8sNodeMemoryPageFaultsMetricConfig{}, K8sNodeMemoryRssMetricConfig{}, K8sNodeMemoryUsageMetricConfig{}, K8sNodeMemoryWorkingSetMetricConfig{}, K8sNodeNetworkErrorsMetricConfig{}, K8sNodeNetworkIoMetricConfig{}, K8sNodeSystemContainerCPUTimeMetricConfig{}, K8sNodeSystemContainerCPUUsageMetricConfig{}, K8sNodeSystemContainerMemoryUsageMetricConfig{}, K8sNodeSystemContainerMemoryWorkingSetMetricConfig{}, K8sNodeUptimeMetricConfig{}, K8sPodCPUNodeUtilizationMetricConfig{}, K8sPodCPUTimeMetricConfig{}, K8sPodCPUUsageMetricConfig{}, K8sPodCPULimitUtilizationMetricConfig{}, K8sPodCPURequestUtilizationMetricConfig{}, K8sPodFilesystemAvailableMetricConfig{}, K8sPodFilesystemCapacityMetricConfig{}, K8sPodFilesystemUsageMetricConfig{}, K8sPodMemoryAvailableMetricConfig{}, K8sPodMemoryMajorPageFaultsMetricConfig{}, K8sPodMemoryNodeUtilizationMetricConfig{}, K8sPodMemoryPageFaultsMetricConfig{}, K8sPodMemoryRssMetricConfig{}, K8sPodMemoryUsageMetricConfig{}, K8sPodMemoryWorkingSetMetricConfig{}, K8sPodMemoryLimitUtilizationMetricConfig{}, K8sPodMemoryRequestUtilizationMetricConfig{}, K8sPodNetworkErrorsMetricConfig{}, K8sPodNetworkIoMetricConfig{}, K8sPodUptimeMetricConfig{}, K8sPodVolumeUsageMetricConfig{}, K8sVolumeAvailableMetricConfig{}, K8sVolumeCapacityMetricConfig{}, K8sVolumeInodesMetricConfig{}, K8sVolumeInodesFreeMetricConfig{}, K8sVolumeInodesUsedMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeDirection specifies the value direction attribute.
@@ -327,9 +335,9 @@ type metricInfo struct {
 }
 
 type metricContainerCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   ContainerCPUTimeMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills container.cpu.time metric with initial data.
@@ -368,7 +376,7 @@ func (m *metricContainerCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerCPUTime(cfg MetricConfig) metricContainerCPUTime {
+func newMetricContainerCPUTime(cfg ContainerCPUTimeMetricConfig) metricContainerCPUTime {
 	m := metricContainerCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -379,9 +387,9 @@ func newMetricContainerCPUTime(cfg MetricConfig) metricContainerCPUTime {
 }
 
 type metricContainerCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   ContainerCPUUsageMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills container.cpu.usage metric with initial data.
@@ -418,7 +426,7 @@ func (m *metricContainerCPUUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerCPUUsage(cfg MetricConfig) metricContainerCPUUsage {
+func newMetricContainerCPUUsage(cfg ContainerCPUUsageMetricConfig) metricContainerCPUUsage {
 	m := metricContainerCPUUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -429,9 +437,9 @@ func newMetricContainerCPUUsage(cfg MetricConfig) metricContainerCPUUsage {
 }
 
 type metricContainerFilesystemAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   ContainerFilesystemAvailableMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
 }
 
 // init fills container.filesystem.available metric with initial data.
@@ -468,7 +476,7 @@ func (m *metricContainerFilesystemAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerFilesystemAvailable(cfg MetricConfig) metricContainerFilesystemAvailable {
+func newMetricContainerFilesystemAvailable(cfg ContainerFilesystemAvailableMetricConfig) metricContainerFilesystemAvailable {
 	m := metricContainerFilesystemAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -479,9 +487,9 @@ func newMetricContainerFilesystemAvailable(cfg MetricConfig) metricContainerFile
 }
 
 type metricContainerFilesystemCapacity struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   ContainerFilesystemCapacityMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills container.filesystem.capacity metric with initial data.
@@ -518,7 +526,7 @@ func (m *metricContainerFilesystemCapacity) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerFilesystemCapacity(cfg MetricConfig) metricContainerFilesystemCapacity {
+func newMetricContainerFilesystemCapacity(cfg ContainerFilesystemCapacityMetricConfig) metricContainerFilesystemCapacity {
 	m := metricContainerFilesystemCapacity{config: cfg}
 
 	if cfg.Enabled {
@@ -529,9 +537,9 @@ func newMetricContainerFilesystemCapacity(cfg MetricConfig) metricContainerFiles
 }
 
 type metricContainerFilesystemUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   ContainerFilesystemUsageMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills container.filesystem.usage metric with initial data.
@@ -568,7 +576,7 @@ func (m *metricContainerFilesystemUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerFilesystemUsage(cfg MetricConfig) metricContainerFilesystemUsage {
+func newMetricContainerFilesystemUsage(cfg ContainerFilesystemUsageMetricConfig) metricContainerFilesystemUsage {
 	m := metricContainerFilesystemUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -579,9 +587,9 @@ func newMetricContainerFilesystemUsage(cfg MetricConfig) metricContainerFilesyst
 }
 
 type metricContainerMemoryAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   ContainerMemoryAvailableMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills container.memory.available metric with initial data.
@@ -618,7 +626,7 @@ func (m *metricContainerMemoryAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerMemoryAvailable(cfg MetricConfig) metricContainerMemoryAvailable {
+func newMetricContainerMemoryAvailable(cfg ContainerMemoryAvailableMetricConfig) metricContainerMemoryAvailable {
 	m := metricContainerMemoryAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -629,9 +637,9 @@ func newMetricContainerMemoryAvailable(cfg MetricConfig) metricContainerMemoryAv
 }
 
 type metricContainerMemoryMajorPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                             // data buffer for generated metric.
+	config   ContainerMemoryMajorPageFaultsMetricConfig // metric config provided by user.
+	capacity int                                        // max observed number of data points added to the metric.
 }
 
 // init fills container.memory.major_page_faults metric with initial data.
@@ -668,7 +676,7 @@ func (m *metricContainerMemoryMajorPageFaults) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricContainerMemoryMajorPageFaults(cfg MetricConfig) metricContainerMemoryMajorPageFaults {
+func newMetricContainerMemoryMajorPageFaults(cfg ContainerMemoryMajorPageFaultsMetricConfig) metricContainerMemoryMajorPageFaults {
 	m := metricContainerMemoryMajorPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -679,9 +687,9 @@ func newMetricContainerMemoryMajorPageFaults(cfg MetricConfig) metricContainerMe
 }
 
 type metricContainerMemoryPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   ContainerMemoryPageFaultsMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills container.memory.page_faults metric with initial data.
@@ -718,7 +726,7 @@ func (m *metricContainerMemoryPageFaults) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerMemoryPageFaults(cfg MetricConfig) metricContainerMemoryPageFaults {
+func newMetricContainerMemoryPageFaults(cfg ContainerMemoryPageFaultsMetricConfig) metricContainerMemoryPageFaults {
 	m := metricContainerMemoryPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -729,9 +737,9 @@ func newMetricContainerMemoryPageFaults(cfg MetricConfig) metricContainerMemoryP
 }
 
 type metricContainerMemoryRss struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   ContainerMemoryRssMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills container.memory.rss metric with initial data.
@@ -768,7 +776,7 @@ func (m *metricContainerMemoryRss) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerMemoryRss(cfg MetricConfig) metricContainerMemoryRss {
+func newMetricContainerMemoryRss(cfg ContainerMemoryRssMetricConfig) metricContainerMemoryRss {
 	m := metricContainerMemoryRss{config: cfg}
 
 	if cfg.Enabled {
@@ -779,9 +787,9 @@ func newMetricContainerMemoryRss(cfg MetricConfig) metricContainerMemoryRss {
 }
 
 type metricContainerMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   ContainerMemoryUsageMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
 }
 
 // init fills container.memory.usage metric with initial data.
@@ -818,7 +826,7 @@ func (m *metricContainerMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerMemoryUsage(cfg MetricConfig) metricContainerMemoryUsage {
+func newMetricContainerMemoryUsage(cfg ContainerMemoryUsageMetricConfig) metricContainerMemoryUsage {
 	m := metricContainerMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -829,9 +837,9 @@ func newMetricContainerMemoryUsage(cfg MetricConfig) metricContainerMemoryUsage 
 }
 
 type metricContainerMemoryWorkingSet struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   ContainerMemoryWorkingSetMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills container.memory.working_set metric with initial data.
@@ -868,7 +876,7 @@ func (m *metricContainerMemoryWorkingSet) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerMemoryWorkingSet(cfg MetricConfig) metricContainerMemoryWorkingSet {
+func newMetricContainerMemoryWorkingSet(cfg ContainerMemoryWorkingSetMetricConfig) metricContainerMemoryWorkingSet {
 	m := metricContainerMemoryWorkingSet{config: cfg}
 
 	if cfg.Enabled {
@@ -879,9 +887,9 @@ func newMetricContainerMemoryWorkingSet(cfg MetricConfig) metricContainerMemoryW
 }
 
 type metricContainerUptime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric              // data buffer for generated metric.
+	config   ContainerUptimeMetricConfig // metric config provided by user.
+	capacity int                         // max observed number of data points added to the metric.
 }
 
 // init fills container.uptime metric with initial data.
@@ -920,7 +928,7 @@ func (m *metricContainerUptime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricContainerUptime(cfg MetricConfig) metricContainerUptime {
+func newMetricContainerUptime(cfg ContainerUptimeMetricConfig) metricContainerUptime {
 	m := metricContainerUptime{config: cfg}
 
 	if cfg.Enabled {
@@ -931,9 +939,9 @@ func newMetricContainerUptime(cfg MetricConfig) metricContainerUptime {
 }
 
 type metricK8sContainerCPUNodeUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                             // data buffer for generated metric.
+	config   K8sContainerCPUNodeUtilizationMetricConfig // metric config provided by user.
+	capacity int                                        // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.cpu.node.utilization metric with initial data.
@@ -970,7 +978,7 @@ func (m *metricK8sContainerCPUNodeUtilization) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricK8sContainerCPUNodeUtilization(cfg MetricConfig) metricK8sContainerCPUNodeUtilization {
+func newMetricK8sContainerCPUNodeUtilization(cfg K8sContainerCPUNodeUtilizationMetricConfig) metricK8sContainerCPUNodeUtilization {
 	m := metricK8sContainerCPUNodeUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -981,9 +989,9 @@ func newMetricK8sContainerCPUNodeUtilization(cfg MetricConfig) metricK8sContaine
 }
 
 type metricK8sContainerCPULimitUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                              // data buffer for generated metric.
+	config   K8sContainerCPULimitUtilizationMetricConfig // metric config provided by user.
+	capacity int                                         // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.cpu_limit_utilization metric with initial data.
@@ -1020,7 +1028,7 @@ func (m *metricK8sContainerCPULimitUtilization) emit(metrics pmetric.MetricSlice
 	}
 }
 
-func newMetricK8sContainerCPULimitUtilization(cfg MetricConfig) metricK8sContainerCPULimitUtilization {
+func newMetricK8sContainerCPULimitUtilization(cfg K8sContainerCPULimitUtilizationMetricConfig) metricK8sContainerCPULimitUtilization {
 	m := metricK8sContainerCPULimitUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -1031,9 +1039,9 @@ func newMetricK8sContainerCPULimitUtilization(cfg MetricConfig) metricK8sContain
 }
 
 type metricK8sContainerCPURequestUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sContainerCPURequestUtilizationMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.cpu_request_utilization metric with initial data.
@@ -1070,7 +1078,7 @@ func (m *metricK8sContainerCPURequestUtilization) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sContainerCPURequestUtilization(cfg MetricConfig) metricK8sContainerCPURequestUtilization {
+func newMetricK8sContainerCPURequestUtilization(cfg K8sContainerCPURequestUtilizationMetricConfig) metricK8sContainerCPURequestUtilization {
 	m := metricK8sContainerCPURequestUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -1081,9 +1089,10 @@ func newMetricK8sContainerCPURequestUtilization(cfg MetricConfig) metricK8sConta
 }
 
 type metricK8sContainerEphemeralStorageUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        K8sContainerEphemeralStorageUsageMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                                       // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.container.ephemeral_storage.usage metric with initial data.
@@ -1095,17 +1104,48 @@ func (m *metricK8sContainerEphemeralStorageUsage) init() {
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sContainerEphemeralStorageUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, fsTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sContainerEphemeralStorageUsageMetricAttributeKeyFsType) {
+		dp.Attributes().PutStr("fs.type", fsTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("fs.type", fsTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1118,13 +1158,18 @@ func (m *metricK8sContainerEphemeralStorageUsage) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sContainerEphemeralStorageUsage) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sContainerEphemeralStorageUsage(cfg MetricConfig) metricK8sContainerEphemeralStorageUsage {
+func newMetricK8sContainerEphemeralStorageUsage(cfg K8sContainerEphemeralStorageUsageMetricConfig) metricK8sContainerEphemeralStorageUsage {
 	m := metricK8sContainerEphemeralStorageUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -1135,9 +1180,9 @@ func newMetricK8sContainerEphemeralStorageUsage(cfg MetricConfig) metricK8sConta
 }
 
 type metricK8sContainerMemoryNodeUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sContainerMemoryNodeUtilizationMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.memory.node.utilization metric with initial data.
@@ -1174,7 +1219,7 @@ func (m *metricK8sContainerMemoryNodeUtilization) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sContainerMemoryNodeUtilization(cfg MetricConfig) metricK8sContainerMemoryNodeUtilization {
+func newMetricK8sContainerMemoryNodeUtilization(cfg K8sContainerMemoryNodeUtilizationMetricConfig) metricK8sContainerMemoryNodeUtilization {
 	m := metricK8sContainerMemoryNodeUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -1185,9 +1230,9 @@ func newMetricK8sContainerMemoryNodeUtilization(cfg MetricConfig) metricK8sConta
 }
 
 type metricK8sContainerMemoryLimitUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                 // data buffer for generated metric.
+	config   K8sContainerMemoryLimitUtilizationMetricConfig // metric config provided by user.
+	capacity int                                            // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.memory_limit_utilization metric with initial data.
@@ -1224,7 +1269,7 @@ func (m *metricK8sContainerMemoryLimitUtilization) emit(metrics pmetric.MetricSl
 	}
 }
 
-func newMetricK8sContainerMemoryLimitUtilization(cfg MetricConfig) metricK8sContainerMemoryLimitUtilization {
+func newMetricK8sContainerMemoryLimitUtilization(cfg K8sContainerMemoryLimitUtilizationMetricConfig) metricK8sContainerMemoryLimitUtilization {
 	m := metricK8sContainerMemoryLimitUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -1235,9 +1280,9 @@ func newMetricK8sContainerMemoryLimitUtilization(cfg MetricConfig) metricK8sCont
 }
 
 type metricK8sContainerMemoryRequestUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                   // data buffer for generated metric.
+	config   K8sContainerMemoryRequestUtilizationMetricConfig // metric config provided by user.
+	capacity int                                              // max observed number of data points added to the metric.
 }
 
 // init fills k8s.container.memory_request_utilization metric with initial data.
@@ -1274,7 +1319,7 @@ func (m *metricK8sContainerMemoryRequestUtilization) emit(metrics pmetric.Metric
 	}
 }
 
-func newMetricK8sContainerMemoryRequestUtilization(cfg MetricConfig) metricK8sContainerMemoryRequestUtilization {
+func newMetricK8sContainerMemoryRequestUtilization(cfg K8sContainerMemoryRequestUtilizationMetricConfig) metricK8sContainerMemoryRequestUtilization {
 	m := metricK8sContainerMemoryRequestUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -1285,9 +1330,9 @@ func newMetricK8sContainerMemoryRequestUtilization(cfg MetricConfig) metricK8sCo
 }
 
 type metricK8sNodeCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   K8sNodeCPUTimeMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.cpu.time metric with initial data.
@@ -1326,7 +1371,7 @@ func (m *metricK8sNodeCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeCPUTime(cfg MetricConfig) metricK8sNodeCPUTime {
+func newMetricK8sNodeCPUTime(cfg K8sNodeCPUTimeMetricConfig) metricK8sNodeCPUTime {
 	m := metricK8sNodeCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -1337,9 +1382,9 @@ func newMetricK8sNodeCPUTime(cfg MetricConfig) metricK8sNodeCPUTime {
 }
 
 type metricK8sNodeCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric              // data buffer for generated metric.
+	config   K8sNodeCPUUsageMetricConfig // metric config provided by user.
+	capacity int                         // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.cpu.usage metric with initial data.
@@ -1376,7 +1421,7 @@ func (m *metricK8sNodeCPUUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeCPUUsage(cfg MetricConfig) metricK8sNodeCPUUsage {
+func newMetricK8sNodeCPUUsage(cfg K8sNodeCPUUsageMetricConfig) metricK8sNodeCPUUsage {
 	m := metricK8sNodeCPUUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -1387,9 +1432,9 @@ func newMetricK8sNodeCPUUsage(cfg MetricConfig) metricK8sNodeCPUUsage {
 }
 
 type metricK8sNodeFilesystemAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   K8sNodeFilesystemAvailableMetricConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.filesystem.available metric with initial data.
@@ -1426,7 +1471,7 @@ func (m *metricK8sNodeFilesystemAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeFilesystemAvailable(cfg MetricConfig) metricK8sNodeFilesystemAvailable {
+func newMetricK8sNodeFilesystemAvailable(cfg K8sNodeFilesystemAvailableMetricConfig) metricK8sNodeFilesystemAvailable {
 	m := metricK8sNodeFilesystemAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -1437,9 +1482,9 @@ func newMetricK8sNodeFilesystemAvailable(cfg MetricConfig) metricK8sNodeFilesyst
 }
 
 type metricK8sNodeFilesystemCapacity struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sNodeFilesystemCapacityMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.filesystem.capacity metric with initial data.
@@ -1476,7 +1521,7 @@ func (m *metricK8sNodeFilesystemCapacity) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeFilesystemCapacity(cfg MetricConfig) metricK8sNodeFilesystemCapacity {
+func newMetricK8sNodeFilesystemCapacity(cfg K8sNodeFilesystemCapacityMetricConfig) metricK8sNodeFilesystemCapacity {
 	m := metricK8sNodeFilesystemCapacity{config: cfg}
 
 	if cfg.Enabled {
@@ -1487,9 +1532,9 @@ func newMetricK8sNodeFilesystemCapacity(cfg MetricConfig) metricK8sNodeFilesyste
 }
 
 type metricK8sNodeFilesystemUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sNodeFilesystemUsageMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.filesystem.usage metric with initial data.
@@ -1526,7 +1571,7 @@ func (m *metricK8sNodeFilesystemUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeFilesystemUsage(cfg MetricConfig) metricK8sNodeFilesystemUsage {
+func newMetricK8sNodeFilesystemUsage(cfg K8sNodeFilesystemUsageMetricConfig) metricK8sNodeFilesystemUsage {
 	m := metricK8sNodeFilesystemUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -1537,9 +1582,9 @@ func newMetricK8sNodeFilesystemUsage(cfg MetricConfig) metricK8sNodeFilesystemUs
 }
 
 type metricK8sNodeMemoryAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sNodeMemoryAvailableMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.memory.available metric with initial data.
@@ -1576,7 +1621,7 @@ func (m *metricK8sNodeMemoryAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeMemoryAvailable(cfg MetricConfig) metricK8sNodeMemoryAvailable {
+func newMetricK8sNodeMemoryAvailable(cfg K8sNodeMemoryAvailableMetricConfig) metricK8sNodeMemoryAvailable {
 	m := metricK8sNodeMemoryAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -1587,9 +1632,9 @@ func newMetricK8sNodeMemoryAvailable(cfg MetricConfig) metricK8sNodeMemoryAvaila
 }
 
 type metricK8sNodeMemoryMajorPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   K8sNodeMemoryMajorPageFaultsMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.memory.major_page_faults metric with initial data.
@@ -1626,7 +1671,7 @@ func (m *metricK8sNodeMemoryMajorPageFaults) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeMemoryMajorPageFaults(cfg MetricConfig) metricK8sNodeMemoryMajorPageFaults {
+func newMetricK8sNodeMemoryMajorPageFaults(cfg K8sNodeMemoryMajorPageFaultsMetricConfig) metricK8sNodeMemoryMajorPageFaults {
 	m := metricK8sNodeMemoryMajorPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -1637,9 +1682,9 @@ func newMetricK8sNodeMemoryMajorPageFaults(cfg MetricConfig) metricK8sNodeMemory
 }
 
 type metricK8sNodeMemoryPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   K8sNodeMemoryPageFaultsMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.memory.page_faults metric with initial data.
@@ -1676,7 +1721,7 @@ func (m *metricK8sNodeMemoryPageFaults) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeMemoryPageFaults(cfg MetricConfig) metricK8sNodeMemoryPageFaults {
+func newMetricK8sNodeMemoryPageFaults(cfg K8sNodeMemoryPageFaultsMetricConfig) metricK8sNodeMemoryPageFaults {
 	m := metricK8sNodeMemoryPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -1687,9 +1732,9 @@ func newMetricK8sNodeMemoryPageFaults(cfg MetricConfig) metricK8sNodeMemoryPageF
 }
 
 type metricK8sNodeMemoryRss struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   K8sNodeMemoryRssMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.memory.rss metric with initial data.
@@ -1726,7 +1771,7 @@ func (m *metricK8sNodeMemoryRss) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeMemoryRss(cfg MetricConfig) metricK8sNodeMemoryRss {
+func newMetricK8sNodeMemoryRss(cfg K8sNodeMemoryRssMetricConfig) metricK8sNodeMemoryRss {
 	m := metricK8sNodeMemoryRss{config: cfg}
 
 	if cfg.Enabled {
@@ -1737,9 +1782,9 @@ func newMetricK8sNodeMemoryRss(cfg MetricConfig) metricK8sNodeMemoryRss {
 }
 
 type metricK8sNodeMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   K8sNodeMemoryUsageMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.memory.usage metric with initial data.
@@ -1776,7 +1821,7 @@ func (m *metricK8sNodeMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeMemoryUsage(cfg MetricConfig) metricK8sNodeMemoryUsage {
+func newMetricK8sNodeMemoryUsage(cfg K8sNodeMemoryUsageMetricConfig) metricK8sNodeMemoryUsage {
 	m := metricK8sNodeMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -1787,9 +1832,9 @@ func newMetricK8sNodeMemoryUsage(cfg MetricConfig) metricK8sNodeMemoryUsage {
 }
 
 type metricK8sNodeMemoryWorkingSet struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   K8sNodeMemoryWorkingSetMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.memory.working_set metric with initial data.
@@ -1826,7 +1871,7 @@ func (m *metricK8sNodeMemoryWorkingSet) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeMemoryWorkingSet(cfg MetricConfig) metricK8sNodeMemoryWorkingSet {
+func newMetricK8sNodeMemoryWorkingSet(cfg K8sNodeMemoryWorkingSetMetricConfig) metricK8sNodeMemoryWorkingSet {
 	m := metricK8sNodeMemoryWorkingSet{config: cfg}
 
 	if cfg.Enabled {
@@ -1837,9 +1882,10 @@ func newMetricK8sNodeMemoryWorkingSet(cfg MetricConfig) metricK8sNodeMemoryWorki
 }
 
 type metricK8sNodeNetworkErrors struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        K8sNodeNetworkErrorsMetricConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                          // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.node.network.errors metric with initial data.
@@ -1851,18 +1897,51 @@ func (m *metricK8sNodeNetworkErrors) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sNodeNetworkErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sNodeNetworkErrorsMetricAttributeKeyInterface) {
+		dp.Attributes().PutStr("interface", interfaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, K8sNodeNetworkErrorsMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1875,13 +1954,18 @@ func (m *metricK8sNodeNetworkErrors) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeNetworkErrors) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeNetworkErrors(cfg MetricConfig) metricK8sNodeNetworkErrors {
+func newMetricK8sNodeNetworkErrors(cfg K8sNodeNetworkErrorsMetricConfig) metricK8sNodeNetworkErrors {
 	m := metricK8sNodeNetworkErrors{config: cfg}
 
 	if cfg.Enabled {
@@ -1892,9 +1976,10 @@ func newMetricK8sNodeNetworkErrors(cfg MetricConfig) metricK8sNodeNetworkErrors 
 }
 
 type metricK8sNodeNetworkIo struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric               // data buffer for generated metric.
+	config        K8sNodeNetworkIoMetricConfig // metric config provided by user.
+	capacity      int                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                      // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.node.network.io metric with initial data.
@@ -1906,18 +1991,51 @@ func (m *metricK8sNodeNetworkIo) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sNodeNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sNodeNetworkIoMetricAttributeKeyInterface) {
+		dp.Attributes().PutStr("interface", interfaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, K8sNodeNetworkIoMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1930,13 +2048,18 @@ func (m *metricK8sNodeNetworkIo) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeNetworkIo) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeNetworkIo(cfg MetricConfig) metricK8sNodeNetworkIo {
+func newMetricK8sNodeNetworkIo(cfg K8sNodeNetworkIoMetricConfig) metricK8sNodeNetworkIo {
 	m := metricK8sNodeNetworkIo{config: cfg}
 
 	if cfg.Enabled {
@@ -1947,9 +2070,9 @@ func newMetricK8sNodeNetworkIo(cfg MetricConfig) metricK8sNodeNetworkIo {
 }
 
 type metricK8sNodeSystemContainerCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   K8sNodeSystemContainerCPUTimeMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.system_container.cpu.time metric with initial data.
@@ -1988,7 +2111,7 @@ func (m *metricK8sNodeSystemContainerCPUTime) emit(metrics pmetric.MetricSlice) 
 	}
 }
 
-func newMetricK8sNodeSystemContainerCPUTime(cfg MetricConfig) metricK8sNodeSystemContainerCPUTime {
+func newMetricK8sNodeSystemContainerCPUTime(cfg K8sNodeSystemContainerCPUTimeMetricConfig) metricK8sNodeSystemContainerCPUTime {
 	m := metricK8sNodeSystemContainerCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -1999,9 +2122,9 @@ func newMetricK8sNodeSystemContainerCPUTime(cfg MetricConfig) metricK8sNodeSyste
 }
 
 type metricK8sNodeSystemContainerCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                             // data buffer for generated metric.
+	config   K8sNodeSystemContainerCPUUsageMetricConfig // metric config provided by user.
+	capacity int                                        // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.system_container.cpu.usage metric with initial data.
@@ -2038,7 +2161,7 @@ func (m *metricK8sNodeSystemContainerCPUUsage) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricK8sNodeSystemContainerCPUUsage(cfg MetricConfig) metricK8sNodeSystemContainerCPUUsage {
+func newMetricK8sNodeSystemContainerCPUUsage(cfg K8sNodeSystemContainerCPUUsageMetricConfig) metricK8sNodeSystemContainerCPUUsage {
 	m := metricK8sNodeSystemContainerCPUUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -2049,9 +2172,9 @@ func newMetricK8sNodeSystemContainerCPUUsage(cfg MetricConfig) metricK8sNodeSyst
 }
 
 type metricK8sNodeSystemContainerMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                // data buffer for generated metric.
+	config   K8sNodeSystemContainerMemoryUsageMetricConfig // metric config provided by user.
+	capacity int                                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.system_container.memory.usage metric with initial data.
@@ -2088,7 +2211,7 @@ func (m *metricK8sNodeSystemContainerMemoryUsage) emit(metrics pmetric.MetricSli
 	}
 }
 
-func newMetricK8sNodeSystemContainerMemoryUsage(cfg MetricConfig) metricK8sNodeSystemContainerMemoryUsage {
+func newMetricK8sNodeSystemContainerMemoryUsage(cfg K8sNodeSystemContainerMemoryUsageMetricConfig) metricK8sNodeSystemContainerMemoryUsage {
 	m := metricK8sNodeSystemContainerMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -2099,9 +2222,9 @@ func newMetricK8sNodeSystemContainerMemoryUsage(cfg MetricConfig) metricK8sNodeS
 }
 
 type metricK8sNodeSystemContainerMemoryWorkingSet struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   K8sNodeSystemContainerMemoryWorkingSetMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.system_container.memory.working_set metric with initial data.
@@ -2138,7 +2261,7 @@ func (m *metricK8sNodeSystemContainerMemoryWorkingSet) emit(metrics pmetric.Metr
 	}
 }
 
-func newMetricK8sNodeSystemContainerMemoryWorkingSet(cfg MetricConfig) metricK8sNodeSystemContainerMemoryWorkingSet {
+func newMetricK8sNodeSystemContainerMemoryWorkingSet(cfg K8sNodeSystemContainerMemoryWorkingSetMetricConfig) metricK8sNodeSystemContainerMemoryWorkingSet {
 	m := metricK8sNodeSystemContainerMemoryWorkingSet{config: cfg}
 
 	if cfg.Enabled {
@@ -2149,9 +2272,9 @@ func newMetricK8sNodeSystemContainerMemoryWorkingSet(cfg MetricConfig) metricK8s
 }
 
 type metricK8sNodeUptime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   K8sNodeUptimeMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills k8s.node.uptime metric with initial data.
@@ -2190,7 +2313,7 @@ func (m *metricK8sNodeUptime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sNodeUptime(cfg MetricConfig) metricK8sNodeUptime {
+func newMetricK8sNodeUptime(cfg K8sNodeUptimeMetricConfig) metricK8sNodeUptime {
 	m := metricK8sNodeUptime{config: cfg}
 
 	if cfg.Enabled {
@@ -2201,9 +2324,9 @@ func newMetricK8sNodeUptime(cfg MetricConfig) metricK8sNodeUptime {
 }
 
 type metricK8sPodCPUNodeUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   K8sPodCPUNodeUtilizationMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.cpu.node.utilization metric with initial data.
@@ -2240,7 +2363,7 @@ func (m *metricK8sPodCPUNodeUtilization) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodCPUNodeUtilization(cfg MetricConfig) metricK8sPodCPUNodeUtilization {
+func newMetricK8sPodCPUNodeUtilization(cfg K8sPodCPUNodeUtilizationMetricConfig) metricK8sPodCPUNodeUtilization {
 	m := metricK8sPodCPUNodeUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -2251,9 +2374,9 @@ func newMetricK8sPodCPUNodeUtilization(cfg MetricConfig) metricK8sPodCPUNodeUtil
 }
 
 type metricK8sPodCPUTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   K8sPodCPUTimeMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.cpu.time metric with initial data.
@@ -2292,7 +2415,7 @@ func (m *metricK8sPodCPUTime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodCPUTime(cfg MetricConfig) metricK8sPodCPUTime {
+func newMetricK8sPodCPUTime(cfg K8sPodCPUTimeMetricConfig) metricK8sPodCPUTime {
 	m := metricK8sPodCPUTime{config: cfg}
 
 	if cfg.Enabled {
@@ -2303,9 +2426,9 @@ func newMetricK8sPodCPUTime(cfg MetricConfig) metricK8sPodCPUTime {
 }
 
 type metricK8sPodCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   K8sPodCPUUsageMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.cpu.usage metric with initial data.
@@ -2342,7 +2465,7 @@ func (m *metricK8sPodCPUUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodCPUUsage(cfg MetricConfig) metricK8sPodCPUUsage {
+func newMetricK8sPodCPUUsage(cfg K8sPodCPUUsageMetricConfig) metricK8sPodCPUUsage {
 	m := metricK8sPodCPUUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -2353,9 +2476,9 @@ func newMetricK8sPodCPUUsage(cfg MetricConfig) metricK8sPodCPUUsage {
 }
 
 type metricK8sPodCPULimitUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sPodCPULimitUtilizationMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.cpu_limit_utilization metric with initial data.
@@ -2392,7 +2515,7 @@ func (m *metricK8sPodCPULimitUtilization) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodCPULimitUtilization(cfg MetricConfig) metricK8sPodCPULimitUtilization {
+func newMetricK8sPodCPULimitUtilization(cfg K8sPodCPULimitUtilizationMetricConfig) metricK8sPodCPULimitUtilization {
 	m := metricK8sPodCPULimitUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -2403,9 +2526,9 @@ func newMetricK8sPodCPULimitUtilization(cfg MetricConfig) metricK8sPodCPULimitUt
 }
 
 type metricK8sPodCPURequestUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   K8sPodCPURequestUtilizationMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.cpu_request_utilization metric with initial data.
@@ -2442,7 +2565,7 @@ func (m *metricK8sPodCPURequestUtilization) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodCPURequestUtilization(cfg MetricConfig) metricK8sPodCPURequestUtilization {
+func newMetricK8sPodCPURequestUtilization(cfg K8sPodCPURequestUtilizationMetricConfig) metricK8sPodCPURequestUtilization {
 	m := metricK8sPodCPURequestUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -2453,9 +2576,9 @@ func newMetricK8sPodCPURequestUtilization(cfg MetricConfig) metricK8sPodCPUReque
 }
 
 type metricK8sPodFilesystemAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   K8sPodFilesystemAvailableMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.filesystem.available metric with initial data.
@@ -2492,7 +2615,7 @@ func (m *metricK8sPodFilesystemAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodFilesystemAvailable(cfg MetricConfig) metricK8sPodFilesystemAvailable {
+func newMetricK8sPodFilesystemAvailable(cfg K8sPodFilesystemAvailableMetricConfig) metricK8sPodFilesystemAvailable {
 	m := metricK8sPodFilesystemAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -2503,9 +2626,9 @@ func newMetricK8sPodFilesystemAvailable(cfg MetricConfig) metricK8sPodFilesystem
 }
 
 type metricK8sPodFilesystemCapacity struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                       // data buffer for generated metric.
+	config   K8sPodFilesystemCapacityMetricConfig // metric config provided by user.
+	capacity int                                  // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.filesystem.capacity metric with initial data.
@@ -2542,7 +2665,7 @@ func (m *metricK8sPodFilesystemCapacity) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodFilesystemCapacity(cfg MetricConfig) metricK8sPodFilesystemCapacity {
+func newMetricK8sPodFilesystemCapacity(cfg K8sPodFilesystemCapacityMetricConfig) metricK8sPodFilesystemCapacity {
 	m := metricK8sPodFilesystemCapacity{config: cfg}
 
 	if cfg.Enabled {
@@ -2553,9 +2676,9 @@ func newMetricK8sPodFilesystemCapacity(cfg MetricConfig) metricK8sPodFilesystemC
 }
 
 type metricK8sPodFilesystemUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   K8sPodFilesystemUsageMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.filesystem.usage metric with initial data.
@@ -2592,7 +2715,7 @@ func (m *metricK8sPodFilesystemUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodFilesystemUsage(cfg MetricConfig) metricK8sPodFilesystemUsage {
+func newMetricK8sPodFilesystemUsage(cfg K8sPodFilesystemUsageMetricConfig) metricK8sPodFilesystemUsage {
 	m := metricK8sPodFilesystemUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -2603,9 +2726,9 @@ func newMetricK8sPodFilesystemUsage(cfg MetricConfig) metricK8sPodFilesystemUsag
 }
 
 type metricK8sPodMemoryAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   K8sPodMemoryAvailableMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.available metric with initial data.
@@ -2642,7 +2765,7 @@ func (m *metricK8sPodMemoryAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryAvailable(cfg MetricConfig) metricK8sPodMemoryAvailable {
+func newMetricK8sPodMemoryAvailable(cfg K8sPodMemoryAvailableMetricConfig) metricK8sPodMemoryAvailable {
 	m := metricK8sPodMemoryAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -2653,9 +2776,9 @@ func newMetricK8sPodMemoryAvailable(cfg MetricConfig) metricK8sPodMemoryAvailabl
 }
 
 type metricK8sPodMemoryMajorPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   K8sPodMemoryMajorPageFaultsMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.major_page_faults metric with initial data.
@@ -2692,7 +2815,7 @@ func (m *metricK8sPodMemoryMajorPageFaults) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryMajorPageFaults(cfg MetricConfig) metricK8sPodMemoryMajorPageFaults {
+func newMetricK8sPodMemoryMajorPageFaults(cfg K8sPodMemoryMajorPageFaultsMetricConfig) metricK8sPodMemoryMajorPageFaults {
 	m := metricK8sPodMemoryMajorPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -2703,9 +2826,9 @@ func newMetricK8sPodMemoryMajorPageFaults(cfg MetricConfig) metricK8sPodMemoryMa
 }
 
 type metricK8sPodMemoryNodeUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   K8sPodMemoryNodeUtilizationMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.node.utilization metric with initial data.
@@ -2742,7 +2865,7 @@ func (m *metricK8sPodMemoryNodeUtilization) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryNodeUtilization(cfg MetricConfig) metricK8sPodMemoryNodeUtilization {
+func newMetricK8sPodMemoryNodeUtilization(cfg K8sPodMemoryNodeUtilizationMetricConfig) metricK8sPodMemoryNodeUtilization {
 	m := metricK8sPodMemoryNodeUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -2753,9 +2876,9 @@ func newMetricK8sPodMemoryNodeUtilization(cfg MetricConfig) metricK8sPodMemoryNo
 }
 
 type metricK8sPodMemoryPageFaults struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sPodMemoryPageFaultsMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.page_faults metric with initial data.
@@ -2792,7 +2915,7 @@ func (m *metricK8sPodMemoryPageFaults) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryPageFaults(cfg MetricConfig) metricK8sPodMemoryPageFaults {
+func newMetricK8sPodMemoryPageFaults(cfg K8sPodMemoryPageFaultsMetricConfig) metricK8sPodMemoryPageFaults {
 	m := metricK8sPodMemoryPageFaults{config: cfg}
 
 	if cfg.Enabled {
@@ -2803,9 +2926,9 @@ func newMetricK8sPodMemoryPageFaults(cfg MetricConfig) metricK8sPodMemoryPageFau
 }
 
 type metricK8sPodMemoryRss struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric              // data buffer for generated metric.
+	config   K8sPodMemoryRssMetricConfig // metric config provided by user.
+	capacity int                         // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.rss metric with initial data.
@@ -2842,7 +2965,7 @@ func (m *metricK8sPodMemoryRss) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryRss(cfg MetricConfig) metricK8sPodMemoryRss {
+func newMetricK8sPodMemoryRss(cfg K8sPodMemoryRssMetricConfig) metricK8sPodMemoryRss {
 	m := metricK8sPodMemoryRss{config: cfg}
 
 	if cfg.Enabled {
@@ -2853,9 +2976,9 @@ func newMetricK8sPodMemoryRss(cfg MetricConfig) metricK8sPodMemoryRss {
 }
 
 type metricK8sPodMemoryUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sPodMemoryUsageMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.usage metric with initial data.
@@ -2892,7 +3015,7 @@ func (m *metricK8sPodMemoryUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryUsage(cfg MetricConfig) metricK8sPodMemoryUsage {
+func newMetricK8sPodMemoryUsage(cfg K8sPodMemoryUsageMetricConfig) metricK8sPodMemoryUsage {
 	m := metricK8sPodMemoryUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -2903,9 +3026,9 @@ func newMetricK8sPodMemoryUsage(cfg MetricConfig) metricK8sPodMemoryUsage {
 }
 
 type metricK8sPodMemoryWorkingSet struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   K8sPodMemoryWorkingSetMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory.working_set metric with initial data.
@@ -2942,7 +3065,7 @@ func (m *metricK8sPodMemoryWorkingSet) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryWorkingSet(cfg MetricConfig) metricK8sPodMemoryWorkingSet {
+func newMetricK8sPodMemoryWorkingSet(cfg K8sPodMemoryWorkingSetMetricConfig) metricK8sPodMemoryWorkingSet {
 	m := metricK8sPodMemoryWorkingSet{config: cfg}
 
 	if cfg.Enabled {
@@ -2953,9 +3076,9 @@ func newMetricK8sPodMemoryWorkingSet(cfg MetricConfig) metricK8sPodMemoryWorking
 }
 
 type metricK8sPodMemoryLimitUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   K8sPodMemoryLimitUtilizationMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory_limit_utilization metric with initial data.
@@ -2992,7 +3115,7 @@ func (m *metricK8sPodMemoryLimitUtilization) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodMemoryLimitUtilization(cfg MetricConfig) metricK8sPodMemoryLimitUtilization {
+func newMetricK8sPodMemoryLimitUtilization(cfg K8sPodMemoryLimitUtilizationMetricConfig) metricK8sPodMemoryLimitUtilization {
 	m := metricK8sPodMemoryLimitUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -3003,9 +3126,9 @@ func newMetricK8sPodMemoryLimitUtilization(cfg MetricConfig) metricK8sPodMemoryL
 }
 
 type metricK8sPodMemoryRequestUtilization struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                             // data buffer for generated metric.
+	config   K8sPodMemoryRequestUtilizationMetricConfig // metric config provided by user.
+	capacity int                                        // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.memory_request_utilization metric with initial data.
@@ -3042,7 +3165,7 @@ func (m *metricK8sPodMemoryRequestUtilization) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricK8sPodMemoryRequestUtilization(cfg MetricConfig) metricK8sPodMemoryRequestUtilization {
+func newMetricK8sPodMemoryRequestUtilization(cfg K8sPodMemoryRequestUtilizationMetricConfig) metricK8sPodMemoryRequestUtilization {
 	m := metricK8sPodMemoryRequestUtilization{config: cfg}
 
 	if cfg.Enabled {
@@ -3053,9 +3176,10 @@ func newMetricK8sPodMemoryRequestUtilization(cfg MetricConfig) metricK8sPodMemor
 }
 
 type metricK8sPodNetworkErrors struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        K8sPodNetworkErrorsMetricConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.pod.network.errors metric with initial data.
@@ -3067,18 +3191,51 @@ func (m *metricK8sPodNetworkErrors) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sPodNetworkErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sPodNetworkErrorsMetricAttributeKeyInterface) {
+		dp.Attributes().PutStr("interface", interfaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, K8sPodNetworkErrorsMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3091,13 +3248,18 @@ func (m *metricK8sPodNetworkErrors) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodNetworkErrors) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodNetworkErrors(cfg MetricConfig) metricK8sPodNetworkErrors {
+func newMetricK8sPodNetworkErrors(cfg K8sPodNetworkErrorsMetricConfig) metricK8sPodNetworkErrors {
 	m := metricK8sPodNetworkErrors{config: cfg}
 
 	if cfg.Enabled {
@@ -3108,9 +3270,10 @@ func newMetricK8sPodNetworkErrors(cfg MetricConfig) metricK8sPodNetworkErrors {
 }
 
 type metricK8sPodNetworkIo struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric              // data buffer for generated metric.
+	config        K8sPodNetworkIoMetricConfig // metric config provided by user.
+	capacity      int                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                     // slice containing number of aggregated datapoints at each index
 }
 
 // init fills k8s.pod.network.io metric with initial data.
@@ -3122,18 +3285,51 @@ func (m *metricK8sPodNetworkIo) init() {
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricK8sPodNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, K8sPodNetworkIoMetricAttributeKeyInterface) {
+		dp.Attributes().PutStr("interface", interfaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, K8sPodNetworkIoMetricAttributeKeyDirection) {
+		dp.Attributes().PutStr("direction", directionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("interface", interfaceAttributeValue)
-	dp.Attributes().PutStr("direction", directionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3146,13 +3342,18 @@ func (m *metricK8sPodNetworkIo) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodNetworkIo) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodNetworkIo(cfg MetricConfig) metricK8sPodNetworkIo {
+func newMetricK8sPodNetworkIo(cfg K8sPodNetworkIoMetricConfig) metricK8sPodNetworkIo {
 	m := metricK8sPodNetworkIo{config: cfg}
 
 	if cfg.Enabled {
@@ -3163,9 +3364,9 @@ func newMetricK8sPodNetworkIo(cfg MetricConfig) metricK8sPodNetworkIo {
 }
 
 type metricK8sPodUptime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric           // data buffer for generated metric.
+	config   K8sPodUptimeMetricConfig // metric config provided by user.
+	capacity int                      // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.uptime metric with initial data.
@@ -3204,7 +3405,7 @@ func (m *metricK8sPodUptime) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodUptime(cfg MetricConfig) metricK8sPodUptime {
+func newMetricK8sPodUptime(cfg K8sPodUptimeMetricConfig) metricK8sPodUptime {
 	m := metricK8sPodUptime{config: cfg}
 
 	if cfg.Enabled {
@@ -3215,9 +3416,9 @@ func newMetricK8sPodUptime(cfg MetricConfig) metricK8sPodUptime {
 }
 
 type metricK8sPodVolumeUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sPodVolumeUsageMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.pod.volume.usage metric with initial data.
@@ -3256,7 +3457,7 @@ func (m *metricK8sPodVolumeUsage) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sPodVolumeUsage(cfg MetricConfig) metricK8sPodVolumeUsage {
+func newMetricK8sPodVolumeUsage(cfg K8sPodVolumeUsageMetricConfig) metricK8sPodVolumeUsage {
 	m := metricK8sPodVolumeUsage{config: cfg}
 
 	if cfg.Enabled {
@@ -3267,9 +3468,9 @@ func newMetricK8sPodVolumeUsage(cfg MetricConfig) metricK8sPodVolumeUsage {
 }
 
 type metricK8sVolumeAvailable struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   K8sVolumeAvailableMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
 // init fills k8s.volume.available metric with initial data.
@@ -3306,7 +3507,7 @@ func (m *metricK8sVolumeAvailable) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sVolumeAvailable(cfg MetricConfig) metricK8sVolumeAvailable {
+func newMetricK8sVolumeAvailable(cfg K8sVolumeAvailableMetricConfig) metricK8sVolumeAvailable {
 	m := metricK8sVolumeAvailable{config: cfg}
 
 	if cfg.Enabled {
@@ -3317,9 +3518,9 @@ func newMetricK8sVolumeAvailable(cfg MetricConfig) metricK8sVolumeAvailable {
 }
 
 type metricK8sVolumeCapacity struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   K8sVolumeCapacityMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
 }
 
 // init fills k8s.volume.capacity metric with initial data.
@@ -3356,7 +3557,7 @@ func (m *metricK8sVolumeCapacity) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sVolumeCapacity(cfg MetricConfig) metricK8sVolumeCapacity {
+func newMetricK8sVolumeCapacity(cfg K8sVolumeCapacityMetricConfig) metricK8sVolumeCapacity {
 	m := metricK8sVolumeCapacity{config: cfg}
 
 	if cfg.Enabled {
@@ -3367,9 +3568,9 @@ func newMetricK8sVolumeCapacity(cfg MetricConfig) metricK8sVolumeCapacity {
 }
 
 type metricK8sVolumeInodes struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric              // data buffer for generated metric.
+	config   K8sVolumeInodesMetricConfig // metric config provided by user.
+	capacity int                         // max observed number of data points added to the metric.
 }
 
 // init fills k8s.volume.inodes metric with initial data.
@@ -3406,7 +3607,7 @@ func (m *metricK8sVolumeInodes) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sVolumeInodes(cfg MetricConfig) metricK8sVolumeInodes {
+func newMetricK8sVolumeInodes(cfg K8sVolumeInodesMetricConfig) metricK8sVolumeInodes {
 	m := metricK8sVolumeInodes{config: cfg}
 
 	if cfg.Enabled {
@@ -3417,9 +3618,9 @@ func newMetricK8sVolumeInodes(cfg MetricConfig) metricK8sVolumeInodes {
 }
 
 type metricK8sVolumeInodesFree struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   K8sVolumeInodesFreeMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
 }
 
 // init fills k8s.volume.inodes.free metric with initial data.
@@ -3456,7 +3657,7 @@ func (m *metricK8sVolumeInodesFree) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sVolumeInodesFree(cfg MetricConfig) metricK8sVolumeInodesFree {
+func newMetricK8sVolumeInodesFree(cfg K8sVolumeInodesFreeMetricConfig) metricK8sVolumeInodesFree {
 	m := metricK8sVolumeInodesFree{config: cfg}
 
 	if cfg.Enabled {
@@ -3467,9 +3668,9 @@ func newMetricK8sVolumeInodesFree(cfg MetricConfig) metricK8sVolumeInodesFree {
 }
 
 type metricK8sVolumeInodesUsed struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   K8sVolumeInodesUsedMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
 }
 
 // init fills k8s.volume.inodes.used metric with initial data.
@@ -3506,7 +3707,7 @@ func (m *metricK8sVolumeInodesUsed) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricK8sVolumeInodesUsed(cfg MetricConfig) metricK8sVolumeInodesUsed {
+func newMetricK8sVolumeInodesUsed(cfg K8sVolumeInodesUsedMetricConfig) metricK8sVolumeInodesUsed {
 	m := metricK8sVolumeInodesUsed{config: cfg}
 
 	if cfg.Enabled {

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,6 +66,12 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["k8s.container.ephemeral_storage.usage"] = mb.metricK8sContainerEphemeralStorageUsage.config.AggregationStrategy
+			aggMap["k8s.node.network.errors"] = mb.metricK8sNodeNetworkErrors.config.AggregationStrategy
+			aggMap["k8s.node.network.io"] = mb.metricK8sNodeNetworkIo.config.AggregationStrategy
+			aggMap["k8s.pod.network.errors"] = mb.metricK8sPodNetworkErrors.config.AggregationStrategy
+			aggMap["k8s.pod.network.io"] = mb.metricK8sPodNetworkIo.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.resAttrsSet == testDataSetAll {
@@ -86,7 +98,9 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Equal(t, "[WARNING] `partition` should not be enabled: This resource_attribute is deprecated and will be removed soon", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -149,6 +163,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordK8sContainerEphemeralStorageUsageDataPoint(ts, 1, AttributeFsTypeRootfs)
+			if tt.name == "reaggregate_set" {
+				mb.RecordK8sContainerEphemeralStorageUsageDataPoint(ts, 3, AttributeFsTypeLogs)
+			}
 
 			allMetricsCount++
 			mb.RecordK8sContainerMemoryNodeUtilizationDataPoint(ts, 1)
@@ -206,10 +223,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordK8sNodeNetworkErrorsDataPoint(ts, 1, "interface-val", AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordK8sNodeNetworkErrorsDataPoint(ts, 3, "interface-val-2", AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordK8sNodeNetworkIoDataPoint(ts, 1, "interface-val", AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordK8sNodeNetworkIoDataPoint(ts, 3, "interface-val-2", AttributeDirectionTransmit)
+			}
 
 			allMetricsCount++
 			mb.RecordK8sNodeSystemContainerCPUTimeDataPoint(ts, 1)
@@ -291,10 +314,16 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordK8sPodNetworkErrorsDataPoint(ts, 1, "interface-val", AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordK8sPodNetworkErrorsDataPoint(ts, 3, "interface-val-2", AttributeDirectionTransmit)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordK8sPodNetworkIoDataPoint(ts, 1, "interface-val", AttributeDirectionReceive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordK8sPodNetworkIoDataPoint(ts, 3, "interface-val-2", AttributeDirectionTransmit)
+			}
 
 			allMetricsCount++
 			mb.RecordK8sPodUptimeDataPoint(ts, 1)
@@ -341,6 +370,13 @@ func TestMetricsBuilder(t *testing.T) {
 			rb.SetPartition("partition-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricK8sContainerEphemeralStorageUsage.aggDataPoints)
+				assert.Empty(t, mb.metricK8sNodeNetworkErrors.aggDataPoints)
+				assert.Empty(t, mb.metricK8sNodeNetworkIo.aggDataPoints)
+				assert.Empty(t, mb.metricK8sPodNetworkErrors.aggDataPoints)
+				assert.Empty(t, mb.metricK8sPodNetworkIo.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -552,22 +588,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "k8s.container.ephemeral_storage.usage":
-					assert.False(t, validatedMetrics["k8s.container.ephemeral_storage.usage"], "Found a duplicate in the metrics slice: k8s.container.ephemeral_storage.usage")
-					validatedMetrics["k8s.container.ephemeral_storage.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Ephemeral storage used by the container.", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.False(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					fsTypeAttrVal, ok := dp.Attributes().Get("fs.type")
-					assert.True(t, ok)
-					assert.Equal(t, "rootfs", fsTypeAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.container.ephemeral_storage.usage"], "Found a duplicate in the metrics slice: k8s.container.ephemeral_storage.usage")
+						validatedMetrics["k8s.container.ephemeral_storage.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Ephemeral storage used by the container.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						fsTypeAttrVal, ok := dp.Attributes().Get("fs.type")
+						assert.True(t, ok)
+						assert.Equal(t, "rootfs", fsTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.container.ephemeral_storage.usage"], "Found a duplicate in the metrics slice: k8s.container.ephemeral_storage.usage")
+						validatedMetrics["k8s.container.ephemeral_storage.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Ephemeral storage used by the container.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.container.ephemeral_storage.usage"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("fs.type")
+						assert.False(t, ok)
+					}
 				case "k8s.container.memory.node.utilization":
 					assert.False(t, validatedMetrics["k8s.container.memory.node.utilization"], "Found a duplicate in the metrics slice: k8s.container.memory.node.utilization")
 					validatedMetrics["k8s.container.memory.node.utilization"] = true
@@ -739,45 +802,103 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "k8s.node.network.errors":
-					assert.False(t, validatedMetrics["k8s.node.network.errors"], "Found a duplicate in the metrics slice: k8s.node.network.errors")
-					validatedMetrics["k8s.node.network.errors"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Node network errors", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					interfaceAttrVal, ok := dp.Attributes().Get("interface")
-					assert.True(t, ok)
-					assert.Equal(t, "interface-val", interfaceAttrVal.Str())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.node.network.errors"], "Found a duplicate in the metrics slice: k8s.node.network.errors")
+						validatedMetrics["k8s.node.network.errors"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Node network errors", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						interfaceAttrVal, ok := dp.Attributes().Get("interface")
+						assert.True(t, ok)
+						assert.Equal(t, "interface-val", interfaceAttrVal.Str())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.node.network.errors"], "Found a duplicate in the metrics slice: k8s.node.network.errors")
+						validatedMetrics["k8s.node.network.errors"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Node network errors", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.node.network.errors"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("interface")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "k8s.node.network.io":
-					assert.False(t, validatedMetrics["k8s.node.network.io"], "Found a duplicate in the metrics slice: k8s.node.network.io")
-					validatedMetrics["k8s.node.network.io"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Node network IO", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					interfaceAttrVal, ok := dp.Attributes().Get("interface")
-					assert.True(t, ok)
-					assert.Equal(t, "interface-val", interfaceAttrVal.Str())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.node.network.io"], "Found a duplicate in the metrics slice: k8s.node.network.io")
+						validatedMetrics["k8s.node.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Node network IO", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						interfaceAttrVal, ok := dp.Attributes().Get("interface")
+						assert.True(t, ok)
+						assert.Equal(t, "interface-val", interfaceAttrVal.Str())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.node.network.io"], "Found a duplicate in the metrics slice: k8s.node.network.io")
+						validatedMetrics["k8s.node.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Node network IO", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.node.network.io"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("interface")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "k8s.node.system_container.cpu.time":
 					assert.False(t, validatedMetrics["k8s.node.system_container.cpu.time"], "Found a duplicate in the metrics slice: k8s.node.system_container.cpu.time")
 					validatedMetrics["k8s.node.system_container.cpu.time"] = true
@@ -1049,45 +1170,103 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "k8s.pod.network.errors":
-					assert.False(t, validatedMetrics["k8s.pod.network.errors"], "Found a duplicate in the metrics slice: k8s.pod.network.errors")
-					validatedMetrics["k8s.pod.network.errors"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Pod network errors", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					interfaceAttrVal, ok := dp.Attributes().Get("interface")
-					assert.True(t, ok)
-					assert.Equal(t, "interface-val", interfaceAttrVal.Str())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.pod.network.errors"], "Found a duplicate in the metrics slice: k8s.pod.network.errors")
+						validatedMetrics["k8s.pod.network.errors"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Pod network errors", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						interfaceAttrVal, ok := dp.Attributes().Get("interface")
+						assert.True(t, ok)
+						assert.Equal(t, "interface-val", interfaceAttrVal.Str())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.pod.network.errors"], "Found a duplicate in the metrics slice: k8s.pod.network.errors")
+						validatedMetrics["k8s.pod.network.errors"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Pod network errors", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.pod.network.errors"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("interface")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "k8s.pod.network.io":
-					assert.False(t, validatedMetrics["k8s.pod.network.io"], "Found a duplicate in the metrics slice: k8s.pod.network.io")
-					validatedMetrics["k8s.pod.network.io"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Pod network IO", mi.Description())
-					assert.Equal(t, "By", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					interfaceAttrVal, ok := dp.Attributes().Get("interface")
-					assert.True(t, ok)
-					assert.Equal(t, "interface-val", interfaceAttrVal.Str())
-					directionAttrVal, ok := dp.Attributes().Get("direction")
-					assert.True(t, ok)
-					assert.Equal(t, "receive", directionAttrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["k8s.pod.network.io"], "Found a duplicate in the metrics slice: k8s.pod.network.io")
+						validatedMetrics["k8s.pod.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Pod network IO", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						interfaceAttrVal, ok := dp.Attributes().Get("interface")
+						assert.True(t, ok)
+						assert.Equal(t, "interface-val", interfaceAttrVal.Str())
+						directionAttrVal, ok := dp.Attributes().Get("direction")
+						assert.True(t, ok)
+						assert.Equal(t, "receive", directionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["k8s.pod.network.io"], "Found a duplicate in the metrics slice: k8s.pod.network.io")
+						validatedMetrics["k8s.pod.network.io"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Pod network IO", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["k8s.pod.network.io"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("interface")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("direction")
+						assert.False(t, ok)
+					}
 				case "k8s.pod.uptime":
 					assert.False(t, validatedMetrics["k8s.pod.uptime"], "Found a duplicate in the metrics slice: k8s.pod.uptime")
 					validatedMetrics["k8s.pod.uptime"] = true

--- a/receiver/kubeletstatsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/internal/metadata/testdata/config.yaml
@@ -33,6 +33,7 @@ all_set:
       enabled: true
     k8s.container.ephemeral_storage.usage:
       enabled: true
+      attributes: ["fs.type"]
     k8s.container.memory.node.utilization:
       enabled: true
     k8s.container.memory_limit_utilization:
@@ -63,8 +64,10 @@ all_set:
       enabled: true
     k8s.node.network.errors:
       enabled: true
+      attributes: ["interface","direction"]
     k8s.node.network.io:
       enabled: true
+      attributes: ["interface","direction"]
     k8s.node.system_container.cpu.time:
       enabled: true
     k8s.node.system_container.cpu.usage:
@@ -111,8 +114,176 @@ all_set:
       enabled: true
     k8s.pod.network.errors:
       enabled: true
+      attributes: ["interface","direction"]
     k8s.pod.network.io:
       enabled: true
+      attributes: ["interface","direction"]
+    k8s.pod.uptime:
+      enabled: true
+    k8s.pod.volume.usage:
+      enabled: true
+    k8s.volume.available:
+      enabled: true
+    k8s.volume.capacity:
+      enabled: true
+    k8s.volume.inodes:
+      enabled: true
+    k8s.volume.inodes.free:
+      enabled: true
+    k8s.volume.inodes.used:
+      enabled: true
+  resource_attributes:
+    aws.volume.id:
+      enabled: true
+    container.id:
+      enabled: true
+    fs.type:
+      enabled: true
+    gce.pd.name:
+      enabled: true
+    glusterfs.endpoints.name:
+      enabled: true
+    glusterfs.path:
+      enabled: true
+    k8s.container.name:
+      enabled: true
+    k8s.namespace.name:
+      enabled: true
+    k8s.node.name:
+      enabled: true
+    k8s.node.system_container.name:
+      enabled: true
+    k8s.persistentvolumeclaim.name:
+      enabled: true
+    k8s.pod.name:
+      enabled: true
+    k8s.pod.uid:
+      enabled: true
+    k8s.volume.name:
+      enabled: true
+    k8s.volume.type:
+      enabled: true
+    partition:
+      enabled: true
+reaggregate_set:
+  metrics:
+    container.cpu.time:
+      enabled: true
+    container.cpu.usage:
+      enabled: true
+    container.filesystem.available:
+      enabled: true
+    container.filesystem.capacity:
+      enabled: true
+    container.filesystem.usage:
+      enabled: true
+    container.memory.available:
+      enabled: true
+    container.memory.major_page_faults:
+      enabled: true
+    container.memory.page_faults:
+      enabled: true
+    container.memory.rss:
+      enabled: true
+    container.memory.usage:
+      enabled: true
+    container.memory.working_set:
+      enabled: true
+    container.uptime:
+      enabled: true
+    k8s.container.cpu.node.utilization:
+      enabled: true
+    k8s.container.cpu_limit_utilization:
+      enabled: true
+    k8s.container.cpu_request_utilization:
+      enabled: true
+    k8s.container.ephemeral_storage.usage:
+      enabled: true
+      attributes: []
+    k8s.container.memory.node.utilization:
+      enabled: true
+    k8s.container.memory_limit_utilization:
+      enabled: true
+    k8s.container.memory_request_utilization:
+      enabled: true
+    k8s.node.cpu.time:
+      enabled: true
+    k8s.node.cpu.usage:
+      enabled: true
+    k8s.node.filesystem.available:
+      enabled: true
+    k8s.node.filesystem.capacity:
+      enabled: true
+    k8s.node.filesystem.usage:
+      enabled: true
+    k8s.node.memory.available:
+      enabled: true
+    k8s.node.memory.major_page_faults:
+      enabled: true
+    k8s.node.memory.page_faults:
+      enabled: true
+    k8s.node.memory.rss:
+      enabled: true
+    k8s.node.memory.usage:
+      enabled: true
+    k8s.node.memory.working_set:
+      enabled: true
+    k8s.node.network.errors:
+      enabled: true
+      attributes: []
+    k8s.node.network.io:
+      enabled: true
+      attributes: []
+    k8s.node.system_container.cpu.time:
+      enabled: true
+    k8s.node.system_container.cpu.usage:
+      enabled: true
+    k8s.node.system_container.memory.usage:
+      enabled: true
+    k8s.node.system_container.memory.working_set:
+      enabled: true
+    k8s.node.uptime:
+      enabled: true
+    k8s.pod.cpu.node.utilization:
+      enabled: true
+    k8s.pod.cpu.time:
+      enabled: true
+    k8s.pod.cpu.usage:
+      enabled: true
+    k8s.pod.cpu_limit_utilization:
+      enabled: true
+    k8s.pod.cpu_request_utilization:
+      enabled: true
+    k8s.pod.filesystem.available:
+      enabled: true
+    k8s.pod.filesystem.capacity:
+      enabled: true
+    k8s.pod.filesystem.usage:
+      enabled: true
+    k8s.pod.memory.available:
+      enabled: true
+    k8s.pod.memory.major_page_faults:
+      enabled: true
+    k8s.pod.memory.node.utilization:
+      enabled: true
+    k8s.pod.memory.page_faults:
+      enabled: true
+    k8s.pod.memory.rss:
+      enabled: true
+    k8s.pod.memory.usage:
+      enabled: true
+    k8s.pod.memory.working_set:
+      enabled: true
+    k8s.pod.memory_limit_utilization:
+      enabled: true
+    k8s.pod.memory_request_utilization:
+      enabled: true
+    k8s.pod.network.errors:
+      enabled: true
+      attributes: []
+    k8s.pod.network.io:
+      enabled: true
+      attributes: []
     k8s.pod.uptime:
       enabled: true
     k8s.pod.volume.usage:
@@ -194,6 +365,7 @@ none_set:
       enabled: false
     k8s.container.ephemeral_storage.usage:
       enabled: false
+      attributes: ["fs.type"]
     k8s.container.memory.node.utilization:
       enabled: false
     k8s.container.memory_limit_utilization:
@@ -224,8 +396,10 @@ none_set:
       enabled: false
     k8s.node.network.errors:
       enabled: false
+      attributes: ["interface","direction"]
     k8s.node.network.io:
       enabled: false
+      attributes: ["interface","direction"]
     k8s.node.system_container.cpu.time:
       enabled: false
     k8s.node.system_container.cpu.usage:
@@ -272,8 +446,10 @@ none_set:
       enabled: false
     k8s.pod.network.errors:
       enabled: false
+      attributes: ["interface","direction"]
     k8s.pod.network.io:
       enabled: false
+      attributes: ["interface","direction"]
     k8s.pod.uptime:
       enabled: false
     k8s.pod.volume.usage:

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -1,6 +1,7 @@
 display_name: Kubelet Stats Receiver
 type: kubelet_stats
 deprecated_type: kubeletstats
+reaggregation_enabled: true
 
 description: |
   The Kubelet Stats Receiver pulls node, pod, container, and volume metrics from the API server on a kubelet
@@ -95,6 +96,7 @@ resource_attributes:
 attributes:
   direction:
     description: Direction of flow of bytes/operations (receive or transmit).
+    requirement_level: recommended
     type: string
     enum: [receive, transmit]
   fs.type:
@@ -103,6 +105,7 @@ attributes:
     enum: [rootfs, logs]
   interface:
     description: Name of the network interface.
+    requirement_level: recommended
     type: string
 
 metrics:

--- a/receiver/kubeletstatsreceiver/scraper_test.go
+++ b/receiver/kubeletstatsreceiver/scraper_test.go
@@ -228,10 +228,10 @@ func TestScraperWithCPUNodeUtilization(t *testing.T) {
 		options,
 		metadata.MetricsBuilderConfig{
 			Metrics: metadata.MetricsConfig{
-				K8sContainerCPUNodeUtilization: metadata.MetricConfig{
+				K8sContainerCPUNodeUtilization: metadata.K8sContainerCPUNodeUtilizationMetricConfig{
 					Enabled: true,
 				},
-				K8sPodCPUNodeUtilization: metadata.MetricConfig{
+				K8sPodCPUNodeUtilization: metadata.K8sPodCPUNodeUtilizationMetricConfig{
 					Enabled: true,
 				},
 			},
@@ -308,9 +308,9 @@ func TestScraperWithMemoryNodeUtilization(t *testing.T) {
 		options,
 		metadata.MetricsBuilderConfig{
 			Metrics: metadata.MetricsConfig{
-				K8sContainerMemoryNodeUtilization: metadata.MetricConfig{
+				K8sContainerMemoryNodeUtilization: metadata.K8sContainerMemoryNodeUtilizationMetricConfig{
 					Enabled: true,
-				}, K8sPodMemoryNodeUtilization: metadata.MetricConfig{
+				}, K8sPodMemoryNodeUtilization: metadata.K8sPodMemoryNodeUtilizationMetricConfig{
 					Enabled: true,
 				},
 			},
@@ -433,148 +433,148 @@ func TestScraperWithPercentMetrics(t *testing.T) {
 	}
 	metricsConfig := metadata.MetricsBuilderConfig{
 		Metrics: metadata.MetricsConfig{
-			ContainerCPUTime: metadata.MetricConfig{
+			ContainerCPUTime: metadata.ContainerCPUTimeMetricConfig{
 				Enabled: false,
 			},
-			ContainerFilesystemAvailable: metadata.MetricConfig{
+			ContainerFilesystemAvailable: metadata.ContainerFilesystemAvailableMetricConfig{
 				Enabled: false,
 			},
-			ContainerFilesystemCapacity: metadata.MetricConfig{
+			ContainerFilesystemCapacity: metadata.ContainerFilesystemCapacityMetricConfig{
 				Enabled: false,
 			},
-			ContainerFilesystemUsage: metadata.MetricConfig{
+			ContainerFilesystemUsage: metadata.ContainerFilesystemUsageMetricConfig{
 				Enabled: false,
 			},
-			ContainerMemoryAvailable: metadata.MetricConfig{
+			ContainerMemoryAvailable: metadata.ContainerMemoryAvailableMetricConfig{
 				Enabled: false,
 			},
-			ContainerMemoryMajorPageFaults: metadata.MetricConfig{
+			ContainerMemoryMajorPageFaults: metadata.ContainerMemoryMajorPageFaultsMetricConfig{
 				Enabled: false,
 			},
-			ContainerMemoryPageFaults: metadata.MetricConfig{
+			ContainerMemoryPageFaults: metadata.ContainerMemoryPageFaultsMetricConfig{
 				Enabled: false,
 			},
-			ContainerMemoryRss: metadata.MetricConfig{
+			ContainerMemoryRss: metadata.ContainerMemoryRssMetricConfig{
 				Enabled: false,
 			},
-			ContainerMemoryUsage: metadata.MetricConfig{
+			ContainerMemoryUsage: metadata.ContainerMemoryUsageMetricConfig{
 				Enabled: false,
 			},
-			K8sContainerCPULimitUtilization: metadata.MetricConfig{
+			K8sContainerCPULimitUtilization: metadata.K8sContainerCPULimitUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sContainerCPURequestUtilization: metadata.MetricConfig{
+			K8sContainerCPURequestUtilization: metadata.K8sContainerCPURequestUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sContainerMemoryLimitUtilization: metadata.MetricConfig{
+			K8sContainerMemoryLimitUtilization: metadata.K8sContainerMemoryLimitUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sContainerMemoryRequestUtilization: metadata.MetricConfig{
+			K8sContainerMemoryRequestUtilization: metadata.K8sContainerMemoryRequestUtilizationMetricConfig{
 				Enabled: true,
 			},
-			ContainerMemoryWorkingSet: metadata.MetricConfig{
+			ContainerMemoryWorkingSet: metadata.ContainerMemoryWorkingSetMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeCPUTime: metadata.MetricConfig{
+			K8sNodeCPUTime: metadata.K8sNodeCPUTimeMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeFilesystemAvailable: metadata.MetricConfig{
+			K8sNodeFilesystemAvailable: metadata.K8sNodeFilesystemAvailableMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeFilesystemCapacity: metadata.MetricConfig{
+			K8sNodeFilesystemCapacity: metadata.K8sNodeFilesystemCapacityMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeFilesystemUsage: metadata.MetricConfig{
+			K8sNodeFilesystemUsage: metadata.K8sNodeFilesystemUsageMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeMemoryAvailable: metadata.MetricConfig{
+			K8sNodeMemoryAvailable: metadata.K8sNodeMemoryAvailableMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeMemoryMajorPageFaults: metadata.MetricConfig{
+			K8sNodeMemoryMajorPageFaults: metadata.K8sNodeMemoryMajorPageFaultsMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeMemoryPageFaults: metadata.MetricConfig{
+			K8sNodeMemoryPageFaults: metadata.K8sNodeMemoryPageFaultsMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeMemoryRss: metadata.MetricConfig{
+			K8sNodeMemoryRss: metadata.K8sNodeMemoryRssMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeMemoryUsage: metadata.MetricConfig{
+			K8sNodeMemoryUsage: metadata.K8sNodeMemoryUsageMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeMemoryWorkingSet: metadata.MetricConfig{
+			K8sNodeMemoryWorkingSet: metadata.K8sNodeMemoryWorkingSetMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeNetworkErrors: metadata.MetricConfig{
+			K8sNodeNetworkErrors: metadata.K8sNodeNetworkErrorsMetricConfig{
 				Enabled: false,
 			},
-			K8sNodeNetworkIo: metadata.MetricConfig{
+			K8sNodeNetworkIo: metadata.K8sNodeNetworkIoMetricConfig{
 				Enabled: false,
 			},
-			K8sPodCPUTime: metadata.MetricConfig{
+			K8sPodCPUTime: metadata.K8sPodCPUTimeMetricConfig{
 				Enabled: false,
 			},
-			K8sPodFilesystemAvailable: metadata.MetricConfig{
+			K8sPodFilesystemAvailable: metadata.K8sPodFilesystemAvailableMetricConfig{
 				Enabled: false,
 			},
-			K8sPodFilesystemCapacity: metadata.MetricConfig{
+			K8sPodFilesystemCapacity: metadata.K8sPodFilesystemCapacityMetricConfig{
 				Enabled: false,
 			},
-			K8sPodFilesystemUsage: metadata.MetricConfig{
+			K8sPodFilesystemUsage: metadata.K8sPodFilesystemUsageMetricConfig{
 				Enabled: false,
 			},
-			K8sPodMemoryAvailable: metadata.MetricConfig{
+			K8sPodMemoryAvailable: metadata.K8sPodMemoryAvailableMetricConfig{
 				Enabled: false,
 			},
-			K8sPodMemoryMajorPageFaults: metadata.MetricConfig{
+			K8sPodMemoryMajorPageFaults: metadata.K8sPodMemoryMajorPageFaultsMetricConfig{
 				Enabled: false,
 			},
-			K8sPodMemoryPageFaults: metadata.MetricConfig{
+			K8sPodMemoryPageFaults: metadata.K8sPodMemoryPageFaultsMetricConfig{
 				Enabled: false,
 			},
-			K8sPodMemoryRss: metadata.MetricConfig{
+			K8sPodMemoryRss: metadata.K8sPodMemoryRssMetricConfig{
 				Enabled: false,
 			},
-			K8sPodMemoryUsage: metadata.MetricConfig{
+			K8sPodMemoryUsage: metadata.K8sPodMemoryUsageMetricConfig{
 				Enabled: false,
 			},
-			K8sPodCPULimitUtilization: metadata.MetricConfig{
+			K8sPodCPULimitUtilization: metadata.K8sPodCPULimitUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sPodCPURequestUtilization: metadata.MetricConfig{
+			K8sPodCPURequestUtilization: metadata.K8sPodCPURequestUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sPodMemoryLimitUtilization: metadata.MetricConfig{
+			K8sPodMemoryLimitUtilization: metadata.K8sPodMemoryLimitUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sPodMemoryRequestUtilization: metadata.MetricConfig{
+			K8sPodMemoryRequestUtilization: metadata.K8sPodMemoryRequestUtilizationMetricConfig{
 				Enabled: true,
 			},
-			K8sPodMemoryWorkingSet: metadata.MetricConfig{
+			K8sPodMemoryWorkingSet: metadata.K8sPodMemoryWorkingSetMetricConfig{
 				Enabled: false,
 			},
-			K8sPodNetworkErrors: metadata.MetricConfig{
+			K8sPodNetworkErrors: metadata.K8sPodNetworkErrorsMetricConfig{
 				Enabled: false,
 			},
-			K8sPodNetworkIo: metadata.MetricConfig{
+			K8sPodNetworkIo: metadata.K8sPodNetworkIoMetricConfig{
 				Enabled: false,
 			},
-			K8sVolumeAvailable: metadata.MetricConfig{
+			K8sVolumeAvailable: metadata.K8sVolumeAvailableMetricConfig{
 				Enabled: false,
 			},
-			K8sVolumeCapacity: metadata.MetricConfig{
+			K8sVolumeCapacity: metadata.K8sVolumeCapacityMetricConfig{
 				Enabled: false,
 			},
-			K8sPodVolumeUsage: metadata.MetricConfig{
+			K8sPodVolumeUsage: metadata.K8sPodVolumeUsageMetricConfig{
 				Enabled: false,
 			},
-			K8sVolumeInodes: metadata.MetricConfig{
+			K8sVolumeInodes: metadata.K8sVolumeInodesMetricConfig{
 				Enabled: false,
 			},
-			K8sVolumeInodesFree: metadata.MetricConfig{
+			K8sVolumeInodesFree: metadata.K8sVolumeInodesFreeMetricConfig{
 				Enabled: false,
 			},
-			K8sVolumeInodesUsed: metadata.MetricConfig{
+			K8sVolumeInodesUsed: metadata.K8sVolumeInodesUsedMetricConfig{
 				Enabled: false,
 			},
 		},


### PR DESCRIPTION
Part of #45396. Replaces #47750.

Enables `reaggregation_enabled: true` in `metadata.yaml` and assigns `recommended` requirement levels to the `direction` and `interface` network metric attributes. All other metrics in this receiver have no attributes and are unaffected.

Regenerated metadata files with mdatagen.