### PR TITLE
[receiver/awscloudwatch] Use LogGroupIdentifier for cross-account log groups

### DIFF
--- a/.chloggen/fix-cloudwatch-cross-account-arn.yaml
+++ b/.chloggen/fix-cloudwatch-cross-account-arn.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use LogGroupIdentifier (ARN) instead of LogGroupName for cross-account log group discovery via OAM, fixing ResourceNotFoundException errors.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46159]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,16 +55,21 @@ type client interface {
 }
 
 type streamNames struct {
-	group string
-	names []*string
+	group           string
+	groupIdentifier string
+	names           []*string
 }
 
 func (sn *streamNames) request(limit int, nextToken string, st, et *time.Time) *cloudwatchlogs.FilterLogEventsInput {
 	base := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupName: &sn.group,
-		StartTime:    aws.Int64(st.UnixMilli()),
-		EndTime:      aws.Int64(et.UnixMilli()),
-		Limit:        aws.Int32(int32(limit)),
+		StartTime: aws.Int64(st.UnixMilli()),
+		EndTime:   aws.Int64(et.UnixMilli()),
+		Limit:     aws.Int32(int32(limit)),
+	}
+	if sn.groupIdentifier != "" {
+		base.LogGroupIdentifier = &sn.groupIdentifier
+	} else {
+		base.LogGroupName = &sn.group
 	}
 	if len(sn.names) > 0 {
 		base.LogStreamNames = aws.ToStringSlice(sn.names)
@@ -79,17 +85,22 @@ func (sn *streamNames) groupName() string {
 }
 
 type streamPrefix struct {
-	group  string
-	prefix *string
+	group           string
+	groupIdentifier string
+	prefix          *string
 }
 
 func (sp *streamPrefix) request(limit int, nextToken string, st, et *time.Time) *cloudwatchlogs.FilterLogEventsInput {
 	base := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupName:        &sp.group,
 		StartTime:           aws.Int64(st.UnixMilli()),
 		EndTime:             aws.Int64(et.UnixMilli()),
 		Limit:               aws.Int32(int32(limit)),
 		LogStreamNamePrefix: sp.prefix,
+	}
+	if sp.groupIdentifier != "" {
+		base.LogGroupIdentifier = &sp.groupIdentifier
+	} else {
+		base.LogGroupName = &sp.group
 	}
 	if nextToken != "" {
 		base.NextToken = aws.String(nextToken)
@@ -452,18 +463,26 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 
 			numGroups++
 
+			var groupArn string
+			if lg.Arn != nil {
+				// AWS DescribeLogGroups returns ARNs with a trailing ":*" suffix
+				// (e.g. "arn:aws:logs:us-east-2:123456:log-group:/my/group:*")
+				// but FilterLogEvents LogGroupIdentifier rejects the ":*".
+				groupArn = strings.TrimSuffix(*lg.Arn, ":*")
+			}
+
 			// default behavior is to collect all if not stream filtered
 			if len(auto.Streams.Names) == 0 && len(auto.Streams.Prefixes) == 0 {
-				groups = append(groups, &streamNames{group: *lg.LogGroupName})
+				groups = append(groups, &streamNames{group: *lg.LogGroupName, groupIdentifier: groupArn})
 				continue
 			}
 
 			for _, prefix := range auto.Streams.Prefixes {
-				groups = append(groups, &streamPrefix{group: *lg.LogGroupName, prefix: prefix})
+				groups = append(groups, &streamPrefix{group: *lg.LogGroupName, groupIdentifier: groupArn, prefix: prefix})
 			}
 
 			if len(auto.Streams.Names) > 0 {
-				groups = append(groups, &streamNames{group: *lg.LogGroupName, names: auto.Streams.Names})
+				groups = append(groups, &streamNames{group: *lg.LogGroupName, groupIdentifier: groupArn, names: auto.Streams.Names})
 			}
 		}
 		nextToken = dlgResults.NextToken

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -84,6 +84,13 @@ func (sn *streamNames) groupName() string {
 	return sn.group
 }
 
+func (sn *streamNames) checkpointKey() string {
+	if sn.groupIdentifier != "" {
+		return sn.groupIdentifier
+	}
+	return sn.group
+}
+
 type streamPrefix struct {
 	group           string
 	groupIdentifier string
@@ -112,9 +119,17 @@ func (sp *streamPrefix) groupName() string {
 	return sp.group
 }
 
+func (sp *streamPrefix) checkpointKey() string {
+	if sp.groupIdentifier != "" {
+		return sp.groupIdentifier
+	}
+	return sp.group
+}
+
 type groupRequest interface {
 	request(limit int, nextToken string, st, et *time.Time) *cloudwatchlogs.FilterLogEventsInput
 	groupName() string
+	checkpointKey() string
 }
 
 func newLogsReceiver(cfg *Config, settings receiver.Settings, consumer consumer.Logs) *logsReceiver {
@@ -238,23 +253,38 @@ func (l *logsReceiver) poll(ctx context.Context) error {
 
 		// Retrieve the last persisted timestamp for this log group if exists
 		if l.cloudwatchCheckpointPersister != nil {
-			logGroup := r.groupName()
-			checkpoint, err := l.cloudwatchCheckpointPersister.GetCheckpoint(ctx, logGroup)
+			cpKey := r.checkpointKey()
+			checkpoint, err := l.cloudwatchCheckpointPersister.GetCheckpoint(ctx, cpKey)
+			if err != nil || checkpoint == "" {
+				// Migrate: try the old key (group name) if the new key (ARN) has no checkpoint
+				oldKey := r.groupName()
+				if oldKey != cpKey {
+					checkpoint, err = l.cloudwatchCheckpointPersister.GetCheckpoint(ctx, oldKey)
+					if err == nil && checkpoint != "" {
+						// Migrate old checkpoint to new key and delete old
+						_ = l.cloudwatchCheckpointPersister.SetCheckpoint(ctx, cpKey, checkpoint)
+						_ = l.cloudwatchCheckpointPersister.DeleteCheckpoint(ctx, oldKey)
+						l.settings.Logger.Info("Migrated checkpoint from log group name to ARN key",
+							zap.String("oldKey", oldKey),
+							zap.String("newKey", cpKey))
+					}
+				}
+			}
 			if err == nil && checkpoint != "" {
 				parsedTime, parseErr := time.Parse(time.RFC3339, checkpoint)
 				if parseErr == nil && parsedTime.After(startTime) {
 					startTime = parsedTime
 					l.settings.Logger.Info("Resuming from previously known checkpoint(s)",
-						zap.String("logGroup", logGroup),
+						zap.String("checkpointKey", cpKey),
 						zap.Time("startTime", startTime))
 				} else if parseErr != nil {
 					l.settings.Logger.Warn("Failed to parse persisted timestamp, using default start time",
-						zap.String("logGroup", logGroup),
+						zap.String("checkpointKey", cpKey),
 						zap.String("checkpoint", checkpoint),
 						zap.Error(parseErr))
-					if err := l.cloudwatchCheckpointPersister.DeleteCheckpoint(ctx, logGroup); err != nil {
+					if err := l.cloudwatchCheckpointPersister.DeleteCheckpoint(ctx, cpKey); err != nil {
 						l.settings.Logger.Error("Failed to delete invalid checkpoint",
-							zap.String("logGroup", logGroup),
+							zap.String("checkpointKey", cpKey),
 							zap.String("checkpoint", checkpoint),
 							zap.Error(err))
 					}
@@ -270,12 +300,12 @@ func (l *logsReceiver) poll(ctx context.Context) error {
 
 		// Persist the new end time as the checkpoint for this log group
 		if l.cloudwatchCheckpointPersister != nil {
-			logGroup := r.groupName()
+			cpKey := r.checkpointKey()
 			newCheckpoint := endTime.Format(time.RFC3339)
-			err := l.cloudwatchCheckpointPersister.SetCheckpoint(ctx, logGroup, newCheckpoint)
+			err := l.cloudwatchCheckpointPersister.SetCheckpoint(ctx, cpKey, newCheckpoint)
 			if err != nil {
 				l.settings.Logger.Error("failed to persist timestamp checkpoint",
-					zap.String("logGroup", logGroup),
+					zap.String("checkpointKey", cpKey),
 					zap.String("checkpoint", newCheckpoint),
 					zap.Error(err))
 			}

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -929,6 +929,77 @@ type mockClient struct {
 	mock.Mock
 }
 
+func TestCheckpointKeyUsesARN(t *testing.T) {
+	arn := "arn:aws:logs:us-east-2:123456789012:log-group:/my/group"
+
+	sn := &streamNames{group: "/my/group", groupIdentifier: arn}
+	require.Equal(t, arn, sn.checkpointKey())
+
+	sp := &streamPrefix{group: "/my/group", groupIdentifier: arn}
+	require.Equal(t, arn, sp.checkpointKey())
+}
+
+func TestCheckpointKeyFallsBackToGroupName(t *testing.T) {
+	sn := &streamNames{group: "/my/group"}
+	require.Equal(t, "/my/group", sn.checkpointKey())
+
+	sp := &streamPrefix{group: "/my/group"}
+	require.Equal(t, "/my/group", sp.checkpointKey())
+}
+
+func TestAutodiscoverTrimsARNSuffix(t *testing.T) {
+	mc := &mockClient{}
+	logGroupName := "/test/group"
+	logGroupARN := "arn:aws:logs:us-east-2:123456789012:log-group:/test/group:*"
+
+	mc.On("DescribeLogGroups", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []types.LogGroup{
+				{
+					LogGroupName: &logGroupName,
+					Arn:          &logGroupARN,
+				},
+			},
+			NextToken: nil,
+		}, nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-east-2"
+	cfg.Logs.Groups = GroupConfig{
+		AutodiscoverConfig: &AutodiscoverConfig{
+			Limit: 10,
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	rcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+	rcvr.client = mc
+
+	grs, err := rcvr.discoverGroups(t.Context(), cfg.Logs.Groups.AutodiscoverConfig)
+	require.NoError(t, err)
+	require.Len(t, grs, 1)
+	require.Equal(t, logGroupName, grs[0].groupName())
+	// The checkpoint key should use the trimmed ARN (no :* suffix)
+	require.Equal(t, "arn:aws:logs:us-east-2:123456789012:log-group:/test/group", grs[0].checkpointKey())
+}
+
+func TestLogGroupIdentifierUsedInFilterRequest(t *testing.T) {
+	arn := "arn:aws:logs:us-east-2:123456789012:log-group:/my/group"
+	sn := &streamNames{group: "/my/group", groupIdentifier: arn}
+
+	st := time.Now().Add(-time.Hour)
+	et := time.Now()
+	req := sn.request(100, "", &st, &et)
+
+	require.NotNil(t, req.LogGroupIdentifier)
+	require.Equal(t, arn, *req.LogGroupIdentifier)
+	require.Nil(t, req.LogGroupName)
+}
+
 func (mc *mockClient) DescribeLogGroups(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 	args := mc.Called(ctx, input, opts)
 	return args.Get(0).(*cloudwatchlogs.DescribeLogGroupsOutput), args.Error(1)


### PR DESCRIPTION
Reopened from #47746 (stale-closed). Uses ARN via LogGroupIdentifier for cross-account OAM discovery instead of LogGroupName. Fixes #46159