### PR TITLE
[receiver/statsd] Clean up stale unix socket on startup

### DIFF
--- a/.chloggen/fix-statsd-uds-socket-cleanup.yaml
+++ b/.chloggen/fix-statsd-uds-socket-cleanup.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/statsd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Clean up stale unix socket file on startup to prevent "address already in use" errors after unclean shutdown.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44866]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/statsdreceiver/internal/transport/uds_server.go
+++ b/receiver/statsdreceiver/internal/transport/uds_server.go
@@ -22,6 +22,13 @@ func NewUDSServer(transport Transport, socketPath string, socketPermissions os.F
 		return nil, fmt.Errorf("NewUDSServer with %s: %w", transport.String(), ErrUnsupportedPacketTransport)
 	}
 
+	// Remove any stale socket file from a previous instance that didn't
+	// shut down cleanly (e.g., crash, SIGKILL). Only remove if the file
+	// is actually a socket to avoid accidentally deleting unrelated files.
+	if fi, statErr := os.Stat(socketPath); statErr == nil && fi.Mode()&os.ModeSocket != 0 {
+		_ = os.Remove(socketPath)
+	}
+
 	conn, err := net.ListenPacket(transport.String(), socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("starting to listen %s socket: %w", transport.String(), err)

--- a/receiver/statsdreceiver/internal/transport/uds_server_test.go
+++ b/receiver/statsdreceiver/internal/transport/uds_server_test.go
@@ -40,6 +40,32 @@ func Test_UDSServer_Close(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func Test_NewUDSServer_CleansUpStaleSocket(t *testing.T) {
+	socketPath := "/tmp/test_socket_stale"
+	defer os.Remove(socketPath)
+
+	// Create first server
+	server1, err := NewUDSServer("unixgram", socketPath, 0o622)
+	require.NoError(t, err)
+	require.NotNil(t, server1)
+
+	// Simulate a crash — close the connection but leave the socket file
+	// (don't call server1.Close() which would remove the file)
+	server1.(*udsServer).packetConn.Close()
+
+	// Verify socket file still exists (simulating stale socket after crash)
+	_, err = os.Stat(socketPath)
+	require.NoError(t, err, "socket file should still exist after simulated crash")
+
+	// Create second server on the same path — should succeed
+	server2, err := NewUDSServer("unixgram", socketPath, 0o622)
+	require.NoError(t, err, "should be able to start a new server on the same socket path")
+	require.NotNil(t, server2)
+
+	err = server2.Close()
+	assert.NoError(t, err)
+}
+
 func Test_NewUDSServer_AppliesChmod(t *testing.T) {
 	socketPath := "/tmp/test_socket_chmod"
 	defer os.Remove(socketPath) // Cleanup after test


### PR DESCRIPTION
Reopened from #47724 (stale-closed). Removes stale socket file before bind to prevent 'address already in use' after crashes. Fixes #44866