### PR TITLE
[pkg/pdatatest] Add pmetricassert collection count matcher (#48472)

### DIFF
--- a/.chloggen/feat_pmetricassert-collection-matchers.yaml
+++ b/.chloggen/feat_pmetricassert-collection-matchers.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add collection operator support (`/exact`, `/include`, `/count`) to `pmetricassert` resources, scopes, metrics, and datapoints, including YAML parsing and end-to-end assertion validation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48472]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/feat_pmetricassert-count-matcher.yaml
+++ b/.chloggen/feat_pmetricassert-count-matcher.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pkg/pdatatest
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add collection operator support (`/exact`, `/include`, `/count`) to `pmetricassert` resources, scopes, metrics, and datapoints, including YAML parsing and end-to-end assertion validation.
+note: Add collection operator support (`/exact` and `/count`) to `pmetricassert` resources, scopes, metrics, and datapoints, including YAML parsing and end-to-end assertion validation.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [48472]
@@ -15,7 +15,10 @@ issues: [48472]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  This change introduces the `/count` operator for cardinality matching while
+  preserving default exact matching for collections. The `/include` operator is
+  submitted in a separate PR to keep reviews atomic.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/pkg/pdatatest/pmetricassert/assert.go
+++ b/pkg/pdatatest/pmetricassert/assert.go
@@ -28,51 +28,40 @@ func AssertMetrics(expectedPath string, actual pmetric.Metrics) error {
 }
 
 func compareDocuments(expected, actual *document) error {
-	var errs []error
-	matched := make([]bool, len(actual.Resources))
-
-	for _, er := range expected.Resources {
-		idx := findMatchingAttributes(er.Attributes, matched, len(actual.Resources), func(i int) map[string]any {
-			return actual.Resources[i].Attributes
-		})
-		if idx < 0 {
-			errs = append(errs, fmt.Errorf("missing expected resource: %v", er.Attributes))
-			continue
-		}
-		matched[idx] = true
-		if err := compareResource(er, actual.Resources[idx]); err != nil {
-			errs = append(errs, fmt.Errorf("resource %v: %w", er.Attributes, err))
-		}
+	if err := expected.Resources.Validate(actual.Resources.Exact); err != nil {
+		return fmt.Errorf("resources assertion failed: %w", err)
 	}
-	for i, ar := range actual.Resources {
-		if !matched[i] {
-			errs = append(errs, fmt.Errorf("unexpected resource: %v", ar.Attributes))
-		}
-	}
-	return errors.Join(errs...)
+	return nil
 }
 
 func compareResource(expected, actual resourceAssertion) error {
-	var errs []error
-	expScopes := indexScopes(expected.Scopes)
-	actScopes := indexScopes(actual.Scopes)
+	if len(expected.Scopes.Include) == 0 && expected.Scopes.Count == nil {
+		var errs []error
+		expScopes := indexScopes(expected.Scopes.Exact)
+		actScopes := indexScopes(actual.Scopes.Exact)
 
-	for key, es := range expScopes {
-		as, ok := actScopes[key]
-		if !ok {
-			errs = append(errs, fmt.Errorf("missing expected scope name=%q version=%q", es.Name, es.Version))
-			continue
+		for key, es := range expScopes {
+			as, ok := actScopes[key]
+			if !ok {
+				errs = append(errs, fmt.Errorf("missing expected scope name=%q version=%q", es.Name, es.Version))
+				continue
+			}
+			if err := compareScope(es, as); err != nil {
+				errs = append(errs, fmt.Errorf("scope name=%q: %w", es.Name, err))
+			}
 		}
-		if err := compareScope(es, as); err != nil {
-			errs = append(errs, fmt.Errorf("scope name=%q: %w", es.Name, err))
+		for key, as := range actScopes {
+			if _, ok := expScopes[key]; !ok {
+				errs = append(errs, fmt.Errorf("unexpected scope name=%q version=%q", as.Name, as.Version))
+			}
 		}
+		return errors.Join(errs...)
 	}
-	for key, as := range actScopes {
-		if _, ok := expScopes[key]; !ok {
-			errs = append(errs, fmt.Errorf("unexpected scope name=%q version=%q", as.Name, as.Version))
-		}
+
+	if err := expected.Scopes.Validate(actual.Scopes.Exact); err != nil {
+		return fmt.Errorf("scopes assertion failed: %w", err)
 	}
-	return errors.Join(errs...)
+	return nil
 }
 
 func indexScopes(ss []scopeAssertion) map[string]scopeAssertion {
@@ -84,31 +73,40 @@ func indexScopes(ss []scopeAssertion) map[string]scopeAssertion {
 }
 
 func compareScope(expected, actual scopeAssertion) error {
-	var errs []error
-	expMetrics := indexMetrics(expected.Metrics)
-	actMetrics := indexMetrics(actual.Metrics)
+	if len(expected.Metrics.Include) == 0 && expected.Metrics.Count == nil {
+		var errs []error
+		expMetrics := indexMetrics(expected.Metrics.Exact)
+		actMetrics := indexMetrics(actual.Metrics.Exact)
 
-	for name, em := range expMetrics {
-		am, ok := actMetrics[name]
-		if !ok {
-			errs = append(errs, fmt.Errorf("missing expected metric %q", name))
-			continue
+		for name := range expMetrics {
+			em := expMetrics[name]
+			am, ok := actMetrics[name]
+			if !ok {
+				errs = append(errs, fmt.Errorf("missing expected metric %q", name))
+				continue
+			}
+			if err := compareMetric(em, am); err != nil {
+				errs = append(errs, fmt.Errorf("metric %q: %w", name, err))
+			}
 		}
-		if err := compareMetric(em, am); err != nil {
-			errs = append(errs, fmt.Errorf("metric %q: %w", name, err))
+		for name := range actMetrics {
+			if _, ok := expMetrics[name]; !ok {
+				errs = append(errs, fmt.Errorf("unexpected metric %q", name))
+			}
 		}
+		return errors.Join(errs...)
 	}
-	for name := range actMetrics {
-		if _, ok := expMetrics[name]; !ok {
-			errs = append(errs, fmt.Errorf("unexpected metric %q", name))
-		}
+
+	if err := expected.Metrics.ValidateAssertions(actual.Metrics.Exact); err != nil {
+		return fmt.Errorf("metrics assertion failed: %w", err)
 	}
-	return errors.Join(errs...)
+	return nil
 }
 
 func indexMetrics(ms []metricAssertion) map[string]metricAssertion {
 	out := make(map[string]metricAssertion, len(ms))
-	for _, m := range ms {
+	for i := range ms {
+		m := ms[i]
 		out[m.Name] = m
 	}
 	return out
@@ -129,8 +127,12 @@ func compareMetric(expected, actual metricAssertion) error {
 		errs = append(errs, fmt.Errorf("monotonic mismatch: expected %v, got %v",
 			boolPtrString(expected.Monotonic), boolPtrString(actual.Monotonic)))
 	}
-	if err := compareDatapoints(expected.Datapoints, actual.Datapoints); err != nil {
-		errs = append(errs, err)
+	if len(expected.Datapoints.Include) == 0 && expected.Datapoints.Count == nil {
+		if err := compareDatapoints(expected.Datapoints.Exact, actual.Datapoints.Exact); err != nil {
+			errs = append(errs, err)
+		}
+	} else if err := expected.Datapoints.Validate(actual.Datapoints.Exact); err != nil {
+		errs = append(errs, fmt.Errorf("datapoints assertion failed: %w", err))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/pdatatest/pmetricassert/assert.go
+++ b/pkg/pdatatest/pmetricassert/assert.go
@@ -35,7 +35,7 @@ func compareDocuments(expected, actual *document) error {
 }
 
 func compareResource(expected, actual resourceAssertion) error {
-	if len(expected.Scopes.Include) == 0 && expected.Scopes.Count == nil {
+	if expected.Scopes.Count == nil {
 		var errs []error
 		expScopes := indexScopes(expected.Scopes.Exact)
 		actScopes := indexScopes(actual.Scopes.Exact)
@@ -73,7 +73,7 @@ func indexScopes(ss []scopeAssertion) map[string]scopeAssertion {
 }
 
 func compareScope(expected, actual scopeAssertion) error {
-	if len(expected.Metrics.Include) == 0 && expected.Metrics.Count == nil {
+	if expected.Metrics.Count == nil {
 		var errs []error
 		expMetrics := indexMetrics(expected.Metrics.Exact)
 		actMetrics := indexMetrics(actual.Metrics.Exact)
@@ -127,7 +127,7 @@ func compareMetric(expected, actual metricAssertion) error {
 		errs = append(errs, fmt.Errorf("monotonic mismatch: expected %v, got %v",
 			boolPtrString(expected.Monotonic), boolPtrString(actual.Monotonic)))
 	}
-	if len(expected.Datapoints.Include) == 0 && expected.Datapoints.Count == nil {
+	if expected.Datapoints.Count == nil {
 		if err := compareDatapoints(expected.Datapoints.Exact, actual.Datapoints.Exact); err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/pdatatest/pmetricassert/collection_assertion.go
+++ b/pkg/pdatatest/pmetricassert/collection_assertion.go
@@ -207,6 +207,13 @@ func unmarshalCollectionBySuffix[T any](value *yaml.Node, baseKey string) (exact
 
 // Validate checks actual metrics against exact/count operators.
 func (a MetricsAssertion) Validate(actualMetrics pmetric.MetricSlice) error {
+	if a.Count == nil && a.Exact == nil {
+		if actualMetrics.Len() != 0 {
+			return fmt.Errorf("metrics assertion failed: expected 0 metrics, got %d", actualMetrics.Len())
+		}
+		return nil
+	}
+
 	if err := a.Count.Validate(actualMetrics.Len()); err != nil {
 		return fmt.Errorf("metrics/count: %w", err)
 	}
@@ -221,11 +228,18 @@ func (a MetricsAssertion) Validate(actualMetrics pmetric.MetricSlice) error {
 }
 
 func (a MetricsAssertion) ValidateAssertions(actual []metricAssertion) error {
+	if a.Count == nil && a.Exact == nil {
+		if len(actual) != 0 {
+			return fmt.Errorf("metrics assertion failed: expected 0 metrics, got %d", len(actual))
+		}
+		return nil
+	}
+
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("metrics/count: %w", err)
 	}
 
-	if len(a.Exact) > 0 {
+	if a.Exact != nil {
 		if err := validateExactCollection("metric", a.Exact, actual, func(expected, got metricAssertion) error {
 			return expected.MatchesAssertion(got)
 		}); err != nil {
@@ -237,6 +251,13 @@ func (a MetricsAssertion) ValidateAssertions(actual []metricAssertion) error {
 }
 
 func (a ResourcesAssertion) Validate(actual []resourceAssertion) error {
+	if a.Count == nil && a.Exact == nil {
+		if len(actual) != 0 {
+			return fmt.Errorf("resources assertion failed: expected 0 resources, got %d", len(actual))
+		}
+		return nil
+	}
+
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("resources/count: %w", err)
 	}
@@ -251,6 +272,13 @@ func (a ResourcesAssertion) Validate(actual []resourceAssertion) error {
 }
 
 func (a ScopesAssertion) Validate(actual []scopeAssertion) error {
+	if a.Count == nil && a.Exact == nil {
+		if len(actual) != 0 {
+			return fmt.Errorf("scopes assertion failed: expected 0 scopes, got %d", len(actual))
+		}
+		return nil
+	}
+
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("scopes/count: %w", err)
 	}
@@ -265,6 +293,13 @@ func (a ScopesAssertion) Validate(actual []scopeAssertion) error {
 }
 
 func (a DatapointsAssertion) Validate(actual []datapointAssertion) error {
+	if a.Count == nil && a.Exact == nil {
+		if len(actual) != 0 {
+			return fmt.Errorf("datapoints assertion failed: expected 0 datapoints, got %d", len(actual))
+		}
+		return nil
+	}
+
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("datapoints/count: %w", err)
 	}

--- a/pkg/pdatatest/pmetricassert/collection_assertion.go
+++ b/pkg/pdatatest/pmetricassert/collection_assertion.go
@@ -70,124 +70,111 @@ func (c *CountAssertion) Validate(actualLength int) error {
 	return nil
 }
 
-// MetricsAssertion supports exact/include/count collection operators.
+// MetricsAssertion supports exact/count collection operators.
 type MetricsAssertion struct {
-	Exact   []MetricAssertion `yaml:"-"`
-	Include []MetricAssertion `yaml:"-"`
-	Count   *CountAssertion   `yaml:"-"`
+	Exact []MetricAssertion `yaml:"-"`
+	Count *CountAssertion   `yaml:"-"`
 }
 
-// ResourcesAssertion supports exact/include/count collection operators.
+// ResourcesAssertion supports exact/count collection operators.
 type ResourcesAssertion struct {
-	Exact   []ResourceAssertion `yaml:"-"`
-	Include []ResourceAssertion `yaml:"-"`
-	Count   *CountAssertion     `yaml:"-"`
+	Exact []ResourceAssertion `yaml:"-"`
+	Count *CountAssertion     `yaml:"-"`
 }
 
-// ScopesAssertion supports exact/include/count collection operators.
+// ScopesAssertion supports exact/count collection operators.
 type ScopesAssertion struct {
-	Exact   []ScopeAssertion `yaml:"-"`
-	Include []ScopeAssertion `yaml:"-"`
-	Count   *CountAssertion  `yaml:"-"`
+	Exact []ScopeAssertion `yaml:"-"`
+	Count *CountAssertion  `yaml:"-"`
 }
 
-// DatapointsAssertion supports exact/include/count collection operators.
+// DatapointsAssertion supports exact/count collection operators.
 type DatapointsAssertion struct {
-	Exact   []DatapointAssertion `yaml:"-"`
-	Include []DatapointAssertion `yaml:"-"`
-	Count   *CountAssertion      `yaml:"-"`
+	Exact []DatapointAssertion `yaml:"-"`
+	Count *CountAssertion      `yaml:"-"`
 }
 
 // UnmarshalYAML supports these forms:
 // - sequence node (equivalent to metrics/exact)
-// - map node with keys: metrics, metrics/exact, metrics/include, metrics/count
+// - map node with keys: metrics, metrics/exact, metrics/count
 func (a *MetricsAssertion) UnmarshalYAML(value *yaml.Node) error {
-	exact, include, count, err := unmarshalCollectionBySuffix[MetricAssertion](value, "metrics")
+	exact, count, err := unmarshalCollectionBySuffix[MetricAssertion](value, "metrics")
 	if err != nil {
 		return err
 	}
 	a.Exact = exact
-	a.Include = include
 	a.Count = count
 	return nil
 }
 
 func (a MetricsAssertion) MarshalYAML() (any, error) {
-	return marshalCollection(a.Exact, a.Include, a.Count), nil
+	return marshalCollection(a.Exact, a.Count), nil
 }
 
 func (a *ResourcesAssertion) UnmarshalYAML(value *yaml.Node) error {
-	exact, include, count, err := unmarshalCollectionBySuffix[ResourceAssertion](value, "resources")
+	exact, count, err := unmarshalCollectionBySuffix[ResourceAssertion](value, "resources")
 	if err != nil {
 		return err
 	}
 	a.Exact = exact
-	a.Include = include
 	a.Count = count
 	return nil
 }
 
 func (a ResourcesAssertion) MarshalYAML() (any, error) {
-	return marshalCollection(a.Exact, a.Include, a.Count), nil
+	return marshalCollection(a.Exact, a.Count), nil
 }
 
 func (a *ScopesAssertion) UnmarshalYAML(value *yaml.Node) error {
-	exact, include, count, err := unmarshalCollectionBySuffix[ScopeAssertion](value, "scopes")
+	exact, count, err := unmarshalCollectionBySuffix[ScopeAssertion](value, "scopes")
 	if err != nil {
 		return err
 	}
 	a.Exact = exact
-	a.Include = include
 	a.Count = count
 	return nil
 }
 
 func (a ScopesAssertion) MarshalYAML() (any, error) {
-	return marshalCollection(a.Exact, a.Include, a.Count), nil
+	return marshalCollection(a.Exact, a.Count), nil
 }
 
 func (a *DatapointsAssertion) UnmarshalYAML(value *yaml.Node) error {
-	exact, include, count, err := unmarshalCollectionBySuffix[DatapointAssertion](value, "datapoints")
+	exact, count, err := unmarshalCollectionBySuffix[DatapointAssertion](value, "datapoints")
 	if err != nil {
 		return err
 	}
 	a.Exact = exact
-	a.Include = include
 	a.Count = count
 	return nil
 }
 
 func (a DatapointsAssertion) MarshalYAML() (any, error) {
-	return marshalCollection(a.Exact, a.Include, a.Count), nil
+	return marshalCollection(a.Exact, a.Count), nil
 }
 
-func marshalCollection[T any](exact, include []T, count *CountAssertion) any {
-	if len(include) == 0 && count == nil {
+func marshalCollection[T any](exact []T, count *CountAssertion) any {
+	if count == nil {
 		return exact
 	}
 	out := map[string]any{}
 	if len(exact) > 0 {
 		out["exact"] = exact
 	}
-	if len(include) > 0 {
-		out["include"] = include
-	}
-	if count != nil {
-		out["count"] = count
-	}
+	out["count"] = count
 	return out
 }
 
-func unmarshalCollectionBySuffix[T any](value *yaml.Node, baseKey string) (exact, include []T, count *CountAssertion, err error) {
+func unmarshalCollectionBySuffix[T any](value *yaml.Node, baseKey string) (exact []T, count *CountAssertion, err error) {
 	if value.Kind == yaml.SequenceNode {
 		if err := value.Decode(&exact); err != nil {
-			return nil, nil, nil, fmt.Errorf("decode %s exact assertions: %w", baseKey, err)
+			return nil, nil, fmt.Errorf("decode %s exact assertions: %w", baseKey, err)
 		}
-		return exact, nil, nil, nil
+		return exact, nil, nil
 	}
 
 	if value.Kind != yaml.MappingNode {
-		return nil, nil, nil, fmt.Errorf("%s assertion must be a sequence or map, got YAML kind %d", baseKey, value.Kind)
+		return nil, nil, fmt.Errorf("%s assertion must be a sequence or map, got YAML kind %d", baseKey, value.Kind)
 	}
 
 	for i := 0; i < len(value.Content); i += 2 {
@@ -197,35 +184,28 @@ func unmarshalCollectionBySuffix[T any](value *yaml.Node, baseKey string) (exact
 		switch key {
 		case baseKey, baseKey + "/exact", "exact":
 			if len(exact) > 0 {
-				return nil, nil, nil, fmt.Errorf("duplicate %s exact assertion key %q", baseKey, key)
+				return nil, nil, fmt.Errorf("duplicate %s exact assertion key %q", baseKey, key)
 			}
 			if err := valNode.Decode(&exact); err != nil {
-				return nil, nil, nil, fmt.Errorf("decode %q: %w", key, err)
-			}
-		case baseKey + "/include", "include":
-			if len(include) > 0 {
-				return nil, nil, nil, fmt.Errorf("duplicate %s include assertion key %q", baseKey, key)
-			}
-			if err := valNode.Decode(&include); err != nil {
-				return nil, nil, nil, fmt.Errorf("decode %q: %w", key, err)
+				return nil, nil, fmt.Errorf("decode %q: %w", key, err)
 			}
 		case baseKey + "/count", "count":
 			if count != nil {
-				return nil, nil, nil, fmt.Errorf("duplicate %s count assertion key %q", baseKey, key)
+				return nil, nil, fmt.Errorf("duplicate %s count assertion key %q", baseKey, key)
 			}
 			count = &CountAssertion{}
 			if err := valNode.Decode(count); err != nil {
-				return nil, nil, nil, fmt.Errorf("decode %q: %w", key, err)
+				return nil, nil, fmt.Errorf("decode %q: %w", key, err)
 			}
 		default:
-			return nil, nil, nil, fmt.Errorf("unsupported %s assertion key %q", baseKey, key)
+			return nil, nil, fmt.Errorf("unsupported %s assertion key %q", baseKey, key)
 		}
 	}
 
-	return exact, include, count, nil
+	return exact, count, nil
 }
 
-// Validate checks actual metrics against exact/include/count operators.
+// Validate checks actual metrics against exact/count operators.
 func (a MetricsAssertion) Validate(actualMetrics pmetric.MetricSlice) error {
 	if err := a.Count.Validate(actualMetrics.Len()); err != nil {
 		return fmt.Errorf("metrics/count: %w", err)
@@ -234,12 +214,6 @@ func (a MetricsAssertion) Validate(actualMetrics pmetric.MetricSlice) error {
 	if a.Exact != nil {
 		if err := validateMetricExact(a.Exact, actualMetrics); err != nil {
 			return fmt.Errorf("metrics exact assertion failed: %w", err)
-		}
-	}
-
-	if len(a.Include) > 0 {
-		if err := validateMetricInclude(a.Include, actualMetrics); err != nil {
-			return fmt.Errorf("metrics include assertion failed: %w", err)
 		}
 	}
 
@@ -259,14 +233,6 @@ func (a MetricsAssertion) ValidateAssertions(actual []metricAssertion) error {
 		}
 	}
 
-	if len(a.Include) > 0 {
-		if err := validateIncludeCollection("metric", a.Include, actual, func(expected, got metricAssertion) error {
-			return expected.MatchesAssertion(got)
-		}); err != nil {
-			return fmt.Errorf("metrics include assertion failed: %w", err)
-		}
-	}
-
 	return nil
 }
 
@@ -279,13 +245,6 @@ func (a ResourcesAssertion) Validate(actual []resourceAssertion) error {
 			return expected.Matches(got)
 		}); err != nil {
 			return fmt.Errorf("resources exact assertion failed: %w", err)
-		}
-	}
-	if len(a.Include) > 0 {
-		if err := validateIncludeCollection("resource", a.Include, actual, func(expected, got resourceAssertion) error {
-			return expected.Matches(got)
-		}); err != nil {
-			return fmt.Errorf("resources include assertion failed: %w", err)
 		}
 	}
 	return nil
@@ -302,13 +261,6 @@ func (a ScopesAssertion) Validate(actual []scopeAssertion) error {
 			return fmt.Errorf("scopes exact assertion failed: %w", err)
 		}
 	}
-	if len(a.Include) > 0 {
-		if err := validateIncludeCollection("scope", a.Include, actual, func(expected, got scopeAssertion) error {
-			return expected.Matches(got)
-		}); err != nil {
-			return fmt.Errorf("scopes include assertion failed: %w", err)
-		}
-	}
 	return nil
 }
 
@@ -321,13 +273,6 @@ func (a DatapointsAssertion) Validate(actual []datapointAssertion) error {
 			return expected.Matches(got)
 		}); err != nil {
 			return fmt.Errorf("datapoints exact assertion failed: %w", err)
-		}
-	}
-	if len(a.Include) > 0 {
-		if err := validateIncludeCollection("datapoint", a.Include, actual, func(expected, got datapointAssertion) error {
-			return expected.Matches(got)
-		}); err != nil {
-			return fmt.Errorf("datapoints include assertion failed: %w", err)
 		}
 	}
 	return nil
@@ -355,23 +300,6 @@ func validateMetricExact(expected []MetricAssertion, actual pmetric.MetricSlice)
 			return fmt.Errorf("expected metric[%d] (%q) was not found in actual metrics", i, em.Name)
 		}
 		used[found] = true
-	}
-	return nil
-}
-
-func validateMetricInclude(expected []MetricAssertion, actual pmetric.MetricSlice) error {
-	for i := range expected {
-		em := expected[i]
-		matched := false
-		for j := 0; j < actual.Len(); j++ {
-			if err := em.Matches(actual.At(j)); err == nil {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return fmt.Errorf("included metric[%d] (%q) was not found in actual metrics", i, em.Name)
-		}
 	}
 	return nil
 }
@@ -408,28 +336,6 @@ func validateExactCollection[T any](itemName string, expected, actual []T, match
 	return nil
 }
 
-func validateIncludeCollection[T any](itemName string, expected, actual []T, matches func(T, T) error) error {
-	for i, e := range expected {
-		matched := false
-		var candidateErrs []error
-		for _, a := range actual {
-			err := matches(e, a)
-			if err == nil {
-				matched = true
-				break
-			}
-			candidateErrs = append(candidateErrs, err)
-		}
-		if !matched {
-			if len(candidateErrs) > 0 {
-				return fmt.Errorf("included %s[%d] was not found in actual %ss: %w", itemName, i, itemName, errors.Join(candidateErrs...))
-			}
-			return fmt.Errorf("included %s[%d] was not found in actual %ss", itemName, i, itemName)
-		}
-	}
-	return nil
-}
-
 func (r resourceAssertion) Matches(actual resourceAssertion) error {
 	if err := compareAttributes(r.Attributes, actual.Attributes); err != nil {
 		return fmt.Errorf("attributes: %w", err)
@@ -454,7 +360,7 @@ func (d datapointAssertion) Matches(actual datapointAssertion) error {
 // Matches validates one actual metric against this expected metric assertion.
 func (m metricAssertion) Matches(actual pmetric.Metric) error {
 	expected := m
-	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 && expected.Datapoints.Count == nil {
+	if len(expected.Datapoints.Exact) == 0 && expected.Datapoints.Count == nil {
 		expected.Datapoints.Exact = []datapointAssertion{{}}
 	}
 
@@ -468,7 +374,7 @@ func (m metricAssertion) Matches(actual pmetric.Metric) error {
 
 func (m metricAssertion) MatchesAssertion(actual metricAssertion) error {
 	expected := m
-	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 && expected.Datapoints.Count == nil {
+	if len(expected.Datapoints.Exact) == 0 && expected.Datapoints.Count == nil {
 		expected.Datapoints.Exact = []datapointAssertion{{}}
 	}
 	return compareMetric(expected, actual)

--- a/pkg/pdatatest/pmetricassert/collection_assertion.go
+++ b/pkg/pdatatest/pmetricassert/collection_assertion.go
@@ -1,0 +1,475 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pmetricassert // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetricassert"
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"gopkg.in/yaml.v3"
+)
+
+// MetricAssertion is the public assertion shape for metric identity checks.
+//
+// The base type is intentionally shared with the internal document model so
+// matcher behavior stays consistent between file assertions and in-memory
+// collection assertions.
+type (
+	MetricAssertion    = metricAssertion
+	ResourceAssertion  = resourceAssertion
+	ScopeAssertion     = scopeAssertion
+	DatapointAssertion = datapointAssertion
+)
+
+// CountAssertion constrains collection length.
+//
+// Exact requires one exact value. Min/Max can be used as an inclusive range.
+// Exact cannot be combined with Min/Max.
+type CountAssertion struct {
+	Min   *int `yaml:"min,omitempty"`
+	Max   *int `yaml:"max,omitempty"`
+	Exact *int `yaml:"exact,omitempty"`
+}
+
+// Validate checks the actual collection length against the configured count
+// operator.
+func (c *CountAssertion) Validate(actualLength int) error {
+	if c == nil {
+		return nil
+	}
+	if c.Exact != nil {
+		if c.Min != nil || c.Max != nil {
+			return errors.New("count assertion is invalid: exact cannot be combined with min/max")
+		}
+		if *c.Exact < 0 {
+			return fmt.Errorf("count assertion is invalid: exact must be >= 0, got %d", *c.Exact)
+		}
+		if actualLength != *c.Exact {
+			return fmt.Errorf("count assertion failed: expected exactly %d items, got %d", *c.Exact, actualLength)
+		}
+		return nil
+	}
+
+	if c.Min != nil && *c.Min < 0 {
+		return fmt.Errorf("count assertion is invalid: min must be >= 0, got %d", *c.Min)
+	}
+	if c.Max != nil && *c.Max < 0 {
+		return fmt.Errorf("count assertion is invalid: max must be >= 0, got %d", *c.Max)
+	}
+	if c.Min != nil && c.Max != nil && *c.Min > *c.Max {
+		return fmt.Errorf("count assertion is invalid: min (%d) cannot be greater than max (%d)", *c.Min, *c.Max)
+	}
+	if c.Min != nil && actualLength < *c.Min {
+		return fmt.Errorf("count assertion failed: expected at least %d items, got %d", *c.Min, actualLength)
+	}
+	if c.Max != nil && actualLength > *c.Max {
+		return fmt.Errorf("count assertion failed: expected at most %d items, got %d", *c.Max, actualLength)
+	}
+	return nil
+}
+
+// MetricsAssertion supports exact/include/count collection operators.
+type MetricsAssertion struct {
+	Exact   []MetricAssertion `yaml:"-"`
+	Include []MetricAssertion `yaml:"-"`
+	Count   *CountAssertion   `yaml:"-"`
+}
+
+// ResourcesAssertion supports exact/include/count collection operators.
+type ResourcesAssertion struct {
+	Exact   []ResourceAssertion `yaml:"-"`
+	Include []ResourceAssertion `yaml:"-"`
+	Count   *CountAssertion     `yaml:"-"`
+}
+
+// ScopesAssertion supports exact/include/count collection operators.
+type ScopesAssertion struct {
+	Exact   []ScopeAssertion `yaml:"-"`
+	Include []ScopeAssertion `yaml:"-"`
+	Count   *CountAssertion  `yaml:"-"`
+}
+
+// DatapointsAssertion supports exact/include/count collection operators.
+type DatapointsAssertion struct {
+	Exact   []DatapointAssertion `yaml:"-"`
+	Include []DatapointAssertion `yaml:"-"`
+	Count   *CountAssertion      `yaml:"-"`
+}
+
+// UnmarshalYAML supports these forms:
+// - sequence node (equivalent to metrics/exact)
+// - map node with keys: metrics, metrics/exact, metrics/include, metrics/count
+func (a *MetricsAssertion) UnmarshalYAML(value *yaml.Node) error {
+	exact, include, count, err := unmarshalCollectionBySuffix[MetricAssertion](value, "metrics")
+	if err != nil {
+		return err
+	}
+	a.Exact = exact
+	a.Include = include
+	a.Count = count
+	return nil
+}
+
+func (a MetricsAssertion) MarshalYAML() (any, error) {
+	return marshalCollection(a.Exact, a.Include, a.Count), nil
+}
+
+func (a *ResourcesAssertion) UnmarshalYAML(value *yaml.Node) error {
+	exact, include, count, err := unmarshalCollectionBySuffix[ResourceAssertion](value, "resources")
+	if err != nil {
+		return err
+	}
+	a.Exact = exact
+	a.Include = include
+	a.Count = count
+	return nil
+}
+
+func (a ResourcesAssertion) MarshalYAML() (any, error) {
+	return marshalCollection(a.Exact, a.Include, a.Count), nil
+}
+
+func (a *ScopesAssertion) UnmarshalYAML(value *yaml.Node) error {
+	exact, include, count, err := unmarshalCollectionBySuffix[ScopeAssertion](value, "scopes")
+	if err != nil {
+		return err
+	}
+	a.Exact = exact
+	a.Include = include
+	a.Count = count
+	return nil
+}
+
+func (a ScopesAssertion) MarshalYAML() (any, error) {
+	return marshalCollection(a.Exact, a.Include, a.Count), nil
+}
+
+func (a *DatapointsAssertion) UnmarshalYAML(value *yaml.Node) error {
+	exact, include, count, err := unmarshalCollectionBySuffix[DatapointAssertion](value, "datapoints")
+	if err != nil {
+		return err
+	}
+	a.Exact = exact
+	a.Include = include
+	a.Count = count
+	return nil
+}
+
+func (a DatapointsAssertion) MarshalYAML() (any, error) {
+	return marshalCollection(a.Exact, a.Include, a.Count), nil
+}
+
+func marshalCollection[T any](exact, include []T, count *CountAssertion) any {
+	if len(include) == 0 && count == nil {
+		return exact
+	}
+	out := map[string]any{}
+	if len(exact) > 0 {
+		out["exact"] = exact
+	}
+	if len(include) > 0 {
+		out["include"] = include
+	}
+	if count != nil {
+		out["count"] = count
+	}
+	return out
+}
+
+func unmarshalCollectionBySuffix[T any](value *yaml.Node, baseKey string) (exact, include []T, count *CountAssertion, err error) {
+	if value.Kind == yaml.SequenceNode {
+		if err := value.Decode(&exact); err != nil {
+			return nil, nil, nil, fmt.Errorf("decode %s exact assertions: %w", baseKey, err)
+		}
+		return exact, nil, nil, nil
+	}
+
+	if value.Kind != yaml.MappingNode {
+		return nil, nil, nil, fmt.Errorf("%s assertion must be a sequence or map, got YAML kind %d", baseKey, value.Kind)
+	}
+
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valNode := value.Content[i+1]
+		key := keyNode.Value
+		switch key {
+		case baseKey, baseKey + "/exact", "exact":
+			if len(exact) > 0 {
+				return nil, nil, nil, fmt.Errorf("duplicate %s exact assertion key %q", baseKey, key)
+			}
+			if err := valNode.Decode(&exact); err != nil {
+				return nil, nil, nil, fmt.Errorf("decode %q: %w", key, err)
+			}
+		case baseKey + "/include", "include":
+			if len(include) > 0 {
+				return nil, nil, nil, fmt.Errorf("duplicate %s include assertion key %q", baseKey, key)
+			}
+			if err := valNode.Decode(&include); err != nil {
+				return nil, nil, nil, fmt.Errorf("decode %q: %w", key, err)
+			}
+		case baseKey + "/count", "count":
+			if count != nil {
+				return nil, nil, nil, fmt.Errorf("duplicate %s count assertion key %q", baseKey, key)
+			}
+			count = &CountAssertion{}
+			if err := valNode.Decode(count); err != nil {
+				return nil, nil, nil, fmt.Errorf("decode %q: %w", key, err)
+			}
+		default:
+			return nil, nil, nil, fmt.Errorf("unsupported %s assertion key %q", baseKey, key)
+		}
+	}
+
+	return exact, include, count, nil
+}
+
+// Validate checks actual metrics against exact/include/count operators.
+func (a MetricsAssertion) Validate(actualMetrics pmetric.MetricSlice) error {
+	if err := a.Count.Validate(actualMetrics.Len()); err != nil {
+		return fmt.Errorf("metrics/count: %w", err)
+	}
+
+	if len(a.Exact) > 0 {
+		if err := validateMetricExact(a.Exact, actualMetrics); err != nil {
+			return fmt.Errorf("metrics exact assertion failed: %w", err)
+		}
+	}
+
+	if len(a.Include) > 0 {
+		if err := validateMetricInclude(a.Include, actualMetrics); err != nil {
+			return fmt.Errorf("metrics include assertion failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (a MetricsAssertion) ValidateAssertions(actual []metricAssertion) error {
+	if err := a.Count.Validate(len(actual)); err != nil {
+		return fmt.Errorf("metrics/count: %w", err)
+	}
+
+	if len(a.Exact) > 0 {
+		if err := validateExactCollection("metric", a.Exact, actual, func(expected, got metricAssertion) error {
+			return expected.MatchesAssertion(got)
+		}); err != nil {
+			return fmt.Errorf("metrics exact assertion failed: %w", err)
+		}
+	}
+
+	if len(a.Include) > 0 {
+		if err := validateIncludeCollection("metric", a.Include, actual, func(expected, got metricAssertion) error {
+			return expected.MatchesAssertion(got)
+		}); err != nil {
+			return fmt.Errorf("metrics include assertion failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (a ResourcesAssertion) Validate(actual []resourceAssertion) error {
+	if err := a.Count.Validate(len(actual)); err != nil {
+		return fmt.Errorf("resources/count: %w", err)
+	}
+	if len(a.Exact) > 0 {
+		if err := validateExactCollection("resource", a.Exact, actual, func(expected, got resourceAssertion) error {
+			return expected.Matches(got)
+		}); err != nil {
+			return fmt.Errorf("resources exact assertion failed: %w", err)
+		}
+	}
+	if len(a.Include) > 0 {
+		if err := validateIncludeCollection("resource", a.Include, actual, func(expected, got resourceAssertion) error {
+			return expected.Matches(got)
+		}); err != nil {
+			return fmt.Errorf("resources include assertion failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func (a ScopesAssertion) Validate(actual []scopeAssertion) error {
+	if err := a.Count.Validate(len(actual)); err != nil {
+		return fmt.Errorf("scopes/count: %w", err)
+	}
+	if len(a.Exact) > 0 {
+		if err := validateExactCollection("scope", a.Exact, actual, func(expected, got scopeAssertion) error {
+			return expected.Matches(got)
+		}); err != nil {
+			return fmt.Errorf("scopes exact assertion failed: %w", err)
+		}
+	}
+	if len(a.Include) > 0 {
+		if err := validateIncludeCollection("scope", a.Include, actual, func(expected, got scopeAssertion) error {
+			return expected.Matches(got)
+		}); err != nil {
+			return fmt.Errorf("scopes include assertion failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func (a DatapointsAssertion) Validate(actual []datapointAssertion) error {
+	if err := a.Count.Validate(len(actual)); err != nil {
+		return fmt.Errorf("datapoints/count: %w", err)
+	}
+	if len(a.Exact) > 0 {
+		if err := validateExactCollection("datapoint", a.Exact, actual, func(expected, got datapointAssertion) error {
+			return expected.Matches(got)
+		}); err != nil {
+			return fmt.Errorf("datapoints exact assertion failed: %w", err)
+		}
+	}
+	if len(a.Include) > 0 {
+		if err := validateIncludeCollection("datapoint", a.Include, actual, func(expected, got datapointAssertion) error {
+			return expected.Matches(got)
+		}); err != nil {
+			return fmt.Errorf("datapoints include assertion failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateMetricExact(expected []MetricAssertion, actual pmetric.MetricSlice) error {
+	if len(expected) != actual.Len() {
+		return fmt.Errorf("expected %d metrics, got %d", len(expected), actual.Len())
+	}
+
+	used := make([]bool, actual.Len())
+	for i := range expected {
+		em := expected[i]
+		found := -1
+		for j := 0; j < actual.Len(); j++ {
+			if used[j] {
+				continue
+			}
+			if err := em.Matches(actual.At(j)); err == nil {
+				found = j
+				break
+			}
+		}
+		if found < 0 {
+			return fmt.Errorf("expected metric[%d] (%q) was not found in actual metrics", i, em.Name)
+		}
+		used[found] = true
+	}
+	return nil
+}
+
+func validateMetricInclude(expected []MetricAssertion, actual pmetric.MetricSlice) error {
+	for i := range expected {
+		em := expected[i]
+		matched := false
+		for j := 0; j < actual.Len(); j++ {
+			if err := em.Matches(actual.At(j)); err == nil {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("included metric[%d] (%q) was not found in actual metrics", i, em.Name)
+		}
+	}
+	return nil
+}
+
+func validateExactCollection[T any](itemName string, expected, actual []T, matches func(T, T) error) error {
+	if len(expected) != len(actual) {
+		return fmt.Errorf("expected %d %ss, got %d", len(expected), itemName, len(actual))
+	}
+
+	used := make([]bool, len(actual))
+	for i, e := range expected {
+		found := -1
+		var candidateErrs []error
+		for j, a := range actual {
+			if used[j] {
+				continue
+			}
+			err := matches(e, a)
+			if err == nil {
+				found = j
+				break
+			}
+			candidateErrs = append(candidateErrs, err)
+		}
+		if found < 0 {
+			if len(candidateErrs) > 0 {
+				return fmt.Errorf("expected %s[%d] was not found in actual %ss: %w", itemName, i, itemName, errors.Join(candidateErrs...))
+			}
+			return fmt.Errorf("expected %s[%d] was not found in actual %ss", itemName, i, itemName)
+		}
+		used[found] = true
+	}
+
+	return nil
+}
+
+func validateIncludeCollection[T any](itemName string, expected, actual []T, matches func(T, T) error) error {
+	for i, e := range expected {
+		matched := false
+		var candidateErrs []error
+		for _, a := range actual {
+			err := matches(e, a)
+			if err == nil {
+				matched = true
+				break
+			}
+			candidateErrs = append(candidateErrs, err)
+		}
+		if !matched {
+			if len(candidateErrs) > 0 {
+				return fmt.Errorf("included %s[%d] was not found in actual %ss: %w", itemName, i, itemName, errors.Join(candidateErrs...))
+			}
+			return fmt.Errorf("included %s[%d] was not found in actual %ss", itemName, i, itemName)
+		}
+	}
+	return nil
+}
+
+func (r resourceAssertion) Matches(actual resourceAssertion) error {
+	if err := compareAttributes(r.Attributes, actual.Attributes); err != nil {
+		return fmt.Errorf("attributes: %w", err)
+	}
+	return compareResource(r, actual)
+}
+
+func (s scopeAssertion) Matches(actual scopeAssertion) error {
+	if s.Name != actual.Name {
+		return fmt.Errorf("name mismatch: expected %q, got %q", s.Name, actual.Name)
+	}
+	if s.Version != actual.Version {
+		return fmt.Errorf("version mismatch: expected %q, got %q", s.Version, actual.Version)
+	}
+	return compareScope(s, actual)
+}
+
+func (d datapointAssertion) Matches(actual datapointAssertion) error {
+	return compareAttributes(d.Attributes, actual.Attributes)
+}
+
+// Matches validates one actual metric against this expected metric assertion.
+func (m metricAssertion) Matches(actual pmetric.Metric) error {
+	expected := m
+	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 {
+		expected.Datapoints.Exact = []datapointAssertion{{}}
+	}
+
+	actualAssertion := buildMetricAssertion(actual)
+	actualAssertion.Datapoints.Exact = make([]datapointAssertion, 0, len(extractDatapointAttributes(actual)))
+	for _, attrs := range extractDatapointAttributes(actual) {
+		actualAssertion.Datapoints.Exact = append(actualAssertion.Datapoints.Exact, datapointAssertion{Attributes: attrMapToRaw(attrs)})
+	}
+	return compareMetric(expected, actualAssertion)
+}
+
+func (m metricAssertion) MatchesAssertion(actual metricAssertion) error {
+	expected := m
+	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 {
+		expected.Datapoints.Exact = []datapointAssertion{{}}
+	}
+	return compareMetric(expected, actual)
+}

--- a/pkg/pdatatest/pmetricassert/collection_assertion.go
+++ b/pkg/pdatatest/pmetricassert/collection_assertion.go
@@ -231,7 +231,7 @@ func (a MetricsAssertion) Validate(actualMetrics pmetric.MetricSlice) error {
 		return fmt.Errorf("metrics/count: %w", err)
 	}
 
-	if len(a.Exact) > 0 {
+	if a.Exact != nil {
 		if err := validateMetricExact(a.Exact, actualMetrics); err != nil {
 			return fmt.Errorf("metrics exact assertion failed: %w", err)
 		}
@@ -274,7 +274,7 @@ func (a ResourcesAssertion) Validate(actual []resourceAssertion) error {
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("resources/count: %w", err)
 	}
-	if len(a.Exact) > 0 {
+	if a.Exact != nil {
 		if err := validateExactCollection("resource", a.Exact, actual, func(expected, got resourceAssertion) error {
 			return expected.Matches(got)
 		}); err != nil {
@@ -295,7 +295,7 @@ func (a ScopesAssertion) Validate(actual []scopeAssertion) error {
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("scopes/count: %w", err)
 	}
-	if len(a.Exact) > 0 {
+	if a.Exact != nil {
 		if err := validateExactCollection("scope", a.Exact, actual, func(expected, got scopeAssertion) error {
 			return expected.Matches(got)
 		}); err != nil {
@@ -316,7 +316,7 @@ func (a DatapointsAssertion) Validate(actual []datapointAssertion) error {
 	if err := a.Count.Validate(len(actual)); err != nil {
 		return fmt.Errorf("datapoints/count: %w", err)
 	}
-	if len(a.Exact) > 0 {
+	if a.Exact != nil {
 		if err := validateExactCollection("datapoint", a.Exact, actual, func(expected, got datapointAssertion) error {
 			return expected.Matches(got)
 		}); err != nil {
@@ -454,7 +454,7 @@ func (d datapointAssertion) Matches(actual datapointAssertion) error {
 // Matches validates one actual metric against this expected metric assertion.
 func (m metricAssertion) Matches(actual pmetric.Metric) error {
 	expected := m
-	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 {
+	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 && expected.Datapoints.Count == nil {
 		expected.Datapoints.Exact = []datapointAssertion{{}}
 	}
 
@@ -468,7 +468,7 @@ func (m metricAssertion) Matches(actual pmetric.Metric) error {
 
 func (m metricAssertion) MatchesAssertion(actual metricAssertion) error {
 	expected := m
-	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 {
+	if len(expected.Datapoints.Exact) == 0 && len(expected.Datapoints.Include) == 0 && expected.Datapoints.Count == nil {
 		expected.Datapoints.Exact = []datapointAssertion{{}}
 	}
 	return compareMetric(expected, actual)

--- a/pkg/pdatatest/pmetricassert/collection_assertion_test.go
+++ b/pkg/pdatatest/pmetricassert/collection_assertion_test.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pmetricassert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCountAssertionValidate(t *testing.T) {
+	t.Run("exact pass", func(t *testing.T) {
+		exact := 2
+		c := &CountAssertion{Exact: &exact}
+		require.NoError(t, c.Validate(2))
+	})
+
+	t.Run("exact fail", func(t *testing.T) {
+		exact := 1
+		c := &CountAssertion{Exact: &exact}
+		err := c.Validate(2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected exactly 1 items, got 2")
+	})
+
+	t.Run("range pass", func(t *testing.T) {
+		minVal := 1
+		maxVal := 3
+		c := &CountAssertion{Min: &minVal, Max: &maxVal}
+		require.NoError(t, c.Validate(2))
+	})
+
+	t.Run("range fail", func(t *testing.T) {
+		minVal := 3
+		c := &CountAssertion{Min: &minVal}
+		err := c.Validate(2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected at least 3 items, got 2")
+	})
+
+	t.Run("invalid exact with min", func(t *testing.T) {
+		exact := 1
+		minVal := 0
+		c := &CountAssertion{Exact: &exact, Min: &minVal}
+		err := c.Validate(1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exact cannot be combined with min/max")
+	})
+}
+
+func TestMetricsAssertionUnmarshalYAML(t *testing.T) {
+	var a MetricsAssertion
+	err := yaml.Unmarshal([]byte(`
+metrics/exact:
+  - name: svc.active
+    type: gauge
+metrics/include:
+  - name: svc.requests
+    type: sum
+metrics/count:
+  min: 1
+  max: 3
+`), &a)
+	require.NoError(t, err)
+	require.Len(t, a.Exact, 1)
+	require.Equal(t, "svc.active", a.Exact[0].Name)
+	require.Len(t, a.Include, 1)
+	require.Equal(t, "svc.requests", a.Include[0].Name)
+	require.NotNil(t, a.Count)
+	require.NotNil(t, a.Count.Min)
+	require.NotNil(t, a.Count.Max)
+	require.Equal(t, 1, *a.Count.Min)
+	require.Equal(t, 3, *a.Count.Max)
+}
+
+func TestMetricsAssertionValidate(t *testing.T) {
+	actual := buildMetricSlice(t, []metricAssertion{
+		{Name: "svc.requests", Type: "sum", Unit: "{requests}", Temporality: "cumulative", Monotonic: boolPtr(true)},
+		{Name: "svc.active", Type: "gauge", Unit: "1"},
+	})
+
+	t.Run("exact order insensitive", func(t *testing.T) {
+		exact := []MetricAssertion{
+			{Name: "svc.active", Type: "gauge", Unit: "1"},
+			{Name: "svc.requests", Type: "sum", Unit: "{requests}", Temporality: "cumulative", Monotonic: boolPtr(true)},
+		}
+		assertion := MetricsAssertion{Exact: exact}
+		require.NoError(t, assertion.Validate(actual))
+	})
+
+	t.Run("include subset", func(t *testing.T) {
+		include := []MetricAssertion{{Name: "svc.active", Type: "gauge", Unit: "1"}}
+		assertion := MetricsAssertion{Include: include}
+		require.NoError(t, assertion.Validate(actual))
+	})
+
+	t.Run("count plus include", func(t *testing.T) {
+		exactCount := 2
+		assertion := MetricsAssertion{
+			Include: []MetricAssertion{{Name: "svc.active", Type: "gauge", Unit: "1"}},
+			Count:   &CountAssertion{Exact: &exactCount},
+		}
+		require.NoError(t, assertion.Validate(actual))
+	})
+
+	t.Run("include missing", func(t *testing.T) {
+		assertion := MetricsAssertion{Include: []MetricAssertion{{Name: "svc.latency", Type: "histogram"}}}
+		err := assertion.Validate(actual)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "included metric[0] (\"svc.latency\") was not found")
+	})
+}
+
+func buildMetricSlice(t *testing.T, assertions []metricAssertion) pmetric.MetricSlice {
+	t.Helper()
+
+	m := pmetric.NewMetrics()
+	rm := m.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	ms := sm.Metrics()
+
+	for i := range assertions {
+		a := assertions[i]
+		metric := ms.AppendEmpty()
+		metric.SetName(a.Name)
+		metric.SetUnit(a.Unit)
+
+		switch a.Type {
+		case "gauge":
+			metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+		case "sum":
+			sum := metric.SetEmptySum()
+			sum.SetIsMonotonic(a.Monotonic != nil && *a.Monotonic)
+			if a.Temporality == "delta" {
+				sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+			} else {
+				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			}
+			sum.DataPoints().AppendEmpty().SetIntValue(1)
+		default:
+			t.Fatalf("unsupported metric type for test helper: %q", a.Type)
+		}
+	}
+
+	return sm.Metrics()
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/pkg/pdatatest/pmetricassert/collection_assertion_test.go
+++ b/pkg/pdatatest/pmetricassert/collection_assertion_test.go
@@ -57,9 +57,6 @@ func TestMetricsAssertionUnmarshalYAML(t *testing.T) {
 metrics/exact:
   - name: svc.active
     type: gauge
-metrics/include:
-  - name: svc.requests
-    type: sum
 metrics/count:
   min: 1
   max: 3
@@ -67,8 +64,6 @@ metrics/count:
 	require.NoError(t, err)
 	require.Len(t, a.Exact, 1)
 	require.Equal(t, "svc.active", a.Exact[0].Name)
-	require.Len(t, a.Include, 1)
-	require.Equal(t, "svc.requests", a.Include[0].Name)
 	require.NotNil(t, a.Count)
 	require.NotNil(t, a.Count.Min)
 	require.NotNil(t, a.Count.Max)
@@ -91,26 +86,18 @@ func TestMetricsAssertionValidate(t *testing.T) {
 		require.NoError(t, assertion.Validate(actual))
 	})
 
-	t.Run("include subset", func(t *testing.T) {
-		include := []MetricAssertion{{Name: "svc.active", Type: "gauge", Unit: "1"}}
-		assertion := MetricsAssertion{Include: include}
-		require.NoError(t, assertion.Validate(actual))
-	})
-
-	t.Run("count plus include", func(t *testing.T) {
+	t.Run("count exact pass", func(t *testing.T) {
 		exactCount := 2
-		assertion := MetricsAssertion{
-			Include: []MetricAssertion{{Name: "svc.active", Type: "gauge", Unit: "1"}},
-			Count:   &CountAssertion{Exact: &exactCount},
-		}
+		assertion := MetricsAssertion{Count: &CountAssertion{Exact: &exactCount}}
 		require.NoError(t, assertion.Validate(actual))
 	})
 
-	t.Run("include missing", func(t *testing.T) {
-		assertion := MetricsAssertion{Include: []MetricAssertion{{Name: "svc.latency", Type: "histogram"}}}
+	t.Run("count exact fail", func(t *testing.T) {
+		exactCount := 1
+		assertion := MetricsAssertion{Count: &CountAssertion{Exact: &exactCount}}
 		err := assertion.Validate(actual)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "included metric[0] (\"svc.latency\") was not found")
+		require.Contains(t, err.Error(), "expected exactly 1 items, got 2")
 	})
 }
 

--- a/pkg/pdatatest/pmetricassert/document.go
+++ b/pkg/pdatatest/pmetricassert/document.go
@@ -287,17 +287,11 @@ func expandShorthand(doc *document) {
 	for i := range doc.Resources.Exact {
 		expandResourceShorthand(&doc.Resources.Exact[i])
 	}
-	for i := range doc.Resources.Include {
-		expandResourceShorthand(&doc.Resources.Include[i])
-	}
 }
 
 func expandResourceShorthand(r *resourceAssertion) {
 	for i := range r.Scopes.Exact {
 		expandScopeShorthand(&r.Scopes.Exact[i])
-	}
-	for i := range r.Scopes.Include {
-		expandScopeShorthand(&r.Scopes.Include[i])
 	}
 }
 
@@ -305,13 +299,10 @@ func expandScopeShorthand(s *scopeAssertion) {
 	for i := range s.Metrics.Exact {
 		expandMetricShorthand(&s.Metrics.Exact[i])
 	}
-	for i := range s.Metrics.Include {
-		expandMetricShorthand(&s.Metrics.Include[i])
-	}
 }
 
 func expandMetricShorthand(m *metricAssertion) {
-	if len(m.Datapoints.Exact) == 0 && len(m.Datapoints.Include) == 0 && m.Datapoints.Count == nil {
+	if len(m.Datapoints.Exact) == 0 && m.Datapoints.Count == nil {
 		m.Datapoints.Exact = []datapointAssertion{{}}
 	}
 }
@@ -332,10 +323,7 @@ func compactShorthand(doc *document) {
 	for i := range doc.Resources.Exact {
 		compactResourceShorthand(&doc.Resources.Exact[i])
 	}
-	for i := range doc.Resources.Include {
-		compactResourceShorthand(&doc.Resources.Include[i])
-	}
-	if len(doc.Resources.Include) == 0 && doc.Resources.Count == nil {
+	if doc.Resources.Count == nil {
 		doc.Resources = ResourcesAssertion{Exact: doc.Resources.Exact}
 	}
 }
@@ -344,10 +332,7 @@ func compactResourceShorthand(r *resourceAssertion) {
 	for i := range r.Scopes.Exact {
 		compactScopeShorthand(&r.Scopes.Exact[i])
 	}
-	for i := range r.Scopes.Include {
-		compactScopeShorthand(&r.Scopes.Include[i])
-	}
-	if len(r.Scopes.Include) == 0 && r.Scopes.Count == nil {
+	if r.Scopes.Count == nil {
 		r.Scopes = ScopesAssertion{Exact: r.Scopes.Exact}
 	}
 }
@@ -356,16 +341,13 @@ func compactScopeShorthand(s *scopeAssertion) {
 	for i := range s.Metrics.Exact {
 		compactMetricShorthand(&s.Metrics.Exact[i])
 	}
-	for i := range s.Metrics.Include {
-		compactMetricShorthand(&s.Metrics.Include[i])
-	}
-	if len(s.Metrics.Include) == 0 && s.Metrics.Count == nil {
+	if s.Metrics.Count == nil {
 		s.Metrics = MetricsAssertion{Exact: s.Metrics.Exact}
 	}
 }
 
 func compactMetricShorthand(m *metricAssertion) {
-	if len(m.Datapoints.Exact) == 1 && len(m.Datapoints.Exact[0].Attributes) == 0 && len(m.Datapoints.Include) == 0 && m.Datapoints.Count == nil {
+	if len(m.Datapoints.Exact) == 1 && len(m.Datapoints.Exact[0].Attributes) == 0 && m.Datapoints.Count == nil {
 		m.Datapoints = DatapointsAssertion{}
 	}
 }

--- a/pkg/pdatatest/pmetricassert/document.go
+++ b/pkg/pdatatest/pmetricassert/document.go
@@ -311,7 +311,7 @@ func expandScopeShorthand(s *scopeAssertion) {
 }
 
 func expandMetricShorthand(m *metricAssertion) {
-	if len(m.Datapoints.Exact) == 0 && len(m.Datapoints.Include) == 0 {
+	if len(m.Datapoints.Exact) == 0 && len(m.Datapoints.Include) == 0 && m.Datapoints.Count == nil {
 		m.Datapoints.Exact = []datapointAssertion{{}}
 	}
 }

--- a/pkg/pdatatest/pmetricassert/document.go
+++ b/pkg/pdatatest/pmetricassert/document.go
@@ -6,6 +6,7 @@ package pmetricassert // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -22,33 +23,235 @@ const documentVersion = 1
 // identity fields only. Operator-suffix extensions (/include, /regex,
 // /count, ...) are tracked as follow-ups.
 type document struct {
-	Version   int                 `yaml:"version"`
-	Signal    string              `yaml:"signal"`
-	Resources []resourceAssertion `yaml:"resources"`
+	Version   int                `yaml:"version"`
+	Signal    string             `yaml:"signal"`
+	Resources ResourcesAssertion `yaml:"resources"`
 }
 
 type resourceAssertion struct {
-	Attributes map[string]any   `yaml:"attributes,omitempty"`
-	Scopes     []scopeAssertion `yaml:"scopes"`
+	Attributes map[string]any  `yaml:"attributes,omitempty"`
+	Scopes     ScopesAssertion `yaml:"scopes"`
 }
 
 type scopeAssertion struct {
-	Name    string            `yaml:"name,omitempty"`
-	Version string            `yaml:"version,omitempty"`
-	Metrics []metricAssertion `yaml:"metrics"`
+	Name    string           `yaml:"name,omitempty"`
+	Version string           `yaml:"version,omitempty"`
+	Metrics MetricsAssertion `yaml:"metrics"`
 }
 
 type metricAssertion struct {
-	Name        string               `yaml:"name"`
-	Type        string               `yaml:"type"`
-	Unit        string               `yaml:"unit,omitempty"`
-	Temporality string               `yaml:"temporality,omitempty"`
-	Monotonic   *bool                `yaml:"monotonic,omitempty"`
-	Datapoints  []datapointAssertion `yaml:"datapoints,omitempty"`
+	Name        string              `yaml:"name"`
+	Type        string              `yaml:"type"`
+	Unit        string              `yaml:"unit,omitempty"`
+	Temporality string              `yaml:"temporality,omitempty"`
+	Monotonic   *bool               `yaml:"monotonic,omitempty"`
+	Datapoints  DatapointsAssertion `yaml:"datapoints,omitempty"`
 }
 
 type datapointAssertion struct {
 	Attributes map[string]any `yaml:"attributes,omitempty"`
+}
+
+func (d *document) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("document must be a map, got YAML kind %d", value.Kind)
+	}
+
+	resourcesNode, err := extractCollectionNodeFromParent(value, "resources")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch {
+		case key == "version":
+			if err := val.Decode(&d.Version); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "signal":
+			if err := val.Decode(&d.Signal); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "resources" || strings.HasPrefix(key, "resources/"):
+			// Handled through ResourcesAssertion below.
+		default:
+			return fmt.Errorf("unsupported document key %q", key)
+		}
+	}
+
+	if resourcesNode != nil {
+		if err := d.Resources.UnmarshalYAML(resourcesNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *resourceAssertion) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("resource assertion must be a map, got YAML kind %d", value.Kind)
+	}
+
+	scopesNode, err := extractCollectionNodeFromParent(value, "scopes")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch {
+		case key == "attributes":
+			if err := val.Decode(&r.Attributes); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "scopes" || strings.HasPrefix(key, "scopes/"):
+			// Handled through ScopesAssertion below.
+		default:
+			return fmt.Errorf("unsupported resource assertion key %q", key)
+		}
+	}
+
+	if scopesNode != nil {
+		if err := r.Scopes.UnmarshalYAML(scopesNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *scopeAssertion) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("scope assertion must be a map, got YAML kind %d", value.Kind)
+	}
+
+	metricsNode, err := extractCollectionNodeFromParent(value, "metrics")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch {
+		case key == "name":
+			if err := val.Decode(&s.Name); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "version":
+			if err := val.Decode(&s.Version); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "metrics" || strings.HasPrefix(key, "metrics/"):
+			// Handled through MetricsAssertion below.
+		default:
+			return fmt.Errorf("unsupported scope assertion key %q", key)
+		}
+	}
+
+	if metricsNode != nil {
+		if err := s.Metrics.UnmarshalYAML(metricsNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *metricAssertion) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("metric assertion must be a map, got YAML kind %d", value.Kind)
+	}
+
+	datapointsNode, err := extractCollectionNodeFromParent(value, "datapoints")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		val := value.Content[i+1]
+		switch {
+		case key == "name":
+			if err := val.Decode(&m.Name); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "type":
+			if err := val.Decode(&m.Type); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "unit":
+			if err := val.Decode(&m.Unit); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "temporality":
+			if err := val.Decode(&m.Temporality); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "monotonic":
+			if err := val.Decode(&m.Monotonic); err != nil {
+				return fmt.Errorf("decode %q: %w", key, err)
+			}
+		case key == "datapoints" || strings.HasPrefix(key, "datapoints/"):
+			// Handled through DatapointsAssertion below.
+		default:
+			return fmt.Errorf("unsupported metric assertion key %q", key)
+		}
+	}
+
+	if datapointsNode != nil {
+		if err := m.Datapoints.UnmarshalYAML(datapointsNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func extractCollectionNodeFromParent(parent *yaml.Node, baseKey string) (*yaml.Node, error) {
+	var direct *yaml.Node
+	var withSuffix []struct {
+		key string
+		val *yaml.Node
+	}
+
+	for i := 0; i < len(parent.Content); i += 2 {
+		key := parent.Content[i].Value
+		val := parent.Content[i+1]
+		switch {
+		case key == baseKey:
+			if direct != nil {
+				return nil, fmt.Errorf("duplicate %s assertion key %q", baseKey, key)
+			}
+			direct = val
+		case strings.HasPrefix(key, baseKey+"/"):
+			withSuffix = append(withSuffix, struct {
+				key string
+				val *yaml.Node
+			}{key: key, val: val})
+		}
+	}
+
+	if direct == nil && len(withSuffix) == 0 {
+		return nil, nil
+	}
+
+	if len(withSuffix) == 0 {
+		return direct, nil
+	}
+
+	m := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	if direct != nil {
+		m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: baseKey}, direct)
+	}
+	for _, entry := range withSuffix {
+		m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: entry.key}, entry.val)
+	}
+	return m, nil
 }
 
 func readDocument(path string) (*document, error) {
@@ -81,15 +284,35 @@ func readDocument(path string) (*document, error) {
 // before comparison, so pmetricassert does not accept the empty-metric
 // encoding as a valid assertion either.
 func expandShorthand(doc *document) {
-	for i := range doc.Resources {
-		for j := range doc.Resources[i].Scopes {
-			for k := range doc.Resources[i].Scopes[j].Metrics {
-				m := &doc.Resources[i].Scopes[j].Metrics[k]
-				if len(m.Datapoints) == 0 {
-					m.Datapoints = []datapointAssertion{{}}
-				}
-			}
-		}
+	for i := range doc.Resources.Exact {
+		expandResourceShorthand(&doc.Resources.Exact[i])
+	}
+	for i := range doc.Resources.Include {
+		expandResourceShorthand(&doc.Resources.Include[i])
+	}
+}
+
+func expandResourceShorthand(r *resourceAssertion) {
+	for i := range r.Scopes.Exact {
+		expandScopeShorthand(&r.Scopes.Exact[i])
+	}
+	for i := range r.Scopes.Include {
+		expandScopeShorthand(&r.Scopes.Include[i])
+	}
+}
+
+func expandScopeShorthand(s *scopeAssertion) {
+	for i := range s.Metrics.Exact {
+		expandMetricShorthand(&s.Metrics.Exact[i])
+	}
+	for i := range s.Metrics.Include {
+		expandMetricShorthand(&s.Metrics.Include[i])
+	}
+}
+
+func expandMetricShorthand(m *metricAssertion) {
+	if len(m.Datapoints.Exact) == 0 && len(m.Datapoints.Include) == 0 {
+		m.Datapoints.Exact = []datapointAssertion{{}}
 	}
 }
 
@@ -106,14 +329,43 @@ func writeDocument(path string, doc *document) error {
 // single empty-attribute datapoint so the emitted YAML reads as "metric with
 // no dimensioning attributes" rather than "metric with one empty datapoint".
 func compactShorthand(doc *document) {
-	for i := range doc.Resources {
-		for j := range doc.Resources[i].Scopes {
-			for k := range doc.Resources[i].Scopes[j].Metrics {
-				m := &doc.Resources[i].Scopes[j].Metrics[k]
-				if len(m.Datapoints) == 1 && len(m.Datapoints[0].Attributes) == 0 {
-					m.Datapoints = nil
-				}
-			}
-		}
+	for i := range doc.Resources.Exact {
+		compactResourceShorthand(&doc.Resources.Exact[i])
+	}
+	for i := range doc.Resources.Include {
+		compactResourceShorthand(&doc.Resources.Include[i])
+	}
+	if len(doc.Resources.Include) == 0 && doc.Resources.Count == nil {
+		doc.Resources = ResourcesAssertion{Exact: doc.Resources.Exact}
+	}
+}
+
+func compactResourceShorthand(r *resourceAssertion) {
+	for i := range r.Scopes.Exact {
+		compactScopeShorthand(&r.Scopes.Exact[i])
+	}
+	for i := range r.Scopes.Include {
+		compactScopeShorthand(&r.Scopes.Include[i])
+	}
+	if len(r.Scopes.Include) == 0 && r.Scopes.Count == nil {
+		r.Scopes = ScopesAssertion{Exact: r.Scopes.Exact}
+	}
+}
+
+func compactScopeShorthand(s *scopeAssertion) {
+	for i := range s.Metrics.Exact {
+		compactMetricShorthand(&s.Metrics.Exact[i])
+	}
+	for i := range s.Metrics.Include {
+		compactMetricShorthand(&s.Metrics.Include[i])
+	}
+	if len(s.Metrics.Include) == 0 && s.Metrics.Count == nil {
+		s.Metrics = MetricsAssertion{Exact: s.Metrics.Exact}
+	}
+}
+
+func compactMetricShorthand(m *metricAssertion) {
+	if len(m.Datapoints.Exact) == 1 && len(m.Datapoints.Exact[0].Attributes) == 0 && len(m.Datapoints.Include) == 0 && m.Datapoints.Count == nil {
+		m.Datapoints = DatapointsAssertion{}
 	}
 }

--- a/pkg/pdatatest/pmetricassert/document_test.go
+++ b/pkg/pdatatest/pmetricassert/document_test.go
@@ -1,0 +1,82 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pmetricassert
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadDocument_CollectionOperatorSuffixes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`version: 1
+signal: metrics
+resources/count:
+  exact: 1
+resources/include:
+  - attributes:
+      service.name: svc
+    scopes/include:
+      - name: scope-a
+        metrics/include:
+          - name: svc.requests
+            type: sum
+            unit: "{requests}"
+            temporality: cumulative
+            monotonic: true
+            datapoints/include:
+              - attributes:
+                  method: GET
+`), 0o600))
+
+	doc, err := readDocument(path)
+	require.NoError(t, err)
+	require.NotNil(t, doc.Resources.Count)
+	require.NotNil(t, doc.Resources.Count.Exact)
+	require.Equal(t, 1, *doc.Resources.Count.Exact)
+	require.Len(t, doc.Resources.Include, 1)
+
+	res := doc.Resources.Include[0]
+	require.Len(t, res.Scopes.Include, 1)
+	scope := res.Scopes.Include[0]
+	require.Len(t, scope.Metrics.Include, 1)
+	metric := scope.Metrics.Include[0]
+	require.Len(t, metric.Datapoints.Include, 1)
+	require.Equal(t, "GET", metric.Datapoints.Include[0].Attributes["method"])
+}
+
+func TestWriteDocument_DefaultCollectionsMarshalAsExact(t *testing.T) {
+	doc := &document{
+		Version: documentVersion,
+		Signal:  "metrics",
+		Resources: ResourcesAssertion{Exact: []resourceAssertion{
+			{
+				Attributes: map[string]any{"service.name": "svc"},
+				Scopes: ScopesAssertion{Exact: []scopeAssertion{
+					{
+						Name: "scope",
+						Metrics: MetricsAssertion{Exact: []metricAssertion{
+							{Name: "svc.active", Type: "gauge", Unit: "1", Datapoints: DatapointsAssertion{Exact: []datapointAssertion{{}}}},
+						}},
+					},
+				}},
+			},
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
+	require.NoError(t, writeDocument(path, doc))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "resources:")
+	require.Contains(t, string(raw), "scopes:")
+	require.Contains(t, string(raw), "metrics:")
+	require.NotContains(t, string(raw), "resources/exact")
+	require.NotContains(t, string(raw), "scopes/exact")
+	require.NotContains(t, string(raw), "metrics/exact")
+}

--- a/pkg/pdatatest/pmetricassert/document_test.go
+++ b/pkg/pdatatest/pmetricassert/document_test.go
@@ -13,40 +13,40 @@ import (
 
 func TestReadDocument_CollectionOperatorSuffixes(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
-	require.NoError(t, os.WriteFile(path, []byte(`version: 1
-signal: metrics
-resources/count:
-  exact: 1
-resources/include:
-  - attributes:
-      service.name: svc
-    scopes/include:
-      - name: scope-a
-        metrics/include:
-          - name: svc.requests
-            type: sum
-            unit: "{requests}"
-            temporality: cumulative
-            monotonic: true
-            datapoints/include:
-              - attributes:
-                  method: GET
-`), 0o600))
+	yamlContent := "version: 1\n" +
+		"signal: metrics\n" +
+		"resources/count:\n" +
+		"  exact: 1\n" +
+		"resources/exact:\n" +
+		"  - attributes:\n" +
+		"      service.name: svc\n" +
+		"    scopes/exact:\n" +
+		"      - name: scope-a\n" +
+		"        metrics/exact:\n" +
+		"          - name: svc.requests\n" +
+		"            type: sum\n" +
+		"            unit: \"{requests}\"\n" +
+		"            temporality: cumulative\n" +
+		"            monotonic: true\n" +
+		"            datapoints/exact:\n" +
+		"              - attributes:\n" +
+		"                  method: GET\n"
+	require.NoError(t, os.WriteFile(path, []byte(yamlContent), 0o600))
 
 	doc, err := readDocument(path)
 	require.NoError(t, err)
 	require.NotNil(t, doc.Resources.Count)
 	require.NotNil(t, doc.Resources.Count.Exact)
 	require.Equal(t, 1, *doc.Resources.Count.Exact)
-	require.Len(t, doc.Resources.Include, 1)
+	require.Len(t, doc.Resources.Exact, 1)
 
-	res := doc.Resources.Include[0]
-	require.Len(t, res.Scopes.Include, 1)
-	scope := res.Scopes.Include[0]
-	require.Len(t, scope.Metrics.Include, 1)
-	metric := scope.Metrics.Include[0]
-	require.Len(t, metric.Datapoints.Include, 1)
-	require.Equal(t, "GET", metric.Datapoints.Include[0].Attributes["method"])
+	res := doc.Resources.Exact[0]
+	require.Len(t, res.Scopes.Exact, 1)
+	scope := res.Scopes.Exact[0]
+	require.Len(t, scope.Metrics.Exact, 1)
+	metric := scope.Metrics.Exact[0]
+	require.Len(t, metric.Datapoints.Exact, 1)
+	require.Equal(t, "GET", metric.Datapoints.Exact[0].Attributes["method"])
 }
 
 func TestWriteDocument_DefaultCollectionsMarshalAsExact(t *testing.T) {

--- a/pkg/pdatatest/pmetricassert/normalize.go
+++ b/pkg/pdatatest/pmetricassert/normalize.go
@@ -120,12 +120,12 @@ func normalize(m pmetric.Metrics) *document {
 				sort.Slice(dpList, func(i, j int) bool {
 					return canonKey(dpList[i].Attributes) < canonKey(dpList[j].Attributes)
 				})
-				metricAssert.Datapoints = dpList
-				scope.Metrics = append(scope.Metrics, metricAssert)
+				metricAssert.Datapoints = DatapointsAssertion{Exact: dpList}
+				scope.Metrics.Exact = append(scope.Metrics.Exact, metricAssert)
 			}
-			res.Scopes = append(res.Scopes, scope)
+			res.Scopes.Exact = append(res.Scopes.Exact, scope)
 		}
-		doc.Resources = append(doc.Resources, res)
+		doc.Resources.Exact = append(doc.Resources.Exact, res)
 	}
 	return doc
 }


### PR DESCRIPTION
#### Description
This PR introduces support for the `/count` collection operator in the `pmetricassert` package, allowing tests to check collection cardinality (min, max, or exact count) without needing to match the entire telemetry payload exactly. 

*Note: To keep reviews atomic as requested, the `/include` operator mentioned in the tracking issue has been submitted in a separate PR.*

**High-level outcomes:**
* **Collection Assertion Types:** Added `CountAssertion` and integrated it into `ResourcesAssertion`, `ScopesAssertion`, `MetricsAssertion`, and `DatapointsAssertion` with robust bounds validation.
* **YAML Parsing:** Unmarshaling now handles operator suffixes dynamically from parent maps (e.g., `resources/count`, `metrics/count`).
* **Comparison Pipeline:** Wired `AssertMetrics` to route through the new collection validators. 

#### Link to tracking issue
Fixes #48472
Relates to #48079

#### Testing
* **`collection_assertion_test.go`**: Added tests for `CountAssertion` bounds (min/max/exact) and edge cases.
* **`document_test.go`**: Added tests verifying suffix parsing from parent-level YAML maps and default exact marshaling behavior.
* Verified that existing `assert_test.go` exact-match flows continue to pass with the new nested structs.