### PR TITLE
[exporter/elasticsearch] avoid logging context cancelled errors

### DIFF
--- a/.chloggen/esexporter-bulkindexer.yaml
+++ b/.chloggen/esexporter-bulkindexer.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid logging bulk indexer errors if context is cancelled
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48511]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Index failures and bulk indexer errors include a lot of details that are not useful when the error is just context canceled.
+  These verbose logs take up space and make the real errors harder to spot. 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -329,7 +329,9 @@ func flushBulkIndexer(
 		}
 	}
 	if err != nil {
-		logger.Error("bulk indexer flush error", append(fields, zap.Error(err))...)
+		if !errors.Is(err, context.Canceled) {
+			logger.Error("bulk indexer flush error", append(fields, zap.Error(err))...)
+		}
 		var bulkFailedErr docappender.ErrorFlushFailed
 		switch {
 		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
@@ -410,7 +412,9 @@ func flushBulkIndexer(
 				fields = append(fields, zap.String("hint", hint))
 			}
 		}
-		logger.Error("failed to index document", fields...)
+		if !errors.Is(err, context.Canceled) {
+			logger.Error("failed to index document", fields...)
+		}
 
 		if resp.Input != "" {
 			fields = append(fields, zap.String("input", resp.Input))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Avoid logging error if it is `context cancelled`. It takes up a lot of space and bloat the error logs, making it difficult to spot actual errors.
