### PR TITLE
[chore]: support scoped unit tests in build-and-test.yaml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -277,30 +277,15 @@ jobs:
           make generate-chloggen-components
           git diff --exit-code || (echo '.chloggen/config.yaml is out of date, please run "make generate-chloggen-components" and commit the changes.' && exit 1)
   unittest-matrix:
+    needs: [setup-environment, ci-scope]
+    if: ${{ needs.ci-scope.outputs.matrix != '[]' && needs.ci-scope.outputs.matrix != '' }}
     strategy:
       fail-fast: false
       matrix:
         go-version: [stable, oldstable]
         runner: [ubuntu-24.04]
-        group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - other
+        group: ${{ fromJSON(needs.ci-scope.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
-    needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
@@ -321,7 +306,7 @@ jobs:
       - name: Run Unit Tests
         id: tests
         if: github.ref != 'refs/heads/main' || !startsWith( matrix.go-version, 'oldstable' )
-        run: make gotest GROUP=${{ matrix.group }}
+        run: make gotest GROUP="${{ matrix.group }}"
 
       # JUnit tests are super long, so we only run them for one go version.
       # This is used for automation that automatically creates issues for flaky tests that are
@@ -330,7 +315,7 @@ jobs:
         id: tests-with-junit
         if: startsWith( matrix.go-version, 'oldstable' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
         continue-on-error: true # Allow uploading artifacts even if the test fails
-        run: make gotest-with-junit-and-cover GROUP=${{ matrix.group }}
+        run: make gotest-with-junit-and-cover GROUP="${{ matrix.group }}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: startsWith( matrix.go-version, 'oldstable' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
@@ -361,7 +346,7 @@ jobs:
         run: echo ${{ needs.unittest-matrix.result }}
       - name: Interpret result
         run: |
-          if [[ success == ${{ needs.unittest-matrix.result }} ]]
+          if [[ success == ${{ needs.unittest-matrix.result }} || skipped == ${{ needs.unittest-matrix.result }} ]]
           then
             echo "All matrix jobs passed!"
           else


### PR DESCRIPTION
#### Description

Adds support for scoped unit tests to build-and-test. This is based on the capability in build-and-test-experimental. Certain changes still cause everything to be unit tests, as determined by the CRITICAL_FILES in compute-scope job.