### PR TITLE
[chore][pkg/stanza] refactor: remove unused WaitGroup

### DIFF
--- a/pkg/stanza/operator/parser/container/config.go
+++ b/pkg/stanza/operator/parser/container/config.go
@@ -6,7 +6,6 @@ package container // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"errors"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/collector/component"
 
@@ -72,13 +71,10 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		}
 	}
 
-	wg := sync.WaitGroup{}
-
 	p := &Parser{
 		ParserOperator:          parserOperator,
 		format:                  c.Format,
 		addMetadataFromFilepath: c.AddMetadataFromFilePath,
-		criConsumers:            &wg,
 	}
 
 	cLogEmitter := helper.NewBatchingLogEmitter(set, p.consumeEntries)

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -64,9 +64,8 @@ type Parser struct {
 	format                  string
 	addMetadataFromFilepath bool
 	criLogEmitter           *helper.BatchingLogEmitter
-	asyncConsumerStarted    bool
-	criConsumerStartOnce    sync.Once
-	criConsumers            *sync.WaitGroup
+	recombineStarted        bool
+	recombineStartOnce      sync.Once
 	timeLayout              string
 }
 
@@ -115,7 +114,7 @@ func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error
 			_ = write(ctx, ent)
 
 		case containerdFormat, crioFormat:
-			p.criConsumerStartOnce.Do(func() {
+			p.recombineStartOnce.Do(func() {
 				err = p.criLogEmitter.Start(nil)
 				if err != nil {
 					p.Logger().Error("unable to start the internal LogEmitter", zap.Error(err))
@@ -126,7 +125,7 @@ func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error
 					p.Logger().Error("unable to start the internal recombine operator", zap.Error(err))
 					return
 				}
-				p.asyncConsumerStarted = true
+				p.recombineStarted = true
 			})
 
 			if format == containerdFormat {
@@ -202,7 +201,7 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 			return fmt.Errorf("failed to process the docker log: %w", err)
 		}
 	case containerdFormat, crioFormat:
-		p.criConsumerStartOnce.Do(func() {
+		p.recombineStartOnce.Do(func() {
 			err = p.criLogEmitter.Start(nil)
 			if err != nil {
 				p.Logger().Error("unable to start the internal LogEmitter", zap.Error(err))
@@ -213,7 +212,7 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 				p.Logger().Error("unable to start the internal recombine operator", zap.Error(err))
 				return
 			}
-			p.asyncConsumerStarted = true
+			p.recombineStarted = true
 		})
 
 		if format == containerdFormat {
@@ -249,11 +248,10 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 	return nil
 }
 
-// Stop ensures that the internal recombineParser, the internal criLogEmitter and
-// the crioConsumer are stopped in the proper order without being affected by
-// any possible race conditions
+// Stop ensures that the internal recombineParser and criLogEmitter are stopped
+// in the proper order without being affected by any possible race conditions.
 func (p *Parser) Stop() error {
-	if !p.asyncConsumerStarted {
+	if !p.recombineStarted {
 		// nothing is started return
 		return nil
 	}
@@ -261,14 +259,9 @@ func (p *Parser) Stop() error {
 	if err := p.recombineParser.Stop(); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("unable to stop the internal recombine operator: %w", err))
 	}
-	// the recombineParser will call the Process of the criLogEmitter synchronously so the entries will be first
-	// written to the channel before the Stop of the recombineParser returns. Then since the criLogEmitter handles
-	// the entries synchronously it is safe to call its Stop.
-	// After criLogEmitter is stopped the crioConsumer will consume the remaining messages and return.
 	if err := p.criLogEmitter.Stop(); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("unable to stop the internal LogEmitter: %w", err))
 	}
-	p.criConsumers.Wait()
 	return errs
 }
 


### PR DESCRIPTION
Removes `criConsumers` WaitGroup from `container` parser. This has been dead code since https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35669. Also renames two other fields for easier comprehension.