### PR TITLE
[processor/transform] Add limit_buckets method to merge_histogram_buckets

### DIFF
--- a/.chloggen/48527-limit-histogram-buckets.yaml
+++ b/.chloggen/48527-limit-histogram-buckets.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: processor/transform
+note: Add the `limit_buckets` method to the `merge_histogram_buckets` OTTL function to reduce explicit histogram bucket counts.
+issues: [48527]
+change_logs: [user]

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -661,20 +661,24 @@ To aggregate only using a specified set of attributes, you can use `keep_matchin
 
 ### merge_histogram_buckets
 
-`merge_histogram_buckets(bound)`
+`merge_histogram_buckets(target_value, method)`
 
-The `merge_histogram_buckets` function merges a specific bucket of a histogram with the next bucket by removing the specified boundary. This effectively combines the counts of the bucket ending at the specified bound with the counts of the next bucket.
+The `merge_histogram_buckets` function merges explicit histogram buckets. The `method` argument is optional and defaults to `remove_explicit_bound`.
 
-`bound` is a float64 value that specifies which bucket boundary to remove. The function will merge the bucket that ends at this boundary with the next bucket.
+`target_value` is interpreted according to `method`:
+- `remove_explicit_bound`: `target_value` is the explicit boundary to remove. The function merges the bucket ending at this boundary with the next bucket. This method uses floating-point tolerance (epsilon = 1e-12) when matching the boundary.
+- `limit_buckets`: `target_value` is the maximum number of buckets to keep. It must be a positive integer. The function reduces resolution in uniform compaction passes until the histogram has no more than `target_value` buckets. In each pass, it merges adjacent bucket pairs from lower to higher bucket order, combines their counts, and keeps an unpaired final bucket unchanged. Bucket count values and boundary widths do not affect which buckets are merged. Because each pass roughly halves the number of buckets, the resulting histogram may have fewer than `target_value` buckets.
 
 The function:
-- Preserves the total count and sum of the histogram.  
-- Only works on histogram metrics (no-op for other metric types).  
-- Uses floating-point tolerance (epsilon = 1e-12) when matching the bound.  
-- Makes no changes if:  
-  - The bound is not found.  
-  - The histogram is empty.  
-  - The histogram structure is invalid (mismatched bounds and counts).
+- Preserves the total count and sum of the histogram.
+- Only works on histogram metrics (no-op for other metric types).
+- Makes no changes if:
+  - The explicit boundary is not found when using `remove_explicit_bound`.
+  - The histogram is already at or below the requested bucket limit when using `limit_buckets`.
+  - The histogram is empty.
+  - The histogram structure is invalid (mismatched bounds and counts, or unordered bounds when using `limit_buckets`).
+
+**NOTE:** The `limit_buckets` method reduces histogram resolution and may affect percentile or quantile accuracy. Use only when you are confident that reducing bucket detail is acceptable for downstream consumers.
 
 Examples:
 
@@ -689,6 +693,17 @@ Examples:
 # After merging at 0.5:
 # bounds: [0.1, 1.0]
 # counts: [5, 11, 1]
+
+# Limit histograms to at most 5 buckets
+- merge_histogram_buckets(5, method="limit_buckets") where metric.name == "http_request_duration"
+
+# Given a histogram with:
+# bounds: [0.1, 0.2, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0]
+# counts: [80, 4, 6, 120, 3, 2, 40, 10, 1]
+#
+# After limiting to 5 buckets, one compaction pass merges bucket pairs:
+# bounds: [0.2, 1.0, 5.0, 30.0]
+# counts: [84, 126, 5, 50, 1]
 ```
 
 ### set_semconv_span_name

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets.go
@@ -6,16 +6,24 @@ package metrics // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 )
 
+const (
+	mergeHistogramBucketsMethodRemoveExplicitBound = "remove_explicit_bound"
+	mergeHistogramBucketsMethodLimitBuckets        = "limit_buckets"
+)
+
 type mergeHistogramBucketsArguments struct {
-	Bound float64
+	TargetValue ottl.FloatLikeGetter[*ottldatapoint.TransformContext]
+	Method      ottl.Optional[string]
 }
 
 func newMergeHistogramBucketsFactory() ottl.Factory[*ottldatapoint.TransformContext] {
@@ -28,27 +36,79 @@ func createMergeHistogramBucketsFunction(_ ottl.FunctionContext, oArgs ottl.Argu
 		return nil, errors.New("mergeHistogramBucketsFactory args must be of type *mergeHistogramBucketsArguments")
 	}
 
-	return mergeHistogramBuckets(args.Bound)
+	return mergeHistogramBuckets(args.TargetValue, args.Method)
 }
 
-func mergeHistogramBuckets(bound float64) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
-	return func(_ context.Context, tCtx *ottldatapoint.TransformContext) (any, error) {
-		dataPoint := tCtx.GetDataPoint()
-		if dataPoint == nil {
-			return nil, nil
-		}
+func mergeHistogramBuckets(targetValue ottl.FloatLikeGetter[*ottldatapoint.TransformContext], method ottl.Optional[string]) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
+	methodValue := method.GetOr(mergeHistogramBucketsMethodRemoveExplicitBound)
+	if methodValue != mergeHistogramBucketsMethodRemoveExplicitBound && methodValue != mergeHistogramBucketsMethodLimitBuckets {
+		return nil, fmt.Errorf("unsupported method %q, expected %q or %q", methodValue, mergeHistogramBucketsMethodRemoveExplicitBound, mergeHistogramBucketsMethodLimitBuckets)
+	}
 
-		histogramDataPoint, ok := dataPoint.(pmetric.HistogramDataPoint)
+	var literalTarget *float64
+	var literalMaxBuckets *int64
+	if target, ok := ottl.GetLiteralValue(targetValue); ok {
+		if target == nil {
+			return nil, errors.New("target_value must not be nil")
+		}
+		literalTarget = target
+
+		if methodValue == mergeHistogramBucketsMethodLimitBuckets {
+			maxBuckets, err := maxBucketsFromTargetValue(*target)
+			if err != nil {
+				return nil, err
+			}
+			literalMaxBuckets = &maxBuckets
+		}
+	}
+
+	return func(ctx context.Context, tCtx *ottldatapoint.TransformContext) (any, error) {
+		histogramDataPoint, ok := histogramDataPointFromContext(tCtx)
 		if !ok {
 			return nil, nil
 		}
 
-		mergeHistogramBucketsFromDataPoint(histogramDataPoint, bound)
+		target := literalTarget
+		if target == nil {
+			var err error
+			target, err = targetValue.Get(ctx, tCtx)
+			if err != nil {
+				return nil, err
+			}
+			if target == nil {
+				return nil, errors.New("target_value must not be nil")
+			}
+		}
+
+		switch methodValue {
+		case mergeHistogramBucketsMethodRemoveExplicitBound:
+			mergeHistogramBucketsByExplicitBoundFromDataPoint(histogramDataPoint, *target)
+		case mergeHistogramBucketsMethodLimitBuckets:
+			maxBuckets := literalMaxBuckets
+			if maxBuckets == nil {
+				dynamicMaxBuckets, err := maxBucketsFromTargetValue(*target)
+				if err != nil {
+					return nil, err
+				}
+				maxBuckets = &dynamicMaxBuckets
+			}
+			limitHistogramBucketsFromDataPoint(histogramDataPoint, *maxBuckets)
+		}
 		return nil, nil
 	}, nil
 }
 
-func mergeHistogramBucketsFromDataPoint(dp pmetric.HistogramDataPoint, bound float64) {
+func histogramDataPointFromContext(tCtx *ottldatapoint.TransformContext) (pmetric.HistogramDataPoint, bool) {
+	dataPoint := tCtx.GetDataPoint()
+	if dataPoint == nil {
+		return pmetric.HistogramDataPoint{}, false
+	}
+
+	histogramDataPoint, ok := dataPoint.(pmetric.HistogramDataPoint)
+	return histogramDataPoint, ok
+}
+
+func mergeHistogramBucketsByExplicitBoundFromDataPoint(dp pmetric.HistogramDataPoint, bound float64) {
 	explicitBounds := dp.ExplicitBounds()
 	bucketCounts := dp.BucketCounts()
 
@@ -81,6 +141,64 @@ func mergeHistogramBucketsFromDataPoint(dp pmetric.HistogramDataPoint, bound flo
 
 	explicitBounds.FromRaw(newBounds)
 	bucketCounts.FromRaw(newCounts)
+}
+
+func maxBucketsFromTargetValue(targetValue float64) (int64, error) {
+	if targetValue < 1 || math.Trunc(targetValue) != targetValue || targetValue > float64(math.MaxInt64) {
+		return 0, fmt.Errorf("target_value must be a positive integer when method is %q, got %v", mergeHistogramBucketsMethodLimitBuckets, targetValue)
+	}
+	return int64(targetValue), nil
+}
+
+func limitHistogramBucketsFromDataPoint(dp pmetric.HistogramDataPoint, maxBuckets int64) {
+	explicitBounds := dp.ExplicitBounds()
+	bucketCounts := dp.BucketCounts()
+
+	if explicitBounds.Len()+1 != bucketCounts.Len() {
+		return
+	}
+
+	if int64(bucketCounts.Len()) <= maxBuckets || bucketCounts.Len() <= 1 {
+		return
+	}
+
+	if !strictlyIncreasing(explicitBounds) {
+		return
+	}
+
+	for int64(bucketCounts.Len()) > maxBuckets {
+		compactHistogramBuckets(explicitBounds, bucketCounts)
+	}
+}
+
+func compactHistogramBuckets(bounds pcommon.Float64Slice, counts pcommon.UInt64Slice) {
+	compactCounts := pcommon.NewUInt64Slice()
+	compactCounts.EnsureCapacity((counts.Len() + 1) / 2)
+	for i := 0; i < counts.Len(); i += 2 {
+		if i+1 == counts.Len() {
+			compactCounts.Append(counts.At(i))
+			continue
+		}
+		compactCounts.Append(counts.At(i) + counts.At(i+1))
+	}
+
+	compactBounds := pcommon.NewFloat64Slice()
+	compactBounds.EnsureCapacity(compactCounts.Len() - 1)
+	for i := 1; i < bounds.Len(); i += 2 {
+		compactBounds.Append(bounds.At(i))
+	}
+
+	compactBounds.MoveTo(bounds)
+	compactCounts.MoveTo(counts)
+}
+
+func strictlyIncreasing(bounds pcommon.Float64Slice) bool {
+	for i := 1; i < bounds.Len(); i++ {
+		if !(bounds.At(i) > bounds.At(i-1)) {
+			return false
+		}
+	}
+	return true
 }
 
 // findBoundIndex finds the index of a target bound in the bounds slice with epsilon tolerance

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
@@ -4,6 +4,7 @@
 package metrics
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,12 +24,14 @@ func TestMergeHistogramBuckets(t *testing.T) {
 		inputCounts    []uint64
 		inputCount     uint64
 		inputSum       float64
-		bound          float64
+		targetValue    any
+		method         ottl.Optional[string]
 		expectedBounds []float64
 		expectedCounts []uint64
 
-		expectNoChange bool
-		expectError    bool
+		expectNoChange     bool
+		expectError        bool
+		expectProcessError bool
 	}{
 		{
 			name:           "drop middle bucket by bound (0.5)",
@@ -36,7 +39,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{5, 8, 3, 1},
 			inputCount:     17,
 			inputSum:       25.5,
-			bound:          0.5,
+			targetValue:    0.5,
 			expectedBounds: []float64{0.1, 1.0},
 			expectedCounts: []uint64{5, 11, 1},
 		},
@@ -46,7 +49,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{5, 8, 3, 1},
 			inputCount:     17,
 			inputSum:       25.5,
-			bound:          0.1,
+			targetValue:    0.1,
 			expectedBounds: []float64{0.5, 1.0},
 			expectedCounts: []uint64{13, 3, 1},
 		},
@@ -56,7 +59,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{5, 8, 3, 1},
 			inputCount:     17,
 			inputSum:       25.5,
-			bound:          1.0,
+			targetValue:    1.0,
 			expectedBounds: []float64{0.1, 0.5},
 			expectedCounts: []uint64{5, 8, 4},
 		},
@@ -66,7 +69,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{10, 5},
 			inputCount:     15,
 			inputSum:       20.0,
-			bound:          0.5,
+			targetValue:    0.5,
 			expectedBounds: nil,
 			expectedCounts: []uint64{15},
 		},
@@ -76,7 +79,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{1, 2, 3, 4, 0},
 			inputCount:     10,
 			inputSum:       10,
-			bound:          3,
+			targetValue:    3.0,
 			expectedBounds: []float64{1, 2, 4},
 			expectedCounts: []uint64{1, 2, 7, 0},
 		},
@@ -86,7 +89,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{5, 8, 3, 1},
 			inputCount:     17,
 			inputSum:       25.5,
-			bound:          2.0,
+			targetValue:    2.0,
 			expectedBounds: []float64{0.1, 0.5, 1.0},
 			expectedCounts: []uint64{5, 8, 3, 1},
 
@@ -98,7 +101,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{5, 8, 3, 1, 2},
 			inputCount:     19,
 			inputSum:       25.5,
-			bound:          0.5,
+			targetValue:    0.5,
 			expectedBounds: []float64{0.1, 0.5},
 			expectedCounts: []uint64{5, 8, 3, 1, 2},
 
@@ -110,7 +113,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{0},
 			inputCount:     0,
 			inputSum:       0.0,
-			bound:          0.5,
+			targetValue:    0.5,
 			expectedBounds: nil,
 			expectedCounts: []uint64{0},
 
@@ -122,15 +125,82 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			inputCounts:    []uint64{5, 8, 3, 1},
 			inputCount:     17,
 			inputSum:       25.5,
-			bound:          0.5,
+			targetValue:    0.5,
 			expectedBounds: []float64{0.1, 1.0},
 			expectedCounts: []uint64{5, 11, 1},
+		},
+		{
+			name:           "limit buckets by uniform compaction",
+			inputBounds:    []float64{0.1, 0.2, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0},
+			inputCounts:    []uint64{80, 4, 6, 120, 3, 2, 40, 10, 1},
+			inputCount:     266,
+			inputSum:       512.5,
+			targetValue:    int64(5),
+			method:         ottl.NewTestingOptional(mergeHistogramBucketsMethodLimitBuckets),
+			expectedBounds: []float64{0.2, 1.0, 5.0, 30.0},
+			expectedCounts: []uint64{84, 126, 5, 50, 1},
+		},
+		{
+			name:           "limit buckets single compaction pass may reduce below limit",
+			inputBounds:    []float64{0.1, 0.5, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			targetValue:    int64(3),
+			method:         ottl.NewTestingOptional(mergeHistogramBucketsMethodLimitBuckets),
+			expectedBounds: []float64{0.5},
+			expectedCounts: []uint64{13, 4},
+		},
+		{
+			name:           "limit buckets collapse to one bucket",
+			inputBounds:    []float64{1, 2},
+			inputCounts:    []uint64{1, 2, 3},
+			inputCount:     6,
+			inputSum:       12,
+			targetValue:    int64(1),
+			method:         ottl.NewTestingOptional(mergeHistogramBucketsMethodLimitBuckets),
+			expectedBounds: nil,
+			expectedCounts: []uint64{6},
+		},
+		{
+			name:           "limit buckets already within limit",
+			inputBounds:    []float64{0.1, 0.5, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			targetValue:    int64(4),
+			method:         ottl.NewTestingOptional(mergeHistogramBucketsMethodLimitBuckets),
+			expectedBounds: []float64{0.1, 0.5, 1.0},
+			expectedCounts: []uint64{5, 8, 3, 1},
+			expectNoChange: true,
+		},
+		{
+			name:           "limit buckets unordered bounds do not change",
+			inputBounds:    []float64{0.5, 0.1, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			targetValue:    int64(2),
+			method:         ottl.NewTestingOptional(mergeHistogramBucketsMethodLimitBuckets),
+			expectedBounds: []float64{0.5, 0.1, 1.0},
+			expectedCounts: []uint64{5, 8, 3, 1},
+			expectNoChange: true,
+		},
+		{
+			name:               "limit buckets rejects fractional target value",
+			inputBounds:        []float64{0.1, 0.5, 1.0},
+			inputCounts:        []uint64{5, 8, 3, 1},
+			inputCount:         17,
+			inputSum:           25.5,
+			targetValue:        2.5,
+			method:             ottl.NewTestingOptional(mergeHistogramBucketsMethodLimitBuckets),
+			expectProcessError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc, err := mergeHistogramBuckets(tt.bound)
+			exprFunc, err := mergeHistogramBuckets(floatLikeGetter(tt.targetValue), tt.method)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -154,6 +224,11 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			defer ctx.Close()
 
 			result, err := exprFunc(t.Context(), ctx)
+
+			if tt.expectProcessError {
+				assert.Error(t, err)
+				return
+			}
 
 			require.NoError(t, err)
 			assert.Nil(t, result)
@@ -197,7 +272,7 @@ func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
 	dp := gauge.DataPoints().AppendEmpty()
 	dp.SetDoubleValue(10.0)
 
-	exprFunc, err := mergeHistogramBuckets(0.5)
+	exprFunc, err := mergeHistogramBuckets(floatLikeGetter(0.5), ottl.Optional[string]{})
 	require.NoError(t, err)
 	assert.NotNil(t, exprFunc)
 
@@ -211,6 +286,12 @@ func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
 	assert.Equal(t, 10.0, dp.DoubleValue())
 }
 
+func TestMergeHistogramBucketsInvalidMethod(t *testing.T) {
+	_, err := mergeHistogramBuckets(floatLikeGetter(0.5), ottl.NewTestingOptional("invalid"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported method "invalid"`)
+}
+
 func TestNewMergeHistogramBucketsFactory(t *testing.T) {
 	factory := newMergeHistogramBucketsFactory()
 	assert.NotNil(t, factory)
@@ -222,4 +303,12 @@ func TestMergeHistogramBucketsFactoryWithInvalidArgs(t *testing.T) {
 	_, err := factory.CreateFunction(ottl.FunctionContext{}, "invalid")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mergeHistogramBucketsFactory args must be of type *mergeHistogramBucketsArguments")
+}
+
+func floatLikeGetter(value any) ottl.FloatLikeGetter[*ottldatapoint.TransformContext] {
+	return ottl.StandardFloatLikeGetter[*ottldatapoint.TransformContext]{
+		Getter: func(context.Context, *ottldatapoint.TransformContext) (any, error) {
+			return value, nil
+		},
+	}
 }

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -1022,6 +1022,57 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 	}
 }
 
+func Test_ProcessMetrics_MergeHistogramBucketsLimitBuckets(t *testing.T) {
+	td := pmetric.NewMetrics()
+	metric := td.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("test_histogram")
+	dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
+	dp.SetCount(17)
+	dp.SetSum(25.5)
+	dp.ExplicitBounds().FromRaw([]float64{0.1, 0.5, 1.0})
+	dp.BucketCounts().FromRaw([]uint64{5, 8, 3, 1})
+
+	processor, err := NewProcessor(
+		[]common.ContextStatements{
+			{
+				Context:    "datapoint",
+				Statements: []string{`merge_histogram_buckets(3, method="limit_buckets") where metric.name == "test_histogram"`},
+			},
+		},
+		ottl.IgnoreError,
+		componenttest.NewNopTelemetrySettings(),
+		DefaultMetricFunctions,
+		DefaultDataPointFunctions,
+	)
+	require.NoError(t, err)
+
+	_, err = processor.ProcessMetrics(t.Context(), td)
+	require.NoError(t, err)
+
+	assert.Equal(t, []float64{0.5}, dp.ExplicitBounds().AsRaw())
+	assert.Equal(t, []uint64{13, 4}, dp.BucketCounts().AsRaw())
+	assert.Equal(t, uint64(17), dp.Count())
+	assert.Equal(t, 25.5, dp.Sum())
+}
+
+func Test_ProcessMetrics_MergeHistogramBucketsLimitBucketsInvalidLiteralTargetValue(t *testing.T) {
+	processor, err := NewProcessor(
+		[]common.ContextStatements{
+			{
+				Context:    "datapoint",
+				Statements: []string{`merge_histogram_buckets(2.5, method="limit_buckets") where metric.name == "test_histogram"`},
+			},
+		},
+		ottl.IgnoreError,
+		componenttest.NewNopTelemetrySettings(),
+		DefaultMetricFunctions,
+		DefaultDataPointFunctions,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `target_value must be a positive integer when method is "limit_buckets"`)
+	assert.Nil(t, processor)
+}
+
 func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 	tests := []struct {
 		statements []string


### PR DESCRIPTION
Extends merge_histogram_buckets with method="limit_buckets" to cap explicit histogram bucket counts while preserving histogram count and sum.

Fixes #48527