### PR TITLE
[chore] narrow cache-dependency-path in direct setup-go callers

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: oldstable
-          cache-dependency-path: "**/*.sum"
+          cache: false
 
       - name: Ensure no changes to the CHANGELOG.md or CHANGELOG-API.md
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -40,7 +40,7 @@ jobs:
         id: go-setup
         with:
           go-version: oldstable
-          cache-dependency-path: "**/*.sum"
+          cache: false
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,9 @@ jobs:
         id: go-setup
         with:
           go-version: oldstable
-          cache-dependency-path: "**/*.sum"
+          cache-dependency-path: |
+            internal/tools/go.sum
+            testbed/go.sum
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -37,7 +37,9 @@ jobs:
         id: go-setup
         with:
           go-version: oldstable
-          cache-dependency-path: "**/*.sum"
+          cache-dependency-path: |
+            opentelemetry-collector-contrib/internal/tools/go.sum
+            opentelemetry-collector-contrib/testbed/go.sum
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
         working-directory: opentelemetry-collector-contrib


### PR DESCRIPTION
#### Description

extend https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48678 to workflows that do not use our action and instead use `setup-go` directly. For check codeowners and changelog just disable the cache - it wasn't helping and it takes up precious space.