### PR TITLE
[chore]: make publish-check wait for cross-compile

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -539,7 +539,7 @@ jobs:
 
   publish-check:
     runs-on: ubuntu-24.04
-    needs: [lint, unittest, integration-tests]
+    needs: [lint, unittest, integration-tests, cross-compile]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
#### Description

publish-check verifies that all cross-compile binaries were produced by downloading the collector-binaries-* artifacts. It only declared a dependency on [lint, unittest, integration-tests], so it could start before the cross-compile matrix finished and fail with messages like "bin/otelcontribcol_darwin_arm64 does not exist."