### PR TITLE
[chore] Skip test packages in scoped cross-compile

### DIFF
--- a/.github/workflows/build-and-test-experimental.yml
+++ b/.github/workflows/build-and-test-experimental.yml
@@ -573,6 +573,6 @@ jobs:
           modules=$(echo "$MATRIX" | jq -r '.[]' | tr ' ' '\n' | sort -u | grep -v '^$')
           for mod in $modules; do
             echo "Building $mod for $GOOS/$GOARCH"
-            (cd "$mod" && go build ./...)
+            (cd "$mod" && go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... | sed '/test$/d' | xargs -r go build)
           done
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
Builds scoped experimental cross-compile inputs from `go list`, dropping empty package dirs and import paths ending in `test`, so integration-test helper packages are covered by integration-test jobs instead of every cross target.

Fixes #48688.

Verified with `make actionlint`, an AIX/ppc64 scoped build of `internal/coreinternal`, and a Linux/amd64 scoped build of `internal/coreinternal`.