### PR TITLE
[chore]: in build-and-test-experimental don't lint transitive deps

### DIFF
--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -37,8 +37,14 @@ jobs:
       - name: Check Collector Module Version
         run: ./.github/workflows/scripts/check-collector-module-version.sh
 
-  # Runs compute-ci-scope.sh to classify the PR's change set. Outputs a JSON
-  # matrix that downstream jobs consume directly as their `group` dimension:
+  # Runs compute-ci-scope.sh to classify the PR's change set. Outputs two JSON
+  # matrices that downstream jobs consume directly as their `group` dimension:
+  #   - matrix:        modules + transitive dependents (build/test/checks).
+  #   - direct_matrix: modules whose files actually changed (lint-only). A
+  #                    downstream module's lint result doesn't depend on
+  #                    whether an upstream module's source changed, so lint
+  #                    skips transitive dependents.
+  # In both:
   #   - full mode: ["receiver-0", "receiver-1", ...] (the named groups)
   #   - scoped mode: ["receiver/foo receiver/bar", ...] (bucketed module dirs)
   #   - skip: []
@@ -50,6 +56,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       matrix: ${{ steps.post.outputs.matrix }}
+      direct_matrix: ${{ steps.post.outputs.direct_matrix }}
       mode: ${{ steps.post.outputs.mode }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -100,6 +107,7 @@ jobs:
         shell: bash
         env:
           RAW_MATRIX: ${{ steps.scope.outputs.matrix }}
+          RAW_DIRECT_MATRIX: ${{ steps.scope.outputs.direct_matrix }}
         run: |
           # The script maps top-level files (Makefile, .github/, etc.) to "."
           # the root module. Strip "." entries from buckets and drop buckets
@@ -107,11 +115,16 @@ jobs:
           # don't define a target for ".", so `make TARGET GROUP="."` would
           # fail with "No rule to make target 'for-.-target'". Top-level paths
           # that should force a full run belong in CRITICAL_FILES instead.
-          matrix=$(echo "$RAW_MATRIX" | jq -c '[.[] | split(" ") | map(select(. != ".")) | join(" ") | select(. != "")]')
+          filter='[.[] | split(" ") | map(select(. != ".")) | join(" ") | select(. != "")]'
+          matrix=$(echo "$RAW_MATRIX" | jq -c "$filter")
+          direct_matrix=$(echo "$RAW_DIRECT_MATRIX" | jq -c "$filter")
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "direct_matrix=$direct_matrix" >> "$GITHUB_OUTPUT"
 
           # Scoped buckets contain "/" (module paths); full mode emits named
-          # groups like "receiver-0" (no slashes). [] is skip.
+          # groups like "receiver-0" (no slashes). [] is skip. `mode` is
+          # derived from the transitive matrix -- it drives cross-compile
+          # and gating decisions that need the broader view.
           if [[ "$matrix" == "[]" ]]; then
             mode=skip
           elif [[ "$matrix" == *"/"* ]]; then
@@ -120,18 +133,23 @@ jobs:
             mode=full
           fi
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
-          echo "Raw matrix:      $RAW_MATRIX"
-          echo "Filtered matrix: $matrix"
-          echo "Mode:            $mode"
+          echo "Raw matrix:             $RAW_MATRIX"
+          echo "Filtered matrix:        $matrix"
+          echo "Raw direct matrix:      $RAW_DIRECT_MATRIX"
+          echo "Filtered direct matrix: $direct_matrix"
+          echo "Mode:                   $mode"
 
+  # Lint runs against the direct-changes matrix only: a downstream module's
+  # lint result doesn't depend on whether an upstream module's source changed,
+  # so dragging transitive dependents in here just wastes runners.
   exp-lint-matrix:
     needs: [exp-setup-environment, exp-ci-scope]
-    if: ${{ needs.exp-ci-scope.outputs.matrix != '[]' && needs.exp-ci-scope.outputs.matrix != '' }}
+    if: ${{ needs.exp-ci-scope.outputs.direct_matrix != '[]' && needs.exp-ci-scope.outputs.direct_matrix != '' }}
     strategy:
       fail-fast: false
       matrix:
         goos: [windows, linux]
-        group: ${{ fromJSON(needs.exp-ci-scope.outputs.matrix) }}
+        group: ${{ fromJSON(needs.exp-ci-scope.outputs.direct_matrix) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/scripts/compute-ci-scope.sh
+++ b/.github/workflows/scripts/compute-ci-scope.sh
@@ -3,14 +3,19 @@ set -euo pipefail
 
 # ======================================================================================
 # Optimizes CI by calculating the minimum set of modules that need testing based
-# on the files changed in a Pull Request. It outputs a JSON matrix for GitHub Actions.
+# on the files changed in a Pull Request. It outputs two JSON matrices for
+# GitHub Actions:
+#   - matrix:        modules + transitive dependents (build/test/checks).
+#   - direct_matrix: modules whose files actually changed (lint-only -- a
+#                    downstream module's lint result doesn't depend on whether
+#                    an upstream module's source changed).
 # The logic goes like this:
-# 1. If 'ci:full' label is present OR event is not a PR -> Full Matrix.
-# 2. If core build files (Makefile, workflows) changed -> Full Matrix.
-# 3. Identifies Go modules directly modified by the git diff.
+# 1. If 'ci:full' label is present OR event is not a PR -> Full Matrix (both).
+# 2. If core build files (Makefile, workflows) changed -> Full Matrix (both).
+# 3. Identifies Go modules directly modified by the git diff (direct_matrix).
 # 4. Recursively finds modules that depend on the modified modules
 #    (e.g., if 'pkg/ottl' changes, we must test 'processor/filterprocessor').
-# 5. Groups the resulting modules into a fixed number of "buckets"
+# 5. Groups each resulting set of modules into a fixed number of "buckets"
 #    (TARGET_CONCURRENCY) to prevent spawning hundreds of concurrent CI jobs.
 #
 #
@@ -67,15 +72,20 @@ exit_full_mode() {
   echo "Reason: $1" >&2
   echo "Selecting FULL Matrix." >&2
   echo "matrix=${ALL_TEST_GROUPS}" >> "$GITHUB_OUTPUT"
+  echo "direct_matrix=${ALL_TEST_GROUPS}" >> "$GITHUB_OUTPUT"
   exit 0
 }
 
 exit_scoped_mode() {
   local matrix_json="$1"
   local count="$2"
-  echo "Reason: Scoped changes detected ($count modules affected)." >&2
-  echo "Computed Matrix: ${matrix_json}" >&2
+  local direct_matrix_json="${3:-$matrix_json}"
+  local direct_count="${4:-$count}"
+  echo "Reason: Scoped changes detected ($count modules affected, $direct_count direct)." >&2
+  echo "Computed Matrix:        ${matrix_json}" >&2
+  echo "Computed Direct Matrix: ${direct_matrix_json}" >&2
   echo "matrix=${matrix_json}" >> "$GITHUB_OUTPUT"
+  echo "direct_matrix=${direct_matrix_json}" >> "$GITHUB_OUTPUT"
   exit 0
 }
 
@@ -161,6 +171,15 @@ if [[ ${#affected_dirs[@]} -eq 0 ]]; then
   exit_scoped_mode "[]" 0
 fi
 
+# Snapshot directly-changed modules before transitive expansion. Lint runs
+# against this set only -- a downstream module's lint result doesn't depend
+# on whether an upstream module's source changed, so dragging transitive
+# dependents into the lint matrix wastes time.
+declare -A direct_dirs
+for dir in "${!affected_dirs[@]}"; do
+  direct_dirs["${dir}"]=1
+done
+
 # Resolve Transitive Dependencies
 all_go_mods="$(find . -type f -name "go.mod" -not -path "*/.git/*" -not -path "*/vendor/*")"
 
@@ -197,29 +216,34 @@ done
 # -----------------------------------------------------------------------------
 # Bucket results so we can launch multiple workers on CI
 # -----------------------------------------------------------------------------
-declare -a buckets
-for ((i=0; i<TARGET_CONCURRENCY; i++)); do buckets[$i]=""; done
+bucket_dirs_to_json() {
+  local -n _dirs=$1
+  local -a _buckets
+  for ((i=0; i<TARGET_CONCURRENCY; i++)); do _buckets[$i]=""; done
 
-idx=0
-for dir in "${!affected_dirs[@]}"; do
-  bucket_id=$((idx % TARGET_CONCURRENCY))
-  if [[ -z "${buckets[$bucket_id]}" ]]; then
-    buckets[$bucket_id]="${dir}"
-  else
-    buckets[$bucket_id]="${buckets[$bucket_id]} ${dir}"
-  fi
-  idx=$((idx + 1))
-done
+  local idx=0 bucket_id
+  for dir in "${!_dirs[@]}"; do
+    bucket_id=$((idx % TARGET_CONCURRENCY))
+    if [[ -z "${_buckets[$bucket_id]}" ]]; then
+      _buckets[$bucket_id]="${dir}"
+    else
+      _buckets[$bucket_id]="${_buckets[$bucket_id]} ${dir}"
+    fi
+    idx=$((idx + 1))
+  done
 
-# Construct JSON Array
-json_array="["
-first=true
-for bucket in "${buckets[@]}"; do
-  if [[ -n "${bucket}" ]]; then
-    [[ "$first" == "true" ]] && first=false || json_array+=","
-    json_array+="\"${bucket}\""
-  fi
-done
-json_array+="]"
+  local out="[" first=true
+  for bucket in "${_buckets[@]}"; do
+    if [[ -n "${bucket}" ]]; then
+      [[ "$first" == "true" ]] && first=false || out+=","
+      out+="\"${bucket}\""
+    fi
+  done
+  out+="]"
+  echo "${out}"
+}
 
-exit_scoped_mode "${json_array}" "${#affected_dirs[@]}"
+json_array="$(bucket_dirs_to_json affected_dirs)"
+direct_json_array="$(bucket_dirs_to_json direct_dirs)"
+
+exit_scoped_mode "${json_array}" "${#affected_dirs[@]}" "${direct_json_array}" "${#direct_dirs[@]}"


### PR DESCRIPTION
#### Description

I saw that in `build-and-test-experimental` the transitive dependencies in the scoped matrix were being used to decide what to lint. We really only want to lint the changed files as transitive dependencies lint results could not change.