### PR TITLE
[exporter/alibabacloudlogservice] Add support for STS security_token authentication

### DIFF
--- a/.chloggen/feat_alibabacloudlogservice-sts-token.yaml
+++ b/.chloggen/feat_alibabacloudlogservice-sts-token.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/alibabacloud_logservice
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `security_token` (STS) support alongside AK/SK; preserve ECS role/token-file fallback."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48624]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `security_token` is provided in the exporter configuration the SDK is
+  configured to use static STS credentials via the provider. The existing
+  `ecs_ram_role` and `token_file_path` behavior remains the higher-priority
+  authentication method and is unchanged.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/alibabacloudlogserviceexporter/README.md
+++ b/exporter/alibabacloudlogserviceexporter/README.md
@@ -22,6 +22,7 @@ This exporter supports sending OpenTelemetry data to [LogService](https://www.al
 - `logstore` (required): LogService's store Name. For metrics data, you should use metric store.
 - `access_key_id` (optional): AlibabaCloud access key id.
 - `access_key_secret` (optional): AlibabaCloud access key secret.
+- `security_token` (optional): AlibabaCloud security token for STS credentials.
 - `ecs_ram_role` (optional): set AlibabaCLoud ECS ram role if you are using ACK.
 - `token_file_path` (optional): Set token file path if you are using ACK.
 

--- a/exporter/alibabacloudlogserviceexporter/config.go
+++ b/exporter/alibabacloudlogserviceexporter/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	AccessKeyID string `mapstructure:"access_key_id"`
 	// AlibabaCloud access key secret
 	AccessKeySecret configopaque.String `mapstructure:"access_key_secret"`
+	// AlibabaCloud security token for STS credentials
+	SecurityToken string `mapstructure:"security_token"`
 	// Set AlibabaCLoud ECS ram role if you are using ACK
 	ECSRamRole string `mapstructure:"ecs_ram_role"`
 	// Set Token File Path if you are using ACK

--- a/exporter/alibabacloudlogserviceexporter/config.go
+++ b/exporter/alibabacloudlogserviceexporter/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// AlibabaCloud access key secret
 	AccessKeySecret configopaque.String `mapstructure:"access_key_secret"`
 	// AlibabaCloud security token for STS credentials
-	SecurityToken string `mapstructure:"security_token"`
+	SecurityToken configopaque.String `mapstructure:"security_token"`
 	// Set AlibabaCLoud ECS ram role if you are using ACK
 	ECSRamRole string `mapstructure:"ecs_ram_role"`
 	// Set Token File Path if you are using ACK

--- a/exporter/alibabacloudlogserviceexporter/config.schema.yaml
+++ b/exporter/alibabacloudlogserviceexporter/config.schema.yaml
@@ -20,7 +20,7 @@ properties:
     type: string
   security_token:
     description: AlibabaCloud security token for STS credentials
-    type: string
+    $ref: go.opentelemetry.io/collector/config/configopaque.string
   token_file_path:
     description: Set Token File Path if you are using ACK
     type: string

--- a/exporter/alibabacloudlogserviceexporter/config.schema.yaml
+++ b/exporter/alibabacloudlogserviceexporter/config.schema.yaml
@@ -18,6 +18,9 @@ properties:
   project:
     description: LogService's Project Name
     type: string
+  security_token:
+    description: AlibabaCloud security token for STS credentials
+    type: string
   token_file_path:
     description: Set Token File Path if you are using ACK
     type: string

--- a/exporter/alibabacloudlogserviceexporter/config_test.go
+++ b/exporter/alibabacloudlogserviceexporter/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
@@ -42,7 +43,7 @@ func TestLoadConfig(t *testing.T) {
 				Logstore:        "demo-logstore",
 				AccessKeyID:     "test-id",
 				AccessKeySecret: "test-secret",
-				SecurityToken:   "test-token",
+				SecurityToken:   configopaque.String("test-token"),
 			},
 		},
 	}

--- a/exporter/alibabacloudlogserviceexporter/config_test.go
+++ b/exporter/alibabacloudlogserviceexporter/config_test.go
@@ -42,6 +42,7 @@ func TestLoadConfig(t *testing.T) {
 				Logstore:        "demo-logstore",
 				AccessKeyID:     "test-id",
 				AccessKeySecret: "test-secret",
+				SecurityToken:   "test-token",
 			},
 		},
 	}

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
@@ -5,9 +5,12 @@ package alibabacloudlogserviceexporter
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/aliyun/aliyun-log-go-sdk/producer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -76,6 +79,19 @@ func TestNewLogServiceClient_STSCredentials(t *testing.T) {
 	}, exportertest.NewNopSettings(metadata.Type).Logger)
 	assert.NoError(t, err)
 	require.NotNil(t, client)
+
+	clientImpl, ok := client.(*logServiceClientImpl)
+	require.True(t, ok)
+	require.NotNil(t, clientImpl.clientInstance)
+	producerValue := reflect.ValueOf(clientImpl.clientInstance).Elem()
+	producerConfigField := producerValue.FieldByName("producerConfig")
+	require.True(t, producerConfigField.IsValid())
+	producerConfig := reflect.NewAt(producerConfigField.Type(), unsafe.Pointer(producerConfigField.UnsafeAddr())).Elem().Interface().(*producer.ProducerConfig)
+	provider := producerConfig.CredentialsProvider
+	require.NotNil(t, provider)
+	credentials, err := provider.GetCredentials()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-token", credentials.SecurityToken)
 }
 
 func TestNewFailsWithEmptyLogsExporterName(t *testing.T) {

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
@@ -65,6 +65,19 @@ func TestSTSTokenExporter(t *testing.T) {
 	require.NotNil(t, got)
 }
 
+func TestNewLogServiceClient_STSCredentials(t *testing.T) {
+	client, err := newLogServiceClient(&Config{
+		Endpoint:        "us-west-1.log.aliyuncs.com",
+		Project:         "demo-project",
+		Logstore:        "demo-logstore",
+		AccessKeyID:     "test-id",
+		AccessKeySecret: "test-secret",
+		SecurityToken:   "test-token",
+	}, exportertest.NewNopSettings(metadata.Type).Logger)
+	assert.NoError(t, err)
+	require.NotNil(t, client)
+}
+
 func TestNewFailsWithEmptyLogsExporterName(t *testing.T) {
 	got, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), &Config{})
 	assert.Error(t, err)

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
@@ -5,12 +5,9 @@ package alibabacloudlogserviceexporter
 
 import (
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
-	"unsafe"
 
-	"github.com/aliyun/aliyun-log-go-sdk/producer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -69,6 +66,20 @@ func TestSTSTokenExporter(t *testing.T) {
 }
 
 func TestNewLogServiceClient_STSCredentials(t *testing.T) {
+	producerConfig := newProducerConfig(&Config{
+		Endpoint:        "us-west-1.log.aliyuncs.com",
+		Project:         "demo-project",
+		Logstore:        "demo-logstore",
+		AccessKeyID:     "test-id",
+		AccessKeySecret: "test-secret",
+		SecurityToken:   "test-token",
+	})
+	require.NotNil(t, producerConfig)
+	require.NotNil(t, producerConfig.CredentialsProvider)
+	credentials, err := producerConfig.CredentialsProvider.GetCredentials()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-token", credentials.SecurityToken)
+
 	client, err := newLogServiceClient(&Config{
 		Endpoint:        "us-west-1.log.aliyuncs.com",
 		Project:         "demo-project",
@@ -79,19 +90,6 @@ func TestNewLogServiceClient_STSCredentials(t *testing.T) {
 	}, exportertest.NewNopSettings(metadata.Type).Logger)
 	assert.NoError(t, err)
 	require.NotNil(t, client)
-
-	clientImpl, ok := client.(*logServiceClientImpl)
-	require.True(t, ok)
-	require.NotNil(t, clientImpl.clientInstance)
-	producerValue := reflect.ValueOf(clientImpl.clientInstance).Elem()
-	producerConfigField := producerValue.FieldByName("producerConfig")
-	require.True(t, producerConfigField.IsValid())
-	producerConfig := reflect.NewAt(producerConfigField.Type(), unsafe.Pointer(producerConfigField.UnsafeAddr())).Elem().Interface().(*producer.ProducerConfig)
-	provider := producerConfig.CredentialsProvider
-	require.NotNil(t, provider)
-	credentials, err := provider.GetCredentials()
-	assert.NoError(t, err)
-	assert.Equal(t, "test-token", credentials.SecurityToken)
 }
 
 func TestNewFailsWithEmptyLogsExporterName(t *testing.T) {

--- a/exporter/alibabacloudlogserviceexporter/testdata/config.yaml
+++ b/exporter/alibabacloudlogserviceexporter/testdata/config.yaml
@@ -6,3 +6,4 @@ alibabacloud_logservice/2:
   logstore: "demo-logstore"
   access_key_id: "test-id"
   access_key_secret: "test-secret"
+  security_token: "test-token"

--- a/exporter/alibabacloudlogserviceexporter/uploader.go
+++ b/exporter/alibabacloudlogserviceexporter/uploader.go
@@ -58,6 +58,12 @@ func newLogServiceClient(config *Config, logger *zap.Logger) (logServiceClient, 
 		producerConfig.CredentialsProvider = provider
 
 		producerConfig.StsTokenShutDown = make(chan struct{})
+	} else if config.SecurityToken != "" {
+		producerConfig.CredentialsProvider = sls.NewStaticCredentialsProvider(
+			config.AccessKeyID,
+			string(config.AccessKeySecret),
+			config.SecurityToken,
+		)
 	}
 
 	producer, err := producer.NewProducer(producerConfig)

--- a/exporter/alibabacloudlogserviceexporter/uploader.go
+++ b/exporter/alibabacloudlogserviceexporter/uploader.go
@@ -48,23 +48,7 @@ func newLogServiceClient(config *Config, logger *zap.Logger) (logServiceClient, 
 		return nil, errors.New("missing logservice params: Endpoint, Project, Logstore")
 	}
 
-	producerConfig := producer.GetDefaultProducerConfig()
-	producerConfig.Endpoint = config.Endpoint
-	producerConfig.AccessKeyID = config.AccessKeyID
-	producerConfig.AccessKeySecret = string(config.AccessKeySecret)
-	if config.ECSRamRole != "" || config.TokenFilePath != "" {
-		tokenUpdateFunc, _ := slsutil.NewTokenUpdateFunc(config.ECSRamRole, config.TokenFilePath)
-		provider := sls.NewUpdateFuncProviderAdapter(tokenUpdateFunc)
-		producerConfig.CredentialsProvider = provider
-
-		producerConfig.StsTokenShutDown = make(chan struct{})
-	} else if config.SecurityToken != "" {
-		producerConfig.CredentialsProvider = sls.NewStaticCredentialsProvider(
-			config.AccessKeyID,
-			string(config.AccessKeySecret),
-			string(config.SecurityToken),
-		)
-	}
+	producerConfig := newProducerConfig(config)
 
 	producer, err := producer.NewProducer(producerConfig)
 	if err != nil {
@@ -83,6 +67,28 @@ func newLogServiceClient(config *Config, logger *zap.Logger) (logServiceClient, 
 	c.source, _ = getIPAddress()
 	logger.Info("Create LogService client success", zap.String("project", config.Project), zap.String("logstore", config.Logstore))
 	return c, nil
+}
+
+func newProducerConfig(config *Config) *producer.ProducerConfig {
+	producerConfig := producer.GetDefaultProducerConfig()
+	producerConfig.Endpoint = config.Endpoint
+	producerConfig.AccessKeyID = config.AccessKeyID
+	producerConfig.AccessKeySecret = string(config.AccessKeySecret)
+	if config.ECSRamRole != "" || config.TokenFilePath != "" {
+		tokenUpdateFunc, _ := slsutil.NewTokenUpdateFunc(config.ECSRamRole, config.TokenFilePath)
+		provider := sls.NewUpdateFuncProviderAdapter(tokenUpdateFunc)
+		producerConfig.CredentialsProvider = provider
+
+		producerConfig.StsTokenShutDown = make(chan struct{})
+	} else if config.SecurityToken != "" {
+		producerConfig.CredentialsProvider = sls.NewStaticCredentialsProvider(
+			config.AccessKeyID,
+			string(config.AccessKeySecret),
+			string(config.SecurityToken),
+		)
+	}
+
+	return producerConfig
 }
 
 // sendLogs send message to LogService

--- a/exporter/alibabacloudlogserviceexporter/uploader.go
+++ b/exporter/alibabacloudlogserviceexporter/uploader.go
@@ -62,7 +62,7 @@ func newLogServiceClient(config *Config, logger *zap.Logger) (logServiceClient, 
 		producerConfig.CredentialsProvider = sls.NewStaticCredentialsProvider(
 			config.AccessKeyID,
 			string(config.AccessKeySecret),
-			config.SecurityToken,
+			string(config.SecurityToken),
 		)
 	}
 


### PR DESCRIPTION
#### Description
This PR adds an optional `security_token` configuration field to the Alibaba Cloud Log Service exporter to enable STS authentication. 

The client initialization in `uploader.go` now utilizes `sls.NewStaticCredentialsProvider` when a `security_token` is provided. Crucially, the logic is structured to preserve the existing ECS RAM role and token-file workflows as the primary fallback, ensuring backward compatibility.

#### Link to tracking issue
Fixes #48624

#### Testing
- Updated configuration unit tests in `config_test.go` and `testdata/config.yaml` to validate the new `security_token` field.
- Successfully ran package tests (`go test ./...`) locally within the `exporter/alibabacloudlogserviceexporter` module to ensure there are no regressions in client initialization.

#### Documentation
- Documented the new `security_token` (STS) field in the exporter's `README.md`.