### PR TITLE
[pkg/pdatatest] Add duplicate ResourceMetrics check to ValidateMetrics

### DIFF
--- a/.chloggen/pmetric-valid-part3.yaml
+++ b/.chloggen/pmetric-valid-part3.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add check for duplicate ResourceMetrics to pmetrictest.ValidateMetrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48106]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/pdatatest/pmetrictest/validate.go
+++ b/pkg/pdatatest/pmetrictest/validate.go
@@ -44,7 +44,10 @@ func ValidateMetrics(md pmetric.Metrics) error {
 		// TODO (PR 4): Check for multiple ScopeMetrics with equal scope under the same resource
 	}
 
-	// TODO (PR 3): Check for multiple ResourceMetrics with equal resource attributes
+	// Check for multiple ResourceMetrics with equal resource attributes.
+	if err := validateDuplicateResources(rms); err != nil {
+		errs = multierr.Append(errs, err)
+	}
 
 	return errs
 }
@@ -129,6 +132,27 @@ func validateDuplicateMetricNames(ms pmetric.MetricSlice) error {
 			))
 		} else {
 			seen[name] = i
+		}
+	}
+
+	return errs
+}
+
+// validateDuplicateResources checks that no two ResourceMetrics in rms share
+// the same resource attributes. Each resource should appear at most once.
+func validateDuplicateResources(rms pmetric.ResourceMetricsSlice) error {
+	seen := make(map[[16]byte]int, rms.Len()) // resource attributes hash to first-seen index
+	var errs error
+
+	for i := 0; i < rms.Len(); i++ {
+		h := pdatautil.MapHash(rms.At(i).Resource().Attributes())
+		if firstIdx, exists := seen[h]; exists {
+			errs = multierr.Append(errs, fmt.Errorf(
+				"resource %v at index %d is a duplicate of resource at index %d",
+				rms.At(i).Resource().Attributes().AsRaw(), i, firstIdx,
+			))
+		} else {
+			seen[h] = i
 		}
 	}
 

--- a/pkg/pdatatest/pmetrictest/validate_test.go
+++ b/pkg/pdatatest/pmetrictest/validate_test.go
@@ -437,5 +437,83 @@ func TestValidateMetrics(t *testing.T) {
 
 	// TODO (PR 4): Add tests for multiple ScopeMetrics with equal scope under the same resource
 
-	// TODO (PR 3): Add tests for multiple ResourceMetrics with equal resource attributes
+	t.Run("duplicate-resource-attributes", func(t *testing.T) {
+		md := pmetric.NewMetrics()
+
+		rm1 := md.ResourceMetrics().AppendEmpty()
+		rm1.Resource().Attributes().PutStr("host.name", "worker-42")
+
+		rm2 := md.ResourceMetrics().AppendEmpty()
+		rm2.Resource().Attributes().PutStr("host.name", "worker-42")
+
+		err := ValidateMetrics(md)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resource map[host.name:worker-42] at index 1 is a duplicate of resource at index 0")
+	})
+
+	t.Run("no-duplicate-different-resource-attributes", func(t *testing.T) {
+		md := pmetric.NewMetrics()
+
+		rm1 := md.ResourceMetrics().AppendEmpty()
+		rm1.Resource().Attributes().PutStr("host.name", "worker-42")
+
+		rm2 := md.ResourceMetrics().AppendEmpty()
+		rm2.Resource().Attributes().PutStr("host.name", "worker-99")
+
+		assert.NoError(t, ValidateMetrics(md))
+	})
+
+	t.Run("duplicate-resource-multiple-duplicates", func(t *testing.T) {
+		md := pmetric.NewMetrics()
+
+		for range 3 {
+			rm := md.ResourceMetrics().AppendEmpty()
+			rm.Resource().Attributes().PutStr("host.name", "worker-42")
+		}
+
+		err := ValidateMetrics(md)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at index 1 is a duplicate of resource at index 0")
+		assert.Contains(t, err.Error(), "at index 2 is a duplicate of resource at index 0")
+	})
+
+	t.Run("duplicate-resource-multiple-pairs", func(t *testing.T) {
+		md := pmetric.NewMetrics()
+
+		rm1 := md.ResourceMetrics().AppendEmpty()
+		rm1.Resource().Attributes().PutStr("host.name", "worker-42")
+		rm2 := md.ResourceMetrics().AppendEmpty()
+		rm2.Resource().Attributes().PutStr("host.name", "worker-42")
+
+		rm3 := md.ResourceMetrics().AppendEmpty()
+		rm3.Resource().Attributes().PutStr("host.name", "worker-99")
+		rm4 := md.ResourceMetrics().AppendEmpty()
+		rm4.Resource().Attributes().PutStr("host.name", "worker-99")
+
+		err := ValidateMetrics(md)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "worker-42")
+		assert.Contains(t, err.Error(), "worker-99")
+	})
+
+	t.Run("duplicate-resource-empty-attributes", func(t *testing.T) {
+		md := pmetric.NewMetrics()
+
+		// Two ResourceMetrics with empty attributes — they are duplicates.
+		md.ResourceMetrics().AppendEmpty()
+		md.ResourceMetrics().AppendEmpty()
+
+		err := ValidateMetrics(md)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at index 1 is a duplicate of resource at index 0")
+	})
+
+	t.Run("single-resource-no-duplicate", func(t *testing.T) {
+		md := pmetric.NewMetrics()
+
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("host.name", "worker-42")
+
+		assert.NoError(t, ValidateMetrics(md))
+	})
 }


### PR DESCRIPTION
Step 3 in #48106

This PR adds:
logic to `pmetrictest.ValidateMetrics` to detect and reject multiple `ResourceMetrics` entries that share identical resource attributes.

Used Opus 4.6 to write tests

#### Authorship

- [x] I, a human, wrote this pull request description myself.
