### PR TITLE
[pkg/ottl]: Add UTF-8 safe slicing support to `Substring` function

### DIFF
--- a/.chloggen/feat_ottl-substring-utf-8.yaml
+++ b/.chloggen/feat_ottl-substring-utf-8.yaml
@@ -7,7 +7,7 @@ change_type: "enhancement"
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `utf8_safe` optional parameter to `Substring` function for UTF-8 aware slicing on rune boundaries.
+note: "`Substring` function now supports UTF-8 safe slicing"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [48436]
@@ -15,7 +15,11 @@ issues: [48436]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Default is `false` to preserve backward compatibility.
+subtext: |
+  New optional parameter `utf8_safe` (default: `false`). Set to `true` to adjust slice
+  boundaries so multi-byte UTF-8 characters are never cut in the middle; the result
+  may then be shorter than `length` bytes. Default preserves the existing byte-level
+  slicing behavior.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/feat_ottl-substring-utf-8.yaml
+++ b/.chloggen/feat_ottl-substring-utf-8.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `utf8_safe` optional parameter to `Substring` function for UTF-8 aware slicing on rune boundaries.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48436]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Default is `false` to preserve backward compatibility.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -1263,6 +1263,23 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], Substring("一二三", 0, 1, true))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "一")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Substring("一二三", 1, 2, true))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "二三")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Substring("一二三", 0, 4, true))`,
+			want:      func(*ottllog.TransformContext) {},
+			errMsg:    "invalid range for substring function",
+		},
+		{
 			statement: `set(trace_id, TraceID(0x00000000000000000000000000000000))`,
 			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().SetTraceID(pcommon.NewTraceIDEmpty())

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -1263,19 +1263,19 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
-			statement: `set(attributes["test"], Substring("一二三", 0, 1, true))`,
+			statement: `set(attributes["test"], Substring("一二三", 0, 3, true))`,
 			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "一")
 			},
 		},
 		{
-			statement: `set(attributes["test"], Substring("一二三", 1, 2, true))`,
+			statement: `set(attributes["test"], Substring("一二三", 0, 4, true))`,
 			want: func(tCtx *ottllog.TransformContext) {
-				tCtx.GetLogRecord().Attributes().PutStr("test", "二三")
+				tCtx.GetLogRecord().Attributes().PutStr("test", "一")
 			},
 		},
 		{
-			statement: `set(attributes["test"], Substring("一二三", 0, 4, true))`,
+			statement: `set(attributes["test"], Substring("一二三", 0, 10, true))`,
 			want:      func(*ottllog.TransformContext) {},
 			errMsg:    "invalid range for substring function",
 		},

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2389,7 +2389,7 @@ Examples:
 
 The `Substring` Converter returns a substring from the given start index to the specified length.
 
-`target` is a string. `start` and `length` are `int64`. `utf8_safe` is an optional boolean (default: `false`); when `true`, slice boundaries are snapped to UTF-8 character boundaries so multi-byte characters are never split, and the result may be shorter than `length` bytes.
+`target` is a string. `start` and `length` are byte offsets as `int64`. `utf8_safe` is an optional boolean (default: `false`); when `true`, a mid-character `start` advances to the next UTF-8 boundary and a mid-character end (`start+length`) backs up to the previous one, so multi-byte characters are never split, and the result may be shorter than `length` bytes.
 
 If `target` is not a string or is nil, an error is returned.
 If the start/length exceed the length of the `target` string, an error is returned.

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2389,19 +2389,15 @@ Examples:
 
 The `Substring` Converter returns a substring from the given start index to the specified length.
 
-`target` is a string. `start` and `length` are `int64`. `utf8_safe` is an optional boolean (default: `false`) that enables UTF-8 aware slicing.
-
-By default, `start` and `length` are byte offsets. Multi-byte UTF-8 characters may be split and the result can be invalid UTF-8.
-
-When `utf8_safe` is `true`, `start` and `length` are rune counts and the slice is taken on rune boundaries.
+`target` is a string. `start` and `length` are `int64`. `utf8_safe` is an optional boolean (default: `false`); when `true`, slice boundaries are snapped to UTF-8 character boundaries so multi-byte characters are never split, and the result may be shorter than `length` bytes.
 
 If `target` is not a string or is nil, an error is returned.
-If `start`/`length` exceed the length of `target`, an error is returned. When `utf8_safe` is `true`, the comparison is against the rune length.
+If the start/length exceed the length of the `target` string, an error is returned.
 
 Examples:
 
 - `Substring("123456789", 0, 3)`
-- `Substring("一二三", 0, 1, true)`
+- `Substring("一二三", 0, 4, true)`
 
 ### Time
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2385,18 +2385,23 @@ Examples:
 
 ### Substring
 
-`Substring(target, start, length)`
+`Substring(target, start, length, Optional[utf8_safe])`
 
 The `Substring` Converter returns a substring from the given start index to the specified length.
 
-`target` is a string. `start` and `length` are `int64`.
+`target` is a string. `start` and `length` are `int64`. `utf8_safe` is an optional boolean (default: `false`) that enables UTF-8 aware slicing.
+
+By default, `start` and `length` are byte offsets. Multi-byte UTF-8 characters may be split and the result can be invalid UTF-8.
+
+When `utf8_safe` is `true`, `start` and `length` are rune counts and the slice is taken on rune boundaries.
 
 If `target` is not a string or is nil, an error is returned.
-If the start/length exceed the length of the `target` string, an error is returned.
+If `start`/`length` exceed the length of `target`, an error is returned. When `utf8_safe` is `true`, the comparison is against the rune length.
 
 Examples:
 
 - `Substring("123456789", 0, 3)`
+- `Substring("一二三", 0, 1, true)`
 
 ### Time
 

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -72,7 +72,7 @@ func substring[K any](
 			for byteStart < len(val) && !utf8.RuneStart(val[byteStart]) {
 				byteStart++
 			}
-			for byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
+			for byteStart < byteEnd && byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
 				byteEnd--
 			}
 			if byteEnd < byteStart {

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -12,9 +12,10 @@ import (
 )
 
 type SubstringArguments[K any] struct {
-	Target ottl.StringGetter[K]
-	Start  ottl.IntGetter[K]
-	Length ottl.IntGetter[K]
+	Target   ottl.StringGetter[K]
+	Start    ottl.IntGetter[K]
+	Length   ottl.IntGetter[K]
+	Utf8Safe ottl.Optional[bool]
 }
 
 func NewSubstringFactory[K any]() ottl.Factory[K] {
@@ -28,10 +29,15 @@ func createSubstringFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments
 		return nil, errors.New("SubstringFactory args must be of type *SubstringArguments[K]")
 	}
 
-	return substring(args.Target, args.Start, args.Length), nil
+	return substring(args.Target, args.Start, args.Length, args.Utf8Safe), nil
 }
 
-func substring[K any](target ottl.StringGetter[K], startGetter, lengthGetter ottl.IntGetter[K]) ottl.ExprFunc[K] {
+func substring[K any](
+	target ottl.StringGetter[K],
+	startGetter, lengthGetter ottl.IntGetter[K],
+	utf8Safe ottl.Optional[bool],
+) ottl.ExprFunc[K] {
+	useUTF8Safe := utf8Safe.GetOr(false)
 	return func(ctx context.Context, tCtx K) (any, error) {
 		start, err := startGetter.Get(ctx, tCtx)
 		if err != nil {
@@ -51,9 +57,69 @@ func substring[K any](target ottl.StringGetter[K], startGetter, lengthGetter ott
 		if err != nil {
 			return nil, err
 		}
+
+		if useUTF8Safe {
+			out, err := substringRunes(val, start, length)
+			if err != nil {
+				return nil, err
+			}
+			return out, nil
+		}
 		if start > int64(len(val)) || length > int64(len(val))-start {
-			return nil, fmt.Errorf("invalid range for substring function, start(%d)+length(%d) cannot be greater than the length of target string(%d)", start, length, len(val))
+			return nil, fmt.Errorf(
+				"invalid range for substring function, start(%d)+length(%d) cannot be greater than the length of target string(%d)",
+				start,
+				length,
+				len(val),
+			)
 		}
 		return val[start : start+length], nil
 	}
+}
+
+func substringRunes(val string, start, length int64) (string, error) {
+	end := start + length
+	// runes ≤ bytes in UTF-8; short-circuit when end exceeds byte length.
+	if end > int64(len(val)) {
+		return "", fmt.Errorf(
+			"invalid range for substring function, start(%d)+length(%d) exceeds byte length(%d) of target string",
+			start,
+			length,
+			len(val),
+		)
+	}
+	// ASCII fast path; on miss the fallback re-reads bytes still in L1.
+	if isASCII(val[:end]) {
+		return val[start:end], nil
+	}
+
+	var byteStart int
+	var runes int64
+	for i := range val {
+		if runes == start {
+			byteStart = i
+		}
+		if runes == end {
+			return val[byteStart:i], nil
+		}
+		runes++
+	}
+	if runes == end {
+		return val[byteStart:], nil
+	}
+	return "", fmt.Errorf(
+		"invalid range for substring function, start(%d)+length(%d) cannot be greater than the rune length of target string(%d)",
+		start,
+		length,
+		runes,
+	)
+}
+
+func isASCII(s string) bool {
+	for i := range len(s) {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -57,14 +58,6 @@ func substring[K any](
 		if err != nil {
 			return nil, err
 		}
-
-		if useUTF8Safe {
-			out, err := substringRunes(val, start, length)
-			if err != nil {
-				return nil, err
-			}
-			return out, nil
-		}
 		if start > int64(len(val)) || length > int64(len(val))-start {
 			return nil, fmt.Errorf(
 				"invalid range for substring function, start(%d)+length(%d) cannot be greater than the length of target string(%d)",
@@ -73,53 +66,19 @@ func substring[K any](
 				len(val),
 			)
 		}
-		return val[start : start+length], nil
-	}
-}
-
-func substringRunes(val string, start, length int64) (string, error) {
-	end := start + length
-	// runes ≤ bytes in UTF-8; short-circuit when end exceeds byte length.
-	if end > int64(len(val)) {
-		return "", fmt.Errorf(
-			"invalid range for substring function, start(%d)+length(%d) exceeds byte length(%d) of target string",
-			start,
-			length,
-			len(val),
-		)
-	}
-	// ASCII fast path; on miss the fallback re-reads bytes still in L1.
-	if isASCII(val[:end]) {
-		return val[start:end], nil
-	}
-
-	var byteStart int
-	var runes int64
-	for i := range val {
-		if runes == start {
-			byteStart = i
+		byteStart := int(start)
+		byteEnd := int(start + length)
+		if useUTF8Safe {
+			for byteStart < len(val) && !utf8.RuneStart(val[byteStart]) {
+				byteStart++
+			}
+			for byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
+				byteEnd--
+			}
+			if byteEnd < byteStart {
+				byteEnd = byteStart
+			}
 		}
-		if runes == end {
-			return val[byteStart:i], nil
-		}
-		runes++
+		return val[byteStart:byteEnd], nil
 	}
-	if runes == end {
-		return val[byteStart:], nil
-	}
-	return "", fmt.Errorf(
-		"invalid range for substring function, start(%d)+length(%d) cannot be greater than the rune length of target string(%d)",
-		start,
-		length,
-		runes,
-	)
-}
-
-func isASCII(s string) bool {
-	for i := range len(s) {
-		if s[i] >= 0x80 {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -72,7 +72,7 @@ func substring[K any](
 			for byteStart < len(val) && !utf8.RuneStart(val[byteStart]) {
 				byteStart++
 			}
-			for byteEnd > byteStart && byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
+			for byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
 				byteEnd--
 			}
 			if byteEnd < byteStart {

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -72,7 +72,7 @@ func substring[K any](
 			for byteStart < len(val) && !utf8.RuneStart(val[byteStart]) {
 				byteStart++
 			}
-			for byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
+			for byteEnd > byteStart && byteEnd < len(val) && !utf8.RuneStart(val[byteEnd]) {
 				byteEnd--
 			}
 			if byteEnd < byteStart {

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -60,10 +60,29 @@ func Test_substring(t *testing.T) {
 			},
 			expected: "123456789",
 		},
+		{
+			name: "default byte mode splits multibyte rune",
+			target: &ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return "一二三", nil
+				},
+			},
+			start: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(0), nil
+				},
+			},
+			length: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(1), nil
+				},
+			},
+			expected: "\xe4",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := substring(tt.target, tt.start, tt.length)
+			exprFunc := substring(tt.target, tt.start, tt.length, ottl.Optional[bool]{})
 			result, err := exprFunc(nil, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -117,7 +136,7 @@ func Test_substring_validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := substring(tt.target, tt.start, tt.length)
+			exprFunc := substring(tt.target, tt.start, tt.length, ottl.Optional[bool]{})
 			result, err := exprFunc(nil, nil)
 			assert.Error(t, err)
 			assert.Nil(t, result)
@@ -243,10 +262,126 @@ func Test_substring_error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := substring(tt.target, tt.start, tt.length)
+			exprFunc := substring(tt.target, tt.start, tt.length, ottl.Optional[bool]{})
 			result, err := exprFunc(nil, nil)
 			assert.Error(t, err)
 			assert.Nil(t, result)
 		})
+	}
+}
+
+func Test_substring_utf8Safe(t *testing.T) {
+	target := func(s string) ottl.StringGetter[any] {
+		return &ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return s, nil },
+		}
+	}
+	intGetter := func(v int64) ottl.IntGetter[any] {
+		return &ottl.StandardIntGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return v, nil },
+		}
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		start    int64
+		length   int64
+		expected any
+	}{
+		{
+			name:     "CJK single rune at start",
+			input:    "一二三",
+			start:    0,
+			length:   1,
+			expected: "一",
+		},
+		{
+			name:     "CJK full string by rune count",
+			input:    "一二三",
+			start:    0,
+			length:   3,
+			expected: "一二三",
+		},
+		{name: "CJK mid", input: "一二三", start: 1, length: 1, expected: "二"},
+		{
+			name:     "emoji multiple runes",
+			input:    "🎉🎊🎈",
+			start:    1,
+			length:   2,
+			expected: "🎊🎈",
+		},
+		{
+			name:     "ascii unchanged",
+			input:    "12345",
+			start:    1,
+			length:   3,
+			expected: "234",
+		},
+		{
+			name:     "mixed ascii and CJK",
+			input:    "ab一c",
+			start:    1,
+			length:   2,
+			expected: "b一",
+		},
+	}
+	utf8SafeOpt := ottl.NewTestingOptional(true)
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				exprFunc := substring(
+					target(tt.input),
+					intGetter(tt.start),
+					intGetter(tt.length),
+					utf8SafeOpt,
+				)
+				result, err := exprFunc(nil, nil)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			},
+		)
+	}
+}
+
+func Test_substring_utf8Safe_error(t *testing.T) {
+	target := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (
+			any,
+			error,
+		) {
+			return "一二三", nil
+		},
+	}
+	intGetter := func(v int64) ottl.IntGetter[any] {
+		return &ottl.StandardIntGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return v, nil },
+		}
+	}
+	utf8SafeOpt := ottl.NewTestingOptional(true)
+
+	tests := []struct {
+		name   string
+		start  int64
+		length int64
+	}{
+		{name: "start past rune length", start: 4, length: 1},
+		{name: "length past rune length", start: 0, length: 4},
+		{name: "start+length past rune length", start: 2, length: 2},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				exprFunc := substring(
+					target,
+					intGetter(tt.start),
+					intGetter(tt.length),
+					utf8SafeOpt,
+				)
+				result, err := exprFunc(nil, nil)
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			},
+		)
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -340,6 +340,14 @@ func Test_substring_utf8Safe(t *testing.T) {
 			utf8Safe: ottl.NewTestingOptional(false),
 			expected: "\xe4",
 		},
+		{
+			name:     "all mid-character bytes",
+			input:    "\x80\x80",
+			start:    0,
+			length:   2,
+			utf8Safe: ottl.NewTestingOptional(true),
+			expected: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -60,33 +60,21 @@ func Test_substring(t *testing.T) {
 			},
 			expected: "123456789",
 		},
-		{
-			name: "default byte mode splits multibyte rune",
-			target: &ottl.StandardStringGetter[any]{
-				Getter: func(context.Context, any) (any, error) {
-					return "一二三", nil
-				},
-			},
-			start: &ottl.StandardIntGetter[any]{
-				Getter: func(context.Context, any) (any, error) {
-					return int64(0), nil
-				},
-			},
-			length: &ottl.StandardIntGetter[any]{
-				Getter: func(context.Context, any) (any, error) {
-					return int64(1), nil
-				},
-			},
-			expected: "\xe4",
-		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := substring(tt.target, tt.start, tt.length, ottl.Optional[bool]{})
-			result, err := exprFunc(nil, nil)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				exprFunc := substring(
+					tt.target,
+					tt.start,
+					tt.length,
+					ottl.Optional[bool]{},
+				)
+				result, err := exprFunc(nil, nil)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			},
+		)
 	}
 }
 
@@ -135,12 +123,19 @@ func Test_substring_validation(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := substring(tt.target, tt.start, tt.length, ottl.Optional[bool]{})
-			result, err := exprFunc(nil, nil)
-			assert.Error(t, err)
-			assert.Nil(t, result)
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				exprFunc := substring(
+					tt.target,
+					tt.start,
+					tt.length,
+					ottl.Optional[bool]{},
+				)
+				result, err := exprFunc(nil, nil)
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			},
+		)
 	}
 }
 
@@ -261,12 +256,19 @@ func Test_substring_error(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := substring(tt.target, tt.start, tt.length, ottl.Optional[bool]{})
-			result, err := exprFunc(nil, nil)
-			assert.Error(t, err)
-			assert.Nil(t, result)
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				exprFunc := substring(
+					tt.target,
+					tt.start,
+					tt.length,
+					ottl.Optional[bool]{},
+				)
+				result, err := exprFunc(nil, nil)
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			},
+		)
 	}
 }
 
@@ -287,46 +289,58 @@ func Test_substring_utf8Safe(t *testing.T) {
 		input    string
 		start    int64
 		length   int64
+		utf8Safe ottl.Optional[bool]
 		expected any
 	}{
 		{
-			name:     "CJK single rune at start",
+			name:     "end backs up to rune boundary",
 			input:    "一二三",
 			start:    0,
-			length:   1,
+			length:   4,
+			utf8Safe: ottl.NewTestingOptional(true),
 			expected: "一",
 		},
 		{
-			name:     "CJK full string by rune count",
+			name:     "start advances to rune boundary",
+			input:    "一二三",
+			start:    1,
+			length:   5,
+			utf8Safe: ottl.NewTestingOptional(true),
+			expected: "二",
+		},
+		{
+			name:     "start advances past end yields empty",
+			input:    "一二三",
+			start:    1,
+			length:   2,
+			utf8Safe: ottl.NewTestingOptional(true),
+			expected: "",
+		},
+		{
+			name:     "ascii unaffected",
+			input:    "abcdef",
+			start:    1,
+			length:   3,
+			utf8Safe: ottl.NewTestingOptional(true),
+			expected: "bcd",
+		},
+		{
+			name:     "default (utf8_safe omitted) splits multibyte rune",
 			input:    "一二三",
 			start:    0,
-			length:   3,
-			expected: "一二三",
-		},
-		{name: "CJK mid", input: "一二三", start: 1, length: 1, expected: "二"},
-		{
-			name:     "emoji multiple runes",
-			input:    "🎉🎊🎈",
-			start:    1,
-			length:   2,
-			expected: "🎊🎈",
+			length:   4,
+			utf8Safe: ottl.Optional[bool]{},
+			expected: "一\xe4",
 		},
 		{
-			name:     "ascii unchanged",
-			input:    "12345",
-			start:    1,
-			length:   3,
-			expected: "234",
-		},
-		{
-			name:     "mixed ascii and CJK",
-			input:    "ab一c",
-			start:    1,
-			length:   2,
-			expected: "b一",
+			name:     "utf8_safe=false splits multibyte rune",
+			input:    "一二三",
+			start:    0,
+			length:   1,
+			utf8Safe: ottl.NewTestingOptional(false),
+			expected: "\xe4",
 		},
 	}
-	utf8SafeOpt := ottl.NewTestingOptional(true)
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
@@ -334,7 +348,7 @@ func Test_substring_utf8Safe(t *testing.T) {
 					target(tt.input),
 					intGetter(tt.start),
 					intGetter(tt.length),
-					utf8SafeOpt,
+					tt.utf8Safe,
 				)
 				result, err := exprFunc(nil, nil)
 				require.NoError(t, err)
@@ -346,10 +360,7 @@ func Test_substring_utf8Safe(t *testing.T) {
 
 func Test_substring_utf8Safe_error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(context.Context, any) (
-			any,
-			error,
-		) {
+		Getter: func(context.Context, any) (any, error) {
 			return "一二三", nil
 		},
 	}
@@ -365,9 +376,9 @@ func Test_substring_utf8Safe_error(t *testing.T) {
 		start  int64
 		length int64
 	}{
-		{name: "start past rune length", start: 4, length: 1},
-		{name: "length past rune length", start: 0, length: 4},
-		{name: "start+length past rune length", start: 2, length: 2},
+		{name: "start past byte length", start: 10, length: 1},
+		{name: "start+length past byte length", start: 0, length: 10},
+		{name: "length past remaining byte length", start: 6, length: 5},
 	}
 	for _, tt := range tests {
 		t.Run(

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -349,6 +349,14 @@ func Test_substring_utf8Safe(t *testing.T) {
 			expected: "",
 		},
 		{
+			name:     "negative index",
+			input:    "\x80\x80",
+			start:    0,
+			length:   1,
+			utf8Safe: ottl.NewTestingOptional(true),
+			expected: "",
+		},
+		{
 			// start snaps forward to end-of-rune,
 			// end snaps back to start-of-rune byteStart > byteEnd;
 			// the clamp prevents a val[hi:lo] slice panic.

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -348,6 +348,17 @@ func Test_substring_utf8Safe(t *testing.T) {
 			utf8Safe: ottl.NewTestingOptional(true),
 			expected: "",
 		},
+		{
+			// start snaps forward to end-of-rune,
+			// end snaps back to start-of-rune byteStart > byteEnd;
+			// the clamp prevents a val[hi:lo] slice panic.
+			name:     "both bounds inside one multibyte rune yields empty",
+			input:    "\xf0\x9f\x98\x80",
+			start:    1,
+			length:   1,
+			utf8Safe: ottl.NewTestingOptional(true),
+			expected: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds an optional `utf8_safe` parameter to `Substring`. With `true`,  `start` and `length` count runes and slicing lands on rune boundaries. Defaults to `false`. Existing byte behavior doesn't change.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48436

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests for the rune path (CJK, emoji, out-of-range) plus an e2e case using the exact repro from the issue.

<!--Describe the documentation added.-->
#### Documentation
Updated the `Substring` entry in `pkg/ottl/ottlfuncs/README.md`.

<!--Please delete paragraphs that you did not use before submitting.-->
