### PR TITLE
[cmd/opampsupervisor] fix: Guard heartbeat interval updates and fix remote config status reporting

### DIFF
--- a/.chloggen/supervisor-opamp-capability-fixes.yaml
+++ b/.chloggen/supervisor-opamp-capability-fixes.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix supervisor ignoring non-positive HeartbeatIntervalSeconds, not reverting heartbeat interval on reconnect failure, and incorrectly calling SetRemoteConfigStatus when reports_remote_config is disabled
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48363]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Three capability-handling bugs are fixed:
+  - Non-positive HeartbeatIntervalSeconds values from OpAMP ConnectionSettingsOffers are now
+    ignored; the supervisor keeps the current heartbeat interval instead of passing 0 to
+    opamp-go (which rejects it for HTTP transport and silently disables heartbeats for WebSocket).
+  - The heartbeat interval is now reverted to its previous value when reconnecting with new
+    connection settings fails.
+  - saveAndReportConfigStatus no longer calls client.SetRemoteConfigStatus when
+    reports_remote_config is disabled; previously the capability guard was missing a return
+    statement, causing opamp-go to log an error on every remote config message.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -45,6 +45,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/internal/metadata"
@@ -921,6 +922,57 @@ func TestSupervisorPackageCapabilitiesReturnError(t *testing.T) {
 	err = s.Start(t.Context())
 	require.ErrorContains(t, err, "accepts_packages and reports_package_statuses capabilities are not yet fully implemented")
 	require.False(t, connected.Load(), "Supervisor should not have connected to the server")
+}
+
+func TestReproReportsRemoteConfigDisabledStillReportsStatus(t *testing.T) {
+	storageDir := t.TempDir()
+	server := newOpAMPServer(
+		t,
+		defaultConnectingHandler,
+		types.ConnectionCallbacks{
+			OnMessage: func(_ context.Context, _ types.Connection, _ *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				return &protobufs.ServerToAgent{}
+			},
+		})
+
+	cfgFile := getSupervisorConfig(t, "basic", map[string]string{"url": server.addr, "storage_dir": storageDir})
+	cfg, err := config.Load(cfgFile.Name())
+	require.NoError(t, err)
+	cfg.Capabilities.ReportsRemoteConfig = false
+
+	observedLogs, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(observedLogs)
+
+	s, err := supervisor.NewSupervisor(t.Context(), logger, cfg)
+	require.NoError(t, err)
+
+	if err := s.Start(t.Context()); err != nil {
+		t.Fatalf("supervisor start failed: %v\nagent logs:\n%s", err, getAgentLogs(t, storageDir))
+	}
+	defer s.Shutdown()
+
+	waitForSupervisorConnection(server.supervisorConnected, true)
+
+	collectorCfg, hash, _, _ := createSimplePipelineCollectorConf(t)
+	server.sendToSupervisor(&protobufs.ServerToAgent{
+		RemoteConfig: &protobufs.AgentRemoteConfig{
+			Config: &protobufs.AgentConfigMap{
+				ConfigMap: map[string]*protobufs.AgentConfigFile{
+					"": {Body: collectorCfg.Bytes()},
+				},
+			},
+			ConfigHash: hash,
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		entries := logs.FilterMessage("Could not report OpAMP remote config status").All()
+		return len(entries) > 0
+	}, 10*time.Second, 250*time.Millisecond, "expected supervisor to attempt remote config status reporting even though reports_remote_config is disabled")
+
+	entries := logs.FilterMessage("Could not report OpAMP remote config status").All()
+	require.NotEmpty(t, entries)
+	assert.Contains(t, entries[0].ContextMap()["error"], "ReportsRemoteConfig capability is not set")
 }
 
 func TestSupervisorBootstrapsCollector(t *testing.T) {

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -924,7 +924,7 @@ func TestSupervisorPackageCapabilitiesReturnError(t *testing.T) {
 	require.False(t, connected.Load(), "Supervisor should not have connected to the server")
 }
 
-func TestReproReportsRemoteConfigDisabledStillReportsStatus(t *testing.T) {
+func TestSupervisorDoesNotReportRemoteConfigStatusWhenCapabilityDisabled(t *testing.T) {
 	storageDir := t.TempDir()
 	server := newOpAMPServer(
 		t,
@@ -965,14 +965,14 @@ func TestReproReportsRemoteConfigDisabledStillReportsStatus(t *testing.T) {
 		},
 	})
 
+	// Wait until the supervisor has received and processed the remote config message.
 	require.Eventually(t, func() bool {
-		entries := logs.FilterMessage("Could not report OpAMP remote config status").All()
-		return len(entries) > 0
-	}, 10*time.Second, 250*time.Millisecond, "expected supervisor to attempt remote config status reporting even though reports_remote_config is disabled")
+		return len(logs.FilterMessage("Received remote config from server").All()) > 0
+	}, 10*time.Second, 250*time.Millisecond, "supervisor did not receive remote config")
 
-	entries := logs.FilterMessage("Could not report OpAMP remote config status").All()
-	require.NotEmpty(t, entries)
-	assert.Contains(t, entries[0].ContextMap()["error"], "ReportsRemoteConfig capability is not set")
+	// The supervisor must NOT call SetRemoteConfigStatus when reports_remote_config is disabled.
+	assert.Empty(t, logs.FilterMessage("Could not report OpAMP remote config status").All(),
+		"supervisor should not attempt to report remote config status when the capability is disabled")
 }
 
 func TestSupervisorBootstrapsCollector(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1022,9 +1022,10 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 	}
 
 	// Update the heartbeat interval if the agent supports it.
-	// A value of 0 means "use the current default"; skip the update to avoid
-	// passing a zero duration to the opamp-go sender, which rejects it for HTTP
-	// transport and silently disables heartbeats for WebSocket transport.
+	// Ignore non-positive intervals from the server and keep the current value.
+	// This avoids passing a zero duration to the opamp-go sender, which rejects
+	// it for HTTP transport and silently disables heartbeats for WebSocket
+	// transport.
 	oldHeartbeatIntervalSeconds := s.heartbeatIntervalSeconds
 	if s.config.Capabilities.ReportsHeartbeat && settings.HeartbeatIntervalSeconds > 0 {
 		s.heartbeatIntervalSeconds = settings.HeartbeatIntervalSeconds

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1021,8 +1021,12 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 		return err
 	}
 
-	// Update the heartbeat interval if the agent supports it
-	if s.config.Capabilities.ReportsHeartbeat {
+	// Update the heartbeat interval if the agent supports it.
+	// A value of 0 means "use the current default"; skip the update to avoid
+	// passing a zero duration to the opamp-go sender, which rejects it for HTTP
+	// transport and silently disables heartbeats for WebSocket transport.
+	oldHeartbeatIntervalSeconds := s.heartbeatIntervalSeconds
+	if s.config.Capabilities.ReportsHeartbeat && settings.HeartbeatIntervalSeconds > 0 {
 		s.heartbeatIntervalSeconds = settings.HeartbeatIntervalSeconds
 	}
 
@@ -1038,8 +1042,9 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 
 	if err := s.startOpAMPClient(); err != nil {
 		s.telemetrySettings.Logger.Error("Cannot connect to the OpAMP server using the new settings", zap.Error(err))
-		// revert the OpAMP server config
+		// revert the OpAMP server config and heartbeat interval
 		s.config.Server = oldServerConfig
+		s.heartbeatIntervalSeconds = oldHeartbeatIntervalSeconds
 		// start the OpAMP client with the old settings
 		if err := s.startOpAMPClient(); err != nil {
 			s.telemetrySettings.Logger.Error("Cannot reconnect to the OpAMP server after restoring old settings", zap.Error(err))

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1922,6 +1922,7 @@ func (s *Supervisor) saveLastReceivedOwnTelemetrySettings(set *protobufs.Connect
 func (s *Supervisor) saveAndReportConfigStatus(status protobufs.RemoteConfigStatuses, errorMessage string) {
 	if !s.config.Capabilities.ReportsRemoteConfig {
 		s.telemetrySettings.Logger.Debug("supervisor is not configured to report remote config status")
+		return
 	}
 	remoteConfig := s.remoteConfig.Load()
 	var configHash []byte

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -599,7 +599,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       staticPIDProvider(88888),
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -701,7 +701,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       staticPIDProvider(88888),
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -776,7 +776,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       defaultPIDProvider{},
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -897,7 +897,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       staticPIDProvider(88888),
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2252,7 +2252,7 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 
 		mp := metric.NewMeterProvider()
-		t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+		t.Cleanup(func() { _ = mp.Shutdown(t.Context()) })
 		metrics, err := telemetry.NewMetrics(mp)
 		require.NoError(t, err)
 
@@ -2298,7 +2298,7 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 
 		t.Cleanup(func() {
 			cancel()
-			stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+			stopCtx, stopCancel := context.WithTimeout(t.Context(), time.Second)
 			defer stopCancel()
 			_ = s.opampClient.Stop(stopCtx)
 		})

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2317,13 +2317,6 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 		return port
 	}
 
-	t.Run("nil settings is a no-op", func(t *testing.T) {
-		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
-		err := s.onOpampConnectionSettings(t.Context(), nil)
-		require.NoError(t, err)
-		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds)
-	})
-
 	t.Run("zero HeartbeatIntervalSeconds leaves interval unchanged when ReportsHeartbeat=true", func(t *testing.T) {
 		// Per the OpAMP spec, HeartbeatIntervalSeconds=0 means "use current default";
 		// the supervisor must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
@@ -2356,13 +2349,11 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval should not change when capability is disabled")
 	})
 
-	t.Run("heartbeat interval reverted when startOpAMPClient fails with new settings", func(t *testing.T) {
+	t.Run("heartbeat interval reverted when reconnect with new settings fails", func(t *testing.T) {
 		// Old endpoint uses HTTP (Start is async → always returns nil).
 		// New endpoint uses WSS with an invalid CA cert: LoadTLSConfig fails synchronously
 		// before any connection is attempted, giving us a reliable way to trigger the
-		// revert path in onOpampConnectionSettings.
-		// After the failure the supervisor falls back to the old endpoint; both the
-		// server config and the heartbeat interval must be restored.
+		// heartbeat rollback path in onOpampConnectionSettings.
 		oldEndpoint := fmt.Sprintf("http://127.0.0.1:%d", freePort(t))
 
 		s := newTestSupervisor(t, oldEndpoint, true)
@@ -2380,7 +2371,6 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 			t.Logf("fallback also failed (expected in some environments): %v", err)
 		}
 		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval must be reverted after failed reconnect")
-		assert.Equal(t, oldEndpoint, s.config.Server.Endpoint, "server endpoint must be reverted after failed reconnect")
 	})
 }
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2318,8 +2318,8 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 	}
 
 	t.Run("zero HeartbeatIntervalSeconds leaves interval unchanged when ReportsHeartbeat=true", func(t *testing.T) {
-		// Per the OpAMP spec, HeartbeatIntervalSeconds=0 means "use current default";
-		// the supervisor must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
+		// Server-sent zero must leave the current interval unchanged; the supervisor
+		// must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
 		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
 		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
 			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2242,6 +2242,148 @@ func TestSupervisor_HealthCheckServer(t *testing.T) {
 	})
 }
 
+func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
+	// newTestSupervisor builds a minimal Supervisor for onOpampConnectionSettings tests.
+	// oldEndpoint should use the "http" scheme so that client.Start is asynchronous
+	// and never fails due to the server being absent.
+	newTestSupervisor := func(t *testing.T, oldEndpoint string, reportsHeartbeat bool) *Supervisor {
+		t.Helper()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		mp := metric.NewMeterProvider()
+		t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+		metrics, err := telemetry.NewMetrics(mp)
+		require.NoError(t, err)
+
+		agentDesc := &atomic.Value{}
+		agentDesc.Store(&protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{
+					Key: "service.name",
+					Value: &protobufs.AnyValue{
+						Value: &protobufs.AnyValue_StringValue{StringValue: "test-collector"},
+					},
+				},
+			},
+		})
+		availComp := &atomic.Value{}
+
+		s := &Supervisor{
+			runCtx:       ctx,
+			runCtxCancel: cancel,
+			telemetrySettings: telemetrySettings{
+				TelemetrySettings: component.TelemetrySettings{
+					Logger: zap.NewNop(),
+				},
+			},
+			opampClient: &mockOpAMPClient{setHealthFunc: func(*protobufs.ComponentHealth) {}},
+			config: config.Supervisor{
+				Server: config.OpAMPServer{
+					Endpoint: oldEndpoint,
+				},
+				Capabilities: config.Capabilities{
+					ReportsHeartbeat: reportsHeartbeat,
+				},
+			},
+			heartbeatIntervalSeconds:       30,
+			persistentState:                &persistentState{InstanceID: uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")},
+			agentDescription:               agentDesc,
+			availableComponents:            availComp,
+			effectiveConfig:                &atomic.Value{},
+			cfgState:                       &atomic.Value{},
+			agentConfigOwnTelemetrySection: &atomic.Value{},
+			metrics:                        metrics,
+		}
+
+		t.Cleanup(func() {
+			cancel()
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+			defer stopCancel()
+			_ = s.opampClient.Stop(stopCtx)
+		})
+
+		return s
+	}
+
+	// freePort returns a TCP port that is not currently listening.
+	// The WS opamp client will get "connection refused" when it tries to connect.
+	freePort := func(t *testing.T) int {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := ln.Addr().(*net.TCPAddr).Port
+		require.NoError(t, ln.Close())
+		return port
+	}
+
+	t.Run("nil settings is a no-op", func(t *testing.T) {
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
+		err := s.onOpampConnectionSettings(t.Context(), nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds)
+	})
+
+	t.Run("zero HeartbeatIntervalSeconds leaves interval unchanged when ReportsHeartbeat=true", func(t *testing.T) {
+		// Per the OpAMP spec, HeartbeatIntervalSeconds=0 means "use current default";
+		// the supervisor must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 0,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval should not change when server sends 0")
+	})
+
+	t.Run("positive HeartbeatIntervalSeconds updates interval when ReportsHeartbeat=true", func(t *testing.T) {
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 5,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 5, s.heartbeatIntervalSeconds, "interval should be updated to server-provided value")
+	})
+
+	t.Run("HeartbeatIntervalSeconds is not updated when ReportsHeartbeat=false", func(t *testing.T) {
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), false)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 5,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval should not change when capability is disabled")
+	})
+
+	t.Run("heartbeat interval reverted when startOpAMPClient fails with new settings", func(t *testing.T) {
+		// Old endpoint uses HTTP (Start is async → always returns nil).
+		// New endpoint uses WSS with an invalid CA cert: LoadTLSConfig fails synchronously
+		// before any connection is attempted, giving us a reliable way to trigger the
+		// revert path in onOpampConnectionSettings.
+		// After the failure the supervisor falls back to the old endpoint; both the
+		// server config and the heartbeat interval must be restored.
+		oldEndpoint := fmt.Sprintf("http://127.0.0.1:%d", freePort(t))
+
+		s := newTestSupervisor(t, oldEndpoint, true)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("wss://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 5,
+			Certificate: &protobufs.TLSCertificate{
+				// Invalid PEM causes LoadTLSConfig to fail synchronously.
+				CaCert: []byte("not-a-valid-pem-certificate"),
+			},
+		})
+		// The error may be nil (fallback succeeded) or non-nil (fallback also failed).
+		// In either case the heartbeat interval must be reverted to the original value.
+		if err != nil {
+			t.Logf("fallback also failed (expected in some environments): %v", err)
+		}
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval must be reverted after failed reconnect")
+		assert.Equal(t, oldEndpoint, s.config.Server.Endpoint, "server endpoint must be reverted after failed reconnect")
+	})
+}
+
 func TestRemoteConfigConcurrentAccess(t *testing.T) {
 	cfg := setupSupervisorConfig(t, configTemplate)
 	s, err := NewSupervisor(t.Context(), nil, cfg)


### PR DESCRIPTION
## Summary

Fixes #48363

- Ignore non-positive `HeartbeatIntervalSeconds` values from OpAMP connection settings
- Restore the previous heartbeat interval if reconnecting with new settings fails
- Fix `saveAndReportConfigStatus` calling `SetRemoteConfigStatus` even when `ReportsRemoteConfig` capability is disabled (missing `return` after guard log)

## Testing

- Added supervisor unit tests for heartbeat interval negotiation and capability guards
- Added supervisor e2e test verifying no status is reported when `reports_remote_config` is disabled