### PR TITLE
[receiver/googlecloudpubsub] use available context in responseStream

### DIFF
--- a/.chloggen/codeboten_use-available-context.yaml
+++ b/.chloggen/codeboten_use-available-context.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use available context in responseStream
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48665]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/googlecloudpubsubreceiver/internal/handler.go
+++ b/receiver/googlecloudpubsubreceiver/internal/handler.go
@@ -227,7 +227,7 @@ func (handler *StreamHandler) responseStream(ctx context.Context, cancel context
 		if err == nil {
 			for _, message := range resp.ReceivedMessages {
 				// handle all the messages in the response, could be one or more
-				err = handler.pushMessage(context.Background(), message)
+				err = handler.pushMessage(ctx, message)
 				if err == nil {
 					// When sending a message though the pipeline fails, we ignore the error. We'll let Pubsub
 					// handle the flow control.


### PR DESCRIPTION
Small fix pointed out by update to linter. Related to #41780
