### PR TITLE
[chore][pkg/ottl] Remove length>255 case from relaxed-name OTTL tests

### DIFF
--- a/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
@@ -4,7 +4,6 @@
 package ctxmetric_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -176,8 +175,6 @@ func TestPathGetSetter_RelaxedNames(t *testing.T) {
 		".leadingDot",
 		"with🦀utf8",
 		"",
-		// Length intentionally exceeds the current 255-char spec limit.
-		strings.Repeat("a", 300),
 	}
 
 	path := &pathtest.Path[*testContext]{N: "name"}

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -5,7 +5,6 @@ package ottlmetric
 
 import (
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -318,8 +317,6 @@ func Test_newPathGetSetter_RelaxedNames(t *testing.T) {
 		".leadingDot",
 		"with🦀utf8",
 		"",
-		// Length intentionally exceeds the current 255-char spec limit.
-		strings.Repeat("a", 300),
 	}
 
 	cacheGetter := func(*TransformContext) pcommon.Map {


### PR DESCRIPTION
Follow-up to #48345.

Removes the `strings.Repeat("a", 300)` case from the relaxed-instrument-name OTTL tests added in #48345. The 300-character test was scoped to demonstrate length tolerance, but the [forthcoming spec change](https://github.com/open-telemetry/opentelemetry-specification/pull/5092) only relaxes the character set — the 255-character maximum is unchanged. The test was misleading about the scope of the spec change. Other relaxed-name cases (`:`, `\`, leading `-` / `.`, emoji, empty string) are kept.

Test-only change.
