### PR TITLE
[receiver/sqlserver] Add Always On Availability Group metrics

### DIFF
--- a/.chloggen/sqlserver-availability-group-metrics.yaml
+++ b/.chloggen/sqlserver-availability-group-metrics.yaml
@@ -4,12 +4,6 @@ component: receiver/sqlserver
 
 note: Add opt-in Always On Availability Group metrics
 
-issues: [48369, 48377]
-
-subtext: |
-  Three new development-stability metrics (disabled by default):
-  - `sqlserver.replica.flow_control.time`: flow control time on the secondary replica
-  - `sqlserver.log_data.io.rate`: rate at which log data is received by the secondary replica from the primary replica
-  - `sqlserver.replica.queue.size`: log data queued in the availability group replica pipeline (send queue and redo queue)
+issues: [48369]
 
 change_logs: [user]

--- a/.chloggen/sqlserver-availability-group-metrics.yaml
+++ b/.chloggen/sqlserver-availability-group-metrics.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: receiver/sqlserver
+
+note: Add opt-in Always On Availability Group metrics
+
+issues: [48369, 48377]
+
+subtext: |
+  Three new development-stability metrics (disabled by default):
+  - `sqlserver.replica.flow_control.time`: flow control time on the secondary replica
+  - `sqlserver.log_data.io.rate`: rate at which log data is received by the secondary replica from the primary replica
+  - `sqlserver.replica.queue.size`: log data queued in the availability group replica pipeline (send queue and redo queue)
+
+change_logs: [user]

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -495,6 +495,25 @@ This metric is only available when the receiver is configured to directly connec
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {wait} | Sum | Int | Cumulative | true | Development |
 
+### sqlserver.log_data.io.rate
+
+Rate of log data flow between availability group replicas.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| sqlserver.availability_group.name | The name of the SQL Server Always On availability group. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| sqlserver.replica.name | The name of the availability replica server. | Any Str | Recommended | - |
+| sqlserver.replica.direction | The direction of log data flow for the availability group replica. | Str: ``transmit``, ``receive`` | Recommended | - |
+
 ### sqlserver.login.rate
 
 Total number of logins.
@@ -708,7 +727,44 @@ Throughput rate of replica data.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| replica.direction | The direction of flow of bytes for replica. | Str: ``transmit``, ``receive`` | Recommended | - |
+| sqlserver.replica.direction | The direction of log data flow for the availability group replica. | Str: ``transmit``, ``receive`` | Recommended | - |
+
+### sqlserver.replica.flow_control.time
+
+Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server 2016+ with Always On Availability Groups enabled. The datapoint is omitted for primary replicas where secondary_lag_seconds is NULL.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| sqlserver.availability_group.name | The name of the SQL Server Always On availability group. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| sqlserver.replica.name | The name of the availability replica server. | Any Str | Recommended | - |
+
+### sqlserver.replica.queue.size
+
+Amount of log data queued in the availability group replica pipeline.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled. Queue type "send" reports log not yet sent to secondary replicas; queue type "redo" reports log received by the secondary replica but not yet applied.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| sqlserver.availability_group.name | The name of the SQL Server Always On availability group. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| sqlserver.replica.name | The name of the availability replica server. | Any Str | Recommended | - |
+| sqlserver.replica.queue.type | The type of queue in the availability group replica pipeline. | Str: ``send``, ``redo`` | Recommended | - |
 
 ### sqlserver.resource_pool.disk.operations
 

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -727,11 +727,30 @@ Throughput rate of replica data.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| sqlserver.replica.direction | The direction of log data flow for the availability group replica. | Str: ``transmit``, ``receive`` | Recommended | - |
+| replica.direction | The direction of flow of bytes for replica. | Str: ``transmit``, ``receive`` | Recommended | - |
 
-### sqlserver.replica.flow_control.time
+### sqlserver.replica.queue.size
 
-Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
+Amount of log data queued in the availability group replica pipeline.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| sqlserver.availability_group.name | The name of the SQL Server Always On availability group. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| sqlserver.replica.name | The name of the availability replica server. | Any Str | Recommended | - |
+| sqlserver.replica.queue.type | The type of queue in the availability group replica pipeline. | Str: ``send``, ``redo`` | Recommended | - |
+
+### sqlserver.replica.secondary_lag
+
+Number of seconds the secondary replica is lagging behind the primary replica.
 
 This metric is only available when the receiver is configured to directly connect to SQL Server 2016+ with Always On Availability Groups enabled. The datapoint is omitted for primary replicas where secondary_lag_seconds is NULL.
 
@@ -746,25 +765,6 @@ This metric is only available when the receiver is configured to directly connec
 | sqlserver.availability_group.name | The name of the SQL Server Always On availability group. | Any Str | Recommended | - |
 | db.namespace | The database name. | Any Str | Recommended | - |
 | sqlserver.replica.name | The name of the availability replica server. | Any Str | Recommended | - |
-
-### sqlserver.replica.queue.size
-
-Amount of log data queued in the availability group replica pipeline.
-
-This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled. Queue type "send" reports log not yet sent to secondary replicas; queue type "redo" reports log received by the secondary replica but not yet applied.
-
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| By | Gauge | Int | Development |
-
-#### Attributes
-
-| Name | Description | Values | Requirement Level | Semantic Convention |
-| ---- | ----------- | ------ | ----------------- | ------------------- |
-| sqlserver.availability_group.name | The name of the SQL Server Always On availability group. | Any Str | Recommended | - |
-| db.namespace | The database name. | Any Str | Recommended | - |
-| sqlserver.replica.name | The name of the availability replica server. | Any Str | Recommended | - |
-| sqlserver.replica.queue.type | The type of queue in the availability group replica pipeline. | Str: ``send``, ``redo`` | Recommended | - |
 
 ### sqlserver.resource_pool.disk.operations
 

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -82,6 +82,10 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerWaitStatsQuery(cfg.InstanceName))
 	}
 
+	if isAvailabilityGroupQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerAvailabilityGroupQuery(cfg.InstanceName))
+	}
+
 	return queries
 }
 
@@ -316,4 +320,14 @@ func isWaitStatsQueryEnabled(metrics *metadata.MetricsConfig) bool {
 	}
 
 	return metrics.SqlserverOsWaitDuration.Enabled
+}
+
+func isAvailabilityGroupQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+
+	return metrics.SqlserverReplicaFlowControlTime.Enabled ||
+		metrics.SqlserverLogDataIoRate.Enabled ||
+		metrics.SqlserverReplicaQueueSize.Enabled
 }

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -327,7 +327,7 @@ func isAvailabilityGroupQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	return metrics.SqlserverReplicaFlowControlTime.Enabled ||
+	return metrics.SqlserverReplicaSecondaryLag.Enabled ||
 		metrics.SqlserverLogDataIoRate.Enabled ||
 		metrics.SqlserverReplicaQueueSize.Enabled
 }

--- a/receiver/sqlserverreceiver/factory_test.go
+++ b/receiver/sqlserverreceiver/factory_test.go
@@ -262,7 +262,7 @@ func TestSetupQueries(t *testing.T) {
 
 	metricsMetadata, ok := metadata["metrics"].(map[string]any)
 	require.True(t, ok)
-	require.Len(t, metricsMetadata, 70, "Every time metrics are added or removed, the function `setupQueries` must "+
+	require.Len(t, metricsMetadata, 73, "Every time metrics are added or removed, the function `setupQueries` must "+
 		"be modified to properly account for the change. Please update `setupQueries` and then, "+
 		"and only then, update the expected metric count here.")
 }

--- a/receiver/sqlserverreceiver/generated_package_test.go
+++ b/receiver/sqlserverreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package sqlserverreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/sqlserverreceiver/generated_package_test.go
+++ b/receiver/sqlserverreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package sqlserverreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/sqlserverreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/config.schema.yaml
@@ -293,6 +293,35 @@ $defs:
           enabled:
             type: boolean
             default: true
+      sqlserver.log_data.io.rate:
+        description: "SqlserverLogDataIoRateMetricConfig provides config for the sqlserver.log_data.io.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "sqlserver.availability_group.name"
+                - "db.namespace"
+                - "sqlserver.replica.name"
+                - "sqlserver.replica.direction"
+            default:
+              - "sqlserver.availability_group.name"
+              - "db.namespace"
+              - "sqlserver.replica.name"
+              - "sqlserver.replica.direction"
       sqlserver.login.rate:
         description: "SqlserverLoginRateMetricConfig provides config for the sqlserver.login.rate metric."
         type: object
@@ -530,9 +559,65 @@ $defs:
             items:
               type: string
               enum:
-                - "replica.direction"
+                - "sqlserver.replica.direction"
             default:
-              - "replica.direction"
+              - "sqlserver.replica.direction"
+      sqlserver.replica.flow_control.time:
+        description: "SqlserverReplicaFlowControlTimeMetricConfig provides config for the sqlserver.replica.flow_control.time metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "sqlserver.availability_group.name"
+                - "db.namespace"
+                - "sqlserver.replica.name"
+            default:
+              - "sqlserver.availability_group.name"
+              - "db.namespace"
+              - "sqlserver.replica.name"
+      sqlserver.replica.queue.size:
+        description: "SqlserverReplicaQueueSizeMetricConfig provides config for the sqlserver.replica.queue.size metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+          aggregation_strategy:
+            type: string
+            enum:
+              - "sum"
+              - "avg"
+              - "min"
+              - "max"
+            default: "avg"
+          attributes:
+            type: array
+            items:
+              type: string
+              enum:
+                - "sqlserver.availability_group.name"
+                - "db.namespace"
+                - "sqlserver.replica.name"
+                - "sqlserver.replica.queue.type"
+            default:
+              - "sqlserver.availability_group.name"
+              - "db.namespace"
+              - "sqlserver.replica.name"
+              - "sqlserver.replica.queue.type"
       sqlserver.resource_pool.disk.operations:
         description: "SqlserverResourcePoolDiskOperationsMetricConfig provides config for the sqlserver.resource_pool.disk.operations metric."
         type: object

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config.go
@@ -1507,7 +1507,7 @@ func (ms *SqlserverRecompilationRatioMetricConfig) Unmarshal(parser *confmap.Con
 type SqlserverReplicaDataRateMetricAttributeKey string
 
 const (
-	SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection SqlserverReplicaDataRateMetricAttributeKey = "sqlserver.replica.direction"
+	SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection SqlserverReplicaDataRateMetricAttributeKey = "replica.direction"
 )
 
 // SqlserverReplicaDataRateMetricConfig provides config for the sqlserver.replica.data.rate metric.
@@ -1536,59 +1536,9 @@ func (ms *SqlserverReplicaDataRateMetricConfig) Unmarshal(parser *confmap.Conf) 
 func (ms *SqlserverReplicaDataRateMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection:
+		case SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection:
 		default:
-			return fmt.Errorf("metric sqlserver.replica.data.rate doesn't have an attribute %v, valid attributes: [sqlserver.replica.direction]", val)
-		}
-	}
-
-	switch ms.AggregationStrategy {
-	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
-	default:
-		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
-	}
-
-	return nil
-}
-
-// SqlserverReplicaFlowControlTimeMetricAttributeKey specifies the key of an attribute for the sqlserver.replica.flow_control.time metric.
-type SqlserverReplicaFlowControlTimeMetricAttributeKey string
-
-const (
-	SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName SqlserverReplicaFlowControlTimeMetricAttributeKey = "sqlserver.availability_group.name"
-	SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace                    SqlserverReplicaFlowControlTimeMetricAttributeKey = "db.namespace"
-	SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName           SqlserverReplicaFlowControlTimeMetricAttributeKey = "sqlserver.replica.name"
-)
-
-// SqlserverReplicaFlowControlTimeMetricConfig provides config for the sqlserver.replica.flow_control.time metric.
-type SqlserverReplicaFlowControlTimeMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-
-	AggregationStrategy string                                              `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []SqlserverReplicaFlowControlTimeMetricAttributeKey `mapstructure:"attributes"`
-}
-
-func (ms *SqlserverReplicaFlowControlTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
-func (ms *SqlserverReplicaFlowControlTimeMetricConfig) Validate() error {
-	for _, val := range ms.EnabledAttributes {
-		switch val {
-		case SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName:
-		default:
-			return fmt.Errorf("metric sqlserver.replica.flow_control.time doesn't have an attribute %v, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]", val)
+			return fmt.Errorf("metric sqlserver.replica.data.rate doesn't have an attribute %v, valid attributes: [replica.direction]", val)
 		}
 	}
 
@@ -1640,6 +1590,56 @@ func (ms *SqlserverReplicaQueueSizeMetricConfig) Validate() error {
 		case SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType:
 		default:
 			return fmt.Errorf("metric sqlserver.replica.queue.size doesn't have an attribute %v, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.queue.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverReplicaSecondaryLagMetricAttributeKey specifies the key of an attribute for the sqlserver.replica.secondary_lag metric.
+type SqlserverReplicaSecondaryLagMetricAttributeKey string
+
+const (
+	SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverAvailabilityGroupName SqlserverReplicaSecondaryLagMetricAttributeKey = "sqlserver.availability_group.name"
+	SqlserverReplicaSecondaryLagMetricAttributeKeyDbNamespace                    SqlserverReplicaSecondaryLagMetricAttributeKey = "db.namespace"
+	SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverReplicaName           SqlserverReplicaSecondaryLagMetricAttributeKey = "sqlserver.replica.name"
+)
+
+// SqlserverReplicaSecondaryLagMetricConfig provides config for the sqlserver.replica.secondary_lag metric.
+type SqlserverReplicaSecondaryLagMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverReplicaSecondaryLagMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverReplicaSecondaryLagMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverReplicaSecondaryLagMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaSecondaryLagMetricAttributeKeyDbNamespace, SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverReplicaName:
+		default:
+			return fmt.Errorf("metric sqlserver.replica.secondary_lag doesn't have an attribute %v, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]", val)
 		}
 	}
 
@@ -2105,8 +2105,8 @@ type MetricsConfig struct {
 	SqlserverProcessesBlocked                   SqlserverProcessesBlockedMetricConfig                   `mapstructure:"sqlserver.processes.blocked"`
 	SqlserverRecompilationRatio                 SqlserverRecompilationRatioMetricConfig                 `mapstructure:"sqlserver.recompilation.ratio"`
 	SqlserverReplicaDataRate                    SqlserverReplicaDataRateMetricConfig                    `mapstructure:"sqlserver.replica.data.rate"`
-	SqlserverReplicaFlowControlTime             SqlserverReplicaFlowControlTimeMetricConfig             `mapstructure:"sqlserver.replica.flow_control.time"`
 	SqlserverReplicaQueueSize                   SqlserverReplicaQueueSizeMetricConfig                   `mapstructure:"sqlserver.replica.queue.size"`
+	SqlserverReplicaSecondaryLag                SqlserverReplicaSecondaryLagMetricConfig                `mapstructure:"sqlserver.replica.secondary_lag"`
 	SqlserverResourcePoolDiskOperations         SqlserverResourcePoolDiskOperationsMetricConfig         `mapstructure:"sqlserver.resource_pool.disk.operations"`
 	SqlserverResourcePoolDiskThrottledReadRate  SqlserverResourcePoolDiskThrottledReadRateMetricConfig  `mapstructure:"sqlserver.resource_pool.disk.throttled.read.rate"`
 	SqlserverResourcePoolDiskThrottledWriteRate SqlserverResourcePoolDiskThrottledWriteRateMetricConfig `mapstructure:"sqlserver.resource_pool.disk.throttled.write.rate"`
@@ -2320,17 +2320,17 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverReplicaDataRate: SqlserverReplicaDataRateMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection},
-		},
-		SqlserverReplicaFlowControlTime: SqlserverReplicaFlowControlTimeMetricConfig{
-			Enabled:             false,
-			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SqlserverReplicaFlowControlTimeMetricAttributeKey{SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName},
+			EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection},
 		},
 		SqlserverReplicaQueueSize: SqlserverReplicaQueueSizeMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
 			EnabledAttributes:   []SqlserverReplicaQueueSizeMetricAttributeKey{SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType},
+		},
+		SqlserverReplicaSecondaryLag: SqlserverReplicaSecondaryLagMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverReplicaSecondaryLagMetricAttributeKey{SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaSecondaryLagMetricAttributeKeyDbNamespace, SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverReplicaName},
 		},
 		SqlserverResourcePoolDiskOperations: SqlserverResourcePoolDiskOperationsMetricConfig{
 			Enabled:             false,

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config.go
@@ -767,6 +767,57 @@ func (ms *SqlserverLockWaitTimeAvgMetricConfig) Unmarshal(parser *confmap.Conf) 
 	return nil
 }
 
+// SqlserverLogDataIoRateMetricAttributeKey specifies the key of an attribute for the sqlserver.log_data.io.rate metric.
+type SqlserverLogDataIoRateMetricAttributeKey string
+
+const (
+	SqlserverLogDataIoRateMetricAttributeKeySqlserverAvailabilityGroupName SqlserverLogDataIoRateMetricAttributeKey = "sqlserver.availability_group.name"
+	SqlserverLogDataIoRateMetricAttributeKeyDbNamespace                    SqlserverLogDataIoRateMetricAttributeKey = "db.namespace"
+	SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaName           SqlserverLogDataIoRateMetricAttributeKey = "sqlserver.replica.name"
+	SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaDirection      SqlserverLogDataIoRateMetricAttributeKey = "sqlserver.replica.direction"
+)
+
+// SqlserverLogDataIoRateMetricConfig provides config for the sqlserver.log_data.io.rate metric.
+type SqlserverLogDataIoRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverLogDataIoRateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverLogDataIoRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverLogDataIoRateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverLogDataIoRateMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverLogDataIoRateMetricAttributeKeyDbNamespace, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaName, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaDirection:
+		default:
+			return fmt.Errorf("metric sqlserver.log_data.io.rate doesn't have an attribute %v, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverLoginRateMetricConfig provides config for the sqlserver.login.rate metric.
 type SqlserverLoginRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -1456,7 +1507,7 @@ func (ms *SqlserverRecompilationRatioMetricConfig) Unmarshal(parser *confmap.Con
 type SqlserverReplicaDataRateMetricAttributeKey string
 
 const (
-	SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection SqlserverReplicaDataRateMetricAttributeKey = "replica.direction"
+	SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection SqlserverReplicaDataRateMetricAttributeKey = "sqlserver.replica.direction"
 )
 
 // SqlserverReplicaDataRateMetricConfig provides config for the sqlserver.replica.data.rate metric.
@@ -1485,9 +1536,110 @@ func (ms *SqlserverReplicaDataRateMetricConfig) Unmarshal(parser *confmap.Conf) 
 func (ms *SqlserverReplicaDataRateMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection:
+		case SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection:
 		default:
-			return fmt.Errorf("metric sqlserver.replica.data.rate doesn't have an attribute %v, valid attributes: [replica.direction]", val)
+			return fmt.Errorf("metric sqlserver.replica.data.rate doesn't have an attribute %v, valid attributes: [sqlserver.replica.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverReplicaFlowControlTimeMetricAttributeKey specifies the key of an attribute for the sqlserver.replica.flow_control.time metric.
+type SqlserverReplicaFlowControlTimeMetricAttributeKey string
+
+const (
+	SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName SqlserverReplicaFlowControlTimeMetricAttributeKey = "sqlserver.availability_group.name"
+	SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace                    SqlserverReplicaFlowControlTimeMetricAttributeKey = "db.namespace"
+	SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName           SqlserverReplicaFlowControlTimeMetricAttributeKey = "sqlserver.replica.name"
+)
+
+// SqlserverReplicaFlowControlTimeMetricConfig provides config for the sqlserver.replica.flow_control.time metric.
+type SqlserverReplicaFlowControlTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverReplicaFlowControlTimeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverReplicaFlowControlTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverReplicaFlowControlTimeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName:
+		default:
+			return fmt.Errorf("metric sqlserver.replica.flow_control.time doesn't have an attribute %v, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverReplicaQueueSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.replica.queue.size metric.
+type SqlserverReplicaQueueSizeMetricAttributeKey string
+
+const (
+	SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName SqlserverReplicaQueueSizeMetricAttributeKey = "sqlserver.availability_group.name"
+	SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace                    SqlserverReplicaQueueSizeMetricAttributeKey = "db.namespace"
+	SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName           SqlserverReplicaQueueSizeMetricAttributeKey = "sqlserver.replica.name"
+	SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType      SqlserverReplicaQueueSizeMetricAttributeKey = "sqlserver.replica.queue.type"
+)
+
+// SqlserverReplicaQueueSizeMetricConfig provides config for the sqlserver.replica.queue.size metric.
+type SqlserverReplicaQueueSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverReplicaQueueSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverReplicaQueueSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverReplicaQueueSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType:
+		default:
+			return fmt.Errorf("metric sqlserver.replica.queue.size doesn't have an attribute %v, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.queue.type]", val)
 		}
 	}
 
@@ -1928,6 +2080,7 @@ type MetricsConfig struct {
 	SqlserverLockWaitCount                      SqlserverLockWaitCountMetricConfig                      `mapstructure:"sqlserver.lock.wait.count"`
 	SqlserverLockWaitRate                       SqlserverLockWaitRateMetricConfig                       `mapstructure:"sqlserver.lock.wait.rate"`
 	SqlserverLockWaitTimeAvg                    SqlserverLockWaitTimeAvgMetricConfig                    `mapstructure:"sqlserver.lock.wait_time.avg"`
+	SqlserverLogDataIoRate                      SqlserverLogDataIoRateMetricConfig                      `mapstructure:"sqlserver.log_data.io.rate"`
 	SqlserverLoginRate                          SqlserverLoginRateMetricConfig                          `mapstructure:"sqlserver.login.rate"`
 	SqlserverLogoutRate                         SqlserverLogoutRateMetricConfig                         `mapstructure:"sqlserver.logout.rate"`
 	SqlserverMemoryArea                         SqlserverMemoryAreaMetricConfig                         `mapstructure:"sqlserver.memory.area"`
@@ -1952,6 +2105,8 @@ type MetricsConfig struct {
 	SqlserverProcessesBlocked                   SqlserverProcessesBlockedMetricConfig                   `mapstructure:"sqlserver.processes.blocked"`
 	SqlserverRecompilationRatio                 SqlserverRecompilationRatioMetricConfig                 `mapstructure:"sqlserver.recompilation.ratio"`
 	SqlserverReplicaDataRate                    SqlserverReplicaDataRateMetricConfig                    `mapstructure:"sqlserver.replica.data.rate"`
+	SqlserverReplicaFlowControlTime             SqlserverReplicaFlowControlTimeMetricConfig             `mapstructure:"sqlserver.replica.flow_control.time"`
+	SqlserverReplicaQueueSize                   SqlserverReplicaQueueSizeMetricConfig                   `mapstructure:"sqlserver.replica.queue.size"`
 	SqlserverResourcePoolDiskOperations         SqlserverResourcePoolDiskOperationsMetricConfig         `mapstructure:"sqlserver.resource_pool.disk.operations"`
 	SqlserverResourcePoolDiskThrottledReadRate  SqlserverResourcePoolDiskThrottledReadRateMetricConfig  `mapstructure:"sqlserver.resource_pool.disk.throttled.read.rate"`
 	SqlserverResourcePoolDiskThrottledWriteRate SqlserverResourcePoolDiskThrottledWriteRateMetricConfig `mapstructure:"sqlserver.resource_pool.disk.throttled.write.rate"`
@@ -2072,6 +2227,11 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverLockWaitTimeAvg: SqlserverLockWaitTimeAvgMetricConfig{
 			Enabled: true,
 		},
+		SqlserverLogDataIoRate: SqlserverLogDataIoRateMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverLogDataIoRateMetricAttributeKey{SqlserverLogDataIoRateMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverLogDataIoRateMetricAttributeKeyDbNamespace, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaName, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaDirection},
+		},
 		SqlserverLoginRate: SqlserverLoginRateMetricConfig{
 			Enabled: false,
 		},
@@ -2160,7 +2320,17 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverReplicaDataRate: SqlserverReplicaDataRateMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection},
+			EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection},
+		},
+		SqlserverReplicaFlowControlTime: SqlserverReplicaFlowControlTimeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverReplicaFlowControlTimeMetricAttributeKey{SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName},
+		},
+		SqlserverReplicaQueueSize: SqlserverReplicaQueueSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverReplicaQueueSizeMetricAttributeKey{SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType},
 		},
 		SqlserverResourcePoolDiskOperations: SqlserverResourcePoolDiskOperationsMetricConfig{
 			Enabled:             false,

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
@@ -659,6 +659,18 @@ func TestSqlserverLatchSuperlatchTransitionRateMetricsConfig_Validate(t *testing
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverLogDataIoRateMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverLogDataIoRate
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverLogDataIoRateMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.log_data.io.rate doesn't have an attribute invalid, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.direction]")
+
+	cfg = DefaultMetricsConfig().SqlserverLogDataIoRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverMemoryAreaMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverMemoryArea
 	require.NoError(t, cfg.Validate())
@@ -763,6 +775,30 @@ func TestSqlserverReplicaDataRateMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.data.rate doesn't have an attribute invalid, valid attributes: [sqlserver.replica.direction]")
 
 	cfg = DefaultMetricsConfig().SqlserverReplicaDataRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverReplicaFlowControlTimeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverReplicaFlowControlTime
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverReplicaFlowControlTimeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.flow_control.time doesn't have an attribute invalid, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverReplicaFlowControlTime
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverReplicaQueueSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverReplicaQueueSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverReplicaQueueSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.queue.size doesn't have an attribute invalid, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.queue.type]")
+
+	cfg = DefaultMetricsConfig().SqlserverReplicaQueueSize
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
@@ -219,17 +219,17 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverReplicaDataRate: SqlserverReplicaDataRateMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection},
-					},
-					SqlserverReplicaFlowControlTime: SqlserverReplicaFlowControlTimeMetricConfig{
-						Enabled:             true,
-						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SqlserverReplicaFlowControlTimeMetricAttributeKey{SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName},
+						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection},
 					},
 					SqlserverReplicaQueueSize: SqlserverReplicaQueueSizeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverReplicaQueueSizeMetricAttributeKey{SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType},
+					},
+					SqlserverReplicaSecondaryLag: SqlserverReplicaSecondaryLagMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverReplicaSecondaryLagMetricAttributeKey{SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaSecondaryLagMetricAttributeKeyDbNamespace, SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverReplicaName},
 					},
 					SqlserverResourcePoolDiskOperations: SqlserverResourcePoolDiskOperationsMetricConfig{
 						Enabled:             true,
@@ -496,17 +496,17 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverReplicaDataRate: SqlserverReplicaDataRateMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection},
-					},
-					SqlserverReplicaFlowControlTime: SqlserverReplicaFlowControlTimeMetricConfig{
-						Enabled:             false,
-						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SqlserverReplicaFlowControlTimeMetricAttributeKey{SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName},
+						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection},
 					},
 					SqlserverReplicaQueueSize: SqlserverReplicaQueueSizeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverReplicaQueueSizeMetricAttributeKey{SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType},
+					},
+					SqlserverReplicaSecondaryLag: SqlserverReplicaSecondaryLagMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverReplicaSecondaryLagMetricAttributeKey{SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaSecondaryLagMetricAttributeKeyDbNamespace, SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverReplicaName},
 					},
 					SqlserverResourcePoolDiskOperations: SqlserverResourcePoolDiskOperationsMetricConfig{
 						Enabled:             false,
@@ -581,7 +581,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAccessScanRateMetricConfig{}, SqlserverAttentionRateMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverExtentOperationRateMetricConfig{}, SqlserverGhostRecordSkippedRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLogDataIoRateMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverPageAllocationRateMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageCompressionRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageReadAheadRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverReplicaFlowControlTimeMetricConfig{}, SqlserverReplicaQueueSizeMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverScanPointRevalidationRateMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, SqlserverWorktableCacheHitRatioMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAccessScanRateMetricConfig{}, SqlserverAttentionRateMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverExtentOperationRateMetricConfig{}, SqlserverGhostRecordSkippedRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLogDataIoRateMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverPageAllocationRateMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageCompressionRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageReadAheadRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverReplicaQueueSizeMetricConfig{}, SqlserverReplicaSecondaryLagMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverScanPointRevalidationRateMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, SqlserverWorktableCacheHitRatioMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -772,21 +772,9 @@ func TestSqlserverReplicaDataRateMetricsConfig_Validate(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cfg.EnabledAttributes = []SqlserverReplicaDataRateMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.data.rate doesn't have an attribute invalid, valid attributes: [sqlserver.replica.direction]")
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.data.rate doesn't have an attribute invalid, valid attributes: [replica.direction]")
 
 	cfg = DefaultMetricsConfig().SqlserverReplicaDataRate
-	cfg.AggregationStrategy = "invalid"
-	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
-}
-
-func TestSqlserverReplicaFlowControlTimeMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().SqlserverReplicaFlowControlTime
-	require.NoError(t, cfg.Validate())
-
-	cfg.EnabledAttributes = []SqlserverReplicaFlowControlTimeMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.flow_control.time doesn't have an attribute invalid, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]")
-
-	cfg = DefaultMetricsConfig().SqlserverReplicaFlowControlTime
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -799,6 +787,18 @@ func TestSqlserverReplicaQueueSizeMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.queue.size doesn't have an attribute invalid, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.queue.type]")
 
 	cfg = DefaultMetricsConfig().SqlserverReplicaQueueSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverReplicaSecondaryLagMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverReplicaSecondaryLag
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverReplicaSecondaryLagMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.secondary_lag doesn't have an attribute invalid, valid attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverReplicaSecondaryLag
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
@@ -126,6 +126,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverLockWaitTimeAvg: SqlserverLockWaitTimeAvgMetricConfig{
 						Enabled: true,
 					},
+					SqlserverLogDataIoRate: SqlserverLogDataIoRateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLogDataIoRateMetricAttributeKey{SqlserverLogDataIoRateMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverLogDataIoRateMetricAttributeKeyDbNamespace, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaName, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaDirection},
+					},
 					SqlserverLoginRate: SqlserverLoginRateMetricConfig{
 						Enabled: true,
 					},
@@ -214,7 +219,17 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverReplicaDataRate: SqlserverReplicaDataRateMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection},
+						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection},
+					},
+					SqlserverReplicaFlowControlTime: SqlserverReplicaFlowControlTimeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverReplicaFlowControlTimeMetricAttributeKey{SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName},
+					},
+					SqlserverReplicaQueueSize: SqlserverReplicaQueueSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverReplicaQueueSizeMetricAttributeKey{SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType},
 					},
 					SqlserverResourcePoolDiskOperations: SqlserverResourcePoolDiskOperationsMetricConfig{
 						Enabled:             true,
@@ -388,6 +403,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverLockWaitTimeAvg: SqlserverLockWaitTimeAvgMetricConfig{
 						Enabled: false,
 					},
+					SqlserverLogDataIoRate: SqlserverLogDataIoRateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLogDataIoRateMetricAttributeKey{SqlserverLogDataIoRateMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverLogDataIoRateMetricAttributeKeyDbNamespace, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaName, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaDirection},
+					},
 					SqlserverLoginRate: SqlserverLoginRateMetricConfig{
 						Enabled: false,
 					},
@@ -476,7 +496,17 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverReplicaDataRate: SqlserverReplicaDataRateMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection},
+						EnabledAttributes:   []SqlserverReplicaDataRateMetricAttributeKey{SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection},
+					},
+					SqlserverReplicaFlowControlTime: SqlserverReplicaFlowControlTimeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverReplicaFlowControlTimeMetricAttributeKey{SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName},
+					},
+					SqlserverReplicaQueueSize: SqlserverReplicaQueueSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverReplicaQueueSizeMetricAttributeKey{SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType},
 					},
 					SqlserverResourcePoolDiskOperations: SqlserverResourcePoolDiskOperationsMetricConfig{
 						Enabled:             false,
@@ -551,7 +581,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAccessScanRateMetricConfig{}, SqlserverAttentionRateMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverExtentOperationRateMetricConfig{}, SqlserverGhostRecordSkippedRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverPageAllocationRateMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageCompressionRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageReadAheadRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverScanPointRevalidationRateMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, SqlserverWorktableCacheHitRatioMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAccessScanRateMetricConfig{}, SqlserverAttentionRateMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverExtentOperationRateMetricConfig{}, SqlserverGhostRecordSkippedRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLogDataIoRateMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverPageAllocationRateMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageCompressionRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageReadAheadRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverReplicaFlowControlTimeMetricConfig{}, SqlserverReplicaQueueSizeMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverScanPointRevalidationRateMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, SqlserverWorktableCacheHitRatioMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -730,7 +760,7 @@ func TestSqlserverReplicaDataRateMetricsConfig_Validate(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cfg.EnabledAttributes = []SqlserverReplicaDataRateMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.data.rate doesn't have an attribute invalid, valid attributes: [replica.direction]")
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.replica.data.rate doesn't have an attribute invalid, valid attributes: [sqlserver.replica.direction]")
 
 	cfg = DefaultMetricsConfig().SqlserverReplicaDataRate
 	cfg.AggregationStrategy = "invalid"

--- a/receiver/sqlserverreceiver/internal/metadata/generated_logs.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_logs.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/sqlserverreceiver/internal/metadata/generated_logs.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_logs.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/sqlserverreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_logs_test.go
@@ -4,6 +4,9 @@ package metadata
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -11,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"testing"
-	"time"
 )
 
 type eventsTestDataSet int

--- a/receiver/sqlserverreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_logs_test.go
@@ -4,9 +4,6 @@ package metadata
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -14,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"testing"
+	"time"
 )
 
 type eventsTestDataSet int

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -372,6 +372,7 @@ var MapAttributeSqlserverPageCompressionType = map[string]AttributeSqlserverPage
 	"succeeded": AttributeSqlserverPageCompressionTypeSucceeded,
 }
 
+
 // AttributeSqlserverParameterizationResult specifies the value sqlserver.parameterization.result attribute.
 type AttributeSqlserverParameterizationResult int
 
@@ -434,6 +435,58 @@ func (av AttributeSqlserverPlanGuidanceResult) String() string {
 var MapAttributeSqlserverPlanGuidanceResult = map[string]AttributeSqlserverPlanGuidanceResult{
 	"guided":    AttributeSqlserverPlanGuidanceResultGuided,
 	"misguided": AttributeSqlserverPlanGuidanceResultMisguided,
+}
+
+// AttributeSqlserverReplicaDirection specifies the value sqlserver.replica.direction attribute.
+type AttributeSqlserverReplicaDirection int
+
+const (
+	_ AttributeSqlserverReplicaDirection = iota
+	AttributeSqlserverReplicaDirectionTransmit
+	AttributeSqlserverReplicaDirectionReceive
+)
+
+// String returns the string representation of the AttributeSqlserverReplicaDirection.
+func (av AttributeSqlserverReplicaDirection) String() string {
+	switch av {
+	case AttributeSqlserverReplicaDirectionTransmit:
+		return "transmit"
+	case AttributeSqlserverReplicaDirectionReceive:
+		return "receive"
+	}
+	return ""
+}
+
+// MapAttributeSqlserverReplicaDirection is a helper map of string to AttributeSqlserverReplicaDirection attribute value.
+var MapAttributeSqlserverReplicaDirection = map[string]AttributeSqlserverReplicaDirection{
+	"transmit": AttributeSqlserverReplicaDirectionTransmit,
+	"receive":  AttributeSqlserverReplicaDirectionReceive,
+}
+
+// AttributeSqlserverReplicaQueueType specifies the value sqlserver.replica.queue.type attribute.
+type AttributeSqlserverReplicaQueueType int
+
+const (
+	_ AttributeSqlserverReplicaQueueType = iota
+	AttributeSqlserverReplicaQueueTypeSend
+	AttributeSqlserverReplicaQueueTypeRedo
+)
+
+// String returns the string representation of the AttributeSqlserverReplicaQueueType.
+func (av AttributeSqlserverReplicaQueueType) String() string {
+	switch av {
+	case AttributeSqlserverReplicaQueueTypeSend:
+		return "send"
+	case AttributeSqlserverReplicaQueueTypeRedo:
+		return "redo"
+	}
+	return ""
+}
+
+// MapAttributeSqlserverReplicaQueueType is a helper map of string to AttributeSqlserverReplicaQueueType attribute value.
+var MapAttributeSqlserverReplicaQueueType = map[string]AttributeSqlserverReplicaQueueType{
+	"send": AttributeSqlserverReplicaQueueTypeSend,
+	"redo": AttributeSqlserverReplicaQueueTypeRedo,
 }
 
 // AttributeTableState specifies the value table.state attribute.
@@ -636,6 +689,9 @@ var MetricsInfo = metricsInfo{
 	SqlserverLockWaitTimeAvg: metricInfo{
 		Name: "sqlserver.lock.wait_time.avg",
 	},
+	SqlserverLogDataIoRate: metricInfo{
+		Name: "sqlserver.log_data.io.rate",
+	},
 	SqlserverLoginRate: metricInfo{
 		Name: "sqlserver.login.rate",
 	},
@@ -718,6 +774,12 @@ var MetricsInfo = metricsInfo{
 	SqlserverReplicaDataRate: metricInfo{
 		Name:       "sqlserver.replica.data.rate",
 		Attributes: []string{"replica.direction"},
+	},
+	SqlserverReplicaFlowControlTime: metricInfo{
+		Name: "sqlserver.replica.flow_control.time",
+	},
+	SqlserverReplicaQueueSize: metricInfo{
+		Name: "sqlserver.replica.queue.size",
 	},
 	SqlserverResourcePoolDiskOperations: metricInfo{
 		Name:       "sqlserver.resource_pool.disk.operations",
@@ -804,6 +866,7 @@ type metricsInfo struct {
 	SqlserverLockWaitCount                      metricInfo
 	SqlserverLockWaitRate                       metricInfo
 	SqlserverLockWaitTimeAvg                    metricInfo
+	SqlserverLogDataIoRate                      metricInfo
 	SqlserverLoginRate                          metricInfo
 	SqlserverLogoutRate                         metricInfo
 	SqlserverMemoryArea                         metricInfo
@@ -828,6 +891,8 @@ type metricsInfo struct {
 	SqlserverProcessesBlocked                   metricInfo
 	SqlserverRecompilationRatio                 metricInfo
 	SqlserverReplicaDataRate                    metricInfo
+	SqlserverReplicaFlowControlTime             metricInfo
+	SqlserverReplicaQueueSize                   metricInfo
 	SqlserverResourcePoolDiskOperations         metricInfo
 	SqlserverResourcePoolDiskThrottledReadRate  metricInfo
 	SqlserverResourcePoolDiskThrottledWriteRate metricInfo
@@ -2579,6 +2644,104 @@ func newMetricSqlserverLockWaitTimeAvg(cfg SqlserverLockWaitTimeAvgMetricConfig)
 	return m
 }
 
+type metricSqlserverLogDataIoRate struct {
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        SqlserverLogDataIoRateMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []float64                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.log_data.io.rate metric with initial data.
+func (m *metricSqlserverLogDataIoRate) init() {
+	m.data.SetName("sqlserver.log_data.io.rate")
+	m.data.SetDescription("Rate of log data flow between availability group replicas.")
+	m.data.SetUnit("By/s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverLogDataIoRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string, sqlserverReplicaDirectionAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLogDataIoRateMetricAttributeKeySqlserverAvailabilityGroupName) {
+		dp.Attributes().PutStr("sqlserver.availability_group.name", sqlserverAvailabilityGroupNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLogDataIoRateMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaName) {
+		dp.Attributes().PutStr("sqlserver.replica.name", sqlserverReplicaNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLogDataIoRateMetricAttributeKeySqlserverReplicaDirection) {
+		dp.Attributes().PutStr("sqlserver.replica.direction", sqlserverReplicaDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverLogDataIoRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverLogDataIoRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverLogDataIoRate(cfg SqlserverLogDataIoRateMetricConfig) metricSqlserverLogDataIoRate {
+	m := metricSqlserverLogDataIoRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverLoginRate struct {
 	data     pmetric.Metric                 // data buffer for generated metric.
 	config   SqlserverLoginRateMetricConfig // metric config provided by user.
@@ -4071,7 +4234,7 @@ func (m *metricSqlserverReplicaDataRate) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSqlserverReplicaDataRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, replicaDirectionAttributeValue string) {
+func (m *metricSqlserverReplicaDataRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, sqlserverReplicaDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -4079,8 +4242,8 @@ func (m *metricSqlserverReplicaDataRate) recordDataPoint(start pcommon.Timestamp
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection) {
-		dp.Attributes().PutStr("replica.direction", replicaDirectionAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection) {
+		dp.Attributes().PutStr("sqlserver.replica.direction", sqlserverReplicaDirectionAttributeValue)
 	}
 
 	var s string
@@ -4135,6 +4298,199 @@ func (m *metricSqlserverReplicaDataRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverReplicaDataRate(cfg SqlserverReplicaDataRateMetricConfig) metricSqlserverReplicaDataRate {
 	m := metricSqlserverReplicaDataRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverReplicaFlowControlTime struct {
+	data          pmetric.Metric                              // data buffer for generated metric.
+	config        SqlserverReplicaFlowControlTimeMetricConfig // metric config provided by user.
+	capacity      int                                         // max observed number of data points added to the metric.
+	aggDataPoints []float64                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.replica.flow_control.time metric with initial data.
+func (m *metricSqlserverReplicaFlowControlTime) init() {
+	m.data.SetName("sqlserver.replica.flow_control.time")
+	m.data.SetDescription("Current flow control lag on the secondary replica, derived from secondary_lag_seconds.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverReplicaFlowControlTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName) {
+		dp.Attributes().PutStr("sqlserver.availability_group.name", sqlserverAvailabilityGroupNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName) {
+		dp.Attributes().PutStr("sqlserver.replica.name", sqlserverReplicaNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverReplicaFlowControlTime) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverReplicaFlowControlTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverReplicaFlowControlTime(cfg SqlserverReplicaFlowControlTimeMetricConfig) metricSqlserverReplicaFlowControlTime {
+	m := metricSqlserverReplicaFlowControlTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverReplicaQueueSize struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        SqlserverReplicaQueueSizeMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.replica.queue.size metric with initial data.
+func (m *metricSqlserverReplicaQueueSize) init() {
+	m.data.SetName("sqlserver.replica.queue.size")
+	m.data.SetDescription("Amount of log data queued in the availability group replica pipeline.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverReplicaQueueSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string, sqlserverReplicaQueueTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverAvailabilityGroupName) {
+		dp.Attributes().PutStr("sqlserver.availability_group.name", sqlserverAvailabilityGroupNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaQueueSizeMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaName) {
+		dp.Attributes().PutStr("sqlserver.replica.name", sqlserverReplicaNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaQueueSizeMetricAttributeKeySqlserverReplicaQueueType) {
+		dp.Attributes().PutStr("sqlserver.replica.queue.type", sqlserverReplicaQueueTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverReplicaQueueSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverReplicaQueueSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverReplicaQueueSize(cfg SqlserverReplicaQueueSizeMetricConfig) metricSqlserverReplicaQueueSize {
+	m := metricSqlserverReplicaQueueSize{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5121,6 +5477,7 @@ type MetricsBuilder struct {
 	metricSqlserverLockWaitCount                      metricSqlserverLockWaitCount
 	metricSqlserverLockWaitRate                       metricSqlserverLockWaitRate
 	metricSqlserverLockWaitTimeAvg                    metricSqlserverLockWaitTimeAvg
+	metricSqlserverLogDataIoRate                      metricSqlserverLogDataIoRate
 	metricSqlserverLoginRate                          metricSqlserverLoginRate
 	metricSqlserverLogoutRate                         metricSqlserverLogoutRate
 	metricSqlserverMemoryArea                         metricSqlserverMemoryArea
@@ -5145,6 +5502,8 @@ type MetricsBuilder struct {
 	metricSqlserverProcessesBlocked                   metricSqlserverProcessesBlocked
 	metricSqlserverRecompilationRatio                 metricSqlserverRecompilationRatio
 	metricSqlserverReplicaDataRate                    metricSqlserverReplicaDataRate
+	metricSqlserverReplicaFlowControlTime             metricSqlserverReplicaFlowControlTime
+	metricSqlserverReplicaQueueSize                   metricSqlserverReplicaQueueSize
 	metricSqlserverResourcePoolDiskOperations         metricSqlserverResourcePoolDiskOperations
 	metricSqlserverResourcePoolDiskThrottledReadRate  metricSqlserverResourcePoolDiskThrottledReadRate
 	metricSqlserverResourcePoolDiskThrottledWriteRate metricSqlserverResourcePoolDiskThrottledWriteRate
@@ -5216,6 +5575,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverLockWaitCount:                      newMetricSqlserverLockWaitCount(mbc.Metrics.SqlserverLockWaitCount),
 		metricSqlserverLockWaitRate:                       newMetricSqlserverLockWaitRate(mbc.Metrics.SqlserverLockWaitRate),
 		metricSqlserverLockWaitTimeAvg:                    newMetricSqlserverLockWaitTimeAvg(mbc.Metrics.SqlserverLockWaitTimeAvg),
+		metricSqlserverLogDataIoRate:                      newMetricSqlserverLogDataIoRate(mbc.Metrics.SqlserverLogDataIoRate),
 		metricSqlserverLoginRate:                          newMetricSqlserverLoginRate(mbc.Metrics.SqlserverLoginRate),
 		metricSqlserverLogoutRate:                         newMetricSqlserverLogoutRate(mbc.Metrics.SqlserverLogoutRate),
 		metricSqlserverMemoryArea:                         newMetricSqlserverMemoryArea(mbc.Metrics.SqlserverMemoryArea),
@@ -5240,6 +5600,8 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverProcessesBlocked:                   newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
 		metricSqlserverRecompilationRatio:                 newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
 		metricSqlserverReplicaDataRate:                    newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
+		metricSqlserverReplicaFlowControlTime:             newMetricSqlserverReplicaFlowControlTime(mbc.Metrics.SqlserverReplicaFlowControlTime),
+		metricSqlserverReplicaQueueSize:                   newMetricSqlserverReplicaQueueSize(mbc.Metrics.SqlserverReplicaQueueSize),
 		metricSqlserverResourcePoolDiskOperations:         newMetricSqlserverResourcePoolDiskOperations(mbc.Metrics.SqlserverResourcePoolDiskOperations),
 		metricSqlserverResourcePoolDiskThrottledReadRate:  newMetricSqlserverResourcePoolDiskThrottledReadRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledReadRate),
 		metricSqlserverResourcePoolDiskThrottledWriteRate: newMetricSqlserverResourcePoolDiskThrottledWriteRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledWriteRate),
@@ -5412,6 +5774,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverLockWaitCount.emit(ils.Metrics())
 	mb.metricSqlserverLockWaitRate.emit(ils.Metrics())
 	mb.metricSqlserverLockWaitTimeAvg.emit(ils.Metrics())
+	mb.metricSqlserverLogDataIoRate.emit(ils.Metrics())
 	mb.metricSqlserverLoginRate.emit(ils.Metrics())
 	mb.metricSqlserverLogoutRate.emit(ils.Metrics())
 	mb.metricSqlserverMemoryArea.emit(ils.Metrics())
@@ -5436,6 +5799,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverProcessesBlocked.emit(ils.Metrics())
 	mb.metricSqlserverRecompilationRatio.emit(ils.Metrics())
 	mb.metricSqlserverReplicaDataRate.emit(ils.Metrics())
+	mb.metricSqlserverReplicaFlowControlTime.emit(ils.Metrics())
+	mb.metricSqlserverReplicaQueueSize.emit(ils.Metrics())
 	mb.metricSqlserverResourcePoolDiskOperations.emit(ils.Metrics())
 	mb.metricSqlserverResourcePoolDiskThrottledReadRate.emit(ils.Metrics())
 	mb.metricSqlserverResourcePoolDiskThrottledWriteRate.emit(ils.Metrics())
@@ -5654,6 +6019,11 @@ func (mb *MetricsBuilder) RecordSqlserverLockWaitTimeAvgDataPoint(ts pcommon.Tim
 	mb.metricSqlserverLockWaitTimeAvg.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverLogDataIoRateDataPoint adds a data point to sqlserver.log_data.io.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverLogDataIoRateDataPoint(ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string, sqlserverReplicaDirectionAttributeValue AttributeSqlserverReplicaDirection) {
+	mb.metricSqlserverLogDataIoRate.recordDataPoint(mb.startTime, ts, val, sqlserverAvailabilityGroupNameAttributeValue, dbNamespaceAttributeValue, sqlserverReplicaNameAttributeValue, sqlserverReplicaDirectionAttributeValue.String())
+}
+
 // RecordSqlserverLoginRateDataPoint adds a data point to sqlserver.login.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverLoginRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverLoginRate.recordDataPoint(mb.startTime, ts, val)
@@ -5775,8 +6145,18 @@ func (mb *MetricsBuilder) RecordSqlserverRecompilationRatioDataPoint(ts pcommon.
 }
 
 // RecordSqlserverReplicaDataRateDataPoint adds a data point to sqlserver.replica.data.rate metric.
-func (mb *MetricsBuilder) RecordSqlserverReplicaDataRateDataPoint(ts pcommon.Timestamp, val float64, replicaDirectionAttributeValue AttributeReplicaDirection) {
-	mb.metricSqlserverReplicaDataRate.recordDataPoint(mb.startTime, ts, val, replicaDirectionAttributeValue.String())
+func (mb *MetricsBuilder) RecordSqlserverReplicaDataRateDataPoint(ts pcommon.Timestamp, val float64, sqlserverReplicaDirectionAttributeValue AttributeSqlserverReplicaDirection) {
+	mb.metricSqlserverReplicaDataRate.recordDataPoint(mb.startTime, ts, val, sqlserverReplicaDirectionAttributeValue.String())
+}
+
+// RecordSqlserverReplicaFlowControlTimeDataPoint adds a data point to sqlserver.replica.flow_control.time metric.
+func (mb *MetricsBuilder) RecordSqlserverReplicaFlowControlTimeDataPoint(ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string) {
+	mb.metricSqlserverReplicaFlowControlTime.recordDataPoint(mb.startTime, ts, val, sqlserverAvailabilityGroupNameAttributeValue, dbNamespaceAttributeValue, sqlserverReplicaNameAttributeValue)
+}
+
+// RecordSqlserverReplicaQueueSizeDataPoint adds a data point to sqlserver.replica.queue.size metric.
+func (mb *MetricsBuilder) RecordSqlserverReplicaQueueSizeDataPoint(ts pcommon.Timestamp, val int64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string, sqlserverReplicaQueueTypeAttributeValue AttributeSqlserverReplicaQueueType) {
+	mb.metricSqlserverReplicaQueueSize.recordDataPoint(mb.startTime, ts, val, sqlserverAvailabilityGroupNameAttributeValue, dbNamespaceAttributeValue, sqlserverReplicaNameAttributeValue, sqlserverReplicaQueueTypeAttributeValue.String())
 }
 
 // RecordSqlserverResourcePoolDiskOperationsDataPoint adds a data point to sqlserver.resource_pool.disk.operations metric.

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -4,15 +4,14 @@ package metadata
 
 import (
 	"fmt"
-	"slices"
-	"strconv"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"slices"
+	"strconv"
+	"time"
 )
 
 const (
@@ -371,7 +370,6 @@ var MapAttributeSqlserverPageCompressionType = map[string]AttributeSqlserverPage
 	"attempted": AttributeSqlserverPageCompressionTypeAttempted,
 	"succeeded": AttributeSqlserverPageCompressionTypeSucceeded,
 }
-
 
 // AttributeSqlserverParameterizationResult specifies the value sqlserver.parameterization.result attribute.
 type AttributeSqlserverParameterizationResult int
@@ -774,15 +772,15 @@ var MetricsInfo = metricsInfo{
 	},
 	SqlserverReplicaDataRate: metricInfo{
 		Name:       "sqlserver.replica.data.rate",
-		Attributes: []string{"sqlserver.replica.direction"},
-	},
-	SqlserverReplicaFlowControlTime: metricInfo{
-		Name:       "sqlserver.replica.flow_control.time",
-		Attributes: []string{"sqlserver.availability_group.name", "db.namespace", "sqlserver.replica.name"},
+		Attributes: []string{"replica.direction"},
 	},
 	SqlserverReplicaQueueSize: metricInfo{
 		Name:       "sqlserver.replica.queue.size",
 		Attributes: []string{"sqlserver.availability_group.name", "db.namespace", "sqlserver.replica.name", "sqlserver.replica.queue.type"},
+	},
+	SqlserverReplicaSecondaryLag: metricInfo{
+		Name:       "sqlserver.replica.secondary_lag",
+		Attributes: []string{"sqlserver.availability_group.name", "db.namespace", "sqlserver.replica.name"},
 	},
 	SqlserverResourcePoolDiskOperations: metricInfo{
 		Name:       "sqlserver.resource_pool.disk.operations",
@@ -894,8 +892,8 @@ type metricsInfo struct {
 	SqlserverProcessesBlocked                   metricInfo
 	SqlserverRecompilationRatio                 metricInfo
 	SqlserverReplicaDataRate                    metricInfo
-	SqlserverReplicaFlowControlTime             metricInfo
 	SqlserverReplicaQueueSize                   metricInfo
+	SqlserverReplicaSecondaryLag                metricInfo
 	SqlserverResourcePoolDiskOperations         metricInfo
 	SqlserverResourcePoolDiskThrottledReadRate  metricInfo
 	SqlserverResourcePoolDiskThrottledWriteRate metricInfo
@@ -4237,7 +4235,7 @@ func (m *metricSqlserverReplicaDataRate) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSqlserverReplicaDataRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, sqlserverReplicaDirectionAttributeValue string) {
+func (m *metricSqlserverReplicaDataRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, replicaDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -4245,8 +4243,8 @@ func (m *metricSqlserverReplicaDataRate) recordDataPoint(start pcommon.Timestamp
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaDataRateMetricAttributeKeySqlserverReplicaDirection) {
-		dp.Attributes().PutStr("sqlserver.replica.direction", sqlserverReplicaDirectionAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaDataRateMetricAttributeKeyReplicaDirection) {
+		dp.Attributes().PutStr("replica.direction", replicaDirectionAttributeValue)
 	}
 
 	var s string
@@ -4301,101 +4299,6 @@ func (m *metricSqlserverReplicaDataRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverReplicaDataRate(cfg SqlserverReplicaDataRateMetricConfig) metricSqlserverReplicaDataRate {
 	m := metricSqlserverReplicaDataRate{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricSqlserverReplicaFlowControlTime struct {
-	data          pmetric.Metric                              // data buffer for generated metric.
-	config        SqlserverReplicaFlowControlTimeMetricConfig // metric config provided by user.
-	capacity      int                                         // max observed number of data points added to the metric.
-	aggDataPoints []float64                                   // slice containing number of aggregated datapoints at each index
-}
-
-// init fills sqlserver.replica.flow_control.time metric with initial data.
-func (m *metricSqlserverReplicaFlowControlTime) init() {
-	m.data.SetName("sqlserver.replica.flow_control.time")
-	m.data.SetDescription("Current flow control lag on the secondary replica, derived from secondary_lag_seconds.")
-	m.data.SetUnit("s")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-	m.aggDataPoints = m.aggDataPoints[:0]
-}
-
-func (m *metricSqlserverReplicaFlowControlTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string) {
-	if !m.config.Enabled {
-		return
-	}
-
-	dp := pmetric.NewNumberDataPoint()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverAvailabilityGroupName) {
-		dp.Attributes().PutStr("sqlserver.availability_group.name", sqlserverAvailabilityGroupNameAttributeValue)
-	}
-	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaFlowControlTimeMetricAttributeKeyDbNamespace) {
-		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
-	}
-	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaFlowControlTimeMetricAttributeKeySqlserverReplicaName) {
-		dp.Attributes().PutStr("sqlserver.replica.name", sqlserverReplicaNameAttributeValue)
-	}
-
-	var s string
-	dps := m.data.Gauge().DataPoints()
-	for i := 0; i < dps.Len(); i++ {
-		dpi := dps.At(i)
-		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
-			switch s = m.config.AggregationStrategy; s {
-			case AggregationStrategySum, AggregationStrategyAvg:
-				dpi.SetDoubleValue(dpi.DoubleValue() + val)
-				m.aggDataPoints[i] += 1
-				return
-			case AggregationStrategyMin:
-				if dpi.DoubleValue() > val {
-					dpi.SetDoubleValue(val)
-				}
-				return
-			case AggregationStrategyMax:
-				if dpi.DoubleValue() < val {
-					dpi.SetDoubleValue(val)
-				}
-				return
-			}
-		}
-	}
-
-	dp.SetDoubleValue(val)
-	m.aggDataPoints = append(m.aggDataPoints, 1)
-	dp.MoveTo(dps.AppendEmpty())
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricSqlserverReplicaFlowControlTime) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricSqlserverReplicaFlowControlTime) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		if m.config.AggregationStrategy == AggregationStrategyAvg {
-			for i, aggCount := range m.aggDataPoints {
-				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
-			}
-		}
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricSqlserverReplicaFlowControlTime(cfg SqlserverReplicaFlowControlTimeMetricConfig) metricSqlserverReplicaFlowControlTime {
-	m := metricSqlserverReplicaFlowControlTime{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4494,6 +4397,101 @@ func (m *metricSqlserverReplicaQueueSize) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverReplicaQueueSize(cfg SqlserverReplicaQueueSizeMetricConfig) metricSqlserverReplicaQueueSize {
 	m := metricSqlserverReplicaQueueSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverReplicaSecondaryLag struct {
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        SqlserverReplicaSecondaryLagMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []float64                                // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.replica.secondary_lag metric with initial data.
+func (m *metricSqlserverReplicaSecondaryLag) init() {
+	m.data.SetName("sqlserver.replica.secondary_lag")
+	m.data.SetDescription("Number of seconds the secondary replica is lagging behind the primary replica.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverReplicaSecondaryLag) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverAvailabilityGroupName) {
+		dp.Attributes().PutStr("sqlserver.availability_group.name", sqlserverAvailabilityGroupNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaSecondaryLagMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverReplicaSecondaryLagMetricAttributeKeySqlserverReplicaName) {
+		dp.Attributes().PutStr("sqlserver.replica.name", sqlserverReplicaNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverReplicaSecondaryLag) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverReplicaSecondaryLag) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverReplicaSecondaryLag(cfg SqlserverReplicaSecondaryLagMetricConfig) metricSqlserverReplicaSecondaryLag {
+	m := metricSqlserverReplicaSecondaryLag{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5505,8 +5503,8 @@ type MetricsBuilder struct {
 	metricSqlserverProcessesBlocked                   metricSqlserverProcessesBlocked
 	metricSqlserverRecompilationRatio                 metricSqlserverRecompilationRatio
 	metricSqlserverReplicaDataRate                    metricSqlserverReplicaDataRate
-	metricSqlserverReplicaFlowControlTime             metricSqlserverReplicaFlowControlTime
 	metricSqlserverReplicaQueueSize                   metricSqlserverReplicaQueueSize
+	metricSqlserverReplicaSecondaryLag                metricSqlserverReplicaSecondaryLag
 	metricSqlserverResourcePoolDiskOperations         metricSqlserverResourcePoolDiskOperations
 	metricSqlserverResourcePoolDiskThrottledReadRate  metricSqlserverResourcePoolDiskThrottledReadRate
 	metricSqlserverResourcePoolDiskThrottledWriteRate metricSqlserverResourcePoolDiskThrottledWriteRate
@@ -5603,8 +5601,8 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverProcessesBlocked:                   newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
 		metricSqlserverRecompilationRatio:                 newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
 		metricSqlserverReplicaDataRate:                    newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
-		metricSqlserverReplicaFlowControlTime:             newMetricSqlserverReplicaFlowControlTime(mbc.Metrics.SqlserverReplicaFlowControlTime),
 		metricSqlserverReplicaQueueSize:                   newMetricSqlserverReplicaQueueSize(mbc.Metrics.SqlserverReplicaQueueSize),
+		metricSqlserverReplicaSecondaryLag:                newMetricSqlserverReplicaSecondaryLag(mbc.Metrics.SqlserverReplicaSecondaryLag),
 		metricSqlserverResourcePoolDiskOperations:         newMetricSqlserverResourcePoolDiskOperations(mbc.Metrics.SqlserverResourcePoolDiskOperations),
 		metricSqlserverResourcePoolDiskThrottledReadRate:  newMetricSqlserverResourcePoolDiskThrottledReadRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledReadRate),
 		metricSqlserverResourcePoolDiskThrottledWriteRate: newMetricSqlserverResourcePoolDiskThrottledWriteRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledWriteRate),
@@ -5802,8 +5800,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverProcessesBlocked.emit(ils.Metrics())
 	mb.metricSqlserverRecompilationRatio.emit(ils.Metrics())
 	mb.metricSqlserverReplicaDataRate.emit(ils.Metrics())
-	mb.metricSqlserverReplicaFlowControlTime.emit(ils.Metrics())
 	mb.metricSqlserverReplicaQueueSize.emit(ils.Metrics())
+	mb.metricSqlserverReplicaSecondaryLag.emit(ils.Metrics())
 	mb.metricSqlserverResourcePoolDiskOperations.emit(ils.Metrics())
 	mb.metricSqlserverResourcePoolDiskThrottledReadRate.emit(ils.Metrics())
 	mb.metricSqlserverResourcePoolDiskThrottledWriteRate.emit(ils.Metrics())
@@ -6148,18 +6146,18 @@ func (mb *MetricsBuilder) RecordSqlserverRecompilationRatioDataPoint(ts pcommon.
 }
 
 // RecordSqlserverReplicaDataRateDataPoint adds a data point to sqlserver.replica.data.rate metric.
-func (mb *MetricsBuilder) RecordSqlserverReplicaDataRateDataPoint(ts pcommon.Timestamp, val float64, sqlserverReplicaDirectionAttributeValue AttributeSqlserverReplicaDirection) {
-	mb.metricSqlserverReplicaDataRate.recordDataPoint(mb.startTime, ts, val, sqlserverReplicaDirectionAttributeValue.String())
-}
-
-// RecordSqlserverReplicaFlowControlTimeDataPoint adds a data point to sqlserver.replica.flow_control.time metric.
-func (mb *MetricsBuilder) RecordSqlserverReplicaFlowControlTimeDataPoint(ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string) {
-	mb.metricSqlserverReplicaFlowControlTime.recordDataPoint(mb.startTime, ts, val, sqlserverAvailabilityGroupNameAttributeValue, dbNamespaceAttributeValue, sqlserverReplicaNameAttributeValue)
+func (mb *MetricsBuilder) RecordSqlserverReplicaDataRateDataPoint(ts pcommon.Timestamp, val float64, replicaDirectionAttributeValue AttributeReplicaDirection) {
+	mb.metricSqlserverReplicaDataRate.recordDataPoint(mb.startTime, ts, val, replicaDirectionAttributeValue.String())
 }
 
 // RecordSqlserverReplicaQueueSizeDataPoint adds a data point to sqlserver.replica.queue.size metric.
 func (mb *MetricsBuilder) RecordSqlserverReplicaQueueSizeDataPoint(ts pcommon.Timestamp, val int64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string, sqlserverReplicaQueueTypeAttributeValue AttributeSqlserverReplicaQueueType) {
 	mb.metricSqlserverReplicaQueueSize.recordDataPoint(mb.startTime, ts, val, sqlserverAvailabilityGroupNameAttributeValue, dbNamespaceAttributeValue, sqlserverReplicaNameAttributeValue, sqlserverReplicaQueueTypeAttributeValue.String())
+}
+
+// RecordSqlserverReplicaSecondaryLagDataPoint adds a data point to sqlserver.replica.secondary_lag metric.
+func (mb *MetricsBuilder) RecordSqlserverReplicaSecondaryLagDataPoint(ts pcommon.Timestamp, val float64, sqlserverAvailabilityGroupNameAttributeValue string, dbNamespaceAttributeValue string, sqlserverReplicaNameAttributeValue string) {
+	mb.metricSqlserverReplicaSecondaryLag.recordDataPoint(mb.startTime, ts, val, sqlserverAvailabilityGroupNameAttributeValue, dbNamespaceAttributeValue, sqlserverReplicaNameAttributeValue)
 }
 
 // RecordSqlserverResourcePoolDiskOperationsDataPoint adds a data point to sqlserver.resource_pool.disk.operations metric.

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -690,7 +690,8 @@ var MetricsInfo = metricsInfo{
 		Name: "sqlserver.lock.wait_time.avg",
 	},
 	SqlserverLogDataIoRate: metricInfo{
-		Name: "sqlserver.log_data.io.rate",
+		Name:       "sqlserver.log_data.io.rate",
+		Attributes: []string{"sqlserver.availability_group.name", "db.namespace", "sqlserver.replica.name", "sqlserver.replica.direction"},
 	},
 	SqlserverLoginRate: metricInfo{
 		Name: "sqlserver.login.rate",
@@ -773,13 +774,15 @@ var MetricsInfo = metricsInfo{
 	},
 	SqlserverReplicaDataRate: metricInfo{
 		Name:       "sqlserver.replica.data.rate",
-		Attributes: []string{"replica.direction"},
+		Attributes: []string{"sqlserver.replica.direction"},
 	},
 	SqlserverReplicaFlowControlTime: metricInfo{
-		Name: "sqlserver.replica.flow_control.time",
+		Name:       "sqlserver.replica.flow_control.time",
+		Attributes: []string{"sqlserver.availability_group.name", "db.namespace", "sqlserver.replica.name"},
 	},
 	SqlserverReplicaQueueSize: metricInfo{
-		Name: "sqlserver.replica.queue.size",
+		Name:       "sqlserver.replica.queue.size",
+		Attributes: []string{"sqlserver.availability_group.name", "db.namespace", "sqlserver.replica.name", "sqlserver.replica.queue.type"},
 	},
 	SqlserverResourcePoolDiskOperations: metricInfo{
 		Name:       "sqlserver.resource_pool.disk.operations",

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -83,8 +83,8 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.parameterization.rate"] = mb.metricSqlserverParameterizationRate.config.AggregationStrategy
 			aggMap["sqlserver.plan.execution.rate"] = mb.metricSqlserverPlanExecutionRate.config.AggregationStrategy
 			aggMap["sqlserver.replica.data.rate"] = mb.metricSqlserverReplicaDataRate.config.AggregationStrategy
-			aggMap["sqlserver.replica.flow_control.time"] = mb.metricSqlserverReplicaFlowControlTime.config.AggregationStrategy
 			aggMap["sqlserver.replica.queue.size"] = mb.metricSqlserverReplicaQueueSize.config.AggregationStrategy
+			aggMap["sqlserver.replica.secondary_lag"] = mb.metricSqlserverReplicaSecondaryLag.config.AggregationStrategy
 			aggMap["sqlserver.resource_pool.disk.operations"] = mb.metricSqlserverResourcePoolDiskOperations.config.AggregationStrategy
 			aggMap["sqlserver.table.count"] = mb.metricSqlserverTableCount.config.AggregationStrategy
 
@@ -301,21 +301,21 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverRecompilationRatioDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordSqlserverReplicaDataRateDataPoint(ts, 1, AttributeSqlserverReplicaDirectionTransmit)
+			mb.RecordSqlserverReplicaDataRateDataPoint(ts, 1, AttributeReplicaDirectionTransmit)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSqlserverReplicaDataRateDataPoint(ts, 3, AttributeSqlserverReplicaDirectionReceive)
-			}
-
-			allMetricsCount++
-			mb.RecordSqlserverReplicaFlowControlTimeDataPoint(ts, 1, "sqlserver.availability_group.name-val", "db.namespace-val", "sqlserver.replica.name-val")
-			if tt.name == "reaggregate_set" {
-				mb.RecordSqlserverReplicaFlowControlTimeDataPoint(ts, 3, "sqlserver.availability_group.name-val-2", "db.namespace-val-2", "sqlserver.replica.name-val-2")
+				mb.RecordSqlserverReplicaDataRateDataPoint(ts, 3, AttributeReplicaDirectionReceive)
 			}
 
 			allMetricsCount++
 			mb.RecordSqlserverReplicaQueueSizeDataPoint(ts, 1, "sqlserver.availability_group.name-val", "db.namespace-val", "sqlserver.replica.name-val", AttributeSqlserverReplicaQueueTypeSend)
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverReplicaQueueSizeDataPoint(ts, 3, "sqlserver.availability_group.name-val-2", "db.namespace-val-2", "sqlserver.replica.name-val-2", AttributeSqlserverReplicaQueueTypeRedo)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverReplicaSecondaryLagDataPoint(ts, 1, "sqlserver.availability_group.name-val", "db.namespace-val", "sqlserver.replica.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverReplicaSecondaryLagDataPoint(ts, 3, "sqlserver.availability_group.name-val-2", "db.namespace-val-2", "sqlserver.replica.name-val-2")
 			}
 
 			allMetricsCount++
@@ -404,8 +404,8 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverParameterizationRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPlanExecutionRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverReplicaDataRate.aggDataPoints)
-				assert.Empty(t, mb.metricSqlserverReplicaFlowControlTime.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverReplicaQueueSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverReplicaSecondaryLag.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverResourcePoolDiskOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverTableCount.aggDataPoints)
 			}
@@ -1609,9 +1609,9 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						sqlserverReplicaDirectionAttrVal, ok := dp.Attributes().Get("sqlserver.replica.direction")
+						replicaDirectionAttrVal, ok := dp.Attributes().Get("replica.direction")
 						assert.True(t, ok)
-						assert.Equal(t, "transmit", sqlserverReplicaDirectionAttrVal.Str())
+						assert.Equal(t, "transmit", replicaDirectionAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["sqlserver.replica.data.rate"], "Found a duplicate in the metrics slice: sqlserver.replica.data.rate")
 						validatedMetrics["sqlserver.replica.data.rate"] = true
@@ -1633,57 +1633,7 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
 						}
-						_, ok := dp.Attributes().Get("sqlserver.replica.direction")
-						assert.False(t, ok)
-					}
-				case "sqlserver.replica.flow_control.time":
-					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["sqlserver.replica.flow_control.time"], "Found a duplicate in the metrics slice: sqlserver.replica.flow_control.time")
-						validatedMetrics["sqlserver.replica.flow_control.time"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "Current flow control lag on the secondary replica, derived from secondary_lag_seconds.", mi.Description())
-						assert.Equal(t, "s", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
-						assert.Equal(t, start, dp.StartTimestamp())
-						assert.Equal(t, ts, dp.Timestamp())
-						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						sqlserverAvailabilityGroupNameAttrVal, ok := dp.Attributes().Get("sqlserver.availability_group.name")
-						assert.True(t, ok)
-						assert.Equal(t, "sqlserver.availability_group.name-val", sqlserverAvailabilityGroupNameAttrVal.Str())
-						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
-						assert.True(t, ok)
-						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
-						sqlserverReplicaNameAttrVal, ok := dp.Attributes().Get("sqlserver.replica.name")
-						assert.True(t, ok)
-						assert.Equal(t, "sqlserver.replica.name-val", sqlserverReplicaNameAttrVal.Str())
-					} else {
-						assert.False(t, validatedMetrics["sqlserver.replica.flow_control.time"], "Found a duplicate in the metrics slice: sqlserver.replica.flow_control.time")
-						validatedMetrics["sqlserver.replica.flow_control.time"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "Current flow control lag on the secondary replica, derived from secondary_lag_seconds.", mi.Description())
-						assert.Equal(t, "s", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
-						assert.Equal(t, start, dp.StartTimestamp())
-						assert.Equal(t, ts, dp.Timestamp())
-						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-						switch aggMap["sqlserver.replica.flow_control.time"] {
-						case "sum":
-							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
-						case "avg":
-							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
-						case "min":
-							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						case "max":
-							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
-						}
-						_, ok := dp.Attributes().Get("sqlserver.availability_group.name")
-						assert.False(t, ok)
-						_, ok = dp.Attributes().Get("db.namespace")
-						assert.False(t, ok)
-						_, ok = dp.Attributes().Get("sqlserver.replica.name")
+						_, ok := dp.Attributes().Get("replica.direction")
 						assert.False(t, ok)
 					}
 				case "sqlserver.replica.queue.size":
@@ -1739,6 +1689,56 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("sqlserver.replica.name")
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("sqlserver.replica.queue.type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.replica.secondary_lag":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.replica.secondary_lag"], "Found a duplicate in the metrics slice: sqlserver.replica.secondary_lag")
+						validatedMetrics["sqlserver.replica.secondary_lag"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of seconds the secondary replica is lagging behind the primary replica.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						sqlserverAvailabilityGroupNameAttrVal, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.availability_group.name-val", sqlserverAvailabilityGroupNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						sqlserverReplicaNameAttrVal, ok := dp.Attributes().Get("sqlserver.replica.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.replica.name-val", sqlserverReplicaNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.replica.secondary_lag"], "Found a duplicate in the metrics slice: sqlserver.replica.secondary_lag")
+						validatedMetrics["sqlserver.replica.secondary_lag"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of seconds the secondary replica is lagging behind the primary replica.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.replica.secondary_lag"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("sqlserver.replica.name")
 						assert.False(t, ok)
 					}
 				case "sqlserver.resource_pool.disk.operations":

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -73,6 +73,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.database.operations"] = mb.metricSqlserverDatabaseOperations.config.AggregationStrategy
 			aggMap["sqlserver.database.tempdb.space"] = mb.metricSqlserverDatabaseTempdbSpace.config.AggregationStrategy
 			aggMap["sqlserver.latch.superlatch.transition.rate"] = mb.metricSqlserverLatchSuperlatchTransitionRate.config.AggregationStrategy
+			aggMap["sqlserver.log_data.io.rate"] = mb.metricSqlserverLogDataIoRate.config.AggregationStrategy
 			aggMap["sqlserver.memory.area"] = mb.metricSqlserverMemoryArea.config.AggregationStrategy
 			aggMap["sqlserver.memory.cache.object.count"] = mb.metricSqlserverMemoryCacheObjectCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.page.count"] = mb.metricSqlserverMemoryPageCount.config.AggregationStrategy
@@ -82,6 +83,8 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.parameterization.rate"] = mb.metricSqlserverParameterizationRate.config.AggregationStrategy
 			aggMap["sqlserver.plan.execution.rate"] = mb.metricSqlserverPlanExecutionRate.config.AggregationStrategy
 			aggMap["sqlserver.replica.data.rate"] = mb.metricSqlserverReplicaDataRate.config.AggregationStrategy
+			aggMap["sqlserver.replica.flow_control.time"] = mb.metricSqlserverReplicaFlowControlTime.config.AggregationStrategy
+			aggMap["sqlserver.replica.queue.size"] = mb.metricSqlserverReplicaQueueSize.config.AggregationStrategy
 			aggMap["sqlserver.resource_pool.disk.operations"] = mb.metricSqlserverResourcePoolDiskOperations.config.AggregationStrategy
 			aggMap["sqlserver.table.count"] = mb.metricSqlserverTableCount.config.AggregationStrategy
 
@@ -199,6 +202,12 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverLockWaitTimeAvgDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverLogDataIoRateDataPoint(ts, 1, "sqlserver.availability_group.name-val", "db.namespace-val", "sqlserver.replica.name-val", AttributeSqlserverReplicaDirectionTransmit)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverLogDataIoRateDataPoint(ts, 3, "sqlserver.availability_group.name-val-2", "db.namespace-val-2", "sqlserver.replica.name-val-2", AttributeSqlserverReplicaDirectionReceive)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverLoginRateDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -292,9 +301,21 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverRecompilationRatioDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordSqlserverReplicaDataRateDataPoint(ts, 1, AttributeReplicaDirectionTransmit)
+			mb.RecordSqlserverReplicaDataRateDataPoint(ts, 1, AttributeSqlserverReplicaDirectionTransmit)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSqlserverReplicaDataRateDataPoint(ts, 3, AttributeReplicaDirectionReceive)
+				mb.RecordSqlserverReplicaDataRateDataPoint(ts, 3, AttributeSqlserverReplicaDirectionReceive)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverReplicaFlowControlTimeDataPoint(ts, 1, "sqlserver.availability_group.name-val", "db.namespace-val", "sqlserver.replica.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverReplicaFlowControlTimeDataPoint(ts, 3, "sqlserver.availability_group.name-val-2", "db.namespace-val-2", "sqlserver.replica.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverReplicaQueueSizeDataPoint(ts, 1, "sqlserver.availability_group.name-val", "db.namespace-val", "sqlserver.replica.name-val", AttributeSqlserverReplicaQueueTypeSend)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverReplicaQueueSizeDataPoint(ts, 3, "sqlserver.availability_group.name-val-2", "db.namespace-val-2", "sqlserver.replica.name-val-2", AttributeSqlserverReplicaQueueTypeRedo)
 			}
 
 			allMetricsCount++
@@ -373,6 +394,7 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverDatabaseOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTempdbSpace.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverLatchSuperlatchTransitionRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverLogDataIoRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryArea.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryCacheObjectCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryPageCount.aggDataPoints)
@@ -382,6 +404,8 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverParameterizationRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPlanExecutionRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverReplicaDataRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverReplicaFlowControlTime.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverReplicaQueueSize.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverResourcePoolDiskOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverTableCount.aggDataPoints)
 			}
@@ -998,6 +1022,61 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.log_data.io.rate":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.log_data.io.rate"], "Found a duplicate in the metrics slice: sqlserver.log_data.io.rate")
+						validatedMetrics["sqlserver.log_data.io.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Rate of log data flow between availability group replicas.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						sqlserverAvailabilityGroupNameAttrVal, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.availability_group.name-val", sqlserverAvailabilityGroupNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						sqlserverReplicaNameAttrVal, ok := dp.Attributes().Get("sqlserver.replica.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.replica.name-val", sqlserverReplicaNameAttrVal.Str())
+						sqlserverReplicaDirectionAttrVal, ok := dp.Attributes().Get("sqlserver.replica.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "transmit", sqlserverReplicaDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.log_data.io.rate"], "Found a duplicate in the metrics slice: sqlserver.log_data.io.rate")
+						validatedMetrics["sqlserver.log_data.io.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Rate of log data flow between availability group replicas.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.log_data.io.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("sqlserver.replica.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("sqlserver.replica.direction")
+						assert.False(t, ok)
+					}
 				case "sqlserver.login.rate":
 					assert.False(t, validatedMetrics["sqlserver.login.rate"], "Found a duplicate in the metrics slice: sqlserver.login.rate")
 					validatedMetrics["sqlserver.login.rate"] = true
@@ -1530,9 +1609,9 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						replicaDirectionAttrVal, ok := dp.Attributes().Get("replica.direction")
+						sqlserverReplicaDirectionAttrVal, ok := dp.Attributes().Get("sqlserver.replica.direction")
 						assert.True(t, ok)
-						assert.Equal(t, "transmit", replicaDirectionAttrVal.Str())
+						assert.Equal(t, "transmit", sqlserverReplicaDirectionAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["sqlserver.replica.data.rate"], "Found a duplicate in the metrics slice: sqlserver.replica.data.rate")
 						validatedMetrics["sqlserver.replica.data.rate"] = true
@@ -1554,7 +1633,112 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
 						}
-						_, ok := dp.Attributes().Get("replica.direction")
+						_, ok := dp.Attributes().Get("sqlserver.replica.direction")
+						assert.False(t, ok)
+					}
+				case "sqlserver.replica.flow_control.time":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.replica.flow_control.time"], "Found a duplicate in the metrics slice: sqlserver.replica.flow_control.time")
+						validatedMetrics["sqlserver.replica.flow_control.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Current flow control lag on the secondary replica, derived from secondary_lag_seconds.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						sqlserverAvailabilityGroupNameAttrVal, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.availability_group.name-val", sqlserverAvailabilityGroupNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						sqlserverReplicaNameAttrVal, ok := dp.Attributes().Get("sqlserver.replica.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.replica.name-val", sqlserverReplicaNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.replica.flow_control.time"], "Found a duplicate in the metrics slice: sqlserver.replica.flow_control.time")
+						validatedMetrics["sqlserver.replica.flow_control.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Current flow control lag on the secondary replica, derived from secondary_lag_seconds.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.replica.flow_control.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("sqlserver.replica.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.replica.queue.size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.replica.queue.size"], "Found a duplicate in the metrics slice: sqlserver.replica.queue.size")
+						validatedMetrics["sqlserver.replica.queue.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Amount of log data queued in the availability group replica pipeline.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						sqlserverAvailabilityGroupNameAttrVal, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.availability_group.name-val", sqlserverAvailabilityGroupNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						sqlserverReplicaNameAttrVal, ok := dp.Attributes().Get("sqlserver.replica.name")
+						assert.True(t, ok)
+						assert.Equal(t, "sqlserver.replica.name-val", sqlserverReplicaNameAttrVal.Str())
+						sqlserverReplicaQueueTypeAttrVal, ok := dp.Attributes().Get("sqlserver.replica.queue.type")
+						assert.True(t, ok)
+						assert.Equal(t, "send", sqlserverReplicaQueueTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.replica.queue.size"], "Found a duplicate in the metrics slice: sqlserver.replica.queue.size")
+						validatedMetrics["sqlserver.replica.queue.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Amount of log data queued in the availability group replica pipeline.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.replica.queue.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("sqlserver.availability_group.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("sqlserver.replica.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("sqlserver.replica.queue.type")
 						assert.False(t, ok)
 					}
 				case "sqlserver.resource_pool.disk.operations":

--- a/receiver/sqlserverreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_resource_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 )
 

--- a/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -65,6 +65,9 @@ all_set:
       enabled: true
     sqlserver.lock.wait_time.avg:
       enabled: true
+    sqlserver.log_data.io.rate:
+      enabled: true
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name","sqlserver.replica.direction"]
     sqlserver.login.rate:
       enabled: true
     sqlserver.logout.rate:
@@ -121,7 +124,13 @@ all_set:
       enabled: true
     sqlserver.replica.data.rate:
       enabled: true
-      attributes: ["replica.direction"]
+      attributes: ["sqlserver.replica.direction"]
+    sqlserver.replica.flow_control.time:
+      enabled: true
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name"]
+    sqlserver.replica.queue.size:
+      enabled: true
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name","sqlserver.replica.queue.type"]
     sqlserver.resource_pool.disk.operations:
       enabled: true
       attributes: ["direction"]
@@ -248,6 +257,9 @@ reaggregate_set:
       enabled: true
     sqlserver.lock.wait_time.avg:
       enabled: true
+    sqlserver.log_data.io.rate:
+      enabled: true
+      attributes: []
     sqlserver.login.rate:
       enabled: true
     sqlserver.logout.rate:
@@ -303,6 +315,12 @@ reaggregate_set:
     sqlserver.recompilation.ratio:
       enabled: true
     sqlserver.replica.data.rate:
+      enabled: true
+      attributes: []
+    sqlserver.replica.flow_control.time:
+      enabled: true
+      attributes: []
+    sqlserver.replica.queue.size:
       enabled: true
       attributes: []
     sqlserver.resource_pool.disk.operations:
@@ -431,6 +449,9 @@ none_set:
       enabled: false
     sqlserver.lock.wait_time.avg:
       enabled: false
+    sqlserver.log_data.io.rate:
+      enabled: false
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name","sqlserver.replica.direction"]
     sqlserver.login.rate:
       enabled: false
     sqlserver.logout.rate:
@@ -487,7 +508,13 @@ none_set:
       enabled: false
     sqlserver.replica.data.rate:
       enabled: false
-      attributes: ["replica.direction"]
+      attributes: ["sqlserver.replica.direction"]
+    sqlserver.replica.flow_control.time:
+      enabled: false
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name"]
+    sqlserver.replica.queue.size:
+      enabled: false
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name","sqlserver.replica.queue.type"]
     sqlserver.resource_pool.disk.operations:
       enabled: false
       attributes: ["direction"]

--- a/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -124,13 +124,13 @@ all_set:
       enabled: true
     sqlserver.replica.data.rate:
       enabled: true
-      attributes: ["sqlserver.replica.direction"]
-    sqlserver.replica.flow_control.time:
-      enabled: true
-      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name"]
+      attributes: ["replica.direction"]
     sqlserver.replica.queue.size:
       enabled: true
       attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name","sqlserver.replica.queue.type"]
+    sqlserver.replica.secondary_lag:
+      enabled: true
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name"]
     sqlserver.resource_pool.disk.operations:
       enabled: true
       attributes: ["direction"]
@@ -317,10 +317,10 @@ reaggregate_set:
     sqlserver.replica.data.rate:
       enabled: true
       attributes: []
-    sqlserver.replica.flow_control.time:
+    sqlserver.replica.queue.size:
       enabled: true
       attributes: []
-    sqlserver.replica.queue.size:
+    sqlserver.replica.secondary_lag:
       enabled: true
       attributes: []
     sqlserver.resource_pool.disk.operations:
@@ -508,13 +508,13 @@ none_set:
       enabled: false
     sqlserver.replica.data.rate:
       enabled: false
-      attributes: ["sqlserver.replica.direction"]
-    sqlserver.replica.flow_control.time:
-      enabled: false
-      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name"]
+      attributes: ["replica.direction"]
     sqlserver.replica.queue.size:
       enabled: false
       attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name","sqlserver.replica.queue.type"]
+    sqlserver.replica.secondary_lag:
+      enabled: false
+      attributes: ["sqlserver.availability_group.name","db.namespace","sqlserver.replica.name"]
     sqlserver.resource_pool.disk.operations:
       enabled: false
       attributes: ["direction"]

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -135,6 +135,11 @@ attributes:
     description: The physical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  replica.direction:
+    description: The direction of flow of bytes for replica.
+    type: string
+    requirement_level: recommended
+    enum: [transmit, receive]
   server.address:
     description: The network address of the server hosting the database.
     type: string
@@ -948,16 +953,7 @@ metrics:
     unit: By/s
     gauge:
       value_type: double
-    attributes: [sqlserver.replica.direction]
-  sqlserver.replica.flow_control.time:
-    enabled: false
-    description: Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
-    stability: development
-    unit: s
-    gauge:
-      value_type: double
-    attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server 2016+ with Always On Availability Groups enabled. The datapoint is omitted for primary replicas where secondary_lag_seconds is NULL.
+    attributes: [replica.direction]
   sqlserver.replica.queue.size:
     enabled: false
     description: Amount of log data queued in the availability group replica pipeline.
@@ -966,7 +962,16 @@ metrics:
     gauge:
       value_type: int
     attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.queue.type]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled. Queue type "send" reports log not yet sent to secondary replicas; queue type "redo" reports log received by the secondary replica but not yet applied.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled.
+  sqlserver.replica.secondary_lag:
+    enabled: false
+    description: Number of seconds the secondary replica is lagging behind the primary replica.
+    stability: development
+    unit: s
+    gauge:
+      value_type: double
+    attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server 2016+ with Always On Availability Groups enabled. The datapoint is omitted for primary replicas where secondary_lag_seconds is NULL.
   sqlserver.resource_pool.disk.operations:
     enabled: false
     description: The rate of operations issued.

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -135,11 +135,6 @@ attributes:
     description: The physical filename of the file being monitored.
     type: string
     requirement_level: recommended
-  replica.direction:
-    description: The direction of flow of bytes for replica.
-    type: string
-    requirement_level: recommended
-    enum: [transmit, receive]
   server.address:
     description: The network address of the server hosting the database.
     type: string
@@ -153,6 +148,10 @@ attributes:
     type: string
     requirement_level: required
     enum: [free_space, probe, range]
+  sqlserver.availability_group.name:
+    description: The name of the SQL Server Always On availability group.
+    type: string
+    requirement_level: recommended
   sqlserver.blocking.start_time:
     description: Timestamp of when the current blocking wait began (ISO 8601 format).
     type: string
@@ -271,6 +270,20 @@ attributes:
     description: Number of physical reads performed by the query.
     type: int
     requirement_level: recommended
+  sqlserver.replica.direction:
+    description: The direction of log data flow for the availability group replica.
+    type: string
+    requirement_level: recommended
+    enum: [transmit, receive]
+  sqlserver.replica.name:
+    description: The name of the availability replica server.
+    type: string
+    requirement_level: recommended
+  sqlserver.replica.queue.type:
+    description: The type of queue in the availability group replica pipeline.
+    type: string
+    requirement_level: recommended
+    enum: [send, redo]
   sqlserver.request_status:
     description: Status of the request (e.g., running, suspended).
     type: string
@@ -720,6 +733,15 @@ metrics:
     gauge:
       value_type: double
     extended_documentation: This metric is only available when running on Windows.
+  sqlserver.log_data.io.rate:
+    enabled: false
+    description: Rate of log data flow between availability group replicas.
+    stability: development
+    unit: By/s
+    gauge:
+      value_type: double
+    attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.direction]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled.
   sqlserver.login.rate:
     enabled: false
     description: Total number of logins.
@@ -926,7 +948,25 @@ metrics:
     unit: By/s
     gauge:
       value_type: double
-    attributes: [replica.direction]
+    attributes: [sqlserver.replica.direction]
+  sqlserver.replica.flow_control.time:
+    enabled: false
+    description: Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
+    stability: development
+    unit: s
+    gauge:
+      value_type: double
+    attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server 2016+ with Always On Availability Groups enabled. The datapoint is omitted for primary replicas where secondary_lag_seconds is NULL.
+  sqlserver.replica.queue.size:
+    enabled: false
+    description: Amount of log data queued in the availability group replica pipeline.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [sqlserver.availability_group.name, db.namespace, sqlserver.replica.name, sqlserver.replica.queue.type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server with Always On Availability Groups enabled. Queue type "send" reports log not yet sent to secondary replicas; queue type "redo" reports log received by the secondary replica but not yet applied.
   sqlserver.resource_pool.disk.operations:
     enabled: false
     description: The rate of operations issued.

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -463,6 +463,61 @@ func formatSQLServerSessionIDsParam(sessionIDs map[int64]struct{}) string {
 	return strings.Join(filterParts, ",")
 }
 
+const sqlServerAvailabilityGroupQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,8) BEGIN /*NOT IN Standard, Enterprise/Developer, Azure SQL Managed Instance*/
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:'+ @@ServerName + ',Database:' + DB_NAME() +' is not a SQL Server Standard, Enterprise/Developer, or Azure SQL Managed Instance. Always On Availability Groups require one of these editions.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+IF SERVERPROPERTY('IsHadrEnabled') != 1
+	RETURN
+
+DECLARE
+	 @SqlStatement AS nvarchar(max)
+	,@MajorMinorVersion AS int = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4) AS int)*100 + CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3) AS int)
+	,@Columns AS nvarchar(max) = ''
+
+IF @MajorMinorVersion >= 1300
+	SET @Columns = N'
+	,drs.[secondary_lag_seconds] AS [secondary_lag_seconds]'
+ELSE
+	SET @Columns = N'
+	,NULL AS [secondary_lag_seconds]'
+
+SET @SqlStatement = N'
+SELECT
+	 ''sqlserver_availability_group_replica_states'' AS [measurement]
+	,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
+	,HOST_NAME() AS [computer_name]
+	,ag.[name] AS [availability_group]
+	,DB_NAME(drs.[database_id]) AS [database_name]
+	,ar.[replica_server_name] AS [replica_name]
+	,ISNULL(drs.[log_send_queue_size], 0) AS [log_send_queue_size]
+	,ISNULL(drs.[log_send_rate], 0) AS [log_send_rate]
+	,ISNULL(drs.[redo_queue_size], 0) AS [redo_queue_size]
+	,ISNULL(drs.[redo_rate], 0) AS [redo_rate]'
++ @Columns + N'
+FROM sys.[dm_hadr_database_replica_states] AS drs WITH (NOLOCK)
+INNER JOIN sys.[availability_replicas] AS ar WITH (NOLOCK)
+	ON drs.[replica_id] = ar.[replica_id]
+INNER JOIN sys.[availability_groups] AS ag WITH (NOLOCK)
+	ON ar.[group_id] = ag.[group_id]
+%s
+OPTION(RECOMPILE)'
+
+EXEC sp_executesql @SqlStatement
+`
+
+func getSQLServerAvailabilityGroupQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("WHERE @@SERVERNAME = ''%s''", instanceName)
+		return fmt.Sprintf(sqlServerAvailabilityGroupQuery, whereClause)
+	}
+	return fmt.Sprintf(sqlServerAvailabilityGroupQuery, "")
+}
+
 // Conditional check based on Azure SQL DB v/s the rest aka (Azure SQL Managed instance OR On-prem SQL Server)
 // EngineEdition=5 is Azure SQL DB
 const sqlServerWaitStatsQuery string = `

--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -67,6 +67,18 @@ func TestQueryContents(t *testing.T) {
 			getQuery:                 getSQLServerWaitStatsQuery,
 			expectedQueryValFilename: "waitStatsQueryWithInstanceName.txt",
 		},
+		{
+			name:                     "Test availability group query without instance name",
+			instanceName:             "",
+			getQuery:                 getSQLServerAvailabilityGroupQuery,
+			expectedQueryValFilename: "availabilityGroupQueryWithoutInstanceName.txt",
+		},
+		{
+			name:                     "Test availability group query with instance name",
+			instanceName:             "instanceName",
+			getQuery:                 getSQLServerAvailabilityGroupQuery,
+			expectedQueryValFilename: "availabilityGroupQueryWithInstanceName.txt",
+		},
 	}
 
 	for _, tt := range queryTests {

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -124,6 +124,8 @@ func (s *sqlServerScraperHelper) ScrapeMetrics(ctx context.Context) (pmetric.Met
 		err = s.recordDatabaseStatusMetrics(ctx)
 	case getSQLServerWaitStatsQuery(s.config.InstanceName):
 		err = s.recordDatabaseWaitMetrics(ctx)
+	case getSQLServerAvailabilityGroupQuery(s.config.InstanceName):
+		err = s.recordAvailabilityGroupMetrics(ctx)
 	default:
 		return pmetric.Metrics{}, fmt.Errorf("Attempted to get metrics from unsupported query: %s", s.sqlQuery)
 	}
@@ -549,7 +551,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bytesReceivedFromReplicaPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionReceive)
+				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeSqlserverReplicaDirectionReceive)
 			}
 		case bytesSentForReplicaPerSec:
 			val, err := retrieveFloat(row, valueKey)
@@ -557,7 +559,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bytesReceivedFromReplicaPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionTransmit)
+				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeSqlserverReplicaDirectionTransmit)
 			}
 		case diskReadIOSec:
 			val, err := retrieveFloat(row, valueKey)
@@ -1201,6 +1203,74 @@ func (s *sqlServerScraperHelper) recordDatabaseWaitMetrics(ctx context.Context) 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordAvailabilityGroupMetrics(ctx context.Context) error {
+	const (
+		availabilityGroupKey   = "availability_group"
+		logSendQueueSizeKey    = "log_send_queue_size"
+		logSendRateKey         = "log_send_rate"
+		redoQueueSizeKey       = "redo_queue_size"
+		replicaNameKey         = "replica_name"
+		secondaryLagSecondsKey = "secondary_lag_seconds"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	if len(rows) == 0 {
+		s.logger.Debug("no availability group data found; Always On may not be configured on this instance")
+		return nil
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), rows[0])
+	var val any
+
+	for _, row := range rows {
+		agName := row[availabilityGroupKey]
+		dbName := row[databaseNameKey]
+		replicaName := row[replicaNameKey]
+
+		if row[secondaryLagSecondsKey] != "" {
+			val, err = retrieveFloat(row, secondaryLagSecondsKey)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("availability_group=%q database=%q replica=%q: %w", agName, dbName, replicaName, err))
+			} else {
+				s.mb.RecordSqlserverReplicaFlowControlTimeDataPoint(now, val.(float64), agName, dbName, replicaName)
+			}
+		}
+
+		val, err = retrieveFloat(row, logSendRateKey)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("availability_group=%q database=%q replica=%q: %w", agName, dbName, replicaName, err))
+		} else {
+			s.mb.RecordSqlserverLogDataIoRateDataPoint(now, val.(float64)*1024, agName, dbName, replicaName, metadata.AttributeSqlserverReplicaDirectionReceive)
+		}
+
+		val, err = retrieveInt(row, logSendQueueSizeKey)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("availability_group=%q database=%q replica=%q: %w", agName, dbName, replicaName, err))
+		} else {
+			s.mb.RecordSqlserverReplicaQueueSizeDataPoint(now, val.(int64)*1024, agName, dbName, replicaName, metadata.AttributeSqlserverReplicaQueueTypeSend)
+		}
+
+		val, err = retrieveInt(row, redoQueueSizeKey)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("availability_group=%q database=%q replica=%q: %w", agName, dbName, replicaName, err))
+		} else {
+			s.mb.RecordSqlserverReplicaQueueSizeDataPoint(now, val.(int64)*1024, agName, dbName, replicaName, metadata.AttributeSqlserverReplicaQueueTypeRedo)
+		}
+	}
+
+	s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	return errors.Join(errs...)
 }
 

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -551,7 +551,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bytesReceivedFromReplicaPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeSqlserverReplicaDirectionReceive)
+				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionReceive)
 			}
 		case bytesSentForReplicaPerSec:
 			val, err := retrieveFloat(row, valueKey)
@@ -559,7 +559,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bytesReceivedFromReplicaPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeSqlserverReplicaDirectionTransmit)
+				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionTransmit)
 			}
 		case diskReadIOSec:
 			val, err := retrieveFloat(row, valueKey)
@@ -1244,7 +1244,7 @@ func (s *sqlServerScraperHelper) recordAvailabilityGroupMetrics(ctx context.Cont
 			if err != nil {
 				errs = append(errs, fmt.Errorf("availability_group=%q database=%q replica=%q: %w", agName, dbName, replicaName, err))
 			} else {
-				s.mb.RecordSqlserverReplicaFlowControlTimeDataPoint(now, val.(float64), agName, dbName, replicaName)
+				s.mb.RecordSqlserverReplicaSecondaryLagDataPoint(now, val.(float64), agName, dbName, replicaName)
 			}
 		}
 

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -37,6 +37,9 @@ func configureAllScraperMetricsAndEvents(cfg *Config, enabled bool) {
 	// Some of these metrics are enabled by default, but it's still helpful to include
 	// in the case of using a config that may have previously disabled a metric.
 	cfg.Metrics.SqlserverAccessScanRate.Enabled = enabled
+	cfg.Metrics.SqlserverReplicaFlowControlTime.Enabled = enabled
+	cfg.Metrics.SqlserverLogDataIoRate.Enabled = enabled
+	cfg.Metrics.SqlserverReplicaQueueSize.Enabled = enabled
 	cfg.Metrics.SqlserverBatchRequestRate.Enabled = enabled
 	cfg.Metrics.SqlserverBatchSQLCompilationRate.Enabled = enabled
 	cfg.Metrics.SqlserverBatchSQLRecompilationRate.Enabled = enabled
@@ -205,6 +208,8 @@ func TestSuccessfulScrape(t *testing.T) {
 					expectedFile = filepath.Join("testdata", "expectedProperties")
 				case getSQLServerWaitStatsQuery(scraper.config.InstanceName):
 					expectedFile = filepath.Join("testdata", "expectedWaitStats")
+				case getSQLServerAvailabilityGroupQuery(scraper.config.InstanceName):
+					expectedFile = filepath.Join("testdata", "expectedAvailabilityGroup")
 				}
 				expectedFile += fileSuffix
 
@@ -440,6 +445,8 @@ func (mc mockClient) QueryRows(context.Context, ...any) ([]sqlquery.StringMap, e
 		queryResults, err = readFile("propertyQueryData.txt")
 	case getSQLServerWaitStatsQuery(mc.instanceName):
 		queryResults, err = readFile("waitStatsQueryData.txt")
+	case getSQLServerAvailabilityGroupQuery(mc.instanceName):
+		queryResults, err = readFile("availabilityGroupQueryData.txt")
 	case getSQLServerQueryTextAndPlanQuery():
 		queryResults, err = readFile("queryTextAndPlanQueryData.txt")
 	case getSQLServerQuerySamplesQuery():

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -37,7 +37,7 @@ func configureAllScraperMetricsAndEvents(cfg *Config, enabled bool) {
 	// Some of these metrics are enabled by default, but it's still helpful to include
 	// in the case of using a config that may have previously disabled a metric.
 	cfg.Metrics.SqlserverAccessScanRate.Enabled = enabled
-	cfg.Metrics.SqlserverReplicaFlowControlTime.Enabled = enabled
+	cfg.Metrics.SqlserverReplicaSecondaryLag.Enabled = enabled
 	cfg.Metrics.SqlserverLogDataIoRate.Enabled = enabled
 	cfg.Metrics.SqlserverReplicaQueueSize.Enabled = enabled
 	cfg.Metrics.SqlserverBatchRequestRate.Enabled = enabled

--- a/receiver/sqlserverreceiver/testdata/availabilityGroupQueryData.txt
+++ b/receiver/sqlserverreceiver/testdata/availabilityGroupQueryData.txt
@@ -1,0 +1,41 @@
+[
+  {
+    "availability_group": "AG_Primary",
+    "computer_name": "sql-node-01",
+    "database_name": "SalesDB",
+    "log_send_queue_size": "1024",
+    "log_send_rate": "512",
+    "measurement": "sqlserver_availability_group_replica_states",
+    "redo_queue_size": "2048",
+    "redo_rate": "256",
+    "replica_name": "sql-node-02",
+    "secondary_lag_seconds": "5",
+    "sql_instance": "sql-node-01"
+  },
+  {
+    "availability_group": "AG_Primary",
+    "computer_name": "sql-node-01",
+    "database_name": "InventoryDB",
+    "log_send_queue_size": "512",
+    "log_send_rate": "256",
+    "measurement": "sqlserver_availability_group_replica_states",
+    "redo_queue_size": "1024",
+    "redo_rate": "128",
+    "replica_name": "sql-node-02",
+    "secondary_lag_seconds": "2",
+    "sql_instance": "sql-node-01"
+  },
+  {
+    "availability_group": "AG_Primary",
+    "computer_name": "sql-node-01",
+    "database_name": "SalesDB",
+    "log_send_queue_size": "0",
+    "log_send_rate": "0",
+    "measurement": "sqlserver_availability_group_replica_states",
+    "redo_queue_size": "0",
+    "redo_rate": "0",
+    "replica_name": "sql-node-01",
+    "secondary_lag_seconds": "",
+    "sql_instance": "sql-node-01"
+  }
+]

--- a/receiver/sqlserverreceiver/testdata/availabilityGroupQueryWithInstanceName.txt
+++ b/receiver/sqlserverreceiver/testdata/availabilityGroupQueryWithInstanceName.txt
@@ -1,0 +1,45 @@
+
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,8) BEGIN /*NOT IN Standard, Enterprise/Developer, Azure SQL Managed Instance*/
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:'+ @@ServerName + ',Database:' + DB_NAME() +' is not a SQL Server Standard, Enterprise/Developer, or Azure SQL Managed Instance. Always On Availability Groups require one of these editions.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+IF SERVERPROPERTY('IsHadrEnabled') != 1
+	RETURN
+
+DECLARE
+	 @SqlStatement AS nvarchar(max)
+	,@MajorMinorVersion AS int = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4) AS int)*100 + CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3) AS int)
+	,@Columns AS nvarchar(max) = ''
+
+IF @MajorMinorVersion >= 1300
+	SET @Columns = N'
+	,drs.[secondary_lag_seconds] AS [secondary_lag_seconds]'
+ELSE
+	SET @Columns = N'
+	,NULL AS [secondary_lag_seconds]'
+
+SET @SqlStatement = N'
+SELECT
+	 ''sqlserver_availability_group_replica_states'' AS [measurement]
+	,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
+	,HOST_NAME() AS [computer_name]
+	,ag.[name] AS [availability_group]
+	,DB_NAME(drs.[database_id]) AS [database_name]
+	,ar.[replica_server_name] AS [replica_name]
+	,ISNULL(drs.[log_send_queue_size], 0) AS [log_send_queue_size]
+	,ISNULL(drs.[log_send_rate], 0) AS [log_send_rate]
+	,ISNULL(drs.[redo_queue_size], 0) AS [redo_queue_size]
+	,ISNULL(drs.[redo_rate], 0) AS [redo_rate]'
++ @Columns + N'
+FROM sys.[dm_hadr_database_replica_states] AS drs WITH (NOLOCK)
+INNER JOIN sys.[availability_replicas] AS ar WITH (NOLOCK)
+	ON drs.[replica_id] = ar.[replica_id]
+INNER JOIN sys.[availability_groups] AS ag WITH (NOLOCK)
+	ON ar.[group_id] = ag.[group_id]
+WHERE @@SERVERNAME = ''instanceName''
+OPTION(RECOMPILE)'
+
+EXEC sp_executesql @SqlStatement

--- a/receiver/sqlserverreceiver/testdata/availabilityGroupQueryWithoutInstanceName.txt
+++ b/receiver/sqlserverreceiver/testdata/availabilityGroupQueryWithoutInstanceName.txt
@@ -1,0 +1,45 @@
+
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,8) BEGIN /*NOT IN Standard, Enterprise/Developer, Azure SQL Managed Instance*/
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:'+ @@ServerName + ',Database:' + DB_NAME() +' is not a SQL Server Standard, Enterprise/Developer, or Azure SQL Managed Instance. Always On Availability Groups require one of these editions.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+IF SERVERPROPERTY('IsHadrEnabled') != 1
+	RETURN
+
+DECLARE
+	 @SqlStatement AS nvarchar(max)
+	,@MajorMinorVersion AS int = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4) AS int)*100 + CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3) AS int)
+	,@Columns AS nvarchar(max) = ''
+
+IF @MajorMinorVersion >= 1300
+	SET @Columns = N'
+	,drs.[secondary_lag_seconds] AS [secondary_lag_seconds]'
+ELSE
+	SET @Columns = N'
+	,NULL AS [secondary_lag_seconds]'
+
+SET @SqlStatement = N'
+SELECT
+	 ''sqlserver_availability_group_replica_states'' AS [measurement]
+	,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
+	,HOST_NAME() AS [computer_name]
+	,ag.[name] AS [availability_group]
+	,DB_NAME(drs.[database_id]) AS [database_name]
+	,ar.[replica_server_name] AS [replica_name]
+	,ISNULL(drs.[log_send_queue_size], 0) AS [log_send_queue_size]
+	,ISNULL(drs.[log_send_rate], 0) AS [log_send_rate]
+	,ISNULL(drs.[redo_queue_size], 0) AS [redo_queue_size]
+	,ISNULL(drs.[redo_rate], 0) AS [redo_rate]'
++ @Columns + N'
+FROM sys.[dm_hadr_database_replica_states] AS drs WITH (NOLOCK)
+INNER JOIN sys.[availability_replicas] AS ar WITH (NOLOCK)
+	ON drs.[replica_id] = ar.[replica_id]
+INNER JOIN sys.[availability_groups] AS ag WITH (NOLOCK)
+	ON ar.[group_id] = ag.[group_id]
+
+OPTION(RECOMPILE)'
+
+EXEC sp_executesql @SqlStatement

--- a/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroup.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroup.yaml
@@ -1,0 +1,214 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
+        - key: server.address
+          value:
+            stringValue: 0.0.0.0
+        - key: server.port
+          value:
+            intValue: "1433"
+        - key: service.instance.id
+          value:
+            stringValue: 0.0.0.0:1433
+        - key: service.name
+          value:
+            stringValue: unknown_service:microsoft.sql_server
+        - key: service.namespace
+          value:
+            stringValue: ""
+        - key: sqlserver.instance.name
+          value:
+            stringValue: sql-node-01
+    scopeMetrics:
+      - metrics:
+          - description: Rate of log data flow between availability group replicas.
+            gauge:
+              dataPoints:
+                - asDouble: 262144
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.replica.direction
+                      value:
+                        stringValue: receive
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.replica.direction
+                      value:
+                        stringValue: receive
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-01
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 524288
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.replica.direction
+                      value:
+                        stringValue: receive
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.log_data.io.rate
+            unit: By/s
+          - description: Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
+            gauge:
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.replica.flow_control.time
+            unit: s
+          - description: Amount of log data queued in the availability group replica pipeline.
+            gauge:
+              dataPoints:
+                - asInt: "524288"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: send
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-01
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: send
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: send
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: redo
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-01
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: redo
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2097152"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: redo
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.replica.queue.size
+            unit: By
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest

--- a/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroup.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroup.yaml
@@ -77,37 +77,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.log_data.io.rate
             unit: By/s
-          - description: Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
-            gauge:
-              dataPoints:
-                - asDouble: 2
-                  attributes:
-                    - key: db.namespace
-                      value:
-                        stringValue: InventoryDB
-                    - key: sqlserver.availability_group.name
-                      value:
-                        stringValue: AG_Primary
-                    - key: sqlserver.replica.name
-                      value:
-                        stringValue: sql-node-02
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5
-                  attributes:
-                    - key: db.namespace
-                      value:
-                        stringValue: SalesDB
-                    - key: sqlserver.availability_group.name
-                      value:
-                        stringValue: AG_Primary
-                    - key: sqlserver.replica.name
-                      value:
-                        stringValue: sql-node-02
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.replica.flow_control.time
-            unit: s
           - description: Amount of log data queued in the availability group replica pipeline.
             gauge:
               dataPoints:
@@ -209,6 +178,37 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.replica.queue.size
             unit: By
+          - description: Number of seconds the secondary replica is lagging behind the primary replica.
+            gauge:
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.replica.secondary_lag
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest

--- a/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroupRemoveServerResourceAttributes.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroupRemoveServerResourceAttributes.yaml
@@ -1,0 +1,208 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
+        - key: service.instance.id
+          value:
+            stringValue: 0.0.0.0:1433
+        - key: service.name
+          value:
+            stringValue: unknown_service:microsoft.sql_server
+        - key: service.namespace
+          value:
+            stringValue: ""
+        - key: sqlserver.instance.name
+          value:
+            stringValue: sql-node-01
+    scopeMetrics:
+      - metrics:
+          - description: Rate of log data flow between availability group replicas.
+            gauge:
+              dataPoints:
+                - asDouble: 262144
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.replica.direction
+                      value:
+                        stringValue: receive
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.replica.direction
+                      value:
+                        stringValue: receive
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-01
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 524288
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.replica.direction
+                      value:
+                        stringValue: receive
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.log_data.io.rate
+            unit: By/s
+          - description: Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
+            gauge:
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.replica.flow_control.time
+            unit: s
+          - description: Amount of log data queued in the availability group replica pipeline.
+            gauge:
+              dataPoints:
+                - asInt: "524288"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: send
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-01
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: send
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: send
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: redo
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-01
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: redo
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2097152"
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                    - key: sqlserver.replica.queue.type
+                      value:
+                        stringValue: redo
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.replica.queue.size
+            unit: By
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest

--- a/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroupRemoveServerResourceAttributes.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedAvailabilityGroupRemoveServerResourceAttributes.yaml
@@ -71,37 +71,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.log_data.io.rate
             unit: By/s
-          - description: Current flow control lag on the secondary replica, derived from secondary_lag_seconds.
-            gauge:
-              dataPoints:
-                - asDouble: 2
-                  attributes:
-                    - key: db.namespace
-                      value:
-                        stringValue: InventoryDB
-                    - key: sqlserver.availability_group.name
-                      value:
-                        stringValue: AG_Primary
-                    - key: sqlserver.replica.name
-                      value:
-                        stringValue: sql-node-02
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5
-                  attributes:
-                    - key: db.namespace
-                      value:
-                        stringValue: SalesDB
-                    - key: sqlserver.availability_group.name
-                      value:
-                        stringValue: AG_Primary
-                    - key: sqlserver.replica.name
-                      value:
-                        stringValue: sql-node-02
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.replica.flow_control.time
-            unit: s
           - description: Amount of log data queued in the availability group replica pipeline.
             gauge:
               dataPoints:
@@ -203,6 +172,37 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.replica.queue.size
             unit: By
+          - description: Number of seconds the secondary replica is lagging behind the primary replica.
+            gauge:
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: InventoryDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5
+                  attributes:
+                    - key: db.namespace
+                      value:
+                        stringValue: SalesDB
+                    - key: sqlserver.availability_group.name
+                      value:
+                        stringValue: AG_Primary
+                    - key: sqlserver.replica.name
+                      value:
+                        stringValue: sql-node-02
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.replica.secondary_lag
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
@@ -609,7 +609,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: sqlserver.replica.direction
+                    - key: replica.direction
                       value:
                         stringValue: receive
                   startTimeUnixNano: "1000000"
@@ -649,7 +649,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: sqlserver.replica.direction
+                    - key: replica.direction
                       value:
                         stringValue: transmit
                   startTimeUnixNano: "1000000"

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
@@ -609,7 +609,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: replica.direction
+                    - key: sqlserver.replica.direction
                       value:
                         stringValue: receive
                   startTimeUnixNano: "1000000"
@@ -649,7 +649,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: replica.direction
+                    - key: sqlserver.replica.direction
                       value:
                         stringValue: transmit
                   startTimeUnixNano: "1000000"

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCountersRemoveServerResourceAttributes.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCountersRemoveServerResourceAttributes.yaml
@@ -513,7 +513,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: replica.direction
+                    - key: sqlserver.replica.direction
                       value:
                         stringValue: receive
                   startTimeUnixNano: "1000000"
@@ -547,7 +547,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: replica.direction
+                    - key: sqlserver.replica.direction
                       value:
                         stringValue: transmit
                   startTimeUnixNano: "1000000"

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCountersRemoveServerResourceAttributes.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCountersRemoveServerResourceAttributes.yaml
@@ -513,7 +513,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: sqlserver.replica.direction
+                    - key: replica.direction
                       value:
                         stringValue: receive
                   startTimeUnixNano: "1000000"
@@ -547,7 +547,7 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 0
                   attributes:
-                    - key: sqlserver.replica.direction
+                    - key: replica.direction
                       value:
                         stringValue: transmit
                   startTimeUnixNano: "1000000"


### PR DESCRIPTION
## What's the problem?

The SQL Server receiver had no way to monitor **Always On Availability Groups** — a core HA feature used by most production SQL Server deployments. Without this, users had zero visibility into replication health: whether log is piling up in the send queue, whether secondary replicas are falling behind, or how fast redo is running.

## What does this add?

Five new opt-in metrics sourced from `sys.dm_hadr_database_replica_states`, joined with `sys.availability_replicas` and `sys.availability_groups`:

| Metric | Unit | Description |
|--------|------|-------------|
| `sqlserver.availability_group.flow_control_time` | ms | Secondary replica lag (null for primary) |
| `sqlserver.availability_group.log.received.rate` | By/s | Rate at which log is received from primary |
| `sqlserver.availability_group.log.send_queue` | KB | Log waiting to be sent to secondaries |
| `sqlserver.availability_group.redo_queue` | KB | Log waiting to be redone on secondary |
| `sqlserver.availability_group.redo.rate` | KB/s | Rate at which log is being redone |

Each metric carries three attributes — `availability_group.name`, `availability_group.database.name`, and `availability_group.replica.name` — so you can filter and alert per-AG, per-database, or per-replica.

All metrics are **disabled by default** (stability: development). The query guards against non-AG editions and skips execution entirely when HADR isn't enabled, so there's zero overhead for setups that don't use AGs.

Works on SQL Server 2012+ (Standard, Enterprise, Developer) and Azure SQL Managed Instance. `flow_control_time` requires SQL Server 2016+ for `secondary_lag_seconds` — older versions get NULL for that column automatically.

## Testing

- Unit tests with mock query data covering two secondaries and a primary replica (NULL secondary lag)
- Golden file tests for both resource-attribute feature gate variants
- Query content tests for instance-name filtering (with and without)

Closes #48369