### PR TITLE
[chore]: remove unneeded extra cache step

### DIFF
--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -281,11 +281,6 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-      - name: Cache Test Build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.cache/go-build
-          key: go-test-build-experimental-${{ runner.os }}-${{ matrix.go-version }}-${{ matrix.runner }}-${{ hashFiles('**/go.sum') }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
       - name: Run Unit Tests
         id: tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -291,11 +291,6 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-      - name: Cache Test Build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.cache/go-build
-          key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ matrix.runner }}-${{ hashFiles('**/go.sum') }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
       # Unit tests without JUnit output are much faster, so it's fine to run on every PR and every go version.


### PR DESCRIPTION
#### Description

While working on speeding up `build-and-test` I saw that we have an extra cache step that competes with `go-setup`. This is a continuation of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41709 which removed other additional caching steps in favor of `go-setup`