### PR TITLE
[exporter/kafka] Add per-signal message_key_from_metadata_key

### DIFF
--- a/.chloggen/kafkaexporter-message-key-from-metadata.yaml
+++ b/.chloggen/kafkaexporter-message-key-from-metadata.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add per-signal `message_key_from_metadata_key` to derive the Kafka record key from client metadata.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29433]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Each signal (`logs`, `metrics`, `traces`, `profiles`) now accepts a `message_key_from_metadata_key`
+  field that names a client metadata key whose value is used as the Kafka record key. This is mutually
+  exclusive with the existing `partition_*` flags for the same signal. If the metadata key is absent
+  or empty the record key is left nil.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -38,14 +38,17 @@ The following settings can be optionally configured:
   - `topic` (default = otlp\_logs): The name of the Kafka topic to which logs will be exported.
   - `encoding` (default = otlp\_proto): The encoding for logs. See [Supported encodings](#supported-encodings).
   - `topic_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the message's topic. Useful to dynamically produce to topics based on request inputs. It takes precedence over `topic_from_attribute` and `topic` settings.
+  - `message_key_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the Kafka record key for log messages. If the metadata key is absent or empty, the record key is left nil. Mutually exclusive with `partition_logs_by_resource_attributes` and `partition_logs_by_trace_id`. See [Message Key](#message-key) for details.
 - `metrics`
   - `topic` (default = otlp\_metrics): The name of the Kafka topic to publish metrics to.
   - `encoding` (default = otlp\_proto): The encoding for metrics. See [Supported encodings](#supported-encodings).
   - `topic_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the message's topic. Useful to dynamically produce to topics based on request inputs. It takes precedence over `topic_from_attribute` and `topic` settings.
+  - `message_key_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the Kafka record key for metric messages. If the metadata key is absent or empty, the record key is left nil. Mutually exclusive with `partition_metrics_by_resource_attributes`. See [Message Key](#message-key) for details.
 - `traces`
   - `topic` (default = otlp\_spans): The name of the Kafka topic to publish traces to.
   - `encoding` (default = otlp\_proto): The encoding for traces. See [Supported encodings](#supported-encodings).
   - `topic_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the message's topic. Useful to dynamically produce to topics based on request inputs. It takes precedence over `topic_from_attribute` and `topic` settings.
+  - `message_key_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the Kafka record key for trace messages. If the metadata key is absent or empty, the record key is left nil. Mutually exclusive with `partition_traces_by_id`. See [Message Key](#message-key) for details.
 - `topic_from_attribute` (default = ""): Specify the resource attribute whose value should be used as the message's topic. See [Destination Topic](#destination-topic) below for more details.
 - `include_metadata_keys` (default = []): Specifies a list of metadata keys to propagate as Kafka message headers. If one or more keys aren't found in the metadata, they are ignored. When `sending_queue::batch` is enabled, `sending_queue::batch::partition::metadata_keys` must be configured and include all values configured in `include_metadata_keys`.
 - `record_headers` (default = {}): Specifies a map of key/value pairs to set as static headers on every outgoing Kafka record.
@@ -166,6 +169,16 @@ The destination topic can be defined in a few different ways and takes priority 
 2. Otherwise, if `topic_from_attribute` is configured, and the corresponding attribute is found on the ingested data, the value of this attribute is used.
 3. If a prior component in the collector pipeline sets the topic on the context via the `topic.WithTopic` function (from the `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic` package), the value set in the context is used.
 4. Finally, the `<signal>::topic` configuration is used for the signal-specific destination topic.
+
+## Message Key
+
+The Kafka record key can be set in the following ways, in order of precedence:
+
+1. When `<signal>::message_key_from_metadata_key` is configured and the named metadata key is present and non-empty, its value is used as the record key. This is intended to be used together with an upstream processor that evaluates OTTL expressions and stores the result in request metadata.
+2. When one of the `partition_*` flags is set (`partition_traces_by_id`, `partition_metrics_by_resource_attributes`, `partition_logs_by_resource_attributes`, or `partition_logs_by_trace_id`), the record key is derived from the signal data. These flags are mutually exclusive with `message_key_from_metadata_key` for the same signal.
+3. For Jaeger encodings (`jaeger_proto`, `jaeger_json`), the marshaler always keys records by the trace ID.
+4. Otherwise the record key is nil and the configured `record_partitioner` strategy determines which partition receives the record.
+
 
 ## Partitioning Kafka Records
 

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -31,6 +31,13 @@ var errLogsPartitionExclusive = errors.New(
 )
 
 var (
+	errTracesMessageKeyExclusive        = errors.New("traces::message_key_from_metadata_key cannot be combined with partition_traces_by_id")
+	errMetricsMessageKeyExclusive       = errors.New("metrics::message_key_from_metadata_key cannot be combined with partition_metrics_by_resource_attributes")
+	errLogsMessageKeyExclusive          = errors.New("logs::message_key_from_metadata_key cannot be combined with partition_logs_by_resource_attributes or partition_logs_by_trace_id")
+	errMessageKeyMetadataKeyNotIncluded = errors.New("message_key_from_metadata_key must be present in sending_queue::batch::partition::metadata_keys if batching is enabled")
+)
+
+var (
 	errTopicMetadataKeyNotIncluded        = errors.New("topic_from_metadata_key must be present in sending_queue::batch::partition::metadata_keys if batching is enabled")
 	errBatchPartitionMetadataKeysRequired = errors.New("sending_queue::batch::partition::metadata_keys must be configured when include_metadata_keys is set and batching is enabled")
 	errIncludeMetadataKeysNotPartitioned  = errors.New("sending_queue::batch::partition::metadata_keys must include all include_metadata_keys values")
@@ -184,6 +191,15 @@ func (c *Config) Validate() error {
 	if c.PartitionLogsByResourceAttributes && c.PartitionLogsByTraceID {
 		return errLogsPartitionExclusive
 	}
+	if c.Traces.MessageKeyFromMetadataKey != "" && c.PartitionTracesByID {
+		return errTracesMessageKeyExclusive
+	}
+	if c.Metrics.MessageKeyFromMetadataKey != "" && c.PartitionMetricsByResourceAttributes {
+		return errMetricsMessageKeyExclusive
+	}
+	if c.Logs.MessageKeyFromMetadataKey != "" && (c.PartitionLogsByResourceAttributes || c.PartitionLogsByTraceID) {
+		return errLogsMessageKeyExclusive
+	}
 	if err := c.RecordPartitioner.Validate(); err != nil {
 		return fmt.Errorf("record_partitioner: %w", err)
 	}
@@ -209,6 +225,12 @@ type SignalConfig struct {
 	// topic name for this signal type. If this is set, it takes precedence
 	// over the topic name set in the topic field.
 	TopicFromMetadataKey string `mapstructure:"topic_from_metadata_key"`
+
+	// MessageKeyFromMetadataKey holds the name of the metadata key whose value
+	// will be used as the Kafka record key for this signal type. If the metadata
+	// key is absent or empty the record key is left nil.
+	// Mutually exclusive with the partition_* flags for the same signal.
+	MessageKeyFromMetadataKey string `mapstructure:"message_key_from_metadata_key"`
 
 	// Encoding holds the encoding of messages for the signal type.
 	//
@@ -261,6 +283,20 @@ func validateBatchPartitionerKeys(c *Config) error {
 		return fmt.Errorf("profiles::topic_from_metadata_key: %w", err)
 	}
 
+	// Validate if message_key_from_metadata_key is included in partition_keys
+	if err := validateMessageKeyFromMetadataKey(c.Logs.MessageKeyFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("logs::message_key_from_metadata_key: %w", err)
+	}
+	if err := validateMessageKeyFromMetadataKey(c.Metrics.MessageKeyFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("metrics::message_key_from_metadata_key: %w", err)
+	}
+	if err := validateMessageKeyFromMetadataKey(c.Traces.MessageKeyFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("traces::message_key_from_metadata_key: %w", err)
+	}
+	if err := validateMessageKeyFromMetadataKey(c.Profiles.MessageKeyFromMetadataKey, partitionMetadataKeySet); err != nil {
+		return fmt.Errorf("profiles::message_key_from_metadata_key: %w", err)
+	}
+
 	return nil
 }
 
@@ -280,6 +316,20 @@ func validateTopicFromMetadataKey(topicFromMetadataKey string, partitionKeysSet 
 		return fmt.Errorf("%w: %q not found in partition keys=%v",
 			errTopicMetadataKeyNotIncluded,
 			topicFromMetadataKey,
+			slices.Collect(maps.Keys(partitionKeysSet)),
+		)
+	}
+	return nil
+}
+
+func validateMessageKeyFromMetadataKey(messageKeyFromMetadataKey string, partitionKeysSet map[string]struct{}) error {
+	if messageKeyFromMetadataKey == "" {
+		return nil
+	}
+	if _, ok := partitionKeysSet[messageKeyFromMetadataKey]; !ok {
+		return fmt.Errorf("%w: %q not found in partition keys=%v",
+			errMessageKeyMetadataKeyNotIncluded,
+			messageKeyFromMetadataKey,
 			slices.Collect(maps.Keys(partitionKeysSet)),
 		)
 	}

--- a/exporter/kafkaexporter/config.schema.yaml
+++ b/exporter/kafkaexporter/config.schema.yaml
@@ -27,6 +27,9 @@ $defs:
       encoding:
         description: Encoding holds the encoding of messages for the signal type. Defaults to "otlp_proto".
         type: string
+      message_key_from_metadata_key:
+        description: MessageKeyFromMetadataKey holds the name of the metadata key whose value will be used as the Kafka record key for this signal type. If the metadata key is absent or empty the record key is left nil. Mutually exclusive with the partition_* flags for the same signal.
+        type: string
       topic:
         description: 'Topic holds the name of the Kafka topic to which messages of the signal type should be produced. The default depends on the signal type: - "otlp_spans" for traces - "otlp_metrics" for metrics - "otlp_logs" for logs - "otlp_profiles" for profiles'
         type: string

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -363,6 +363,31 @@ func TestLoadConfigFailed(t *testing.T) {
 			errorContains: `sticky_key: unknown hasher "invalid_hasher", valid values are "sarama_compat", "murmur2"`,
 			configFile:    "config-partitioning-failed.yaml",
 		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "traces_message_key_exclusive"),
+			errorContains: errTracesMessageKeyExclusive.Error(),
+			configFile:    "config-partitioning-failed.yaml",
+		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "metrics_message_key_exclusive"),
+			errorContains: errMetricsMessageKeyExclusive.Error(),
+			configFile:    "config-partitioning-failed.yaml",
+		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "logs_message_key_exclusive_resource"),
+			errorContains: errLogsMessageKeyExclusive.Error(),
+			configFile:    "config-partitioning-failed.yaml",
+		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "logs_message_key_exclusive_traceid"),
+			errorContains: errLogsMessageKeyExclusive.Error(),
+			configFile:    "config-partitioning-failed.yaml",
+		},
+		{
+			id:            component.NewIDWithName(metadata.Type, "missing_message_key_batch_partition"),
+			errorContains: `logs::message_key_from_metadata_key: message_key_from_metadata_key must be present in sending_queue::batch::partition::metadata_keys`,
+			configFile:    "config-topic-from-metadata-failed.yaml",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -45,6 +45,11 @@ type messenger[T any] interface {
 
 	// getTopic returns the topic name for the given context and data.
 	getTopic(context.Context, T) string
+
+	// getMessageKey returns the Kafka record key derived from client metadata,
+	// or nil if message_key_from_metadata_key is not configured or the metadata
+	// value is absent.
+	getMessageKey(context.Context) []byte
 }
 
 // recordsBuffer is a pooled holder for a batch of kgo.Records. space owns
@@ -146,13 +151,18 @@ func (e *kafkaExporter[T]) exportData(ctx context.Context, data T) error {
 		clear(buf.pointers)
 		e.recordsPool.Put(buf)
 	}()
+	metadataKey := e.messenger.getMessageKey(ctx)
 	for partitionKey, data := range e.messenger.partitionData(data) {
 		topic := e.messenger.getTopic(ctx, data)
 		err := e.messenger.marshalData(data, func(key, value []byte) {
 			// Marshalers may set the key, but a non-nil partition key
-			// from partitionData takes precedence.
+			// from partitionData takes precedence. The metadata-derived key
+			// is mutually exclusive with partition_* flags (validated at config
+			// time), so it applies when partitionData yields nil.
 			if partitionKey != nil {
 				key = partitionKey
+			} else if metadataKey != nil {
+				key = metadataKey
 			}
 			buf.space = append(buf.space, kgo.Record{
 				Topic: topic,
@@ -232,6 +242,10 @@ func (e *kafkaTracesMessenger) getTopic(ctx context.Context, td ptrace.Traces) s
 	return getTopic[ptrace.ResourceSpans](ctx, e.config.Traces, e.config.TopicFromAttribute, td.ResourceSpans())
 }
 
+func (e *kafkaTracesMessenger) getMessageKey(ctx context.Context) []byte {
+	return getMessageKey(ctx, e.config.Traces)
+}
+
 func (e *kafkaTracesMessenger) partitionData(td ptrace.Traces) iter.Seq2[[]byte, ptrace.Traces] {
 	return func(yield func([]byte, ptrace.Traces) bool) {
 		if e.config.PartitionTracesByID {
@@ -289,6 +303,10 @@ func (e *kafkaLogsMessenger) marshalData(ld plog.Logs, yield func(key, value []b
 
 func (e *kafkaLogsMessenger) getTopic(ctx context.Context, ld plog.Logs) string {
 	return getTopic[plog.ResourceLogs](ctx, e.config.Logs, e.config.TopicFromAttribute, ld.ResourceLogs())
+}
+
+func (e *kafkaLogsMessenger) getMessageKey(ctx context.Context) []byte {
+	return getMessageKey(ctx, e.config.Logs)
 }
 
 func (e *kafkaLogsMessenger) partitionData(ld plog.Logs) iter.Seq2[[]byte, plog.Logs] {
@@ -357,6 +375,10 @@ func (e *kafkaMetricsMessenger) getTopic(ctx context.Context, md pmetric.Metrics
 	return getTopic[pmetric.ResourceMetrics](ctx, e.config.Metrics, e.config.TopicFromAttribute, md.ResourceMetrics())
 }
 
+func (e *kafkaMetricsMessenger) getMessageKey(ctx context.Context) []byte {
+	return getMessageKey(ctx, e.config.Metrics)
+}
+
 func (e *kafkaMetricsMessenger) partitionData(md pmetric.Metrics) iter.Seq2[[]byte, pmetric.Metrics] {
 	return func(yield func([]byte, pmetric.Metrics) bool) {
 		splitByResource := e.config.PartitionMetricsByResourceAttributes ||
@@ -410,6 +432,10 @@ func (e *kafkaProfilesMessenger) getTopic(ctx context.Context, ld pprofile.Profi
 	return getTopic[pprofile.ResourceProfiles](ctx, e.config.Profiles, e.config.TopicFromAttribute, ld.ResourceProfiles())
 }
 
+func (e *kafkaProfilesMessenger) getMessageKey(ctx context.Context) []byte {
+	return getMessageKey(ctx, e.config.Profiles)
+}
+
 func (e *kafkaProfilesMessenger) partitionData(pd pprofile.Profiles) iter.Seq2[[]byte, pprofile.Profiles] {
 	return func(yield func([]byte, pprofile.Profiles) bool) {
 		if e.config.TopicFromAttribute != "" {
@@ -437,6 +463,15 @@ type resourceSlice[T any] interface {
 
 type resource interface {
 	Resource() pcommon.Resource
+}
+
+func getMessageKey(ctx context.Context, signalCfg SignalConfig) []byte {
+	if k := signalCfg.MessageKeyFromMetadataKey; k != "" {
+		if vals := client.FromContext(ctx).Metadata.Get(k); len(vals) > 0 && vals[0] != "" {
+			return []byte(vals[0])
+		}
+	}
+	return nil
 }
 
 func getTopic[T resource](ctx context.Context,

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -855,6 +855,150 @@ func Test_GetTopic(t *testing.T) {
 	}
 }
 
+func TestGetMessageKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		signalCfg SignalConfig
+		ctx       context.Context
+		wantKey   []byte
+	}{
+		{
+			name:      "not configured returns nil",
+			signalCfg: SignalConfig{},
+			ctx:       t.Context(),
+			wantKey:   nil,
+		},
+		{
+			name: "metadata key present",
+			signalCfg: SignalConfig{
+				MessageKeyFromMetadataKey: "my_partition_key",
+			},
+			ctx: client.NewContext(t.Context(),
+				client.Info{Metadata: client.NewMetadata(map[string][]string{
+					"my_partition_key": {"tenant-123"},
+				})},
+			),
+			wantKey: []byte("tenant-123"),
+		},
+		{
+			name: "metadata key not found returns nil",
+			signalCfg: SignalConfig{
+				MessageKeyFromMetadataKey: "my_partition_key",
+			},
+			ctx: client.NewContext(t.Context(),
+				client.Info{Metadata: client.NewMetadata(map[string][]string{
+					"other_key": {"tenant-123"},
+				})},
+			),
+			wantKey: nil,
+		},
+		{
+			name: "empty metadata value returns nil",
+			signalCfg: SignalConfig{
+				MessageKeyFromMetadataKey: "my_partition_key",
+			},
+			ctx: client.NewContext(t.Context(),
+				client.Info{Metadata: client.NewMetadata(map[string][]string{
+					"my_partition_key": {""},
+				})},
+			),
+			wantKey: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantKey, getMessageKey(tt.ctx, tt.signalCfg))
+		})
+	}
+}
+
+func TestMessageKeyFromMetadataKey(t *testing.T) {
+	const metadataKey = "kafka_message_key"
+	const keyValue = "my-partition-key"
+
+	metaCtx := client.NewContext(t.Context(),
+		client.Info{Metadata: client.NewMetadata(map[string][]string{
+			metadataKey: {keyValue},
+		})},
+	)
+
+	t.Run("logs", func(t *testing.T) {
+		config := createDefaultConfig().(*Config)
+		config.Logs.MessageKeyFromMetadataKey = metadataKey
+		exp, fakeCluster := newKgoMockLogsExporter(t, *config,
+			componenttest.NewNopHost(), config.Logs.Topic)
+		defer fakeCluster.Close()
+
+		input := testdata.GenerateLogs(1)
+		require.NoError(t, exp.exportData(metaCtx, input))
+
+		records := fetchKgoRecords(t, fakeCluster.ListenAddrs(), config.Logs.Topic, 1)
+		require.Len(t, records, 1)
+		assert.Equal(t, []byte(keyValue), records[0].Key)
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		config := createDefaultConfig().(*Config)
+		config.Metrics.MessageKeyFromMetadataKey = metadataKey
+		exp, fakeCluster := newKgoMockMetricsExporter(t, *config,
+			componenttest.NewNopHost(), config.Metrics.Topic)
+		defer fakeCluster.Close()
+
+		input := testdata.GenerateMetrics(1)
+		require.NoError(t, exp.exportData(metaCtx, input))
+
+		records := fetchKgoRecords(t, fakeCluster.ListenAddrs(), config.Metrics.Topic, 1)
+		require.Len(t, records, 1)
+		assert.Equal(t, []byte(keyValue), records[0].Key)
+	})
+
+	t.Run("traces", func(t *testing.T) {
+		config := createDefaultConfig().(*Config)
+		config.Traces.MessageKeyFromMetadataKey = metadataKey
+		exp, fakeCluster := newKgoMockTracesExporter(t, *config,
+			componenttest.NewNopHost(), config.Traces.Topic)
+		defer fakeCluster.Close()
+
+		input := testdata.GenerateTraces(1)
+		require.NoError(t, exp.exportData(metaCtx, input))
+
+		records := fetchKgoRecords(t, fakeCluster.ListenAddrs(), config.Traces.Topic, 1)
+		require.Len(t, records, 1)
+		assert.Equal(t, []byte(keyValue), records[0].Key)
+	})
+
+	t.Run("profiles", func(t *testing.T) {
+		config := createDefaultConfig().(*Config)
+		config.Profiles.MessageKeyFromMetadataKey = metadataKey
+		exp, fakeCluster := newKgoMockProfilesExporter(t, *config,
+			componenttest.NewNopHost(), config.Profiles.Topic)
+		defer fakeCluster.Close()
+
+		input := testdata.GenerateProfiles(1)
+		require.NoError(t, exp.exportData(metaCtx, input))
+
+		records := fetchKgoRecords(t, fakeCluster.ListenAddrs(), config.Profiles.Topic, 1)
+		require.Len(t, records, 1)
+		assert.Equal(t, []byte(keyValue), records[0].Key)
+	})
+
+	t.Run("metadata absent leaves key nil", func(t *testing.T) {
+		config := createDefaultConfig().(*Config)
+		config.Logs.MessageKeyFromMetadataKey = "absent_key"
+		exp, fakeCluster := newKgoMockLogsExporter(t, *config,
+			componenttest.NewNopHost(), config.Logs.Topic)
+		defer fakeCluster.Close()
+
+		input := testdata.GenerateLogs(1)
+		require.NoError(t, exp.exportData(metaCtx, input))
+
+		records := fetchKgoRecords(t, fakeCluster.ListenAddrs(), config.Logs.Topic, 1)
+		require.Len(t, records, 1)
+		assert.Nil(t, records[0].Key)
+	})
+}
+
 func TestLogsPusher_partitioning(t *testing.T) {
 	// Build input with 2 distinct resources, each with 1 scope + 1 log record.
 	input := plog.NewLogs()

--- a/exporter/kafkaexporter/testdata/config-partitioning-failed.yaml
+++ b/exporter/kafkaexporter/testdata/config-partitioning-failed.yaml
@@ -45,6 +45,22 @@ kafka/per_signal_encoding:
     encoding: per_signal_encoding
   profiles:
     encoding: per_signal_encoding
+kafka/traces_message_key_exclusive:
+  traces:
+    message_key_from_metadata_key: my_key
+  partition_traces_by_id: true
+kafka/metrics_message_key_exclusive:
+  metrics:
+    message_key_from_metadata_key: my_key
+  partition_metrics_by_resource_attributes: true
+kafka/logs_message_key_exclusive_resource:
+  logs:
+    message_key_from_metadata_key: my_key
+  partition_logs_by_resource_attributes: true
+kafka/logs_message_key_exclusive_traceid:
+  logs:
+    message_key_from_metadata_key: my_key
+  partition_logs_by_trace_id: true
 kafka/multiple_partitioner:
   record_partitioner:
     round_robin: {}

--- a/exporter/kafkaexporter/testdata/config-topic-from-metadata-failed.yaml
+++ b/exporter/kafkaexporter/testdata/config-topic-from-metadata-failed.yaml
@@ -7,3 +7,12 @@ kafka:
       sizer: bytes
   logs:
     topic_from_metadata_key: missing_metadata_key
+kafka/missing_message_key_batch_partition:
+  brokers:
+    - "foo:123"
+  sending_queue:
+    enabled: true
+    batch:
+      sizer: bytes
+  logs:
+    message_key_from_metadata_key: missing_metadata_key


### PR DESCRIPTION
#### Description

Adds a `message_key_from_metadata_key` field to signal-specific config, parallel to the existing `topic_from_metadata_key`.

When set, the named client metadata key's value is used as the Kafka record key. Mutually exclusive with the existing `partition_*` config.

Assisted-by: Claude Opus 4.7

#### Link to tracking issue

Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29433 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38484

(Those issues will be fixed with this change in conjunction with https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39199.)

#### Testing

Unit tests added.

#### Documentation

README updated.