### PR TITLE
[receiver/kafkareceiver] added support for kafka metadata fields with a single boolean config

### DIFF
--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -49,6 +49,7 @@ The following settings can be optionally configured:
   - `exclude_topic` (Deprecated [v0.142.0]: use `exclude_topics`)
      (default = ""): If this is set, it will take precedence over default value of `exclude_topics`
   - `exclude_topics` (default = ""): When using regex topic patterns (prefix with `^`), this regex pattern excludes matching topics.
+  - `extract_kafka_metadata` (default = false): When true, adds `kafka.topic`, `kafka.partition`, `kafka.offset`, and `kafka.consumer.group` as resource attributes on all consumed telemetry.
 - `metrics`
   - `topic` (Deprecated [v0.142.0]: use `topics`)
      (default = otlp\_metrics): If this is set, it will take precedence over default value of `topics`
@@ -57,6 +58,7 @@ The following settings can be optionally configured:
   - `exclude_topic` (Deprecated [v0.142.0]: use `exclude_topics`)
      (default = ""): If this is set, it will take precedence over default value of `exclude_topics`
   - `exclude_topics` (default = ""): When using regex topic patterns (prefix with `^`), this regex pattern excludes matching topics.
+  - `extract_kafka_metadata` (default = false): When true, adds `kafka.topic`, `kafka.partition`, `kafka.offset`, and `kafka.consumer.group` as resource attributes on all consumed telemetry.
 - `traces`
   - `topic` (Deprecated [v0.142.0]: use `topics`)
      (default = otlp\_spans): If this is set, it will take precedence over default value of `topics`
@@ -65,6 +67,7 @@ The following settings can be optionally configured:
   - `exclude_topic` (Deprecated [v0.142.0]: use `exclude_topics`)
      (default = ""): If this is set, it will take precedence over default value of `exclude_topics`
   - `exclude_topics` (default = ""): When using regex topic patterns (prefix with `^`), this regex pattern excludes matching topics.
+  - `extract_kafka_metadata` (default = false): When true, adds `kafka.topic`, `kafka.partition`, `kafka.offset`, and `kafka.consumer.group` as resource attributes on all consumed telemetry.
 - `profiles`
   - `topic`  (Deprecated [v0.142.0]: use `topics`)
      (default = otlp\_profiles): If this is set, it will take precedence over default value of `topics`
@@ -73,6 +76,7 @@ The following settings can be optionally configured:
   - `exclude_topic` (Deprecated [v0.142.0]: use `exclude_topics`)
      (default = ""): If this is set, it will take precedence over default value of `exclude_topics`
   - `exclude_topics` (default = ""): When using regex topic patterns (prefix with `^`), this regex pattern excludes matching topics.
+  - `extract_kafka_metadata` (default = false): When true, adds `kafka.topic`, `kafka.partition`, `kafka.offset`, and `kafka.consumer.group` as resource attributes on all consumed telemetry.
 - `group_id` (default = otel-collector): The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `rack_id` (default = ""): The rack identifier for this client. When set and brokers are configured with a rack-aware replica selector, the client will prefer fetching from the closest replica.

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -156,6 +156,11 @@ type TopicEncodingConfig struct {
 
 	// Optional exclude topics option, used only in regex mode.
 	ExcludeTopics []string `mapstructure:"exclude_topics"`
+
+	// ExtractKafkaMetadata controls whether Kafka record metadata (topic, partition,
+	// offset, consumer group) is added as resource attributes on consumed telemetry.
+	// Defaults to false.
+	ExtractKafkaMetadata bool `mapstructure:"extract_kafka_metadata"`
 }
 
 type MessageMarking struct {

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -268,6 +268,34 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "extract_kafka_metadata"),
+			expected: &Config{
+				ClientConfig:   configkafka.NewDefaultClientConfig(),
+				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
+				Logs: TopicEncodingConfig{
+					Topics:               []string{"otlp_logs"},
+					Encoding:             "otlp_proto",
+					ExtractKafkaMetadata: true,
+				},
+				Metrics: TopicEncodingConfig{
+					Topics:   []string{"otlp_metrics"},
+					Encoding: "otlp_proto",
+				},
+				Traces: TopicEncodingConfig{
+					Topics:               []string{"otlp_spans"},
+					Encoding:             "otlp_proto",
+					ExtractKafkaMetadata: true,
+				},
+				Profiles: TopicEncodingConfig{
+					Topics:   []string{"otlp_profiles"},
+					Encoding: "otlp_proto",
+				},
+				ErrorBackOff: configretry.BackOffConfig{
+					Enabled: false,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -424,4 +452,12 @@ func TestConfigValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTopicEncodingConfigExtractKafkaMetadataDefaultsFalse(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.False(t, cfg.Logs.ExtractKafkaMetadata)
+	assert.False(t, cfg.Metrics.ExtractKafkaMetadata)
+	assert.False(t, cfg.Traces.ExtractKafkaMetadata)
+	assert.False(t, cfg.Profiles.ExtractKafkaMetadata)
 }

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -89,6 +89,7 @@ func newLogsReceiver(config *Config, set receiver.Settings, nextConsumer consume
 				},
 				attrs,
 				headerAttrKeys,
+				config.Logs.ExtractKafkaMetadata,
 			)
 		}, nil
 	}
@@ -116,6 +117,7 @@ func newMetricsReceiver(config *Config, set receiver.Settings, nextConsumer cons
 				},
 				attrs,
 				headerAttrKeys,
+				config.Metrics.ExtractKafkaMetadata,
 			)
 		}, nil
 	}
@@ -143,6 +145,7 @@ func newTracesReceiver(config *Config, set receiver.Settings, nextConsumer consu
 				},
 				attrs,
 				headerAttrKeys,
+				config.Traces.ExtractKafkaMetadata,
 			)
 		}, nil
 	}
@@ -170,6 +173,7 @@ func newProfilesReceiver(config *Config, set receiver.Settings, nextConsumer xco
 				},
 				attrs,
 				headerAttrKeys,
+				config.Profiles.ExtractKafkaMetadata,
 			)
 		}, nil
 	}
@@ -363,6 +367,7 @@ func processMessage[T plog.Logs | pmetric.Metrics | ptrace.Traces | pprofile.Pro
 	handler messageHandler[T],
 	attrs attribute.Set,
 	headerAttrKeys map[string]string,
+	extractKafkaMetadata bool,
 ) error {
 	if logger.Core().Enabled(zap.DebugLevel) {
 		logger.Debug("kafka message received",
@@ -397,6 +402,13 @@ func processMessage[T plog.Logs | pmetric.Metrics | ptrace.Traces | pprofile.Pro
 		}
 	}
 
+	// Add Kafka record metadata as resource attributes if configured.
+	if extractKafkaMetadata {
+		for resource := range handler.getResources(data) {
+			setKafkaMetadataAttributes(record, config.ConsumerConfig.GroupID, resource.Attributes())
+		}
+	}
+
 	err = handler.consumeData(ctx, data)
 	handler.endObsReport(obsCtx, n, err)
 	return err
@@ -415,6 +427,14 @@ func getMessageHeaderResourceAttributes(headers []kgo.RecordHeader, headerKeys m
 			}
 		}
 	}
+}
+
+// setKafkaMetadataAttributes adds Kafka record metadata as resource attributes.
+func setKafkaMetadataAttributes(record *kgo.Record, consumerGroup string, dest pcommon.Map) {
+	dest.PutStr("kafka.topic", record.Topic)
+	dest.PutInt("kafka.partition", int64(record.Partition))
+	dest.PutInt("kafka.offset", record.Offset)
+	dest.PutStr("kafka.consumer.group", consumerGroup)
 }
 
 // buildHeaderAttrKeys pre-computes the mapping from raw header names to their

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -145,6 +145,64 @@ func TestReceiver_Headers_Metadata(t *testing.T) {
 	}
 }
 
+func TestReceiver_ExtractKafkaMetadata(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "enabled"
+		if !enabled {
+			name = "disabled"
+		}
+		t.Run(name, func(t *testing.T) {
+			runTestForClients(t, func(t *testing.T) {
+				kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+
+				traces := testdata.GenerateTraces(1)
+				data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+				require.NoError(t, err)
+				results := kafkaClient.ProduceSync(t.Context(), &kgo.Record{
+					Topic: "otlp_spans",
+					Value: data,
+				})
+				require.NoError(t, results.FirstErr())
+
+				received := make(chan consumerArgs[ptrace.Traces], 1)
+				receiverConfig.Traces.ExtractKafkaMetadata = enabled
+				mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
+				args := <-received
+
+				resource := args.data.ResourceSpans().At(0).Resource()
+
+				checkAttr := func(key string) {
+					t.Helper()
+					_, ok := resource.Attributes().Get(key)
+					if enabled {
+						assert.True(t, ok, "expected attribute %q to be present", key)
+					} else {
+						assert.False(t, ok, "expected attribute %q to be absent", key)
+					}
+				}
+				checkAttr("kafka.topic")
+				checkAttr("kafka.partition")
+				checkAttr("kafka.offset")
+				checkAttr("kafka.consumer.group")
+
+				if enabled {
+					topic, _ := resource.Attributes().Get("kafka.topic")
+					assert.Equal(t, "otlp_spans", topic.Str())
+
+					partition, _ := resource.Attributes().Get("kafka.partition")
+					assert.Equal(t, int64(0), partition.Int())
+
+					offset, _ := resource.Attributes().Get("kafka.offset")
+					assert.Equal(t, int64(0), offset.Int())
+
+					consumerGroup, _ := resource.Attributes().Get("kafka.consumer.group")
+					assert.Equal(t, receiverConfig.ConsumerConfig.GroupID, consumerGroup.Str())
+				}
+			})
+		})
+	}
+}
+
 func TestReceiver_Headers_HeaderExtraction(t *testing.T) {
 	for _, enabled := range []bool{false, true} {
 		name := "enabled"


### PR DESCRIPTION
#### Description                                                                         
                                                                                           
  Adds a per-signal `extract_kafka_metadata` boolean config option to `kafkareceiver`      
  (default `false`). When enabled, the receiver attaches four Kafka record metadata fields 
  as resource attributes on every piece of telemetry consumed from that topic:             
                                                                                           
  | Attribute | Value |                                                                    
  |---|---|                                                                                
  | `kafka.topic` | The topic the record was consumed from |                               
  | `kafka.partition` | The partition number |                                             
  | `kafka.offset` | The record offset |                                                   
  | `kafka.consumer.group` | The configured consumer group ID |                            
                                          
  The option is configured per-signal under `logs`, `metrics`, `traces`, or `profiles`, so
  metadata extraction can be enabled selectively. Example:                                 
   
  ```yaml                                                                                  
  receivers:                                                
    kafka:                                                                                 
      logs:                                                 
        topics: [otlp_logs]                                                              
        encoding: otlp_proto
        extract_kafka_metadata: true
      traces:
        topics: [otlp_spans]
        encoding: otlp_proto                  
        # extract_kafka_metadata defaults to false
```
  Link to tracking issue                                                                   
   
  Fixes                                                                                    
                                                            
  Testing                                                                                

  - Unit test verifying extract_kafka_metadata defaults to false for all signals
  - TestLoadConfig case verifying the field unmarshals correctly from YAML
  - Integration test TestReceiver_ExtractKafkaMetadata using an in-process Kafka cluster
  (kfake), covering both enabled and disabled paths and asserting correct attribute values 
                                          
  Documentation                                                                            
                                                                                           
  Updated README.md to document extract_kafka_metadata in the configuration table for all
  four signal types (logs, metrics, traces, profiles).  