### PR TITLE
[pkg/datadog,exporter/datadog] Propagate tls.insecure_skip_verify to …

### DIFF
--- a/.chloggen/datadogexporter-propagate-tls-skip-for-logs.yaml
+++ b/.chloggen/datadogexporter-propagate-tls-skip-for-logs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Honor tls.insecure_skip_verify for logs flowing through datadogexporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48523]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/datadogexporter/logs_exporter.go
+++ b/exporter/datadogexporter/logs_exporter.go
@@ -47,6 +47,7 @@ func newLogsAgentExporter(
 		agentcomponents.WithLogsConfig(cfg),
 		agentcomponents.WithLogsDefaults(),
 		agentcomponents.WithProxy(cfg),
+		agentcomponents.WithTLSSetting(cfg),
 	)
 	hostnameComponent := logs.NewHostnameService(sourceProvider)
 	logsAgentConfig := &logsagentexporter.Config{

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -238,6 +238,13 @@ func WithProxy(cfg *datadogconfig.Config) ConfigOption {
 	}
 }
 
+// WithTLSSetting propagates tls.insecure_skip_verify into the DD-agent forwarder's TLS config
+func WithTLSSetting(cfg *datadogconfig.Config) ConfigOption {
+	return func(pkgconfig pkgconfigmodel.Config) {
+		setTLSSetting(cfg, pkgconfig)
+	}
+}
+
 // WithCustomConfig allows setting arbitrary configuration values
 func WithCustomConfig(key string, value any, source pkgconfigmodel.Source) ConfigOption {
 	return func(pkgconfig pkgconfigmodel.Config) {
@@ -268,6 +275,13 @@ func setProxy(cfg *datadogconfig.Config, pkgconfig pkgconfigmodel.Config) {
 		noProxy = append(noProxy, v)
 	}
 	pkgconfig.Set("proxy.no_proxy", noProxy, pkgconfigmodel.SourceEnvVar)
+}
+
+func setTLSSetting(cfg *datadogconfig.Config, pkgconfig pkgconfigmodel.Config) {
+	if cfg.TLS.InsecureSkipVerify {
+		pkgconfig.Set("skip_ssl_validation", cfg.TLS.InsecureSkipVerify, pkgconfigmodel.SourceFile)
+	}
+	pkgconfig.Set("apm_config.skip_ssl_validation", cfg.TLS.InsecureSkipVerify, pkgconfigmodel.SourceFile)
 }
 
 // newForwarderComponent creates a new forwarder that sends payloads to Datadog backend

--- a/pkg/datadog/agentcomponents/agentcomponents_test.go
+++ b/pkg/datadog/agentcomponents/agentcomponents_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -444,6 +445,33 @@ func TestWithProxy(t *testing.T) {
 			// Verify NO_PROXY setting
 			noProxySlice := config.Get("proxy.no_proxy")
 			assert.Equal(t, tt.expectedNoProxy, noProxySlice)
+		})
+	}
+}
+
+func TestWithTLSSetting(t *testing.T) {
+	tests := []struct {
+		name               string
+		insecureSkipVerify bool
+	}{
+		{name: "insecure_skip_verify true", insecureSkipVerify: true},
+		{name: "insecure_skip_verify false", insecureSkipVerify: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &datadogconfig.Config{
+				ClientConfig: confighttp.ClientConfig{
+					TLS: configtls.ClientConfig{InsecureSkipVerify: tt.insecureSkipVerify},
+				},
+			}
+
+			configComponent := NewConfigComponent(WithTLSSetting(cfg))
+			require.NotNil(t, configComponent)
+			config := configComponent.(pkgconfigmodel.Config)
+
+			assert.Equal(t, tt.insecureSkipVerify, config.GetBool("skip_ssl_validation"))
+			assert.Equal(t, tt.insecureSkipVerify, config.GetBool("apm_config.skip_ssl_validation"))
 		})
 	}
 }


### PR DESCRIPTION
Respect `tls.insecure_skip_verify` for logs in datadogexporter by passing it to the underlying agent config (mirroring  what's done for DDOT's exporter). Allows us to use the logs exporter with a proxy that intercepts TLS.

More context on https://datadoghq.atlassian.net/browse/OTEL-3050