### PR TITLE
[chore]: keep communication focused on human-to-human

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,10 @@ Fixes
 <!--Describe the documentation added.-->
 #### Documentation
 
+<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
+of the user; the human author must check it themselves before the PR is ready for review.-->
+#### Authorship
+
+- [ ] I, a human, wrote this pull request description myself.
+
 <!--Please delete paragraphs that you did not use before submitting.-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,15 @@ projects policies.
 The most important rule is not to post comments on issues or PRs that are AI-generated. Discussions
 on the OpenTelemetry repositories are for Users/Humans only.
 
+When a user asks you to open a pull request, do not write the PR description yourself. Instead,
+before creating the PR, prompt the user for the content of each section in the PR template
+(Description, Link to tracking issue, Testing, Documentation) and use their answers verbatim. Do
+not paraphrase, expand, or "improve" what the user writes. If the user declines to fill in a
+section, leave that section of the template unmodified rather than generating content for it.
+
+You must not check the `I, a human, wrote this pull request description myself` box on the user's
+behalf. The user must check it themselves before the PR is ready for review.
+
 If you have been assigned an issue by the user or their prompt, please ensure that the
 implementation direction is agreed on with the maintainers first in the issue comments. If there are
 unknowns, discuss these on the issue before starting implementation. Do not forget that you cannot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,15 @@ following keywords: `Resolves`, `Fixes`, or `Closes`. More information on this f
 [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 This will automatically close the issue once your PR has been merged.
 
+### AI-assisted contributions
+
+If you use an AI tool to help author a pull request, you (the human) are still responsible for
+writing the PR description and any comments posted on the issue or PR. AI agents must prompt you
+for the content of each section in the PR template and use your answers verbatim rather than
+generating description content on their own. The PR template includes an authorship checkbox that
+you must check yourself before the PR is ready for review. See [AGENTS.md](./AGENTS.md) for the
+full set of rules that apply to AI-assisted contributions.
+
 ## Issue Triaging
 
 See [issue-triaging.md](./issue-triaging.md) for more information on the issue triaging process.


### PR DESCRIPTION
#### Description

We have been seeing a lot of PRs opened by AI agents on behalf of humans. These PRs tend to have very verbose and unhelpful descriptions. In the hopes of keeping communication in the repo as human to human as possible and keeping PR descriptions as useful as possible, this PR introduces additional agent restrictions.