### PR TITLE
[chore] fix errInvalidEndpoint not wrapped in error chain in check receivers

### DIFF
--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -71,14 +71,14 @@ func (cfg *targetConfig) Validate() error {
 	// Validate the single endpoint in ClientConfig.
 	if cfg.Endpoint != "" {
 		if _, parseErr := url.ParseRequestURI(cfg.Endpoint); parseErr != nil {
-			err = multierr.Append(err, fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr))
+			err = multierr.Append(err, fmt.Errorf("%w: %s", errInvalidEndpoint, parseErr))
 		}
 	}
 
 	// Validate each endpoint in the Endpoints list.
 	for _, endpoint := range cfg.Endpoints {
 		if _, parseErr := url.ParseRequestURI(endpoint); parseErr != nil {
-			err = multierr.Append(err, fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr))
+			err = multierr.Append(err, fmt.Errorf("%w: %s", errInvalidEndpoint, parseErr))
 		}
 	}
 

--- a/receiver/rabbitmqreceiver/config.go
+++ b/receiver/rabbitmqreceiver/config.go
@@ -47,7 +47,7 @@ func (cfg *Config) Validate() error {
 
 	_, parseErr := url.Parse(cfg.Endpoint)
 	if parseErr != nil {
-		wrappedErr := fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr)
+		wrappedErr := fmt.Errorf("%w: %s", errInvalidEndpoint, parseErr)
 		err = append(err, wrappedErr)
 	}
 

--- a/receiver/riakreceiver/config.go
+++ b/receiver/riakreceiver/config.go
@@ -48,7 +48,7 @@ func (cfg *Config) Validate() error {
 
 	_, parseErr := url.Parse(cfg.Endpoint)
 	if parseErr != nil {
-		wrappedErr := fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr)
+		wrappedErr := fmt.Errorf("%w: %s", errInvalidEndpoint, parseErr)
 		err = multierr.Append(err, wrappedErr)
 	}
 

--- a/receiver/tcpcheckreceiver/config.go
+++ b/receiver/tcpcheckreceiver/config.go
@@ -58,12 +58,12 @@ func validateTarget(cfg *confignet.TCPAddrConfig) error {
 
 	_, port, parseErr := net.SplitHostPort(cfg.Endpoint)
 	if parseErr != nil {
-		return fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr)
+		return fmt.Errorf("%w: %s", errInvalidEndpoint, parseErr)
 	}
 
 	portParseErr := validatePort(port)
 	if portParseErr != nil {
-		return fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), portParseErr)
+		return fmt.Errorf("%w: %s", errInvalidEndpoint, portParseErr)
 	}
 
 	return err

--- a/receiver/tlscheckreceiver/scraper.go
+++ b/receiver/tlscheckreceiver/scraper.go
@@ -76,10 +76,10 @@ func validateEndpoint(endpoint string) error {
 	}
 	_, port, err := net.SplitHostPort(endpoint)
 	if err != nil {
-		return fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), err)
+		return fmt.Errorf("%w: %s", errInvalidEndpoint, err)
 	}
 	if err := validatePort(port); err != nil {
-		return fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), err)
+		return fmt.Errorf("%w: %s", errInvalidEndpoint, err)
 	}
 	return nil
 }


### PR DESCRIPTION
#### Description

5 check receivers define `errInvalidEndpoint` as sentinel but wrapping is backwards. 
`fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr)` puts parse error in chain, not the sentinel. 
So `errors.Is(err, errInvalidEndpoint)` returns false when it shouldnt.

Tests use `%w` for sentinel in expected errors but only do string comparison via `EqualError`, so this slipped through unnoticed.

Reproduce:
```go
cfg := &Config{Targets: []*confignet.TCPAddrConfig{{Endpoint: "bad-endpoint"}}}
err := cfg.Validate()
fmt.Println(errors.Is(err, errInvalidEndpoint)) // false, should be true
```

Fix: swap to `fmt.Errorf("%w: %s", errInvalidEndpoint, parseErr)`. 
Same error string, correct chain.

Affected: tcpcheckreceiver, httpcheckreceiver, riakreceiver, rabbitmqreceiver, tlscheckreceiver

#### Link to tracking issue
Fixes

#### Testing

All existing tests pass unchanged - error strings are identical, wrapping order is corrected.

#### Documentation

N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself