### PR TITLE
[chore] Fix clickhouse exporter changelog entry

### DIFF
--- a/.chloggen/clickhouse-remove-json-featuregate.yaml
+++ b/.chloggen/clickhouse-remove-json-featuregate.yaml
@@ -4,10 +4,10 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: exporter/clickhouseexporter
+component: exporter/clickhouse
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove deprecated `clickhouse.json` feature gate. Users should set `json: true` in the exporter config directly.
+note: "Remove deprecated `clickhouse.json` feature gate. Users should set `json: true` in the exporter config directly."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [47888]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Looks like changelog validation is failing in contrib main since https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47888 got merged.

For some reason Github Actions decide to skip running `make chlog-validate` on the PR's build and let this one pass: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/26107689962/job/76776011469