### PR TITLE
[receiver/fluentforward] Bound MessagePack allocation sizes

### DIFF
--- a/.chloggen/fluentforward-bound-msgpack-allocation-sizes.yaml
+++ b/.chloggen/fluentforward-bound-msgpack-allocation-sizes.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: receiver/fluent_forward
+note: Bound MessagePack-declared lengths while decoding Fluent Forward events to reject oversized payloads before large allocations.
+issues: [48519]

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -18,7 +18,17 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-const tagAttributeKey = "fluent.tag"
+const (
+	tagAttributeKey = "fluent.tag"
+
+	maxMessagePackElements     = 1_000_000
+	maxMessagePackStringLength = 20 * 1024 * 1024
+	maxForwardEntries          = 100_000
+	maxRecordFields            = 1_024
+	maxOptionFields            = 128
+	maxPackedForwardPayload    = 20 * 1024 * 1024
+	maxTagLength               = maxMessagePackStringLength
+)
 
 // Most of this logic is derived directly from
 // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1,
@@ -48,6 +58,18 @@ type eventMode int
 
 type peeker interface {
 	Peek(n int) ([]byte, error)
+}
+
+func configureMessagePackReader(reader *msgp.Reader) {
+	reader.SetMaxElements(maxMessagePackElements)
+	reader.SetMaxStringLength(maxMessagePackStringLength)
+}
+
+func checkMessagePackLen(name string, got, limit uint32) error {
+	if got > limit {
+		return fmt.Errorf("%s length %d exceeds limit %d: %w", name, got, limit, msgp.ErrLimitExceeded)
+	}
+	return nil
 }
 
 // Values for enum eventMode.
@@ -157,6 +179,9 @@ func parseRecordToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
 	if err != nil {
 		return msgp.WrapError(err, "Record")
 	}
+	if err = checkMessagePackLen("record", recordLen, maxRecordFields); err != nil {
+		return msgp.WrapError(err, "Record")
+	}
 
 	for recordLen > 0 {
 		recordLen--
@@ -234,6 +259,9 @@ func parseOptions(dc *msgp.Reader) (optionsMap, error) {
 	if err != nil {
 		return nil, msgp.WrapError(err, "Option")
 	}
+	if err = checkMessagePackLen("option", optionLen, maxOptionFields); err != nil {
+		return nil, msgp.WrapError(err, "Option")
+	}
 	out := make(optionsMap, optionLen)
 
 	for optionLen > 0 {
@@ -278,6 +306,9 @@ func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 
 	entryLen, err := dc.ReadArrayHeader()
 	if err != nil {
+		return msgp.WrapError(err, "Record")
+	}
+	if err = checkMessagePackLen("entries", entryLen, maxForwardEntries); err != nil {
 		return msgp.WrapError(err, "Record")
 	}
 
@@ -352,19 +383,14 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	var entriesRaw []byte
 	switch entriesType {
 	case msgp.StrType:
-		var entriesStr string
-		entriesStr, err = dc.ReadString()
-		if err != nil {
-			return msgp.WrapError(err, "EntriesRaw")
-		}
-		entriesRaw = []byte(entriesStr)
+		entriesRaw, err = readStringPayload(dc, maxPackedForwardPayload)
 	case msgp.BinType:
-		entriesRaw, err = dc.ReadBytes(nil)
-		if err != nil {
-			return msgp.WrapError(err, "EntriesRaw")
-		}
+		entriesRaw, err = readBytesPayload(dc, maxPackedForwardPayload)
 	default:
 		return msgp.WrapError(fmt.Errorf("invalid type %d", entriesType), "EntriesRaw")
+	}
+	if err != nil {
+		return msgp.WrapError(err, "EntriesRaw")
 	}
 
 	if arrLen == 3 {
@@ -382,6 +408,32 @@ func (pfe *packedForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	return nil
 }
 
+func readStringPayload(dc *msgp.Reader, limit uint32) ([]byte, error) {
+	size, err := dc.ReadStringHeader()
+	if err != nil {
+		return nil, err
+	}
+	if size > limit {
+		return nil, msgp.ErrLimitExceeded
+	}
+	out := make([]byte, size)
+	_, err = dc.ReadFull(out)
+	return out, err
+}
+
+func readBytesPayload(dc *msgp.Reader, limit uint32) ([]byte, error) {
+	size, err := dc.ReadBytesHeader()
+	if err != nil {
+		return nil, err
+	}
+	if size > limit {
+		return nil, msgp.ErrLimitExceeded
+	}
+	out := make([]byte, size)
+	_, err = dc.ReadFull(out)
+	return out, err
+}
+
 func (pfe *packedForwardEventLogRecords) parseEntries(entriesRaw []byte, isGzipped bool, tag string) error {
 	var reader io.Reader
 	reader = bytes.NewReader(entriesRaw)
@@ -396,8 +448,10 @@ func (pfe *packedForwardEventLogRecords) parseEntries(entriesRaw []byte, isGzipp
 	}
 
 	msgpReader := msgp.NewReader(reader)
+	configureMessagePackReader(msgpReader)
 	// Allocate only once, since the MoveTo cleans the lr, so we can reuse.
 	lr := plog.NewLogRecord()
+	entryCount := 0
 	for {
 		err := parseEntryToLogRecord(msgpReader, lr)
 		if err != nil {
@@ -405,6 +459,10 @@ func (pfe *packedForwardEventLogRecords) parseEntries(entriesRaw []byte, isGzipp
 				return nil
 			}
 			return err
+		}
+		entryCount++
+		if entryCount > maxForwardEntries {
+			return checkMessagePackLen("entries", uint32(entryCount), maxForwardEntries)
 		}
 		lr.Attributes().PutStr(tagAttributeKey, tag)
 		lr.MoveTo(pfe.AppendEmpty())

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -133,6 +133,95 @@ func TestTimeFromTimestampBadType(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMessagePackReaderLimits(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 3)
+	b = appendStringHeader(b, maxMessagePackStringLength+1)
+
+	reader := newLimitedMessagePackReader(b)
+	var event messageEventLogRecord
+	err := event.DecodeMsg(reader)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+}
+
+func TestDecodeRejectsOversizedRecordMap(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 3)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendInt(b, 5000)
+	b = msgp.AppendMapHeader(b, maxRecordFields+1)
+
+	reader := newLimitedMessagePackReader(b)
+	var event messageEventLogRecord
+	err := event.DecodeMsg(reader)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+	require.ErrorContains(t, err, "Record")
+}
+
+func TestDecodeRejectsOversizedOptionsMap(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 4)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendInt(b, 5000)
+	b = msgp.AppendMapHeader(b, 0)
+	b = msgp.AppendMapHeader(b, maxOptionFields+1)
+
+	reader := newLimitedMessagePackReader(b)
+	var event messageEventLogRecord
+	err := event.DecodeMsg(reader)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+	require.ErrorContains(t, err, "Option")
+}
+
+func TestForwardDecodeRejectsOversizedEntryCount(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 2)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendArrayHeader(b, maxForwardEntries+1)
+
+	reader := newLimitedMessagePackReader(b)
+	var event forwardEventLogRecords
+	err := event.DecodeMsg(reader)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+	require.ErrorContains(t, err, "Record")
+}
+
+func TestPackedForwardDecodeRejectsOversizedRawPayload(t *testing.T) {
+	tests := []struct {
+		name  string
+		event func() []byte
+	}{
+		{
+			name: "bin",
+			event: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 2)
+				b = msgp.AppendString(b, "my-tag")
+				return msgp.AppendBytesHeader(b, maxPackedForwardPayload+1)
+			},
+		},
+		{
+			name: "str",
+			event: func() []byte {
+				var b []byte
+				b = msgp.AppendArrayHeader(b, 2)
+				b = msgp.AppendString(b, "my-tag")
+				return appendStringHeader(b, maxPackedForwardPayload+1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := newLimitedMessagePackReader(tt.event())
+			var event packedForwardEventLogRecords
+			err := event.DecodeMsg(reader)
+			require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+			require.ErrorContains(t, err, "EntriesRaw")
+		})
+	}
+}
+
 func TestMessageEventConversionWithErrors(t *testing.T) {
 	var b []byte
 
@@ -245,4 +334,23 @@ func TestBodyConversion(t *testing.T) {
 			},
 		},
 	).ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0), le))
+}
+
+func newLimitedMessagePackReader(b []byte) *msgp.Reader {
+	reader := msgp.NewReader(bytes.NewReader(b))
+	configureMessagePackReader(reader)
+	return reader
+}
+
+func appendStringHeader(b []byte, size uint32) []byte {
+	switch {
+	case size <= 31:
+		return append(b, 0xa0|byte(size))
+	case size <= 255:
+		return append(b, 0xd9, byte(size))
+	case size <= 65535:
+		return append(b, 0xda, byte(size>>8), byte(size))
+	default:
+		return append(b, 0xdb, byte(size>>24), byte(size>>16), byte(size>>8), byte(size))
+	}
 }

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -94,6 +94,7 @@ func (s *server) handleConnections(ctx context.Context, listener net.Listener) {
 
 func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 	reader := msgp.NewReaderSize(conn, readBufferSize)
+	configureMessagePackReader(reader)
 
 	for {
 		mode, err := determineNextEventMode(reader.R)
@@ -159,11 +160,12 @@ func determineNextEventMode(peeker peeker) (eventMode, error) {
 	// is the tag string header.
 	tagType := chunk[1]
 	// We already read the first type for the type
-	tagLen := 1
+	tagLen := uint64(1)
+	var tagValueLen uint64
 
 	isFixStr := tagType&0b10100000 == 0b10100000
 	if isFixStr {
-		tagLen += int(tagType & 0b00011111)
+		tagValueLen = uint64(tagType & 0b00011111)
 	} else {
 		switch tagType {
 		case 0xd9:
@@ -171,32 +173,40 @@ func determineNextEventMode(peeker peeker) (eventMode, error) {
 			if err != nil {
 				return unknownMode, err
 			}
-			tagLen += 1 + int(chunk[2])
+			tagLen++
+			tagValueLen = uint64(chunk[2])
 		case 0xda:
 			chunk, err = peeker.Peek(4)
 			if err != nil {
 				return unknownMode, err
 			}
-			tagLen += 2 + int(binary.BigEndian.Uint16(chunk[2:]))
+			tagLen += 2
+			tagValueLen = uint64(binary.BigEndian.Uint16(chunk[2:]))
 		case 0xdb:
 			chunk, err = peeker.Peek(6)
 			if err != nil {
 				return unknownMode, err
 			}
-			tagLen += 4 + int(binary.BigEndian.Uint32(chunk[2:]))
+			tagLen += 4
+			tagValueLen = uint64(binary.BigEndian.Uint32(chunk[2:]))
 		default:
 			return unknownMode, errors.New("malformed tag field")
 		}
 	}
+	if tagValueLen > maxTagLength {
+		return unknownMode, fmt.Errorf("tag length %d exceeds limit %d: %w", tagValueLen, maxTagLength, msgp.ErrLimitExceeded)
+	}
+	tagLen += tagValueLen
+	tagLenInt := int(tagLen)
 
 	// Skip past the first byte (array header) and the entire tag and then get
 	// one byte into the second field -- that is enough to know its type.
-	chunk, err = peeker.Peek(1 + tagLen + 1)
+	chunk, err = peeker.Peek(1 + tagLenInt + 1)
 	if err != nil {
 		return unknownMode, err
 	}
 
-	secondElmType := msgp.NextType(chunk[1+tagLen:])
+	secondElmType := msgp.NextType(chunk[1+tagLenInt:])
 
 	switch secondElmType {
 	case msgp.IntType, msgp.UintType, msgp.ExtensionType:

--- a/receiver/fluentforwardreceiver/server_test.go
+++ b/receiver/fluentforwardreceiver/server_test.go
@@ -114,3 +114,14 @@ func TestDetermineNextEventMode(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineNextEventModeRejectsOversizedTag(t *testing.T) {
+	var b []byte
+	b = msgp.AppendArrayHeader(b, 3)
+	b = appendStringHeader(b, maxTagLength+1)
+
+	peeker := bufio.NewReaderSize(bytes.NewReader(b), 1024)
+	mode, err := determineNextEventMode(peeker)
+	require.Equal(t, unknownMode, mode)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+}


### PR DESCRIPTION
Bounds Fluent Forward MessagePack decoding to reject oversized declared lengths before large allocations.

Fixes #48519