### PR TITLE
feat[receiver/azure_blob]: Add support for encoding extensions

### DIFF
--- a/.chloggen/azureblobreceiver-encoding-extension.yaml
+++ b/.chloggen/azureblobreceiver-encoding-extension.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azure_blob
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow `logs.encoding` and `traces.encoding` to reference an encoding extension ID, in addition to the built-in `otlp_json` and `otlp_proto` values.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48238]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `encoding` is set to a value other than `otlp_json` or `otlp_proto`, it is
+  treated as the component ID of an encoding extension. The extension is resolved
+  from the collector's configured extensions when the receiver starts and used to
+  unmarshal blob payloads for that signal.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -15,7 +15,7 @@
 
 This receiver reads logs and trace data from [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/).
 
-Each blob is expected to contain a single OTLP payload, encoded as either OTLP/JSON or OTLP/Protobuf. The encoding is configured per signal via `logs.encoding` and `traces.encoding` (see below).
+Each blob is expected to contain a single payload. By default the payload is decoded as OTLP/JSON, but the encoding is configurable per signal via `logs.encoding` and `traces.encoding` (see below). In addition to the built-in `otlp_json` and `otlp_proto` encodings, you may reference an [encoding extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding) by its component ID to decode other formats.
 
 ## Modes of Operation
 
@@ -37,10 +37,10 @@ The following settings can be optionally configured:
 - `cloud` (default = "AzureCloud"): Defines which Azure Cloud to use when using the `service_principal` authentication method. Value is either `AzureCloud` or `AzureUSGovernment`.
 - `logs:`
   - `container_name:` (default = "logs"): Name of the blob container with the logs
-  - `encoding:` (default = "otlp_json"): Encoding of log blob payloads. Supported values: `otlp_json`, `otlp_proto`.
+  - `encoding:` (default = "otlp_json"): Encoding of log blob payloads. Either one of the built-in values `otlp_json` or `otlp_proto`, or the ID of an encoding extension that implements `plog.Unmarshaler`.
 - `traces:`
   - `container_name:` (default = "traces"): Name of the blob container with the traces
-  - `encoding:` (default = "otlp_json"): Encoding of trace blob payloads. Supported values: `otlp_json`, `otlp_proto`.
+  - `encoding:` (default = "otlp_json"): Encoding of trace blob payloads. Either one of the built-in values `otlp_json` or `otlp_proto`, or the ID of an encoding extension that implements `ptrace.Unmarshaler`.
 
 Authenticating using a connection string requires configuration of the following additional setting:
 
@@ -91,6 +91,19 @@ Using polling mode (no Event Hub):
 receivers:
   azure_blob:
     connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
+```
+
+Using an encoding extension to decode log blobs:
+
+```yaml
+extensions:
+  text_encoding:
+
+receivers:
+  azure_blob:
+    connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
+    logs:
+      encoding: text_encoding
 ```
 
 ## Behavior

--- a/receiver/azureblobreceiver/config.go
+++ b/receiver/azureblobreceiver/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/multierr"
 )
@@ -53,7 +54,8 @@ type LogsConfig struct {
 	// Name of the blob container with the logs (default = "logs")
 	ContainerName string `mapstructure:"container_name"`
 	// Encoding of log blobs in this container (default = "otlp_json").
-	// Supported values: "otlp_json", "otlp_proto".
+	// Either one of the built-in values "otlp_json" or "otlp_proto", or the
+	// ID of an encoding extension that implements plog.Unmarshaler.
 	Encoding string `mapstructure:"encoding"`
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -63,7 +65,8 @@ type TracesConfig struct {
 	// Name of the blob container with the traces (default = "traces")
 	ContainerName string `mapstructure:"container_name"`
 	// Encoding of trace blobs in this container (default = "otlp_json").
-	// Supported values: "otlp_json", "otlp_proto".
+	// Either one of the built-in values "otlp_json" or "otlp_proto", or the
+	// ID of an encoding extension that implements ptrace.Unmarshaler.
 	Encoding string `mapstructure:"encoding"`
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -124,13 +127,30 @@ const (
 	EncodingOTLPProto = "otlp_proto"
 )
 
-// supportedEncodings is the set of encoding values supported by the
-// receiver. Keep this consistent with the encoding constants above and
-// the README. Issue #48238 will extend this to also accept encoding
-// extension IDs resolved at component construction.
-var supportedEncodings = map[string]struct{}{
-	EncodingOTLPJSON:  {},
-	EncodingOTLPProto: {},
+// isBuiltinEncoding reports whether enc is one of the encodings the receiver
+// can unmarshal without an encoding extension.
+func isBuiltinEncoding(enc string) bool {
+	switch enc {
+	case EncodingOTLPJSON, EncodingOTLPProto:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateEncoding accepts either a built-in encoding or a syntactically valid
+// encoding extension ID. The existence of the referenced extension cannot be
+// checked here as the host's extensions are only available once the component
+// starts; it is verified in blobReceiver.Start.
+func validateEncoding(enc string) error {
+	if isBuiltinEncoding(enc) {
+		return nil
+	}
+	var id component.ID
+	if err := id.UnmarshalText([]byte(enc)); err != nil {
+		return fmt.Errorf("encoding %q is not a supported built-in encoding (%q, %q) or a valid encoding extension ID: %w", enc, EncodingOTLPJSON, EncodingOTLPProto, err)
+	}
+	return nil
 }
 
 // Validate validates the configuration by checking for missing or invalid fields
@@ -158,11 +178,11 @@ func (c Config) Validate() (err error) {
 		}
 	}
 
-	if _, ok := supportedEncodings[c.Logs.Encoding]; !ok {
-		err = multierr.Append(err, fmt.Errorf("logs.encoding %q is not supported; supported values: [%v, %v]", c.Logs.Encoding, EncodingOTLPJSON, EncodingOTLPProto))
+	if encErr := validateEncoding(c.Logs.Encoding); encErr != nil {
+		err = multierr.Append(err, fmt.Errorf("logs.%w", encErr))
 	}
-	if _, ok := supportedEncodings[c.Traces.Encoding]; !ok {
-		err = multierr.Append(err, fmt.Errorf("traces.encoding %q is not supported; supported values: [%v, %v]", c.Traces.Encoding, EncodingOTLPJSON, EncodingOTLPProto))
+	if encErr := validateEncoding(c.Traces.Encoding); encErr != nil {
+		err = multierr.Append(err, fmt.Errorf("traces.%w", encErr))
 	}
 
 	return err

--- a/receiver/azureblobreceiver/config.schema.yaml
+++ b/receiver/azureblobreceiver/config.schema.yaml
@@ -16,7 +16,7 @@ $defs:
         description: Name of the blob container with the logs (default = "logs")
         type: string
       encoding:
-        description: 'Encoding of log blobs in this container (default = "otlp_json"). Supported values: "otlp_json", "otlp_proto".'
+        description: Encoding of log blobs in this container (default = "otlp_json"). Either one of the built-in values "otlp_json" or "otlp_proto", or the ID of an encoding extension that implements plog.Unmarshaler.
         type: string
   service_principal_config:
     type: object
@@ -37,7 +37,7 @@ $defs:
         description: Name of the blob container with the traces (default = "traces")
         type: string
       encoding:
-        description: 'Encoding of trace blobs in this container (default = "otlp_json"). Supported values: "otlp_json", "otlp_proto".'
+        description: Encoding of trace blobs in this container (default = "otlp_json"). Either one of the built-in values "otlp_json" or "otlp_proto", or the ID of an encoding extension that implements ptrace.Unmarshaler.
         type: string
 type: object
 properties:

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -115,5 +115,4 @@ func TestBlankEncoding(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `logs.encoding "" is not a supported built-in encoding`)
 	assert.Contains(t, err.Error(), `traces.encoding "" is not a supported built-in encoding`)
-	assert.Contains(t, err.Error(), "id must not be empty")
 }

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -78,14 +78,42 @@ func TestMissingServicePrincipalCredentials(t *testing.T) {
 	assert.EqualError(t, err, `"TenantID" is not specified in config; "ClientID" is not specified in config; "ClientSecret" is not specified in config; "StorageAccountURL" is not specified in config`)
 }
 
-func TestUnsupportedEncoding(t *testing.T) {
+func TestInvalidEncoding(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.ConnectionString = goodConnectionString
-	cfg.Logs.Encoding = "totally_made_up"
-	cfg.Traces.Encoding = "also_made_up"
+	// Values that are neither a built-in encoding nor a syntactically valid
+	// encoding extension ID are rejected during validation.
+	cfg.Logs.Encoding = "not a valid id"
+	cfg.Traces.Encoding = "also not valid"
 	err := xconfmap.Validate(cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `logs.encoding "totally_made_up" is not supported`)
-	assert.Contains(t, err.Error(), `traces.encoding "also_made_up" is not supported`)
+	assert.Contains(t, err.Error(), `logs.encoding "not a valid id" is not a supported built-in encoding`)
+	assert.Contains(t, err.Error(), `traces.encoding "also not valid" is not a supported built-in encoding`)
+}
+
+func TestEncodingExtensionIDAcceptedByValidation(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.ConnectionString = goodConnectionString
+	// An encoding extension ID is syntactically valid; its existence is only
+	// checked when the receiver starts.
+	cfg.Logs.Encoding = "myencoding"
+	cfg.Traces.Encoding = "myencoding/traces"
+	require.NoError(t, xconfmap.Validate(cfg))
+}
+
+func TestBlankEncoding(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.ConnectionString = goodConnectionString
+	// A blank encoding is neither a built-in nor a valid extension ID, since an
+	// empty component ID is rejected.
+	cfg.Logs.Encoding = ""
+	cfg.Traces.Encoding = ""
+	err := xconfmap.Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `logs.encoding "" is not a supported built-in encoding`)
+	assert.Contains(t, err.Error(), `traces.encoding "" is not a supported built-in encoding`)
+	assert.Contains(t, err.Error(), "id must not be empty")
 }

--- a/receiver/azureblobreceiver/receiver.go
+++ b/receiver/azureblobreceiver/receiver.go
@@ -31,6 +31,8 @@ type tracesDataConsumer interface {
 type blobReceiver struct {
 	blobEventHandler   eventHandler
 	logger             *zap.Logger
+	logsEncoding       string
+	tracesEncoding     string
 	logsUnmarshaler    plog.Unmarshaler
 	tracesUnmarshaler  ptrace.Unmarshaler
 	nextLogsConsumer   consumer.Logs
@@ -38,10 +40,28 @@ type blobReceiver struct {
 	obsrecv            *receiverhelper.ObsReport
 }
 
-func (b *blobReceiver) Start(ctx context.Context, _ component.Host) error {
-	err := b.blobEventHandler.run(ctx)
+func (b *blobReceiver) Start(ctx context.Context, host component.Host) error {
+	// Unmarshalers are resolved here rather than at construction because
+	// extension-based encodings are only available once the host's extensions
+	// have been started.
+	if err := b.resolveUnmarshalers(host); err != nil {
+		return err
+	}
 
-	return err
+	return b.blobEventHandler.run(ctx)
+}
+
+// resolveUnmarshalers resolves the configured logs and traces encodings into
+// unmarshalers, looking up encoding extensions from the host as needed.
+func (b *blobReceiver) resolveUnmarshalers(host component.Host) error {
+	var err error
+	if b.logsUnmarshaler, err = newLogsUnmarshaler(b.logsEncoding, host); err != nil {
+		return err
+	}
+	if b.tracesUnmarshaler, err = newTracesUnmarshaler(b.tracesEncoding, host); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *blobReceiver) Shutdown(ctx context.Context) error {
@@ -107,33 +127,67 @@ func newReceiver(set receiver.Settings, eventHandler eventHandler, logsEncoding,
 		return nil, err
 	}
 
-	var logsUnmarshaler plog.Unmarshaler
-	switch logsEncoding {
+	return &blobReceiver{
+		blobEventHandler: eventHandler,
+		logger:           set.Logger,
+		logsEncoding:     logsEncoding,
+		tracesEncoding:   tracesEncoding,
+		obsrecv:          obsrecv,
+	}, nil
+}
+
+// newLogsUnmarshaler resolves encoding into a plog.Unmarshaler. Built-in
+// encodings are handled directly; any other value is treated as the ID of an
+// encoding extension looked up from the host.
+func newLogsUnmarshaler(encoding string, host component.Host) (plog.Unmarshaler, error) {
+	switch encoding {
 	case EncodingOTLPJSON:
-		logsUnmarshaler = &plog.JSONUnmarshaler{}
+		return &plog.JSONUnmarshaler{}, nil
 	case EncodingOTLPProto:
-		logsUnmarshaler = &plog.ProtoUnmarshaler{}
-	default:
-		return nil, fmt.Errorf("logs.encoding %q is not supported; supported values: [%v, %v]", logsEncoding, EncodingOTLPJSON, EncodingOTLPProto)
+		return &plog.ProtoUnmarshaler{}, nil
 	}
+	ext, id, err := encodingExtension(encoding, host)
+	if err != nil {
+		return nil, fmt.Errorf("logs.%w", err)
+	}
+	unmarshaler, ok := ext.(plog.Unmarshaler)
+	if !ok {
+		return nil, fmt.Errorf("logs.encoding extension %q is not a logs unmarshaler", id)
+	}
+	return unmarshaler, nil
+}
 
-	var tracesUnmarshaler ptrace.Unmarshaler
-	switch tracesEncoding {
+// newTracesUnmarshaler resolves encoding into a ptrace.Unmarshaler. Built-in
+// encodings are handled directly; any other value is treated as the ID of an
+// encoding extension looked up from the host.
+func newTracesUnmarshaler(encoding string, host component.Host) (ptrace.Unmarshaler, error) {
+	switch encoding {
 	case EncodingOTLPJSON:
-		tracesUnmarshaler = &ptrace.JSONUnmarshaler{}
+		return &ptrace.JSONUnmarshaler{}, nil
 	case EncodingOTLPProto:
-		tracesUnmarshaler = &ptrace.ProtoUnmarshaler{}
-	default:
-		return nil, fmt.Errorf("traces.encoding %q is not supported; supported values: [%v, %v]", tracesEncoding, EncodingOTLPJSON, EncodingOTLPProto)
+		return &ptrace.ProtoUnmarshaler{}, nil
 	}
-
-	blobReceiver := &blobReceiver{
-		blobEventHandler:  eventHandler,
-		logger:            set.Logger,
-		logsUnmarshaler:   logsUnmarshaler,
-		tracesUnmarshaler: tracesUnmarshaler,
-		obsrecv:           obsrecv,
+	ext, id, err := encodingExtension(encoding, host)
+	if err != nil {
+		return nil, fmt.Errorf("traces.%w", err)
 	}
+	unmarshaler, ok := ext.(ptrace.Unmarshaler)
+	if !ok {
+		return nil, fmt.Errorf("traces.encoding extension %q is not a traces unmarshaler", id)
+	}
+	return unmarshaler, nil
+}
 
-	return blobReceiver, nil
+// encodingExtension resolves the encoding extension referenced by encoding from
+// the host's extensions.
+func encodingExtension(encoding string, host component.Host) (component.Component, component.ID, error) {
+	var id component.ID
+	if err := id.UnmarshalText([]byte(encoding)); err != nil {
+		return nil, id, fmt.Errorf("encoding %q is not a valid encoding extension ID: %w", encoding, err)
+	}
+	ext, ok := host.GetExtensions()[id]
+	if !ok {
+		return nil, id, fmt.Errorf("encoding extension %q not found", id)
+	}
+	return ext, id, nil
 }

--- a/receiver/azureblobreceiver/receiver.go
+++ b/receiver/azureblobreceiver/receiver.go
@@ -146,13 +146,13 @@ func newLogsUnmarshaler(encoding string, host component.Host) (plog.Unmarshaler,
 	case EncodingOTLPProto:
 		return &plog.ProtoUnmarshaler{}, nil
 	}
-	ext, id, err := encodingExtension(encoding, host)
+	ext, err := encodingExtension(encoding, host)
 	if err != nil {
 		return nil, fmt.Errorf("logs.%w", err)
 	}
 	unmarshaler, ok := ext.(plog.Unmarshaler)
 	if !ok {
-		return nil, fmt.Errorf("logs.encoding extension %q is not a logs unmarshaler", id)
+		return nil, fmt.Errorf("logs.encoding extension %q is not a logs unmarshaler", encoding)
 	}
 	return unmarshaler, nil
 }
@@ -167,27 +167,27 @@ func newTracesUnmarshaler(encoding string, host component.Host) (ptrace.Unmarsha
 	case EncodingOTLPProto:
 		return &ptrace.ProtoUnmarshaler{}, nil
 	}
-	ext, id, err := encodingExtension(encoding, host)
+	ext, err := encodingExtension(encoding, host)
 	if err != nil {
 		return nil, fmt.Errorf("traces.%w", err)
 	}
 	unmarshaler, ok := ext.(ptrace.Unmarshaler)
 	if !ok {
-		return nil, fmt.Errorf("traces.encoding extension %q is not a traces unmarshaler", id)
+		return nil, fmt.Errorf("traces.encoding extension %q is not a traces unmarshaler", encoding)
 	}
 	return unmarshaler, nil
 }
 
 // encodingExtension resolves the encoding extension referenced by encoding from
 // the host's extensions.
-func encodingExtension(encoding string, host component.Host) (component.Component, component.ID, error) {
+func encodingExtension(encoding string, host component.Host) (component.Component, error) {
 	var id component.ID
 	if err := id.UnmarshalText([]byte(encoding)); err != nil {
-		return nil, id, fmt.Errorf("encoding %q is not a valid encoding extension ID: %w", encoding, err)
+		return nil, fmt.Errorf("encoding %q is not a valid encoding extension ID: %w", encoding, err)
 	}
 	ext, ok := host.GetExtensions()[id]
 	if !ok {
-		return nil, id, fmt.Errorf("encoding extension %q not found", id)
+		return nil, fmt.Errorf("encoding extension %q not found", id)
 	}
-	return ext, id, nil
+	return ext, nil
 }

--- a/receiver/azureblobreceiver/receiver_test.go
+++ b/receiver/azureblobreceiver/receiver_test.go
@@ -4,12 +4,14 @@
 package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -166,22 +168,105 @@ func TestConsumeLogsEncoding(t *testing.T) {
 	}
 }
 
-func TestNewReceiverUnsupportedEncoding(t *testing.T) {
+func TestUnknownEncodingExtension(t *testing.T) {
 	tests := []struct {
 		name           string
 		logsEncoding   string
 		tracesEncoding string
 	}{
-		{name: "unsupported logs encoding", logsEncoding: "totally_made_up", tracesEncoding: EncodingOTLPJSON},
-		{name: "unsupported traces encoding", logsEncoding: EncodingOTLPJSON, tracesEncoding: "totally_made_up"},
+		{name: "missing logs encoding extension", logsEncoding: "missing_extension", tracesEncoding: EncodingOTLPJSON},
+		{name: "missing traces encoding extension", logsEncoding: EncodingOTLPJSON, tracesEncoding: "missing_extension"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// The referenced extension is not registered with the host, so
+			// resolution fails.
 			_, err := getBlobReceiverWithEncodings(t, "polling", tc.logsEncoding, tc.tracesEncoding)
-			require.Error(t, err)
+			require.ErrorContains(t, err, "not found")
 		})
 	}
+}
+
+func TestWrongExtensionType(t *testing.T) {
+	host := &hostWithExtensions{
+		extensions: map[component.ID]component.Component{
+			component.MustNewID("not_an_unmarshaler"): &nonUnmarshalerExtension{},
+		},
+	}
+
+	_, err := getBlobReceiverWithHost(t, "polling", "not_an_unmarshaler", EncodingOTLPJSON, host)
+	require.ErrorContains(t, err, "is not a logs unmarshaler")
+}
+
+func TestConsumeWithEncodingExtension(t *testing.T) {
+	encID := component.MustNewID("fake_encoding")
+	host := &hostWithExtensions{
+		extensions: map[component.ID]component.Component{
+			encID: &fakeUnmarshalerExtension{},
+		},
+	}
+
+	receiver, err := getBlobReceiverWithHost(t, "polling", encID.String(), encID.String(), host)
+	require.NoError(t, err)
+
+	logsSink := new(consumertest.LogsSink)
+	logsConsumer := receiver.(logsDataConsumer)
+	logsConsumer.setNextLogsConsumer(logsSink)
+	require.NoError(t, logsConsumer.consumeLogs(t.Context(), []byte("anything")))
+	assert.Equal(t, 1, logsSink.LogRecordCount())
+
+	tracesSink := new(consumertest.TracesSink)
+	tracesConsumer := receiver.(tracesDataConsumer)
+	tracesConsumer.setNextTracesConsumer(tracesSink)
+	require.NoError(t, tracesConsumer.consumeTraces(t.Context(), []byte("anything")))
+	assert.Equal(t, 1, tracesSink.SpanCount())
+}
+
+// TestStartShutdown exercises the full lifecycle, including unmarshaler
+// resolution and the blob poller started by Start.
+func TestStartShutdown(t *testing.T) {
+	receiver, err := getBlobReceiver(t, "polling")
+	require.NoError(t, err)
+
+	require.NoError(t, receiver.Start(t.Context(), componenttest.NewNopHost()))
+	require.NoError(t, receiver.Shutdown(t.Context()))
+}
+
+// hostWithExtensions is a component.Host that exposes a fixed set of extensions.
+type hostWithExtensions struct {
+	component.Host
+	extensions map[component.ID]component.Component
+}
+
+func (h *hostWithExtensions) GetExtensions() map[component.ID]component.Component {
+	return h.extensions
+}
+
+// nonUnmarshalerExtension is an extension that does not implement any
+// unmarshaler interface.
+type nonUnmarshalerExtension struct{}
+
+func (nonUnmarshalerExtension) Start(context.Context, component.Host) error { return nil }
+func (nonUnmarshalerExtension) Shutdown(context.Context) error              { return nil }
+
+// fakeUnmarshalerExtension is an encoding extension that unmarshals any input
+// into a single log record and a single span.
+type fakeUnmarshalerExtension struct{}
+
+func (fakeUnmarshalerExtension) Start(context.Context, component.Host) error { return nil }
+func (fakeUnmarshalerExtension) Shutdown(context.Context) error              { return nil }
+
+func (fakeUnmarshalerExtension) UnmarshalLogs([]byte) (plog.Logs, error) {
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	return logs, nil
+}
+
+func (fakeUnmarshalerExtension) UnmarshalTraces([]byte) (ptrace.Traces, error) {
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	return traces, nil
 }
 
 func getBlobReceiver(t *testing.T, mode string) (component.Component, error) {
@@ -189,16 +274,29 @@ func getBlobReceiver(t *testing.T, mode string) (component.Component, error) {
 }
 
 func getBlobReceiverWithEncodings(t *testing.T, mode, logsEncoding, tracesEncoding string) (component.Component, error) {
+	return getBlobReceiverWithHost(t, mode, logsEncoding, tracesEncoding, componenttest.NewNopHost())
+}
+
+// getBlobReceiverWithHost builds a receiver and resolves its unmarshalers
+// against host, the same way Start does, but without starting the blob poller.
+func getBlobReceiverWithHost(t *testing.T, mode, logsEncoding, tracesEncoding string, host component.Host) (component.Component, error) {
 	set := receivertest.NewNopSettings(metadata.Type)
-	if mode == "eventhub" {
-		blobClient := newMockBlobClient()
-		blobEventHandler := getEventHubEventHandler(t, blobClient)
-		return newReceiver(set, blobEventHandler, logsEncoding, tracesEncoding)
+	var blobEventHandler eventHandler
+	switch mode {
+	case "eventhub":
+		blobEventHandler = getEventHubEventHandler(t, newMockBlobClient())
+	case "polling":
+		blobEventHandler = getBlobEventHandler(t, newMockBlobClient())
+	default:
+		return nil, errors.New("invalid mode")
 	}
-	if mode == "polling" {
-		blobClient := newMockBlobClient()
-		blobEventHandler := getBlobEventHandler(t, blobClient)
-		return newReceiver(set, blobEventHandler, logsEncoding, tracesEncoding)
+
+	r, err := newReceiver(set, blobEventHandler, logsEncoding, tracesEncoding)
+	if err != nil {
+		return nil, err
 	}
-	return nil, errors.New("invalid mode")
+	if err := r.(*blobReceiver).resolveUnmarshalers(host); err != nil {
+		return r, err
+	}
+	return r, nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds support for utilizing encoding extensions to parse blobs received by the azure blob receiver. Previously, this receiver only supported OTLP protobuf or JSON blobs.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48238 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests for configuration validation and telemetry consumption with an encoding extension.

<!--Describe the documentation added.-->
#### Documentation

Enhanced receiver documentation to describe and give examples of the new functionality.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
