### PR TITLE
[chore]: fix issue in build-and-test-experimental where some dirs were incorrectly treated as groups

### DIFF
--- a/.github/workflows/scripts/compute-ci-scope.sh
+++ b/.github/workflows/scripts/compute-ci-scope.sh
@@ -224,6 +224,12 @@ bucket_dirs_to_json() {
   local idx=0 bucket_id
   for dir in "${!_dirs[@]}"; do
     bucket_id=$((idx % TARGET_CONCURRENCY))
+    # The Makefile uses "/" in GROUP to tell module paths from named
+    # groups; single-segment paths (e.g. "testbed") need a "/" or they
+    # route to a nonexistent `for-<name>-target`.
+    if [[ "${dir}" != "." && "${dir}" != */* ]]; then
+      dir="./${dir}"
+    fi
     if [[ -z "${_buckets[$bucket_id]}" ]]; then
       _buckets[$bucket_id]="${dir}"
     else


### PR DESCRIPTION
#### Description

Fixes the issue seen [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/26033625209?pr=48312) where the scope found was `testbed` and that was being treated as a group name instead of a directory.