### PR TITLE
[receiver/libhoney] Validate msgpack payload sizes

### DIFF
--- a/.chloggen/libhoney-msgpack-limits.yaml
+++ b/.chloggen/libhoney-msgpack-limits.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/libhoney
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject oversized MessagePack headers before decoding Libhoney payloads.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48486]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/libhoneyreceiver/internal/codec/codec.go
+++ b/receiver/libhoneyreceiver/internal/codec/codec.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/eventtime"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/libhoneyevent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/msgpackvalidator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/response"
 )
 
@@ -83,6 +84,9 @@ func DecodeEvents(contentType string, body []byte, headers http.Header) ([]libho
 
 // decodeMsgpack decodes msgpack-encoded libhoney events
 func decodeMsgpack(body []byte, headers http.Header) ([]libhoneyevent.LibhoneyEvent, error) {
+	if err := msgpackvalidator.Validate(body); err != nil {
+		return nil, fmt.Errorf("invalid msgpack: %w", err)
+	}
 	if isSingleMsgpackObject(body) {
 		return decodeSingleMsgpackEvent(body, headers)
 	}

--- a/receiver/libhoneyreceiver/internal/codec/codec_test.go
+++ b/receiver/libhoneyreceiver/internal/codec/codec_test.go
@@ -173,6 +173,49 @@ func TestDecodeEvents_Msgpack(t *testing.T) {
 	}
 }
 
+func TestDecodeEvents_MsgpackRejectsForgedLengthHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    string
+	}{
+		{
+			name:    "array length",
+			payload: []byte{0xdd, 0xff, 0xff, 0xff, 0xff},
+			want:    "array length",
+		},
+		{
+			name:    "map length",
+			payload: []byte{0xdf, 0xff, 0xff, 0xff, 0xff},
+			want:    "map length",
+		},
+		{
+			name:    "string length",
+			payload: []byte{0xdb, 0xff, 0xff, 0xff, 0xff},
+			want:    "string length",
+		},
+		{
+			name:    "binary length",
+			payload: []byte{0xc6, 0xff, 0xff, 0xff, 0xff},
+			want:    "bin length",
+		},
+		{
+			name:    "extension length",
+			payload: []byte{0xc9, 0xff, 0xff, 0xff, 0xff, 0},
+			want:    "extension length",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeEvents("application/msgpack", tt.payload, http.Header{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid msgpack")
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
 func TestDecodeEvents_UnsupportedContentType(t *testing.T) {
 	_, err := DecodeEvents("application/xml", []byte("<xml/>"), http.Header{})
 	require.Error(t, err)

--- a/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent.go
+++ b/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/eventtime"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/msgpackvalidator"
 )
 
 // FieldMapConfig is used to map the fields from the LibhoneyEvent to PData formats
@@ -91,6 +92,10 @@ func (l *LibhoneyEvent) UnmarshalJSON(j []byte) error {
 
 // UnmarshalMsgpack overrides the unmarshall to make sure the MsgPackTimestamp is set
 func (l *LibhoneyEvent) UnmarshalMsgpack(data []byte) error {
+	if err := msgpackvalidator.Validate(data); err != nil {
+		return fmt.Errorf("invalid msgpack: %w", err)
+	}
+
 	type _libhoneyEvent LibhoneyEvent
 	tstr := eventtime.GetEventTimeDefaultString()
 	tzero := time.Time{}

--- a/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent_test.go
+++ b/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent_test.go
@@ -1105,3 +1105,17 @@ func TestLibhoneyEvent_UnmarshalMsgpack(t *testing.T) {
 		})
 	}
 }
+
+func TestLibhoneyEvent_UnmarshalMsgpackRejectsForgedLengthHeader(t *testing.T) {
+	payload := []byte{
+		0x81,
+		0xa4, 'd', 'a', 't', 'a',
+		0xdf, 0xff, 0xff, 0xff, 0xff,
+	}
+
+	var event LibhoneyEvent
+	err := event.UnmarshalMsgpack(payload)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid msgpack")
+	assert.Contains(t, err.Error(), "map length")
+}

--- a/receiver/libhoneyreceiver/internal/msgpackvalidator/validator.go
+++ b/receiver/libhoneyreceiver/internal/msgpackvalidator/validator.go
@@ -14,7 +14,6 @@ const (
 	// bound allocations that would otherwise be driven only by msgpack headers.
 	maxMsgpackContainerElements = 1 << 20
 	maxMsgpackBinStringLen      = 20 * 1024 * 1024
-	maxMsgpackExtLen            = maxMsgpackBinStringLen
 	maxMsgpackDepth             = 64
 )
 
@@ -55,7 +54,7 @@ func (s *msgpackScanner) validateValue(depth int) error {
 	case c >= 0x90 && c <= 0x9f:
 		return s.validateArray(uint64(c&0x0f), depth)
 	case c >= 0xa0 && c <= 0xbf:
-		return s.validateBytes("string", uint64(c&0x1f), maxMsgpackBinStringLen)
+		return s.validateBytes("string", uint64(c&0x1f))
 	}
 
 	switch c {
@@ -68,19 +67,19 @@ func (s *msgpackScanner) validateValue(depth int) error {
 		if err != nil {
 			return err
 		}
-		return s.validateBytes("bin", n, maxMsgpackBinStringLen)
+		return s.validateBytes("bin", n)
 	case 0xc5:
 		n, err := s.readUint16()
 		if err != nil {
 			return err
 		}
-		return s.validateBytes("bin", n, maxMsgpackBinStringLen)
+		return s.validateBytes("bin", n)
 	case 0xc6:
 		n, err := s.readUint32()
 		if err != nil {
 			return err
 		}
-		return s.validateBytes("bin", n, maxMsgpackBinStringLen)
+		return s.validateBytes("bin", n)
 	case 0xc7:
 		n, err := s.readUint8()
 		if err != nil {
@@ -122,19 +121,19 @@ func (s *msgpackScanner) validateValue(depth int) error {
 		if err != nil {
 			return err
 		}
-		return s.validateBytes("string", n, maxMsgpackBinStringLen)
+		return s.validateBytes("string", n)
 	case 0xda:
 		n, err := s.readUint16()
 		if err != nil {
 			return err
 		}
-		return s.validateBytes("string", n, maxMsgpackBinStringLen)
+		return s.validateBytes("string", n)
 	case 0xdb:
 		n, err := s.readUint32()
 		if err != nil {
 			return err
 		}
-		return s.validateBytes("string", n, maxMsgpackBinStringLen)
+		return s.validateBytes("string", n)
 	case 0xdc:
 		n, err := s.readUint16()
 		if err != nil {
@@ -201,9 +200,9 @@ func validateElementCount(kind string, size uint64, remaining, objectsPerElement
 	return nil
 }
 
-func (s *msgpackScanner) validateBytes(kind string, size, limit uint64) error {
-	if size > limit {
-		return fmt.Errorf("msgpack %s length %d exceeds limit %d", kind, size, limit)
+func (s *msgpackScanner) validateBytes(kind string, size uint64) error {
+	if size > maxMsgpackBinStringLen {
+		return fmt.Errorf("msgpack %s length %d exceeds limit %d", kind, size, maxMsgpackBinStringLen)
 	}
 	if size > uint64(s.remaining()) {
 		return fmt.Errorf("msgpack %s length %d exceeds remaining payload size %d", kind, size, s.remaining())
@@ -215,7 +214,7 @@ func (s *msgpackScanner) validateExt(size uint64) error {
 	if _, err := s.readByte(); err != nil {
 		return err
 	}
-	return s.validateBytes("extension", size, maxMsgpackExtLen)
+	return s.validateBytes("extension", size)
 }
 
 func (s *msgpackScanner) readByte() (byte, error) {

--- a/receiver/libhoneyreceiver/internal/msgpackvalidator/validator.go
+++ b/receiver/libhoneyreceiver/internal/msgpackvalidator/validator.go
@@ -1,0 +1,266 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package msgpackvalidator
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+const (
+	// These caps are intentionally above normal libhoney payload sizes; they
+	// bound allocations that would otherwise be driven only by msgpack headers.
+	maxMsgpackContainerElements = 1 << 20
+	maxMsgpackBinStringLen      = 20 * 1024 * 1024
+	maxMsgpackExtLen            = maxMsgpackBinStringLen
+	maxMsgpackDepth             = 64
+)
+
+var errShortBytes = errors.New("msgpack: short bytes")
+
+// Validate walks a single MessagePack object without materializing it.
+func Validate(b []byte) error {
+	scanner := msgpackScanner{b: b}
+	if err := scanner.validateValue(0); err != nil {
+		return err
+	}
+	if scanner.remaining() != 0 {
+		return fmt.Errorf("msgpack has %d trailing bytes", scanner.remaining())
+	}
+	return nil
+}
+
+type msgpackScanner struct {
+	b   []byte
+	off int
+}
+
+func (s *msgpackScanner) validateValue(depth int) error {
+	if depth > maxMsgpackDepth {
+		return fmt.Errorf("msgpack nesting exceeds depth limit %d", maxMsgpackDepth)
+	}
+
+	c, err := s.readByte()
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case c <= 0x7f || c >= 0xe0:
+		return nil
+	case c >= 0x80 && c <= 0x8f:
+		return s.validateMap(uint64(c&0x0f), depth)
+	case c >= 0x90 && c <= 0x9f:
+		return s.validateArray(uint64(c&0x0f), depth)
+	case c >= 0xa0 && c <= 0xbf:
+		return s.validateBytes("string", uint64(c&0x1f), maxMsgpackBinStringLen)
+	}
+
+	switch c {
+	case 0xc0, 0xc2, 0xc3:
+		return nil
+	case 0xc1:
+		return fmt.Errorf("msgpack: unknown code 0x%x", c)
+	case 0xc4:
+		n, err := s.readUint8()
+		if err != nil {
+			return err
+		}
+		return s.validateBytes("bin", n, maxMsgpackBinStringLen)
+	case 0xc5:
+		n, err := s.readUint16()
+		if err != nil {
+			return err
+		}
+		return s.validateBytes("bin", n, maxMsgpackBinStringLen)
+	case 0xc6:
+		n, err := s.readUint32()
+		if err != nil {
+			return err
+		}
+		return s.validateBytes("bin", n, maxMsgpackBinStringLen)
+	case 0xc7:
+		n, err := s.readUint8()
+		if err != nil {
+			return err
+		}
+		return s.validateExt(n)
+	case 0xc8:
+		n, err := s.readUint16()
+		if err != nil {
+			return err
+		}
+		return s.validateExt(n)
+	case 0xc9:
+		n, err := s.readUint32()
+		if err != nil {
+			return err
+		}
+		return s.validateExt(n)
+	case 0xca, 0xce, 0xd2:
+		return s.skip(4)
+	case 0xcb, 0xcf, 0xd3:
+		return s.skip(8)
+	case 0xcc, 0xd0:
+		return s.skip(1)
+	case 0xcd, 0xd1:
+		return s.skip(2)
+	case 0xd4:
+		return s.validateExt(1)
+	case 0xd5:
+		return s.validateExt(2)
+	case 0xd6:
+		return s.validateExt(4)
+	case 0xd7:
+		return s.validateExt(8)
+	case 0xd8:
+		return s.validateExt(16)
+	case 0xd9:
+		n, err := s.readUint8()
+		if err != nil {
+			return err
+		}
+		return s.validateBytes("string", n, maxMsgpackBinStringLen)
+	case 0xda:
+		n, err := s.readUint16()
+		if err != nil {
+			return err
+		}
+		return s.validateBytes("string", n, maxMsgpackBinStringLen)
+	case 0xdb:
+		n, err := s.readUint32()
+		if err != nil {
+			return err
+		}
+		return s.validateBytes("string", n, maxMsgpackBinStringLen)
+	case 0xdc:
+		n, err := s.readUint16()
+		if err != nil {
+			return err
+		}
+		return s.validateArray(n, depth)
+	case 0xdd:
+		n, err := s.readUint32()
+		if err != nil {
+			return err
+		}
+		return s.validateArray(n, depth)
+	case 0xde:
+		n, err := s.readUint16()
+		if err != nil {
+			return err
+		}
+		return s.validateMap(n, depth)
+	case 0xdf:
+		n, err := s.readUint32()
+		if err != nil {
+			return err
+		}
+		return s.validateMap(n, depth)
+	default:
+		return fmt.Errorf("msgpack: unknown code 0x%x", c)
+	}
+}
+
+func (s *msgpackScanner) validateArray(size uint64, depth int) error {
+	if err := validateElementCount("array", size, s.remaining(), 1); err != nil {
+		return err
+	}
+	for range size {
+		if err := s.validateValue(depth + 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *msgpackScanner) validateMap(size uint64, depth int) error {
+	if err := validateElementCount("map", size, s.remaining(), 2); err != nil {
+		return err
+	}
+	for range size {
+		if err := s.validateValue(depth + 1); err != nil {
+			return err
+		}
+		if err := s.validateValue(depth + 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateElementCount(kind string, size uint64, remaining, objectsPerElement int) error {
+	if size > maxMsgpackContainerElements {
+		return fmt.Errorf("msgpack %s length %d exceeds limit %d", kind, size, maxMsgpackContainerElements)
+	}
+	if size > uint64(remaining)/uint64(objectsPerElement) {
+		return fmt.Errorf("msgpack %s length %d exceeds remaining payload size %d", kind, size, remaining)
+	}
+	return nil
+}
+
+func (s *msgpackScanner) validateBytes(kind string, size uint64, limit uint64) error {
+	if size > limit {
+		return fmt.Errorf("msgpack %s length %d exceeds limit %d", kind, size, limit)
+	}
+	if size > uint64(s.remaining()) {
+		return fmt.Errorf("msgpack %s length %d exceeds remaining payload size %d", kind, size, s.remaining())
+	}
+	return s.skip(size)
+}
+
+func (s *msgpackScanner) validateExt(size uint64) error {
+	if _, err := s.readByte(); err != nil {
+		return err
+	}
+	return s.validateBytes("extension", size, maxMsgpackExtLen)
+}
+
+func (s *msgpackScanner) readByte() (byte, error) {
+	if s.remaining() < 1 {
+		return 0, errShortBytes
+	}
+	c := s.b[s.off]
+	s.off++
+	return c, nil
+}
+
+func (s *msgpackScanner) readUint8() (uint64, error) {
+	c, err := s.readByte()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(c), nil
+}
+
+func (s *msgpackScanner) readUint16() (uint64, error) {
+	if s.remaining() < 2 {
+		return 0, errShortBytes
+	}
+	n := binary.BigEndian.Uint16(s.b[s.off : s.off+2])
+	s.off += 2
+	return uint64(n), nil
+}
+
+func (s *msgpackScanner) readUint32() (uint64, error) {
+	if s.remaining() < 4 {
+		return 0, errShortBytes
+	}
+	n := binary.BigEndian.Uint32(s.b[s.off : s.off+4])
+	s.off += 4
+	return uint64(n), nil
+}
+
+func (s *msgpackScanner) skip(n uint64) error {
+	if n > uint64(s.remaining()) {
+		return errShortBytes
+	}
+	s.off += int(n)
+	return nil
+}
+
+func (s *msgpackScanner) remaining() int {
+	return len(s.b) - s.off
+}

--- a/receiver/libhoneyreceiver/internal/msgpackvalidator/validator.go
+++ b/receiver/libhoneyreceiver/internal/msgpackvalidator/validator.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package msgpackvalidator
+package msgpackvalidator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/msgpackvalidator"
 
 import (
 	"encoding/binary"
@@ -201,7 +201,7 @@ func validateElementCount(kind string, size uint64, remaining, objectsPerElement
 	return nil
 }
 
-func (s *msgpackScanner) validateBytes(kind string, size uint64, limit uint64) error {
+func (s *msgpackScanner) validateBytes(kind string, size, limit uint64) error {
 	if size > limit {
 		return fmt.Errorf("msgpack %s length %d exceeds limit %d", kind, size, limit)
 	}

--- a/receiver/libhoneyreceiver/internal/msgpackvalidator/validator_test.go
+++ b/receiver/libhoneyreceiver/internal/msgpackvalidator/validator_test.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package msgpackvalidator
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestValidateAcceptsBoundedPayload(t *testing.T) {
+	payload := []byte{
+		0x81,
+		0xa4, 'd', 'a', 't', 'a',
+		0x81,
+		0xa2, 'o', 'k',
+		0xc3,
+	}
+
+	if err := Validate(payload); err != nil {
+		t.Fatalf("Validate() returned unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsForgedLengthHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    string
+	}{
+		{
+			name:    "array length over limit",
+			payload: appendLength32Header(0xdd, maxMsgpackContainerElements+1),
+			want:    "array length",
+		},
+		{
+			name:    "array length exceeds payload",
+			payload: []byte{0x93},
+			want:    "remaining payload",
+		},
+		{
+			name:    "map length over limit",
+			payload: appendLength32Header(0xdf, maxMsgpackContainerElements+1),
+			want:    "map length",
+		},
+		{
+			name:    "string length over limit",
+			payload: appendLength32Header(0xdb, maxMsgpackBinStringLen+1),
+			want:    "string length",
+		},
+		{
+			name:    "binary length over limit",
+			payload: appendLength32Header(0xc6, maxMsgpackBinStringLen+1),
+			want:    "bin length",
+		},
+		{
+			name:    "extension length over limit",
+			payload: append(appendLength32Header(0xc9, maxMsgpackExtLen+1), 0),
+			want:    "extension length",
+		},
+		{
+			name:    "trailing bytes",
+			payload: []byte{0xc0, 0xc0},
+			want:    "trailing bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.payload)
+			if err == nil {
+				t.Fatal("Validate() returned nil error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func appendLength32Header(prefix byte, size uint64) []byte {
+	var sizeBytes [4]byte
+	binary.BigEndian.PutUint32(sizeBytes[:], uint32(size))
+	return append([]byte{prefix}, sizeBytes[:]...)
+}

--- a/receiver/libhoneyreceiver/internal/msgpackvalidator/validator_test.go
+++ b/receiver/libhoneyreceiver/internal/msgpackvalidator/validator_test.go
@@ -56,7 +56,7 @@ func TestValidateRejectsForgedLengthHeaders(t *testing.T) {
 		},
 		{
 			name:    "extension length over limit",
-			payload: append(appendLength32Header(0xc9, maxMsgpackExtLen+1), 0),
+			payload: append(appendLength32Header(0xc9, maxMsgpackBinStringLen+1), 0),
 			want:    "extension length",
 		},
 		{


### PR DESCRIPTION
Validates Libhoney MessagePack payload structure and length headers before msgpack decoders handle HTTP ingestion.