### PR TITLE
receiver/libhoneyreceiver: apply MaxRequestBodySize cap to decompressed body

### DIFF
--- a/.chloggen/libhoneyreceiver-decompressed-body-cap.yaml
+++ b/.chloggen/libhoneyreceiver-decompressed-body-cap.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/libhoneyreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply `MaxRequestBodySize` to the decompressed request body.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48697]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The receiver decompresses gzip / deflate / zstd bodies inline and previously
+  read the result with an uncapped `io.ReadAll`, so `MaxRequestBodySize` only
+  bounded the compressed bytes. The decompressed stream is now wrapped with
+  `http.MaxBytesReader`, matching the cap that `confighttp`'s decompressor
+  middleware applies on the path this receiver bypasses; oversized payloads
+  return `413 Request Entity Too Large`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -32,6 +32,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/response"
 )
 
+// defaultMaxRequestBodySize matches confighttp's default body cap (20 MiB)
+// and is used as a fallback when the embedded ServerConfig does not set one.
+// See go.opentelemetry.io/collector/config/confighttp:server.go.
+const defaultMaxRequestBodySize = 20 * 1024 * 1024
+
 type libhoneyReceiver struct {
 	cfg        *Config
 	server     *http.Server
@@ -282,6 +287,18 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 		}
 	}()
 
+	// Bound the decompressed read so a compressed payload cannot amplify into an
+	// unbounded in-memory buffer. confighttp applies the same MaxRequestBodySize
+	// cap to the decompressed stream when its own decompressor middleware is
+	// enabled; because this receiver disables that middleware (via
+	// CompressionAlgorithms: []string{} in factory.go) and decompresses inline,
+	// the cap has to be applied here.
+	maxDecompressedSize := httpCfg.MaxRequestBodySize
+	if maxDecompressedSize <= 0 {
+		maxDecompressedSize = defaultMaxRequestBodySize
+	}
+	limitedReader := http.MaxBytesReader(resp, io.NopCloser(bodyReader), maxDecompressedSize)
+
 	var body []byte
 	func() {
 		defer func() {
@@ -297,10 +314,25 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 				err = errors.New("failed to decompress: panic during decompression")
 			}
 		}()
-		body, err = io.ReadAll(bodyReader)
+		body, err = io.ReadAll(limitedReader)
 	}()
 
 	if err != nil {
+		// Distinguish the decompressed-size cap from generic decompression
+		// failure so callers see the expected 413 response.
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			r.settings.Logger.Warn("Decompressed body exceeded max size",
+				zap.Int64("limit", maxBytesErr.Limit),
+				zap.String("content-encoding", contentEncoding),
+				zap.String("content-type", req.Header.Get("Content-Type")),
+				zap.Int("compressed-size", len(compressedBody)),
+				zap.String("endpoint", req.RequestURI),
+				zap.String("api-key-masked", maskedKey))
+			writeResponse(resp, enc.ContentType(), http.StatusRequestEntityTooLarge,
+				fmt.Appendf(nil, `{"error":"decompressed body exceeds max size of %d bytes"}`, maxBytesErr.Limit))
+			return
+		}
 		r.settings.Logger.Error("Failed to decompress buffered body",
 			zap.Error(err),
 			zap.String("content-encoding", contentEncoding),

--- a/receiver/libhoneyreceiver/receiver_test.go
+++ b/receiver/libhoneyreceiver/receiver_test.go
@@ -5,6 +5,7 @@ package libhoneyreceiver
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1263,6 +1264,99 @@ func TestMsgpackTraceEvent(t *testing.T) {
 	attrs := span.Attributes()
 	signalType, _ := attrs.Get("meta.signal_type")
 	assert.Equal(t, "trace", signalType.AsString())
+}
+
+// TestLibhoneyReceiver_DecompressedBodyCap verifies that a compressed payload
+// whose decompressed size exceeds MaxRequestBodySize is rejected before the
+// receiver fully materializes the inflated bytes. This guards against
+// decompression amplification: confighttp normally bounds the post-decompression
+// stream via http.MaxBytesReader, but libhoneyreceiver disables that middleware
+// (CompressionAlgorithms: []string{}) and decompresses inline, so the cap must
+// be enforced here.
+func TestLibhoneyReceiver_DecompressedBodyCap(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	httpCfg := getOrInsertDefault(t, &cfg.HTTP)
+	// Use a small cap so the test stays fast; the production default is 20 MiB.
+	httpCfg.MaxRequestBodySize = 1 * 1024 * 1024 // 1 MiB
+
+	set := receivertest.NewNopSettings(metadata.Type)
+	recv, err := newLibhoneyReceiver(cfg, &set)
+	require.NoError(t, err)
+	recv.registerLogConsumer(consumertest.NewNop())
+	recv.registerTraceConsumer(consumertest.NewNop())
+
+	// Craft a gzip payload that inflates to 8 MiB (8x the cap) from
+	// well-compressing input so the compressed bytes stay tiny.
+	const decompressedSize = 8 * 1024 * 1024
+	var compressed bytes.Buffer
+	gz, err := gzip.NewWriterLevel(&compressed, gzip.BestCompression)
+	require.NoError(t, err)
+	chunk := bytes.Repeat([]byte{'0'}, 64*1024)
+	written := 0
+	for written < decompressedSize {
+		toWrite := len(chunk)
+		if written+toWrite > decompressedSize {
+			toWrite = decompressedSize - written
+		}
+		_, werr := gz.Write(chunk[:toWrite])
+		require.NoError(t, werr)
+		written += toWrite
+	}
+	require.NoError(t, gz.Close())
+	require.Less(t, compressed.Len(), 64*1024,
+		"compressed bomb should be far smaller than its inflated size; got %d bytes", compressed.Len())
+
+	req := httptest.NewRequest(http.MethodPost, "/events/test_dataset", bytes.NewReader(compressed.Bytes()))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	w := httptest.NewRecorder()
+	recv.handleEvent(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code,
+		"decompressed payload past MaxRequestBodySize should be rejected with 413, got %d: %s",
+		w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "exceeds max size",
+		"413 response should explain the cap was exceeded")
+}
+
+// TestLibhoneyReceiver_DecompressedBodyUnderCap verifies that a compressed
+// payload whose decompressed size is within MaxRequestBodySize still succeeds
+// end-to-end after the cap is applied.
+func TestLibhoneyReceiver_DecompressedBodyUnderCap(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	httpCfg := getOrInsertDefault(t, &cfg.HTTP)
+	httpCfg.MaxRequestBodySize = 1 * 1024 * 1024 // 1 MiB cap
+
+	set := receivertest.NewNopSettings(metadata.Type)
+	recv, err := newLibhoneyReceiver(cfg, &set)
+	require.NoError(t, err)
+	sink := &consumertest.LogsSink{}
+	recv.registerLogConsumer(sink)
+
+	events := []libhoneyevent.LibhoneyEvent{{
+		Time:       time.Now().Format(time.RFC3339),
+		Data:       map[string]any{"message": "under cap"},
+		Samplerate: 1,
+	}}
+	jsonData, err := json.Marshal(events)
+	require.NoError(t, err)
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err = gz.Write(jsonData)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/events/test_dataset", bytes.NewReader(compressed.Bytes()))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	w := httptest.NewRecorder()
+	recv.handleEvent(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code,
+		"payload under cap should succeed, got %d: %s", w.Code, w.Body.String())
 }
 
 // TestMsgpackEmptyArray verifies that empty msgpack arrays are handled gracefully


### PR DESCRIPTION
**Description:**

`receiver/libhoneyreceiver` decompresses gzip / deflate / zstd request bodies inline in `decompressBody` and reads the result with an uncapped `io.ReadAll`, so the `MaxRequestBodySize` from the embedded `confighttp.ServerConfig` only bounds the compressed bytes. The decompressed stream is unbounded.

`confighttp`'s own decompressor middleware applies the cap to the inflated output via `http.MaxBytesReader` (see [`config/confighttp/compression.go`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/compression.go) in the core repo). The receiver opts out of that middleware via `CompressionAlgorithms: []string{}` in [`factory.go#L50`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/libhoneyreceiver/factory.go#L50) and handles decompression itself, but never reapplies the post-decompression cap, so the bound is inconsistent with the rest of the collector.

This PR wraps the decompressed reader returned by `decompressBody` with `http.MaxBytesReader` using `httpCfg.MaxRequestBodySize` (falling back to `confighttp`'s 20 MiB default when unset) and returns `413 Request Entity Too Large` when the inflated stream exceeds the cap.

**Link to tracking Issue:** Fixes #48697

A private security advisory (GHSA-hw5m-prvm-9rph) was filed for this and closed by the maintainers as out of scope for the security policy; @kentquirk asked that it be reposted as a standard issue / PR. #48697 is that public follow-up.

**Testing:**

Added two unit tests in `receiver/libhoneyreceiver/receiver_test.go`:

- `TestLibhoneyReceiver_DecompressedBodyCap` POSTs a gzip payload that inflates to 8 MiB against a 1 MiB cap and asserts the response is `413` with an "exceeds max size" body. With this PR removed, the same request returns `400` after the receiver fully materializes the 8 MiB into memory (and at production cap / compression ratio, multi-GiB).
- `TestLibhoneyReceiver_DecompressedBodyUnderCap` POSTs a small gzip payload that fits under the cap and asserts a normal `200` so the new code path does not regress the happy path.

`go test ./receiver/libhoneyreceiver/...` passes locally (all existing tests + the two new ones).

**Documentation:**

`.chloggen/libhoneyreceiver-decompressed-body-cap.yaml` (bug_fix entry, references #48697).

No user-facing config surface changes; the existing `max_request_body_size` setting now also bounds the decompressed body.