### PR TITLE
[chore] [pkg/pdatatest] Keep pmetricassert normalization non-validating

### DIFF
--- a/.chloggen/48775-pmetricassert-normalize-no-validation.yaml
+++ b/.chloggen/48775-pmetricassert-normalize-no-validation.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pkg/pdatatest
+note: Keep pmetricassert normalization from returning validation errors for duplicate datapoints
+issues: [48775]
+change_logs: [api]

--- a/pkg/pdatatest/pmetricassert/README.md
+++ b/pkg/pdatatest/pmetricassert/README.md
@@ -35,6 +35,9 @@ The following are ignored:
 - batch boundaries — multiple `ResourceMetrics` / `ScopeMetrics` / `Metric`
   entries with the same identity are normalized before comparison.
 
+`WriteAssertionFile` expects semantically valid metrics. It normalizes valid
+metrics into an assertion snapshot; it is not a validator for producer output.
+
 ## Typical usage
 
 ```go

--- a/pkg/pdatatest/pmetricassert/assert.go
+++ b/pkg/pdatatest/pmetricassert/assert.go
@@ -24,10 +24,7 @@ func AssertMetrics(expectedPath string, actual pmetric.Metrics) error {
 	if err != nil {
 		return err
 	}
-	actualDoc, err := normalize(actual, writeOptions{includeValues: true})
-	if err != nil {
-		return err
-	}
+	actualDoc := normalize(actual, writeOptions{includeValues: true})
 	return compareDocuments(expected, actualDoc)
 }
 

--- a/pkg/pdatatest/pmetricassert/normalize.go
+++ b/pkg/pdatatest/pmetricassert/normalize.go
@@ -5,7 +5,6 @@ package pmetricassert // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -16,9 +15,9 @@ import (
 //
 // Normalization merges compatible resources (by resource attributes), scopes
 // (by name+version) and metrics (by name) so that batch boundaries do not
-// influence the assertion. Datapoints are folded into a set keyed by their
-// attribute values; duplicate logical MTS entries collapse to one.
-func normalize(m pmetric.Metrics, opts writeOptions) (*document, error) {
+// influence the assertion. Datapoints are keyed by their attribute values for
+// order-insensitive comparison.
+func normalize(m pmetric.Metrics, opts writeOptions) *document {
 	type dpKey struct {
 		attrs string
 	}
@@ -77,12 +76,6 @@ func normalize(m pmetric.Metrics, opts writeOptions) (*document, error) {
 				for _, extDP := range extractDatapointAttributes(metric) {
 					raw := attrMapToRaw(extDP.attributes)
 					key := dpKey{attrs: canonKey(raw)}
-					if _, dup := mAgg.datapoints[key]; dup {
-						if opts.includeValues {
-							return nil, fmt.Errorf("duplicate datapoint for metric %q with attributes %s", metric.Name(), key.attrs)
-						}
-						continue
-					}
 					dp := datapointAssertion{Attributes: raw}
 					if opts.includeValues && extDP.value != nil {
 						dp.Value = extDP.value
@@ -135,7 +128,7 @@ func normalize(m pmetric.Metrics, opts writeOptions) (*document, error) {
 		}
 		doc.Resources = append(doc.Resources, res)
 	}
-	return doc, nil
+	return doc
 }
 
 func buildMetricAssertion(metric pmetric.Metric) metricAssertion {

--- a/pkg/pdatatest/pmetricassert/write.go
+++ b/pkg/pdatatest/pmetricassert/write.go
@@ -37,15 +37,16 @@ func IncludeValues() WriteOption {
 // name/version, metric name/type/unit/temporality/monotonic, and the set of
 // datapoint attribute permutations. Values, timestamps, and exemplars are
 // omitted.
+//
+// The input metrics must be semantically valid. WriteAssertionFile normalizes
+// valid metrics for assertion readability; it does not validate producer
+// output.
 func WriteAssertionFile(tb testing.TB, path string, actual pmetric.Metrics, opts ...WriteOption) error {
 	tb.Helper()
 	var o writeOptions
 	for _, opt := range opts {
 		opt.apply(&o)
 	}
-	doc, err := normalize(actual, o)
-	if err != nil {
-		return err
-	}
+	doc := normalize(actual, o)
 	return writeDocument(path, doc)
 }


### PR DESCRIPTION
Fixes a divergence from a goal outlined in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48106 introduced in open-telemetry/opentelemetry-collector-contrib#48541

Normalization should only canonicalize semantically valid metrics into pmetricassert documents; it should not return validation errors. `WriteAssertionFile` now documents that its input must already be semantically valid, leaving producer-output validation to the separate pmetrictest validator work.