### PR TITLE
[chore] Remove deprecated SetKnown from logs config

### DIFF
--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -208,7 +208,6 @@ func WithLogsDefaults() ConfigOption {
 		pkgconfig.Set("logs_config.sender_recovery_interval", pkgconfigsetup.DefaultForwarderRecoveryInterval, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.stop_grace_period", 30, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.use_v2_api", true, pkgconfigmodel.SourceDefault)
-		pkgconfig.SetKnown("logs_config.dev_mode_no_ssl")
 		// add logs config pipelines config value, see https://github.com/DataDog/datadog-agent/pull/31190
 		logsPipelines := min(4, runtime.GOMAXPROCS(0))
 		pkgconfig.Set("logs_config.pipelines", logsPipelines, pkgconfigmodel.SourceDefault)


### PR DESCRIPTION
#### Description

The method SetKnown is being removed from the DD Agent Config's API. It has already been removed from the datadog-agent codebase, aside from internal code and tests. Removing this line should be safe, since the setting `logs_config.dev_mode_no_ssl` is deprecated and no longer in use.

#### Link to tracking issue

N/A

#### Testing

Built using `make otelcontribcol`

#### Documentation

N/A

#### Authorship

- [X] I, a human, wrote this pull request description myself.