### PR TITLE
[feat][extension/bearertokenauthextension] Add option to start without available auth-token file so retry, instead of failing

### DIFF
--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -30,6 +30,11 @@ The authenticator type has to be set to `bearertokenauth`.
 
 - `filename`: Name of file that contains authorization tokens. The file is parsed line by line. On each line, the first whitespace-delimited string is treated as the token. Any text following the first whitespace is ignored and can be used for comments (e.g., `my-token # comment` or `my-token // comment`).
 
+- `file_retry`: Optional. Controls retry behaviour during startup when the file referenced by `filename` is not yet available (e.g., the secret is mounted shortly after the collector starts).
+  - `enabled`: When true, startup waits for the file to appear instead of failing immediately. Defaults to `false`.
+  - `max_retries`: Maximum number of retry attempts before giving up. Required when `enabled` is `true`.
+  - `retry_interval`: Interval between retry attempts (e.g., `1s`, `500ms`). Required when `enabled` is `true`.
+
 Either one of `token` or `filename` field is required. If both are specified, then the `token` field value is **ignored**. In any case, the value of the token will be prepended by `${scheme}` before being sent as a value of "authorization" key in the request header in case of HTTP and metadata in case of gRPC.
 
 **Note**: bearertokenauth requires transport layer security enabled on the exporter.

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -54,14 +54,16 @@ type bearerTokenAuth struct {
 	authorizationValuesAtomic atomic.Value
 
 	tokenResolver credentialsfile.ValueResolver
+	fileRetry     FileRetryConfig
 	logger        *zap.Logger
 }
 
 func newBearerTokenAuth(cfg *Config, logger *zap.Logger) *bearerTokenAuth {
 	a := &bearerTokenAuth{
-		header: cfg.Header,
-		scheme: cfg.Scheme,
-		logger: logger,
+		header:    cfg.Header,
+		scheme:    cfg.Scheme,
+		fileRetry: cfg.FileRetry,
+		logger:    logger,
 	}
 
 	var inlineToken string
@@ -111,6 +113,9 @@ func newBearerTokenAuth(cfg *Config, logger *zap.Logger) *bearerTokenAuth {
 // the token to be transferred.
 func (b *bearerTokenAuth) Start(ctx context.Context, _ component.Host) error {
 	if b.tokenResolver != nil {
+		if b.fileRetry.Enabled {
+			return b.tokenResolver.StartWithRetry(ctx, b.fileRetry.MaxRetries, b.fileRetry.RetryInterval)
+		}
 		return b.tokenResolver.Start(ctx)
 	}
 	return nil

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -539,3 +539,53 @@ func TestBearerTokenFileWithComments(t *testing.T) {
 
 	assert.NoError(t, bauth.Shutdown(t.Context()))
 }
+
+func TestBearerStartWithFileRetry(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "delayed.token")
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Filename = tokenPath
+	cfg.FileRetry = FileRetryConfig{
+		Enabled:       true,
+		MaxRetries:    20,
+		RetryInterval: 100 * time.Millisecond,
+	}
+
+	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))
+	assert.NotNil(t, bauth)
+
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- bauth.Start(t.Context(), componenttest.NewNopHost())
+	}()
+
+	// Create the file after a delay so the watcher has to retry.
+	time.Sleep(250 * time.Millisecond)
+	assert.NoError(t, os.WriteFile(tokenPath, []byte("delayed-token"), 0o600))
+
+	select {
+	case err := <-startErr:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Start with retry to succeed")
+	}
+
+	assert.NoError(t, bauth.Shutdown(t.Context()))
+}
+
+func TestBearerStartWithFileRetryGivesUp(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Filename = filepath.Join(t.TempDir(), "never-appears.token")
+	cfg.FileRetry = FileRetryConfig{
+		Enabled:       true,
+		MaxRetries:    2,
+		RetryInterval: 50 * time.Millisecond,
+	}
+
+	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))
+	assert.NotNil(t, bauth)
+
+	assert.Error(t, bauth.Start(t.Context(), componenttest.NewNopHost()))
+	assert.NoError(t, bauth.Shutdown(t.Context()))
+}

--- a/extension/bearertokenauthextension/config.go
+++ b/extension/bearertokenauthextension/config.go
@@ -5,6 +5,7 @@ package bearertokenauthextension // import "github.com/open-telemetry/openteleme
 
 import (
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -27,14 +28,35 @@ type Config struct {
 	// Filename points to a file that contains the bearer token(s) to use for every RPC.
 	Filename string `mapstructure:"filename,omitempty"`
 
+	// FileRetry configures startup retry behavior when the file referenced by
+	// Filename is not yet available. Disabled by default.
+	FileRetry FileRetryConfig `mapstructure:"file_retry,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
 
+// FileRetryConfig configures retry-on-missing-file behavior for the file watcher.
+type FileRetryConfig struct {
+	// Enabled, when true, makes startup retry reading the file referenced by
+	// Filename instead of failing immediately when it is missing. Defaults to false.
+	Enabled bool `mapstructure:"enabled,omitempty"`
+
+	// MaxRetries is the maximum number of times to retry reading the file when
+	// Enabled is true.
+	MaxRetries int `mapstructure:"max_retries,omitempty"`
+
+	// RetryInterval is the interval between retries when Enabled is true.
+	RetryInterval time.Duration `mapstructure:"retry_interval,omitempty"`
+}
+
 var (
-	_                         component.Config = (*Config)(nil)
-	errNoTokenProvided                         = errors.New("no bearer token provided")
-	errTokensAndTokenProvided                  = errors.New("either tokens or token should be provided, not both")
+	_                             component.Config = (*Config)(nil)
+	errNoTokenProvided                             = errors.New("no bearer token provided")
+	errTokensAndTokenProvided                      = errors.New("either tokens or token should be provided, not both")
+	errFileRetryNoFile                             = errors.New("file_retry.enabled requires filename to be set")
+	errFileRetryInvalidMaxRetries                  = errors.New("file_retry.max_retries must be greater than 0 when file_retry.enabled is true")
+	errFileRetryInvalidInterval                    = errors.New("file_retry.retry_interval must be greater than 0 when file_retry.enabled is true")
 )
 
 // Validate checks if the extension configuration is valid
@@ -44,6 +66,17 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.BearerToken != "" && len(cfg.Tokens) > 0 {
 		return errTokensAndTokenProvided
+	}
+	if cfg.FileRetry.Enabled {
+		if cfg.Filename == "" {
+			return errFileRetryNoFile
+		}
+		if cfg.FileRetry.MaxRetries <= 0 {
+			return errFileRetryInvalidMaxRetries
+		}
+		if cfg.FileRetry.RetryInterval <= 0 {
+			return errFileRetryInvalidInterval
+		}
 	}
 	return nil
 }

--- a/extension/bearertokenauthextension/config.schema.yaml
+++ b/extension/bearertokenauthextension/config.schema.yaml
@@ -4,6 +4,19 @@ properties:
   filename:
     description: Filename points to a file that contains the bearer token(s) to use for every RPC.
     type: string
+  file_retry:
+    description: FileRetry configures startup retry behaviour when the file referenced by Filename is not yet available. Disabled by default.
+    type: object
+    properties:
+      enabled:
+        description: Enabled, when true, makes startup retry reading the file referenced by Filename instead of failing immediately when it is missing. Defaults to false.
+        type: boolean
+      max_retries:
+        description: MaxRetries is the maximum number of times to retry reading the file when Enabled is true.
+        type: integer
+      retry_interval:
+        description: RetryInterval is the interval between retries when Enabled is true.
+        $ref: time.duration
   header:
     description: Header specifies the auth-header for the token. Defaults to "Authorization"
     type: string

--- a/extension/bearertokenauthextension/config_test.go
+++ b/extension/bearertokenauthextension/config_test.go
@@ -6,6 +6,7 @@ package bearertokenauthextension
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -97,6 +98,19 @@ func TestLoadConfig(t *testing.T) {
 				BearerToken: "my-token",
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "withfileretry"),
+			expected: &Config{
+				Header:   defaultHeader,
+				Scheme:   "Bearer",
+				Filename: "file-containing.token",
+				FileRetry: FileRetryConfig{
+					Enabled:       true,
+					MaxRetries:    5,
+					RetryInterval: 2 * time.Second,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -114,6 +128,83 @@ func TestLoadConfig(t *testing.T) {
 			}
 			assert.NoError(t, xconfmap.Validate(cfg))
 			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestValidate_FileRetry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr error
+	}{
+		{
+			name: "enabled without filename",
+			cfg: &Config{
+				BearerToken: "tok",
+				FileRetry: FileRetryConfig{
+					Enabled:       true,
+					MaxRetries:    1,
+					RetryInterval: time.Second,
+				},
+			},
+			wantErr: errFileRetryNoFile,
+		},
+		{
+			name: "enabled with zero max_retries",
+			cfg: &Config{
+				Filename: "file.token",
+				FileRetry: FileRetryConfig{
+					Enabled:       true,
+					RetryInterval: time.Second,
+				},
+			},
+			wantErr: errFileRetryInvalidMaxRetries,
+		},
+		{
+			name: "enabled with zero retry_interval",
+			cfg: &Config{
+				Filename: "file.token",
+				FileRetry: FileRetryConfig{
+					Enabled:    true,
+					MaxRetries: 1,
+				},
+			},
+			wantErr: errFileRetryInvalidInterval,
+		},
+		{
+			name: "enabled with valid values",
+			cfg: &Config{
+				Filename: "file.token",
+				FileRetry: FileRetryConfig{
+					Enabled:       true,
+					MaxRetries:    3,
+					RetryInterval: time.Second,
+				},
+			},
+		},
+		{
+			name: "disabled ignores other fields",
+			cfg: &Config{
+				Filename: "file.token",
+				FileRetry: FileRetryConfig{
+					MaxRetries:    0,
+					RetryInterval: 0,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/extension/bearertokenauthextension/testdata/config.yaml
+++ b/extension/bearertokenauthextension/testdata/config.yaml
@@ -32,3 +32,10 @@ bearertokenauth/withheader:
   header: "X-Custom-Authorization"
   scheme: ""
   token: "my-token"
+bearertokenauth/withfileretry:
+  scheme: "Bearer"
+  filename: "file-containing.token"
+  file_retry:
+    enabled: true
+    max_retries: 5
+    retry_interval: 2s

--- a/extension/internal/credentialsfile/credentialsfile.go
+++ b/extension/internal/credentialsfile/credentialsfile.go
@@ -8,6 +8,7 @@ package credentialsfile // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -21,6 +22,9 @@ type ValueResolver interface {
 	Value() string
 	// Start begins any background operations (e.g., file watching).
 	Start(ctx context.Context) error
+	// StartWithRetry begins any background operations (e.g., file watching)
+	// and continuously retries startup until all prerequisites are available.
+	StartWithRetry(ctx context.Context, maxRetries int, retryInterval time.Duration) error
 	// Shutdown stops any background operations.
 	Shutdown() error
 }
@@ -59,6 +63,7 @@ func NewValueResolver(inlineValue, filePath string, logger *zap.Logger, opts ...
 // staticValue is a ValueResolver that returns a fixed string.
 type staticValue string
 
-func (s staticValue) Value() string             { return string(s) }
-func (staticValue) Start(context.Context) error { return nil }
-func (staticValue) Shutdown() error             { return nil }
+func (s staticValue) Value() string                                          { return string(s) }
+func (staticValue) Start(context.Context) error                              { return nil }
+func (staticValue) StartWithRetry(context.Context, int, time.Duration) error { return nil }
+func (staticValue) Shutdown() error                                          { return nil }

--- a/extension/internal/credentialsfile/credentialsfile_test.go
+++ b/extension/internal/credentialsfile/credentialsfile_test.go
@@ -4,6 +4,7 @@
 package credentialsfile
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -55,6 +56,44 @@ func TestFileWatcher_StartFailsMissingFile(t *testing.T) {
 	r, err := NewValueResolver("", "/nonexistent/path/secret", zaptest.NewLogger(t))
 	require.NoError(t, err)
 	require.Error(t, r.Start(t.Context()))
+}
+
+func TestFileWatcher_StartWithRetryToleratesMissingFile(t *testing.T) {
+	t.Parallel()
+	r, err := NewValueResolver("", "/nonexistent/path/secret", zaptest.NewLogger(t))
+	require.NoError(t, err)
+	require.Error(t, r.StartWithRetry(t.Context(), 1, time.Second))
+}
+
+func TestFileWatcher_PicksUpFileAfterItAppears(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "secret")
+
+	r, err := NewValueResolver("", f, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, r.Shutdown()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- r.StartWithRetry(ctx, 5, 100*time.Millisecond)
+	}()
+
+	// Simulate the file appearing later
+	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, os.WriteFile(f, []byte("secret"), 0o600))
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for StartWithRetry")
+	}
 }
 
 func TestFileWatcher_StartFailsEmptyFile(t *testing.T) {

--- a/extension/internal/credentialsfile/filewatcher.go
+++ b/extension/internal/credentialsfile/filewatcher.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
@@ -63,6 +64,27 @@ func (w *fileWatcher) Start(ctx context.Context) error {
 	// fsnotify follows the symlink and watches the underlying inode. On Remove/Chmod
 	// events the watcher is re-added to follow the new symlink target.
 	return watcher.Add(w.path)
+}
+
+func (w *fileWatcher) StartWithRetry(ctx context.Context, maxRetries int, retryInterval time.Duration) error {
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+	counter := 0
+	for {
+		if counter > maxRetries {
+			return fmt.Errorf("failed to read credentials file %q after reaching out max number of retries", w.path)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("failed to read credentials file %q after %d retry", w.path, counter)
+		case <-ticker.C:
+			if _, err := os.Stat(w.path); err == nil {
+				return w.Start(ctx)
+			}
+			counter++
+		}
+	}
 }
 
 func (w *fileWatcher) Shutdown() error {


### PR DESCRIPTION
#### Description
Added `StartWithRetry` to the `credentialsfile` resolver and exposed it in `bearertokenauthextension` via a new `file_retry` config block (`enabled`, `max_retries`, `retry_interval`) so startup can wait for a token file to appear instead of failing immediately. This is needed, because in distributed environments there might be a delay in mechanisms that populate the tokens, so resilience option is necessary.

#### Testing
Added unit tests at both `extension/internal/credentialsfile` and `extension/bearertokenauthextension` that validate that the retry logic when enabled works as expected.

<!--Describe the documentation added.-->
#### Documentation
Add information about the new `file_retry` block in the `extension/bearertokenauthextension/README.md`
