### PR TITLE
receiver/googlecloudmonitoring: add default_ingest_delay config option

### DIFF
--- a/.chloggen/googlecloudmonitoringreceiver-default-ingest-delay.yaml
+++ b/.chloggen/googlecloudmonitoringreceiver-default-ingest-delay.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudmonitoring
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `default_ingest_delay` config option to override the hardcoded 60s fallback used when a metric descriptor does not populate Metadata.IngestDelay.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48465]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Useful for log-based, custom and external Prometheus metrics whose
+  descriptors do not declare an ingest delay and where real ingestion
+  latency exceeds 60s, causing empty data windows. Defaults to 60s, so
+  existing configurations are unaffected.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudmonitoringreceiver/README.md
+++ b/receiver/googlecloudmonitoringreceiver/README.md
@@ -42,6 +42,7 @@ receivers:
 - `timeout`: (default = `1m`) The timeout of running commands against the GCP Monitoring REST API.
 - `project_id` (Required): The GCP project ID.
 - `endpoint` (Optional): Overrides the default `monitoring.googleapis.com:443` endpoint. Use this when targeting non-standard universe domains.
+- `default_ingest_delay` (default = `60s`): Fallback ingest delay used only when a metric's descriptor does not populate `Metadata.IngestDelay`. Common for log-based metrics (`logging.googleapis.com/user/*`), custom metrics (`custom.googleapis.com/*`) and external Prometheus metrics (`external.googleapis.com/prometheus/*`), where real ingestion latency can exceed 60s and the default produces empty data windows. Increase this if you observe missing data points for these metric types. Metrics whose descriptors already declare `Metadata.IngestDelay` (most GCP service metrics) are unaffected.
 - `metrics_list` (Required): A list of services metrics to monitor.
 
 Each single metric can have the following configuration:

--- a/receiver/googlecloudmonitoringreceiver/config.go
+++ b/receiver/googlecloudmonitoringreceiver/config.go
@@ -23,8 +23,13 @@ type Config struct {
 	ProjectID string `mapstructure:"project_id"`
 	// Overrides the default monitoring.googleapis.com:443 endpoint.
 	// Use this when targeting non-standard universe domains.
-	Endpoint    string         `mapstructure:"endpoint"`
-	MetricsList []MetricConfig `mapstructure:"metrics_list"`
+	Endpoint string `mapstructure:"endpoint"`
+	// DefaultIngestDelay is used as the fallback ingest delay when a metric's
+	// descriptor does not populate Metadata.IngestDelay. Common for log-based,
+	// custom and external Prometheus metrics, where real ingestion latency can
+	// exceed the previous hardcoded 60s default and produce empty data windows.
+	DefaultIngestDelay time.Duration  `mapstructure:"default_ingest_delay"`
+	MetricsList        []MetricConfig `mapstructure:"metrics_list"`
 }
 
 type MetricConfig struct {
@@ -37,6 +42,10 @@ type MetricConfig struct {
 func (config *Config) Validate() error {
 	if config.CollectionInterval < minCollectionInterval {
 		return fmt.Errorf("\"collection_interval\" must be not lower than the collection interval: %v, current value is %v", minCollectionInterval, config.CollectionInterval)
+	}
+
+	if config.DefaultIngestDelay < 0 {
+		return fmt.Errorf("\"default_ingest_delay\" must not be negative, current value is %v", config.DefaultIngestDelay)
 	}
 
 	if len(config.MetricsList) == 0 {

--- a/receiver/googlecloudmonitoringreceiver/config.schema.yaml
+++ b/receiver/googlecloudmonitoringreceiver/config.schema.yaml
@@ -9,6 +9,9 @@ $defs:
         type: string
 type: object
 properties:
+  default_ingest_delay:
+    description: Fallback ingest delay used when a metric's descriptor does not populate Metadata.IngestDelay. Defaults to 60s. Useful for log-based, custom and external Prometheus metrics where real ingestion latency exceeds 60s.
+    type: string
   endpoint:
     description: Overrides the default monitoring.googleapis.com:443 endpoint. Use this when targeting non-standard universe domains.
     type: string

--- a/receiver/googlecloudmonitoringreceiver/config_test.go
+++ b/receiver/googlecloudmonitoringreceiver/config_test.go
@@ -33,7 +33,8 @@ func TestLoadConfig(t *testing.T) {
 					CollectionInterval: 120 * time.Second,
 					InitialDelay:       1 * time.Second,
 				},
-				ProjectID: "my-project-id",
+				ProjectID:          "my-project-id",
+				DefaultIngestDelay: 60 * time.Second,
 				MetricsList: []MetricConfig{
 					{MetricName: "compute.googleapis.com/instance/cpu/usage_time"},
 					{MetricName: "connectors.googleapis.com/flex/instance/cpu/usage_time"},
@@ -48,10 +49,25 @@ func TestLoadConfig(t *testing.T) {
 					CollectionInterval: 120 * time.Second,
 					InitialDelay:       1 * time.Second,
 				},
-				ProjectID: "my-project-id",
-				Endpoint:  "monitoring.example.com:443",
+				ProjectID:          "my-project-id",
+				Endpoint:           "monitoring.example.com:443",
+				DefaultIngestDelay: 60 * time.Second,
 				MetricsList: []MetricConfig{
 					{MetricName: "compute.googleapis.com/instance/cpu/usage_time"},
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "default_ingest_delay"),
+			expected: &Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: 120 * time.Second,
+					InitialDelay:       1 * time.Second,
+				},
+				ProjectID:          "my-project-id",
+				DefaultIngestDelay: 3 * time.Minute,
+				MetricsList: []MetricConfig{
+					{MetricName: "logging.googleapis.com/user/my_log_metric"},
 				},
 			},
 		},
@@ -105,12 +121,16 @@ func TestValidateConfig(t *testing.T) {
 	testCases := map[string]struct {
 		metricsList        []MetricConfig
 		collectionInterval time.Duration
+		defaultIngestDelay time.Duration
 		requireError       bool
 	}{
-		"Valid Config":                {[]MetricConfig{validMetric}, 300 * time.Second, false},
-		"Empty Services":              {nil, 300 * time.Second, true},
-		"Invalid Service in Services": {[]MetricConfig{{}}, 300 * time.Second, true},
-		"Invalid Collection Interval": {[]MetricConfig{validMetric}, 0 * time.Second, true},
+		"Valid Config":                       {[]MetricConfig{validMetric}, 300 * time.Second, 60 * time.Second, false},
+		"Empty Services":                     {nil, 300 * time.Second, 60 * time.Second, true},
+		"Invalid Service in Services":        {[]MetricConfig{{}}, 300 * time.Second, 60 * time.Second, true},
+		"Invalid Collection Interval":        {[]MetricConfig{validMetric}, 0 * time.Second, 60 * time.Second, true},
+		"Zero Default Ingest Delay":          {[]MetricConfig{validMetric}, 300 * time.Second, 0, false},
+		"Negative Default Ingest Delay":      {[]MetricConfig{validMetric}, 300 * time.Second, -1 * time.Second, true},
+		"Custom Positive Default Ingest Delay": {[]MetricConfig{validMetric}, 300 * time.Second, 3 * time.Minute, false},
 	}
 
 	for name, testCase := range testCases {
@@ -119,7 +139,8 @@ func TestValidateConfig(t *testing.T) {
 				ControllerConfig: scraperhelper.ControllerConfig{
 					CollectionInterval: testCase.collectionInterval,
 				},
-				MetricsList: testCase.metricsList,
+				DefaultIngestDelay: testCase.defaultIngestDelay,
+				MetricsList:        testCase.metricsList,
 			}
 
 			err := cfg.Validate()

--- a/receiver/googlecloudmonitoringreceiver/factory.go
+++ b/receiver/googlecloudmonitoringreceiver/factory.go
@@ -28,7 +28,8 @@ func createDefaultConfig() component.Config {
 	cfg.CollectionInterval = defaultCollectionInterval
 
 	return &Config{
-		ControllerConfig: cfg,
+		ControllerConfig:   cfg,
+		DefaultIngestDelay: defaultFetchDelay,
 	}
 }
 

--- a/receiver/googlecloudmonitoringreceiver/receiver.go
+++ b/receiver/googlecloudmonitoringreceiver/receiver.go
@@ -99,10 +99,7 @@ func (mr *monitoringReceiver) Scrape(ctx context.Context) (pmetric.Metrics, erro
 			gInterval = defaultCollectionInterval
 		}
 
-		gDelay = metricDesc.GetMetadata().GetIngestDelay().AsDuration()
-		if gDelay <= 0 {
-			gDelay = defaultFetchDelay
-		}
+		gDelay = ingestDelay(metricDesc, mr.config.DefaultIngestDelay)
 
 		// Calculate the start and end times
 		calStartTime, calEndTime = calculateStartEndTime(gInterval, gDelay)
@@ -216,6 +213,18 @@ func (mr *monitoringReceiver) metricDescriptorAPI(ctx context.Context) error {
 
 // calculateStartEndTime calculates the start and end times based on the current time, interval, and delay.
 // It enforces a maximum interval of 23 hours to avoid querying data older than 24 hours.
+// ingestDelay returns the ingest delay reported by the metric descriptor's
+// metadata. When the descriptor does not populate Metadata.IngestDelay
+// (common for log-based, custom and external Prometheus metrics), it falls
+// back to the provided default.
+func ingestDelay(desc *metric.MetricDescriptor, fallback time.Duration) time.Duration {
+	d := desc.GetMetadata().GetIngestDelay().AsDuration()
+	if d <= 0 {
+		return fallback
+	}
+	return d
+}
+
 func calculateStartEndTime(interval, delay time.Duration) (time.Time, time.Time) {
 	const maxInterval = 23 * time.Hour // Maximum allowed interval is 23 hours
 

--- a/receiver/googlecloudmonitoringreceiver/receiver_test.go
+++ b/receiver/googlecloudmonitoringreceiver/receiver_test.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package googlecloudmonitoringreceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/genproto/googleapis/api/metric"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestIngestDelay(t *testing.T) {
+	fallback := 3 * time.Minute
+
+	testCases := map[string]struct {
+		desc *metric.MetricDescriptor
+		want time.Duration
+	}{
+		"metadata populated uses descriptor value": {
+			desc: &metric.MetricDescriptor{
+				Metadata: &metric.MetricDescriptor_MetricDescriptorMetadata{
+					IngestDelay: durationpb.New(210 * time.Second),
+				},
+			},
+			want: 210 * time.Second,
+		},
+		"metadata nil falls back to default": {
+			desc: &metric.MetricDescriptor{},
+			want: fallback,
+		},
+		"metadata present but ingest delay zero falls back to default": {
+			desc: &metric.MetricDescriptor{
+				Metadata: &metric.MetricDescriptor_MetricDescriptorMetadata{
+					IngestDelay: durationpb.New(0),
+				},
+			},
+			want: fallback,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ingestDelay(tc.desc, fallback))
+		})
+	}
+}
+
+func TestCalculateStartEndTime(t *testing.T) {
+	interval := 1 * time.Minute
+	delay := 2 * time.Minute
+
+	startTime, endTime := calculateStartEndTime(interval, delay)
+
+	gap := endTime.Sub(startTime)
+	assert.Equal(t, interval, gap, "window length must equal interval")
+
+	timeSinceEnd := time.Since(endTime)
+	assert.GreaterOrEqual(t, timeSinceEnd, delay-time.Second, "endTime should be at least 'delay' ago")
+	assert.LessOrEqual(t, timeSinceEnd, delay+time.Second, "endTime should be at most 'delay' ago plus jitter")
+}
+
+func TestCalculateStartEndTimeIntervalCap(t *testing.T) {
+	interval := 48 * time.Hour
+	delay := 1 * time.Minute
+
+	startTime, endTime := calculateStartEndTime(interval, delay)
+
+	gap := endTime.Sub(startTime)
+	assert.Equal(t, 23*time.Hour, gap, "interval must be capped at 23h")
+}

--- a/receiver/googlecloudmonitoringreceiver/testdata/config.yaml
+++ b/receiver/googlecloudmonitoringreceiver/testdata/config.yaml
@@ -12,3 +12,10 @@ googlecloudmonitoring/endpoint:
   endpoint: monitoring.example.com:443
   metrics_list:
     - metric_name: "compute.googleapis.com/instance/cpu/usage_time"
+
+googlecloudmonitoring/default_ingest_delay:
+  collection_interval: 2m
+  project_id: my-project-id
+  default_ingest_delay: 3m
+  metrics_list:
+    - metric_name: "logging.googleapis.com/user/my_log_metric"


### PR DESCRIPTION
Adds a `default_ingest_delay` duration field to the receiver config.

This replaces the hardcoded 60s fallback that the receiver uses when a
metric descriptor does not populate `Metadata.IngestDelay`. Log-based
metrics (`logging.googleapis.com/user/*`), custom metrics
(`custom.googleapis.com/*`), and external Prometheus metrics
(`external.googleapis.com/prometheus/*`) do not populate this field,
causing the receiver to use the 60s hardcoded fallback even though
real ingestion latency is often 1–4 minutes.

The new field has a default of `60s`, which matches the current
hardcoded value exactly — zero behaviour change for existing users
who do not set it.

Fixes #48465
