### PR TITLE
[receiver/fluentforward] Limit msgpack allocations

### DIFF
--- a/.chloggen/fluentforward-msgpack-limits.yaml
+++ b/.chloggen/fluentforward-msgpack-limits.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/fluent_forward
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject oversized MessagePack headers before decoding Fluent Forward payloads.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48479]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fluentforward-msgpack-limits.yaml
+++ b/.chloggen/fluentforward-msgpack-limits.yaml
@@ -15,7 +15,7 @@ issues: [48479]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: The packed-forward payload byte limit defaults to 16 MiB and can be configured with `max_packed_forward_bytes`.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/fluentforwardreceiver/README.md
+++ b/receiver/fluentforwardreceiver/README.md
@@ -43,6 +43,9 @@ receivers:
     endpoint: 0.0.0.0:8006
 ```
 
+The `max_packed_forward_bytes` setting controls the maximum raw packed-forward
+payload size before decompression. It defaults to `16777216` bytes.
+
 ## Data Conversion
 
 The receiver converts Fluentd events to OpenTelemetry logs. Each Fluentd event

--- a/receiver/fluentforwardreceiver/config.go
+++ b/receiver/fluentforwardreceiver/config.go
@@ -3,6 +3,8 @@
 
 package fluentforwardreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
 
+import "fmt"
+
 // Config defines configuration for the fluentforward receiver.
 type Config struct {
 	// The address to listen on for incoming Fluent Forward events.  Should be
@@ -10,6 +12,22 @@ type Config struct {
 	// domain socket).
 	ListenAddress string `mapstructure:"endpoint"`
 
+	// MaxPackedForwardBytes is the maximum number of bytes accepted for a
+	// packed-forward raw payload (the entries blob before decompression).
+	// Defaults to 16 MiB. Increase this if senders produce large uncompressed
+	// PackedForward frames.
+	MaxPackedForwardBytes int `mapstructure:"max_packed_forward_bytes"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
+}
+
+func (c *Config) Validate() error {
+	if c.MaxPackedForwardBytes <= 0 {
+		return fmt.Errorf("max_packed_forward_bytes must be positive, got %d", c.MaxPackedForwardBytes)
+	}
+	if uint64(c.MaxPackedForwardBytes) > uint64(^uint32(0)) {
+		return fmt.Errorf("max_packed_forward_bytes must be at most %d, got %d", uint64(^uint32(0)), c.MaxPackedForwardBytes)
+	}
+	return nil
 }

--- a/receiver/fluentforwardreceiver/config.schema.yaml
+++ b/receiver/fluentforwardreceiver/config.schema.yaml
@@ -4,3 +4,6 @@ properties:
   endpoint:
     description: The address to listen on for incoming Fluent Forward events.  Should be of the form `<ip addr>:<port>` (TCP) or `unix://<socket_path>` (Unix domain socket).
     type: string
+  max_packed_forward_bytes:
+    description: MaxPackedForwardBytes is the maximum number of bytes accepted for a packed-forward raw payload (the entries blob before decompression). Defaults to 16 MiB. Increase this if senders produce large uncompressed PackedForward frames.
+    type: integer

--- a/receiver/fluentforwardreceiver/config_test.go
+++ b/receiver/fluentforwardreceiver/config_test.go
@@ -29,3 +29,25 @@ func TestLoadConfig(t *testing.T) {
 	assert.NoError(t, xconfmap.Validate(cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 }
+
+func TestLoadConfigWithMaxPackedForwardBytes(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(metadata.Type.String() + "/custom")
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	assert.NoError(t, xconfmap.Validate(cfg))
+	assert.Equal(t, &Config{MaxPackedForwardBytes: 32 * 1024 * 1024}, cfg)
+}
+
+func TestValidateConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.MaxPackedForwardBytes = 0
+
+	assert.ErrorContains(t, xconfmap.Validate(cfg), "max_packed_forward_bytes must be positive")
+}

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -18,7 +18,22 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-const tagAttributeKey = "fluent.tag"
+const (
+	tagAttributeKey = "fluent.tag"
+
+	// Fluent Forward record/option maps and batches are normally much smaller;
+	// 64K keeps legitimate large batches possible while bounding forged
+	// msgpack array/map headers before they can drive large allocations.
+	maxMsgpackElements = 64 * 1024
+
+	// Tags are identifiers and should be small; 128K preserves existing str32
+	// handling without allowing mode detection to peek unbounded tag lengths.
+	maxMsgpackTagBytes = 128 * 1024
+
+	// Packed-forward payloads can carry batches, so allow larger raw payloads
+	// while still rejecting forged str/bin lengths before allocation.
+	maxMsgpackRawBytes = 16 * 1024 * 1024
+)
 
 // Most of this logic is derived directly from
 // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1,
@@ -32,6 +47,71 @@ type event interface {
 }
 
 type optionsMap map[string]any
+
+func setMsgpackReaderLimits(dc *msgp.Reader) {
+	dc.SetMaxElements(maxMsgpackElements)
+	dc.SetMaxStringLength(maxMsgpackRawBytes)
+}
+
+func validateMsgpackElementCount(count uint32) error {
+	if count > maxMsgpackElements {
+		return msgp.ErrLimitExceeded
+	}
+	return nil
+}
+
+func validateMsgpackByteCount(count, limit uint32) error {
+	if count > limit {
+		return msgp.ErrLimitExceeded
+	}
+	return nil
+}
+
+func readStringWithLimit(dc *msgp.Reader, limit uint32) (string, error) {
+	size, err := dc.ReadStringHeader()
+	if err != nil {
+		return "", err
+	}
+	if err := validateMsgpackByteCount(size, limit); err != nil {
+		return "", err
+	}
+	if size == 0 {
+		return "", nil
+	}
+
+	out := make([]byte, int(size))
+	_, err = dc.ReadFull(out)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func readRawBytesWithLimit(dc *msgp.Reader, typ msgp.Type, limit uint32) ([]byte, error) {
+	var size uint32
+	var err error
+	switch typ {
+	case msgp.StrType:
+		size, err = dc.ReadStringHeader()
+	case msgp.BinType:
+		size, err = dc.ReadBytesHeader()
+	default:
+		return nil, fmt.Errorf("invalid type %d", typ)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMsgpackByteCount(size, limit); err != nil {
+		return nil, err
+	}
+
+	out := make([]byte, int(size))
+	_, err = dc.ReadFull(out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
 // Chunk returns the `chunk` option or blank string if it was not set.
 func (om optionsMap) Chunk() string {
@@ -141,6 +221,8 @@ func timeFromTimestamp(ts any) (time.Time, error) {
 }
 
 func parseRecordToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
+	setMsgpackReaderLimits(dc)
+
 	tsIntf, err := dc.ReadIntf()
 	if err != nil {
 		return msgp.WrapError(err, "Time")
@@ -155,6 +237,9 @@ func parseRecordToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
 
 	recordLen, err := dc.ReadMapHeader()
 	if err != nil {
+		return msgp.WrapError(err, "Record")
+	}
+	if err := validateMsgpackElementCount(recordLen); err != nil {
 		return msgp.WrapError(err, "Record")
 	}
 
@@ -196,6 +281,8 @@ func (melr *messageEventLogRecord) LogRecords() plog.LogRecordSlice {
 }
 
 func (melr *messageEventLogRecord) DecodeMsg(dc *msgp.Reader) error {
+	setMsgpackReaderLimits(dc)
+
 	melr.LogRecordSlice = plog.NewLogRecordSlice()
 	var arrLen uint32
 	var err error
@@ -208,7 +295,7 @@ func (melr *messageEventLogRecord) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.ArrayError{Wanted: 3, Got: arrLen}
 	}
 
-	tag, err := dc.ReadString()
+	tag, err := readStringWithLimit(dc, maxMsgpackTagBytes)
 	if err != nil {
 		return msgp.WrapError(err, "Tag")
 	}
@@ -229,9 +316,14 @@ func (melr *messageEventLogRecord) DecodeMsg(dc *msgp.Reader) error {
 }
 
 func parseOptions(dc *msgp.Reader) (optionsMap, error) {
+	setMsgpackReaderLimits(dc)
+
 	var optionLen uint32
 	optionLen, err := dc.ReadMapHeader()
 	if err != nil {
+		return nil, msgp.WrapError(err, "Option")
+	}
+	if err := validateMsgpackElementCount(optionLen); err != nil {
 		return nil, msgp.WrapError(err, "Option")
 	}
 	out := make(optionsMap, optionLen)
@@ -261,6 +353,8 @@ func (fe *forwardEventLogRecords) LogRecords() plog.LogRecordSlice {
 }
 
 func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
+	setMsgpackReaderLimits(dc)
+
 	fe.LogRecordSlice = plog.NewLogRecordSlice()
 
 	arrLen, err := dc.ReadArrayHeader()
@@ -271,13 +365,16 @@ func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.ArrayError{Wanted: 2, Got: arrLen}
 	}
 
-	tag, err := dc.ReadString()
+	tag, err := readStringWithLimit(dc, maxMsgpackTagBytes)
 	if err != nil {
 		return msgp.WrapError(err, "Tag")
 	}
 
 	entryLen, err := dc.ReadArrayHeader()
 	if err != nil {
+		return msgp.WrapError(err, "Record")
+	}
+	if err := validateMsgpackElementCount(entryLen); err != nil {
 		return msgp.WrapError(err, "Record")
 	}
 
@@ -323,6 +420,8 @@ func (pfe *packedForwardEventLogRecords) LogRecords() plog.LogRecordSlice {
 // DecodeMsg implements msgp.Decodable.  This was originally code generated but
 // then manually copied here in order to handle the optional Options field.
 func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
+	setMsgpackReaderLimits(dc)
+
 	pfe.LogRecordSlice = plog.NewLogRecordSlice()
 
 	arrLen, err := dc.ReadArrayHeader()
@@ -333,7 +432,7 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.ArrayError{Wanted: 2, Got: arrLen}
 	}
 
-	tag, err := dc.ReadString()
+	tag, err := readStringWithLimit(dc, maxMsgpackTagBytes)
 	if err != nil {
 		return msgp.WrapError(err, "Tag")
 	}
@@ -349,22 +448,9 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	// comes after.  I guess we could use some kind of detection logic to
 	// determine if it is gzipped by peeking and just ignoring options, but
 	// this seems simpler for now.
-	var entriesRaw []byte
-	switch entriesType {
-	case msgp.StrType:
-		var entriesStr string
-		entriesStr, err = dc.ReadString()
-		if err != nil {
-			return msgp.WrapError(err, "EntriesRaw")
-		}
-		entriesRaw = []byte(entriesStr)
-	case msgp.BinType:
-		entriesRaw, err = dc.ReadBytes(nil)
-		if err != nil {
-			return msgp.WrapError(err, "EntriesRaw")
-		}
-	default:
-		return msgp.WrapError(fmt.Errorf("invalid type %d", entriesType), "EntriesRaw")
+	entriesRaw, err := readRawBytesWithLimit(dc, entriesType, maxMsgpackRawBytes)
+	if err != nil {
+		return msgp.WrapError(err, "EntriesRaw")
 	}
 
 	if arrLen == 3 {
@@ -396,8 +482,10 @@ func (pfe *packedForwardEventLogRecords) parseEntries(entriesRaw []byte, isGzipp
 	}
 
 	msgpReader := msgp.NewReader(reader)
+	setMsgpackReaderLimits(msgpReader)
 	// Allocate only once, since the MoveTo cleans the lr, so we can reuse.
 	lr := plog.NewLogRecord()
+	var entries uint32
 	for {
 		err := parseEntryToLogRecord(msgpReader, lr)
 		if err != nil {
@@ -406,6 +494,10 @@ func (pfe *packedForwardEventLogRecords) parseEntries(entriesRaw []byte, isGzipp
 			}
 			return err
 		}
+		if entries == maxMsgpackElements {
+			return msgp.WrapError(msgp.ErrLimitExceeded, "Entries")
+		}
+		entries++
 		lr.Attributes().PutStr(tagAttributeKey, tag)
 		lr.MoveTo(pfe.AppendEmpty())
 	}

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -188,8 +188,6 @@ func timeFromTimestamp(ts any) (time.Time, error) {
 }
 
 func parseRecordToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
-	setMsgpackReaderLimits(dc)
-
 	tsIntf, err := dc.ReadIntf()
 	if err != nil {
 		return msgp.WrapError(err, "Time")

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -62,9 +62,20 @@ func validateMsgpackElementCount(count uint32) error {
 	return nil
 }
 
-func readPackedForwardPayload(dc *msgp.Reader, typ msgp.Type) ([]byte, error) {
+func readPackedForwardPayload(dc *msgp.Reader, typ msgp.Type, maxBytes int) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = maxMsgpackRawBytes
+	}
+	if uint64(maxBytes) > uint64(^uint32(0)) {
+		return nil, fmt.Errorf("packed-forward payload limit %d exceeds MessagePack size limit", maxBytes)
+	}
+
 	switch typ {
 	case msgp.StrType:
+		prevMaxStringLength := dc.GetMaxStringLength()
+		dc.SetMaxStringLength(uint64(maxBytes))
+		defer dc.SetMaxStringLength(prevMaxStringLength)
+
 		entriesStr, err := dc.ReadString()
 		if err != nil {
 			return nil, err
@@ -72,9 +83,9 @@ func readPackedForwardPayload(dc *msgp.Reader, typ msgp.Type) ([]byte, error) {
 		return []byte(entriesStr), nil
 	case msgp.BinType:
 		prevMaxElements := dc.GetMaxElements()
-		dc.SetMaxElements(maxMsgpackRawBytes)
+		dc.SetMaxElements(uint32(maxBytes))
 		defer dc.SetMaxElements(prevMaxElements)
-		return dc.ReadBytesLimit(nil, int64(maxMsgpackRawBytes))
+		return dc.ReadBytesLimit(nil, int64(maxBytes))
 	default:
 		return nil, fmt.Errorf("invalid type %d", typ)
 	}
@@ -375,6 +386,7 @@ func parseEntryToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
 type packedForwardEventLogRecords struct {
 	plog.LogRecordSlice
 	optionsMap
+	maxRawBytes int
 }
 
 func (pfe *packedForwardEventLogRecords) LogRecords() plog.LogRecordSlice {
@@ -412,7 +424,7 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	// comes after.  I guess we could use some kind of detection logic to
 	// determine if it is gzipped by peeking and just ignoring options, but
 	// this seems simpler for now.
-	entriesRaw, err := readPackedForwardPayload(dc, entriesType)
+	entriesRaw, err := readPackedForwardPayload(dc, entriesType, pfe.maxRawBytes)
 	if err != nil {
 		return msgp.WrapError(err, "EntriesRaw")
 	}

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -49,6 +49,8 @@ type event interface {
 type optionsMap map[string]any
 
 func setMsgpackReaderLimits(dc *msgp.Reader) {
+	// msgp also uses MaxElements to cap bin/ext byte allocations.
+	// Packed-forward payloads are the only place this receiver intentionally allows larger raw bytes.
 	dc.SetMaxElements(maxMsgpackElements)
 	dc.SetMaxStringLength(maxMsgpackRawBytes)
 }
@@ -60,59 +62,22 @@ func validateMsgpackElementCount(count uint32) error {
 	return nil
 }
 
-func validateMsgpackByteCount(count, limit uint32) error {
-	if count > limit {
-		return msgp.ErrLimitExceeded
-	}
-	return nil
-}
-
-func readStringWithLimit(dc *msgp.Reader, limit uint32) (string, error) {
-	size, err := dc.ReadStringHeader()
-	if err != nil {
-		return "", err
-	}
-	err = validateMsgpackByteCount(size, limit)
-	if err != nil {
-		return "", err
-	}
-	if size == 0 {
-		return "", nil
-	}
-
-	out := make([]byte, int(size))
-	_, err = dc.ReadFull(out)
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
-func readRawBytesWithLimit(dc *msgp.Reader, typ msgp.Type, limit uint32) ([]byte, error) {
-	var size uint32
-	var err error
+func readPackedForwardPayload(dc *msgp.Reader, typ msgp.Type) ([]byte, error) {
 	switch typ {
 	case msgp.StrType:
-		size, err = dc.ReadStringHeader()
+		entriesStr, err := dc.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		return []byte(entriesStr), nil
 	case msgp.BinType:
-		size, err = dc.ReadBytesHeader()
+		prevMaxElements := dc.GetMaxElements()
+		dc.SetMaxElements(maxMsgpackRawBytes)
+		defer dc.SetMaxElements(prevMaxElements)
+		return dc.ReadBytesLimit(nil, int64(maxMsgpackRawBytes))
 	default:
 		return nil, fmt.Errorf("invalid type %d", typ)
 	}
-	if err != nil {
-		return nil, err
-	}
-	err = validateMsgpackByteCount(size, limit)
-	if err != nil {
-		return nil, err
-	}
-
-	out := make([]byte, int(size))
-	_, err = dc.ReadFull(out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 // Chunk returns the `chunk` option or blank string if it was not set.
@@ -297,7 +262,7 @@ func (melr *messageEventLogRecord) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.ArrayError{Wanted: 3, Got: arrLen}
 	}
 
-	tag, err := readStringWithLimit(dc, maxMsgpackTagBytes)
+	tag, err := dc.ReadString()
 	if err != nil {
 		return msgp.WrapError(err, "Tag")
 	}
@@ -367,7 +332,7 @@ func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.ArrayError{Wanted: 2, Got: arrLen}
 	}
 
-	tag, err := readStringWithLimit(dc, maxMsgpackTagBytes)
+	tag, err := dc.ReadString()
 	if err != nil {
 		return msgp.WrapError(err, "Tag")
 	}
@@ -435,7 +400,7 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.ArrayError{Wanted: 2, Got: arrLen}
 	}
 
-	tag, err := readStringWithLimit(dc, maxMsgpackTagBytes)
+	tag, err := dc.ReadString()
 	if err != nil {
 		return msgp.WrapError(err, "Tag")
 	}
@@ -451,7 +416,7 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	// comes after.  I guess we could use some kind of detection logic to
 	// determine if it is gzipped by peeking and just ignoring options, but
 	// this seems simpler for now.
-	entriesRaw, err := readRawBytesWithLimit(dc, entriesType, maxMsgpackRawBytes)
+	entriesRaw, err := readPackedForwardPayload(dc, entriesType)
 	if err != nil {
 		return msgp.WrapError(err, "EntriesRaw")
 	}

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -283,8 +283,6 @@ func (melr *messageEventLogRecord) DecodeMsg(dc *msgp.Reader) error {
 }
 
 func parseOptions(dc *msgp.Reader) (optionsMap, error) {
-	setMsgpackReaderLimits(dc)
-
 	var optionLen uint32
 	optionLen, err := dc.ReadMapHeader()
 	if err != nil {

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -72,7 +72,8 @@ func readStringWithLimit(dc *msgp.Reader, limit uint32) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := validateMsgpackByteCount(size, limit); err != nil {
+	err = validateMsgpackByteCount(size, limit)
+	if err != nil {
 		return "", err
 	}
 	if size == 0 {
@@ -101,7 +102,8 @@ func readRawBytesWithLimit(dc *msgp.Reader, typ msgp.Type, limit uint32) ([]byte
 	if err != nil {
 		return nil, err
 	}
-	if err := validateMsgpackByteCount(size, limit); err != nil {
+	err = validateMsgpackByteCount(size, limit)
+	if err != nil {
 		return nil, err
 	}
 
@@ -374,7 +376,8 @@ func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	if err != nil {
 		return msgp.WrapError(err, "Record")
 	}
-	if err := validateMsgpackElementCount(entryLen); err != nil {
+	err = validateMsgpackElementCount(entryLen)
+	if err != nil {
 		return msgp.WrapError(err, "Record")
 	}
 

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -289,16 +289,6 @@ func TestDecodeMsgRejectsOversizedDirectElementCounts(t *testing.T) {
 	}
 }
 
-func TestDecodeMsgRejectsOversizedTag(t *testing.T) {
-	var b []byte
-	b = msgp.AppendArrayHeader(b, 3)
-	b = appendStringHeader(b, maxMsgpackTagBytes+1)
-
-	var event messageEventLogRecord
-	err := event.DecodeMsg(msgp.NewReader(bytes.NewReader(b)))
-	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
-}
-
 func TestPackedForwardRejectsOversizedEntriesRaw(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -5,6 +5,7 @@ package fluentforwardreceiver
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"testing"
@@ -15,6 +16,23 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
 )
+
+func appendStringHeader(b []byte, size uint32) []byte {
+	switch {
+	case size <= 31:
+		return append(b, 0xa0|byte(size))
+	case size <= 255:
+		return append(b, 0xd9, byte(size))
+	case size <= 65535:
+		var sizeBytes [2]byte
+		binary.BigEndian.PutUint16(sizeBytes[:], uint16(size))
+		return append(append(b, 0xda), sizeBytes[:]...)
+	default:
+		var sizeBytes [4]byte
+		binary.BigEndian.PutUint32(sizeBytes[:], size)
+		return append(append(b, 0xdb), sizeBytes[:]...)
+	}
+}
 
 func TestMessageEventConversion(t *testing.T) {
 	eventBytes := parseHexDump("testdata/message-event")
@@ -192,6 +210,129 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 		require.ErrorContains(t, err, "gzip")
 		fmt.Println(err.Error())
 	})
+}
+
+func TestMessageEventRejectsOversizedNestedRecordArray(t *testing.T) {
+	var b []byte
+
+	b = msgp.AppendArrayHeader(b, 3)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendInt(b, 0)
+	b = msgp.AppendMapHeader(b, 1)
+	b = msgp.AppendString(b, "a")
+	b = msgp.AppendArrayHeader(b, maxMsgpackElements+1)
+	require.Len(t, b, 17)
+
+	var event messageEventLogRecord
+	err := event.DecodeMsg(msgp.NewReader(bytes.NewReader(b)))
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+}
+
+func TestDecodeMsgRejectsOversizedDirectElementCounts(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  func() []byte
+		decode func(*msgp.Reader) error
+	}{
+		{
+			name: "record map",
+			input: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 3)
+				b = msgp.AppendString(b, "my-tag")
+				b = msgp.AppendInt(b, 0)
+				b = msgp.AppendMapHeader(b, maxMsgpackElements+1)
+				return b
+			},
+			decode: func(reader *msgp.Reader) error {
+				var event messageEventLogRecord
+				return event.DecodeMsg(reader)
+			},
+		},
+		{
+			name: "options map",
+			input: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 4)
+				b = msgp.AppendString(b, "my-tag")
+				b = msgp.AppendInt(b, 0)
+				b = msgp.AppendMapHeader(b, 0)
+				b = msgp.AppendMapHeader(b, maxMsgpackElements+1)
+				return b
+			},
+			decode: func(reader *msgp.Reader) error {
+				var event messageEventLogRecord
+				return event.DecodeMsg(reader)
+			},
+		},
+		{
+			name: "forward entries",
+			input: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 2)
+				b = msgp.AppendString(b, "my-tag")
+				b = msgp.AppendArrayHeader(b, maxMsgpackElements+1)
+				return b
+			},
+			decode: func(reader *msgp.Reader) error {
+				var event forwardEventLogRecords
+				return event.DecodeMsg(reader)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.decode(msgp.NewReader(bytes.NewReader(tt.input())))
+			require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+		})
+	}
+}
+
+func TestDecodeMsgRejectsOversizedTag(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 3)
+	b = appendStringHeader(b, maxMsgpackTagBytes+1)
+
+	var event messageEventLogRecord
+	err := event.DecodeMsg(msgp.NewReader(bytes.NewReader(b)))
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+}
+
+func TestPackedForwardRejectsOversizedEntriesRaw(t *testing.T) {
+	tests := []struct {
+		name  string
+		input func() []byte
+	}{
+		{
+			name: "string",
+			input: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 2)
+				b = msgp.AppendString(b, "my-tag")
+				b = appendStringHeader(b, maxMsgpackRawBytes+1)
+				return b
+			},
+		},
+		{
+			name: "binary",
+			input: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 2)
+				b = msgp.AppendString(b, "my-tag")
+				b = msgp.AppendBytesHeader(b, maxMsgpackRawBytes+1)
+				return b
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var event packedForwardEventLogRecords
+			err := event.DecodeMsg(msgp.NewReader(bytes.NewReader(tt.input())))
+			require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+		})
+	}
 }
 
 func TestBodyConversion(t *testing.T) {

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -193,7 +193,7 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 		t.Run(fmt.Sprintf("EOF at byte %d", i), func(t *testing.T) {
 			reader := msgp.NewReader(bytes.NewReader(b[:i]))
 
-			var event packedForwardEventLogRecords
+			event := packedForwardEventLogRecords{maxRawBytes: maxMsgpackRawBytes}
 			err := event.DecodeMsg(reader)
 			require.Error(t, err)
 		})
@@ -318,11 +318,27 @@ func TestPackedForwardRejectsOversizedEntriesRaw(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var event packedForwardEventLogRecords
+			event := packedForwardEventLogRecords{maxRawBytes: maxMsgpackRawBytes}
 			err := event.DecodeMsg(msgp.NewReader(bytes.NewReader(tt.input())))
 			require.ErrorIs(t, err, msgp.ErrLimitExceeded)
 		})
 	}
+}
+
+func TestPackedForwardRejectsConfiguredEntriesRawLimit(t *testing.T) {
+	var payload []byte
+	payload = msgp.AppendArrayHeader(payload, 2)
+	payload = msgp.AppendInt(payload, 0)
+	payload = msgp.AppendMapHeader(payload, 0)
+
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 2)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendBytes(b, payload)
+
+	event := packedForwardEventLogRecords{maxRawBytes: len(payload) - 1}
+	err := event.DecodeMsg(msgp.NewReader(bytes.NewReader(b)))
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
 }
 
 func TestBodyConversion(t *testing.T) {

--- a/receiver/fluentforwardreceiver/factory.go
+++ b/receiver/fluentforwardreceiver/factory.go
@@ -24,7 +24,9 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		MaxPackedForwardBytes: maxMsgpackRawBytes,
+	}
 }
 
 func createLogsReceiver(

--- a/receiver/fluentforwardreceiver/factory_test.go
+++ b/receiver/fluentforwardreceiver/factory_test.go
@@ -20,6 +20,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	assert.Equal(t, maxMsgpackRawBytes, cfg.(*Config).MaxPackedForwardBytes)
 }
 
 func TestCreateReceiver(t *testing.T) {

--- a/receiver/fluentforwardreceiver/receiver.go
+++ b/receiver/fluentforwardreceiver/receiver.go
@@ -48,7 +48,7 @@ func newFluentReceiver(set receiver.Settings, conf *Config, next consumer.Logs) 
 	eventCh := make(chan event, eventChannelLength)
 	collector := newCollector(eventCh, next, set.Logger, obsrecv, telemetryBuilder)
 
-	server := newServer(eventCh, set.Logger, telemetryBuilder)
+	server := newServer(eventCh, set.Logger, telemetryBuilder, conf.MaxPackedForwardBytes)
 
 	return &fluentReceiver{
 		collector: collector,

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -39,9 +39,8 @@ func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observ
 	set := receivertest.NewNopSettings(metadata.Type)
 	set.Logger = logger
 
-	conf := &Config{
-		ListenAddress: "127.0.0.1:0",
-	}
+	conf := createDefaultConfig().(*Config)
+	conf.ListenAddress = "127.0.0.1:0"
 
 	receiver, err := newFluentReceiver(set, conf, next)
 	require.NoError(t, err)
@@ -59,6 +58,22 @@ func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observ
 	}()
 
 	return connect, next, logObserver, cancel, receiver
+}
+
+func TestCreateReceiverAppliesMaxPackedForwardBytes(t *testing.T) {
+	const maxPackedForwardBytes = 1024
+
+	conf := createDefaultConfig().(*Config)
+	conf.ListenAddress = "127.0.0.1:0"
+	conf.MaxPackedForwardBytes = maxPackedForwardBytes
+
+	receiver, err := newFluentReceiver(
+		receivertest.NewNopSettings(metadata.Type),
+		conf,
+		consumertest.NewNop(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, maxPackedForwardBytes, receiver.(*fluentReceiver).server.maxPackedForwardBytes)
 }
 
 func waitForConnectionClose(t *testing.T, conn net.Conn) {
@@ -335,9 +350,8 @@ func TestUnixEndpoint(t *testing.T) {
 
 	tmpdir := t.TempDir()
 
-	conf := &Config{
-		ListenAddress: "unix://" + filepath.Join(tmpdir, "fluent.sock"),
-	}
+	conf := createDefaultConfig().(*Config)
+	conf.ListenAddress = "unix://" + filepath.Join(tmpdir, "fluent.sock")
 
 	receiver, err := newFluentReceiver(receivertest.NewNopSettings(metadata.Type), conf, next)
 	require.NoError(t, err)

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -191,7 +191,8 @@ func determineNextEventMode(peeker peeker) (eventMode, error) {
 			return unknownMode, errors.New("malformed tag field")
 		}
 	}
-	if err := validateMsgpackByteCount(tagValueLen, maxMsgpackTagBytes); err != nil {
+	err = validateMsgpackByteCount(tagValueLen, maxMsgpackTagBytes)
+	if err != nil {
 		return unknownMode, msgp.WrapError(err, "Tag")
 	}
 	tagLen := tagHeaderLen + int(tagValueLen)

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -25,19 +25,21 @@ import (
 const readBufferSize = 10 * 1024
 
 type server struct {
-	outCh            chan<- event
-	logger           *zap.Logger
-	telemetryBuilder *metadata.TelemetryBuilder
-	conns            map[net.Conn]struct{}
-	mu               sync.Mutex
+	outCh                 chan<- event
+	logger                *zap.Logger
+	telemetryBuilder      *metadata.TelemetryBuilder
+	conns                 map[net.Conn]struct{}
+	mu                    sync.Mutex
+	maxPackedForwardBytes int
 }
 
-func newServer(outCh chan<- event, logger *zap.Logger, telemetryBuilder *metadata.TelemetryBuilder) *server {
+func newServer(outCh chan<- event, logger *zap.Logger, telemetryBuilder *metadata.TelemetryBuilder, maxPackedForwardBytes int) *server {
 	return &server{
-		outCh:            outCh,
-		logger:           logger,
-		telemetryBuilder: telemetryBuilder,
-		conns:            make(map[net.Conn]struct{}),
+		outCh:                 outCh,
+		logger:                logger,
+		telemetryBuilder:      telemetryBuilder,
+		conns:                 make(map[net.Conn]struct{}),
+		maxPackedForwardBytes: maxPackedForwardBytes,
 	}
 }
 
@@ -110,7 +112,7 @@ func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 		case forwardMode:
 			e = &forwardEventLogRecords{}
 		case packedForwardMode:
-			e = &packedForwardEventLogRecords{}
+			e = &packedForwardEventLogRecords{maxRawBytes: s.maxPackedForwardBytes}
 		default:
 			panic("programmer bug in mode handling")
 		}

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -158,12 +158,12 @@ func determineNextEventMode(peeker peeker) (eventMode, error) {
 	// message modes have more than 4 entries. So skip to the second byte which
 	// is the tag string header.
 	tagType := chunk[1]
-	// We already read the first type for the type
-	tagLen := 1
 
 	isFixStr := tagType&0b10100000 == 0b10100000
+	tagHeaderLen := 1
+	var tagValueLen uint32
 	if isFixStr {
-		tagLen += int(tagType & 0b00011111)
+		tagValueLen = uint32(tagType & 0b00011111)
 	} else {
 		switch tagType {
 		case 0xd9:
@@ -171,23 +171,30 @@ func determineNextEventMode(peeker peeker) (eventMode, error) {
 			if err != nil {
 				return unknownMode, err
 			}
-			tagLen += 1 + int(chunk[2])
+			tagHeaderLen = 2
+			tagValueLen = uint32(chunk[2])
 		case 0xda:
 			chunk, err = peeker.Peek(4)
 			if err != nil {
 				return unknownMode, err
 			}
-			tagLen += 2 + int(binary.BigEndian.Uint16(chunk[2:]))
+			tagHeaderLen = 3
+			tagValueLen = uint32(binary.BigEndian.Uint16(chunk[2:]))
 		case 0xdb:
 			chunk, err = peeker.Peek(6)
 			if err != nil {
 				return unknownMode, err
 			}
-			tagLen += 4 + int(binary.BigEndian.Uint32(chunk[2:]))
+			tagHeaderLen = 5
+			tagValueLen = binary.BigEndian.Uint32(chunk[2:])
 		default:
 			return unknownMode, errors.New("malformed tag field")
 		}
 	}
+	if err := validateMsgpackByteCount(tagValueLen, maxMsgpackTagBytes); err != nil {
+		return unknownMode, msgp.WrapError(err, "Tag")
+	}
+	tagLen := tagHeaderLen + int(tagValueLen)
 
 	// Skip past the first byte (array header) and the entire tag and then get
 	// one byte into the second field -- that is enough to know its type.

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -191,9 +191,8 @@ func determineNextEventMode(peeker peeker) (eventMode, error) {
 			return unknownMode, errors.New("malformed tag field")
 		}
 	}
-	err = validateMsgpackByteCount(tagValueLen, maxMsgpackTagBytes)
-	if err != nil {
-		return unknownMode, msgp.WrapError(err, "Tag")
+	if tagValueLen > maxMsgpackTagBytes {
+		return unknownMode, msgp.WrapError(msgp.ErrLimitExceeded, "Tag")
 	}
 	tagLen := tagHeaderLen + int(tagValueLen)
 

--- a/receiver/fluentforwardreceiver/server_test.go
+++ b/receiver/fluentforwardreceiver/server_test.go
@@ -114,3 +114,13 @@ func TestDetermineNextEventMode(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineNextEventModeRejectsOversizedTag(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 3)
+	b = appendStringHeader(b, maxMsgpackTagBytes+1)
+
+	peeker := bufio.NewReaderSize(bytes.NewReader(b), 16)
+	_, err := determineNextEventMode(peeker)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+}

--- a/receiver/fluentforwardreceiver/testdata/config.yaml
+++ b/receiver/fluentforwardreceiver/testdata/config.yaml
@@ -1,1 +1,4 @@
 fluent_forward:
+
+fluent_forward/custom:
+  max_packed_forward_bytes: 33554432


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48519

Bounds Fluent Forward MessagePack tag/raw byte lengths and array/map element counts before decode, covering message, forward, packed-forward, and mode detection paths.