### PR TITLE
[chore] more cleanup after 0.153 release

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -14,7 +14,7 @@ dist:
   output_path: ./cmd/otelcontribcol
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.153.0
@@ -61,10 +61,10 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension v0.153.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.153.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.153.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.153.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.153.0
@@ -113,8 +113,8 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.153.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.153.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor v0.153.0
@@ -145,8 +145,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor v0.153.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.153.0
@@ -257,7 +257,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.153.0
 
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector v0.153.0
@@ -272,11 +272,11 @@ connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.153.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.58.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.59.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider v0.153.0

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -11,14 +11,14 @@ dist:
   output_path: ./cmd/oteltestbedcol
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.153.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.153.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.153.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.153.0
@@ -29,8 +29,8 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.153.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.152.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.153.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.153.0
@@ -38,7 +38,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.153.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.152.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.153.0
@@ -54,11 +54,11 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.153.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.58.1-0.20260514231715-e7f22744c28c
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.58.1-0.20260514231715-e7f22744c28c
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.59.0
 
 # When using `make genoteltestbedcol`, the `replaces` content is appended to this
 # file before passing it to OCB, to ensure that local versions are used for all


### PR DESCRIPTION
#### Description
Fix versions in builder-config.yaml to fix `make otelcontribcol` & `make oteltestbedcol`

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48661
