### PR TITLE
[pkg/translator/splunk] propagate LogRecord.EventName into Splunk HEC event

### DIFF
--- a/.chloggen/48048-splunkhec-event-name.yaml
+++ b/.chloggen/48048-splunkhec-event-name.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pkg/translator/splunk
+note: Propagate the OTLP log record `EventName` field into the Splunk HEC event under the configured `otel_to_hec_fields/name` key (default `otel.log.name`).
+issues: [48048]
+change_logs: [user]

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -60,7 +60,7 @@ The following configuration options can also be configured:
 - `otel_attrs_to_hec_metadata/host` (default = 'host.name'):  Specifies the mapping of a specific unified model attribute value to the standard host field and the `host.name` field of a HEC event.
 - `otel_to_hec_fields/severity_text` (default = `otel.log.severity.text`): Specifies the name of the field to map the severity text field of log events.
 - `otel_to_hec_fields/severity_number` (default = `otel.log.severity.number`): Specifies the name of the field to map the severity number field of log events.
-- `otel_to_hec_fields/name` (default = `"otel.log.name`): Specifies the name of the field to map the name field of log events.
+- `otel_to_hec_fields/name` (default = `otel.log.name`): Specifies the name of the field to map the [event name](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-eventname) of log events.
 - `heartbeat/interval` (no default): Specifies the interval of sending hec heartbeat to the destination. If not specified, heartbeat is not enabled.
 - `heartbeat/startup` (default: false): Check heartbeat at start up time. This action enforces a synchronous heartbeat action during the collector start up sequence. The collector will fail to start if the heartbeat returns an error.
 - `telemetry/enabled` (default: false): Specifies whether to enable telemetry inside splunk hec exporter.

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -108,6 +108,7 @@ func TestLoadConfig(t *testing.T) {
 				HecFields: translator.OtelToHecFields{
 					SeverityText:   "myseverityfield",
 					SeverityNumber: "myseveritynumfield",
+					Name:           "mynamefield",
 				},
 				HealthPath:            "/services/collector/health",
 				HecHealthCheckEnabled: false,

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -41,6 +41,7 @@ splunk_hec/allsettings:
   otel_to_hec_fields:
     severity_text: "myseverityfield"
     severity_number: "myseveritynumfield"
+    name: "mynamefield"
   heartbeat:
     interval: 30s
   telemetry:

--- a/pkg/translator/splunk/common.go
+++ b/pkg/translator/splunk/common.go
@@ -58,12 +58,15 @@ type OtelToHecFields struct {
 	SeverityText string `mapstructure:"severity_text"`
 	// SeverityNumber informs the exporter to map the severity number field to a specific HEC field.
 	SeverityNumber string `mapstructure:"severity_number"`
+	// Name informs the exporter to map the log record event name field to a specific HEC field.
+	Name string `mapstructure:"name"`
 }
 
 func DefaultOtelToHecFields() OtelToHecFields {
 	return OtelToHecFields{
 		SeverityText:   splunk.DefaultSeverityTextLabel,
 		SeverityNumber: splunk.DefaultSeverityNumberLabel,
+		Name:           splunk.DefaultNameLabel,
 	}
 }
 

--- a/pkg/translator/splunk/config.schema.yaml
+++ b/pkg/translator/splunk/config.schema.yaml
@@ -19,6 +19,9 @@ $defs:
     description: OtelToHecFields defines the mapping of attributes to HEC fields
     type: object
     properties:
+      name:
+        description: Name informs the exporter to map the log record event name field to a specific HEC field.
+        type: string
       severity_number:
         description: SeverityNumber informs the exporter to map the severity number field to a specific HEC field.
         type: string

--- a/pkg/translator/splunk/logs_to_splunk.go
+++ b/pkg/translator/splunk/logs_to_splunk.go
@@ -43,6 +43,9 @@ func LogToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, toOtelAttrs HecTo
 	if lr.SeverityNumber() != plog.SeverityNumberUnspecified {
 		fields[toHecAttrs.SeverityNumber] = lr.SeverityNumber()
 	}
+	if lr.EventName() != "" {
+		fields[toHecAttrs.Name] = lr.EventName()
+	}
 
 	for k, v := range res.Attributes().All() {
 		switch k {

--- a/pkg/translator/splunk/logs_to_splunk_test.go
+++ b/pkg/translator/splunk/logs_to_splunk_test.go
@@ -55,6 +55,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 			logRecordFn: func() plog.LogRecord {
 				logRecord := plog.NewLogRecord()
 				logRecord.Body().SetStr("mylog")
+				logRecord.SetEventName("my.event")
 				logRecord.Attributes().PutStr(splunk.DefaultSourceLabel, "myapp")
 				logRecord.Attributes().PutStr(splunk.DefaultSourceTypeLabel, "myapp-type")
 				logRecord.Attributes().PutStr("host.name", "myhost")
@@ -69,7 +70,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 			sourceType:    "sourcetype",
 			index:         "",
 			wantSplunkEvents: []*Event{
-				commonLogSplunkEvent("mylog", ts, map[string]any{"custom": "custom"},
+				commonLogSplunkEvent("mylog", ts, map[string]any{"custom": "custom", "otel.log.name": "my.event"},
 					"myhost", "myapp", "myapp-type"),
 			},
 		},
@@ -139,6 +140,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 			logRecordFn: func() plog.LogRecord {
 				logRecord := plog.NewLogRecord()
 				logRecord.Body().SetStr("mylog")
+				logRecord.SetEventName("my.event")
 				logRecord.Attributes().PutStr("custom", "custom")
 				logRecord.Attributes().PutStr("mysource", "mysource")
 				logRecord.Attributes().PutStr("mysourcetype", "mysourcetype")
@@ -159,13 +161,14 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 			toHecAttrs: OtelToHecFields{
 				SeverityNumber: "myseveritynum",
 				SeverityText:   "myseverity",
+				Name:           "myname",
 			},
 			source:     "",
 			sourceType: "",
 			index:      "",
 			wantSplunkEvents: []*Event{
 				func() *Event {
-					event := commonLogSplunkEvent("mylog", ts, map[string]any{"custom": "custom", "myseverity": "DEBUG", "myseveritynum": plog.SeverityNumber(5)}, "myhost", "mysource", "mysourcetype")
+					event := commonLogSplunkEvent("mylog", ts, map[string]any{"custom": "custom", "myseverity": "DEBUG", "myseveritynum": plog.SeverityNumber(5), "myname": "my.event"}, "myhost", "mysource", "mysourcetype")
 					event.Index = "myindex"
 					return event
 				}(),


### PR DESCRIPTION
#### Description

The Splunk HEC translator currently drops `LogRecord.EventName` when building the HEC event. The exporter's README already advertises `otel_to_hec_fields/name` (default `otel.log.name`), and `splunk.DefaultNameLabel` is defined in `internal/splunk`, but the `Name` field on `OtelToHecFields` was never added.

This adds the missing `Name` field, defaulting to `otel.log.name`, and emits `LogRecord.EventName()` under it. Mirrors the existing `SeverityText` / `SeverityNumber` pattern in the same function. Records without `EventName` produce identical output.

Also fixes a typo in the README docs (`\"otel.log.name` -> `otel.log.name`) and links to the [OTel logs spec section on EventName](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-eventname).

#### Link to tracking issue
Fixes #48048

#### Testing

- Extended the existing `with_name` and `with_custom_mapping` cases in `pkg/translator/splunk/logs_to_splunk_test.go` to set `EventName` and assert that it lands in `Fields` under the configured key.
- Extended `splunk_hec/allsettings` in `exporter/splunkhecexporter/testdata/config.yaml` and `config_test.go` to exercise a custom `name` mapping end to end.
- `go test ./...` passes in `pkg/translator/splunk` and `exporter/splunkhecexporter`.
- `chloggen validate` passes.
- Regenerated `pkg/translator/splunk/config.schema.yaml` via `cmd/schemagen`.

#### Documentation

- Fixed the typo on the existing README entry for `otel_to_hec_fields/name` and linked the OTel logs spec.
- Changelog entry: `.chloggen/48048-splunkhec-event-name.yaml`.