### PR TITLE
[processor/k8sattributes] Deprecate deployment_name_from_replicaset

### DIFF
--- a/.chloggen/48447-k8sattributes-deprecate-deployment-name-from-replicaset.yaml
+++ b/.chloggen/48447-k8sattributes-deprecate-deployment-name-from-replicaset.yaml
@@ -1,0 +1,5 @@
+change_type: deprecation
+component: processor/k8s_attributes
+note: Deprecate `deployment_name_from_replicaset` and default deployment name extraction to the ReplicaSet name heuristic.
+issues: [48447]
+change_logs: [user]

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -69,7 +69,7 @@ The following attributes are added by default:
   - k8s.pod.name
   - k8s.pod.uid
   - k8s.pod.start_time
-  - k8s.deployment.name (requires watching Deployment resources unless `deployment_name_from_replicaset` is enabled. In that case, deployment name is derived from the ReplicaSet using a heuristic.)
+  - k8s.deployment.name (derived from the ReplicaSet name by default. Set the deprecated `deployment_name_from_replicaset` option to `false` to use the ReplicaSet informer for deployment name lookup.)
   - k8s.node.name
 
 These attributes are also available for the use within association rules by default.
@@ -278,9 +278,9 @@ The processor can be configured to set the
 [recommended resource attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/):
 
 - `otel_annotations` will translate `resource.opentelemetry.io/foo` to the `foo` resource attribute, etc.
-- `deployment_name_from_replicaset` allows extracting deployment name from replicaset name by trimming the pod-template-hash suffix. When **true**, the processor avoids watching ReplicaSets for deployment names only (useful with limited RBAC and lower memory). **defaults** to `false`. If `k8s.deployment.uid` is included in the `extract metadata` section, or deployment labels or annotations are being extracted (i.e. any `extract.labels` or `extract.annotations` rule with `from: deployment`), then the Deployment/ReplicaSet infomers are started and this setting is ignored.
+- `deployment_name_from_replicaset` is deprecated and will be removed in future releases. Deployment names are derived from ReplicaSet names by default by trimming the pod-template-hash suffix. Set this option to `false` only to force ReplicaSet informer lookup for deployment names. If `k8s.deployment.uid` is included in the `extract metadata` section, or deployment labels or annotations are being extracted (i.e. any `extract.labels` or `extract.annotations` rule with `from: deployment`), then the Deployment/ReplicaSet informers are started and this setting is ignored.
 
-  **Important:** When `deployment_name_from_replicaset: true` is set, you **must still include** `k8s.deployment.name` (or `service.name`) in the `extract.metadata` section for the deployment name to be extracted. The processor derives the deployment name from the ReplicaSet's naming convention without requiring direct access to Deployment resources, but the extraction rules must be enabled.
+  **Important:** You **must still include** `k8s.deployment.name` (or `service.name`) in the `extract.metadata` section for the deployment name to be extracted. The processor derives the deployment name from the ReplicaSet's naming convention without requiring direct access to Deployment resources, but the extraction rules must be enabled.
 
   Take the following ownerReference of a pod managed by deployment for example:
 
@@ -296,7 +296,7 @@ The processor can be configured to set the
 
 The Extracted deployment name is: `opentelemetry-collector`.
 
-**Note:** When using `deployment_name_from_replicaset: true`, in rare cases where deployment names are between 247 and 253 characters, Kubernetes may truncate the name in the ReplicaSet to fit the pod template hash suffix within the DNS subdomain limit (253 chars), causing the extracted `k8s.deployment.name` to be slightly truncated. If this affects your workloads, you can disable `deployment_name_from_replicaset` or enable the `k8s.deployment.uid` attribute for accurate retrieval from the Kubernetes API, but at an extra cost in memory.
+**Note:** When deployment names are derived from ReplicaSet names, in rare cases where deployment names are between 247 and 253 characters, Kubernetes may truncate the name in the ReplicaSet to fit the pod template hash suffix within the DNS subdomain limit (253 chars), causing the extracted `k8s.deployment.name` to be slightly truncated. If this affects your workloads, you can set `deployment_name_from_replicaset: false` or enable the `k8s.deployment.uid` attribute for accurate retrieval from the Kubernetes API, but at an extra cost in memory.
 
 Also note that for **CronJob names (`k8s.cronjob.name`)** a similar pattern applies, but it uses the **Job** informer (not ReplicaSet) and there is **no** `deployment_name_from_replicaset`-style flag. With only `k8s.cronjob.name` in `extract.metadata`, the processor derives the CronJob name from the Job's name using a heuristic (8-digit time suffix aligned with pod creation time) and does **not** start a Job informer. The Job informer is started when `k8s.cronjob.uid` is enabled, or when labels or annotations are extracted with `from: job`, in which case the CronJob name can be resolved from the API when available. That reduces RBAC needs and memory use when you only need the CronJob name (no `jobs` watch for that attribute alone).
 
@@ -305,7 +305,6 @@ Example:
 ```yaml
   extract:
     otel_annotations: true
-    deployment_name_from_replicaset: true
     metadata:
       - service.namespace
       - service.name
@@ -327,7 +326,7 @@ k8s_attributes:
     metadata:
       - k8s.pod.name
       - k8s.pod.uid
-      - k8s.deployment.name  # Requires watching Deployment resources. To avoid this, use deployment_name_from_replicaset instead.
+      - k8s.deployment.name  # Derived from the ReplicaSet name by default.
       - k8s.namespace.name
       - k8s.node.name
       - k8s.pod.start_time
@@ -469,11 +468,9 @@ processors:
         - k8s.namespace.name
         - k8s.pod.name
         - k8s.pod.uid
-        - k8s.deployment.name  # Required to enable deployment name extraction
-        # Note: deployment_name_from_replicaset extracts the name from the ReplicaSet
-        # without watching Deployment resources, but k8s.deployment.name must still be listed
-      # Use deployment name extraction without watching replicasets
-      deployment_name_from_replicaset: true
+        # Deployment names are derived from ReplicaSet names by default, but
+        # k8s.deployment.name must still be listed to enable extraction.
+        - k8s.deployment.name
 ```
 
 ### Example 5: Multi-Container Pod Support
@@ -507,7 +504,7 @@ processors:
 
 ## Cluster-scoped RBAC
 
-If you'd like to set up the k8sattributesprocessor to receive telemetry from across namespaces, it will need `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, for all namespaces and pods included in the configured filters. Additionally, when using `k8s.deployment.uid`, or when using `k8s.deployment.name` with the default `deployment_name_from_replicaset: false`, or when extracting labels or annotations with `from: deployment`, the processor needs `get`, `watch` and `list` permissions for `replicasets` resources.
+If you'd like to set up the k8sattributesprocessor to receive telemetry from across namespaces, it will need `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, for all namespaces and pods included in the configured filters. Additionally, when using `k8s.deployment.uid`, when using `k8s.deployment.name` with the deprecated `deployment_name_from_replicaset: false`, or when extracting labels or annotations with `from: deployment`, the processor needs `get`, `watch` and `list` permissions for `replicasets` resources.
 
 When using `k8s.node.uid` or extracting metadata from `node`, the processor needs `get`, `watch` and `list` permissions for `nodes` resources.
 
@@ -563,8 +560,7 @@ k8s_attributes:
   filter:
     namespace: <WORKLOAD_NAMESPACE>
 ```
-With the namespace filter set, the processor will only look up pods and replicasets (if `deployment_name_from_replicaset` is not enabled) in the selected namesp
-ace. Note that with just a role binding, the processor cannot query metadata such as labels and annotations from k8s `nodes` and `namespaces` which are cluster-scoped objects. This also means that the processor cannot set the value for `k8s.cluster.uid` attribute if enabled, since the `k8s.cluster.uid` attribute is set to the uid of the namespace `kube-system` which is not queryable with namespaced rbac.
+With the namespace filter set, the processor will only look up pods and replicasets (when ReplicaSet lookup is needed, such as `deployment_name_from_replicaset: false`, `k8s.deployment.uid`, or deployment label/annotation extraction) in the selected namespace. Note that with just a role binding, the processor cannot query metadata such as labels and annotations from k8s `nodes` and `namespaces` which are cluster-scoped objects. This also means that the processor cannot set the value for `k8s.cluster.uid` attribute if enabled, since the `k8s.cluster.uid` attribute is set to the uid of the namespace `kube-system` which is not queryable with namespaced rbac.
 
 Please note, when extracting the workload related attributes, these workloads need to be present in the `Role` with the correct permissions. For example, an extraction of `k8s.deployment.label.*` attributes, `deployments` need to be present in `Role`.
 
@@ -809,11 +805,11 @@ k8s_attributes:
     # Default: false
     otel_annotations: true
     
-    # Extract deployment name from replicaset name (disables replicaset watching)
-    # Reduces memory usage and RBAC requirements
+    # Deprecated. Deployment names are derived from ReplicaSet names by default.
+    # Set to false only to force ReplicaSet informer lookup.
     # See [Configuring recommended resource attributes](#configuring-recommended-resource-attributes) section for more details
-    # Default: false
-    deployment_name_from_replicaset: false
+    # Default: true
+    deployment_name_from_replicaset: true
   
   # Filter configuration - restrict which pods to monitor
   filter:
@@ -904,7 +900,7 @@ k8s_attributes:
 | `annotations` | []FieldExtractConfig | `[]` | Pod/namespace/node annotations to extract |
 | `labels` | []FieldExtractConfig | `[]` | Pod/namespace/node labels to extract |
 | `otel_annotations` | bool | `false` | Extract OpenTelemetry resource attributes from pod annotations with prefix `resource.opentelemetry.io/` |
-| `deployment_name_from_replicaset` | bool | `false` | When `true`, ReplicaSet informer is not run for deployment names only, relying on a heuristic instead.|
+| `deployment_name_from_replicaset` | bool | `true` | Deprecated; will be removed in future releases. When `true`, ReplicaSet informer is not run for deployment names only, relying on a heuristic instead.|
 
 **Default metadata fields:**
 - `k8s.namespace.name`
@@ -1018,7 +1014,7 @@ The processor maintains an in-memory cache of K8s metadata for all pods it monit
 **Optimization strategies:**
 1. **Use node filtering** in agent deployments: `filter.node_from_env_var: KUBE_NODE_NAME`
 2. **Limit metadata extraction**: Only extract fields you need
-3. **Use `deployment_name_from_replicaset: true`**: Reduces memory by not caching replicaset data
+3. **Rely on the default deployment-name heuristic**: Reduces memory by not caching replicaset data
 4. **Filter by namespace**: Limits scope when monitoring specific applications
 5. **Avoid extracting workload metadata** unless necessary (deployment, statefulset, etc.)
 

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -175,8 +175,9 @@ type ExtractConfig struct {
 	// E.g. "resource.opentelemetry.io/foo" becomes "foo"
 	OtelAnnotations bool `mapstructure:"otel_annotations"`
 
-	// DeploymentNameFromReplicaSet allows extracting deployment name from replicaset name by trimming pod template hash.
-	// This will disable watching for replicaset resources.
+	// DeploymentNameFromReplicaSet allows extracting deployment name from ReplicaSet name by trimming pod template hash.
+	//
+	// Deprecated: This option now defaults to true and will be removed in future releases.
 	DeploymentNameFromReplicaSet bool `mapstructure:"deployment_name_from_replicaset"`
 }
 

--- a/processor/k8sattributesprocessor/config.schema.yaml
+++ b/processor/k8sattributesprocessor/config.schema.yaml
@@ -23,7 +23,7 @@ $defs:
         items:
           $ref: field_extract_config
       deployment_name_from_replicaset:
-        description: DeploymentNameFromReplicaSet allows extracting deployment name from replicaset name by trimming pod template hash. This will disable watching for replicaset resources.
+        description: 'DeploymentNameFromReplicaSet allows extracting deployment name from ReplicaSet name by trimming pod template hash. Deprecated: This option now defaults to true and will be removed in future releases.'
         type: boolean
       labels:
         description: Labels allows extracting data from pod labels and record it as resource attributes. It is a list of FieldExtractConfig type. See FieldExtractConfig documentation for more details.

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -31,7 +31,7 @@ func TestLoadConfig(t *testing.T) {
 				Exclude:   ExcludeConfig{Pods: []ExcludePodConfig{{Name: "jaeger-agent"}, {Name: "jaeger-collector"}}},
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				WaitForMetadataTimeout: 10 * time.Second,
 				WatchSyncPeriod:        5 * time.Minute,
@@ -52,7 +52,7 @@ func TestLoadConfig(t *testing.T) {
 						{TagName: "l1", Key: "label1", From: "pod"},
 						{TagName: "l2", Key: "label2", From: kube.MetadataFromPod},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Filter: FilterConfig{
 					Namespace:      "ns2",
@@ -124,7 +124,7 @@ func TestLoadConfig(t *testing.T) {
 						{KeyRegex: "opentel.*", From: kube.MetadataFromPod},
 					},
 					Metadata:                     enabledAttributes(),
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude: ExcludeConfig{
 					Pods: []ExcludePodConfig{
@@ -143,6 +143,19 @@ func TestLoadConfig(t *testing.T) {
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
 					DeploymentNameFromReplicaSet: true,
+				},
+				Exclude:                defaultExcludes,
+				WaitForMetadataTimeout: 10 * time.Second,
+				WatchSyncPeriod:        5 * time.Minute,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "deployment_name_from_replicaset_false"),
+			expected: &Config{
+				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
+				Extract: ExtractConfig{
+					Metadata:                     enabledAttributes(),
+					DeploymentNameFromReplicaSet: false,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -183,7 +196,7 @@ func TestLoadConfig(t *testing.T) {
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
 					OtelAnnotations:              true,
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -196,7 +209,7 @@ func TestLoadConfig(t *testing.T) {
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadata:        true,
@@ -211,7 +224,7 @@ func TestLoadConfig(t *testing.T) {
 				Passthrough: true,
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -224,7 +237,7 @@ func TestLoadConfig(t *testing.T) {
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Filter: FilterConfig{
 					Labels: []FieldFilterConfig{
@@ -242,7 +255,7 @@ func TestLoadConfig(t *testing.T) {
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 				Extract: ExtractConfig{
 					Metadata:                     enabledAttributes(),
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Filter: FilterConfig{
 					Labels: []FieldFilterConfig{
@@ -266,7 +279,7 @@ func TestLoadConfig(t *testing.T) {
 					Annotations: []FieldExtractConfig{
 						{TagName: "ns_annotation", Key: "owner", From: "namespace"},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -282,7 +295,7 @@ func TestLoadConfig(t *testing.T) {
 					Labels: []FieldExtractConfig{
 						{TagName: "node_label", Key: "node-role", From: "node"},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -298,7 +311,7 @@ func TestLoadConfig(t *testing.T) {
 					Labels: []FieldExtractConfig{
 						{TagName: "deployment_label", Key: "app", From: "deployment"},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -314,7 +327,7 @@ func TestLoadConfig(t *testing.T) {
 					Labels: []FieldExtractConfig{
 						{TagName: "statefulset_label", Key: "app", From: "statefulset"},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -330,7 +343,7 @@ func TestLoadConfig(t *testing.T) {
 					Labels: []FieldExtractConfig{
 						{TagName: "daemonset_label", Key: "app", From: "daemonset"},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -346,7 +359,7 @@ func TestLoadConfig(t *testing.T) {
 					Labels: []FieldExtractConfig{
 						{TagName: "job_label", Key: "app", From: "job"},
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -368,7 +381,7 @@ func TestLoadConfig(t *testing.T) {
 						"container.image.repo_digests", "service.namespace", "service.name",
 						"service.version", "service.instance.id", "k8s.cluster.uid",
 					},
-					DeploymentNameFromReplicaSet: false,
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -383,6 +396,7 @@ func TestLoadConfig(t *testing.T) {
 					Metadata: []string{
 						"container.image.tag", "container.image.tags",
 					},
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -397,7 +411,8 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 				Extract: ExtractConfig{
-					Metadata: enabledAttributes(),
+					Metadata:                     enabledAttributes(),
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,
@@ -412,7 +427,8 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 				Extract: ExtractConfig{
-					Metadata: enabledAttributes(),
+					Metadata:                     enabledAttributes(),
+					DeploymentNameFromReplicaSet: true,
 				},
 				Exclude:                defaultExcludes,
 				WaitForMetadataTimeout: 10 * time.Second,

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -47,7 +47,8 @@ func createDefaultConfig() component.Config {
 		APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 		Exclude:   defaultExcludes,
 		Extract: ExtractConfig{
-			Metadata: enabledAttributes(),
+			Metadata:                     enabledAttributes(),
+			DeploymentNameFromReplicaSet: true,
 		},
 		WaitForMetadataTimeout: 10 * time.Second,
 		WatchSyncPeriod:        5 * time.Minute,

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -232,6 +232,9 @@ func withOtelAnnotations(enabled bool) option {
 
 func withDeploymentNameFromReplicaSet(enabled bool) option {
 	return func(p *kubernetesprocessor) error {
+		if !enabled && p.logger != nil {
+			p.logger.Warn("`deployment_name_from_replicaset: false` is deprecated and will be removed in future releases")
+		}
 		p.rules.DeploymentNameFromReplicaSet = enabled
 		return nil
 	}

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -156,6 +156,9 @@ k8s_attributes/bad_filter_label_op:
 k8s_attributes/deployment_name_from_replicaset:
   extract:
     deployment_name_from_replicaset: true
+k8s_attributes/deployment_name_from_replicaset_false:
+  extract:
+    deployment_name_from_replicaset: false
 k8s_attributes/bad_filter_field_op:
   filter:
     fields:


### PR DESCRIPTION
Switches `deployment_name_from_replicaset` to default to true, marks the option deprecated, and keeps `false` as an explicit override for ReplicaSet informer lookup.

Fixes #48447.