### PR TITLE
[chore] internal/aws: re-enable k8s shutdown test

### DIFF
--- a/internal/aws/k8s/k8sclient/clientset_test.go
+++ b/internal/aws/k8s/k8sclient/clientset_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestGetShutdown(t *testing.T) {
-	t.Skip("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43918")
 	tmpConfigPath := setKubeConfigPath(t)
 	k8sClient := Get(
 		zap.NewNop(),

--- a/internal/aws/k8s/k8sclient/helpers_test.go
+++ b/internal/aws/k8s/k8sclient/helpers_test.go
@@ -51,6 +51,7 @@ users:
 `
 	tmpfile, err := os.CreateTemp(t.TempDir(), "kubeconfig")
 	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
 	require.NoError(t, os.WriteFile(tmpfile.Name(), []byte(content), 0o600))
 	// overwrite the default kube config path
 	kubeConfigPath = tmpfile.Name()


### PR DESCRIPTION
#### Description
Re-enable `TestGetShutdown` by closing the temporary kubeconfig file handle immediately after creating it. Leaving the handle open can prevent Windows cleanup from removing the temp file after the test starts Kubernetes informers.

Fixes #43918

#### Link to tracking issue
Fixes #43918

#### Testing
- `go test ./k8sclient` from `internal/aws/k8s`
- `git diff --check`

#### Documentation
No documentation changes required.