### PR TITLE
[receiver/iis] Do not fail receiver start if disabled metrics are not installed

### DIFF
--- a/.chloggen/iis-receiver-only-requires-enabled-metrics.yaml
+++ b/.chloggen/iis-receiver-only-requires-enabled-metrics.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/iis
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The IIS receiver was failing to start when a disabled metric was not present in the system
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The IIS receiver was attempting to create watchers for all metrics, even those that were disabled.
+  This was causing the receiver to fail to start if any of the disabled metrics were not present in the system,
+  which is a valid scenario for some of the IIS metrics. Now, the receiver will only attempt to create watchers
+  for enabled metrics, so it should start successfully as long as all enabled metrics are present in the system. 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/iis-receiver-only-requires-enabled-metrics.yaml
+++ b/.chloggen/iis-receiver-only-requires-enabled-metrics.yaml
@@ -10,7 +10,7 @@ component: receiver/iis
 note: The IIS receiver was failing to start when a disabled metric was not present in the system
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48609]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/iisreceiver/recorder.go
+++ b/receiver/iisreceiver/recorder.go
@@ -19,102 +19,164 @@ type perfCounterRecorderConf struct {
 	recorders map[string]recordFunc
 }
 
-var totalPerfCounterRecorders = []perfCounterRecorderConf{
-	{
-		object:   "Process",
-		instance: "_Total",
-		recorders: map[string]recordFunc{
-			"Thread Count": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
-				mb.RecordIisThreadActiveDataPoint(ts, int64(val))
+func buildTotalPerfCounterRecordersFromConfig(metricsConfig metadata.MetricsConfig) []perfCounterRecorderConf {
+	if !metricsConfig.IisThreadActive.Enabled {
+		// if the metric is not enabled, we don't need to build any recorders
+		return nil
+	}
+
+	return []perfCounterRecorderConf{
+		{
+			object:   "Process",
+			instance: "_Total",
+			recorders: map[string]recordFunc{
+				"Thread Count": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+					mb.RecordIisThreadActiveDataPoint(ts, int64(val))
+				},
 			},
 		},
-	},
+	}
 }
 
-var sitePerfCounterRecorders = []perfCounterRecorderConf{
-	{
-		object:   "Web Service",
-		instance: "*",
-		recorders: map[string]recordFunc{
-			"Current Connections": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+func buildSitePerfCounterRecordersFromConfig(metricsConfig metadata.MetricsConfig) []perfCounterRecorderConf {
+	var sitePerfCounterRecorders []perfCounterRecorderConf
+
+	if metricsConfig.IisConnectionActive.Enabled ||
+		metricsConfig.IisNetworkIo.Enabled ||
+		metricsConfig.IisConnectionAttemptCount.Enabled ||
+		metricsConfig.IisRequestCount.Enabled ||
+		metricsConfig.IisNetworkFileCount.Enabled ||
+		metricsConfig.IisConnectionAnonymous.Enabled ||
+		metricsConfig.IisNetworkBlocked.Enabled ||
+		metricsConfig.IisUptime.Enabled {
+		siteRecorders := map[string]recordFunc{}
+
+		if metricsConfig.IisConnectionActive.Enabled {
+			siteRecorders["Current Connections"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisConnectionActiveDataPoint(ts, int64(val))
-			},
-			"Total Bytes Received": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+
+		if metricsConfig.IisNetworkIo.Enabled {
+			siteRecorders["Total Bytes Received"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisNetworkIoDataPoint(ts, int64(val), metadata.AttributeDirectionReceived)
-			},
-			"Total Bytes Sent": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Bytes Sent"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisNetworkIoDataPoint(ts, int64(val), metadata.AttributeDirectionSent)
-			},
-			"Total Connection Attempts (all instances)": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp,
+			}
+		}
+
+		if metricsConfig.IisConnectionAttemptCount.Enabled {
+			siteRecorders["Total Connection Attempts (all instances)"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp,
 				val float64,
 			) {
 				mb.RecordIisConnectionAttemptCountDataPoint(ts, int64(val))
-			},
-			"Total Delete Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+
+		if metricsConfig.IisRequestCount.Enabled {
+			siteRecorders["Total Delete Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestDelete)
-			},
-			"Total Get Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Get Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestGet)
-			},
-			"Total Head Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Head Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestHead)
-			},
-			"Total Options Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Options Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestOptions)
-			},
-			"Total Post Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Post Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestPost)
-			},
-			"Total Put Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Put Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestPut)
-			},
-			"Total Trace Requests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Trace Requests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestCountDataPoint(ts, int64(val), metadata.AttributeRequestTrace)
-			},
-			"Total Files Received": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+
+		if metricsConfig.IisNetworkFileCount.Enabled {
+			siteRecorders["Total Files Received"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisNetworkFileCountDataPoint(ts, int64(val), metadata.AttributeDirectionReceived)
-			},
-			"Total Files Sent": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+			siteRecorders["Total Files Sent"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisNetworkFileCountDataPoint(ts, int64(val), metadata.AttributeDirectionSent)
-			},
-			"Total Anonymous Users": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+
+		if metricsConfig.IisConnectionAnonymous.Enabled {
+			siteRecorders["Total Anonymous Users"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisConnectionAnonymousDataPoint(ts, int64(val))
-			},
-			"Total blocked bandwidth bytes.": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+
+		if metricsConfig.IisNetworkBlocked.Enabled {
+			siteRecorders["Total blocked bandwidth bytes."] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisNetworkBlockedDataPoint(ts, int64(val))
-			},
-			"Service Uptime": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+
+		if metricsConfig.IisUptime.Enabled {
+			siteRecorders["Service Uptime"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisUptimeDataPoint(ts, int64(val))
-			},
-		},
-	},
+			}
+		}
+
+		sitePerfCounterRecorders = append(sitePerfCounterRecorders, perfCounterRecorderConf{
+			object:    "Web Service",
+			instance:  "*",
+			recorders: siteRecorders,
+		})
+	}
+
+	return sitePerfCounterRecorders
 }
 
-var appPoolPerfCounterRecorders = []perfCounterRecorderConf{
-	{
-		object:   "HTTP Service Request Queues",
-		instance: "*",
-		recorders: map[string]recordFunc{
-			"RejectedRequests": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+func buildAppPoolPerfCounterRecordersFromConfig(metricsConfig metadata.MetricsConfig) []perfCounterRecorderConf {
+	appPoolPerfCounterRecorders := []perfCounterRecorderConf{}
+
+	if metricsConfig.IisRequestRejected.Enabled || metricsConfig.IisRequestQueueCount.Enabled {
+		requestRecorders := map[string]recordFunc{}
+		if metricsConfig.IisRequestRejected.Enabled {
+			requestRecorders["RejectedRequests"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestRejectedDataPoint(ts, int64(val))
-			},
-			"CurrentQueueSize": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+		if metricsConfig.IisRequestQueueCount.Enabled {
+			requestRecorders["CurrentQueueSize"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestQueueCountDataPoint(ts, int64(val))
-			},
-		},
-	},
-	{
-		object:   "APP_POOL_WAS",
-		instance: "*",
-		recorders: map[string]recordFunc{
-			"Current Application Pool State": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+		appPoolPerfCounterRecorders = append(appPoolPerfCounterRecorders, perfCounterRecorderConf{
+			object:    "HTTP Service Request Queues",
+			instance:  "*",
+			recorders: requestRecorders,
+		})
+	}
+
+	if metricsConfig.IisApplicationPoolState.Enabled || metricsConfig.IisApplicationPoolUptime.Enabled {
+		appPoolRecorders := map[string]recordFunc{}
+		if metricsConfig.IisApplicationPoolState.Enabled {
+			appPoolRecorders["Current Application Pool State"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisApplicationPoolStateDataPoint(ts, int64(val))
-			},
-			"Current Application Pool Uptime": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+			}
+		}
+		if metricsConfig.IisApplicationPoolUptime.Enabled {
+			appPoolRecorders["Current Application Pool Uptime"] = func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisApplicationPoolUptimeDataPoint(ts, int64(val))
-			},
-		},
-	},
+			}
+		}
+		appPoolPerfCounterRecorders = append(appPoolPerfCounterRecorders, perfCounterRecorderConf{
+			object:    "APP_POOL_WAS",
+			instance:  "*",
+			recorders: appPoolRecorders,
+		})
+	}
+
+	return appPoolPerfCounterRecorders
 }
 
 func recordMaxQueueItemAge(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {

--- a/receiver/iisreceiver/recorder_test.go
+++ b/receiver/iisreceiver/recorder_test.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver/internal/metadata"
+)
+
+func TestBuildTotalPerfCounterRecordersFromConfig(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		metricsConfig := metadata.DefaultMetricsConfig()
+		metricsConfig.IisThreadActive.Enabled = false
+
+		recorders := buildTotalPerfCounterRecordersFromConfig(metricsConfig)
+		require.Nil(t, recorders)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		metricsConfig := metadata.DefaultMetricsConfig()
+		metricsConfig.IisThreadActive.Enabled = true
+
+		recorders := buildTotalPerfCounterRecordersFromConfig(metricsConfig)
+		require.Len(t, recorders, 1)
+		require.Equal(t, "Process", recorders[0].object)
+		require.Equal(t, "_Total", recorders[0].instance)
+		require.Equal(t, []string{"Thread Count"}, sortedRecorderNames(recorders[0].recorders))
+	})
+}
+
+func TestBuildSitePerfCounterRecordersFromConfig(t *testing.T) {
+	t.Run("all disabled", func(t *testing.T) {
+		metricsConfig := metadata.DefaultMetricsConfig()
+		metricsConfig.IisConnectionActive.Enabled = false
+		metricsConfig.IisNetworkIo.Enabled = false
+		metricsConfig.IisConnectionAttemptCount.Enabled = false
+		metricsConfig.IisRequestCount.Enabled = false
+		metricsConfig.IisNetworkFileCount.Enabled = false
+		metricsConfig.IisConnectionAnonymous.Enabled = false
+		metricsConfig.IisNetworkBlocked.Enabled = false
+		metricsConfig.IisUptime.Enabled = false
+
+		recorders := buildSitePerfCounterRecordersFromConfig(metricsConfig)
+		require.Nil(t, recorders)
+	})
+
+	t.Run("partial enabled", func(t *testing.T) {
+		metricsConfig := metadata.DefaultMetricsConfig()
+		metricsConfig.IisConnectionActive.Enabled = false
+		metricsConfig.IisNetworkIo.Enabled = true
+		metricsConfig.IisConnectionAttemptCount.Enabled = false
+		metricsConfig.IisRequestCount.Enabled = false
+		metricsConfig.IisNetworkFileCount.Enabled = true
+		metricsConfig.IisConnectionAnonymous.Enabled = false
+		metricsConfig.IisNetworkBlocked.Enabled = false
+		metricsConfig.IisUptime.Enabled = false
+
+		recorders := buildSitePerfCounterRecordersFromConfig(metricsConfig)
+		require.Len(t, recorders, 1)
+		require.Equal(t, "Web Service", recorders[0].object)
+		require.Equal(t, "*", recorders[0].instance)
+		require.Equal(t,
+			[]string{"Total Bytes Received", "Total Bytes Sent", "Total Files Received", "Total Files Sent"},
+			sortedRecorderNames(recorders[0].recorders),
+		)
+	})
+}
+
+func TestBuildAppPoolPerfCounterRecordersFromConfig(t *testing.T) {
+	t.Run("all disabled", func(t *testing.T) {
+		metricsConfig := metadata.DefaultMetricsConfig()
+		metricsConfig.IisRequestRejected.Enabled = false
+		metricsConfig.IisRequestQueueCount.Enabled = false
+		metricsConfig.IisApplicationPoolState.Enabled = false
+		metricsConfig.IisApplicationPoolUptime.Enabled = false
+
+		recorders := buildAppPoolPerfCounterRecordersFromConfig(metricsConfig)
+		require.Empty(t, recorders)
+	})
+
+	t.Run("partial enabled", func(t *testing.T) {
+		metricsConfig := metadata.DefaultMetricsConfig()
+		metricsConfig.IisRequestRejected.Enabled = false
+		metricsConfig.IisRequestQueueCount.Enabled = true
+		metricsConfig.IisApplicationPoolState.Enabled = true
+		metricsConfig.IisApplicationPoolUptime.Enabled = false
+
+		recorders := buildAppPoolPerfCounterRecordersFromConfig(metricsConfig)
+		require.Len(t, recorders, 2)
+
+		require.Equal(t, "HTTP Service Request Queues", recorders[0].object)
+		require.Equal(t, "*", recorders[0].instance)
+		require.Equal(t, []string{"CurrentQueueSize"}, sortedRecorderNames(recorders[0].recorders))
+
+		require.Equal(t, "APP_POOL_WAS", recorders[1].object)
+		require.Equal(t, "*", recorders[1].instance)
+		require.Equal(t, []string{"Current Application Pool State"}, sortedRecorderNames(recorders[1].recorders))
+	})
+}
+
+func sortedRecorderNames(recorders map[string]recordFunc) []string {
+	names := make([]string, 0, len(recorders))
+	for name := range recorders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/receiver/iisreceiver/scraper.go
+++ b/receiver/iisreceiver/scraper.go
@@ -72,6 +72,10 @@ func newIisReceiver(settings receiver.Settings, cfg *Config, consumer consumer.M
 func (rcvr *iisReceiver) start(_ context.Context, _ component.Host) error {
 	errs := &scrapererror.ScrapeErrors{}
 
+	totalPerfCounterRecorders := buildTotalPerfCounterRecordersFromConfig(rcvr.config.Metrics)
+	sitePerfCounterRecorders := buildSitePerfCounterRecordersFromConfig(rcvr.config.Metrics)
+	appPoolPerfCounterRecorders := buildAppPoolPerfCounterRecordersFromConfig(rcvr.config.Metrics)
+
 	rcvr.totalWatcherRecorders = rcvr.buildWatcherRecorders(totalPerfCounterRecorders, errs)
 	rcvr.siteWatcherRecorders = rcvr.buildWatcherRecorders(sitePerfCounterRecorders, errs)
 	rcvr.appPoolWatcherRecorders = rcvr.buildWatcherRecorders(appPoolPerfCounterRecorders, errs)
@@ -227,6 +231,11 @@ var maxQueueItemAgeInstanceRegex = regexp.MustCompile(`\\HTTP Service Request Qu
 // This is done in order to capture the error when scraping each individual instance, because we want to ignore
 // negative denominator errors.
 func (rcvr *iisReceiver) buildMaxQueueItemAgeWatchers(scrapeErrors *scrapererror.ScrapeErrors) []instanceWatcher {
+	if !rcvr.config.Metrics.IisRequestQueueAgeMax.Enabled {
+		// if the metric is not enabled, we don't need to build any watchers
+		return nil
+	}
+
 	wrs := []instanceWatcher{}
 
 	paths, err := rcvr.expandWildcardPath(`\HTTP Service Request Queues(*)\MaxQueueItemAge`)

--- a/receiver/iisreceiver/scraper_test.go
+++ b/receiver/iisreceiver/scraper_test.go
@@ -8,6 +8,7 @@ package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector
 import (
 	"errors"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -60,6 +61,27 @@ func TestScrape(t *testing.T) {
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
 		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+}
+
+func TestAllMetricsDisabledScrape(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	disableAllMetricEnabledFlags(&cfg.Metrics)
+
+	scraper := newIisReceiver(
+		receivertest.NewNopSettings(metadata.Type),
+		cfg,
+		consumertest.NewNop(),
+	)
+
+	// Do not mock the watchers in this test, because if the metrics are all disabled,
+	// the scraper should not even attempt to create watchers
+
+	err := scraper.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	actualMetrics, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 0, actualMetrics.MetricCount())
 }
 
 func TestScrapeFailure(t *testing.T) {
@@ -161,6 +183,35 @@ func TestMaxQueueItemAgeNegativeDenominatorScrapeFailure(t *testing.T) {
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
 		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+}
+
+func disableAllMetricEnabledFlags(metricsConfig any) {
+	disableEnabledFieldsRecursively(reflect.ValueOf(metricsConfig))
+}
+
+func disableEnabledFieldsRecursively(v reflect.Value) {
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := v.Type().Field(i)
+
+		if fieldType.Name == "Enabled" && field.Kind() == reflect.Bool && field.CanSet() {
+			field.SetBool(false)
+			continue
+		}
+
+		disableEnabledFieldsRecursively(field)
+	}
 }
 
 type mockPerfCounter struct {


### PR DESCRIPTION
This can be seen as an optimization, but in fact came to light in an IIS deployment in which some counters were not installed. The issue is that a configuration disabling the missing counter was not enough since the receiver tried to create the performance counter object at start even if the underlying metric was disabled on the configuration.

This change ensures that the perfcounter objects are only created if the metrics for which they are required are enabled.