### PR TITLE
[processor/tailsampling] Add feature gate to change default error_mode to ignore

### DIFF
--- a/.chloggen/tailsampling-default-error-mode-ignore.yaml
+++ b/.chloggen/tailsampling-default-error-mode-ignore.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: processor/tailsampling
+note: Add `processor.tailsamplingprocessor.defaultErrorModeIgnore` feature gate to change default `error_mode` to `ignore` for ottl_condition policies
+issues: [48420]
+subtext: |
+  When the feature gate is enabled, the processor defaults to `ignore` mode for OTTL condition
+  evaluations which preserves valid data when an OTTL condition error occurs, improving resiliency.
+  This is a breaking change rolled out via feature gate to allow gradual adoption.
+change_logs: [user]

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -296,6 +296,10 @@ type BooleanAttributeCfg struct {
 // OTTLConditionCfg holds the configurable setting to create a OTTL condition filter
 // sampling policy evaluator.
 type OTTLConditionCfg struct {
+	// ErrorMode determines how the processor reacts to OTTL condition errors.
+	// Valid values are `ignore`, `silent`, and `propagate`.
+	// The default value is `propagate`, but when the `processor.tailsamplingprocessor.defaultErrorModeIgnore`
+	// feature gate is enabled, the default changes to `ignore`.
 	ErrorMode           ottl.ErrorMode `mapstructure:"error_mode"`
 	SpanConditions      []string       `mapstructure:"span"`
 	SpanEventConditions []string       `mapstructure:"spanevent"`

--- a/processor/tailsamplingprocessor/internal/metadata/generated_feature_gates.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_feature_gates.go
@@ -38,3 +38,10 @@ var ProcessorTailsamplingprocessorTailstorageextensionFeatureGate = featuregate.
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47331"),
 	featuregate.WithRegisterFromVersion("v0.150.0"),
 )
+
+var ProcessorTailsamplingprocessorDefaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"processor.tailsamplingprocessor.defaultErrorModeIgnore",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, the default error_mode for ottl_condition policies is `ignore` instead of `propagate`."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48420"),
+)

--- a/processor/tailsamplingprocessor/metadata.yaml
+++ b/processor/tailsamplingprocessor/metadata.yaml
@@ -37,6 +37,11 @@ feature_gates:
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47331
 
+  - id: "processor.tailsamplingprocessor.defaultErrorModeIgnore"
+    description: When enabled, the default error_mode for ottl_condition policies is `ignore` instead of `propagate`.
+    stage: alpha
+    reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48420
+
 tests:
   config:
 

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/cache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
@@ -450,7 +451,15 @@ func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedP
 		return sampling.NewBooleanAttributeFilter(settings, bafCfg.Key, bafCfg.Value, bafCfg.InvertMatch), nil
 	case OTTLCondition:
 		ottlfCfg := cfg.OTTLConditionCfg
-		return sampling.NewOTTLConditionFilter(settings, ottlfCfg.SpanConditions, ottlfCfg.SpanEventConditions, ottlfCfg.ErrorMode)
+		errorMode := ottlfCfg.ErrorMode
+		if errorMode == "" {
+			if metadata.ProcessorTailsamplingprocessorDefaultErrorModeIgnoreFeatureGate.IsEnabled() {
+				errorMode = ottl.IgnoreError
+			} else {
+				errorMode = ottl.PropagateError
+			}
+		}
+		return sampling.NewOTTLConditionFilter(settings, ottlfCfg.SpanConditions, ottlfCfg.SpanEventConditions, errorMode)
 	case TraceFlags:
 		return sampling.NewTraceFlags(settings), nil
 	default:

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tailstorageextension"
@@ -1787,4 +1788,53 @@ func (*nonTailStorageExtension) Start(context.Context, component.Host) error {
 
 func (*nonTailStorageExtension) Shutdown(context.Context) error {
 	return nil
+}
+
+func TestOTTLConditionDefaultErrorModeFeatureGate(t *testing.T) {
+	tests := []struct {
+		name              string
+		featureGateEnabled bool
+		expectedErrorMode ottl.ErrorMode
+	}{
+		{
+			name:              "feature gate disabled",
+			featureGateEnabled: false,
+			expectedErrorMode: ottl.PropagateError,
+		},
+		{
+			name:              "feature gate enabled",
+			featureGateEnabled: true,
+			expectedErrorMode: ottl.IgnoreError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := metadata.ProcessorTailsamplingprocessorDefaultErrorModeIgnoreFeatureGate.IsEnabled()
+			require.NoError(t, featuregate.GlobalRegistry().Set(
+				metadata.ProcessorTailsamplingprocessorDefaultErrorModeIgnoreFeatureGate.ID(),
+				tt.featureGateEnabled,
+			))
+			t.Cleanup(func() {
+				require.NoError(t, featuregate.GlobalRegistry().Set(
+					metadata.ProcessorTailsamplingprocessorDefaultErrorModeIgnoreFeatureGate.ID(),
+					prev,
+				))
+			})
+
+			cfg := PolicyCfg{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "ottl-test",
+					Type: OTTLCondition,
+					OTTLConditionCfg: OTTLConditionCfg{
+						SpanConditions: []string{"true"},
+					},
+				},
+			}
+
+			evaluator, err := getSharedPolicyEvaluator(processortest.NewNopSettings(metadata.Type), &cfg, nil)
+			require.NoError(t, err)
+			require.NotNil(t, evaluator)
+		})
+	}
 }


### PR DESCRIPTION
I noticed the `tailsampling` processor's `ottl_condition` policy type defaults to `error_mode: propagate`, which drops the entire payload when any OTTL condition encounters an error. This can be unexpected - a single malformed record causes data loss.

This PR adds a feature gate `processor.tailsamplingprocessor.defaultErrorModeIgnore` that, when enabled, changes the default to `ignore`. With this setting, records that fail OTTL evaluation are skipped but other valid records are preserved. I modeled this on the same feature gates I just added for the routing and signaltometrics connectors (#48418, #48419).

The feature gate starts at alpha stage. Users can opt-in via `--feature-gates=processor.tailsamplingprocessor.defaultErrorModeIgnore`. Once stability is proven, the gate can progress to beta/stable to make `ignore` the permanent default.

Changes:
- Added feature gate definition in `metadata.yaml`
- Updated `processor.go` to use the feature-gated default when `error_mode` is not explicitly set
- Added docs to `OTTLConditionCfg.ErrorMode` explaining the feature gate
- Added unit test covering both gate states
- Created changelog entry

Fixes #48420
