### PR TITLE
[chore] more speedups for build-and-test-experimental

### DIFF
--- a/.github/actions/setup-go-tools/action.yml
+++ b/.github/actions/setup-go-tools/action.yml
@@ -43,4 +43,4 @@ runs:
       if: inputs.gomoddownload == 'true' && steps.go-setup.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.repo-path }}
-      run: make -j2 gomoddownload
+      run: make -j8 gomoddownload

--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -73,12 +73,13 @@ jobs:
           FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
           # `^` anchors mean these match files at repo root, not in subdirectories,
           # so a receiver-component Makefile change doesn't trigger the full suite.
+          # TEMP(testing): "^.github/workflows/" and "^.github/actions/" removed
+          # so this PR exercises scoped mode while iterating on the workflow
+          # itself. Restore before merge.
           CRITICAL_FILES: '[
             "^Makefile",
             "^Makefile.Common",
             "^.golangci.yml",
-            "^.github/workflows/",
-            "^.github/actions/",
             "^internal/tools/",
             "^versions.yaml",
             "^cmd/otelcontribcol/"
@@ -233,7 +234,11 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-      - run: make genotelcontribcol
+          # read-only-checks only runs checkdoc/checkmetadata/checkapi/
+          # multimod-verify, none of which need every module pre-downloaded.
+          gomoddownload: ${{ matrix.shard == 'read-only-checks' && 'false' || 'true' }}
+      - if: matrix.shard != 'read-only-checks'
+        run: make genotelcontribcol
       - name: Run shard ${{ matrix.shard }}
         run: ./.github/workflows/scripts/run-checks-shard.sh "${{ matrix.shard }}"
       - run: ./.github/workflows/scripts/check-disk-space.sh
@@ -522,6 +527,9 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          # Only a handful of modules build here; let `go build` fetch what it
+          # needs lazily rather than pre-downloading every module in the repo.
+          gomoddownload: "false"
       - name: Build affected modules for ${{ matrix.os }}/${{ matrix.arch }}${{ matrix.arm && format('v{0}', matrix.arm) || '' }}
         env:
           MATRIX: ${{ needs.exp-ci-scope.outputs.matrix }}

--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -235,10 +235,11 @@ jobs:
         with:
           go-version: oldstable
           # read-only-checks only runs checkdoc/checkmetadata/checkapi/
-          # multimod-verify, none of which need every module pre-downloaded.
+          # multimod-verify. genotelcontribcol below still pulls what it
+          # actually needs lazily, but bulk-downloading every module up
+          # front isn't required.
           gomoddownload: ${{ matrix.shard == 'read-only-checks' && 'false' || 'true' }}
-      - if: matrix.shard != 'read-only-checks'
-        run: make genotelcontribcol
+      - run: make genotelcontribcol
       - name: Run shard ${{ matrix.shard }}
         run: ./.github/workflows/scripts/run-checks-shard.sh "${{ matrix.shard }}"
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -73,12 +73,11 @@ jobs:
           FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
           # `^` anchors mean these match files at repo root, not in subdirectories,
           # so a receiver-component Makefile change doesn't trigger the full suite.
-          # TEMP(testing): "^.github/workflows/" and "^.github/actions/" removed
-          # so this PR exercises scoped mode while iterating on the workflow
-          # itself. Restore before merge.
+          # TEMP(testing): "^.github/workflows/", "^.github/actions/",
+          # "^Makefile", and "^Makefile.Common" removed so this PR exercises
+          # scoped mode while iterating on the workflow + Make targets
+          # themselves. Restore before merge.
           CRITICAL_FILES: '[
-            "^Makefile",
-            "^Makefile.Common",
             "^.golangci.yml",
             "^internal/tools/",
             "^versions.yaml",

--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -221,8 +221,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # codegen is split across the standard module groups so the slowest
+        # shard bounds wall time. Each codegen-<group> shard runs
+        # `make generate GROUP=<group>` over only that subset.
         shard:
-          - codegen
+          - codegen-receiver-0
+          - codegen-receiver-1
+          - codegen-receiver-2
+          - codegen-receiver-3
+          - codegen-processor-0
+          - codegen-processor-1
+          - codegen-exporter-0
+          - codegen-exporter-1
+          - codegen-exporter-2
+          - codegen-exporter-3
+          - codegen-extension
+          - codegen-connector
+          - codegen-internal
+          - codegen-pkg
+          - codegen-cmd-0
+          - codegen-other
           - porto-and-gci
           - go-mod-hygiene
           - small-generators

--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -73,12 +73,12 @@ jobs:
           FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
           # `^` anchors mean these match files at repo root, not in subdirectories,
           # so a receiver-component Makefile change doesn't trigger the full suite.
-          # TEMP(testing): "^.github/workflows/", "^.github/actions/",
-          # "^Makefile", and "^Makefile.Common" removed so this PR exercises
-          # scoped mode while iterating on the workflow + Make targets
-          # themselves. Restore before merge.
           CRITICAL_FILES: '[
+            "^Makefile",
+            "^Makefile.Common",
             "^.golangci.yml",
+            "^.github/workflows/",
+            "^.github/actions/",
             "^internal/tools/",
             "^versions.yaml",
             "^cmd/otelcontribcol/"

--- a/.github/workflows/scripts/run-checks-shard.sh
+++ b/.github/workflows/scripts/run-checks-shard.sh
@@ -13,7 +13,10 @@ set -euo pipefail
 #   ./run-checks-shard.sh <shard-name>
 #
 # Shards:
-#   codegen                -- `make generate` + git-clean check
+#   codegen-<group>        -- `make generate GROUP=<group>` + git-clean check.
+#                             <group> is one of the standard module groups
+#                             (receiver-0, processor-1, exporter-2, extension,
+#                             connector, internal, pkg, cmd-0, other, ...).
 #   porto-and-gci          -- goporto + gogci (both write to source files)
 #   go-mod-hygiene         -- crosslink + tidylist + gotidy (all touch go.mod/go.sum)
 #   small-generators       -- gendistributions + genlabels + gencodecov
@@ -35,10 +38,11 @@ fi
 shard="$1"
 
 case "${shard}" in
-  codegen)
-    make generate
+  codegen-*)
+    group="${shard#codegen-}"
+    make generate GROUP="${group}"
     if [[ -n $(git status -s) ]]; then
-      echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.'
+      echo "Generated code is out of date for group '${group}', please run \"make generate\" and commit the changes in this PR."
       exit 1
     fi
     ;;
@@ -81,7 +85,7 @@ case "${shard}" in
     ;;
   *)
     echo "Unknown shard: ${shard}" >&2
-    echo "Known shards: codegen porto-and-gci go-mod-hygiene small-generators schemas-and-templates read-only-checks" >&2
+    echo "Known shards: codegen-<group> porto-and-gci go-mod-hygiene small-generators schemas-and-templates read-only-checks" >&2
     exit 2
     ;;
 esac

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -257,9 +257,13 @@ mdatagen:
 .PHONY: generate
 generate:
 ifeq ($(CURDIR),$(SRC_ROOT))
+ifeq ($(GROUP),)
 	$(MAKE) for-all CMD="$(GOCMD) generate ./..."
 	$(MAKE) gofmt
 	$(MAKE) gogci
+else
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET=generate
+endif
 else
 	$(GOCMD) generate ./...
 	$(MAKE) fmt

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -256,7 +256,9 @@ mdatagen:
 
 .PHONY: generate-mod
 generate-mod:
-	$(GOCMD) generate ./...
+	@# Clear MAKEFLAGS so `//go:generate make mdatagen` (one level deeper)
+	@# doesn't warn about an unreachable jobserver from the parent -j8.
+	MAKEFLAGS= $(GOCMD) generate ./...
 
 .PHONY: generate
 generate:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -254,14 +254,10 @@ MDATAGEN_METADATA_YAML?= metadata.yaml
 mdatagen:
 	@$(MDATAGEN) $(MDATAGEN_METADATA_YAML)
 
-.PHONY: generate-mod
-generate-mod:
-	$(GOCMD) generate ./...
-
 .PHONY: generate
 generate:
 ifeq ($(CURDIR),$(SRC_ROOT))
-	$(MAKE) -j8 for-all-target TARGET=generate-mod
+	$(MAKE) for-all CMD="$(GOCMD) generate ./..."
 	$(MAKE) gofmt
 	$(MAKE) gogci
 else

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -254,10 +254,14 @@ MDATAGEN_METADATA_YAML?= metadata.yaml
 mdatagen:
 	@$(MDATAGEN) $(MDATAGEN_METADATA_YAML)
 
+.PHONY: generate-mod
+generate-mod:
+	$(GOCMD) generate ./...
+
 .PHONY: generate
 generate:
 ifeq ($(CURDIR),$(SRC_ROOT))
-	$(MAKE) for-all CMD="$(GOCMD) generate ./..."
+	$(MAKE) -j8 for-all-target TARGET=generate-mod
 	$(MAKE) gofmt
 	$(MAKE) gogci
 else

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -256,9 +256,7 @@ mdatagen:
 
 .PHONY: generate-mod
 generate-mod:
-	@# Clear MAKEFLAGS so `//go:generate make mdatagen` (one level deeper)
-	@# doesn't warn about an unreachable jobserver from the parent -j8.
-	MAKEFLAGS= $(GOCMD) generate ./...
+	$(GOCMD) generate ./...
 
 .PHONY: generate
 generate:

--- a/processor/filterprocessor/doc.go
+++ b/processor/filterprocessor/doc.go
@@ -4,5 +4,5 @@
 //go:generate make mdatagen
 
 // Package filterprocessor implements a processor for filtering
-// (dropping) metrics, logs, and/or spans by various properties.
+// (dropping) metrics and/or spans by various properties.
 package filterprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"

--- a/processor/filterprocessor/doc.go
+++ b/processor/filterprocessor/doc.go
@@ -4,5 +4,5 @@
 //go:generate make mdatagen
 
 // Package filterprocessor implements a processor for filtering
-// (dropping) metrics and/or spans by various properties.
+// (dropping) metrics, logs, and/or spans by various properties.
 package filterprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"


### PR DESCRIPTION
#### Description

Speeds up `build-and-test-experimental`:

- Skip `gomoddownload` for `cross-compile-affected` and the `read-only-checks` shard — neither needs every module pre-downloaded; what they touch is fetched lazily.
- `make gomoddownload`: `-j2` → `-j8`. Network-bound on the 4 vCPU runner; helps every cold-cache run.
- Shard codegen from one job into 16 `codegen-<group>` shards (one per module group). `make generate` learns to honor `GROUP`.

Example run: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/25942633975