### PR TITLE
[chore] remove fatsheep9146 from auto_assign

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -17,7 +17,6 @@ assigneeGroups:
     - crobert-1
     - dashpole
     - dehaansa
-    - fatsheep9146
     - iblancasa
     - jmacd
     - pjanotti


### PR DESCRIPTION
Follow-up of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48051