### PR TITLE
[chore][extension/datadogextension] exclude in AIX cross-compile build

### DIFF
--- a/extension/datadogextension/internal/httpserver/helpers_test.go
+++ b/extension/datadogextension/internal/httpserver/helpers_test.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package httpserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
 
 import (

--- a/extension/datadogextension/internal/httpserver/httpserver.go
+++ b/extension/datadogextension/internal/httpserver/httpserver.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package httpserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
 
 import (

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package httpserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
 
 import (

--- a/extension/datadogextension/internal/metrics/metrics.go
+++ b/extension/datadogextension/internal/metrics/metrics.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/metrics"
 
 import (

--- a/extension/datadogextension/internal/metrics/metrics_test.go
+++ b/extension/datadogextension/internal/metrics/metrics_test.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package metrics
 
 import (


### PR DESCRIPTION
## Description

The `exp-cross-compile-affected (aix, ppc64)` CI job has been failing with:

```
Building extension/datadogextension for aix/ppc64
# github.com/DataDog/datadog-agent/comp/core/config
.../params.go:66:22: undefined: DefaultConfPath
.../params.go:74:22: undefined: DefaultConfPath
.../params.go:87:22: undefined: DefaultConfPath
```

The parent `extension/datadogextension` package already excludes AIX via a stub `factory_aix.go` (because `github.com/DataDog/datadog-agent/comp/core/config` is not supported on AIX — `DefaultConfPath` is only defined on linux, darwin, freebsd, netbsd, openbsd, solaris, dragonfly, and windows).

However, two internal sub-packages, `internal/httpserver` and `internal/metrics`, transitively pull in `comp/core/config` and lacked the `//go:build !aix` constraint, so `go build ./...` in scoped cross-compile CI still tried to build them and failed.

This change adds `//go:build !aix` to the affected files, matching the existing pattern in the parent package.

## Link to tracking issue

N/A — CI infrastructure fix.

## Testing

Reproduced the failure locally and confirmed the fix:

```sh
cd extension/datadogextension
GOOS=aix GOARCH=ppc64 go build ./...   # now passes
go build ./... && go vet ./...         # linux build/vet still clean
go test -run='^$' ./...                # tests still compile
```