### PR TITLE
[receiver/datadog] Validate msgpack payload sizes

### DIFF
--- a/.chloggen/datadog-msgpack-limits.yaml
+++ b/.chloggen/datadog-msgpack-limits.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject oversized MessagePack headers before decoding Datadog API payloads.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/msgpackvalidator/validator.go
+++ b/receiver/datadogreceiver/internal/msgpackvalidator/validator.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package msgpackvalidator
+package msgpackvalidator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/msgpackvalidator"
 
 import (
 	"encoding/binary"

--- a/receiver/datadogreceiver/internal/msgpackvalidator/validator.go
+++ b/receiver/datadogreceiver/internal/msgpackvalidator/validator.go
@@ -60,7 +60,8 @@ func validateArray(b []byte, depth int) ([]byte, error) {
 	if err != nil {
 		return b, err
 	}
-	if err := validateElementCount("array", size, len(remain), 1); err != nil {
+	err = validateElementCount("array", size, len(remain), 1)
+	if err != nil {
 		return b, err
 	}
 	for range size {
@@ -77,7 +78,8 @@ func validateMap(b []byte, depth int) ([]byte, error) {
 	if err != nil {
 		return b, err
 	}
-	if err := validateElementCount("map", size, len(remain), 2); err != nil {
+	err = validateElementCount("map", size, len(remain), 2)
+	if err != nil {
 		return b, err
 	}
 	for range size {

--- a/receiver/datadogreceiver/internal/msgpackvalidator/validator.go
+++ b/receiver/datadogreceiver/internal/msgpackvalidator/validator.go
@@ -1,0 +1,234 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package msgpackvalidator
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+const (
+	maxMsgpackContainerElements = 1 << 20
+	maxMsgpackBinStringLen      = 20 * 1024 * 1024
+	maxMsgpackExtLen            = maxMsgpackBinStringLen
+	maxMsgpackDepth             = 64
+)
+
+// Validate walks a single MessagePack object without materializing it.
+func Validate(b []byte) error {
+	remain, err := validateValue(b, 0)
+	if err != nil {
+		return err
+	}
+	if len(remain) != 0 {
+		return fmt.Errorf("msgpack has %d trailing bytes", len(remain))
+	}
+	return nil
+}
+
+func validateValue(b []byte, depth int) ([]byte, error) {
+	if depth > maxMsgpackDepth {
+		return b, fmt.Errorf("msgpack nesting exceeds depth limit %d", maxMsgpackDepth)
+	}
+	if len(b) == 0 {
+		return b, msgp.ErrShortBytes
+	}
+
+	if isExtensionPrefix(b[0]) {
+		return validateExtension(b)
+	}
+
+	switch msgp.NextType(b) {
+	case msgp.ArrayType:
+		return validateArray(b, depth)
+	case msgp.MapType:
+		return validateMap(b, depth)
+	case msgp.BinType:
+		return validateBin(b)
+	case msgp.StrType:
+		return validateString(b)
+	default:
+		return msgp.Skip(b)
+	}
+}
+
+func validateArray(b []byte, depth int) ([]byte, error) {
+	size, remain, err := msgp.ReadArrayHeaderBytes(b)
+	if err != nil {
+		return b, err
+	}
+	if err := validateElementCount("array", size, len(remain), 1); err != nil {
+		return b, err
+	}
+	for range size {
+		remain, err = validateValue(remain, depth+1)
+		if err != nil {
+			return remain, err
+		}
+	}
+	return remain, nil
+}
+
+func validateMap(b []byte, depth int) ([]byte, error) {
+	size, remain, err := msgp.ReadMapHeaderBytes(b)
+	if err != nil {
+		return b, err
+	}
+	if err := validateElementCount("map", size, len(remain), 2); err != nil {
+		return b, err
+	}
+	for range size {
+		remain, err = validateValue(remain, depth+1)
+		if err != nil {
+			return remain, err
+		}
+		remain, err = validateValue(remain, depth+1)
+		if err != nil {
+			return remain, err
+		}
+	}
+	return remain, nil
+}
+
+func validateElementCount(kind string, size uint32, remaining, objectsPerElement int) error {
+	if size > maxMsgpackContainerElements {
+		return fmt.Errorf("msgpack %s length %d exceeds limit %d", kind, size, maxMsgpackContainerElements)
+	}
+	if uint64(size)*uint64(objectsPerElement) > uint64(remaining) {
+		return fmt.Errorf("msgpack %s length %d exceeds remaining payload size %d", kind, size, remaining)
+	}
+	return nil
+}
+
+func validateBin(b []byte) ([]byte, error) {
+	size, remain, err := msgp.ReadBytesHeader(b)
+	if err != nil {
+		return b, err
+	}
+	if size > maxMsgpackBinStringLen {
+		return b, fmt.Errorf("msgpack bin length %d exceeds limit %d", size, maxMsgpackBinStringLen)
+	}
+	if uint64(size) > uint64(len(remain)) {
+		return b, msgp.ErrShortBytes
+	}
+	return remain[size:], nil
+}
+
+func validateString(b []byte) ([]byte, error) {
+	size, remain, err := readStringHeader(b)
+	if err != nil {
+		return b, err
+	}
+	if size > maxMsgpackBinStringLen {
+		return b, fmt.Errorf("msgpack string length %d exceeds limit %d", size, maxMsgpackBinStringLen)
+	}
+	if uint64(size) > uint64(len(remain)) {
+		return b, msgp.ErrShortBytes
+	}
+	return remain[size:], nil
+}
+
+func validateExtension(b []byte) ([]byte, error) {
+	size, remain, err := readExtensionHeader(b)
+	if err != nil {
+		return b, err
+	}
+	if size > maxMsgpackExtLen {
+		return b, fmt.Errorf("msgpack extension length %d exceeds limit %d", size, maxMsgpackExtLen)
+	}
+	if uint64(size) > uint64(len(remain)) {
+		return b, msgp.ErrShortBytes
+	}
+	return remain[size:], nil
+}
+
+func isExtensionPrefix(prefix byte) bool {
+	switch prefix {
+	case 0xc7, 0xc8, 0xc9, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8:
+		return true
+	default:
+		return false
+	}
+}
+
+func readStringHeader(b []byte) (uint32, []byte, error) {
+	if len(b) == 0 {
+		return 0, b, msgp.ErrShortBytes
+	}
+	lead := b[0]
+	if lead&0xe0 == 0xa0 {
+		return uint32(lead & 0x1f), b[1:], nil
+	}
+	switch lead {
+	case 0xd9:
+		if len(b) < 2 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return uint32(b[1]), b[2:], nil
+	case 0xda:
+		if len(b) < 3 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return uint32(binary.BigEndian.Uint16(b[1:3])), b[3:], nil
+	case 0xdb:
+		if len(b) < 5 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return binary.BigEndian.Uint32(b[1:5]), b[5:], nil
+	default:
+		return 0, b, msgp.TypeError{Method: msgp.StrType, Encoded: msgp.NextType(b)}
+	}
+}
+
+func readExtensionHeader(b []byte) (uint32, []byte, error) {
+	if len(b) == 0 {
+		return 0, b, msgp.ErrShortBytes
+	}
+	switch b[0] {
+	case 0xd4:
+		if len(b) < 2 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return 1, b[2:], nil
+	case 0xd5:
+		if len(b) < 2 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return 2, b[2:], nil
+	case 0xd6:
+		if len(b) < 2 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return 4, b[2:], nil
+	case 0xd7:
+		if len(b) < 2 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return 8, b[2:], nil
+	case 0xd8:
+		if len(b) < 2 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return 16, b[2:], nil
+	case 0xc7:
+		if len(b) < 3 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return uint32(b[1]), b[3:], nil
+	case 0xc8:
+		if len(b) < 4 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return uint32(binary.BigEndian.Uint16(b[1:3])), b[4:], nil
+	case 0xc9:
+		if len(b) < 6 {
+			return 0, b, msgp.ErrShortBytes
+		}
+		return binary.BigEndian.Uint32(b[1:5]), b[6:], nil
+	default:
+		return 0, b, fmt.Errorf("msgpack prefix 0x%x is not an extension", b[0])
+	}
+}

--- a/receiver/datadogreceiver/internal/msgpackvalidator/validator_test.go
+++ b/receiver/datadogreceiver/internal/msgpackvalidator/validator_test.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package msgpackvalidator
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestValidateAcceptsBoundedPayload(t *testing.T) {
+	var payload []byte
+	payload = msgp.AppendMapHeader(payload, 1)
+	payload = msgp.AppendString(payload, "stats")
+	payload = msgp.AppendArrayHeader(payload, 2)
+	payload = msgp.AppendNil(payload)
+	payload = msgp.AppendString(payload, "ok")
+
+	if err := Validate(payload); err != nil {
+		t.Fatalf("Validate() returned unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsForgedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    string
+	}{
+		{
+			name:    "array elements",
+			payload: msgp.AppendArrayHeader(nil, maxMsgpackContainerElements+1),
+			want:    "array length",
+		},
+		{
+			name:    "array larger than remaining payload",
+			payload: msgp.AppendArrayHeader(nil, 3),
+			want:    "remaining payload",
+		},
+		{
+			name:    "string bytes",
+			payload: appendString32Header(maxMsgpackBinStringLen + 1),
+			want:    "string length",
+		},
+		{
+			name:    "binary bytes",
+			payload: msgp.AppendBytesHeader(nil, maxMsgpackBinStringLen+1),
+			want:    "bin length",
+		},
+		{
+			name:    "extension bytes",
+			payload: appendExt32Header(maxMsgpackExtLen + 1),
+			want:    "extension length",
+		},
+		{
+			name:    "nesting depth",
+			payload: nestedArrayPayload(maxMsgpackDepth + 2),
+			want:    "nesting exceeds depth limit",
+		},
+		{
+			name:    "trailing bytes",
+			payload: []byte{0xc0, 0xc0},
+			want:    "trailing bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.payload)
+			if err == nil {
+				t.Fatal("Validate() returned nil error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func appendString32Header(size uint32) []byte {
+	var sizeBytes [4]byte
+	binary.BigEndian.PutUint32(sizeBytes[:], size)
+	return append([]byte{0xdb}, sizeBytes[:]...)
+}
+
+func appendExt32Header(size uint32) []byte {
+	var sizeBytes [4]byte
+	binary.BigEndian.PutUint32(sizeBytes[:], size)
+	payload := append([]byte{0xc9}, sizeBytes[:]...)
+	return append(payload, 0)
+}
+
+func nestedArrayPayload(depth int) []byte {
+	var payload []byte
+	for range depth {
+		payload = msgp.AppendArrayHeader(payload, 1)
+	}
+	return msgp.AppendNil(payload)
+}

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/msgpackvalidator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator/header"
 )
 
@@ -470,6 +471,9 @@ func HandleTracesPayload(req *http.Request) (tp []*pb.TracerPayload, err error) 
 		if _, err = io.Copy(buf, req.Body); err != nil {
 			return nil, err
 		}
+		if err = msgpackvalidator.Validate(buf.Bytes()); err != nil {
+			return nil, err
+		}
 		var tracerPayload pb.TracerPayload
 		if _, err = tracerPayload.UnmarshalMsg(buf.Bytes()); err != nil {
 			return nil, err
@@ -480,6 +484,9 @@ func HandleTracesPayload(req *http.Request) (tp []*pb.TracerPayload, err error) 
 		buf := GetBuffer()
 		defer PutBuffer(buf)
 		if _, err = io.Copy(buf, req.Body); err != nil {
+			return nil, err
+		}
+		if err = msgpackvalidator.Validate(buf.Bytes()); err != nil {
 			return nil, err
 		}
 		var traces pb.Traces
@@ -560,6 +567,9 @@ func decodeRequest(req *http.Request, dest *pb.Traces) (err error) {
 		if err != nil {
 			return err
 		}
+		if err = msgpackvalidator.Validate(buf.Bytes()); err != nil {
+			return err
+		}
 		_, err = dest.UnmarshalMsg(buf.Bytes())
 		return err
 	case "application/json", "text/json", "":
@@ -572,6 +582,9 @@ func decodeRequest(req *http.Request, dest *pb.Traces) (err error) {
 			defer PutBuffer(buf)
 			_, err2 := io.Copy(buf, req.Body)
 			if err2 != nil {
+				return err2
+			}
+			if err2 = msgpackvalidator.Validate(buf.Bytes()); err2 != nil {
 				return err2
 			}
 			_, err2 = dest.UnmarshalMsg(buf.Bytes())

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -471,8 +471,8 @@ func HandleTracesPayload(req *http.Request) (tp []*pb.TracerPayload, err error) 
 		if _, err = io.Copy(buf, req.Body); err != nil {
 			return nil, err
 		}
-		if err = msgpackvalidator.Validate(buf.Bytes()); err != nil {
-			return nil, err
+		if validateErr := msgpackvalidator.Validate(buf.Bytes()); validateErr != nil {
+			return nil, validateErr
 		}
 		var tracerPayload pb.TracerPayload
 		if _, err = tracerPayload.UnmarshalMsg(buf.Bytes()); err != nil {
@@ -486,8 +486,8 @@ func HandleTracesPayload(req *http.Request) (tp []*pb.TracerPayload, err error) 
 		if _, err = io.Copy(buf, req.Body); err != nil {
 			return nil, err
 		}
-		if err = msgpackvalidator.Validate(buf.Bytes()); err != nil {
-			return nil, err
+		if validateErr := msgpackvalidator.Validate(buf.Bytes()); validateErr != nil {
+			return nil, validateErr
 		}
 		var traces pb.Traces
 
@@ -567,8 +567,8 @@ func decodeRequest(req *http.Request, dest *pb.Traces) (err error) {
 		if err != nil {
 			return err
 		}
-		if err = msgpackvalidator.Validate(buf.Bytes()); err != nil {
-			return err
+		if validateErr := msgpackvalidator.Validate(buf.Bytes()); validateErr != nil {
+			return validateErr
 		}
 		_, err = dest.UnmarshalMsg(buf.Bytes())
 		return err
@@ -584,8 +584,8 @@ func decodeRequest(req *http.Request, dest *pb.Traces) (err error) {
 			if err2 != nil {
 				return err2
 			}
-			if err2 = msgpackvalidator.Validate(buf.Bytes()); err2 != nil {
-				return err2
+			if validateErr := msgpackvalidator.Validate(buf.Bytes()); validateErr != nil {
+				return validateErr
 			}
 			_, err2 = dest.UnmarshalMsg(buf.Bytes())
 			return err2

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -73,6 +73,16 @@ var data = [2]any{
 	},
 }
 
+func msgpackMapWithHugeArrayField(field string) []byte {
+	payload := []byte{0x81, 0xa0 | byte(len(field))}
+	payload = append(payload, field...)
+	return append(payload, 0xdd, 0xff, 0xff, 0xff, 0xff)
+}
+
+func msgpackHugeArray() []byte {
+	return []byte{0xdd, 0xff, 0xff, 0xff, 0xff}
+}
+
 func getTraces(t *testing.T) (traces pb.Traces) {
 	payload, err := vmsgp.Marshal(&data)
 	assert.NoError(t, err)
@@ -144,6 +154,46 @@ func TestTracePayloadV07Unmarshalling(t *testing.T) {
 	assert.Equal(t, "my-service", value, "service.name attribute value incorrect")
 	assert.Equal(t, "my-name", span.GetName())
 	assert.Equal(t, "my-resource", span.GetResource())
+}
+
+func TestHandleTracesPayloadRejectsMsgpackWithHugeDeclaredArray(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		contentType string
+		payload     []byte
+	}{
+		{
+			name:    "v0.7 tracer payload chunks",
+			path:    "/v0.7/traces",
+			payload: msgpackMapWithHugeArrayField("chunks"),
+		},
+		{
+			name:    "v0.5 dictionary traces",
+			path:    "/v0.5/traces",
+			payload: append([]byte{0x92}, msgpackHugeArray()...),
+		},
+		{
+			name:        "v0.4 msgpack traces",
+			path:        "/v0.4/traces",
+			contentType: "application/msgpack",
+			payload:     msgpackHugeArray(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, tt.path, io.NopCloser(bytes.NewReader(tt.payload)))
+			require.NoError(t, err)
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+
+			tracePayloads, err := HandleTracesPayload(req)
+			require.Error(t, err)
+			require.Nil(t, tracePayloads)
+		})
+	}
 }
 
 func BenchmarkTranslatorv05(b *testing.B) {

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/agent-payload/v5/gogen"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	lru "github.com/hashicorp/golang-lru/v2"
-	"github.com/tinylib/msgp/msgp"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/errorutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog/clientutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/msgpackvalidator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator/header"
 )
@@ -390,8 +390,19 @@ func (ddr *datadogReceiver) handleStatsV2(w http.ResponseWriter, req *http.Reque
 
 	// Decode the StatsPayload (NOT ClientStatsPayload directly)
 	// The agent wraps ClientStatsPayload(s) inside a StatsPayload
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		ddr.params.Logger.Error("Error reading pb.StatsPayload", zap.Error(err))
+		http.Error(w, "Error reading pb.StatsPayload", http.StatusBadRequest)
+		return
+	}
+	if err = msgpackvalidator.Validate(payload); err != nil {
+		ddr.params.Logger.Error("Error validating pb.StatsPayload", zap.Error(err))
+		http.Error(w, "Error decoding pb.StatsPayload", http.StatusBadRequest)
+		return
+	}
 	statsPayload := &pb.StatsPayload{}
-	err = msgp.Decode(reader, statsPayload)
+	_, err = statsPayload.UnmarshalMsg(payload)
 	if err != nil {
 		ddr.params.Logger.Error("Error decoding pb.StatsPayload", zap.Error(err))
 		http.Error(w, "Error decoding pb.StatsPayload", http.StatusBadRequest)
@@ -681,7 +692,18 @@ func (ddr *datadogReceiver) handleStats(w http.ResponseWriter, req *http.Request
 	req.Header.Set("Accept", "application/msgpack")
 	clientStats := &pb.ClientStatsPayload{}
 
-	err = msgp.Decode(req.Body, clientStats)
+	payload, err := io.ReadAll(req.Body)
+	if err != nil {
+		ddr.params.Logger.Error("Error reading pb.ClientStatsPayload", zap.Error(err))
+		http.Error(w, "Error reading pb.ClientStatsPayload", http.StatusBadRequest)
+		return
+	}
+	if err = msgpackvalidator.Validate(payload); err != nil {
+		ddr.params.Logger.Error("Error validating pb.ClientStatsPayload", zap.Error(err))
+		http.Error(w, "Error decoding pb.ClientStatsPayload", http.StatusBadRequest)
+		return
+	}
+	_, err = clientStats.UnmarshalMsg(payload)
 	if err != nil {
 		ddr.params.Logger.Error("Error decoding pb.ClientStatsPayload", zap.Error(err))
 		http.Error(w, "Error decoding pb.ClientStatsPayload", http.StatusBadRequest)

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -33,6 +34,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator/header"
 )
+
+func msgpackMapWithHugeArrayField(field string) []byte {
+	payload := []byte{0x81, 0xa0 | byte(len(field))}
+	payload = append(payload, field...)
+	return append(payload, 0xdd, 0xff, 0xff, 0xff, 0xff)
+}
 
 func TestDatadogTracesReceiver_Lifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -930,6 +937,55 @@ func TestStatsV2_EndToEnd(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestStatsRejectsMsgpackWithHugeDeclaredArray(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	sink := new(consumertest.MetricsSink)
+
+	dd, err := newDataDogReceiver(
+		t.Context(),
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err)
+	dd.(*datadogReceiver).nextMetricsConsumer = sink
+
+	req := httptest.NewRequest(http.MethodPost, "/v0.6/stats", bytes.NewReader(msgpackMapWithHugeArrayField("Stats")))
+	resp := httptest.NewRecorder()
+
+	dd.(*datadogReceiver).handleStats(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Empty(t, sink.AllMetrics())
+}
+
+func TestStatsV2RejectsCompressedMsgpackWithHugeDeclaredArray(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	sink := new(consumertest.MetricsSink)
+
+	dd, err := newDataDogReceiver(
+		t.Context(),
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err)
+	dd.(*datadogReceiver).nextMetricsConsumer = sink
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err = gz.Write(msgpackMapWithHugeArrayField("Stats"))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v0.2/stats", bytes.NewReader(buf.Bytes()))
+	req.Header.Set("Content-Encoding", "gzip")
+	resp := httptest.NewRecorder()
+
+	dd.(*datadogReceiver).handleStatsV2(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Empty(t, sink.AllMetrics())
 }
 
 func TestDatadogServices_EndToEnd(t *testing.T) {


### PR DESCRIPTION
Validates Datadog MessagePack payload structure and length headers before generated decoders handle stats and trace msgpack endpoints.