### PR TITLE
[receiver/httpcheck] Add per-target custom attributes

### DIFF
--- a/.chloggen/httpcheck-target-attributes.yaml
+++ b/.chloggen/httpcheck-target-attributes.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/http_check
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an optional `attributes` map to each target to set static attributes on the metrics produced for that target.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42525]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Attributes that collide with one already set by the receiver, such as `http.url`, are ignored.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -49,8 +49,19 @@ Each target has the following properties:
 - `endpoints` (optional): A list of URLs to be monitored.
 - `method` (optional, default: `GET`): The HTTP method used to call the endpoint or endpoints.
 - `body` (optional): Request body content for POST, PUT, PATCH, and other methods.
+- `attributes` (optional): A map of static attributes added to every metric produced for this target. Attributes whose key matches one already set by the receiver (for example `http.url`) are ignored.
 
 At least one of `endpoint` or `endpoints` must be specified. Additionally, each target supports the client configuration options of [confighttp].
+
+```yaml
+receivers:
+  http_check:
+    targets:
+      - endpoint: https://example.com/health
+        attributes:
+          environment: production
+          team: platform
+```
 
 ### Optional Metrics
 

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -57,6 +57,7 @@ type targetConfig struct {
 	Body                    string             `mapstructure:"body"`              // Request body content
 	AutoContentType         bool               `mapstructure:"auto_content_type"` // Whether to automatically set Content-Type based on body
 	Validations             []validationConfig `mapstructure:"validations"`       // Response validation rules
+	Attributes              map[string]string  `mapstructure:"attributes"`        // Static attributes added to every metric for this target
 }
 
 // Validate validates an individual targetConfig.

--- a/receiver/httpcheckreceiver/config.schema.yaml
+++ b/receiver/httpcheckreceiver/config.schema.yaml
@@ -7,6 +7,10 @@ properties:
       x-pointer: true
       type: object
       properties:
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
         auto_content_type:
           type: boolean
         body:

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -509,23 +509,20 @@ func addTargetAttributes(metrics pmetric.Metrics, targets []*targetConfig) {
 		return
 	}
 
-	annotate := func(dps pmetric.NumberDataPointSlice) {
-		for i := 0; i < dps.Len(); i++ {
-			dp := dps.At(i)
-			url, ok := dp.Attributes().Get("http.url")
-			if !ok {
+	annotate := func(attrs pcommon.Map) {
+		url, ok := attrs.Get("http.url")
+		if !ok {
+			return
+		}
+		attributes, ok := endpointAttributes[url.Str()]
+		if !ok {
+			return
+		}
+		for key, value := range attributes {
+			if _, exists := attrs.Get(key); exists {
 				continue
 			}
-			attributes, ok := endpointAttributes[url.Str()]
-			if !ok {
-				continue
-			}
-			for key, value := range attributes {
-				if _, exists := dp.Attributes().Get(key); exists {
-					continue
-				}
-				dp.Attributes().PutStr(key, value)
-			}
+			attrs.PutStr(key, value)
 		}
 	}
 
@@ -538,9 +535,30 @@ func addTargetAttributes(metrics pmetric.Metrics, targets []*targetConfig) {
 				m := ms.At(k)
 				switch m.Type() {
 				case pmetric.MetricTypeGauge:
-					annotate(m.Gauge().DataPoints())
+					dps := m.Gauge().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						annotate(dps.At(l).Attributes())
+					}
 				case pmetric.MetricTypeSum:
-					annotate(m.Sum().DataPoints())
+					dps := m.Sum().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						annotate(dps.At(l).Attributes())
+					}
+				case pmetric.MetricTypeHistogram:
+					dps := m.Histogram().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						annotate(dps.At(l).Attributes())
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					dps := m.ExponentialHistogram().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						annotate(dps.At(l).Attributes())
+					}
+				case pmetric.MetricTypeSummary:
+					dps := m.Summary().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						annotate(dps.At(l).Attributes())
+					}
 				}
 			}
 		}

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -459,6 +459,7 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 	// Emit metrics and post-process to remove http.status_code when value is 0
 	metrics := h.mb.Emit()
 	removeStatusCodeForZeroValues(metrics)
+	addTargetAttributes(metrics, h.cfg.Targets)
 
 	return metrics, nil
 }
@@ -486,6 +487,60 @@ func removeStatusCodeForZeroValues(metrics pmetric.Metrics) {
 							}
 						}
 					}
+				}
+			}
+		}
+	}
+}
+
+// addTargetAttributes annotates each data point with the static attributes
+// configured on the target that produced it. Targets are matched by the
+// http.url attribute, which every httpcheck metric carries and which equals the
+// target endpoint. A configured attribute that collides with one already set by
+// the receiver is left untouched.
+func addTargetAttributes(metrics pmetric.Metrics, targets []*targetConfig) {
+	endpointAttributes := make(map[string]map[string]string, len(targets))
+	for _, target := range targets {
+		if len(target.Attributes) > 0 {
+			endpointAttributes[target.Endpoint] = target.Attributes
+		}
+	}
+	if len(endpointAttributes) == 0 {
+		return
+	}
+
+	annotate := func(dps pmetric.NumberDataPointSlice) {
+		for i := 0; i < dps.Len(); i++ {
+			dp := dps.At(i)
+			url, ok := dp.Attributes().Get("http.url")
+			if !ok {
+				continue
+			}
+			attributes, ok := endpointAttributes[url.Str()]
+			if !ok {
+				continue
+			}
+			for key, value := range attributes {
+				if _, exists := dp.Attributes().Get(key); exists {
+					continue
+				}
+				dp.Attributes().PutStr(key, value)
+			}
+		}
+	}
+
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		sms := rms.At(i).ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			ms := sms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				m := ms.At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					annotate(m.Gauge().DataPoints())
+				case pmetric.MetricTypeSum:
+					annotate(m.Sum().DataPoints())
 				}
 			}
 		}

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -1014,3 +1014,135 @@ func TestResponseValidationFailures(t *testing.T) {
 	assert.True(t, foundMetrics["httpcheck.validation.passed"])
 	assert.True(t, foundMetrics["httpcheck.validation.failed"])
 }
+
+// numberDataPoints returns the number data points of a metric regardless of
+// whether it is a gauge or a sum.
+func numberDataPoints(m pmetric.Metric) pmetric.NumberDataPointSlice {
+	switch m.Type() {
+	case pmetric.MetricTypeGauge:
+		return m.Gauge().DataPoints()
+	case pmetric.MetricTypeSum:
+		return m.Sum().DataPoints()
+	default:
+		return pmetric.NewNumberDataPointSlice()
+	}
+}
+
+func TestScraperTargetAttributes(t *testing.T) {
+	ms1 := newMockServer(t, 200)
+	defer ms1.Close()
+	ms2 := newMockServer(t, 200)
+	defer ms2.Close()
+	ms3 := newMockServer(t, 200)
+	defer ms3.Close()
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Targets = []*targetConfig{
+		{
+			ClientConfig: confighttp.ClientConfig{Endpoint: ms1.URL},
+			Attributes:   map[string]string{"environment": "production", "team": "platform"},
+		},
+		{
+			ClientConfig: confighttp.ClientConfig{Endpoint: ms2.URL},
+			Attributes:   map[string]string{"tier": "internal"},
+		},
+		{
+			ClientConfig: confighttp.ClientConfig{Endpoint: ms3.URL},
+		},
+	}
+
+	scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
+
+	actualMetrics, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	// Expected custom attributes per endpoint. The third target has none.
+	expected := map[string]map[string]string{
+		ms1.URL: {"environment": "production", "team": "platform"},
+		ms2.URL: {"tier": "internal"},
+		ms3.URL: {},
+	}
+	customKeys := []string{"environment", "team", "tier"}
+
+	dataPointsChecked := 0
+	rms := actualMetrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		sms := rms.At(i).ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			ms := sms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				m := ms.At(k)
+				dps := numberDataPoints(m)
+				for l := 0; l < dps.Len(); l++ {
+					dp := dps.At(l)
+					url, ok := dp.Attributes().Get("http.url")
+					require.True(t, ok, "metric %s has a data point without http.url", m.Name())
+
+					want, known := expected[url.Str()]
+					require.True(t, known, "unexpected endpoint %q", url.Str())
+
+					// Each data point must carry exactly its own target's custom
+					// attributes: the configured ones are present with the right
+					// value, and no other target's keys leak in.
+					for _, key := range customKeys {
+						got, present := dp.Attributes().Get(key)
+						if value, owned := want[key]; owned {
+							assert.True(t, present, "metric %s data point for %q missing attribute %q", m.Name(), url.Str(), key)
+							assert.Equal(t, value, got.Str())
+						} else {
+							assert.False(t, present, "metric %s data point for %q unexpectedly has attribute %q", m.Name(), url.Str(), key)
+						}
+					}
+					dataPointsChecked++
+				}
+			}
+		}
+	}
+	assert.Positive(t, dataPointsChecked)
+}
+
+func TestScraperTargetAttributesDoNotOverrideReceiverAttributes(t *testing.T) {
+	server := newMockServer(t, 200)
+	defer server.Close()
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Targets = []*targetConfig{
+		{
+			ClientConfig: confighttp.ClientConfig{Endpoint: server.URL},
+			// http.url collides with an attribute the receiver sets itself.
+			Attributes: map[string]string{"http.url": "spoofed", "environment": "production"},
+		},
+	}
+
+	scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
+
+	actualMetrics, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+
+	dataPointsChecked := 0
+	rms := actualMetrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		sms := rms.At(i).ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			ms := sms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				m := ms.At(k)
+				dps := numberDataPoints(m)
+				for l := 0; l < dps.Len(); l++ {
+					dp := dps.At(l)
+					url, ok := dp.Attributes().Get("http.url")
+					require.True(t, ok)
+					assert.Equal(t, server.URL, url.Str(), "metric %s: receiver-set http.url must win over a configured attribute", m.Name())
+
+					env, ok := dp.Attributes().Get("environment")
+					require.True(t, ok, "metric %s: non-colliding custom attribute should still be added", m.Name())
+					assert.Equal(t, "production", env.Str())
+					dataPointsChecked++
+				}
+			}
+		}
+	}
+	assert.Positive(t, dataPointsChecked)
+}

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -1100,6 +1101,68 @@ func TestScraperTargetAttributes(t *testing.T) {
 		}
 	}
 	assert.Positive(t, dataPointsChecked)
+}
+
+// TestAddTargetAttributesAllMetricTypes verifies that addTargetAttributes
+// annotates data points of every metric type, not just the gauge and sum
+// metrics the receiver emits today.
+func TestAddTargetAttributesAllMetricTypes(t *testing.T) {
+	const endpoint = "https://example.com/health"
+
+	targets := []*targetConfig{
+		{
+			ClientConfig: confighttp.ClientConfig{Endpoint: endpoint},
+			Attributes:   map[string]string{"environment": "production"},
+		},
+	}
+
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+	gauge := sm.Metrics().AppendEmpty()
+	gauge.SetName("gauge")
+	gauge.SetEmptyGauge().DataPoints().AppendEmpty().Attributes().PutStr("http.url", endpoint)
+
+	sum := sm.Metrics().AppendEmpty()
+	sum.SetName("sum")
+	sum.SetEmptySum().DataPoints().AppendEmpty().Attributes().PutStr("http.url", endpoint)
+
+	histogram := sm.Metrics().AppendEmpty()
+	histogram.SetName("histogram")
+	histogram.SetEmptyHistogram().DataPoints().AppendEmpty().Attributes().PutStr("http.url", endpoint)
+
+	expHistogram := sm.Metrics().AppendEmpty()
+	expHistogram.SetName("exponential_histogram")
+	expHistogram.SetEmptyExponentialHistogram().DataPoints().AppendEmpty().Attributes().PutStr("http.url", endpoint)
+
+	summary := sm.Metrics().AppendEmpty()
+	summary.SetName("summary")
+	summary.SetEmptySummary().DataPoints().AppendEmpty().Attributes().PutStr("http.url", endpoint)
+
+	addTargetAttributes(metrics, targets)
+
+	assertAnnotated := func(name string, attrs pcommon.Map) {
+		env, ok := attrs.Get("environment")
+		require.True(t, ok, "metric %s data point missing annotated attribute", name)
+		assert.Equal(t, "production", env.Str())
+	}
+
+	ms := sm.Metrics()
+	for k := 0; k < ms.Len(); k++ {
+		m := ms.At(k)
+		switch m.Type() {
+		case pmetric.MetricTypeGauge:
+			assertAnnotated(m.Name(), m.Gauge().DataPoints().At(0).Attributes())
+		case pmetric.MetricTypeSum:
+			assertAnnotated(m.Name(), m.Sum().DataPoints().At(0).Attributes())
+		case pmetric.MetricTypeHistogram:
+			assertAnnotated(m.Name(), m.Histogram().DataPoints().At(0).Attributes())
+		case pmetric.MetricTypeExponentialHistogram:
+			assertAnnotated(m.Name(), m.ExponentialHistogram().DataPoints().At(0).Attributes())
+		case pmetric.MetricTypeSummary:
+			assertAnnotated(m.Name(), m.Summary().DataPoints().At(0).Attributes())
+		}
+	}
 }
 
 func TestScraperTargetAttributesDoNotOverrideReceiverAttributes(t *testing.T) {


### PR DESCRIPTION
#### Description

The HTTP Check receiver applies the same attributes to every target's metrics. There was no way to attach static dimensions (environment, team, owning service) to a single target without adding a downstream resource or transform processor.

This adds an optional `attributes` map to each target. Each key/value is set as a datapoint attribute on every metric produced for that target's endpoint(s).

The attributes are applied in a post-`Emit` pass over the scraped metrics, keyed by the `http.url` attribute that every httpcheck metric already carries and which equals the target endpoint. This mirrors the existing `removeStatusCodeForZeroValues` post-processing in the same file and leaves the generated metrics builder untouched. An attribute whose key collides with one the receiver already sets, such as `http.url`, is left untouched.

Emitting the values as resource attributes via per-target `Emit(WithResource(...))` was also considered, but that would require restructuring the single-builder scrape loop into per-target emits. Datapoint attributes also match the per-series dimensions the requesting use cases describe (for example the signalfx smartagent `extraDimensions`).

#### Link to tracking issue
Fixes #42525

#### Testing

Added `TestScraperTargetAttributes` (multiple targets with distinct attribute maps plus one target with none; asserts each data point carries exactly its own target's attributes and no other target's keys leak in) and `TestScraperTargetAttributesDoNotOverrideReceiverAttributes` (a configured `http.url` does not override the receiver's value). `go test -race ./...` passes for the module.

#### Documentation

Added `attributes` to the per-target properties in the receiver README, with an example.
