### PR TITLE
[exporter/signalfx] Use PUT for entity event dimensions

### DIFF
--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -45,7 +46,7 @@ type DimensionClient struct {
 	sendDelay time.Duration
 	// Set of dims that have been queued up for sending.  Use map to quickly
 	// look up in case we need to replace due to flappy prop generation.
-	delayedSet map[DimensionKey]*DimensionUpdate
+	delayedSet map[delayedDimensionKey]*DimensionUpdate
 	// Queue of dimensions to update.  The ordering should never change once
 	// put in the queue so no need for heap/priority queue.
 	delayedQueue chan *queuedDimension
@@ -71,6 +72,20 @@ type DimensionClient struct {
 type queuedDimension struct {
 	*DimensionUpdate
 	TimeToSend time.Time
+}
+
+type delayedDimensionKey struct {
+	Name    string
+	Value   string
+	Replace bool
+}
+
+func newDelayedDimensionKey(dimUpdate *DimensionUpdate) delayedDimensionKey {
+	return delayedDimensionKey{
+		Name:    dimUpdate.Name,
+		Value:   dimUpdate.Value,
+		Replace: dimUpdate.Replace,
+	}
 }
 
 type DimensionClientOptions struct {
@@ -120,7 +135,7 @@ func NewDimensionClient(options DimensionClientOptions) *DimensionClient {
 		Token:                   options.Token,
 		APIURL:                  options.APIURL,
 		sendDelay:               options.SendDelay,
-		delayedSet:              make(map[DimensionKey]*DimensionUpdate),
+		delayedSet:              make(map[delayedDimensionKey]*DimensionUpdate),
 		delayedQueue:            make(chan *queuedDimension, options.MaxBuffered),
 		requestSender:           sender,
 		client:                  client,
@@ -161,14 +176,15 @@ func (dc *DimensionClient) AcceptDimension(dimUpdate *DimensionUpdate) error {
 	dc.Lock()
 	defer dc.Unlock()
 
-	if delayedDimUpdate := dc.delayedSet[dimUpdate.Key()]; delayedDimUpdate != nil {
+	delayedKey := newDelayedDimensionKey(dimUpdate)
+	if delayedDimUpdate := dc.delayedSet[delayedKey]; delayedDimUpdate != nil {
 		if !reflect.DeepEqual(delayedDimUpdate, dimUpdate) {
 			// Merge the latest updates into existing one.
 			delayedDimUpdate.Properties = mergeProperties(delayedDimUpdate.Properties, dimUpdate.Properties)
 			delayedDimUpdate.Tags = mergeTags(delayedDimUpdate.Tags, dimUpdate.Tags)
 		}
 	} else {
-		dc.delayedSet[dimUpdate.Key()] = dimUpdate
+		dc.delayedSet[delayedKey] = dimUpdate
 		select {
 		case dc.delayedQueue <- &queuedDimension{
 			DimensionUpdate: dimUpdate,
@@ -219,7 +235,7 @@ func (dc *DimensionClient) processQueue(ctx context.Context) {
 			}
 
 			dc.Lock()
-			delete(dc.delayedSet, delayedDimUpdate.Key())
+			delete(dc.delayedSet, newDelayedDimensionKey(delayedDimUpdate.DimensionUpdate))
 			dc.Unlock()
 
 			if err := dc.handleDimensionUpdate(ctx, delayedDimUpdate.DimensionUpdate); err != nil {
@@ -240,26 +256,14 @@ func (dc *DimensionClient) handleDimensionUpdate(ctx context.Context, dimUpdate 
 		err error
 	)
 
-	req, err = dc.makePatchRequest(ctx, dimUpdate)
+	req, err = dc.makeRequest(ctx, dimUpdate)
 	if err != nil {
 		return err
 	}
 
 	req = req.WithContext(
 		context.WithValue(req.Context(), RequestFailedCallbackKey, RequestFailedCallback(func(statusCode int, err error) {
-			retry := false
-			retryMsg := "not retrying"
-			if statusCode == 400 && len(dimUpdate.Tags) > 0 {
-				// It's possible that number of tags is too large. In this case,
-				// we should retry the request without tags to update the dimension properties at least.
-				dimUpdate.Tags = nil
-				retry = true
-				retryMsg = "retrying without tags"
-			} else if statusCode == 404 || statusCode >= 500 {
-				// Retry on 5xx server errors or 404s which can occur due to races within the dimension patch endpoint.
-				retry = true
-				retryMsg = "retrying"
-			}
+			retry, retryMsg := shouldRetryDimensionUpdate(dimUpdate, statusCode)
 
 			dc.logger.Error(
 				"Unable to update dimension, "+retryMsg,
@@ -306,10 +310,54 @@ func (dc *DimensionClient) handleDimensionUpdate(ctx context.Context, dimUpdate 
 func (dc *DimensionClient) makeDimURL(key, value string) (*url.URL, error) {
 	url, err := dc.APIURL.Parse(fmt.Sprintf("/v2/dimension/%s/%s", url.PathEscape(key), url.PathEscape(value)))
 	if err != nil {
-		return nil, fmt.Errorf("could not construct dimension property PATCH URL with %s / %s: %w", key, value, err)
+		return nil, fmt.Errorf("could not construct dimension property URL with %s / %s: %w", key, value, err)
 	}
 
 	return url, nil
+}
+
+func shouldRetryDimensionUpdate(dimUpdate *DimensionUpdate, statusCode int) (bool, string) {
+	if dimUpdate.Replace {
+		if statusCode == 0 || statusCode >= 500 {
+			return true, "retrying"
+		}
+		return false, "not retrying"
+	}
+
+	if statusCode == 400 && len(dimUpdate.Tags) > 0 {
+		// It's possible that number of tags is too large. In this case,
+		// we should retry the request without tags to update the dimension properties at least.
+		dimUpdate.Tags = nil
+		return true, "retrying without tags"
+	}
+	if statusCode == 0 || statusCode == 404 || statusCode >= 500 {
+		// Retry on transport errors, 5xx server errors, or 404s which can occur due to races
+		// within the dimension patch endpoint.
+		return true, "retrying"
+	}
+
+	return false, "not retrying"
+}
+
+func (dc *DimensionClient) makeRequest(ctx context.Context, dim *DimensionUpdate) (*http.Request, error) {
+	if dim.Replace {
+		return dc.makePutRequest(ctx, dim)
+	}
+	return dc.makePatchRequest(ctx, dim)
+}
+
+func splitDimensionTags(tags map[string]bool) (tagsToAdd, tagsToRemove []string) {
+	for tag, shouldAdd := range tags {
+		if shouldAdd {
+			tagsToAdd = append(tagsToAdd, tag)
+		} else {
+			tagsToRemove = append(tagsToRemove, tag)
+		}
+	}
+
+	sort.Strings(tagsToAdd)
+	sort.Strings(tagsToRemove)
+	return tagsToAdd, tagsToRemove
 }
 
 func (dc *DimensionClient) makePatchRequest(ctx context.Context, dim *DimensionUpdate) (*http.Request, error) {
@@ -318,13 +366,7 @@ func (dc *DimensionClient) makePatchRequest(ctx context.Context, dim *DimensionU
 		tagsToRemove []string
 	)
 
-	for tag, shouldAdd := range dim.Tags {
-		if shouldAdd {
-			tagsToAdd = append(tagsToAdd, tag)
-		} else {
-			tagsToRemove = append(tagsToRemove, tag)
-		}
-	}
+	tagsToAdd, tagsToRemove = splitDimensionTags(dim.Tags)
 
 	json, err := json.Marshal(map[string]any{
 		"customProperties": dim.Properties,
@@ -344,6 +386,49 @@ func (dc *DimensionClient) makePatchRequest(ctx context.Context, dim *DimensionU
 		ctx,
 		http.MethodPatch,
 		strings.TrimRight(url.String(), "/")+"/_/sfxagent",
+		bytes.NewReader(json))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-SF-TOKEN", string(dc.Token))
+
+	return req, nil
+}
+
+func (dc *DimensionClient) makePutRequest(ctx context.Context, dim *DimensionUpdate) (*http.Request, error) {
+	customProperties := make(map[string]string, len(dim.Properties))
+	for key, value := range dim.Properties {
+		if value != nil {
+			customProperties[key] = *value
+		}
+	}
+
+	tagsToAdd, _ := splitDimensionTags(dim.Tags)
+	if tagsToAdd == nil {
+		tagsToAdd = []string{}
+	}
+
+	json, err := json.Marshal(map[string]any{
+		"key":              dim.Name,
+		"value":            dim.Value,
+		"customProperties": customProperties,
+		"tags":             tagsToAdd,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := dc.makeDimURL(dim.Name, dim.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		strings.TrimRight(url.String(), "/"),
 		bytes.NewReader(json))
 	if err != nil {
 		return nil, err

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 var patchPathRegexp = regexp.MustCompile(`/v2/dimension/([^/]+)/([^/]+)/_/sfxagent`)
+var putPathRegexp = regexp.MustCompile(`/v2/dimension/([^/]+)/([^/]+)$`)
 
 type dim struct {
 	Key          string             `json:"key"`
@@ -32,6 +33,8 @@ type testServer struct {
 	startCh      chan struct{}
 	finishCh     chan struct{}
 	acceptedDims []dim
+	methods      []string
+	paths        []string
 	server       *httptest.Server
 	respCode     int
 	requestCount *atomic.Int32
@@ -47,7 +50,17 @@ func (ts *testServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	match := patchPathRegexp.FindStringSubmatch(r.URL.Path)
+	var match []string
+	switch r.Method {
+	case http.MethodPatch:
+		match = patchPathRegexp.FindStringSubmatch(r.URL.Path)
+	case http.MethodPut:
+		match = putPathRegexp.FindStringSubmatch(r.URL.Path)
+	default:
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		ts.finishCh <- struct{}{}
+		return
+	}
 	if match == nil {
 		rw.WriteHeader(http.StatusNotFound)
 		ts.finishCh <- struct{}{}
@@ -60,10 +73,18 @@ func (ts *testServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		ts.finishCh <- struct{}{}
 		return
 	}
-	bodyDim.Key = match[1]
-	bodyDim.Value = match[2]
+	if r.Method == http.MethodPatch {
+		bodyDim.Key = match[1]
+		bodyDim.Value = match[2]
+	} else if bodyDim.Key != match[1] || bodyDim.Value != match[2] {
+		rw.WriteHeader(http.StatusBadRequest)
+		ts.finishCh <- struct{}{}
+		return
+	}
 
 	ts.acceptedDims = append(ts.acceptedDims, bodyDim)
+	ts.methods = append(ts.methods, r.Method)
+	ts.paths = append(ts.paths, r.URL.Path)
 
 	ts.finishCh <- struct{}{}
 	rw.WriteHeader(http.StatusOK)
@@ -92,6 +113,8 @@ func (ts *testServer) reset() {
 		ts.finishCh = make(chan struct{})
 	}
 	ts.acceptedDims = nil
+	ts.methods = nil
+	ts.paths = nil
 	ts.respCode = http.StatusOK
 	ts.requestCount.Store(0)
 }
@@ -157,6 +180,85 @@ func TestDimensionClient(t *testing.T) {
 			},
 		}, server.acceptedDims)
 		require.EqualValues(t, 1, server.requestCount.Load())
+	})
+
+	t.Run("send replacement dimension update with properties and tags", func(t *testing.T) {
+		server.reset()
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+			Name:  "k8s.pod.uid",
+			Value: "pod-123",
+			Properties: map[string]*string{
+				"k8s.pod.name":       newString("test-pod"),
+				"k8s.namespace.name": newString("default"),
+			},
+			Tags: map[string]bool{
+				"active":     true,
+				"terminated": false,
+			},
+			Replace: true,
+		}))
+
+		server.handleRequest()
+		require.Equal(t, []dim{
+			{
+				Key:   "k8s.pod.uid",
+				Value: "pod-123",
+				Properties: map[string]*string{
+					"k8s.pod.name":       newString("test-pod"),
+					"k8s.namespace.name": newString("default"),
+				},
+				Tags: []string{"active"},
+			},
+		}, server.acceptedDims)
+		require.Equal(t, []string{http.MethodPut}, server.methods)
+		require.Equal(t, []string{"/v2/dimension/k8s.pod.uid/pod-123"}, server.paths)
+		require.EqualValues(t, 1, server.requestCount.Load())
+	})
+
+	t.Run("does not merge patch and replacement updates for the same dimension", func(t *testing.T) {
+		server.reset()
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+			Name:  "k8s.pod.uid",
+			Value: "pod-456",
+			Properties: map[string]*string{
+				"patch.property": newString("patch"),
+			},
+		}))
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+			Name:  "k8s.pod.uid",
+			Value: "pod-456",
+			Properties: map[string]*string{
+				"k8s.pod.name": newString("test-pod"),
+			},
+			Replace: true,
+		}))
+
+		server.handleRequest()
+		server.handleRequest()
+
+		require.ElementsMatch(t, []string{http.MethodPatch, http.MethodPut}, server.methods)
+		require.ElementsMatch(t, []string{
+			"/v2/dimension/k8s.pod.uid/pod-456/_/sfxagent",
+			"/v2/dimension/k8s.pod.uid/pod-456",
+		}, server.paths)
+		require.ElementsMatch(t, []dim{
+			{
+				Key:   "k8s.pod.uid",
+				Value: "pod-456",
+				Properties: map[string]*string{
+					"patch.property": newString("patch"),
+				},
+			},
+			{
+				Key:   "k8s.pod.uid",
+				Value: "pod-456",
+				Properties: map[string]*string{
+					"k8s.pod.name": newString("test-pod"),
+				},
+				Tags: []string{},
+			},
+		}, server.acceptedDims)
+		require.EqualValues(t, 2, server.requestCount.Load())
 	})
 
 	t.Run("same dimension with different values", func(t *testing.T) {
@@ -256,6 +358,38 @@ func TestDimensionClient(t *testing.T) {
 		require.EqualValues(t, 2, server.requestCount.Load())
 	})
 
+	t.Run("retry replacement dimension update on server error", func(t *testing.T) {
+		server.reset()
+		server.respCode = http.StatusInternalServerError
+
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+			Name:  "k8s.node.uid",
+			Value: "node-456",
+			Properties: map[string]*string{
+				"k8s.node.name": newString("worker-1"),
+			},
+			Replace: true,
+		}))
+		server.handleRequest()
+		require.Empty(t, server.acceptedDims)
+
+		server.respCode = http.StatusOK
+		server.handleRequest()
+
+		require.Equal(t, []dim{
+			{
+				Key:   "k8s.node.uid",
+				Value: "node-456",
+				Properties: map[string]*string{
+					"k8s.node.name": newString("worker-1"),
+				},
+				Tags: []string{},
+			},
+		}, server.acceptedDims)
+		require.Equal(t, []string{http.MethodPut}, server.methods)
+		require.EqualValues(t, 2, server.requestCount.Load())
+	})
+
 	t.Run("does not retry 4xx responses", func(t *testing.T) {
 		server.reset()
 		server.respCode = http.StatusBadRequest
@@ -275,6 +409,32 @@ func TestDimensionClient(t *testing.T) {
 		server.respCode = http.StatusOK
 
 		// there should be no retries
+		require.EqualValues(t, 1, server.requestCount.Load())
+	})
+
+	t.Run("does not retry replacement dimension update 400 responses without dropping tags", func(t *testing.T) {
+		server.reset()
+		server.respCode = http.StatusBadRequest
+
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+			Name:  "k8s.node.uid",
+			Value: "node-789",
+			Properties: map[string]*string{
+				"k8s.node.name": newString("worker-2"),
+			},
+			Tags: map[string]bool{
+				"active": true,
+			},
+			Replace: true,
+		}))
+		server.handleRequest()
+
+		server.respCode = http.StatusOK
+		time.Sleep(3 * client.sendDelay)
+		if server.requestCount.Load() > 1 {
+			server.handleRequest()
+		}
+		require.Empty(t, server.acceptedDims)
 		require.EqualValues(t, 1, server.requestCount.Load())
 	})
 

--- a/exporter/signalfxexporter/internal/dimensions/dimensionupdate.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimensionupdate.go
@@ -13,6 +13,9 @@ type DimensionUpdate struct {
 	Value      string
 	Properties map[string]*string
 	Tags       map[string]bool
+	// Replace uses the public dimension replacement endpoint
+	// (PUT /v2/dimension/{key}/{value}) instead of the sfxagent PATCH endpoint.
+	Replace bool
 }
 
 func (d *DimensionUpdate) String() string {
@@ -25,7 +28,7 @@ func (d *DimensionUpdate) String() string {
 		props += fmt.Sprintf("%v: %q, ", k, val)
 	}
 	props = strings.Trim(props, ", ") + "}"
-	return fmt.Sprintf("{name: %q; value: %q; props: %v; tags: %v}", d.Name, d.Value, props, d.Tags)
+	return fmt.Sprintf("{name: %q; value: %q; props: %v; tags: %v; replace: %t}", d.Name, d.Value, props, d.Tags, d.Replace)
 }
 
 func (d *DimensionUpdate) Key() DimensionKey {

--- a/exporter/signalfxexporter/internal/dimensions/entity_events.go
+++ b/exporter/signalfxexporter/internal/dimensions/entity_events.go
@@ -42,6 +42,7 @@ func (t *EntityEventTransformer) TransformEntityEvent(event metadata.EntityEvent
 		Value:      dimValue,
 		Properties: properties,
 		Tags:       tags,
+		Replace:    true,
 	}, nil
 }
 

--- a/exporter/signalfxexporter/internal/dimensions/entity_events_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/entity_events_test.go
@@ -366,6 +366,7 @@ func TestEntityEventTransformer_TransformEntityEvent(t *testing.T) {
 			assert.Equal(t, tt.wantDimValue, dimUpdate.Value)
 			assert.Equal(t, tt.wantProperties, dimUpdate.Properties)
 			assert.Equal(t, tt.wantTags, dimUpdate.Tags)
+			assert.True(t, dimUpdate.Replace)
 		})
 	}
 }


### PR DESCRIPTION
SignalFx entity state events should replace dimension metadata through the documented dimension PUT endpoint instead of the legacy sfxagent PATCH path. This keeps normal dimension delta updates on PATCH, sends entity-event updates as PUT /v2/dimension/{key}/{value} with key/value/customProperties/tags, and adjusts retry handling to match replacement semantics.
