### PR TITLE
[connector/failover] Disable default 5s timeout in wrapped exporterhelper

### DIFF
--- a/.chloggen/failoverconnector-disable-default-timeout.yaml
+++ b/.chloggen/failoverconnector-disable-default-timeout.yaml
@@ -1,0 +1,12 @@
+change_type: bug_fix
+
+component: connector/failover
+
+note: Stop the connector's wrapped exporterhelper from imposing its default 5s timeout on the downstream pipeline when `sending_queue` is enabled.
+
+issues: [48567]
+
+subtext: |
+  Previously, enabling `sending_queue` caused the connector to wrap itself in `exporterhelper.NewLogs/Traces/Metrics`, which silently installs a `timeoutSender` with the 5s default `TimeoutConfig.Timeout`. That deadline propagated through to downstream exporters via `ctx.Deadline()`, capping their configured timeouts (e.g., a downstream exporter configured with `timeout: 30s` would only see ~5s of budget at its `pushLogsData`). The connector now passes `WithTimeout(TimeoutConfig{Timeout: 0})` explicitly, matching the pattern used by signalfxexporter and splunkhecexporter. A user-facing `timeout` config field on the connector may be added separately if there is demand for connector-level hang-protection.
+
+change_logs: [user]

--- a/connector/failoverconnector/factory.go
+++ b/connector/failoverconnector/factory.go
@@ -59,11 +59,15 @@ func createTracesToTraces(
 		return t, nil
 	}
 
-	// If queue is enabled, wrap with exporterhelper
+	// If queue is enabled, wrap with exporterhelper.
+	// Explicitly disable exporterhelper's default 5s timeout: this wrapper exists only to provide
+	// the sending_queue, and any context deadline it imposes would silently cap downstream
+	// exporters' configured timeouts. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48567.
 	wrapped, err := exporterhelper.NewTraces(ctx, expSettings, cfg,
 		t.ConsumeTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 	)
 	if err != nil {
 		return nil, err
@@ -96,11 +100,12 @@ func createMetricsToMetrics(
 		return t, nil
 	}
 
-	// If queue is enabled, wrap with exporterhelper
+	// If queue is enabled, wrap with exporterhelper. See WithTimeout note in createTracesToTraces.
 	wrapped, err := exporterhelper.NewMetrics(ctx, expSettings, cfg,
 		t.ConsumeMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 	)
 	if err != nil {
 		return nil, err
@@ -133,11 +138,12 @@ func createLogsToLogs(
 		return t, nil
 	}
 
-	// If queue is enabled, wrap with exporterhelper
+	// If queue is enabled, wrap with exporterhelper. See WithTimeout note in createTracesToTraces.
 	wrapped, err := exporterhelper.NewLogs(ctx, expSettings, cfg,
 		t.ConsumeLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 	)
 	if err != nil {
 		return nil, err

--- a/connector/failoverconnector/logs_test.go
+++ b/connector/failoverconnector/logs_test.go
@@ -5,11 +5,13 @@ package failoverconnector // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/connector/connectortest"
@@ -168,6 +170,63 @@ func TestLogsWithQueue(t *testing.T) {
 	ld := sampleLog()
 
 	assert.NoError(t, conn.ConsumeLogs(t.Context(), ld))
+}
+
+// deadlineCapturingLogsConsumer records ctx.Deadline() observed during ConsumeLogs.
+type deadlineCapturingLogsConsumer struct {
+	consumer.Logs
+	once        sync.Once
+	called      chan struct{}
+	hasDeadline bool
+	deadline    time.Time
+}
+
+func (c *deadlineCapturingLogsConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	c.once.Do(func() {
+		c.deadline, c.hasDeadline = ctx.Deadline()
+		close(c.called)
+	})
+	return c.Logs.ConsumeLogs(ctx, ld)
+}
+
+// TestLogsQueueDoesNotImposeDownstreamDeadline verifies that when the failover connector's
+// sending_queue is enabled, the wrapped exporterhelper does not impose its default 5s timeout
+// on the downstream pipeline's ctx — see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48567.
+func TestLogsQueueDoesNotImposeDownstreamDeadline(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	capture := &deadlineCapturingLogsConsumer{Logs: sink, called: make(chan struct{})}
+
+	logsFirst := pipeline.NewIDWithName(pipeline.SignalLogs, "logs/first")
+	cfg := &Config{
+		PipelinePriority: [][]pipeline.ID{{logsFirst}},
+		RetryInterval:    50 * time.Millisecond,
+		QueueSettings:    configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
+	}
+	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
+		logsFirst: capture,
+	})
+
+	conn, err := NewFactory().CreateLogsToLogs(t.Context(),
+		connectortest.NewNopSettings(metadata.Type), cfg, router.(consumer.Logs))
+	require.NoError(t, err)
+
+	failoverConnector := conn.(*wrappedLogsConnector)
+	require.NoError(t, failoverConnector.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		assert.NoError(t, failoverConnector.Shutdown(t.Context()))
+	}()
+
+	require.NoError(t, conn.ConsumeLogs(t.Context(), sampleLog()))
+
+	select {
+	case <-capture.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("downstream consumer was not called within 2s")
+	}
+
+	assert.False(t, capture.hasDeadline,
+		"downstream ctx should not carry a deadline imposed by the failover connector, got %v (in %s)",
+		capture.deadline, time.Until(capture.deadline))
 }
 
 func consumeLogsAndCheckStable(conn *logsFailover, idx int, lr plog.Logs) bool {


### PR DESCRIPTION
**Description**

Fixes #48567.

When `sending_queue` is enabled on the failover connector, the connector wraps
itself in `exporterhelper.NewLogs/Traces/Metrics` (factory.go) without passing
`WithTimeout`. `exporterhelper` falls back to `NewDefaultTimeoutConfig()` (5s)
and installs a `timeoutSender` that wraps the ctx of every call into the
downstream pipeline. Since `context.WithTimeout` can only shorten a parent
deadline, this silently caps the configured timeout of every downstream
exporter on a path routed through the connector. A downstream exporter
configured with `timeout: 30s` ends up seeing ~5s of budget at its
`pushLogsData` (or equivalent), and drivers that re-derive settings from
`ctx.Deadline()` see the truncated value, e.g., `clickhouse-go` overwrites
`max_execution_time` with `int(time.Until(deadline).Seconds() + 5)`.

This PR passes `WithTimeout(TimeoutConfig{Timeout: 0})` explicitly in all three
factory paths, disabling the `timeoutSender`.

The same pattern (`WithTimeout(TimeoutConfig{Timeout: 0})`) is already used by
`signalfxexporter` and `splunkhecexporter`.

**Link to tracking issue**

Fixes #48567

**Testing**

Added `TestLogsQueueDoesNotImposeDownstreamDeadline` in `logs_test.go` that
enables `sending_queue` and asserts the downstream consumer's ctx has no
deadline. Verified the test fails without the fix (reporting a deadline ~5s in
the future) and passes with it.

**Documentation**

Chloggen entry added.
