### PR TITLE
[chore] Bump core deps to latest and skip strict validation for existing feature gates

### DIFF
--- a/cmd/opampsupervisor/metadata.yaml
+++ b/cmd/opampsupervisor/metadata.yaml
@@ -10,6 +10,7 @@ status:
 
 feature_gates:
   - id: opampsupervisor.Extensions
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, the opampsupervisor can be configured with and use specific extensions from the collector ecosystem.

--- a/connector/spanmetricsconnector/metadata.yaml
+++ b/connector/spanmetricsconnector/metadata.yaml
@@ -14,18 +14,21 @@ status:
 
 feature_gates:
   - id: connector.spanmetrics.excludeResourceMetrics
+    skip_strict_validation: true
     description: When enabled, connector will exclude all resource attributes.
     stage: alpha
     from_version: v0.137.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42103
 
   - id: connector.spanmetrics.includeCollectorInstanceID
+    skip_strict_validation: true
     description: When enabled, connector add collector.instance.id to default dimensions.
     stage: beta
     from_version: v0.136.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40400
     
   - id: connector.spanmetrics.legacyMetricNames
+    skip_strict_validation: true
     description: When enabled, connector uses legacy metric names.
     # Alpha because we want it disabled by default.
     stage: alpha
@@ -33,12 +36,14 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33227
 
   - id: connector.spanmetrics.useSecondAsDefaultMetricsUnit
+    skip_strict_validation: true
     description: When enabled, connector use second as default unit for duration metrics.
     stage: alpha
     from_version: v0.137.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42462
 
   - id: spanmetrics.statusCodeConvention.useOtelPrefix
+    skip_strict_validation: true
     description: When enabled, generated metrics will use `otel.status_code=ERROR` instead of `status.code=STATUS_CODE_ERROR`
     stage: alpha
     from_version: v0.141.0

--- a/exporter/datadogexporter/metadata.yaml
+++ b/exporter/datadogexporter/metadata.yaml
@@ -13,6 +13,7 @@ status:
 
 feature_gates:
   - id: exporter.datadogexporter.DisableAPMStats
+    skip_strict_validation: true
     stage: beta
     description: >-
       Datadog Exporter will not compute APM Stats
@@ -20,6 +21,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28616
 
   - id: exporter.datadogexporter.TraceExportUseCustomHTTPClient
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, trace export uses the HTTP client from the exporter HTTP configs
@@ -27,6 +29,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34025
 
   - id: exporter.datadogexporter.metricexportserializerclient
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, metric export in datadogexporter uses the serializer exporter from the Datadog Agent.

--- a/exporter/googlecloudexporter/metadata.yaml
+++ b/exporter/googlecloudexporter/metadata.yaml
@@ -11,6 +11,7 @@ status:
 
 feature_gates:
   - id: exporter.googlecloud.CustomMonitoredResources
+    skip_strict_validation: true
     description: >-
       When enabled, the googlecloudexporter will map the OTLP metrics to the monitored resource type
       defined by the resource label gcp.resource_type. The MR labels are defined by resource labels

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -13,6 +13,7 @@ status:
 
 feature_gates:
   - id: exporter.prometheusexporter.DisableAddMetricSuffixes
+    skip_strict_validation: true
     description: When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used
     stage: alpha
     from_version: "v0.132.0"

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -11,16 +11,19 @@ status:
 
 feature_gates:
   - id: exporter.prometheusremotewritexporter.EnableMultipleWorkers
+    skip_strict_validation: true
     description: When enabled and settings configured, the Prometheus remote exporter will spawn multiple workers/goroutines to handle incoming metrics batches concurrently.
     stage: alpha
     from_version: v0.118.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36134
   - id: exporter.prometheusremotewritexporter.RetryOn429
+    skip_strict_validation: true
     description: When enabled, the Prometheus remote write exporter will retry 429 http status code. Requires exporter.prometheusremotewritexporter.metrics.RetryOn429 to be enabled.
     stage: alpha
     from_version: v0.101.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31924
   - id: exporter.prometheusremotewritexporter.enableSendingRW2
+    skip_strict_validation: true
     description: When enabled, the Prometheus remote write exporter will support sending rw2. Extra configuration is still required besides enabling this feature gate.
     stage: alpha
     from_version: v0.125.0

--- a/exporter/signalfxexporter/metadata.yaml
+++ b/exporter/signalfxexporter/metadata.yaml
@@ -11,6 +11,7 @@ status:
 
 feature_gates:
   - id: exporter.signalfx.consumeEntityEvents
+    skip_strict_validation: true
     stage: alpha
     description: Process entity events from logs pipeline and convert to dimension property updates
     from_version: v0.145.0

--- a/extension/encoding/awslogsencodingextension/metadata.yaml
+++ b/extension/encoding/awslogsencodingextension/metadata.yaml
@@ -19,6 +19,7 @@ tests:
 
 feature_gates:
   - id: extension.encoding.awslogsencoding.DontEmitV0RPCConventions
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, CloudTrail log unmarshaler no longer emits the deprecated
@@ -27,6 +28,7 @@ feature_gates:
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47549
   - id: extension.encoding.awslogsencoding.EmitV1RPCConventions
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, CloudTrail log unmarshaler emits rpc.system.name

--- a/extension/encoding/azureencodingextension/metadata.yaml
+++ b/extension/encoding/azureencodingextension/metadata.yaml
@@ -17,11 +17,13 @@ status:
 
 feature_gates:
   - id: extension.azureencoding.DontEmitV0LogConventions
+    skip_strict_validation: true
     stage: alpha
     description: When enabled, v0 semconv log attribute names are not emitted.
     from_version: v0.149.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543
   - id: extension.azureencoding.EmitV1LogConventions
+    skip_strict_validation: true
     stage: alpha
     description: When enabled, v1 semconv log attribute names are emitted.
     from_version: v0.149.0

--- a/extension/healthcheckextension/metadata.yaml
+++ b/extension/healthcheckextension/metadata.yaml
@@ -12,6 +12,7 @@ status:
 
 feature_gates:
   - id: extension.healthcheck.useComponentStatus
+    skip_strict_validation: true
     description: >-
       Switch to the shared healthcheck implementation powered by component status events
     stage: alpha

--- a/extension/opampextension/metadata.yaml
+++ b/extension/opampextension/metadata.yaml
@@ -11,6 +11,7 @@ status:
 
 feature_gates:
   - id: extension.opampextension.RemoteRestarts
+    skip_strict_validation: true
     description: "When enabled, the OpAMP extension supports restart commands from the OpAMP server through the `CommandType_Restart` command."
     stage: alpha
     from_version: "v0.145.0"

--- a/internal/coreinternal/metadata.yaml
+++ b/internal/coreinternal/metadata.yaml
@@ -10,6 +10,7 @@ status:
 
 feature_gates:
   - id: internal.coreinternal.goldendataset.DontEmitV0NetworkConventions
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, goldendataset no longer generates spans with deprecated
@@ -17,6 +18,7 @@ feature_gates:
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45076
   - id: internal.coreinternal.goldendataset.DontEmitV0RPCConventions
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, goldendataset no longer generates spans with deprecated
@@ -24,6 +26,7 @@ feature_gates:
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47548
   - id: internal.coreinternal.goldendataset.EmitV1NetworkConventions
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, goldendataset generates spans with network.local.address,
@@ -35,6 +38,7 @@ feature_gates:
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45076
   - id: internal.coreinternal.goldendataset.EmitV1RPCConventions
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, goldendataset generates spans with rpc.method and

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -280,13 +280,13 @@ require (
 	go.opentelemetry.io/build-tools/issuegenerator v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/multimod v0.30.0 // indirect
 	go.opentelemetry.io/collector/cmd/builder v0.152.1-0.20260514231715-e7f22744c28c // indirect
-	go.opentelemetry.io/collector/cmd/mdatagen v0.152.1-0.20260514231715-e7f22744c28c // indirect
+	go.opentelemetry.io/collector/cmd/mdatagen v0.152.1-0.20260522044224-3708bc75744c // indirect
 	go.opentelemetry.io/collector/component v1.58.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/confmap v1.58.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/collector/featuregate v1.58.1-0.20260514231715-e7f22744c28c // indirect
-	go.opentelemetry.io/collector/filter v0.152.1-0.20260514231715-e7f22744c28c // indirect
-	go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260514231715-e7f22744c28c // indirect
+	go.opentelemetry.io/collector/filter v0.152.1 // indirect
+	go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260521144538-6a86f8609a5c // indirect
 	go.opentelemetry.io/collector/pdata v1.58.1-0.20260514231715-e7f22744c28c // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -616,8 +616,8 @@ go.opentelemetry.io/build-tools/multimod v0.30.0 h1:f3L37C35ds33QIx2pwacH4F+EZp9
 go.opentelemetry.io/build-tools/multimod v0.30.0/go.mod h1:1pbgfye9qeRAWWsiuzeZ4fxfoAqkKr0Lvl+JPLSpbs8=
 go.opentelemetry.io/collector/cmd/builder v0.152.1-0.20260514231715-e7f22744c28c h1:Hb7py/0PBkQdcFYwLJmdYt+mLud/jLK1hTw1xIWpaRQ=
 go.opentelemetry.io/collector/cmd/builder v0.152.1-0.20260514231715-e7f22744c28c/go.mod h1:CVbuNiRlvlKwnMZVg+HhQIJPXG6XlF+FijrEItGk4QI=
-go.opentelemetry.io/collector/cmd/mdatagen v0.152.1-0.20260514231715-e7f22744c28c h1:V0VSOvaHKQtdHnbXxukWLUyGZ77hZx/KnHvPr4l/1kU=
-go.opentelemetry.io/collector/cmd/mdatagen v0.152.1-0.20260514231715-e7f22744c28c/go.mod h1:eOhqZXZeLsjbwX45kJb36agvIY16vc94Ipsde7nvEko=
+go.opentelemetry.io/collector/cmd/mdatagen v0.152.1-0.20260522044224-3708bc75744c h1:wGFeTvAf20e0qOgwgs4KHb5eynkp0eOC/fAk7geIPJE=
+go.opentelemetry.io/collector/cmd/mdatagen v0.152.1-0.20260522044224-3708bc75744c/go.mod h1:xeZRvhjxuqkIi1UQyvT+RkBcRf4Zo8fUy2CuFTszANs=
 go.opentelemetry.io/collector/component v1.58.1-0.20260514231715-e7f22744c28c h1:P+1Mvf17pJj7q8LoMV8ncUe69R5GIsoIuWiiSMXYK/c=
 go.opentelemetry.io/collector/component v1.58.1-0.20260514231715-e7f22744c28c/go.mod h1:oAA7bLZUz/j1r16bQ9Cu/F+72xbQxlci8H2VmqtsAGE=
 go.opentelemetry.io/collector/confmap v1.58.1-0.20260514231715-e7f22744c28c h1:kNwS0tL4wBuD0H6f7WCMz7iSBdKih6b8P+ZkxvzNWF0=
@@ -626,10 +626,10 @@ go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.1-0.2026051423
 go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.1-0.20260514231715-e7f22744c28c/go.mod h1:anqn2j7ZGQZwsYA5dlc51Zu17GANAZaYRTWAwb7n7bg=
 go.opentelemetry.io/collector/featuregate v1.58.1-0.20260514231715-e7f22744c28c h1:BZFW0uJTjqi62M4D8lT/1l/t8gg8weRsi09wxN0QywA=
 go.opentelemetry.io/collector/featuregate v1.58.1-0.20260514231715-e7f22744c28c/go.mod h1:4ga1QBMPEejXXmpyJS8lmaRpknJ3Lb9Bvk6e420bUFU=
-go.opentelemetry.io/collector/filter v0.152.1-0.20260514231715-e7f22744c28c h1:jNYvfcXokCrBwIY0FmbwQ585+MUYOT/0YJiR6Qazpjs=
-go.opentelemetry.io/collector/filter v0.152.1-0.20260514231715-e7f22744c28c/go.mod h1:GNDoOjdDk/HGvgzhUuGzyOtXRk8Xuv2CY+0+qay3QEA=
-go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260514231715-e7f22744c28c h1:pNOeoZRCXrMS3Kpl0ugu+HMxH7wxSv6E9MBOwqjEY/w=
-go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260514231715-e7f22744c28c/go.mod h1:xeXVz0bhLg/xNEiegIdyz+V3FDMH8940iLypyiB3qQY=
+go.opentelemetry.io/collector/filter v0.152.1 h1:T7esgQriCO8kclP86cVxUxJqzAvMSnJ0FhECiwwUnUU=
+go.opentelemetry.io/collector/filter v0.152.1/go.mod h1:GNDoOjdDk/HGvgzhUuGzyOtXRk8Xuv2CY+0+qay3QEA=
+go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260521144538-6a86f8609a5c h1:75GOcLE0Le3zzhmAf0A5VBcwQ/XwApElVwt7mG+1HGQ=
+go.opentelemetry.io/collector/internal/schemagen v0.152.1-0.20260521144538-6a86f8609a5c/go.mod h1:xeXVz0bhLg/xNEiegIdyz+V3FDMH8940iLypyiB3qQY=
 go.opentelemetry.io/collector/internal/testutil v0.152.0 h1:8LGwekR7mLcUDhT1ofLmdnrHRFuUa3U7PBd95ZvJEjQ=
 go.opentelemetry.io/collector/internal/testutil v0.152.0/go.mod h1:Jkjs6rkqs973LqgZ0Fe3zrokQRKULYXPIf4HuqStiEE=
 go.opentelemetry.io/collector/pdata v1.58.1-0.20260514231715-e7f22744c28c h1:lCrVlOGmDDim/4nRYJ6R9YozsXPtyI7evKijtoz2wAw=

--- a/pkg/datadog/metadata.yaml
+++ b/pkg/datadog/metadata.yaml
@@ -11,6 +11,7 @@ status:
 
 feature_gates:
   - id: datadog.EnableOperationAndResourceNameV2
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, datadogexporter and datadogconnector use improved logic to compute operation name and resource name.
@@ -18,6 +19,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36419
 
   - id: datadog.EnableReceiveResourceSpansV2
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, use a refactored implementation of the span receiver which improves performance by 10% and deprecates some not-to-spec functionality.
@@ -25,6 +27,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37171
 
   - id: exporter.datadogexporter.DisableAllMetricRemapping
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled the Datadog Exporter stops mapping OpenTelemetry semantic conventions to Datadog semantic conventions for all locally mapped conventions including system and runtime metrics.
@@ -32,6 +35,7 @@ feature_gates:
     reference_url: https://docs.datadoghq.com/opentelemetry/schema_semantics/metrics_mapping/
 
   - id: exporter.datadogexporter.EnableAttributeSliceMultiTagExporting
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, attributes with slice values will have their elements turned into individual `key:value` Datadog tags.
@@ -39,6 +43,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44859
 
   - id: exporter.datadogexporter.InferIntervalForDeltaMetrics
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, the exporter will infer the metrics interval for OTLP delta sums using a heuristic.
@@ -46,6 +51,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46851
 
   - id: exporter.datadogexporter.metricremappingdisabled
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled the Datadog Exporter stops mapping OpenTelemetry semantic conventions to Datadog semantic conventions. This feature gate is only for internal use. [DEPRECATED] Use 'exporter.datadogexporter.DisableAllMetricRemapping' instead.

--- a/pkg/ottl/metadata.yaml
+++ b/pkg/ottl/metadata.yaml
@@ -13,12 +13,14 @@ status:
 
 feature_gates:
   - id: "ottl.PanicDuplicateName"
+    skip_strict_validation: true
     description: When enabled, the CreateFactoryMap panics if the name is duplicated.
     stage: beta
     from_version: v0.141.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630
 
   - id: "ottl.contexts.enableOTelColContext"
+    skip_strict_validation: true
     description: Enable the `otelcol` context for OTTL. This allows users using `otelcol.*` paths in their OTTL statements and conditions.
     stage: beta
     from_version: v0.147.0

--- a/pkg/stanza/fileconsumer/metadata.yaml
+++ b/pkg/stanza/fileconsumer/metadata.yaml
@@ -11,18 +11,21 @@ status:
 
 feature_gates:
   - id: filelog.allowFileDeletion
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, allows usage of the `delete_after_read` setting.
     from_version: v0.70.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16314
   - id: filelog.allowHeaderMetadataParsing
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, allows usage of the `header` setting.
     from_version: v0.73.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18198
   - id: filelog.decompressFingerprint
+    skip_strict_validation: true
     stage: stable
     description: >-
       Computes fingerprint for compressed files by decompressing its data.
@@ -30,18 +33,21 @@ feature_gates:
     to_version: v0.142.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40256
   - id: filelog.mtimeSortType
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, allows usage of `ordering_criteria.mode` = `mtime`.
     from_version: v0.89.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27812
   - id: filelog.protobufCheckpointEncoding
+    skip_strict_validation: true
     stage: alpha
     description: >-
       Use protobuf encoding for checkpoint storage instead of JSON.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43266
   - id: filelog.windows.caseInsensitive
+    skip_strict_validation: true
     stage: alpha
     description: >-
       On Windows, make matching patterns in include/exclude case insensitive.

--- a/pkg/stanza/metadata.yaml
+++ b/pkg/stanza/metadata.yaml
@@ -12,30 +12,35 @@ status:
 
 feature_gates:
   - id: logs.assignKeys
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, allows usage of `assign_keys` transformer.
     from_version: v0.93.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30321
   - id: logs.jsonParserArray
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, allows usage of `json_array_parser`.
     from_version: v0.93.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30321
   - id: parser.uri.ecscompliant
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled resulting map will be in semconv compliant format.
     from_version: v0.103.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32906
   - id: stanza.synchronousLogEmitter
+    skip_strict_validation: true
     stage: alpha
     description: >-
       Prevents possible data loss in Stanza-based receivers by emitting logs synchronously.
     from_version: v0.122.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35456
   - id: stanza.windows.eventDrivenScraping
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, the Stanza windows input wakes on API signals instead of polling on a fixed interval.

--- a/pkg/translator/azurelogs/metadata.yaml
+++ b/pkg/translator/azurelogs/metadata.yaml
@@ -10,11 +10,13 @@ status:
 
 feature_gates:
   - id: pkg.translator.azurelogs.DontEmitV0LogConventions
+    skip_strict_validation: true
     stage: alpha
     description: When enabled, v0 semconv attribute names are not emitted.
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45033
   - id: pkg.translator.azurelogs.EmitV1LogConventions
+    skip_strict_validation: true
     stage: alpha
     description: When enabled, v1 semconv attribute names are emitted.
     from_version: v0.147.0

--- a/pkg/translator/prometheus/metadata.yaml
+++ b/pkg/translator/prometheus/metadata.yaml
@@ -8,6 +8,7 @@ status:
 
 feature_gates:
   - id: pkg.translator.prometheus.PermissiveLabelSanitization
+    skip_strict_validation: true
     description: Controls whether to change labels starting with '_' to 'key_'.
     stage: alpha
     from_version: v0.55.0

--- a/pkg/translator/skywalking/metadata.yaml
+++ b/pkg/translator/skywalking/metadata.yaml
@@ -11,6 +11,7 @@ status:
 
 feature_gates:
   - id: translator.skywalking.useStableSemconv
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, uses stable semantic conventions (v1.38.0) for attribute names

--- a/pkg/translator/zipkin/metadata.yaml
+++ b/pkg/translator/zipkin/metadata.yaml
@@ -10,6 +10,7 @@ status:
 
 feature_gates:
   - id: pkg.translator.zipkin.DontEmitV0NetworkConventions
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, the Zipkin translator no longer emits the deprecated
@@ -19,6 +20,7 @@ feature_gates:
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45041
   - id: pkg.translator.zipkin.EmitV1NetworkConventions
+    skip_strict_validation: true
     stage: beta
     description: >-
       When enabled, the Zipkin translator emits network.local.address and

--- a/processor/filterprocessor/metadata.yaml
+++ b/processor/filterprocessor/metadata.yaml
@@ -15,6 +15,7 @@ status:
     emeritus: [boostchicken]
 feature_gates:
   - id: processor.filter.defaultErrorModeIgnore
+    skip_strict_validation: true
     description: >-
       Changes the default error_mode of the filter processor from propagate to ignore
     stage: beta

--- a/processor/k8sattributesprocessor/metadata.yaml
+++ b/processor/k8sattributesprocessor/metadata.yaml
@@ -145,6 +145,7 @@ resource_attributes:
 
 feature_gates:
   - id: k8sattr.labelsAnnotationsSingular.allow
+    skip_strict_validation: true
     stage: deprecated
     description: >-
       When enabled, default k8s label and annotation resource attribute keys will be singular, instead of plural
@@ -152,18 +153,21 @@ feature_gates:
     to_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39774
   - id: processor.k8sattributes.DontEmitV0K8sConventions
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, semconv legacy attributes are disabled.
     from_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44589
   - id: processor.k8sattributes.EmitV1K8sConventions
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, semconv stable attributes are enabled.
     from_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44589
   - id: processor.k8sattributes.ShareProcessorBetweenPipelines
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, processor instances with identical configuration are shared
@@ -171,12 +175,14 @@ feature_gates:
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2450
   - id: processor.k8sattributes.telemetry.disableOldFormatMetrics
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, old formatted internal telemetry metrics are disabled.
     from_version: v0.146.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45871
   - id: processor.k8sattributes.telemetry.enableNewFormatMetrics
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, new formatted internal telemetry metrics are enabled.

--- a/processor/metricsgenerationprocessor/metadata.yaml
+++ b/processor/metricsgenerationprocessor/metadata.yaml
@@ -10,6 +10,7 @@ status:
     active: [Aneurysm9, crobert-1]
 feature_gates:
   - id: metricsgeneration.MatchAttributes
+    skip_strict_validation: true
     description: >-
       When enabled, the metric calculations will only be done between data points whose attributes match.
     stage: alpha

--- a/processor/tailsamplingprocessor/metadata.yaml
+++ b/processor/tailsamplingprocessor/metadata.yaml
@@ -13,6 +13,7 @@ status:
 
 feature_gates:
   - id: "processor.tailsamplingprocessor.disableinvertdecisions"
+    skip_strict_validation: true
     description: When enabled, sampling policy 'invert_match' will result in a SAMPLED or NOT SAMPLED decision instead of INVERT SAMPLED or INVERT NOT SAMPLED.
     stage: stable
     from_version: v0.126.0
@@ -20,18 +21,21 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39833
 
   - id: "processor.tailsamplingprocessor.metricstatcountspanssampled"
+    skip_strict_validation: true
     description: "When enabled, a new metric stat_count_spans_sampled will be available in the tail sampling processor. Differently from stat_count_traces_sampled, this metric will count the number of spans sampled or not per sampling policy, where the original counts traces."
     stage: alpha
     from_version: v0.95.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30482
 
   - id: "processor.tailsamplingprocessor.recordpolicy"
+    skip_strict_validation: true
     description: "When enabled, attaches the name of the policy (and if applicable, composite policy) responsible for sampling a trace in the 'tailsampling.policy', 'tailsampling.composite_policy', and `tailsampling.cached_decision` attributes."
     stage: alpha
     from_version: v0.120.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35180
 
   - id: "processor.tailsamplingprocessor.tailstorageextension"
+    skip_strict_validation: true
     description: When enabled, allows configuring tail_storage to use a tail storage extension implementation.
     stage: alpha
     from_version: v0.150.0

--- a/processor/transformprocessor/metadata.yaml
+++ b/processor/transformprocessor/metadata.yaml
@@ -15,12 +15,14 @@ status:
 
 feature_gates:
   - id: "processor.transform.defaultErrorModeIgnore"
+    skip_strict_validation: true
     description: Changes the default error_mode of the transform processor from propagate to ignore
     stage: beta
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231
 
   - id: "transform.flatten.logs"
+    skip_strict_validation: true
     description: Flatten log data prior to transformation so every record has a unique copy of the resource and scope. Regroups logs based on resource and scope after transformations.
     stage: alpha
     from_version: v0.103.0

--- a/receiver/cloudfoundryreceiver/metadata.yaml
+++ b/receiver/cloudfoundryreceiver/metadata.yaml
@@ -19,6 +19,7 @@ status:
 
 feature_gates:
   - id: cloudfoundry.resourceAttributes.allow
+    skip_strict_validation: true
     description: >-
       When enabled, envelope tags are copied to the metrics as resource attributes instead of datapoint attributes
     stage: beta

--- a/receiver/githubreceiver/metadata.yaml
+++ b/receiver/githubreceiver/metadata.yaml
@@ -15,6 +15,7 @@ reaggregation_enabled: true
 
 feature_gates:
   - id: receiver.githubreceiver.UseCheckRunID
+    skip_strict_validation: true
     description: >-
       When enabled, deterministic job, step, and queue span IDs are derived from the
       GitHub check_run_id (the WorkflowJob.id webhook field, also exposed in-runner as

--- a/receiver/hostmetricsreceiver/metadata.yaml
+++ b/receiver/hostmetricsreceiver/metadata.yaml
@@ -16,11 +16,13 @@ status:
 
 feature_gates:
   - id: hostmetrics.process.bootTimeCache
+    skip_strict_validation: true
     description: When enabled, all process scrapes will use the boot time value that is cached at the start of the process.
     stage: beta
     from_version: "v0.98.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28849
   - id: receiver.hostmetricsreceiver.UseLinuxMemAvailable
+    skip_strict_validation: true
     description: When enabled, the used value for the system.memory.usage and system.memory.utilization metrics will be based on the Linux kernel's MemAvailable statistic instead of MemFree, Buffers, and Cached.
     stage: beta
     from_version: "v0.137.0"

--- a/receiver/jaegerreceiver/metadata.yaml
+++ b/receiver/jaegerreceiver/metadata.yaml
@@ -14,6 +14,7 @@ status:
 
 feature_gates:
   - id: receiver.jaeger.DisableRemoteSampling
+    skip_strict_validation: true
     description: "When enabled, the Jaeger Receiver will fail to start when it is configured with remote_sampling config. When disabled, the receiver will start and the remote_sampling config will be no-op."
     stage: stable
     from_version: v0.84.0

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -16,6 +16,7 @@ status:
 
 feature_gates:
   - id: receiver.kafkametricsreceiver.UseFranzGo
+    skip_strict_validation: true
     stage: stable
     description: >-
       The Kafka Metrics receiver now uses the franz-go client to connect to Kafka.

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -19,18 +19,21 @@ reaggregation_enabled: true
 
 feature_gates:
   - id: postgresqlreceiver.preciselagmetrics
+    skip_strict_validation: true
     description: Metric `postgresql.wal.lag` is replaced by more precise `postgresql.wal.delay`.
     stage: beta
     from_version: "v0.89.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30831
 
   - id: receiver.postgresql.connectionPool
+    skip_strict_validation: true
     description: Use of connection pooling
     stage: beta
     from_version: "v0.96.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30831
 
   - id: receiver.postgresql.separateSchemaAttr
+    skip_strict_validation: true
     description: Moves Schema Names into dedicated Attribute
     stage: alpha
     from_version: "v0.122.0"

--- a/receiver/prometheusreceiver/metadata.yaml
+++ b/receiver/prometheusreceiver/metadata.yaml
@@ -24,6 +24,7 @@ tests:
 
 feature_gates:
   - id: receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion
+    skip_strict_validation: true
     stage: alpha
     description: >-
       Enables the Prometheus created-timestamps-zero-injection feature.
@@ -33,6 +34,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40355
 
   - id: receiver.prometheusreceiver.IgnoreScopeInfoMetric
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, the `otel_scope_info` metric is ignored for scope attribute extraction.

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -824,6 +824,7 @@ metrics:
 
 feature_gates:
   - id: receiver.sqlserver.RemoveServerResourceAttribute
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled, the server.address and server.port resource attributes are removed from metrics.

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -16,6 +16,7 @@ status:
 
 feature_gates:
   - id: receiver.vcenter.resourcePoolMemoryUsageAttribute
+    skip_strict_validation: true
     description: >-
       Enables the memory usage type attribute for the vcenter.resource_pool.memory.usage metric
     stage: alpha

--- a/receiver/windowseventlogreceiver/metadata.yaml
+++ b/receiver/windowseventlogreceiver/metadata.yaml
@@ -22,6 +22,7 @@ tests:
 
 feature_gates:
   - id: domainControllers.autodiscovery
+    skip_strict_validation: true
     stage: alpha
     description: >-
       When enabled and is remote automatically discover domain controllers through joined controllers and 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR bumps the core deps (including `mdatagen`) to the same version that the update job (https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/26280337202/job/77354652014) would and adds the `skip_strict_validation` option to all existing feature gates. 

The idea is that all currently existing feature-gates are "grandfathered" and can exist with name that aren't compliant with the new strict validation from `mdatagen`.

Could I have gone components by component to check whether they would already pass strict validation to avoid adding it where it's not needed? **Yes**, but I decided it would be a waste of time. 😬 

All new feature gates must be compliant.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Follow up for https://github.com/open-telemetry/opentelemetry-collector/pull/15310.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48593.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Ran the `mdatagen` validation with the latest version that would be introduced by the `update-otel` workflow (see https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/26280337202/job/77354652014) and it passes.