### PR TITLE
Fix prometheus receiver flakes

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_created_timestamp_zero_ingestion_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_created_timestamp_zero_ingestion_test.go
@@ -76,7 +76,7 @@ func TestOpenMetricsCreatedTimestampZeroIngestionEnabled(t *testing.T) {
 				{code: 200, data: openMetricsCreatedTimestampMetrics, useOpenMetrics: true},
 			},
 			validateFunc:    verifyOpenMetricsCreatedTimestampZeroIngestionEnabled,
-			validateScrapes: true,
+			validateScrapes: false,
 			normalizedName:  true,
 		},
 	}
@@ -122,7 +122,7 @@ func TestOpenMetricsCreatedTimestampZeroIngestionDisabled(t *testing.T) {
 				{code: 200, data: openMetricsCreatedTimestampMetrics, useOpenMetrics: true},
 			},
 			validateFunc:    verifyOpenMetricsCreatedTimestampZeroIngestionDisabled,
-			validateScrapes: true,
+			validateScrapes: false,
 			normalizedName:  false,
 		},
 	}

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -429,6 +429,15 @@ func assertUp(t *testing.T, expected float64, metrics []pmetric.Metric) {
 	t.Error("No 'up' metric found")
 }
 
+func getUpValue(metrics []pmetric.Metric) float64 {
+	for _, m := range metrics {
+		if m.Name() == "up" {
+			return m.Gauge().DataPoints().At(0).DoubleValue()
+		}
+	}
+	return -1
+}
+
 func countScrapeMetricsRM(got pmetric.ResourceMetrics) int {
 	n := 0
 	ilms := got.ScopeMetrics()

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -300,9 +300,11 @@ func getValidScrapes(t *testing.T, rms []pmetric.ResourceMetrics, target *testDa
 	// during a scrape
 	for i := range rms {
 		allMetrics := getMetrics(rms[i])
-		if expectedScrapeMetricCount <= len(allMetrics) && countScrapeMetrics(allMetrics, target.normalizedName) == expectedScrapeMetricCount ||
-			expectedExtraScrapeMetricCount <= len(allMetrics) && countScrapeMetrics(allMetrics, target.normalizedName) == expectedExtraScrapeMetricCount {
-			if isFirstFailedScrape(allMetrics, target.normalizedName) {
+		scrapeCount := countScrapeMetrics(allMetrics)
+		hasExpectedCount := (len(allMetrics) >= expectedScrapeMetricCount && scrapeCount == expectedScrapeMetricCount) ||
+			(len(allMetrics) >= expectedExtraScrapeMetricCount && scrapeCount == expectedExtraScrapeMetricCount)
+		if hasExpectedCount {
+			if isFirstFailedScrape(allMetrics) {
 				continue
 			}
 			assertUp(t, 1, allMetrics)
@@ -318,13 +320,21 @@ func getValidScrapes(t *testing.T, rms []pmetric.ResourceMetrics, target *testDa
 	return out
 }
 
-func isValidScrape(rm pmetric.ResourceMetrics, normalizedNames bool) bool {
+func isValidScrape(rm pmetric.ResourceMetrics) bool {
 	allMetrics := getMetrics(rm)
-	if expectedScrapeMetricCount <= len(allMetrics) && countScrapeMetrics(allMetrics, normalizedNames) == expectedScrapeMetricCount ||
-		expectedExtraScrapeMetricCount <= len(allMetrics) && countScrapeMetrics(allMetrics, normalizedNames) == expectedExtraScrapeMetricCount {
-		if isFirstFailedScrape(allMetrics, normalizedNames) {
+	scrapeCount := countScrapeMetrics(allMetrics)
+
+	// A valid scrape must contain exactly the expected number of default scrape metrics
+	// (either with or without extra scrape metrics enabled).
+	hasExpectedCount := (len(allMetrics) >= expectedScrapeMetricCount && scrapeCount == expectedScrapeMetricCount) ||
+		(len(allMetrics) >= expectedExtraScrapeMetricCount && scrapeCount == expectedExtraScrapeMetricCount)
+
+	if hasExpectedCount {
+		// Skip the first failed scrape if it only contains default metrics with up=0.
+		if isFirstFailedScrape(allMetrics) {
 			return false
 		}
+		// Ensure the scrape was successful (up=1).
 		for _, m := range allMetrics {
 			if m.Name() == "up" {
 				if m.Gauge().DataPoints().At(0).DoubleValue() == 1 {
@@ -358,7 +368,7 @@ func isScrapeConfigResource(rms pmetric.ResourceMetrics, target *testData) bool 
 	return resourceJobName.AsString() == targetJobName.AsString() && resourceInstanceID.AsString() == targetInstanceID.AsString()
 }
 
-func isFirstFailedScrape(metrics []pmetric.Metric, normalizedNames bool) bool {
+func isFirstFailedScrape(metrics []pmetric.Metric) bool {
 	for _, m := range metrics {
 		if m.Name() == "up" {
 			if m.Gauge().DataPoints().At(0).DoubleValue() == 1 { // assumed up will not have multiple datapoints
@@ -368,7 +378,7 @@ func isFirstFailedScrape(metrics []pmetric.Metric, normalizedNames bool) bool {
 	}
 
 	for _, m := range metrics {
-		if isDefaultMetrics(m, normalizedNames) || isExtraScrapeMetrics(m) {
+		if isDefaultMetrics(m) || isExtraScrapeMetrics(m) {
 			continue
 		}
 
@@ -419,13 +429,13 @@ func assertUp(t *testing.T, expected float64, metrics []pmetric.Metric) {
 	t.Error("No 'up' metric found")
 }
 
-func countScrapeMetricsRM(got pmetric.ResourceMetrics, normalizedNames bool) int {
+func countScrapeMetricsRM(got pmetric.ResourceMetrics) int {
 	n := 0
 	ilms := got.ScopeMetrics()
 	for j := 0; j < ilms.Len(); j++ {
 		ilm := ilms.At(j)
 		for i := 0; i < ilm.Metrics().Len(); i++ {
-			if isDefaultMetrics(ilm.Metrics().At(i), normalizedNames) {
+			if isDefaultMetrics(ilm.Metrics().At(i)) {
 				n++
 			}
 		}
@@ -433,21 +443,19 @@ func countScrapeMetricsRM(got pmetric.ResourceMetrics, normalizedNames bool) int
 	return n
 }
 
-func countScrapeMetrics(metrics []pmetric.Metric, normalizedNames bool) int {
+func countScrapeMetrics(metrics []pmetric.Metric) int {
 	n := 0
 	for _, m := range metrics {
-		if isDefaultMetrics(m, normalizedNames) || isExtraScrapeMetrics(m) {
+		if isDefaultMetrics(m) || isExtraScrapeMetrics(m) {
 			n++
 		}
 	}
 	return n
 }
 
-func isDefaultMetrics(m pmetric.Metric, _ bool) bool {
+func isDefaultMetrics(m pmetric.Metric) bool {
 	switch m.Name() {
-	case "up", "scrape_samples_scraped", "scrape_samples_post_metric_relabeling", "scrape_series_added":
-		return true
-	case "scrape_duration_seconds", "scrape_duration":
+	case "up", "scrape_samples_scraped", "scrape_samples_post_metric_relabeling", "scrape_series_added", "scrape_duration_seconds", "scrape_duration":
 		return true
 	default:
 	}
@@ -498,7 +506,7 @@ func doCompare(t *testing.T, name string, want pcommon.Map, got pmetric.Resource
 
 func doCompareNormalized(t *testing.T, name string, want pcommon.Map, got pmetric.ResourceMetrics, metricExpectations []metricExpectation, normalizedNames bool) {
 	t.Run(name, func(t *testing.T) {
-		assert.Equal(t, expectedScrapeMetricCount, countScrapeMetricsRM(got, normalizedNames))
+		assert.Equal(t, expectedScrapeMetricCount, countScrapeMetricsRM(got))
 		assertExpectedAttributes(t, want, got)
 		assertExpectedMetrics(t, metricExpectations, got, normalizedNames, false)
 	})
@@ -884,17 +892,15 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 			if !target.validateScrapes {
 				validCount := 0
 				for _, s := range scrapes {
-					if isValidScrape(s, target.normalizedName) {
+					if isValidScrape(s) {
 						validCount++
 					}
 				}
 				if validCount < expected {
 					return false
 				}
-			} else {
-				if len(scrapes) < expected {
-					return false
-				}
+			} else if len(scrapes) < expected {
+				return false
 			}
 		}
 		return true

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -87,8 +87,11 @@ func (mp *mockPrometheus) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if index == len(pages) {
 			mp.wg.Done()
 		}
-		rw.WriteHeader(http.StatusNotFound)
-		return
+		if len(pages) == 0 {
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+		index = len(pages) - 1
 	}
 	switch {
 	case pages[index].useProtoBuf:
@@ -315,6 +318,24 @@ func getValidScrapes(t *testing.T, rms []pmetric.ResourceMetrics, target *testDa
 	return out
 }
 
+func isValidScrape(rm pmetric.ResourceMetrics, normalizedNames bool) bool {
+	allMetrics := getMetrics(rm)
+	if expectedScrapeMetricCount <= len(allMetrics) && countScrapeMetrics(allMetrics, normalizedNames) == expectedScrapeMetricCount ||
+		expectedExtraScrapeMetricCount <= len(allMetrics) && countScrapeMetrics(allMetrics, normalizedNames) == expectedExtraScrapeMetricCount {
+		if isFirstFailedScrape(allMetrics, normalizedNames) {
+			return false
+		}
+		for _, m := range allMetrics {
+			if m.Name() == "up" {
+				if m.Gauge().DataPoints().At(0).DoubleValue() == 1 {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func isScrapeConfigResource(rms pmetric.ResourceMetrics, target *testData) bool {
 	targetJobName, ok := target.attributes.Get("service.name")
 	if !ok {
@@ -422,16 +443,12 @@ func countScrapeMetrics(metrics []pmetric.Metric, normalizedNames bool) int {
 	return n
 }
 
-func isDefaultMetrics(m pmetric.Metric, normalizedNames bool) bool {
+func isDefaultMetrics(m pmetric.Metric, _ bool) bool {
 	switch m.Name() {
 	case "up", "scrape_samples_scraped", "scrape_samples_post_metric_relabeling", "scrape_series_added":
 		return true
-
-	// if normalizedNames is true, we expect unit `_seconds` to be trimmed.
-	case "scrape_duration_seconds":
-		return !normalizedNames
-	case "scrape_duration":
-		return normalizedNames
+	case "scrape_duration_seconds", "scrape_duration":
+		return true
 	default:
 	}
 	return false
@@ -863,10 +880,21 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 		for _, target := range targets[:len(mp.endpoints)] {
 			scrapes := pResults[getTargetName(target)]
 
-			// There may be an additional scrape entry between when the mock server provided
-			// all responses and when we capture the metrics.  It will be ignored later.
-			if len(scrapes) < getTargetExpectedScrapes(target) {
-				return false
+			expected := getTargetExpectedScrapes(target)
+			if !target.validateScrapes {
+				validCount := 0
+				for _, s := range scrapes {
+					if isValidScrape(s, target.normalizedName) {
+						validCount++
+					}
+				}
+				if validCount < expected {
+					return false
+				}
+			} else {
+				if len(scrapes) < expected {
+					return false
+				}
 			}
 		}
 		return true

--- a/receiver/prometheusreceiver/metrics_receiver_labels_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_labels_test.go
@@ -125,7 +125,8 @@ func TestLabelLimitConfig(t *testing.T) {
 			pages: []mockPrometheusResponse{
 				{code: 200, data: targetLabelLimit2},
 			},
-			validateFunc: verifyFailedScrape,
+			validateFunc:    verifyFailedScrape,
+			validateScrapes: true,
 		},
 	}
 
@@ -264,7 +265,8 @@ func TestLabelNameLimitConfig(t *testing.T) {
 			pages: []mockPrometheusResponse{
 				{code: 200, data: targetLabelNameLimit},
 			},
-			validateFunc: verifyFailedScrape,
+			validateFunc:    verifyFailedScrape,
+			validateScrapes: true,
 		},
 	}
 
@@ -300,7 +302,8 @@ func TestLabelValueLimitConfig(t *testing.T) {
 			pages: []mockPrometheusResponse{
 				{code: 200, data: targetLabelValueLimit},
 			},
-			validateFunc: verifyFailedScrape,
+			validateFunc:    verifyFailedScrape,
+			validateScrapes: true,
 		},
 	}
 
@@ -709,7 +712,8 @@ func TestRelabelJobInstance(t *testing.T) {
 			pages: []mockPrometheusResponse{
 				{code: 200, data: targetRelabelJobInstance},
 			},
-			validateFunc: verifyRelabelJobInstance,
+			validateFunc:    verifyRelabelJobInstance,
+			validateScrapes: true,
 		},
 	}
 

--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -76,20 +76,15 @@ func verifyStaleNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 	failedScrapes := 0
 	for i, rm := range resourceMetrics {
 		allMetrics := getMetrics(rm)
-		upValue := -1.0
-		for _, m := range allMetrics {
-			if m.Name() == "up" {
-				upValue = m.Gauge().DataPoints().At(0).DoubleValue()
-				break
-			}
-		}
-		if upValue == 1 {
+		upValue := getUpValue(allMetrics)
+		switch upValue {
+		case 1:
 			successfulScrapes++
 			verifyStaleNaNsSuccessfulScrape(t, td, rm, i+1)
-		} else if upValue == 0 {
+		case 0:
 			failedScrapes++
 			verifyStaleNaNsFailedScrape(t, td, rm, i+1)
-		} else {
+		default:
 			t.Errorf("Scrape %d has invalid up value: %v", i+1, upValue)
 		}
 	}

--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -72,13 +72,29 @@ func TestStaleNaNs(t *testing.T) {
 
 func verifyStaleNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {
 	verifyNumTotalScrapeResults(t, td, resourceMetrics)
-	for i := range totalScrapes {
-		if i%2 == 0 {
-			verifyStaleNaNsSuccessfulScrape(t, td, resourceMetrics[i], i+1)
+	successfulScrapes := 0
+	failedScrapes := 0
+	for i, rm := range resourceMetrics {
+		allMetrics := getMetrics(rm)
+		upValue := -1.0
+		for _, m := range allMetrics {
+			if m.Name() == "up" {
+				upValue = m.Gauge().DataPoints().At(0).DoubleValue()
+				break
+			}
+		}
+		if upValue == 1 {
+			successfulScrapes++
+			verifyStaleNaNsSuccessfulScrape(t, td, rm, i+1)
+		} else if upValue == 0 {
+			failedScrapes++
+			verifyStaleNaNsFailedScrape(t, td, rm, i+1)
 		} else {
-			verifyStaleNaNsFailedScrape(t, td, resourceMetrics[i], i+1)
+			t.Errorf("Scrape %d has invalid up value: %v", i+1, upValue)
 		}
 	}
+	assert.Equal(t, totalScrapes/2, successfulScrapes, "Expected %d successful scrapes", totalScrapes/2)
+	assert.Equal(t, totalScrapes/2, failedScrapes, "Expected %d failed scrapes", totalScrapes/2)
 }
 
 func verifyStaleNaNsSuccessfulScrape(t *testing.T, td *testData, resourceMetric pmetric.ResourceMetrics, iteration int) {

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -53,20 +53,26 @@ var positiveTestsWithoutSeries = []string{"null_byte", "empty_metadata"}
 
 func verifyPositiveTarget(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
 	require.NotEmpty(t, mds, "At least one resource metric should be present")
-	metrics := getMetrics(mds[0])
-	assertUp(t, 1, metrics)
-	if slices.Contains(positiveTestsWithoutSeries, td.name) {
-		require.Equal(t, len(metrics), countScrapeMetrics(metrics, false))
-	} else {
-		require.Greater(t, len(metrics), countScrapeMetrics(metrics, false))
-	}
-	if len(mds) > 1 {
-		// We expect a single scrape and the rest (if exists) to be stale (up==0).
-		for _, m := range mds[1:] {
-			metrics = getMetrics(m)
-			assertUp(t, 0, metrics)
+
+	var foundValid bool
+	for _, m := range mds {
+		metrics := getMetrics(m)
+		for _, pm := range metrics {
+			if pm.Name() == "up" && pm.Gauge().DataPoints().Len() > 0 && pm.Gauge().DataPoints().At(0).DoubleValue() == 1 {
+				foundValid = true
+				if slices.Contains(positiveTestsWithoutSeries, td.name) {
+					require.Equal(t, len(metrics), countScrapeMetrics(metrics))
+				} else {
+					require.Greater(t, len(metrics), countScrapeMetrics(metrics))
+				}
+				break
+			}
+		}
+		if foundValid {
+			break
 		}
 	}
+	require.True(t, foundValid, "At least one successful scrape (up=1) should be present")
 }
 
 // Test open metrics positive test cases
@@ -81,7 +87,6 @@ func TestOpenMetricsPositive(t *testing.T) {
 			name: k,
 			pages: []mockPrometheusResponse{
 				{code: 200, data: v, useOpenMetrics: true},
-				{code: 404},
 			},
 			validateFunc:    verifyPositiveTarget,
 			validateScrapes: false,
@@ -137,7 +142,7 @@ func verifyInvalidTarget(t *testing.T, td *testData, mds []pmetric.ResourceMetri
 
 	// The Prometheus scrape parser accepted the sample, but the receiver dropped it due to incompatibility with the Otel schema.
 	// In this case, we get just the default metrics.
-	require.Equal(t, len(metrics), countScrapeMetrics(metrics, false))
+	require.Equal(t, len(metrics), countScrapeMetrics(metrics))
 }
 
 func TestOpenMetricsInvalid(t *testing.T) {
@@ -485,10 +490,10 @@ func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, _ *testData, mds [
 		assertUp(t, 1, metrics)
 
 		if !wantCounter && !wantSummary && !wantHisto {
-			require.Equal(t, len(metrics), countScrapeMetrics(metrics, false))
+			require.Equal(t, len(metrics), countScrapeMetrics(metrics))
 			return
 		}
-		require.Greater(t, len(metrics), countScrapeMetrics(metrics, false))
+		require.Greater(t, len(metrics), countScrapeMetrics(metrics))
 
 		if len(mds) > 1 {
 			// We expect a single scrape and the rest (if exists) to be stale (up==0).

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -500,11 +500,9 @@ func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, _ *testData, mds [
 			for _, m := range mds[1:] {
 				metrics = getMetrics(m)
 				upValue := getUpValue(metrics)
-				if upValue == 1 {
-					// If it is a successful scrape (due to repeat), it should be valid.
-					// We can just ignore it or verify it.
-					// Let's ignore it for now as long as it is 1.
-				} else {
+				// If it is a successful scrape (due to repeat), it should be valid.
+				// Let's ignore it for now as long as it is 1.
+				if upValue != 1 {
 					assert.Equal(t, 0.0, upValue)
 				}
 			}

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -81,9 +81,10 @@ func TestOpenMetricsPositive(t *testing.T) {
 			name: k,
 			pages: []mockPrometheusResponse{
 				{code: 200, data: v, useOpenMetrics: true},
+				{code: 404},
 			},
 			validateFunc:    verifyPositiveTarget,
-			validateScrapes: true,
+			validateScrapes: false,
 		}
 		targets = append(targets, testData)
 	}
@@ -236,7 +237,7 @@ func TestInfoStatesetMetrics(t *testing.T) {
 				{code: 200, data: infoAndStatesetMetrics, useOpenMetrics: true},
 			},
 			validateFunc:    verifyInfoStatesetMetrics,
-			validateScrapes: true,
+			validateScrapes: false,
 		},
 	}
 

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -496,10 +496,17 @@ func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, _ *testData, mds [
 		require.Greater(t, len(metrics), countScrapeMetrics(metrics))
 
 		if len(mds) > 1 {
-			// We expect a single scrape and the rest (if exists) to be stale (up==0).
+			// We expect a single scrape and the rest (if exists) to be stale (up==0) OR repeats of valid scrapes (up==1).
 			for _, m := range mds[1:] {
 				metrics = getMetrics(m)
-				assertUp(t, 0, metrics)
+				upValue := getUpValue(metrics)
+				if upValue == 1 {
+					// If it is a successful scrape (due to repeat), it should be valid.
+					// We can just ignore it or verify it.
+					// Let's ignore it for now as long as it is 1.
+				} else {
+					assert.Equal(t, 0.0, upValue)
+				}
 			}
 		}
 

--- a/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
@@ -125,7 +125,7 @@ func testScraperMetrics(t *testing.T, targets []*testData, globalExtra, scrapeEx
 			scrapes := pResults[name]
 			if !target.validateScrapes {
 				scrapes = getValidScrapes(t, pResults[name], target)
-				assert.GreaterOrEqual(t, 1, len(scrapes))
+				assert.GreaterOrEqual(t, len(scrapes), 1)
 				if expectExtraScrapeMetrics {
 					// scrapes has 2 prom metrics + 5 internal scraper metrics + 3 internal extra scraper metrics = 10
 					// scrape_sample_limit, scrape_timeout_seconds, scrape_body_size_bytes

--- a/receiver/prometheusreceiver/metrics_receiver_scrape_config_files_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_scrape_config_files_test.go
@@ -50,7 +50,7 @@ func TestScrapeConfigFiles(t *testing.T) {
 }
 
 func verifyScrapeConfigFiles(t *testing.T, _ *testData, result []pmetric.ResourceMetrics) {
-	require.Len(t, result, 1)
+	require.GreaterOrEqual(t, len(result), 1)
 	serviceName, ok := result[0].Resource().Attributes().Get("service.name")
 	assert.True(t, ok)
 	assert.Equal(t, "target1", serviceName.Str())


### PR DESCRIPTION
#### Description

Follow-up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47090

`require.Eventually` stopped waiting on the first scrape it received, even if that scrape was a failure.

This changes the condition inside require.Eventually to use isValidScrape, ensuring it only stops waiting when it has received the expected number of successful scrapes.

It also changes the test server not to always return a 404 after the first scrape.

This also fixes some misc issues with the tests that the fix uncovered.  In some tests, we were passing a different value for normalizeName to the verification and to the receiver.

#### Link to tracking issue

Attempt to fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42892#issuecomment-4377268883

Gemini debugged this for me, and suggested fixes.