### PR TITLE
[processor/transform/internal/logparsingfuncs] Add ParseELF function for W3C Extended Log Format

### DIFF
--- a/.chloggen/feat-parse-elf-log-function.yaml
+++ b/.chloggen/feat-parse-elf-log-function.yaml
@@ -2,12 +2,12 @@ change_type: enhancement
 
 component: processor/transform
 
-note: Add `parse_elf` function to parse W3C Extended Log Format (ELF) log blocks into structured maps.
+note: Add `ParseELF` function to parse W3C Extended Log Format (ELF) log blocks into structured maps.
 
 issues: [48352]
 
 subtext: |
-  `parse_elf(target)` parses a complete ELF text block and returns a `pcommon.Map` with
+  `ParseELF(target)` parses a complete ELF text block and returns a `pcommon.Map` with
   directive metadata (version, software, date, start_date, end_date, remark), a fields
   slice, and an entries slice keyed by field name. Multiple #Fields directives and
   double-quoted values (IIS-style) are supported.

--- a/.chloggen/feat-parse-elf-log-function.yaml
+++ b/.chloggen/feat-parse-elf-log-function.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: processor/transform
+
+note: Add `parse_elf` function to parse W3C Extended Log Format (ELF) log blocks into structured maps.
+
+issues: [48352]
+
+subtext: |
+  `parse_elf(target)` parses a complete ELF text block and returns a `pcommon.Map` with
+  directive metadata (version, software, date, start_date, end_date, remark), a fields
+  slice, and an entries slice keyed by field name. Multiple #Fields directives and
+  double-quoted values (IIS-style) are supported.
+
+change_logs: [user]

--- a/.chloggen/feat-parse-elf-log-function.yaml
+++ b/.chloggen/feat-parse-elf-log-function.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 
-component: processor/transform
+component: processor/transformprocessor/internal/logparsingfuncs
 
 note: Add `ParseELF` function to parse W3C Extended Log Format (ELF) log blocks into structured maps.
 

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -277,7 +277,7 @@ In addition to the common OTTL functions, the processor defines its own function
 
 - [ParseCLF](#parseclf)
 - [ParseLEEF](#parseleef)
-- [parse_elf](#parse_elf)
+- [ParseELF](#parseelf)
 
 **Traces only functions**
 
@@ -784,13 +784,15 @@ Examples:
 
 - `ParseLEEF("LEEF:2.0|Lancope|StealthWatch|1.0|41|^|src=10.0.1.8^dst=10.0.0.5^sev=5")`
 
-### parse_elf
+### ParseELF
 
-`parse_elf(target)`
+`ParseELF(target)`
 
-The `parse_elf` function returns a `pcommon.Map` that is the result of parsing the `target` string as a [W3C Extended Log Format (ELF)](https://www.w3.org/TR/WD-logfile.html) log block.
+The `ParseELF` function returns a `pcommon.Map` that is the result of parsing the `target` string as a [W3C Extended Log Format (ELF)](https://www.w3.org/TR/WD-logfile.html) log block.
 
 `target` is a Getter that returns a string containing a complete ELF log block (one or more directive lines followed by data lines). If the string is empty or does not contain a valid `#Version` directive, an error is returned.
+
+**Intended usage:** `ParseELF` is designed for pipelines where the full ELF block — header directives (`#Version`, `#Fields`, etc.) and data lines — is available as a single string. This is the case when using the [filelog receiver](../../receiver/filelogreceiver/README.md) with a multiline configuration that groups an entire ELF file (or rotated segment) into one log record body, or when the entire log content is read from a single field. In a line-by-line streaming pipeline where `#Fields` arrives only once at file open, each individual data line does not carry its own header; for that pattern you would need to prepend the known header directives to each data line before passing the string to `ParseELF`.
 
 The returned map contains the following keys:
 
@@ -807,9 +809,9 @@ Multiple `#Fields` directives within a single block are supported; each directiv
 
 Examples:
 
-- `parse_elf(body)`
+- `ParseELF(body)`
 
-- `parse_elf("#Version: 1.0\n#Fields: time cs-method cs-uri\n00:34:23 GET /foo/bar.html")`
+- `ParseELF("#Version: 1.0\n#Fields: time cs-method cs-uri\n00:34:23 GET /foo/bar.html")`
 
 ### set_semconv_span_name
 

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -277,6 +277,7 @@ In addition to the common OTTL functions, the processor defines its own function
 
 - [ParseCLF](#parseclf)
 - [ParseLEEF](#parseleef)
+- [parse_elf](#parse_elf)
 
 **Traces only functions**
 
@@ -782,6 +783,33 @@ Examples:
 - `ParseLEEF("LEEF:1.0|Microsoft|MSExchange|4.0 SP1|15345|src=10.50.1.1\tdst=2.10.20.20\tsev=5")`
 
 - `ParseLEEF("LEEF:2.0|Lancope|StealthWatch|1.0|41|^|src=10.0.1.8^dst=10.0.0.5^sev=5")`
+
+### parse_elf
+
+`parse_elf(target)`
+
+The `parse_elf` function returns a `pcommon.Map` that is the result of parsing the `target` string as a [W3C Extended Log Format (ELF)](https://www.w3.org/TR/WD-logfile.html) log block.
+
+`target` is a Getter that returns a string containing a complete ELF log block (one or more directive lines followed by data lines). If the string is empty or does not contain a valid `#Version` directive, an error is returned.
+
+The returned map contains the following keys:
+
+* `version` — value of the `#Version` directive (required).
+* `software` — value of `#Software` (omitted if not present).
+* `date` — value of `#Date` (omitted if not present).
+* `start_date` — value of `#Start-Date` (omitted if not present).
+* `end_date` — value of `#End-Date` (omitted if not present).
+* `remark` — value of `#Remark` (omitted if not present).
+* `fields` — string slice of field names from the last `#Fields` directive.
+* `entries` — slice of maps, one per data line, keyed by field name. Missing values are represented as `"-"`.
+
+Multiple `#Fields` directives within a single block are supported; each directive applies to subsequent data lines until the next `#Fields` directive is encountered. Double-quoted field values (as produced by Microsoft IIS) are handled correctly.
+
+Examples:
+
+- `parse_elf(body)`
+
+- `parse_elf("#Version: 1.0\n#Fields: time cs-method cs-uri\n00:34:23 GET /foo/bar.html")`
 
 ### set_semconv_span_name
 

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
@@ -21,7 +22,7 @@ type parseELFArguments struct {
 
 // NewParseELFFactory returns an OTTL factory for the parse_elf function.
 func NewParseELFFactory() ottl.Factory[*ottllog.TransformContext] {
-	return ottl.NewFactory("parse_elf", &parseELFArguments{}, createParseELFFunction)
+	return ottl.NewFactory("ParseELF", &parseELFArguments{}, createParseELFFunction)
 }
 
 func createParseELFFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottllog.TransformContext], error) {
@@ -152,32 +153,45 @@ func parseELFDirective(line string) (string, string, error) {
 
 // parseELFDataLine splits a single ELF data line into tokens, honouring double-quoted
 // strings as used by real-world ELF producers (e.g. Microsoft IIS).
+// Whitespace (space or tab) separates tokens; embedded double-quotes inside a quoted
+// string are represented by "" per the W3C ELF spec §2.
 func parseELFDataLine(line string) []string {
+	runes := []rune(line)
 	var values []string
-	i, n := 0, len(line)
+	i, n := 0, len(runes)
 	for i < n {
-		for i < n && line[i] == ' ' {
+		// skip leading whitespace
+		for i < n && unicode.IsSpace(runes[i]) {
 			i++
 		}
 		if i >= n {
 			break
 		}
-		if line[i] == '"' {
-			i++
-			start := i
-			for i < n && line[i] != '"' {
-				i++
+		if runes[i] == '"' {
+			i++ // skip opening '"'
+			var sb strings.Builder
+			for i < n {
+				if runes[i] == '"' {
+					if i+1 < n && runes[i+1] == '"' {
+						// escaped double-quote: "" → "
+						sb.WriteRune('"')
+						i += 2
+					} else {
+						i++ // skip closing '"'
+						break
+					}
+				} else {
+					sb.WriteRune(runes[i])
+					i++
+				}
 			}
-			values = append(values, line[start:i])
-			if i < n {
-				i++ // skip closing '"'
-			}
+			values = append(values, sb.String())
 		} else {
 			start := i
-			for i < n && line[i] != ' ' {
+			for i < n && !unicode.IsSpace(runes[i]) {
 				i++
 			}
-			values = append(values, line[start:i])
+			values = append(values, string(runes[start:i]))
 		}
 	}
 	return values

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logparsingfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logparsingfuncs"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+)
+
+type parseELFArguments struct {
+	Target ottl.StringGetter[*ottllog.TransformContext]
+}
+
+// NewParseELFFactory returns an OTTL factory for the parse_elf function.
+func NewParseELFFactory() ottl.Factory[*ottllog.TransformContext] {
+	return ottl.NewFactory("parse_elf", &parseELFArguments{}, createParseELFFunction)
+}
+
+func createParseELFFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottllog.TransformContext], error) {
+	args, ok := oArgs.(*parseELFArguments)
+	if !ok {
+		return nil, errors.New("parseELFFactory args must be of type *parseELFArguments")
+	}
+	return parseELF(args.Target), nil
+}
+
+func parseELF(target ottl.StringGetter[*ottllog.TransformContext]) ottl.ExprFunc[*ottllog.TransformContext] {
+	return func(ctx context.Context, tCtx *ottllog.TransformContext) (any, error) {
+		source, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		if source == "" {
+			return nil, errors.New("cannot parse empty ELF message")
+		}
+		return parseELFMessage(source)
+	}
+}
+
+// elfMeta holds the directive-level metadata from ELF header lines.
+type elfMeta struct {
+	version   string
+	software  string
+	date      string
+	startDate string
+	endDate   string
+	remark    string
+}
+
+// elfDataEntry holds one parsed data row together with the field names that were
+// active when the row was encountered (multiple #Fields directives are allowed).
+type elfDataEntry struct {
+	fields []string
+	values []string
+}
+
+// parseELFMessage parses a W3C Extended Log Format (ELF) text block and returns a
+// pcommon.Map with the following keys:
+//
+//   - version    – value of #Version (required; returns error if absent)
+//   - software   – value of #Software (omitted if not present)
+//   - date       – value of #Date (omitted if not present)
+//   - start_date – value of #Start-Date (omitted if not present)
+//   - end_date   – value of #End-Date (omitted if not present)
+//   - remark     – value of #Remark (omitted if not present)
+//   - fields     – string slice from the last #Fields directive seen
+//   - entries    – slice of maps, one per data line, keyed by field name
+//
+// Multiple #Fields directives are supported; each applies to subsequent data lines.
+func parseELFMessage(input string) (pcommon.Map, error) {
+	input = strings.ReplaceAll(input, "\r\n", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
+	lines := strings.Split(input, "\n")
+
+	meta := elfMeta{}
+	var currentFields []string
+	var lastFields []string
+	var entries []elfDataEntry
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "#") {
+			key, value, err := parseELFDirective(line)
+			if err != nil {
+				continue
+			}
+			switch strings.ToLower(key) {
+			case "version":
+				meta.version = value
+			case "fields":
+				currentFields = strings.Fields(value)
+				lastFields = currentFields
+			case "software":
+				meta.software = value
+			case "date":
+				meta.date = value
+			case "start-date":
+				meta.startDate = value
+			case "end-date":
+				meta.endDate = value
+			case "remark":
+				meta.remark = value
+			}
+			continue
+		}
+
+		// Data line.
+		if len(currentFields) == 0 {
+			return pcommon.Map{}, errors.New("invalid ELF: data entry found before #Fields directive")
+		}
+		entries = append(entries, elfDataEntry{
+			fields: currentFields,
+			values: parseELFDataLine(line),
+		})
+	}
+
+	if meta.version == "" {
+		return pcommon.Map{}, errors.New("invalid ELF: missing #Version directive")
+	}
+
+	return buildELFResult(meta, lastFields, entries)
+}
+
+// parseELFDirective parses a directive line of the form "#Key: value" and returns
+// the key and trimmed value. Returns an error for lines without a colon separator.
+func parseELFDirective(line string) (string, string, error) {
+	body := line[1:] // strip leading '#'
+	idx := strings.Index(body, ":")
+	if idx == -1 {
+		return "", "", fmt.Errorf("directive %q has no colon separator", line)
+	}
+	return strings.TrimSpace(body[:idx]), strings.TrimSpace(body[idx+1:]), nil
+}
+
+// parseELFDataLine splits a single ELF data line into tokens, honouring double-quoted
+// strings as used by real-world ELF producers (e.g. Microsoft IIS).
+func parseELFDataLine(line string) []string {
+	var values []string
+	i, n := 0, len(line)
+	for i < n {
+		for i < n && line[i] == ' ' {
+			i++
+		}
+		if i >= n {
+			break
+		}
+		if line[i] == '"' {
+			i++
+			start := i
+			for i < n && line[i] != '"' {
+				i++
+			}
+			values = append(values, line[start:i])
+			if i < n {
+				i++ // skip closing '"'
+			}
+		} else {
+			start := i
+			for i < n && line[i] != ' ' {
+				i++
+			}
+			values = append(values, line[start:i])
+		}
+	}
+	return values
+}
+
+func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry) (pcommon.Map, error) {
+	result := pcommon.NewMap()
+
+	result.PutStr("version", meta.version)
+	if meta.software != "" {
+		result.PutStr("software", meta.software)
+	}
+	if meta.date != "" {
+		result.PutStr("date", meta.date)
+	}
+	if meta.startDate != "" {
+		result.PutStr("start_date", meta.startDate)
+	}
+	if meta.endDate != "" {
+		result.PutStr("end_date", meta.endDate)
+	}
+	if meta.remark != "" {
+		result.PutStr("remark", meta.remark)
+	}
+
+	fieldsSlice := result.PutEmptySlice("fields")
+	for _, f := range lastFields {
+		fieldsSlice.AppendEmpty().SetStr(f)
+	}
+
+	entriesSlice := result.PutEmptySlice("entries")
+	for _, e := range entries {
+		m := entriesSlice.AppendEmpty().SetEmptyMap()
+		for i, field := range e.fields {
+			if i < len(e.values) {
+				m.PutStr(field, e.values[i])
+			} else {
+				m.PutStr(field, "-")
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -98,7 +98,7 @@ func parseELFMessage(input string, logger *zap.Logger) (pcommon.Map, error) {
 			if err != nil {
 				// A malformed #Fields directive would silently poison subsequent data
 				// lines, so treat it as a hard error.
-				if strings.HasPrefix(strings.TrimSpace(line[1:]), "Fields") {
+				if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line[1:])), "fields") {
 					return pcommon.Map{}, fmt.Errorf("invalid ELF: malformed #Fields directive %q: %w", line, err)
 				}
 				// Other unrecognised directives (e.g. bare #Remark) are skipped.

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -94,6 +94,12 @@ func parseELFMessage(input string) (pcommon.Map, error) {
 		if strings.HasPrefix(line, "#") {
 			key, value, err := parseELFDirective(line)
 			if err != nil {
+				// A malformed #Fields directive would silently poison subsequent data
+				// lines, so treat it as a hard error.
+				if strings.HasPrefix(strings.TrimSpace(line[1:]), "Fields") {
+					return pcommon.Map{}, fmt.Errorf("invalid ELF: malformed #Fields directive %q: %w", line, err)
+				}
+				// Other unrecognised directives (e.g. bare #Remark) are skipped.
 				continue
 			}
 			switch strings.ToLower(key) {
@@ -130,7 +136,7 @@ func parseELFMessage(input string) (pcommon.Map, error) {
 		return pcommon.Map{}, errors.New("invalid ELF: missing #Version directive")
 	}
 
-	return buildELFResult(meta, lastFields, entries)
+	return buildELFResult(meta, lastFields, entries), nil
 }
 
 // parseELFDirective parses a directive line of the form "#Key: value" and returns
@@ -177,7 +183,7 @@ func parseELFDataLine(line string) []string {
 	return values
 }
 
-func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry) (pcommon.Map, error) {
+func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry) pcommon.Map {
 	result := pcommon.NewMap()
 
 	result.PutStr("version", meta.version)
@@ -214,5 +220,5 @@ func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry) (
 		}
 	}
 
-	return result, nil
+	return result
 }

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -205,15 +205,14 @@ func parseELFDataLine(line string) ([]string, error) {
 					i++
 					continue
 				}
-				if i+1 < n && line[i+1] == '"' {
-					// escaped double-quote: "" → "
-					sb.WriteByte('"')
-					i += 2
-				} else {
+				if i+1 >= n || line[i+1] != '"' {
 					i++ // skip closing '"'
 					closed = true
 					break
 				}
+				// escaped double-quote: "" → "
+				sb.WriteByte('"')
+				i += 2
 			}
 			if !closed {
 				return nil, fmt.Errorf("unterminated quoted value in data line: %q", line)

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
@@ -25,15 +26,15 @@ func NewParseELFFactory() ottl.Factory[*ottllog.TransformContext] {
 	return ottl.NewFactory("ParseELF", &parseELFArguments{}, createParseELFFunction)
 }
 
-func createParseELFFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottllog.TransformContext], error) {
+func createParseELFFunction(fCtx ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottllog.TransformContext], error) {
 	args, ok := oArgs.(*parseELFArguments)
 	if !ok {
 		return nil, errors.New("parseELFFactory args must be of type *parseELFArguments")
 	}
-	return parseELF(args.Target), nil
+	return parseELF(args.Target, fCtx.Set.Logger), nil
 }
 
-func parseELF(target ottl.StringGetter[*ottllog.TransformContext]) ottl.ExprFunc[*ottllog.TransformContext] {
+func parseELF(target ottl.StringGetter[*ottllog.TransformContext], logger *zap.Logger) ottl.ExprFunc[*ottllog.TransformContext] {
 	return func(ctx context.Context, tCtx *ottllog.TransformContext) (any, error) {
 		source, err := target.Get(ctx, tCtx)
 		if err != nil {
@@ -42,7 +43,7 @@ func parseELF(target ottl.StringGetter[*ottllog.TransformContext]) ottl.ExprFunc
 		if source == "" {
 			return nil, errors.New("cannot parse empty ELF message")
 		}
-		return parseELFMessage(source)
+		return parseELFMessage(source, logger)
 	}
 }
 
@@ -76,7 +77,7 @@ type elfDataEntry struct {
 //   - entries    – slice of maps, one per data line, keyed by field name
 //
 // Multiple #Fields directives are supported; each applies to subsequent data lines.
-func parseELFMessage(input string) (pcommon.Map, error) {
+func parseELFMessage(input string, logger *zap.Logger) (pcommon.Map, error) {
 	input = strings.ReplaceAll(input, "\r\n", "\n")
 	input = strings.ReplaceAll(input, "\r", "\n")
 	lines := strings.Split(input, "\n")
@@ -127,9 +128,13 @@ func parseELFMessage(input string) (pcommon.Map, error) {
 		if len(currentFields) == 0 {
 			return pcommon.Map{}, errors.New("invalid ELF: data entry found before #Fields directive")
 		}
+		values, err := parseELFDataLine(line)
+		if err != nil {
+			return pcommon.Map{}, fmt.Errorf("invalid ELF: %w", err)
+		}
 		entries = append(entries, elfDataEntry{
 			fields: currentFields,
-			values: parseELFDataLine(line),
+			values: values,
 		})
 	}
 
@@ -137,7 +142,7 @@ func parseELFMessage(input string) (pcommon.Map, error) {
 		return pcommon.Map{}, errors.New("invalid ELF: missing #Version directive")
 	}
 
-	return buildELFResult(meta, lastFields, entries), nil
+	return buildELFResult(meta, lastFields, entries, logger), nil
 }
 
 // parseELFDirective parses a directive line of the form "#Key: value" and returns
@@ -155,7 +160,8 @@ func parseELFDirective(line string) (string, string, error) {
 // strings as used by real-world ELF producers (e.g. Microsoft IIS).
 // Whitespace (space or tab) separates tokens; embedded double-quotes inside a quoted
 // string are represented by "" per the W3C ELF spec §2.
-func parseELFDataLine(line string) []string {
+// Returns an error for unterminated quoted values.
+func parseELFDataLine(line string) ([]string, error) {
 	runes := []rune(line)
 	var values []string
 	i, n := 0, len(runes)
@@ -170,6 +176,7 @@ func parseELFDataLine(line string) []string {
 		if runes[i] == '"' {
 			i++ // skip opening '"'
 			var sb strings.Builder
+			closed := false
 			for i < n {
 				if runes[i] == '"' {
 					if i+1 < n && runes[i+1] == '"' {
@@ -178,12 +185,16 @@ func parseELFDataLine(line string) []string {
 						i += 2
 					} else {
 						i++ // skip closing '"'
+						closed = true
 						break
 					}
 				} else {
 					sb.WriteRune(runes[i])
 					i++
 				}
+			}
+			if !closed {
+				return nil, fmt.Errorf("unterminated quoted value in data line: %q", line)
 			}
 			values = append(values, sb.String())
 		} else {
@@ -194,10 +205,10 @@ func parseELFDataLine(line string) []string {
 			values = append(values, string(runes[start:i]))
 		}
 	}
-	return values
+	return values, nil
 }
 
-func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry) pcommon.Map {
+func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry, logger *zap.Logger) pcommon.Map {
 	result := pcommon.NewMap()
 
 	result.PutStr("version", meta.version)
@@ -229,6 +240,11 @@ func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry) p
 			if i < len(e.values) {
 				m.PutStr(field, e.values[i])
 			} else {
+				logger.Warn("ELF data line has fewer values than fields; substituting '-'",
+					zap.String("field", field),
+					zap.Int("field_count", len(e.fields)),
+					zap.Int("value_count", len(e.values)),
+				)
 				m.PutStr(field, "-")
 			}
 		}

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"unicode"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
@@ -21,7 +20,6 @@ type parseELFArguments struct {
 	Target ottl.StringGetter[*ottllog.TransformContext]
 }
 
-// NewParseELFFactory returns an OTTL factory for the parse_elf function.
 func NewParseELFFactory() ottl.Factory[*ottllog.TransformContext] {
 	return ottl.NewFactory("ParseELF", &parseELFArguments{}, createParseELFFunction)
 }
@@ -47,79 +45,90 @@ func parseELF(target ottl.StringGetter[*ottllog.TransformContext], logger *zap.L
 	}
 }
 
-// elfMeta holds the directive-level metadata from ELF header lines.
-type elfMeta struct {
-	version   string
-	software  string
-	date      string
-	startDate string
-	endDate   string
-	remark    string
-}
-
-// elfDataEntry holds one parsed data row together with the field names that were
-// active when the row was encountered (multiple #Fields directives are allowed).
-type elfDataEntry struct {
-	fields []string
-	values []string
+// nextLine returns the next non-empty trimmed line from s starting at offset,
+// along with the new offset after that line's ending. Returns ok=false when
+// the end of s is reached. Handles \r\n, \r, and \n line endings without
+// allocating a new string.
+func nextLine(s string, offset int) (line string, next int, ok bool) {
+	n := len(s)
+	for offset < n {
+		end := offset
+		for end < n && s[end] != '\n' && s[end] != '\r' {
+			end++
+		}
+		raw := strings.TrimSpace(s[offset:end])
+		if end < n && s[end] == '\r' {
+			end++
+		}
+		if end < n && s[end] == '\n' {
+			end++
+		}
+		offset = end
+		if raw != "" {
+			return raw, offset, true
+		}
+	}
+	return "", offset, false
 }
 
 // parseELFMessage parses a W3C Extended Log Format (ELF) text block and returns a
-// pcommon.Map with the following keys:
+// pcommon.Map with the following keys (all prefixed with "elf."):
 //
-//   - version    – value of #Version (required; returns error if absent)
-//   - software   – value of #Software (omitted if not present)
-//   - date       – value of #Date (omitted if not present)
-//   - start_date – value of #Start-Date (omitted if not present)
-//   - end_date   – value of #End-Date (omitted if not present)
-//   - remark     – value of #Remark (omitted if not present)
-//   - fields     – string slice from the last #Fields directive seen
-//   - entries    – slice of maps, one per data line, keyed by field name
+//   - elf.version    – value of #Version (required; returns error if absent)
+//   - elf.software   – value of #Software (omitted if not present)
+//   - elf.date       – value of #Date (omitted if not present)
+//   - elf.start_date – value of #Start-Date (omitted if not present)
+//   - elf.end_date   – value of #End-Date (omitted if not present)
+//   - elf.remark     – value of #Remark (omitted if not present)
+//   - elf.fields     – string slice from the last #Fields directive seen
+//   - elf.entries    – slice of maps, one per data line, keyed by "elf.<field>"
 //
 // Multiple #Fields directives are supported; each applies to subsequent data lines.
 func parseELFMessage(input string, logger *zap.Logger) (pcommon.Map, error) {
-	input = strings.ReplaceAll(input, "\r\n", "\n")
-	input = strings.ReplaceAll(input, "\r", "\n")
-	lines := strings.Split(input, "\n")
+	result := pcommon.NewMap()
+	entriesSlice := result.PutEmptySlice("elf.entries")
 
-	meta := elfMeta{}
+	var hasVersion bool
 	var currentFields []string
 	var lastFields []string
-	var entries []elfDataEntry
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	offset := 0
+	for {
+		line, next, ok := nextLine(input, offset)
+		if !ok {
+			break
 		}
+		offset = next
 
 		if strings.HasPrefix(line, "#") {
 			key, value, err := parseELFDirective(line)
 			if err != nil {
 				// A malformed #Fields directive would silently poison subsequent data
 				// lines, so treat it as a hard error.
-				if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line[1:])), "fields") {
+				trimmed := strings.TrimSpace(line[1:])
+				if len(trimmed) >= 6 && strings.EqualFold(trimmed[:6], "fields") {
 					return pcommon.Map{}, fmt.Errorf("invalid ELF: malformed #Fields directive %q: %w", line, err)
 				}
 				// Other unrecognised directives (e.g. bare #Remark) are skipped.
 				continue
 			}
-			switch strings.ToLower(key) {
-			case "version":
-				meta.version = value
-			case "fields":
+			switch {
+			case strings.EqualFold(key, "version"):
+				hasVersion = true
+				result.PutStr("elf.version", value)
+			case strings.EqualFold(key, "fields"):
 				currentFields = strings.Fields(value)
 				lastFields = currentFields
-			case "software":
-				meta.software = value
-			case "date":
-				meta.date = value
-			case "start-date":
-				meta.startDate = value
-			case "end-date":
-				meta.endDate = value
-			case "remark":
-				meta.remark = value
+			case strings.EqualFold(key, "software"):
+				result.PutStr("elf.software", value)
+			case strings.EqualFold(key, "date"):
+				result.PutStr("elf.date", value)
+			case strings.EqualFold(key, "start-date"):
+				result.PutStr("elf.start_date", value)
+			case strings.EqualFold(key, "end-date"):
+				result.PutStr("elf.end_date", value)
+			case strings.EqualFold(key, "remark"):
+				result.PutStr("elf.remark", value)
 			}
 			continue
 		}
@@ -132,17 +141,31 @@ func parseELFMessage(input string, logger *zap.Logger) (pcommon.Map, error) {
 		if err != nil {
 			return pcommon.Map{}, fmt.Errorf("invalid ELF: %w", err)
 		}
-		entries = append(entries, elfDataEntry{
-			fields: currentFields,
-			values: values,
-		})
+		m := entriesSlice.AppendEmpty().SetEmptyMap()
+		for i, field := range currentFields {
+			if i < len(values) {
+				m.PutStr("elf."+field, values[i])
+			} else {
+				logger.Warn("ELF data line has fewer values than fields; substituting '-'",
+					zap.String("field", field),
+					zap.Int("field_count", len(currentFields)),
+					zap.Int("value_count", len(values)),
+				)
+				m.PutStr("elf."+field, "-")
+			}
+		}
 	}
 
-	if meta.version == "" {
+	if !hasVersion {
 		return pcommon.Map{}, errors.New("invalid ELF: missing #Version directive")
 	}
 
-	return buildELFResult(meta, lastFields, entries, logger), nil
+	fieldsSlice := result.PutEmptySlice("elf.fields")
+	for _, f := range lastFields {
+		fieldsSlice.AppendEmpty().SetStr(f)
+	}
+
+	return result, nil
 }
 
 // parseELFDirective parses a directive line of the form "#Key: value" and returns
@@ -162,26 +185,25 @@ func parseELFDirective(line string) (string, string, error) {
 // string are represented by "" per the W3C ELF spec §2.
 // Returns an error for unterminated quoted values.
 func parseELFDataLine(line string) ([]string, error) {
-	runes := []rune(line)
 	var values []string
-	i, n := 0, len(runes)
+	i, n := 0, len(line)
 	for i < n {
-		// skip leading whitespace
-		for i < n && unicode.IsSpace(runes[i]) {
+		// skip leading whitespace (space or tab)
+		for i < n && (line[i] == ' ' || line[i] == '\t') {
 			i++
 		}
 		if i >= n {
 			break
 		}
-		if runes[i] == '"' {
+		if line[i] == '"' {
 			i++ // skip opening '"'
 			var sb strings.Builder
 			closed := false
 			for i < n {
-				if runes[i] == '"' {
-					if i+1 < n && runes[i+1] == '"' {
+				if line[i] == '"' {
+					if i+1 < n && line[i+1] == '"' {
 						// escaped double-quote: "" → "
-						sb.WriteRune('"')
+						sb.WriteByte('"')
 						i += 2
 					} else {
 						i++ // skip closing '"'
@@ -189,7 +211,7 @@ func parseELFDataLine(line string) ([]string, error) {
 						break
 					}
 				} else {
-					sb.WriteRune(runes[i])
+					sb.WriteByte(line[i])
 					i++
 				}
 			}
@@ -199,56 +221,11 @@ func parseELFDataLine(line string) ([]string, error) {
 			values = append(values, sb.String())
 		} else {
 			start := i
-			for i < n && !unicode.IsSpace(runes[i]) {
+			for i < n && line[i] != ' ' && line[i] != '\t' {
 				i++
 			}
-			values = append(values, string(runes[start:i]))
+			values = append(values, line[start:i])
 		}
 	}
 	return values, nil
-}
-
-func buildELFResult(meta elfMeta, lastFields []string, entries []elfDataEntry, logger *zap.Logger) pcommon.Map {
-	result := pcommon.NewMap()
-
-	result.PutStr("version", meta.version)
-	if meta.software != "" {
-		result.PutStr("software", meta.software)
-	}
-	if meta.date != "" {
-		result.PutStr("date", meta.date)
-	}
-	if meta.startDate != "" {
-		result.PutStr("start_date", meta.startDate)
-	}
-	if meta.endDate != "" {
-		result.PutStr("end_date", meta.endDate)
-	}
-	if meta.remark != "" {
-		result.PutStr("remark", meta.remark)
-	}
-
-	fieldsSlice := result.PutEmptySlice("fields")
-	for _, f := range lastFields {
-		fieldsSlice.AppendEmpty().SetStr(f)
-	}
-
-	entriesSlice := result.PutEmptySlice("entries")
-	for _, e := range entries {
-		m := entriesSlice.AppendEmpty().SetEmptyMap()
-		for i, field := range e.fields {
-			if i < len(e.values) {
-				m.PutStr(field, e.values[i])
-			} else {
-				logger.Warn("ELF data line has fewer values than fields; substituting '-'",
-					zap.String("field", field),
-					zap.Int("field_count", len(e.fields)),
-					zap.Int("value_count", len(e.values)),
-				)
-				m.PutStr(field, "-")
-			}
-		}
-	}
-
-	return result
 }

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf.go
@@ -109,7 +109,7 @@ func parseELFMessage(input string, logger *zap.Logger) (pcommon.Map, error) {
 				if len(trimmed) >= 6 && strings.EqualFold(trimmed[:6], "fields") {
 					return pcommon.Map{}, fmt.Errorf("invalid ELF: malformed #Fields directive %q: %w", line, err)
 				}
-				// Other unrecognised directives (e.g. bare #Remark) are skipped.
+				// Other unrecognized directives (e.g. bare #Remark) are skipped.
 				continue
 			}
 			switch {
@@ -179,7 +179,7 @@ func parseELFDirective(line string) (string, string, error) {
 	return strings.TrimSpace(body[:idx]), strings.TrimSpace(body[idx+1:]), nil
 }
 
-// parseELFDataLine splits a single ELF data line into tokens, honouring double-quoted
+// parseELFDataLine splits a single ELF data line into tokens, honoring double-quoted
 // strings as used by real-world ELF producers (e.g. Microsoft IIS).
 // Whitespace (space or tab) separates tokens; embedded double-quotes inside a quoted
 // string are represented by "" per the W3C ELF spec §2.
@@ -200,19 +200,19 @@ func parseELFDataLine(line string) ([]string, error) {
 			var sb strings.Builder
 			closed := false
 			for i < n {
-				if line[i] == '"' {
-					if i+1 < n && line[i+1] == '"' {
-						// escaped double-quote: "" → "
-						sb.WriteByte('"')
-						i += 2
-					} else {
-						i++ // skip closing '"'
-						closed = true
-						break
-					}
-				} else {
+				if line[i] != '"' {
 					sb.WriteByte(line[i])
 					i++
+					continue
+				}
+				if i+1 < n && line[i+1] == '"' {
+					// escaped double-quote: "" → "
+					sb.WriteByte('"')
+					i += 2
+				} else {
+					i++ // skip closing '"'
+					closed = true
+					break
 				}
 			}
 			if !closed {

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
@@ -1,0 +1,338 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logparsingfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+)
+
+func Test_parseELF(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   ottl.StringGetter[*ottllog.TransformContext]
+		expected map[string]any
+		wantErr  bool
+	}{
+		{
+			name: "basic W3C ELF block",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Date: 12-Jan-1996 00:00:00\n#Fields: time cs-method cs-uri\n00:34:23 GET /foo/bar.html\n12:21:16 GET /baz/index.html", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"date":    "12-Jan-1996 00:00:00",
+				"fields":  []any{"time", "cs-method", "cs-uri"},
+				"entries": []any{
+					map[string]any{"time": "00:34:23", "cs-method": "GET", "cs-uri": "/foo/bar.html"},
+					map[string]any{"time": "12:21:16", "cs-method": "GET", "cs-uri": "/baz/index.html"},
+				},
+			},
+		},
+		{
+			name: "IIS W3C extended log with all header directives",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Software: Microsoft Internet Information Services 6.0\n#Version: 1.0\n#Date: 2002-05-24 20:18:01\n#Fields: date time c-ip cs-username s-ip cs-method cs-uri-stem cs-uri-query sc-status\n2002-05-24 20:18:01 172.224.24.114 - 206.73.118.24 GET /Default.htm - 200", nil
+				},
+			},
+			expected: map[string]any{
+				"version":  "1.0",
+				"software": "Microsoft Internet Information Services 6.0",
+				"date":     "2002-05-24 20:18:01",
+				"fields":   []any{"date", "time", "c-ip", "cs-username", "s-ip", "cs-method", "cs-uri-stem", "cs-uri-query", "sc-status"},
+				"entries": []any{
+					map[string]any{
+						"date":          "2002-05-24",
+						"time":          "20:18:01",
+						"c-ip":          "172.224.24.114",
+						"cs-username":   "-",
+						"s-ip":          "206.73.118.24",
+						"cs-method":     "GET",
+						"cs-uri-stem":   "/Default.htm",
+						"cs-uri-query":  "-",
+						"sc-status":     "200",
+					},
+				},
+			},
+		},
+		{
+			name: "missing values filled with dash",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: a b c d\nval1 val2", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"a", "b", "c", "d"},
+				"entries": []any{
+					map[string]any{"a": "val1", "b": "val2", "c": "-", "d": "-"},
+				},
+			},
+		},
+		{
+			name: "quoted field values",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: cs-method cs-uri cs(User-Agent)\nGET /page.html \"Mozilla/5.0 (Windows NT 10.0)\"", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"cs-method", "cs-uri", "cs(User-Agent)"},
+				"entries": []any{
+					map[string]any{
+						"cs-method":      "GET",
+						"cs-uri":         "/page.html",
+						"cs(User-Agent)": "Mozilla/5.0 (Windows NT 10.0)",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple #Fields directives",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: time cs-method\n10:00:00 GET\n#Fields: time sc-status\n10:01:00 200", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"time", "sc-status"}, // last #Fields
+				"entries": []any{
+					map[string]any{"time": "10:00:00", "cs-method": "GET"},
+					map[string]any{"time": "10:01:00", "sc-status": "200"},
+				},
+			},
+		},
+		{
+			name: "start_date and end_date directives",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Start-Date: 2024-01-01 00:00:00\n#End-Date: 2024-01-01 23:59:59\n#Fields: time\n12:00:00", nil
+				},
+			},
+			expected: map[string]any{
+				"version":    "1.0",
+				"start_date": "2024-01-01 00:00:00",
+				"end_date":   "2024-01-01 23:59:59",
+				"fields":     []any{"time"},
+				"entries":    []any{map[string]any{"time": "12:00:00"}},
+			},
+		},
+		{
+			name: "remark directive",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Remark: test log file\n#Fields: time\n00:00:01", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"remark":  "test log file",
+				"fields":  []any{"time"},
+				"entries": []any{map[string]any{"time": "00:00:01"}},
+			},
+		},
+		{
+			name: "blank lines and CRLF line endings",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\r\n\r\n#Fields: time\r\n00:00:01\r\n", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"time"},
+				"entries": []any{map[string]any{"time": "00:00:01"}},
+			},
+		},
+		{
+			name: "no data entries, only directives",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: time cs-method", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"time", "cs-method"},
+				"entries": []any{},
+			},
+		},
+		{
+			name:    "empty input",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "", nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing #Version directive",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Fields: time\n00:00:01", nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "data line before #Fields directive",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n00:00:01 GET /foo", nil
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := parseELF(tt.target)
+			result, err := exprFunc(context.Background(), &ottllog.TransformContext{})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			m, ok := result.(pcommon.Map)
+			require.True(t, ok, "result must be pcommon.Map")
+			assertELFMapEqual(t, tt.expected, m)
+		})
+	}
+}
+
+// assertELFMapEqual compares a pcommon.Map against an expected map[string]any,
+// supporting nested maps and slices of strings / maps.
+func assertELFMapEqual(t *testing.T, expected map[string]any, actual pcommon.Map) {
+	t.Helper()
+	assert.Equal(t, len(expected), actual.Len(), "map length mismatch")
+	for k, wantRaw := range expected {
+		v, ok := actual.Get(k)
+		require.True(t, ok, "key %q missing from result", k)
+
+		switch want := wantRaw.(type) {
+		case string:
+			assert.Equal(t, want, v.Str(), "key %q", k)
+		case []any:
+			s := v.Slice()
+			require.Equal(t, len(want), s.Len(), "slice length for key %q", k)
+			for i, elem := range want {
+				sv := s.At(i)
+				switch e := elem.(type) {
+				case string:
+					assert.Equal(t, e, sv.Str(), "key %q index %d", k, i)
+				case map[string]any:
+					assertELFMapEqual(t, e, sv.Map())
+				}
+			}
+		}
+	}
+}
+
+func Test_parseELFDataLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple tokens",
+			input:    "GET /foo.html 200",
+			expected: []string{"GET", "/foo.html", "200"},
+		},
+		{
+			name:     "quoted string with spaces",
+			input:    `GET /foo.html "Mozilla/5.0 (Windows NT)"`,
+			expected: []string{"GET", "/foo.html", "Mozilla/5.0 (Windows NT)"},
+		},
+		{
+			name:     "dash placeholder",
+			input:    "GET /foo.html - 200",
+			expected: []string{"GET", "/foo.html", "-", "200"},
+		},
+		{
+			name:     "leading and trailing spaces",
+			input:    "  GET /foo.html  ",
+			expected: []string{"GET", "/foo.html"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseELFDataLine(tt.input))
+		})
+	}
+}
+
+func Test_parseELFDirective(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantKey   string
+		wantValue string
+		wantErr   bool
+	}{
+		{
+			name:      "version directive",
+			input:     "#Version: 1.0",
+			wantKey:   "Version",
+			wantValue: "1.0",
+		},
+		{
+			name:      "fields directive with multiple fields",
+			input:     "#Fields: date time c-ip",
+			wantKey:   "Fields",
+			wantValue: "date time c-ip",
+		},
+		{
+			name:      "software with colon in value",
+			input:     "#Software: IIS/6.0: Logging",
+			wantKey:   "Software",
+			wantValue: "IIS/6.0: Logging",
+		},
+		{
+			name:    "no colon separator",
+			input:   "#Remark",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, value, err := parseELFDirective(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKey, key)
+			assert.Equal(t, tt.wantValue, value)
+		})
+	}
+}
+
+func Test_NewParseELFFactory(t *testing.T) {
+	factory := NewParseELFFactory()
+	assert.Equal(t, "parse_elf", string(factory.Name()))
+}

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
@@ -31,12 +31,12 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"date":    "12-Jan-1996 00:00:00",
-				"fields":  []any{"time", "cs-method", "cs-uri"},
-				"entries": []any{
-					map[string]any{"time": "00:34:23", "cs-method": "GET", "cs-uri": "/foo/bar.html"},
-					map[string]any{"time": "12:21:16", "cs-method": "GET", "cs-uri": "/baz/index.html"},
+				"elf.version": "1.0",
+				"elf.date":    "12-Jan-1996 00:00:00",
+				"elf.fields":  []any{"time", "cs-method", "cs-uri"},
+				"elf.entries": []any{
+					map[string]any{"elf.time": "00:34:23", "elf.cs-method": "GET", "elf.cs-uri": "/foo/bar.html"},
+					map[string]any{"elf.time": "12:21:16", "elf.cs-method": "GET", "elf.cs-uri": "/baz/index.html"},
 				},
 			},
 		},
@@ -48,21 +48,21 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version":  "1.0",
-				"software": "Microsoft Internet Information Services 6.0",
-				"date":     "2002-05-24 20:18:01",
-				"fields":   []any{"date", "time", "c-ip", "cs-username", "s-ip", "cs-method", "cs-uri-stem", "cs-uri-query", "sc-status"},
-				"entries": []any{
+				"elf.version":  "1.0",
+				"elf.software": "Microsoft Internet Information Services 6.0",
+				"elf.date":     "2002-05-24 20:18:01",
+				"elf.fields":   []any{"date", "time", "c-ip", "cs-username", "s-ip", "cs-method", "cs-uri-stem", "cs-uri-query", "sc-status"},
+				"elf.entries": []any{
 					map[string]any{
-						"date":          "2002-05-24",
-						"time":          "20:18:01",
-						"c-ip":          "172.224.24.114",
-						"cs-username":   "-",
-						"s-ip":          "206.73.118.24",
-						"cs-method":     "GET",
-						"cs-uri-stem":   "/Default.htm",
-						"cs-uri-query":  "-",
-						"sc-status":     "200",
+						"elf.date":         "2002-05-24",
+						"elf.time":         "20:18:01",
+						"elf.c-ip":         "172.224.24.114",
+						"elf.cs-username":  "-",
+						"elf.s-ip":         "206.73.118.24",
+						"elf.cs-method":    "GET",
+						"elf.cs-uri-stem":  "/Default.htm",
+						"elf.cs-uri-query": "-",
+						"elf.sc-status":    "200",
 					},
 				},
 			},
@@ -75,10 +75,10 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"a", "b", "c", "d"},
-				"entries": []any{
-					map[string]any{"a": "val1", "b": "val2", "c": "-", "d": "-"},
+				"elf.version": "1.0",
+				"elf.fields":  []any{"a", "b", "c", "d"},
+				"elf.entries": []any{
+					map[string]any{"elf.a": "val1", "elf.b": "val2", "elf.c": "-", "elf.d": "-"},
 				},
 			},
 		},
@@ -90,13 +90,13 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"cs-method", "cs-uri", "cs(User-Agent)"},
-				"entries": []any{
+				"elf.version": "1.0",
+				"elf.fields":  []any{"cs-method", "cs-uri", "cs(User-Agent)"},
+				"elf.entries": []any{
 					map[string]any{
-						"cs-method":      "GET",
-						"cs-uri":         "/page.html",
-						"cs(User-Agent)": "Mozilla/5.0 (Windows NT 10.0)",
+						"elf.cs-method":      "GET",
+						"elf.cs-uri":         "/page.html",
+						"elf.cs(User-Agent)": "Mozilla/5.0 (Windows NT 10.0)",
 					},
 				},
 			},
@@ -109,11 +109,11 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"time", "sc-status"}, // last #Fields
-				"entries": []any{
-					map[string]any{"time": "10:00:00", "cs-method": "GET"},
-					map[string]any{"time": "10:01:00", "sc-status": "200"},
+				"elf.version": "1.0",
+				"elf.fields":  []any{"time", "sc-status"}, // last #Fields
+				"elf.entries": []any{
+					map[string]any{"elf.time": "10:00:00", "elf.cs-method": "GET"},
+					map[string]any{"elf.time": "10:01:00", "elf.sc-status": "200"},
 				},
 			},
 		},
@@ -125,11 +125,11 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version":    "1.0",
-				"start_date": "2024-01-01 00:00:00",
-				"end_date":   "2024-01-01 23:59:59",
-				"fields":     []any{"time"},
-				"entries":    []any{map[string]any{"time": "12:00:00"}},
+				"elf.version":    "1.0",
+				"elf.start_date": "2024-01-01 00:00:00",
+				"elf.end_date":   "2024-01-01 23:59:59",
+				"elf.fields":     []any{"time"},
+				"elf.entries":    []any{map[string]any{"elf.time": "12:00:00"}},
 			},
 		},
 		{
@@ -140,10 +140,10 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"remark":  "test log file",
-				"fields":  []any{"time"},
-				"entries": []any{map[string]any{"time": "00:00:01"}},
+				"elf.version": "1.0",
+				"elf.remark":  "test log file",
+				"elf.fields":  []any{"time"},
+				"elf.entries": []any{map[string]any{"elf.time": "00:00:01"}},
 			},
 		},
 		{
@@ -154,9 +154,9 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"time"},
-				"entries": []any{map[string]any{"time": "00:00:01"}},
+				"elf.version": "1.0",
+				"elf.fields":  []any{"time"},
+				"elf.entries": []any{map[string]any{"elf.time": "00:00:01"}},
 			},
 		},
 		{
@@ -167,9 +167,9 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"time", "cs-method"},
-				"entries": []any{},
+				"elf.version": "1.0",
+				"elf.fields":  []any{"time", "cs-method"},
+				"elf.entries": []any{},
 			},
 		},
 		{
@@ -236,10 +236,10 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"time", "cs-method", "cs-uri"},
-				"entries": []any{
-					map[string]any{"time": "00:34:23", "cs-method": "GET", "cs-uri": "/foo/bar.html"},
+				"elf.version": "1.0",
+				"elf.fields":  []any{"time", "cs-method", "cs-uri"},
+				"elf.entries": []any{
+					map[string]any{"elf.time": "00:34:23", "elf.cs-method": "GET", "elf.cs-uri": "/foo/bar.html"},
 				},
 			},
 		},
@@ -251,10 +251,10 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.1",
-				"fields":  []any{"time"},
-				"entries": []any{
-					map[string]any{"time": "12:00:00"},
+				"elf.version": "1.1",
+				"elf.fields":  []any{"time"},
+				"elf.entries": []any{
+					map[string]any{"elf.time": "12:00:00"},
 				},
 			},
 		},
@@ -266,10 +266,10 @@ func Test_parseELF(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"version": "1.0",
-				"fields":  []any{"a", "b"},
-				"entries": []any{
-					map[string]any{"a": "val1", "b": "val2"},
+				"elf.version": "1.0",
+				"elf.fields":  []any{"a", "b"},
+				"elf.entries": []any{
+					map[string]any{"elf.a": "val1", "elf.b": "val2"},
 				},
 			},
 		},

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
@@ -219,6 +219,16 @@ func Test_parseELF(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "malformed lowercase #fields directive",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					// lowercase "#fields" without colon must also be a hard error
+					return "#Version: 1.0\n#fields\n00:00:01", nil
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "tab-separated data line",
 			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
 				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
@@ -278,7 +278,7 @@ func Test_parseELF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc := parseELF(tt.target, zap.NewNop())
-			result, err := exprFunc(context.Background(), &ottllog.TransformContext{})
+			result, err := exprFunc(t.Context(), &ottllog.TransformContext{})
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -440,5 +440,5 @@ func Test_parseELFDirective(t *testing.T) {
 
 func Test_NewParseELFFactory(t *testing.T) {
 	factory := NewParseELFFactory()
-	assert.Equal(t, "ParseELF", string(factory.Name()))
+	assert.Equal(t, "ParseELF", factory.Name())
 }

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
@@ -172,7 +173,7 @@ func Test_parseELF(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty input",
+			name: "empty input",
 			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
 				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
 					return "", nil
@@ -198,11 +199,75 @@ func Test_parseELF(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "unterminated quoted value",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: method uri\nGET \"/unterminated", nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed #Fields directive",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					// #Fields with no colon is a hard error — it would poison subsequent data lines.
+					return "#Version: 1.0\n#Fields\n00:00:01", nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tab-separated data line",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: time cs-method cs-uri\n00:34:23\tGET\t/foo/bar.html", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"time", "cs-method", "cs-uri"},
+				"entries": []any{
+					map[string]any{"time": "00:34:23", "cs-method": "GET", "cs-uri": "/foo/bar.html"},
+				},
+			},
+		},
+		{
+			name: "multiple #Version directives, last one wins",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Version: 1.1\n#Fields: time\n12:00:00", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.1",
+				"fields":  []any{"time"},
+				"entries": []any{
+					map[string]any{"time": "12:00:00"},
+				},
+			},
+		},
+		{
+			name: "extra values beyond field count are dropped",
+			target: ottl.StandardStringGetter[*ottllog.TransformContext]{
+				Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+					return "#Version: 1.0\n#Fields: a b\nval1 val2 val3 val4", nil
+				},
+			},
+			expected: map[string]any{
+				"version": "1.0",
+				"fields":  []any{"a", "b"},
+				"entries": []any{
+					map[string]any{"a": "val1", "b": "val2"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := parseELF(tt.target)
+			exprFunc := parseELF(tt.target, zap.NewNop())
 			result, err := exprFunc(context.Background(), &ottllog.TransformContext{})
 			if tt.wantErr {
 				require.Error(t, err)
@@ -239,8 +304,12 @@ func assertELFMapEqual(t *testing.T, expected map[string]any, actual pcommon.Map
 					assert.Equal(t, e, sv.Str(), "key %q index %d", k, i)
 				case map[string]any:
 					assertELFMapEqual(t, e, sv.Map())
+				default:
+					t.Errorf("assertELFMapEqual: unsupported slice element type %T at key %q index %d", elem, k, i)
 				}
 			}
+		default:
+			t.Errorf("assertELFMapEqual: unsupported expected value type %T for key %q", wantRaw, k)
 		}
 	}
 }
@@ -250,6 +319,7 @@ func Test_parseELFDataLine(t *testing.T) {
 		name     string
 		input    string
 		expected []string
+		wantErr  bool
 	}{
 		{
 			name:     "simple tokens",
@@ -291,11 +361,22 @@ func Test_parseELFDataLine(t *testing.T) {
 			input:    "GET /foo.html\t200",
 			expected: []string{"GET", "/foo.html", "200"},
 		},
+		{
+			name:    "unterminated quoted value",
+			input:   `GET "/unterminated`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, parseELFDataLine(tt.input))
+			got, err := parseELFDataLine(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_elf_test.go
@@ -276,6 +276,21 @@ func Test_parseELFDataLine(t *testing.T) {
 			input:    "",
 			expected: nil,
 		},
+		{
+			name:     "doubled double-quote escape inside quoted value",
+			input:    `GET /page.html "He said ""hi"" today"`,
+			expected: []string{"GET", "/page.html", `He said "hi" today`},
+		},
+		{
+			name:     "tab-separated tokens",
+			input:    "GET\t/foo.html\t200",
+			expected: []string{"GET", "/foo.html", "200"},
+		},
+		{
+			name:     "mixed tab and space separation",
+			input:    "GET /foo.html\t200",
+			expected: []string{"GET", "/foo.html", "200"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,5 +349,5 @@ func Test_parseELFDirective(t *testing.T) {
 
 func Test_NewParseELFFactory(t *testing.T) {
 	factory := NewParseELFFactory()
-	assert.Equal(t, "parse_elf", string(factory.Name()))
+	assert.Equal(t, "ParseELF", string(factory.Name()))
 }

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -18,6 +18,7 @@ func LogFunctions() map[string]ottl.Factory[*ottllog.TransformContext] {
 	logFunctions := ottl.CreateFactoryMap(
 		logparsingfuncs.NewParseCLFFactory(),
 		logparsingfuncs.NewParseLEEFFactory(),
+		logparsingfuncs.NewParseELFFactory(),
 	)
 
 	maps.Copy(functions, logFunctions)

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -18,6 +18,7 @@ func Test_LogFunctions(t *testing.T) {
 	expected := ottlfuncs.StandardFuncs[*ottllog.TransformContext]()
 	expected["ParseCLF"] = logparsingfuncs.NewParseCLFFactory()
 	expected["ParseLEEF"] = logparsingfuncs.NewParseLEEFFactory()
+	expected["parse_elf"] = logparsingfuncs.NewParseELFFactory()
 	actual := LogFunctions()
 	require.Len(t, actual, len(expected))
 	for k := range actual {

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -18,7 +18,7 @@ func Test_LogFunctions(t *testing.T) {
 	expected := ottlfuncs.StandardFuncs[*ottllog.TransformContext]()
 	expected["ParseCLF"] = logparsingfuncs.NewParseCLFFactory()
 	expected["ParseLEEF"] = logparsingfuncs.NewParseLEEFFactory()
-	expected["parse_elf"] = logparsingfuncs.NewParseELFFactory()
+	expected["ParseELF"] = logparsingfuncs.NewParseELFFactory()
 	actual := LogFunctions()
 	require.Len(t, actual, len(expected))
 	for k := range actual {


### PR DESCRIPTION
Closes #48352

## Summary

Adds `parse_elf(target)` to the transform processor's log-only function set, following the same structure as the planned `parse_leef` function.

- Creates `processor/transformprocessor/internal/logparsingfuncs/` with `metadata.yaml` (from #48323 pattern) and the ELF parser implementation
- `parse_elf` accepts a complete ELF log block and returns a `pcommon.Map` with directive metadata (`version`, `software`, `date`, `start_date`, `end_date`, `remark`), a `fields` slice, and an `entries` slice keyed by field name
- Multiple `#Fields` directives within a block are supported; each applies to subsequent data lines
- Double-quoted field values (IIS W3C format) are handled correctly
- Missing field values are represented as `"-"` per the ELF spec
- Registers the function in `internal/logs/functions.go` via `maps.Copy` (same wiring pattern as #48269)

## Notes

This PR depends conceptually on #48323 (directory creation) and follows the pattern established by #48269 (LEEF parser). Since neither has merged, this PR creates the `logparsingfuncs` directory directly. The codeowner entry in CODEOWNERS/issue templates from #48323 is not duplicated here to avoid conflicts.