### PR TITLE
[receiver/awscloudwatch] Fix paginated empty pages incorrectly setting checkpoint

### DIFF
--- a/.chloggen/dylan_handle-blank-pagination.yaml
+++ b/.chloggen/dylan_handle-blank-pagination.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/awscloudwatch
+component: receiver/aws_cloudwatch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix logs being skipped when AWS pagination returns an empty page

--- a/.chloggen/dylan_handle-blank-pagination.yaml
+++ b/.chloggen/dylan_handle-blank-pagination.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix logs being skipped when AWS pagination returns an empty page
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48577]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dylan_handle-blank-pagination.yaml
+++ b/.chloggen/dylan_handle-blank-pagination.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/awscloudwatchreceiver
+component: receiver/awscloudwatch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix logs being skipped when AWS pagination returns an empty page

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -332,12 +332,15 @@ func (l *logsReceiver) pollForLogs(ctx context.Context, pc groupRequest, startTi
 				}
 				// the next timestamp should be 1 more millisecond than the last log
 				nextStartTime = time.UnixMilli(*resp.Events[len(resp.Events)-1].Timestamp + 1)
-			} else {
-				// Skip the time range in case there are no logs
-				nextStartTime = endTime
 			}
 			nextToken = resp.NextToken
 		}
+	}
+
+	// If no events were observed across any page of this window, advance to
+	// endTime so we don't repeatedly re-scan the same empty range.
+	if nextStartTime.Equal(startTime) {
+		nextStartTime = endTime
 	}
 
 	return nextStartTime, nil

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -899,6 +899,71 @@ func TestPollForLogsSetsCheckpointNoData(t *testing.T) {
 	require.Equal(t, expectedTimestamp.UnixMilli(), requiredTime.UnixMilli())
 }
 
+func TestPollForLogsEmptyPaginatedPagePreservesCheckpoint(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.PollInterval = 1 * time.Second
+	cfg.Logs.Groups = GroupConfig{
+		NamedConfigs: map[string]StreamConfig{
+			testLogGroupName: {
+				Names: []*string{&testLogStreamName},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	logsRcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+	mc := mockClient{}
+
+	lastEventTime := time.Date(2020, 1, 1, 0, 0, 30, 0, time.UTC)
+	startTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2020, 1, 1, 0, 1, 0, 0, time.UTC)
+	expectedNextStartTime := lastEventTime.Add(1 * time.Millisecond)
+
+	mc.On("FilterLogEvents", mock.Anything, mock.MatchedBy(
+		func(input *cloudwatchlogs.FilterLogEventsInput) bool {
+			return input.NextToken == nil
+		},
+	), mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events: []types.FilteredLogEvent{
+			{
+				EventId:       aws.String("event1"),
+				LogStreamName: aws.String("stream1"),
+				Message:       aws.String("test message"),
+				Timestamp:     aws.Int64(lastEventTime.UnixMilli()),
+			},
+		},
+		NextToken: aws.String("next-page-token"),
+	}, nil).Once()
+
+	// Paginated follow-up returns empty events despite the prior NextToken.
+	mc.On("FilterLogEvents", mock.Anything, mock.MatchedBy(
+		func(input *cloudwatchlogs.FilterLogEventsInput) bool {
+			return input.NextToken != nil && *input.NextToken == "next-page-token"
+		},
+	), mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events:    []types.FilteredLogEvent{},
+		NextToken: nil,
+	}, nil).Once()
+
+	logsRcvr.client = &mc
+	gotNextStartTime, err := logsRcvr.pollForLogs(
+		t.Context(),
+		&streamNames{group: testLogGroupName, names: []*string{&testLogStreamName}},
+		startTime,
+		endTime,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedNextStartTime.UnixMilli(), gotNextStartTime.UnixMilli(),
+		"empty paginated page must not overwrite the last-seen event timestamp")
+	mc.AssertExpectations(t)
+}
+
 func TestPollSetsGroupNextStartTimes(t *testing.T) {
 	logGroup1 := "log-group-1"
 	logGroup2 := "log-group-2"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Empty paginated `FilterLogEvents` responses were overwriting the last event timestamp with the current window's end time instead of the last log received. This caused logs near a window boundary to occasionally be skipped on the next poll.

The [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html) points out that empty paginated responses are possible.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48577

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Created a test that specifically tests the case where an empty page is returned from AWS and made sure the last event timestamp was correctly set. 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
