### PR TITLE
[chore]: add ci-scope step to build-and-test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,113 @@ jobs:
       - run: make genotelcontribcol
       - name: Check Collector Module Version
         run: ./.github/workflows/scripts/check-collector-module-version.sh
+
+  # Runs compute-ci-scope.sh to classify the PR's change set. Outputs two JSON
+  # matrices that downstream jobs consume directly as their `group` dimension:
+  #   - matrix:        modules + transitive dependents (build/test/checks).
+  #   - direct_matrix: modules whose files actually changed (lint-only). A
+  #                    downstream module's lint result doesn't depend on
+  #                    whether an upstream module's source changed, so lint
+  #                    skips transitive dependents.
+  # In both:
+  #   - full mode: ["receiver-0", "receiver-1", ...] (the named groups)
+  #   - scoped mode: ["receiver/foo receiver/bar", ...] (bucketed module dirs)
+  #   - skip: []
+  # The Makefile's FOR_GROUP_TARGET handling treats both formats correctly.
+  # `mode` is a derived output (skip / full / scoped) used by cross-compile,
+  # which doesn't fit the group-matrix shape.
+  #
+  # Outputs are not yet consumed by any downstream job -- this is preparation
+  # work being merged from build-and-test-experimental incrementally. While
+  # this job runs, real CI behavior is unchanged; subsequent PRs will wire
+  # individual jobs to consume the outputs.
+  ci-scope:
+    runs-on: ubuntu-24.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    outputs:
+      matrix: ${{ steps.post.outputs.matrix }}
+      direct_matrix: ${{ steps.post.outputs.direct_matrix }}
+      mode: ${{ steps.post.outputs.mode }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Compute scope
+        id: scope
+        shell: bash
+        env:
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_CONCURRENCY: 10
+          FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+          # `^` anchors mean these match files at repo root, not in subdirectories,
+          # so a receiver-component Makefile change doesn't trigger the full suite.
+          CRITICAL_FILES: '[
+            "^Makefile",
+            "^Makefile.Common",
+            "^.golangci.yml",
+            "^.github/workflows/",
+            "^.github/actions/",
+            "^internal/tools/",
+            "^versions.yaml",
+            "^cmd/otelcontribcol/"
+          ]'
+          ALL_TEST_GROUPS: '[
+            "receiver-0",
+            "receiver-1",
+            "receiver-2",
+            "receiver-3",
+            "processor-0",
+            "processor-1",
+            "exporter-0",
+            "exporter-1",
+            "exporter-2",
+            "exporter-3",
+            "extension",
+            "connector",
+            "internal",
+            "pkg",
+            "cmd-0",
+            "other"
+          ]'
+        run: ./.github/workflows/scripts/compute-ci-scope.sh
+      - name: Filter matrix and derive mode
+        id: post
+        shell: bash
+        env:
+          RAW_MATRIX: ${{ steps.scope.outputs.matrix }}
+          RAW_DIRECT_MATRIX: ${{ steps.scope.outputs.direct_matrix }}
+        run: |
+          # The script maps top-level files (Makefile, .github/, etc.) to "."
+          # the root module. Strip "." entries from buckets and drop buckets
+          # that become empty -- the Makefile's per-module delegation rules
+          # don't define a target for ".", so `make TARGET GROUP="."` would
+          # fail with "No rule to make target 'for-.-target'". Top-level paths
+          # that should force a full run belong in CRITICAL_FILES instead.
+          filter='[.[] | split(" ") | map(select(. != ".")) | join(" ") | select(. != "")]'
+          matrix=$(echo "$RAW_MATRIX" | jq -c "$filter")
+          direct_matrix=$(echo "$RAW_DIRECT_MATRIX" | jq -c "$filter")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "direct_matrix=$direct_matrix" >> "$GITHUB_OUTPUT"
+
+          # Scoped buckets contain "/" (module paths); full mode emits named
+          # groups like "receiver-0" (no slashes). [] is skip. `mode` is
+          # derived from the transitive matrix -- it drives cross-compile
+          # and gating decisions that need the broader view.
+          if [[ "$matrix" == "[]" ]]; then
+            mode=skip
+          elif [[ "$matrix" == *"/"* ]]; then
+            mode=scoped
+          else
+            mode=full
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Raw matrix:             $RAW_MATRIX"
+          echo "Filtered matrix:        $matrix"
+          echo "Raw direct matrix:      $RAW_DIRECT_MATRIX"
+          echo "Filtered direct matrix: $direct_matrix"
+          echo "Mode:                   $mode"
   lint-matrix:
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,11 +54,6 @@ jobs:
   # The Makefile's FOR_GROUP_TARGET handling treats both formats correctly.
   # `mode` is a derived output (skip / full / scoped) used by cross-compile,
   # which doesn't fit the group-matrix shape.
-  #
-  # Outputs are not yet consumed by any downstream job -- this is preparation
-  # work being merged from build-and-test-experimental incrementally. While
-  # this job runs, real CI behavior is unchanged; subsequent PRs will wire
-  # individual jobs to consume the outputs.
   ci-scope:
     runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
#### Description

This PR starts the integration of the improvements from `build-and-test-experimental` into `build-and-test`. This PR only copies over the `ci-scope` step. In the future, the output of this step scopes down the CI to only files impacted by the PR's changes.

For an example of how ci-scope works, see https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/build-and-test-experimental.yml