### PR TITLE
[chore]: narrow the scope of cache dependency paths

### DIFF
--- a/.github/actions/setup-go-tools/action.yml
+++ b/.github/actions/setup-go-tools/action.yml
@@ -6,17 +6,6 @@ inputs:
     description: Version passed to actions/setup-go.
     required: false
     default: "oldstable"
-  cache-dependency-path:
-    description: |
-      Pattern(s) for actions/setup-go cache-dependency-path. Defaults to high-stability
-      files (tooling and testbed) so per-component Renovate bumps don't invalidate the
-      shared Go module cache. `go test`/`go build` lazy-fetches any module versions not
-      present in the restored cache. Callers needing full-closure invalidation can
-      override with `**/*.sum`.
-    required: false
-    default: |
-      internal/tools/go.sum
-      testbed/go.sum
   gomoddownload:
     description: Whether to run `make -j2 gomoddownload` when Go cache is cold.
     required: false
@@ -38,7 +27,13 @@ runs:
       id: go-setup
       with:
         go-version: ${{ inputs.go-version }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        # Narrow the cache key to high-stability files (tooling and testbed) so
+        # per-component Renovate bumps don't invalidate the shared Go module
+        # cache. `go test`/`go build` lazy-fetches any module versions not
+        # present in the restored cache.
+        cache-dependency-path: |
+          internal/tools/go.sum
+          testbed/go.sum
 
     - name: Install dependencies (gomoddownload)
       # Only download if setup-go didn't restore a cache.

--- a/.github/actions/setup-go-tools/action.yml
+++ b/.github/actions/setup-go-tools/action.yml
@@ -2,10 +2,6 @@ name: Setup Go & repo tooling
 description: Common setup for Go-based workflows (disk cleanup, setup-go cache, optional gomoddownload).
 
 inputs:
-  repo-path:
-    description: Path to the repository root.
-    required: false
-    default: "."
   go-version:
     description: Version passed to actions/setup-go.
     required: false
@@ -34,8 +30,8 @@ runs:
       # Force 'bash' to use Git Bash on Windows runners.
       # This allows us to share the same cleanup script across OSs.
       run: |
-        chmod +x "${{ inputs.repo-path }}/.github/workflows/scripts/free-disk-space.sh"
-        "${{ inputs.repo-path }}/.github/workflows/scripts/free-disk-space.sh"
+        chmod +x ./.github/workflows/scripts/free-disk-space.sh
+        ./.github/workflows/scripts/free-disk-space.sh
 
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -48,5 +44,4 @@ runs:
       # Only download if setup-go didn't restore a cache.
       if: inputs.gomoddownload == 'true' && steps.go-setup.outputs.cache-hit != 'true'
       shell: bash
-      working-directory: ${{ inputs.repo-path }}
       run: make -j8 gomoddownload

--- a/.github/actions/setup-go-tools/action.yml
+++ b/.github/actions/setup-go-tools/action.yml
@@ -11,9 +11,16 @@ inputs:
     required: false
     default: "oldstable"
   cache-dependency-path:
-    description: Pattern(s) for actions/setup-go cache-dependency-path, relative to repo-path.
+    description: |
+      Pattern(s) for actions/setup-go cache-dependency-path. Defaults to high-stability
+      files (tooling and testbed) so per-component Renovate bumps don't invalidate the
+      shared Go module cache. `go test`/`go build` lazy-fetches any module versions not
+      present in the restored cache. Callers needing full-closure invalidation can
+      override with `**/*.sum`.
     required: false
-    default: "**/*.sum"
+    default: |
+      internal/tools/go.sum
+      testbed/go.sum
   gomoddownload:
     description: Whether to run `make -j2 gomoddownload` when Go cache is cold.
     required: false
@@ -35,8 +42,7 @@ runs:
       id: go-setup
       with:
         go-version: ${{ inputs.go-version }}
-        # Always format the path. "./pattern" is valid, handling both root (.) and subdirs.
-        cache-dependency-path: ${{ format('{0}/{1}', inputs.repo-path, inputs.cache-dependency-path) }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     - name: Install dependencies (gomoddownload)
       # Only download if setup-go didn't restore a cache.


### PR DESCRIPTION
#### Description

Updates the default cache path to just be `internal/tools/go.sum` and `testbed/go.sum`. This has the effect of making the cache useful for _most_ of a PR's dependencies while keeping it from becoming stale after each renovatebot PR. The result is that for any given PR most of the go deps it needs will be restored, and then any remaining dependencies will be fetch on-demand.

Also remove 2 unused input params `repo-path` and `cache-dependency-path`. These were never used.