### PR TITLE
[pkg/ottl]: Consider improper datapoint type manipulation an error

### DIFF
--- a/.chloggen/ottl-datapoint-setter-type-validation.yaml
+++ b/.chloggen/ottl-datapoint-setter-type-validation.yaml
@@ -1,8 +1,8 @@
 change_type: breaking
 component: pkg/ottl
 note: Return errors when OTTL datapoint context setters are used on an incompatible data point type
-issues: []
-Ω: |
+issues: [48384]
+subtext: |
   For example, `set(explicit_bounds, [1.0])` against a `NumberDataPoint` now returns an error
   rather than silently no-opping. Statements that were previously failing silently due to data
   point type mismatches will now surface as errors.

--- a/.chloggen/ottl-datapoint-setter-type-validation.yaml
+++ b/.chloggen/ottl-datapoint-setter-type-validation.yaml
@@ -6,4 +6,13 @@ subtext: |
   For example, `set(explicit_bounds, [1.0])` against a `NumberDataPoint` now returns an error
   rather than silently no-opping. Statements that were previously failing silently due to data
   point type mismatches will now surface as errors.
+
+  Affected paths and the data point types they support:
+    - `value_double`, `value_int`: NumberDataPoint
+    - `explicit_bounds`, `bucket_counts`: HistogramDataPoint
+    - `scale`, `zero_count`, `positive`, `positive.offset`, `positive.bucket_counts`,
+      `negative`, `negative.offset`, `negative.bucket_counts`: ExponentialHistogramDataPoint
+    - `quantile_values`: SummaryDataPoint
+    - `exemplars`: NumberDataPoint, HistogramDataPoint, ExponentialHistogramDataPoint
+    - `count`, `sum`: HistogramDataPoint, ExponentialHistogramDataPoint, SummaryDataPoint
 change_logs: [user]

--- a/.chloggen/ottl-datapoint-setter-type-validation.yaml
+++ b/.chloggen/ottl-datapoint-setter-type-validation.yaml
@@ -1,0 +1,9 @@
+change_type: breaking
+component: pkg/ottl
+note: Return errors when OTTL datapoint context setters are used on an incompatible data point type
+issues: []
+Ω: |
+  For example, `set(explicit_bounds, [1.0])` against a `NumberDataPoint` now returns an error
+  rather than silently no-opping. Statements that were previously failing silently due to data
+  point type mismatches will now surface as errors.
+change_logs: [user]

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
@@ -5,6 +5,7 @@ package ctxdatapoint // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -111,8 +112,9 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 				return ctxutil.SetMap(dp.Attributes(), val)
 			case pmetric.SummaryDataPoint:
 				return ctxutil.SetMap(dp.Attributes(), val)
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
-			return nil
 		},
 	}
 }
@@ -142,8 +144,9 @@ func accessAttributesKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K]
 				return ctxutil.SetMapValue(ctx, tCtx, dp.Attributes(), key, val)
 			case pmetric.SummaryDataPoint:
 				return ctxutil.SetMapValue(ctx, tCtx, dp.Attributes(), key, val)
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
-			return nil
 		},
 	}
 }
@@ -177,6 +180,8 @@ func accessStartTimeUnixNano[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 			case pmetric.SummaryDataPoint:
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -212,6 +217,8 @@ func accessStartTime[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(newTime))
 			case pmetric.SummaryDataPoint:
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(newTime))
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -247,6 +254,8 @@ func accessTimeUnixNano[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
 			case pmetric.SummaryDataPoint:
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTime)))
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -282,6 +291,8 @@ func accessTime[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(newTime))
 			case pmetric.SummaryDataPoint:
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(newTime))
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -301,9 +312,11 @@ func accessDoubleValue[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if numberDataPoint, ok := tCtx.GetDataPoint().(pmetric.NumberDataPoint); ok {
-				numberDataPoint.SetDoubleValue(newDouble)
+			numberDataPoint, err := ctxutil.ExpectType[pmetric.NumberDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			numberDataPoint.SetDoubleValue(newDouble)
 			return nil
 		},
 	}
@@ -322,9 +335,11 @@ func accessIntValue[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if numberDataPoint, ok := tCtx.GetDataPoint().(pmetric.NumberDataPoint); ok {
-				numberDataPoint.SetIntValue(newInt)
+			numberDataPoint, err := ctxutil.ExpectType[pmetric.NumberDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			numberDataPoint.SetIntValue(newInt)
 			return nil
 		},
 	}
@@ -355,6 +370,8 @@ func accessExemplars[K Context]() ottl.StandardGetSetter[K] {
 				newExemplars.CopyTo(dp.Exemplars())
 			case pmetric.ExponentialHistogramDataPoint:
 				newExemplars.CopyTo(dp.Exemplars())
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -390,6 +407,8 @@ func accessFlags[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetFlags(pmetric.DataPointFlags(newFlags))
 			case pmetric.SummaryDataPoint:
 				dp.SetFlags(pmetric.DataPointFlags(newFlags))
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -421,6 +440,8 @@ func accessCount[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetCount(uint64(newCount))
 			case pmetric.SummaryDataPoint:
 				dp.SetCount(uint64(newCount))
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -452,6 +473,8 @@ func accessSum[K Context]() ottl.StandardGetSetter[K] {
 				dp.SetSum(newSum)
 			case pmetric.SummaryDataPoint:
 				dp.SetSum(newSum)
+			default:
+				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
 			return nil
 		},
@@ -467,10 +490,11 @@ func accessExplicitBounds[K Context]() ottl.StandardGetSetter[K] {
 			return nil, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
-				return ctxutil.SetCommonTypedSliceValues[float64](histogramDataPoint.ExplicitBounds(), val)
+			histogramDataPoint, err := ctxutil.ExpectType[pmetric.HistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
-			return nil
+			return ctxutil.SetCommonTypedSliceValues[float64](histogramDataPoint.ExplicitBounds(), val)
 		},
 	}
 }
@@ -484,10 +508,11 @@ func accessBucketCounts[K Context]() ottl.StandardGetSetter[K] {
 			return nil, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
-				return ctxutil.SetCommonIntSliceValues[uint64](histogramDataPoint.BucketCounts(), val)
+			histogramDataPoint, err := ctxutil.ExpectType[pmetric.HistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
-			return nil
+			return ctxutil.SetCommonIntSliceValues[uint64](histogramDataPoint.BucketCounts(), val)
 		},
 	}
 }
@@ -505,9 +530,11 @@ func accessScale[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				expoHistogramDataPoint.SetScale(int32(newScale))
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			expoHistogramDataPoint.SetScale(int32(newScale))
 			return nil
 		},
 	}
@@ -526,9 +553,11 @@ func accessZeroCount[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				expoHistogramDataPoint.SetZeroCount(uint64(newZeroCount))
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			expoHistogramDataPoint.SetZeroCount(uint64(newZeroCount))
 			return nil
 		},
 	}
@@ -547,9 +576,11 @@ func accessPositive[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				newPositive.CopyTo(expoHistogramDataPoint.Positive())
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			newPositive.CopyTo(expoHistogramDataPoint.Positive())
 			return nil
 		},
 	}
@@ -568,9 +599,11 @@ func accessPositiveOffset[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				expoHistogramDataPoint.Positive().SetOffset(int32(newPositiveOffset))
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			expoHistogramDataPoint.Positive().SetOffset(int32(newPositiveOffset))
 			return nil
 		},
 	}
@@ -585,10 +618,11 @@ func accessPositiveBucketCounts[K Context]() ottl.StandardGetSetter[K] {
 			return nil, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return ctxutil.SetCommonIntSliceValues[uint64](expoHistogramDataPoint.Positive().BucketCounts(), val)
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
-			return nil
+			return ctxutil.SetCommonIntSliceValues[uint64](expoHistogramDataPoint.Positive().BucketCounts(), val)
 		},
 	}
 }
@@ -606,9 +640,11 @@ func accessNegative[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				newNegative.CopyTo(expoHistogramDataPoint.Negative())
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			newNegative.CopyTo(expoHistogramDataPoint.Negative())
 			return nil
 		},
 	}
@@ -627,9 +663,11 @@ func accessNegativeOffset[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				expoHistogramDataPoint.Negative().SetOffset(int32(newNegativeOffset))
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			expoHistogramDataPoint.Negative().SetOffset(int32(newNegativeOffset))
 			return nil
 		},
 	}
@@ -644,10 +682,11 @@ func accessNegativeBucketCounts[K Context]() ottl.StandardGetSetter[K] {
 			return nil, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return ctxutil.SetCommonIntSliceValues[uint64](expoHistogramDataPoint.Negative().BucketCounts(), val)
+			expoHistogramDataPoint, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
-			return nil
+			return ctxutil.SetCommonIntSliceValues[uint64](expoHistogramDataPoint.Negative().BucketCounts(), val)
 		},
 	}
 }
@@ -665,9 +704,11 @@ func accessQuantileValues[K Context]() ottl.StandardGetSetter[K] {
 			if err != nil {
 				return err
 			}
-			if summaryDataPoint, ok := tCtx.GetDataPoint().(pmetric.SummaryDataPoint); ok {
-				newQuantileValues.CopyTo(summaryDataPoint.QuantileValues())
+			summaryDataPoint, err := ctxutil.ExpectType[pmetric.SummaryDataPoint](tCtx.GetDataPoint())
+			if err != nil {
+				return err
 			}
+			newQuantileValues.CopyTo(summaryDataPoint.QuantileValues())
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -1973,6 +1973,149 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 	}
 }
 
+func TestPathGetSetter_CrossDataPointTypeErrors(t *testing.T) {
+	newBuckets := pmetric.NewExponentialHistogramDataPointBuckets()
+	newQuantileValues := pmetric.NewSummaryDataPointValueAtQuantileSlice()
+	newExemplars := pmetric.NewExemplarSlice()
+
+	tests := []struct {
+		name      string
+		path      ottl.Path[*testContext]
+		dataPoint any
+		val       any
+	}{
+		{
+			name:      "value_double on HistogramDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "value_double"},
+			dataPoint: pmetric.NewHistogramDataPoint(),
+			val:       2.2,
+		},
+		{
+			name:      "value_int on SummaryDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "value_int"},
+			dataPoint: pmetric.NewSummaryDataPoint(),
+			val:       int64(2),
+		},
+		{
+			name:      "explicit_bounds on NumberDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "explicit_bounds"},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       []float64{1.0},
+		},
+		{
+			name:      "bucket_counts on SummaryDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "bucket_counts"},
+			dataPoint: pmetric.NewSummaryDataPoint(),
+			val:       []int64{1},
+		},
+		{
+			name:      "scale on HistogramDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "scale"},
+			dataPoint: pmetric.NewHistogramDataPoint(),
+			val:       int64(1),
+		},
+		{
+			name:      "zero_count on NumberDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "zero_count"},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       int64(1),
+		},
+		{
+			name:      "positive on HistogramDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "positive"},
+			dataPoint: pmetric.NewHistogramDataPoint(),
+			val:       newBuckets,
+		},
+		{
+			name: "positive.offset on NumberDataPoint",
+			path: &pathtest.Path[*testContext]{
+				N:        "positive",
+				NextPath: &pathtest.Path[*testContext]{N: "offset"},
+			},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       int64(1),
+		},
+		{
+			name: "positive.bucket_counts on SummaryDataPoint",
+			path: &pathtest.Path[*testContext]{
+				N:        "positive",
+				NextPath: &pathtest.Path[*testContext]{N: "bucket_counts"},
+			},
+			dataPoint: pmetric.NewSummaryDataPoint(),
+			val:       []int64{1},
+		},
+		{
+			name:      "negative on NumberDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "negative"},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       newBuckets,
+		},
+		{
+			name: "negative.offset on HistogramDataPoint",
+			path: &pathtest.Path[*testContext]{
+				N:        "negative",
+				NextPath: &pathtest.Path[*testContext]{N: "offset"},
+			},
+			dataPoint: pmetric.NewHistogramDataPoint(),
+			val:       int64(1),
+		},
+		{
+			name: "negative.bucket_counts on SummaryDataPoint",
+			path: &pathtest.Path[*testContext]{
+				N:        "negative",
+				NextPath: &pathtest.Path[*testContext]{N: "bucket_counts"},
+			},
+			dataPoint: pmetric.NewSummaryDataPoint(),
+			val:       []int64{1},
+		},
+		{
+			name:      "quantile_values on NumberDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "quantile_values"},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       newQuantileValues,
+		},
+		{
+			name:      "count on NumberDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "count"},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       int64(1),
+		},
+		{
+			name:      "sum on NumberDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "sum"},
+			dataPoint: pmetric.NewNumberDataPoint(),
+			val:       1.0,
+		},
+		{
+			name:      "exemplars on SummaryDataPoint",
+			path:      &pathtest.Path[*testContext]{N: "exemplars"},
+			dataPoint: pmetric.NewSummaryDataPoint(),
+			val:       newExemplars,
+		},
+		{
+			name:      "attributes on unknown data point type",
+			path:      &pathtest.Path[*testContext]{N: "attributes"},
+			dataPoint: struct{}{},
+			val:       pcommon.NewMap(),
+		},
+		{
+			name:      "flags on unknown data point type",
+			path:      &pathtest.Path[*testContext]{N: "flags"},
+			dataPoint: struct{}{},
+			val:       int64(1),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessor, err := ctxdatapoint.PathGetSetter(tt.path)
+			require.NoError(t, err)
+			ctx := newTestContext(tt.dataPoint)
+			err = accessor.Set(t.Context(), ctx, tt.val)
+			require.Error(t, err)
+		})
+	}
+}
+
 func createSummaryDataPointTelemetry() pmetric.SummaryDataPoint {
 	summaryDataPoint := pmetric.NewSummaryDataPoint()
 	summaryDataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))


### PR DESCRIPTION
#### Description

Update datapoint context to consider operations on incorrect datapoint type an error. For example, if you try to set the `datapoint.explicit_bounds` field on a `NumberDatapoint`, OTTL will now return an error.

#### Link to tracking issue

- closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40198

#### Testing

added unit tests
