### PR TITLE
[receiver/github] Process pull-requests in reverse order to adhere to chronological ordering

### DIFF
--- a/.chloggen/github-pr-chronological-order.yaml
+++ b/.chloggen/github-pr-chronological-order.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/github
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Process pull-requests in reverse order to adhere to chronological ordering
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48578]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
@@ -250,8 +250,9 @@ func (ghs *githubScraper) getMergedPullRequests(
 
 		// Process PRs in reverse chronological order (most recent first)
 		// Stop immediately when we hit a PR older than our cutoff
-		for i := range prs.Repository.PullRequests.Nodes {
-			pr := &prs.Repository.PullRequests.Nodes[i]
+		nodes := prs.Repository.PullRequests.Nodes
+		for i := len(nodes) - 1; i >= 0; i-- {
+			pr := &nodes[i]
 
 			// Check if this PR is older than our cutoff date using the Before
 			// method, meaning; earlier in time which is older than our cutoff.

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -389,11 +389,17 @@ func TestCheckOwnerExists(t *testing.T) {
 }
 
 func TestGetPullRequests(t *testing.T) {
+	now := time.Now()
+	type prCount struct {
+		open   int
+		merged int
+	}
 	testCases := []struct {
 		desc            string
 		server          *http.ServeMux
+		lookbackDays    int
 		expectedErr     error
-		expectedPrCount int
+		expectedPrCount prCount
 	}{
 		{
 			desc: "TestSinglePageResponse",
@@ -422,7 +428,7 @@ func TestGetPullRequests(t *testing.T) {
 				},
 			}),
 			expectedErr:     nil,
-			expectedPrCount: 3, // 3 PRs per page, 1 pages
+			expectedPrCount: prCount{open: 3}, // 3 PRs per page, 1 page
 		},
 		{
 			desc: "TestMultiPageResponse",
@@ -467,7 +473,83 @@ func TestGetPullRequests(t *testing.T) {
 				},
 			}),
 			expectedErr:     nil,
-			expectedPrCount: 6, // 3 PRs per page, 2 pages
+			expectedPrCount: prCount{open: 6}, // 3 PRs per page, 2 pages
+		},
+		{
+			desc: "TestSinglePageResponseWithLookback",
+			server: MockServer(&responses{
+				prResponse: prResponse{
+					prs: []getPullRequestDataRepositoryPullRequestsPullRequestConnection{
+						{
+							PageInfo: getPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+								HasNextPage: false,
+							},
+							Nodes: []PullRequestNode{},
+						},
+					},
+					responseCode: http.StatusOK,
+				},
+				mergedPRResponse: mergedPRResponse{
+					prs: []getMergedPullRequestDataRepositoryPullRequestsPullRequestConnection{
+						{
+							PageInfo: getMergedPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+								HasPreviousPage: false,
+							},
+							Nodes: []MergedPullRequestNode{
+								{MergedAt: now.AddDate(0, 0, -10)}, // before cutoff — oldest first in page
+								{MergedAt: now.AddDate(0, 0, -5)},  // within cutoff
+								{MergedAt: now.AddDate(0, 0, -1)},  // within cutoff
+							},
+						},
+					},
+					responseCode: http.StatusOK,
+				},
+			}),
+			lookbackDays:    7,
+			expectedPrCount: prCount{merged: 2},
+		},
+		{
+			desc: "TestMultiPageResponseWithLookback",
+			server: MockServer(&responses{
+				prResponse: prResponse{
+					prs: []getPullRequestDataRepositoryPullRequestsPullRequestConnection{
+						{
+							PageInfo: getPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+								HasNextPage: false,
+							},
+							Nodes: []PullRequestNode{},
+						},
+					},
+					responseCode: http.StatusOK,
+				},
+				mergedPRResponse: mergedPRResponse{
+					prs: []getMergedPullRequestDataRepositoryPullRequestsPullRequestConnection{
+						{
+							// most recent page — both nodes within cutoff
+							PageInfo: getMergedPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+								HasPreviousPage: true,
+							},
+							Nodes: []MergedPullRequestNode{
+								{MergedAt: now.AddDate(0, 0, -3)},
+								{MergedAt: now.AddDate(0, 0, -1)},
+							},
+						},
+						{
+							// older page — all nodes before cutoff, stops pagination
+							PageInfo: getMergedPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+								HasPreviousPage: false,
+							},
+							Nodes: []MergedPullRequestNode{
+								{MergedAt: now.AddDate(0, 0, -12)},
+								{MergedAt: now.AddDate(0, 0, -9)},
+							},
+						},
+					},
+					responseCode: http.StatusOK,
+				},
+			}),
+			lookbackDays:    7,
+			expectedPrCount: prCount{merged: 2},
 		},
 		{
 			desc: "Test404Response",
@@ -477,8 +559,7 @@ func TestGetPullRequests(t *testing.T) {
 					responseCode: http.StatusNotFound,
 				},
 			}),
-			expectedErr:     errors.New("returned error 404"),
-			expectedPrCount: 0,
+			expectedErr: errors.New("returned error 404"),
 		},
 	}
 
@@ -488,18 +569,19 @@ func TestGetPullRequests(t *testing.T) {
 			defaultConfig := factory.CreateDefaultConfig()
 			settings := receivertest.NewNopSettings(metadata.Type)
 			ghs := newGitHubScraper(settings, defaultConfig.(*Config))
+			ghs.cfg.MergedPRLookbackDays = tc.lookbackDays
 			server := httptest.NewServer(tc.server)
 			defer server.Close()
 			client := graphql.NewClient(server.URL, ghs.client)
 
-			openPRs, _, err := ghs.getPullRequests(t.Context(), client, "repo name")
-
-			assert.Len(t, openPRs, tc.expectedPrCount)
+			openPRs, mergedPRs, err := ghs.getPullRequests(t.Context(), client, "repo name")
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)
 			} else {
 				assert.ErrorContains(t, err, tc.expectedErr.Error())
 			}
+
+			assert.Equal(t, prCount{open: len(openPRs), merged: len(mergedPRs)}, tc.expectedPrCount)
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Currently scraper takes last page of PRs ordered by creation time ASC, with idea of going through each node and stopping at cutoff date. Bug lies in the fact that last page is still ASC ordered, so first element is not the newest one but the <page_size> newest (e.g. 100th newest in this case). If this item falls out of cutoff, no further items will be processed.

This PR fixes the issue by reversing the order of processing, making it truly from newest to oldest.