### PR TITLE
[receiver/jaeger] Limit thrift collection sizes

### DIFF
--- a/.chloggen/jaeger-thrift-limits.yaml
+++ b/.chloggen/jaeger-thrift-limits.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/jaeger
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject oversized thrift collection headers before decoding Jaeger thrift payloads.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48481]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/jaegerreceiver/internal/thriftlimit/protocol.go
+++ b/receiver/jaegerreceiver/internal/thriftlimit/protocol.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package thriftlimit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+const maxCollectionElements = 1 << 20 // Allocation guard for untrusted thrift collection counts.
+
+type protocol struct {
+	thrift.TProtocol
+}
+
+type protocolFactory struct {
+	delegate thrift.TProtocolFactory
+}
+
+// NewProtocol wraps delegate with Jaeger-local collection size limits.
+func NewProtocol(delegate thrift.TProtocol) thrift.TProtocol {
+	return &protocol{TProtocol: delegate}
+}
+
+// NewProtocolFactory wraps protocols from delegate with Jaeger-local collection size limits.
+func NewProtocolFactory(delegate thrift.TProtocolFactory) thrift.TProtocolFactory {
+	return &protocolFactory{delegate: delegate}
+}
+
+func (f *protocolFactory) GetProtocol(trans thrift.TTransport) thrift.TProtocol {
+	return NewProtocol(f.delegate.GetProtocol(trans))
+}
+
+func (f *protocolFactory) SetTConfiguration(conf *thrift.TConfiguration) {
+	thrift.PropagateTConfiguration(f.delegate, conf)
+}
+
+func (p *protocol) ReadMapBegin(ctx context.Context) (thrift.TType, thrift.TType, int, error) {
+	keyType, valueType, size, err := p.TProtocol.ReadMapBegin(ctx)
+	if err != nil {
+		return keyType, valueType, size, err
+	}
+	if err := p.checkCollectionSize("map", size); err != nil {
+		return keyType, valueType, size, err
+	}
+	return keyType, valueType, size, nil
+}
+
+func (p *protocol) ReadListBegin(ctx context.Context) (thrift.TType, int, error) {
+	elemType, size, err := p.TProtocol.ReadListBegin(ctx)
+	if err != nil {
+		return elemType, size, err
+	}
+	if err := p.checkCollectionSize("list", size); err != nil {
+		return elemType, size, err
+	}
+	return elemType, size, nil
+}
+
+func (p *protocol) ReadSetBegin(ctx context.Context) (thrift.TType, int, error) {
+	elemType, size, err := p.TProtocol.ReadSetBegin(ctx)
+	if err != nil {
+		return elemType, size, err
+	}
+	if err := p.checkCollectionSize("set", size); err != nil {
+		return elemType, size, err
+	}
+	return elemType, size, nil
+}
+
+func (p *protocol) Skip(ctx context.Context, fieldType thrift.TType) error {
+	return thrift.SkipDefaultDepth(ctx, p, fieldType)
+}
+
+func (p *protocol) SetTConfiguration(conf *thrift.TConfiguration) {
+	thrift.PropagateTConfiguration(p.TProtocol, conf)
+}
+
+func (p *protocol) Reset() {
+	if resetter, ok := p.TProtocol.(interface{ Reset() }); ok {
+		resetter.Reset()
+	}
+}
+
+func (p *protocol) checkCollectionSize(kind string, size int) error {
+	if size < 0 {
+		return thrift.NewTProtocolExceptionWithType(thrift.NEGATIVE_SIZE, fmt.Errorf("thrift %s declares negative size %d", kind, size))
+	}
+	if size > maxCollectionElements {
+		return thrift.NewTProtocolExceptionWithType(thrift.SIZE_LIMIT, fmt.Errorf("thrift %s declares %d elements, limit is %d", kind, size, maxCollectionElements))
+	}
+	if remaining := p.Transport().RemainingBytes(); uint64(size) > remaining {
+		return thrift.NewTProtocolExceptionWithType(thrift.SIZE_LIMIT, fmt.Errorf("thrift %s declares %d elements, only %d payload bytes remain", kind, size, remaining))
+	}
+	return nil
+}
+
+var (
+	_ thrift.TProtocol            = (*protocol)(nil)
+	_ thrift.TProtocolFactory     = (*protocolFactory)(nil)
+	_ thrift.TConfigurationSetter = (*protocol)(nil)
+	_ thrift.TConfigurationSetter = (*protocolFactory)(nil)
+)

--- a/receiver/jaegerreceiver/internal/thriftlimit/protocol.go
+++ b/receiver/jaegerreceiver/internal/thriftlimit/protocol.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package thriftlimit
+package thriftlimit // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver/internal/thriftlimit"
 
 import (
 	"context"

--- a/receiver/jaegerreceiver/internal/thriftlimit/protocol_test.go
+++ b/receiver/jaegerreceiver/internal/thriftlimit/protocol_test.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package thriftlimit
+
+import (
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolRejectsOversizedCollections(t *testing.T) {
+	factories := map[string]thrift.TProtocolFactory{
+		"binary":  thrift.NewTBinaryProtocolFactoryConf(nil),
+		"compact": thrift.NewTCompactProtocolFactoryConf(nil),
+	}
+
+	for factoryName, factory := range factories {
+		for collectionName, collection := range map[string]struct {
+			write func(thrift.TProtocol) error
+			read  func(thrift.TProtocol) error
+		}{
+			"list": {
+				write: func(p thrift.TProtocol) error {
+					return p.WriteListBegin(t.Context(), thrift.STRUCT, maxCollectionElements+1)
+				},
+				read: func(p thrift.TProtocol) error {
+					_, _, err := p.ReadListBegin(t.Context())
+					return err
+				},
+			},
+			"map": {
+				write: func(p thrift.TProtocol) error {
+					return p.WriteMapBegin(t.Context(), thrift.STRING, thrift.STRUCT, maxCollectionElements+1)
+				},
+				read: func(p thrift.TProtocol) error {
+					_, _, _, err := p.ReadMapBegin(t.Context())
+					return err
+				},
+			},
+			"set": {
+				write: func(p thrift.TProtocol) error {
+					return p.WriteSetBegin(t.Context(), thrift.STRUCT, maxCollectionElements+1)
+				},
+				read: func(p thrift.TProtocol) error {
+					_, _, err := p.ReadSetBegin(t.Context())
+					return err
+				},
+			},
+		} {
+			t.Run(factoryName+"/"+collectionName, func(t *testing.T) {
+				trans := thrift.NewTMemoryBuffer()
+				require.NoError(t, collection.write(factory.GetProtocol(trans)))
+
+				err := collection.read(NewProtocolFactory(factory).GetProtocol(trans))
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "declares 1048577 elements")
+			})
+		}
+	}
+}
+
+func TestProtocolRejectsCollectionLargerThanRemainingPayload(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	require.NoError(t, thrift.NewTBinaryProtocolTransport(trans).WriteListBegin(t.Context(), thrift.STRUCT, 1))
+
+	_, _, err := NewProtocol(thrift.NewTBinaryProtocolTransport(trans)).ReadListBegin(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only 0 payload bytes remain")
+}

--- a/receiver/jaegerreceiver/internal/thriftlimit/protocol_test.go
+++ b/receiver/jaegerreceiver/internal/thriftlimit/protocol_test.go
@@ -64,9 +64,9 @@ func TestProtocolRejectsOversizedCollections(t *testing.T) {
 
 func TestProtocolRejectsCollectionLargerThanRemainingPayload(t *testing.T) {
 	trans := thrift.NewTMemoryBuffer()
-	require.NoError(t, thrift.NewTBinaryProtocolTransport(trans).WriteListBegin(t.Context(), thrift.STRUCT, 1))
+	require.NoError(t, thrift.NewTBinaryProtocolConf(trans, &thrift.TConfiguration{}).WriteListBegin(t.Context(), thrift.STRUCT, 1))
 
-	_, _, err := NewProtocol(thrift.NewTBinaryProtocolTransport(trans)).ReadListBegin(t.Context())
+	_, _, err := NewProtocol(thrift.NewTBinaryProtocolConf(trans, &thrift.TConfiguration{})).ReadListBegin(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only 0 payload bytes remain")
 }

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc"
 
 	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver/internal/thriftlimit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver/internal/udpserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver/internal/udpserver/thriftudp"
 )
@@ -259,7 +260,7 @@ func (jr *jReceiver) buildProcessor(address string, cfg ServerConfigUDP, factory
 		}
 	}
 	server := udpserver.NewUDPServer(transport, cfg.QueueSize, cfg.MaxPacketSize)
-	processor, err := udpserver.NewThriftProcessor(server, cfg.Workers, factory, handler, jr.settings.Logger)
+	processor, err := udpserver.NewThriftProcessor(server, cfg.Workers, thriftlimit.NewProtocolFactory(factory), handler, jr.settings.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -291,6 +292,7 @@ func (*jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *httpErr
 	}
 
 	tdes := apacheThrift.NewTDeserializer()
+	tdes.Protocol = thriftlimit.NewProtocol(tdes.Protocol)
 	batch := &jaeger.Batch{}
 	if err = tdes.Read(r.Context(), batch, bodyBytes); err != nil {
 		return nil, &httpError{

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -75,6 +75,23 @@ func TestThriftHTTPBodyDecode(t *testing.T) {
 	assert.Equal(t, batch, gotBatch)
 }
 
+func TestThriftHTTPBodyDecodeRejectsOversizedSpansList(t *testing.T) {
+	var body bytes.Buffer
+	body.WriteByte(byte(thrift.LIST))
+	require.NoError(t, binary.Write(&body, binary.BigEndian, int16(2)))
+	body.WriteByte(byte(thrift.STRUCT))
+	require.NoError(t, binary.Write(&body, binary.BigEndian, int32(1<<20+1)))
+
+	r := httptest.NewRequest(http.MethodPost, "/api/traces", bytes.NewReader(body.Bytes()))
+	r.Header.Add("content-type", "application/x-thrift")
+
+	jr := jReceiver{}
+	_, hErr := jr.decodeThriftHTTPBody(r)
+	require.NotNil(t, hErr)
+	assert.Equal(t, http.StatusBadRequest, hErr.statusCode)
+	assert.Contains(t, hErr.msg, "thrift list declares 1048577 elements")
+}
+
 func TestReception(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	// 1. Create the Jaeger receiver aka "server"


### PR DESCRIPTION
Wraps Jaeger Thrift protocols for HTTP and UDP so oversized list/map/set counts are rejected before generated readers allocate.