### PR TITLE
[processor/redactionprocessor] gate url sanitizer on log bodies

### DIFF
--- a/.chloggen/redaction-sanitize-log-body.yaml
+++ b/.chloggen/redaction-sanitize-log-body.yaml
@@ -1,0 +1,11 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: enhancement
+
+component: processor/redactionprocessor
+
+note: Add optional `url_sanitizer.sanitize_log_body` so URL sanitization applies to string log bodies only when explicitly enabled.
+
+issues: []
+
+change_logs: [user]

--- a/processor/redactionprocessor/README.md
+++ b/processor/redactionprocessor/README.md
@@ -119,6 +119,9 @@ processors:
       # When enabled, span names containing "/" will be sanitized to reduce cardinality
       # Set to false to disable span name sanitization while keeping attribute sanitization active
       sanitize_span_name: true
+      # sanitize_log_body controls whether string log bodies are sanitized (default: false)
+      # The attributes list above applies only to attribute values, not log bodies
+      sanitize_log_body: false
 ```
 
 Refer to [config.yaml](./testdata/config.yaml) for how to fit the configuration
@@ -268,6 +271,8 @@ action occurred.
 ## URL Sanitization
 
 The `url_sanitizer` configuration enables sanitization of URLs in specified attributes by removing potentially sensitive information like UUIDs, timestamps, and other non-essential path segments. This is particularly useful for reducing cardinality in telemetry data while preserving the essential parts of URLs for troubleshooting.
+
+Only attribute keys listed under `attributes` are sanitized by default. String log bodies are **not** sanitized unless you set `sanitize_log_body: true`. This avoids collapsing non-URL log messages when URL sanitization is enabled for trace and metric attributes.
 
 ## Span Name Sanitization
 

--- a/processor/redactionprocessor/internal/url/config.go
+++ b/processor/redactionprocessor/internal/url/config.go
@@ -9,4 +9,6 @@ type URLSanitizationConfig struct {
 	Attributes []string `mapstructure:"attributes"`
 	// SanitizeSpanName controls whether span names should be sanitized.
 	SanitizeSpanName *bool `mapstructure:"sanitize_span_name"`
+	// SanitizeLogBody controls whether string log bodies are sanitized with the URL sanitizer.
+	SanitizeLogBody *bool `mapstructure:"sanitize_log_body"`
 }

--- a/processor/redactionprocessor/internal/url/config.schema.yaml
+++ b/processor/redactionprocessor/internal/url/config.schema.yaml
@@ -13,3 +13,7 @@ $defs:
         description: SanitizeSpanName controls whether span names should be sanitized.
         x-pointer: true
         type: boolean
+      sanitize_log_body:
+        description: SanitizeLogBody controls whether string log bodies are sanitized with the URL sanitizer. When omitted, log bodies are not sanitized.
+        x-pointer: true
+        type: boolean

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -470,7 +470,7 @@ func (s *redaction) processStringValueForLogBody(strVal string) string {
 		}
 	}
 
-	if s.urlSanitizer != nil {
+	if s.shouldSanitizeLogBody() {
 		strVal = s.urlSanitizer.SanitizeURL(strVal)
 	}
 
@@ -557,6 +557,17 @@ func applySpanName(span ptrace.Span, original, candidate string) {
 	if candidate != original {
 		span.SetName(candidate)
 	}
+}
+
+func (s *redaction) shouldSanitizeLogBody() bool {
+	if s.urlSanitizer == nil {
+		return false
+	}
+
+	if s.config.URLSanitization.SanitizeLogBody == nil {
+		return false
+	}
+	return *s.config.URLSanitization.SanitizeLogBody
 }
 
 func (s *redaction) shouldSanitizeSpanNameForURL() bool {

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -1757,12 +1757,14 @@ func TestURLSanitizationWithBlockedValues(t *testing.T) {
 }
 
 func TestURLSanitizationInLogBody(t *testing.T) {
+	sanitizeLogBody := true
 	bodyWithURL := pcommon.NewValueStr("/users/2")
 	tc := testConfig{
 		config: &Config{
 			AllowAllKeys: true,
 			URLSanitization: url.URLSanitizationConfig{
-				Enabled: true,
+				Enabled:         true,
+				SanitizeLogBody: &sanitizeLogBody,
 			},
 		},
 		logBody: &bodyWithURL,
@@ -1775,6 +1777,7 @@ func TestURLSanitizationInLogBody(t *testing.T) {
 }
 
 func TestURLSanitizationComplexLogBody(t *testing.T) {
+	sanitizeLogBody := true
 	complexBody := pcommon.NewValueMap()
 	complexBody.Map().PutStr("message", "/users/2")
 	complexBody.Map().PutStr("url", "/products/1/org/3")
@@ -1783,7 +1786,8 @@ func TestURLSanitizationComplexLogBody(t *testing.T) {
 		config: &Config{
 			AllowAllKeys: true,
 			URLSanitization: url.URLSanitizationConfig{
-				Enabled: true,
+				Enabled:         true,
+				SanitizeLogBody: &sanitizeLogBody,
 			},
 		},
 		logBody: &complexBody,
@@ -2315,10 +2319,12 @@ func TestDBObfuscationOnLogBody(t *testing.T) {
 }
 
 func TestURLSanitizationOnLogBody(t *testing.T) {
+	sanitizeLogBody := true
 	cfg := &Config{
 		AllowAllKeys: true,
 		URLSanitization: url.URLSanitizationConfig{
-			Enabled: true,
+			Enabled:         true,
+			SanitizeLogBody: &sanitizeLogBody,
 		},
 	}
 
@@ -2335,6 +2341,86 @@ func TestURLSanitizationOnLogBody(t *testing.T) {
 
 	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 	assert.Equal(t, "/api/orders/*/details", outLog.Body().Str())
+}
+
+func TestURLSanitizationLogBodyDisabledByDefault(t *testing.T) {
+	const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
+
+	cfg := &Config{
+		AllowAllKeys: true,
+		URLSanitization: url.URLSanitizationConfig{
+			Enabled:    true,
+			Attributes: []string{"http.url"},
+		},
+	}
+
+	inLogs := plog.NewLogs()
+	rl := inLogs.ResourceLogs().AppendEmpty()
+	ils := rl.ScopeLogs().AppendEmpty()
+	logRecord := ils.LogRecords().AppendEmpty()
+	logRecord.Body().SetStr(proseLogBody)
+
+	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	outLogs, err := processor.processLogs(t.Context(), inLogs)
+	require.NoError(t, err)
+
+	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.Equal(t, proseLogBody, outLog.Body().Str())
+}
+
+func TestURLSanitizationLogBodyExplicitFalse(t *testing.T) {
+	sanitizeLogBody := false
+	const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
+
+	cfg := &Config{
+		AllowAllKeys: true,
+		URLSanitization: url.URLSanitizationConfig{
+			Enabled:         true,
+			SanitizeLogBody: &sanitizeLogBody,
+		},
+	}
+
+	inLogs := plog.NewLogs()
+	rl := inLogs.ResourceLogs().AppendEmpty()
+	ils := rl.ScopeLogs().AppendEmpty()
+	logRecord := ils.LogRecords().AppendEmpty()
+	logRecord.Body().SetStr(proseLogBody)
+
+	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	outLogs, err := processor.processLogs(t.Context(), inLogs)
+	require.NoError(t, err)
+
+	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.Equal(t, proseLogBody, outLog.Body().Str())
+}
+
+func TestURLSanitizationLogBodyEnabledMasksProse(t *testing.T) {
+	sanitizeLogBody := true
+	const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
+
+	cfg := &Config{
+		AllowAllKeys: true,
+		URLSanitization: url.URLSanitizationConfig{
+			Enabled:         true,
+			SanitizeLogBody: &sanitizeLogBody,
+		},
+	}
+
+	inLogs := plog.NewLogs()
+	rl := inLogs.ResourceLogs().AppendEmpty()
+	ils := rl.ScopeLogs().AppendEmpty()
+	logRecord := ils.LogRecords().AppendEmpty()
+	logRecord.Body().SetStr(proseLogBody)
+
+	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	outLogs, err := processor.processLogs(t.Context(), inLogs)
+	require.NoError(t, err)
+
+	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.Equal(t, "*", outLog.Body().Str())
 }
 
 func TestDBObfuscationErrorInAttribute(t *testing.T) {

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -1756,51 +1756,163 @@ func TestURLSanitizationWithBlockedValues(t *testing.T) {
 	assert.Equal(t, int64(2), maskedCount.Int())
 }
 
-func TestURLSanitizationInLogBody(t *testing.T) {
-	sanitizeLogBody := true
-	bodyWithURL := pcommon.NewValueStr("/users/2")
-	tc := testConfig{
-		config: &Config{
-			AllowAllKeys: true,
-			URLSanitization: url.URLSanitizationConfig{
-				Enabled:         true,
-				SanitizeLogBody: &sanitizeLogBody,
-			},
-		},
-		logBody: &bodyWithURL,
+// proseLogBody is rejected by clusterurl when run on the whole log body (early '_' in the token).
+const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
+
+// pathLikeLogBody is a slash-separated path clusterurl can normalize when log-body sanitization is on.
+const pathLikeLogBody = "/api/orders/12345/details"
+
+func urlSanitizerAttributesOnly() url.URLSanitizationConfig {
+	return url.URLSanitizationConfig{
+		Enabled:    true,
+		Attributes: []string{"http.url"},
 	}
-
-	outLogs := runLogsTest(t, tc)
-	outLogBody := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body()
-
-	assert.Equal(t, "/users/*", outLogBody.Str())
 }
 
-func TestURLSanitizationComplexLogBody(t *testing.T) {
-	sanitizeLogBody := true
-	complexBody := pcommon.NewValueMap()
-	complexBody.Map().PutStr("message", "/users/2")
-	complexBody.Map().PutStr("url", "/products/1/org/3")
+func processStringLogBody(t *testing.T, cfg *Config, body string) string {
+	t.Helper()
 
-	tc := testConfig{
-		config: &Config{
+	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	inLogs := plog.NewLogs()
+	logRecord := inLogs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	logRecord.Body().SetStr(body)
+
+	outLogs, err := processor.processLogs(t.Context(), inLogs)
+	require.NoError(t, err)
+
+	return outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str()
+}
+
+// TestURLSanitizationLogBody documents the fix for url_sanitizer applying to every string log body
+// even when only attribute keys are listed. Before sanitize_log_body, enabled: true sanitized all
+// bodies; the flag defaults off so bodies are untouched unless operators opt in.
+func TestURLSanitizationLogBody(t *testing.T) {
+	sanitizeLogBodyTrue := true
+	sanitizeLogBodyFalse := false
+	attrsOnly := urlSanitizerAttributesOnly()
+
+	t.Run("fix/url_sanitizer_does_not_touch_log_bodies_by_default", func(t *testing.T) {
+		tests := []struct {
+			name            string
+			sanitizeLogBody *bool
+			input           string
+		}{
+			{
+				name:  "omit_sanitize_log_body_preserves_prose",
+				input: proseLogBody,
+			},
+			{
+				name:            "explicit_false_preserves_prose",
+				sanitizeLogBody: &sanitizeLogBodyFalse,
+				input:           proseLogBody,
+			},
+			{
+				name:  "omit_sanitize_log_body_preserves_path_like_body",
+				input: pathLikeLogBody,
+			},
+			{
+				name:            "explicit_false_preserves_path_like_body",
+				sanitizeLogBody: &sanitizeLogBodyFalse,
+				input:           pathLikeLogBody,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cfg := url.URLSanitizationConfig{
+					Enabled:         attrsOnly.Enabled,
+					Attributes:      attrsOnly.Attributes,
+					SanitizeLogBody: tt.sanitizeLogBody,
+				}
+				got := processStringLogBody(t, &Config{
+					AllowAllKeys:    true,
+					URLSanitization: cfg,
+				}, tt.input)
+				assert.Equal(t, tt.input, got, "log body must not be URL-sanitized unless sanitize_log_body is true")
+			})
+		}
+	})
+
+	t.Run("fix/attributes_list_still_sanitizes_log_record_attributes", func(t *testing.T) {
+		tc := testConfig{
+			config: &Config{
+				AllowAllKeys:    true,
+				URLSanitization: attrsOnly,
+			},
+			allowed: map[string]pcommon.Value{
+				"http.url":  pcommon.NewValueStr("/users/2"),
+				"other.url": pcommon.NewValueStr("/users/3"),
+			},
+			logBody: ptr(pcommon.NewValueStr(proseLogBody)),
+		}
+
+		outLogs := runLogsTest(t, tc)
+		logRecord := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+
+		assert.Equal(t, proseLogBody, logRecord.Body().Str())
+
+		httpURL, ok := logRecord.Attributes().Get("http.url")
+		require.True(t, ok)
+		assert.Equal(t, "/users/*", httpURL.Str())
+
+		otherURL, ok := logRecord.Attributes().Get("other.url")
+		require.True(t, ok)
+		assert.Equal(t, "/users/3", otherURL.Str())
+	})
+
+	t.Run("opt_in/sanitize_log_body_normalizes_path_like_body", func(t *testing.T) {
+		got := processStringLogBody(t, &Config{
 			AllowAllKeys: true,
 			URLSanitization: url.URLSanitizationConfig{
 				Enabled:         true,
-				SanitizeLogBody: &sanitizeLogBody,
+				SanitizeLogBody: &sanitizeLogBodyTrue,
 			},
-		},
-		logBody: &complexBody,
-	}
+		}, pathLikeLogBody)
+		assert.Equal(t, "/api/orders/*/details", got)
+	})
 
-	outLogs := runLogsTest(t, tc)
-	outLogBody := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body()
+	t.Run("opt_in/sanitize_log_body_masks_prose_to_star", func(t *testing.T) {
+		got := processStringLogBody(t, &Config{
+			AllowAllKeys: true,
+			URLSanitization: url.URLSanitizationConfig{
+				Enabled:         true,
+				SanitizeLogBody: &sanitizeLogBodyTrue,
+			},
+		}, proseLogBody)
+		assert.Equal(t, "*", got)
+	})
 
-	message, _ := outLogBody.Map().Get("message")
-	assert.Equal(t, "/users/*", message.Str())
+	t.Run("opt_in/sanitize_log_body_sanitizes_nested_map_strings", func(t *testing.T) {
+		complexBody := pcommon.NewValueMap()
+		complexBody.Map().PutStr("message", "/users/2")
+		complexBody.Map().PutStr("url", "/products/1/org/3")
 
-	url, _ := outLogBody.Map().Get("url")
-	assert.Equal(t, "/products/*/org/*", url.Str())
+		tc := testConfig{
+			config: &Config{
+				AllowAllKeys: true,
+				URLSanitization: url.URLSanitizationConfig{
+					Enabled:         true,
+					SanitizeLogBody: &sanitizeLogBodyTrue,
+				},
+			},
+			logBody: &complexBody,
+		}
+
+		outLogs := runLogsTest(t, tc)
+		outLogBody := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body()
+
+		message, _ := outLogBody.Map().Get("message")
+		assert.Equal(t, "/users/*", message.Str())
+
+		urlVal, _ := outLogBody.Map().Get("url")
+		assert.Equal(t, "/products/*/org/*", urlVal.Str())
+	})
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }
 
 func TestURLSanitizationAttributeFiltering(t *testing.T) {
@@ -2316,111 +2428,6 @@ func TestDBObfuscationOnLogBody(t *testing.T) {
 
 	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 	assert.Equal(t, "SELECT password FROM users WHERE id = ?", outLog.Body().Str())
-}
-
-func TestURLSanitizationOnLogBody(t *testing.T) {
-	sanitizeLogBody := true
-	cfg := &Config{
-		AllowAllKeys: true,
-		URLSanitization: url.URLSanitizationConfig{
-			Enabled:         true,
-			SanitizeLogBody: &sanitizeLogBody,
-		},
-	}
-
-	inLogs := plog.NewLogs()
-	rl := inLogs.ResourceLogs().AppendEmpty()
-	ils := rl.ScopeLogs().AppendEmpty()
-	logRecord := ils.LogRecords().AppendEmpty()
-	logRecord.Body().SetStr("/api/orders/12345/details")
-
-	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
-	require.NoError(t, err)
-	outLogs, err := processor.processLogs(t.Context(), inLogs)
-	require.NoError(t, err)
-
-	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	assert.Equal(t, "/api/orders/*/details", outLog.Body().Str())
-}
-
-func TestURLSanitizationLogBodyDisabledByDefault(t *testing.T) {
-	const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
-
-	cfg := &Config{
-		AllowAllKeys: true,
-		URLSanitization: url.URLSanitizationConfig{
-			Enabled:    true,
-			Attributes: []string{"http.url"},
-		},
-	}
-
-	inLogs := plog.NewLogs()
-	rl := inLogs.ResourceLogs().AppendEmpty()
-	ils := rl.ScopeLogs().AppendEmpty()
-	logRecord := ils.LogRecords().AppendEmpty()
-	logRecord.Body().SetStr(proseLogBody)
-
-	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
-	require.NoError(t, err)
-	outLogs, err := processor.processLogs(t.Context(), inLogs)
-	require.NoError(t, err)
-
-	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	assert.Equal(t, proseLogBody, outLog.Body().Str())
-}
-
-func TestURLSanitizationLogBodyExplicitFalse(t *testing.T) {
-	sanitizeLogBody := false
-	const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
-
-	cfg := &Config{
-		AllowAllKeys: true,
-		URLSanitization: url.URLSanitizationConfig{
-			Enabled:         true,
-			SanitizeLogBody: &sanitizeLogBody,
-		},
-	}
-
-	inLogs := plog.NewLogs()
-	rl := inLogs.ResourceLogs().AppendEmpty()
-	ils := rl.ScopeLogs().AppendEmpty()
-	logRecord := ils.LogRecords().AppendEmpty()
-	logRecord.Body().SetStr(proseLogBody)
-
-	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
-	require.NoError(t, err)
-	outLogs, err := processor.processLogs(t.Context(), inLogs)
-	require.NoError(t, err)
-
-	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	assert.Equal(t, proseLogBody, outLog.Body().Str())
-}
-
-func TestURLSanitizationLogBodyEnabledMasksProse(t *testing.T) {
-	sanitizeLogBody := true
-	const proseLogBody = "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]"
-
-	cfg := &Config{
-		AllowAllKeys: true,
-		URLSanitization: url.URLSanitizationConfig{
-			Enabled:         true,
-			SanitizeLogBody: &sanitizeLogBody,
-		},
-	}
-
-	inLogs := plog.NewLogs()
-	rl := inLogs.ResourceLogs().AppendEmpty()
-	ils := rl.ScopeLogs().AppendEmpty()
-	logRecord := ils.LogRecords().AppendEmpty()
-	logRecord.Body().SetStr(proseLogBody)
-
-	processor, err := newRedaction(t.Context(), cfg, zaptest.NewLogger(t))
-	require.NoError(t, err)
-	outLogs, err := processor.processLogs(t.Context(), inLogs)
-	require.NoError(t, err)
-
-	outLog := outLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	assert.Equal(t, "*", outLog.Body().Str())
 }
 
 func TestDBObfuscationErrorInAttribute(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add optional `url_sanitizer.sanitize_log_body` (default **off** when omitted).
- String log bodies are no longer passed through the URL sanitizer unless `sanitize_log_body: true`.
- The `attributes` list continues to gate **attribute values** only (via `SanitizeAttributeURL`).

Operators often enable `url_sanitizer` with an `attributes` allow-list expecting URL clustering only on those keys. On collector **v0.152.0** (and earlier), `enabled: true` also runs `SanitizeURL` on every string log body, which can collapse non-URL prose to `*` via [grafana/clusterurl](https://github.com/grafana/clusterurl).

## Sample Kubernetes manifest (repro)

Minimal `OpenTelemetryCollector` / Helm `config` excerpt matching a production-style setup: `url_sanitizer.enabled: true` with an attribute allow-list, logs pipeline only.

```yaml
apiVersion: opentelemetry.io/v1beta1
kind: OpenTelemetryCollector
metadata:
  name: otel-aggregation-buffer
spec:
  image: otel/opentelemetry-collector-contrib:0.152.0
  config:
    receivers:
      otlp:
        protocols:
          grpc:
            endpoint: 0.0.0.0:4317
    processors:
      redaction/default:
        allow_all_keys: true
        summary: info
        url_sanitizer:
          enabled: true
          attributes: ["http.url", "url", "url.full", "page.url"]
      batch: {}
    exporters:
      debug:
        verbosity: detailed
    service:
      pipelines:
        logs:
          receivers: [otlp]
          processors: [redaction/default, batch]
          exporters: [debug]
```

Send a log record whose **body** is prose (not a slash-separated URL) and whose **attributes** include a path-like URL:

```json
{
  "body": "test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]",
  "attributes": {
    "http.url": "/api/visits/0194a2b3-c4d5-6789-abcd-ef0123456789"
  }
}
```

## Actual vs expected

| | **v0.152.0 (before this PR)** | **With this PR (default)** | **With this PR + `sanitize_log_body: true`** |
|---|-------------------------------|----------------------------|-----------------------------------------------|
| **Log body** | `*` | `test_event_name [correlation_id=00000000-0000-4000-8000-000000000001]` (unchanged) | `*` (clusterurl still runs on body when opted in) |
| **`http.url` attribute** | `/api/visits/*` (sanitized) | `/api/visits/*` (sanitized) | `/api/visits/*` (sanitized) |
| **Audit attrs** (`summary: info`) | `redaction.body.masked.count: 1` on body | No body mask count for URL sanitizer | `redaction.body.masked.count: 1` on body |

**Actual (bug):** `attributes` is documented/treated as the gate for URL sanitization, but log bodies bypass that gate and always call `SanitizeURL` when `url_sanitizer.enabled: true`.

**Expected (fix):** URL sanitization on log bodies requires an explicit opt-in:

```yaml
url_sanitizer:
  enabled: true
  attributes: ["http.url", "url", "url.full", "page.url"]
  sanitize_log_body: true   # required to sanitize string log bodies
```

**Operational workaround (no code change):** disable URL sanitizer on the logs pipeline only (e.g. separate `redaction/logs` processor with `url_sanitizer.enabled: false`) while keeping it on traces/metrics.

## Test plan

- [x] `go test ./...` in `processor/redactionprocessor`
- [x] `TestURLSanitizationLogBody` — `fix/` subtests (default preserves prose + path-like bodies; attributes still sanitized) and `opt_in/` subtests
- [x] Existing log-body URL tests set `sanitize_log_body: true` where body sanitization is intended