### PR TITLE
[receiver/zipkin] Limit thrift collection sizes

### DIFF
--- a/.chloggen/zipkin-thrift-limits.yaml
+++ b/.chloggen/zipkin-thrift-limits.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/zipkin
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject oversized thrift collection headers before decoding Zipkin thrift payloads.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48485]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/translator/zipkin/zipkinthriftconverter/deserialize.go
+++ b/pkg/translator/zipkin/zipkinthriftconverter/deserialize.go
@@ -33,10 +33,10 @@ func SerializeThrift(ctx context.Context, spans []*zipkincore.Span) ([]byte, err
 
 // DeserializeThrift decodes Thrift bytes to a list of spans.
 func DeserializeThrift(ctx context.Context, b []byte) ([]*zipkincore.Span, error) {
-	buffer := thrift.NewTMemoryBuffer()
-	buffer.Write(b)
+	buffer := thrift.NewTMemoryBufferLen(len(b))
+	_, _ = buffer.Write(b)
 
-	transport := thrift.NewTBinaryProtocolConf(buffer, &thrift.TConfiguration{})
+	transport := newSizeLimitedBinaryProtocol(buffer)
 	_, size, err := transport.ReadListBegin(ctx) // Ignore the returned element type
 	if err != nil {
 		return nil, err

--- a/pkg/translator/zipkin/zipkinthriftconverter/deserialize_test.go
+++ b/pkg/translator/zipkin/zipkinthriftconverter/deserialize_test.go
@@ -6,11 +6,15 @@
 package zipkin
 
 import (
+	"encoding/binary"
 	"testing"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jaegertracing/jaeger-idl/thrift-gen/zipkincore"
 	"github.com/stretchr/testify/require"
 )
+
+const oversizedCollectionSize = 1_000_000
 
 func TestDeserializeWithBadListStart(t *testing.T) {
 	ctx := t.Context()
@@ -35,4 +39,50 @@ func TestDeserialize(t *testing.T) {
 	require.NoError(t, err)
 	_, err = DeserializeThrift(ctx, spanBytes)
 	require.NoError(t, err)
+}
+
+func TestDeserializeRejectsOversizedCollectionHeaders(t *testing.T) {
+	tests := map[string][]byte{
+		"top level list":          thriftListBegin(thrift.STRUCT, oversizedCollectionSize),
+		"span annotations list":   thriftSpanWithField(thrift.LIST, 6, thriftListBegin(thrift.STRUCT, oversizedCollectionSize)),
+		"unknown map field skip":  thriftSpanWithField(thrift.MAP, 99, thriftMapBegin(thrift.BOOL, thrift.BOOL, oversizedCollectionSize)),
+		"unknown set field skip":  thriftSpanWithField(thrift.SET, 99, thriftSetBegin(thrift.BOOL, oversizedCollectionSize)),
+		"binary annotations list": thriftSpanWithField(thrift.LIST, 8, thriftListBegin(thrift.STRUCT, oversizedCollectionSize)),
+	}
+
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := DeserializeThrift(t.Context(), payload)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "payload bytes remain")
+		})
+	}
+}
+
+func TestDeserializeRejectsCollectionHeadersOverLimit(t *testing.T) {
+	_, err := DeserializeThrift(t.Context(), thriftListBegin(thrift.STRUCT, maxThriftCollectionElements+1))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "limit is 1048576")
+}
+
+func thriftSpanWithField(fieldType thrift.TType, fieldID int16, fieldPayload []byte) []byte {
+	payload := thriftListBegin(thrift.STRUCT, 1)
+	payload = append(payload, byte(fieldType))
+	payload = binary.BigEndian.AppendUint16(payload, uint16(fieldID))
+	payload = append(payload, fieldPayload...)
+	return payload
+}
+
+func thriftListBegin(elemType thrift.TType, size int32) []byte {
+	payload := []byte{byte(elemType)}
+	return binary.BigEndian.AppendUint32(payload, uint32(size))
+}
+
+func thriftMapBegin(keyType, valueType thrift.TType, size int32) []byte {
+	payload := []byte{byte(keyType), byte(valueType)}
+	return binary.BigEndian.AppendUint32(payload, uint32(size))
+}
+
+func thriftSetBegin(elemType thrift.TType, size int32) []byte {
+	return thriftListBegin(elemType, size)
 }

--- a/pkg/translator/zipkin/zipkinthriftconverter/thriftlimit.go
+++ b/pkg/translator/zipkin/zipkinthriftconverter/thriftlimit.go
@@ -30,7 +30,8 @@ func (p *sizeLimitedProtocol) ReadMapBegin(ctx context.Context) (thrift.TType, t
 	if err != nil {
 		return keyType, valueType, size, err
 	}
-	if err := p.checkCollectionSize("map", size, 2); err != nil {
+	err = p.checkCollectionSize("map", size, 2)
+	if err != nil {
 		return keyType, valueType, size, err
 	}
 	return keyType, valueType, size, nil
@@ -41,7 +42,8 @@ func (p *sizeLimitedProtocol) ReadListBegin(ctx context.Context) (thrift.TType, 
 	if err != nil {
 		return elemType, size, err
 	}
-	if err := p.checkCollectionSize("list", size, 1); err != nil {
+	err = p.checkCollectionSize("list", size, 1)
+	if err != nil {
 		return elemType, size, err
 	}
 	return elemType, size, nil
@@ -52,7 +54,8 @@ func (p *sizeLimitedProtocol) ReadSetBegin(ctx context.Context) (thrift.TType, i
 	if err != nil {
 		return elemType, size, err
 	}
-	if err := p.checkCollectionSize("set", size, 1); err != nil {
+	err = p.checkCollectionSize("set", size, 1)
+	if err != nil {
 		return elemType, size, err
 	}
 	return elemType, size, nil

--- a/pkg/translator/zipkin/zipkinthriftconverter/thriftlimit.go
+++ b/pkg/translator/zipkin/zipkinthriftconverter/thriftlimit.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zipkin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+const maxThriftCollectionElements = 1 << 20
+
+// sizeLimitedProtocol rejects forged collection sizes before generated thrift readers preallocate slices.
+type sizeLimitedProtocol struct {
+	thrift.TProtocol
+}
+
+func newSizeLimitedBinaryProtocol(buffer *thrift.TMemoryBuffer) thrift.TProtocol {
+	return newSizeLimitedProtocol(thrift.NewTBinaryProtocolConf(buffer, &thrift.TConfiguration{}))
+}
+
+func newSizeLimitedProtocol(delegate thrift.TProtocol) thrift.TProtocol {
+	return &sizeLimitedProtocol{TProtocol: delegate}
+}
+
+func (p *sizeLimitedProtocol) ReadMapBegin(ctx context.Context) (thrift.TType, thrift.TType, int, error) {
+	keyType, valueType, size, err := p.TProtocol.ReadMapBegin(ctx)
+	if err != nil {
+		return keyType, valueType, size, err
+	}
+	if err := p.checkCollectionSize("map", size, 2); err != nil {
+		return keyType, valueType, size, err
+	}
+	return keyType, valueType, size, nil
+}
+
+func (p *sizeLimitedProtocol) ReadListBegin(ctx context.Context) (thrift.TType, int, error) {
+	elemType, size, err := p.TProtocol.ReadListBegin(ctx)
+	if err != nil {
+		return elemType, size, err
+	}
+	if err := p.checkCollectionSize("list", size, 1); err != nil {
+		return elemType, size, err
+	}
+	return elemType, size, nil
+}
+
+func (p *sizeLimitedProtocol) ReadSetBegin(ctx context.Context) (thrift.TType, int, error) {
+	elemType, size, err := p.TProtocol.ReadSetBegin(ctx)
+	if err != nil {
+		return elemType, size, err
+	}
+	if err := p.checkCollectionSize("set", size, 1); err != nil {
+		return elemType, size, err
+	}
+	return elemType, size, nil
+}
+
+func (p *sizeLimitedProtocol) Skip(ctx context.Context, fieldType thrift.TType) error {
+	return thrift.SkipDefaultDepth(ctx, p, fieldType)
+}
+
+func (p *sizeLimitedProtocol) SetTConfiguration(conf *thrift.TConfiguration) {
+	thrift.PropagateTConfiguration(p.TProtocol, conf)
+}
+
+func (p *sizeLimitedProtocol) Reset() {
+	if resetter, ok := p.TProtocol.(interface{ Reset() }); ok {
+		resetter.Reset()
+	}
+}
+
+func (p *sizeLimitedProtocol) checkCollectionSize(kind string, size, minElementBytes int) error {
+	if size < 0 {
+		return thrift.NewTProtocolExceptionWithType(thrift.NEGATIVE_SIZE, fmt.Errorf("thrift %s declares negative size %d", kind, size))
+	}
+	if size > maxThriftCollectionElements {
+		return thrift.NewTProtocolExceptionWithType(thrift.SIZE_LIMIT, fmt.Errorf("thrift %s declares %d elements, limit is %d", kind, size, maxThriftCollectionElements))
+	}
+	if size == 0 {
+		return nil
+	}
+	if minElementBytes <= 0 {
+		minElementBytes = 1
+	}
+	if remaining := p.Transport().RemainingBytes(); uint64(size)*uint64(minElementBytes) > remaining {
+		return thrift.NewTProtocolExceptionWithType(thrift.SIZE_LIMIT, fmt.Errorf("thrift %s declares %d elements, only %d payload bytes remain", kind, size, remaining))
+	}
+	return nil
+}
+
+var (
+	_ thrift.TProtocol            = (*sizeLimitedProtocol)(nil)
+	_ thrift.TConfigurationSetter = (*sizeLimitedProtocol)(nil)
+)

--- a/pkg/translator/zipkin/zipkinthriftconverter/thriftlimit.go
+++ b/pkg/translator/zipkin/zipkinthriftconverter/thriftlimit.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package zipkin
+package zipkin // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinthriftconverter"
 
 import (
 	"context"

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkin
 go 1.25.0
 
 require (
+	github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58
 	github.com/jaegertracing/jaeger-idl v0.7.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.152.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.152.0
@@ -29,7 +30,6 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jaegertracing/jaeger-idl/thrift-gen/zipkincore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -275,6 +277,31 @@ func TestReceiverInvalidContentType(t *testing.T) {
 
 	require.Equal(t, 400, req.Code)
 	require.Equal(t, "invalid character 'i' looking for beginning of object key string\n", req.Body.String())
+}
+
+func TestReceiverRejectsOversizedThriftList(t *testing.T) {
+	body := []byte{byte(thrift.STRUCT)}
+	body = binary.BigEndian.AppendUint32(body, 1<<20+1)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/spans", bytes.NewBuffer(body))
+	r.Header.Add("content-type", "application/x-thrift")
+
+	cfg := &Config{
+		ServerConfig: confighttp.ServerConfig{
+			NetAddr: confignet.AddrConfig{
+				Transport: "tcp",
+				Endpoint:  "",
+			},
+		},
+	}
+	zr, err := newReceiver(cfg, consumertest.NewNop(), receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, err)
+
+	req := httptest.NewRecorder()
+	zr.ServeHTTP(req, r)
+
+	require.Equal(t, http.StatusBadRequest, req.Code)
+	assert.Contains(t, req.Body.String(), "thrift list declares 1048577 elements")
 }
 
 func TestReceiverConsumerError(t *testing.T) {


### PR DESCRIPTION
Wraps Zipkin v1 Thrift decoding so oversized collection counts are rejected before generated readers allocate.