### PR TITLE
feat: enrich CW metadata in logs and client context

### DIFF
--- a/.chloggen/feat_aws_lambda-receiver-cw-metadata.yaml
+++ b/.chloggen/feat_aws_lambda-receiver-cw-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/aws_lambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce metadata for derived logs and enrich client context with the same for CloudWatch logs.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48581]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -73,7 +73,7 @@ This metadata is added to the request context and can be accessed by any downstr
 > Static metadata such as `cloud.provider` are not available through `client.Info`.
 > These can be added using processors (for example, the resource processor).
 
-### CloudWatch Logs subscription
+### CloudWatch Logs subscription handling
 
 CloudWatch Logs events are handled in the following manner:
 
@@ -82,6 +82,19 @@ CloudWatch Logs events are handled in the following manner:
 - Decode payload using the configured encoding extension
   - Default encoding: Parse CloudWatch Logs messages to OpenTelemetry log records
   - Custom encoding: Use specified encoding extension (for example, `aws_logs_encoding` for AWS log formats)
+
+The following metadata is available through `client.Info` for CloudWatch Logs events.
+This metadata is added to the request context and can be accessed by any downstream component in the pipeline (for example, processors):
+
+| Metadata Key         | Description                |
+|----------------------|----------------------------|
+| cloud.account.id     | AWS account ID             |
+| aws.log.group.names  | CloudWatch log group name  |
+| aws.log.stream.names | CloudWatch log stream name |
+
+> [!NOTE]
+> Static metadata such as `cloud.provider` are not available through `client.Info`.
+> These can be added using processors (for example, the resource processor).
 
 ## Deployment
 

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -358,14 +358,24 @@ type cwMetadataEnvelop struct {
 	LogStream string `json:"logStream"`
 }
 
+// getEnrichedCWLog add extra metadata to resource attributes iff metadata is not already present.
+// This makes sure overrides do not happen if configured extensions already populate these attributes.
 func getEnrichedCWLog(logs plog.Logs, cwM cwMetadataEnvelop) {
 	for _, resourceLogs := range logs.ResourceLogs().All() {
 		resourceAttrs := resourceLogs.Resource().Attributes()
 
-		resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
-		resourceAttrs.PutStr(string(conventions.CloudAccountIDKey), cwM.Owner)
-		resourceAttrs.PutStr(string(conventions.AWSLogGroupNamesKey), cwM.LogGroup)
-		resourceAttrs.PutStr(string(conventions.AWSLogStreamNamesKey), cwM.LogStream)
+		if _, ok := resourceAttrs.Get(string(conventions.CloudProviderKey)); !ok {
+			resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
+		}
+		if _, ok := resourceAttrs.Get(string(conventions.CloudAccountIDKey)); !ok {
+			resourceAttrs.PutStr(string(conventions.CloudAccountIDKey), cwM.Owner)
+		}
+		if _, ok := resourceAttrs.Get(string(conventions.AWSLogGroupNamesKey)); !ok {
+			resourceAttrs.PutEmptySlice(string(conventions.AWSLogGroupNamesKey)).AppendEmpty().SetStr(cwM.LogGroup)
+		}
+		if _, ok := resourceAttrs.Get(string(conventions.AWSLogStreamNamesKey)); !ok {
+			resourceAttrs.PutEmptySlice(string(conventions.AWSLogStreamNamesKey)).AppendEmpty().SetStr(cwM.LogStream)
+		}
 	}
 }
 

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -283,7 +283,18 @@ func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMe
 
 	defer reader.Close()
 
-	decoder, err := c.logsDecoder.NewLogsDecoder(reader, encoding.WithFlushBytes(s3StreamBatchSize))
+	// Use T reader to extract metadata but rebuffer for downstream consumption
+	// CloudWatch subscription events are small in size compared to S3.
+	// Hence, parsing here has low impact for overall performance.
+	var buf bytes.Buffer
+	tReader := io.TeeReader(reader, &buf)
+
+	var mData cwMetadataEnvelop
+	if err = gojson.NewDecoder(tReader).Decode(&mData); err != nil {
+		return fmt.Errorf("failed to decode cloudwatch logs envelope: %w", err)
+	}
+
+	decoder, err := c.logsDecoder.NewLogsDecoder(&buf, encoding.WithFlushBytes(s3StreamBatchSize))
 	if err != nil {
 		return err
 	}
@@ -296,9 +307,11 @@ func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMe
 				break
 			}
 
-			return fmt.Errorf("failed to decode S3 logs: %w", err)
+			return fmt.Errorf("failed to decode CloudWatch logs: %w", err)
 		}
-		if err = c.consumer.ConsumeLogs(ctx, logs); err != nil {
+
+		getEnrichedCWLog(logs, mData)
+		if err = c.consumer.ConsumeLogs(getEnrichedCtxForCWLogs(ctx, mData), logs); err != nil {
 			return checkConsumerErrorAndWrap(err)
 		}
 	}
@@ -332,6 +345,35 @@ func getEnrichedContext(ctx context.Context, event events.S3EventRecord) context
 	metadata["aws.s3.bucket.name"] = []string{event.S3.Bucket.Name}
 	metadata["aws.s3.bucket.arn"] = []string{event.S3.Bucket.Arn}
 	metadata[string(conventions.AWSS3KeyKey)] = []string{event.S3.Object.Key}
+
+	info := client.Info{}
+	info.Metadata = client.NewMetadata(metadata)
+	return client.NewContext(ctx, info)
+}
+
+// cwMetadataEnvelop defines the structure to unmarshal the CloudWatch logs event envelope for metadata extraction.
+type cwMetadataEnvelop struct {
+	Owner     string `json:"owner"`
+	LogGroup  string `json:"logGroup"`
+	LogStream string `json:"logStream"`
+}
+
+func getEnrichedCWLog(logs plog.Logs, cwM cwMetadataEnvelop) {
+	for _, resourceLogs := range logs.ResourceLogs().All() {
+		resourceAttrs := resourceLogs.Resource().Attributes()
+
+		resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
+		resourceAttrs.PutStr(string(conventions.CloudAccountIDKey), cwM.Owner)
+		resourceAttrs.PutStr(string(conventions.AWSLogGroupNamesKey), cwM.LogGroup)
+		resourceAttrs.PutStr(string(conventions.AWSLogStreamNamesKey), cwM.LogStream)
+	}
+}
+
+func getEnrichedCtxForCWLogs(ctx context.Context, cwM cwMetadataEnvelop) context.Context {
+	metadata := map[string][]string{}
+	metadata[string(conventions.CloudAccountIDKey)] = []string{cwM.Owner}
+	metadata[string(conventions.AWSLogGroupNamesKey)] = []string{cwM.LogGroup}
+	metadata[string(conventions.AWSLogStreamNamesKey)] = []string{cwM.LogStream}
 
 	info := client.Info{}
 	info.Metadata = client.NewMetadata(metadata)

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -289,7 +289,7 @@ func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMe
 	var buf bytes.Buffer
 	tReader := io.TeeReader(reader, &buf)
 
-	var mData cwMetadataEnvelop
+	var mData cwMetadataEnvelope
 	if err = gojson.NewDecoder(tReader).Decode(&mData); err != nil {
 		return fmt.Errorf("failed to decode cloudwatch logs envelope: %w", err)
 	}
@@ -351,8 +351,8 @@ func getEnrichedContext(ctx context.Context, event events.S3EventRecord) context
 	return client.NewContext(ctx, info)
 }
 
-// cwMetadataEnvelop defines the structure to unmarshal the CloudWatch logs event envelope for metadata extraction.
-type cwMetadataEnvelop struct {
+// cwMetadataEnvelope defines the structure to unmarshal the CloudWatch logs event envelope for metadata extraction.
+type cwMetadataEnvelope struct {
 	Owner     string `json:"owner"`
 	LogGroup  string `json:"logGroup"`
 	LogStream string `json:"logStream"`
@@ -360,7 +360,7 @@ type cwMetadataEnvelop struct {
 
 // getEnrichedCWLog add extra metadata to resource attributes iff metadata is not already present.
 // This makes sure overrides do not happen if configured extensions already populate these attributes.
-func getEnrichedCWLog(logs plog.Logs, cwM cwMetadataEnvelop) {
+func getEnrichedCWLog(logs plog.Logs, cwM cwMetadataEnvelope) {
 	for _, resourceLogs := range logs.ResourceLogs().All() {
 		resourceAttrs := resourceLogs.Resource().Attributes()
 
@@ -379,7 +379,7 @@ func getEnrichedCWLog(logs plog.Logs, cwM cwMetadataEnvelop) {
 	}
 }
 
-func getEnrichedCtxForCWLogs(ctx context.Context, cwM cwMetadataEnvelop) context.Context {
+func getEnrichedCtxForCWLogs(ctx context.Context, cwM cwMetadataEnvelope) context.Context {
 	metadata := map[string][]string{}
 	metadata[string(conventions.CloudAccountIDKey)] = []string{cwM.Owner}
 	metadata[string(conventions.AWSLogGroupNamesKey)] = []string{cwM.LogGroup}

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -393,7 +393,7 @@ func TestHandleCloudwatchLogEvent(t *testing.T) {
 	}
 }
 
-func TestEnrichments(t *testing.T) {
+func TestS3Enrichments(t *testing.T) {
 	t.Parallel()
 
 	observedTimestamp := time.UnixMilli(1765574662915)
@@ -466,6 +466,56 @@ func TestEnrichments(t *testing.T) {
 		require.Equal(t, "bucket-name", metadata.Get("aws.s3.bucket.name")[0])
 		require.Equal(t, "arn:aws:s3:::bucket-name", metadata.Get("aws.s3.bucket.arn")[0])
 		require.Equal(t, "object-key", metadata.Get("aws.s3.key")[0])
+	})
+}
+
+func TestCWLogsEnrichments(t *testing.T) {
+	t.Parallel()
+
+	cwMetadata := cwMetadataEnvelop{
+		Owner:     "123456789012",
+		LogGroup:  "/aws/lambda/my-function",
+		LogStream: "test-stream",
+	}
+
+	// given
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+	// when
+	getEnrichedCWLog(logs, cwMetadata)
+	enrichedCtx := getEnrichedCtxForCWLogs(t.Context(), cwMetadata)
+
+	t.Run("Validate log enrichment", func(t *testing.T) {
+		for _, resource := range logs.ResourceLogs().All() {
+			resourceAttrs := resource.Resource().Attributes()
+
+			v, b := resourceAttrs.Get("cloud.provider")
+			require.True(t, b)
+			require.Equal(t, "aws", v.AsString())
+
+			v, b = resourceAttrs.Get("cloud.account.id")
+			require.True(t, b)
+			require.Equal(t, "123456789012", v.AsString())
+
+			v, b = resourceAttrs.Get("aws.log.group.names")
+			require.True(t, b)
+			require.Equal(t, "/aws/lambda/my-function", v.AsString())
+
+			v, b = resourceAttrs.Get("aws.log.stream.names")
+			require.True(t, b)
+			require.Equal(t, "test-stream", v.AsString())
+		}
+	})
+
+	t.Run("Validate context enrichment", func(t *testing.T) {
+		info := client.FromContext(enrichedCtx)
+		metadata := info.Metadata
+
+		require.Equal(t, "123456789012", metadata.Get("cloud.account.id")[0])
+		require.Equal(t, "/aws/lambda/my-function", metadata.Get("aws.log.group.names")[0])
+		require.Equal(t, "test-stream", metadata.Get("aws.log.stream.names")[0])
 	})
 }
 

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -472,7 +472,7 @@ func TestS3Enrichments(t *testing.T) {
 func TestCWLogsEnrichments(t *testing.T) {
 	t.Parallel()
 
-	cwMetadata := cwMetadataEnvelop{
+	cwMetadata := cwMetadataEnvelope{
 		Owner:     "123456789012",
 		LogGroup:  "/aws/lambda/my-function",
 		LogStream: "test-stream",

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -501,11 +501,12 @@ func TestCWLogsEnrichments(t *testing.T) {
 
 			v, b = resourceAttrs.Get("aws.log.group.names")
 			require.True(t, b)
-			require.Equal(t, "/aws/lambda/my-function", v.AsString())
+
+			require.Equal(t, "/aws/lambda/my-function", v.Slice().At(0).AsString())
 
 			v, b = resourceAttrs.Get("aws.log.stream.names")
 			require.True(t, b)
-			require.Equal(t, "test-stream", v.AsString())
+			require.Equal(t, "test-stream", v.Slice().At(0).AsString())
 		}
 	})
 

--- a/receiver/awslambdareceiver/internal/default_decoders.go
+++ b/receiver/awslambdareceiver/internal/default_decoders.go
@@ -60,8 +60,8 @@ func (*defaultCWLogsDecoder) UnmarshalLogs(data []byte) (plog.Logs, error) {
 	resourceAttrs := rl.Resource().Attributes()
 	resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
 	resourceAttrs.PutStr(string(conventions.CloudAccountIDKey), cwLog.Owner)
-	resourceAttrs.PutStr(string(conventions.AWSLogGroupNamesKey), cwLog.LogGroup)
-	resourceAttrs.PutStr(string(conventions.AWSLogStreamNamesKey), cwLog.LogStream)
+	resourceAttrs.PutEmptySlice(string(conventions.AWSLogGroupNamesKey)).AppendEmpty().SetStr(cwLog.LogGroup)
+	resourceAttrs.PutEmptySlice(string(conventions.AWSLogStreamNamesKey)).AppendEmpty().SetStr(cwLog.LogStream)
 
 	sl := rl.ScopeLogs().AppendEmpty()
 	sl.Scope().SetName(metadata.ScopeName)

--- a/receiver/awslambdareceiver/internal/testdata/default_cw_decoder_expected.yaml
+++ b/receiver/awslambdareceiver/internal/testdata/default_cw_decoder_expected.yaml
@@ -9,10 +9,14 @@ resourceLogs:
             stringValue: "111222333444"
         - key: aws.log.group.names
           value:
-            stringValue: /test/log-group
+            arrayValue:
+              values:
+                - stringValue: /test/log-group
         - key: aws.log.stream.names
           value:
-            stringValue: test-stream
+            arrayValue:
+              values:
+                - stringValue: test-stream
     scopeLogs:
       - logRecords:
           - body:

--- a/receiver/awslambdareceiver/testdata/cloudwatch_log_expected_custom.yaml
+++ b/receiver/awslambdareceiver/testdata/cloudwatch_log_expected_custom.yaml
@@ -1,5 +1,18 @@
 resourceLogs:
-  - resource: {}
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: aws
+        - key: cloud.account.id
+          value:
+            stringValue: "123456789012"
+        - key: aws.log.group.names
+          value:
+            stringValue: /aws/cloudtrail/management
+        - key: aws.log.stream.names
+          value:
+            stringValue: 123456789012_CloudTrail_us-east-1
     scopeLogs:
       - logRecords:
           - body:

--- a/receiver/awslambdareceiver/testdata/cloudwatch_log_expected_custom.yaml
+++ b/receiver/awslambdareceiver/testdata/cloudwatch_log_expected_custom.yaml
@@ -9,10 +9,14 @@ resourceLogs:
             stringValue: "123456789012"
         - key: aws.log.group.names
           value:
-            stringValue: /aws/cloudtrail/management
+            arrayValue:
+              values:
+                - stringValue: /aws/cloudtrail/management
         - key: aws.log.stream.names
           value:
-            stringValue: 123456789012_CloudTrail_us-east-1
+            arrayValue:
+              values:
+                - stringValue: 123456789012_CloudTrail_us-east-1
     scopeLogs:
       - logRecords:
           - body:

--- a/receiver/awslambdareceiver/testdata/cloudwatch_log_expected_default.yaml
+++ b/receiver/awslambdareceiver/testdata/cloudwatch_log_expected_default.yaml
@@ -9,10 +9,14 @@ resourceLogs:
             stringValue: "123456789012"
         - key: aws.log.group.names
           value:
-            stringValue: /aws/cloudtrail/management
+            arrayValue:
+              values:
+                - stringValue: /aws/cloudtrail/management
         - key: aws.log.stream.names
           value:
-            stringValue: 123456789012_CloudTrail_us-east-1
+            arrayValue:
+              values:
+                - stringValue: 123456789012_CloudTrail_us-east-1
     scopeLogs:
       - logRecords:
           - body:


### PR DESCRIPTION
#### Description

Similar to metadata enrichment of S3 bound events, this PR adds metadata enrichment for CloudWatch events. These are extracted from the CW event envelop.

Table below summarize these metadata,

| Metadata Key         | Description                |
|----------------------|----------------------------|
| cloud.account.id     | AWS account ID             |
| aws.log.group.names  | CloudWatch log group name  |
| aws.log.stream.names | CloudWatch log stream name |

Above metadata get added to Client Context for downstream consumption. Along with this, derived logs now have the same metadata (note - with extra attribute `cloud.provider`)


#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48581

#### Testing

Updated unit tests to validate the functionality

#### Documentation

Updated documentation to highlight newly added Client Metadata 
