### PR TITLE
[exporter/azuremonitor] add tag_mappings config for envelope tags

### DIFF
--- a/.chloggen/azuremonitor-tag-mappings.yaml
+++ b/.chloggen/azuremonitor-tag-mappings.yaml
@@ -1,0 +1,41 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `tag_mappings` config to override the resource-attribute precedence used to populate Application Insights envelope tags
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47657]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The optional `tag_mappings:` block accepts an ordered list of sources per tag.
+  Sources containing a `.` are treated as resource attribute keys; sources
+  without a `.` are treated as string-literal terminal defaults. The first
+  non-empty value wins.
+
+  Supported keys: `cloud_role_instance` (default `[service.instance.id]`)
+  and `application_version` (default `[service.version]`). Defaults preserve
+  the historical hardcoded behavior; zero-config users see no change.
+
+  Example for Azure Container Apps:
+      tag_mappings:
+        cloud_role_instance: [host.name, service.instance.id]
+
+  Marked alpha; the schema may evolve.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -45,6 +45,35 @@ The following settings can be optionally configured:
 - `shutdown_timeout` (default = 1s): Timeout to wait for graceful shutdown. Once exceeded, the component will shut down forcibly, dropping any element in queue.
 - `custom_events_enabled` (default = `false`): Enables export log record to custom events when there's attribute `microsoft.custom_event.name` or `APPLICATION_INSIGHTS_EVENT_MARKER_ATTRIBUTE`.
 
+### Tag mappings (alpha)
+
+The optional `tag_mappings:` block overrides how selected Application Insights envelope tags are populated from OpenTelemetry resource attributes. Each field takes an ordered list of sources; the first one that resolves to a non-empty string wins.
+
+A source entry is interpreted as:
+- a **resource attribute key** when it contains a `.` (e.g. `service.instance.id`, `host.name`)
+- a **string literal terminal default** when it does not contain a `.` (e.g. `unknown-instance`)
+
+Defaults preserve the historical hardcoded behavior — when a field is unset, zero-config users see no change.
+
+| Mapping key           | Application Insights tag      | Default                  |
+| --------------------- | ----------------------------- | ------------------------ |
+| `cloud_role_instance` | `ai.cloud.roleInstance`       | `[service.instance.id]`  |
+| `application_version` | `ai.application.ver`          | `[service.version]`      |
+
+> The `cloud_role_name` tag (`ai.cloud.role`) is not yet configurable; its hardcoded `service.namespace`/`service.name` concatenation continues to apply.
+
+Example — Azure Container Apps, where `service.instance.id` is set to a random uuid and operators want the revision/replica hostname instead:
+
+```yaml
+exporters:
+  azuremonitor:
+    connection_string: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/"
+    tag_mappings:
+      cloud_role_instance: [host.name, service.instance.id, unknown-instance]
+```
+
+Validation rejects an explicitly empty array (`cloud_role_instance: []`) at startup. The feature is alpha and the schema may evolve.
+
 Example:
 
 ```yaml

--- a/exporter/azuremonitorexporter/azuremonitor_exporter.go
+++ b/exporter/azuremonitorexporter/azuremonitor_exporter.go
@@ -113,7 +113,7 @@ func (v *traceVisitor) visit(
 	scope pcommon.InstrumentationScope,
 	span ptrace.Span,
 ) (ok bool) {
-	envelopes, err := spanToEnvelopes(resource, scope, span, v.exporter.config.SpanEventsEnabled, v.exporter.logger)
+	envelopes, err := spanToEnvelopes(resource, scope, span, v.exporter.config.SpanEventsEnabled, &v.exporter.config.TagMappings, v.exporter.logger)
 	if err != nil {
 		// record the error and short-circuit
 		v.err = consumererror.NewPermanent(err)

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -4,6 +4,7 @@
 package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 
 import (
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -23,5 +24,44 @@ type Config struct {
 	ShutdownTimeout        time.Duration                                            `mapstructure:"shutdown_timeout"`
 	CustomEventsEnabled    bool                                                     `mapstructure:"custom_events_enabled"`
 	ExceptionEventsEnabled bool                                                     `mapstructure:"exception_events_enabled"`
+	TagMappings            TagMappingsConfig                                        `mapstructure:"tag_mappings"`
 	ClientConfig           confighttp.ClientConfig                                  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+}
+
+// TagMappingsConfig overrides the precedence used to populate selected
+// Application Insights envelope tags from OpenTelemetry resource attributes.
+// Each field is an ordered list of sources consulted left-to-right; the first
+// source that resolves to a non-empty string wins.
+//
+// A source entry is interpreted as a resource attribute key when it contains a
+// "." (e.g. "service.instance.id"); otherwise it is treated as a string
+// literal terminal default (e.g. "unknown-instance").
+//
+// When a field is left unset, the factory default — which preserves the
+// historical hardcoded behavior — is used. This feature is alpha and the
+// schema may evolve.
+type TagMappingsConfig struct {
+	// CloudRoleInstance controls how the ai.cloud.roleInstance envelope tag is
+	// populated. Default: [service.instance.id].
+	CloudRoleInstance []string `mapstructure:"cloud_role_instance"`
+
+	// ApplicationVersion controls how the ai.application.ver envelope tag is
+	// populated. Default: [service.version].
+	ApplicationVersion []string `mapstructure:"application_version"`
+}
+
+// Validate enforces invariants on the configured tag mappings.
+func (m TagMappingsConfig) Validate() error {
+	if m.CloudRoleInstance != nil && len(m.CloudRoleInstance) == 0 {
+		return fmt.Errorf("tag_mappings.cloud_role_instance must contain at least one source when set")
+	}
+	if m.ApplicationVersion != nil && len(m.ApplicationVersion) == 0 {
+		return fmt.Errorf("tag_mappings.application_version must contain at least one source when set")
+	}
+	return nil
+}
+
+// Validate forwards to nested config validators.
+func (c *Config) Validate() error {
+	return c.TagMappings.Validate()
 }

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -4,7 +4,7 @@
 package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -53,10 +53,10 @@ type TagMappingsConfig struct {
 // Validate enforces invariants on the configured tag mappings.
 func (m TagMappingsConfig) Validate() error {
 	if m.CloudRoleInstance != nil && len(m.CloudRoleInstance) == 0 {
-		return fmt.Errorf("tag_mappings.cloud_role_instance must contain at least one source when set")
+		return errors.New("tag_mappings.cloud_role_instance must contain at least one source when set")
 	}
 	if m.ApplicationVersion != nil && len(m.ApplicationVersion) == 0 {
-		return fmt.Errorf("tag_mappings.application_version must contain at least one source when set")
+		return errors.New("tag_mappings.application_version must contain at least one source when set")
 	}
 	return nil
 }

--- a/exporter/azuremonitorexporter/config.schema.yaml
+++ b/exporter/azuremonitorexporter/config.schema.yaml
@@ -1,3 +1,18 @@
+$defs:
+  tag_mappings_config:
+    description: TagMappingsConfig overrides the precedence used to populate selected Application Insights envelope tags from OpenTelemetry resource attributes. Each field is an ordered list of sources consulted left-to-right; the first source that resolves to a non-empty string wins. A source entry is interpreted as a resource attribute key when it contains a "." (e.g. "service.instance.id"); otherwise it is treated as a string literal terminal default (e.g. "unknown-instance"). When a field is left unset, the factory default — which preserves the historical hardcoded behavior — is used. This feature is alpha and the schema may evolve.
+    type: object
+    properties:
+      application_version:
+        description: 'ApplicationVersion controls how the ai.application.ver envelope tag is populated. Default: [service.version].'
+        type: array
+        items:
+          type: string
+      cloud_role_instance:
+        description: 'CloudRoleInstance controls how the ai.cloud.roleInstance envelope tag is populated. Default: [service.instance.id].'
+        type: array
+        items:
+          type: string
 description: Config defines configuration for Azure Monitor
 type: object
 properties:
@@ -22,5 +37,7 @@ properties:
     format: duration
   spaneventsenabled:
     type: boolean
+  tag_mappings:
+    $ref: tag_mappings_config
 allOf:
   - $ref: go.opentelemetry.io/collector/config/confighttp.client_config

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -55,7 +55,23 @@ func TestLoadConfig(t *testing.T) {
 					return queue
 				}()),
 				ShutdownTimeout: 2 * time.Second,
+				TagMappings: TagMappingsConfig{
+					CloudRoleInstance:  []string{"service.instance.id"},
+					ApplicationVersion: []string{"service.version"},
+				},
 			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "tag_mappings"),
+			expected: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/"
+				cfg.TagMappings = TagMappingsConfig{
+					CloudRoleInstance:  []string{"host.name", "service.instance.id", "unknown-instance"},
+					ApplicationVersion: []string{"service.version"},
+				}
+				return cfg
+			}(),
 		},
 	}
 
@@ -70,6 +86,58 @@ func TestLoadConfig(t *testing.T) {
 
 			assert.NoError(t, xconfmap.Validate(cfg))
 			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr string
+	}{
+		{
+			name: "default config is valid",
+			cfg:  createDefaultConfig().(*Config),
+		},
+		{
+			name: "tag_mappings unset is valid",
+			cfg:  &Config{},
+		},
+		{
+			name: "configured tag_mappings are valid",
+			cfg: &Config{TagMappings: TagMappingsConfig{
+				CloudRoleInstance:  []string{"host.name", "service.instance.id"},
+				ApplicationVersion: []string{"service.version", "v0.0.0"},
+			}},
+		},
+		{
+			name: "explicit empty cloud_role_instance is rejected",
+			cfg: &Config{TagMappings: TagMappingsConfig{
+				CloudRoleInstance: []string{},
+			}},
+			wantErr: "tag_mappings.cloud_role_instance must contain at least one source when set",
+		},
+		{
+			name: "explicit empty application_version is rejected",
+			cfg: &Config{TagMappings: TagMappingsConfig{
+				ApplicationVersion: []string{},
+			}},
+			wantErr: "tag_mappings.application_version must contain at least one source when set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
 		})
 	}
 }

--- a/exporter/azuremonitorexporter/contracts_mapping.go
+++ b/exporter/azuremonitorexporter/contracts_mapping.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// resolveMapping walks an ordered list of sources and returns the first
+// non-empty value, plus true. Sources are interpreted as follows:
+//   - An entry containing "." is treated as a resource attribute key;
+//     resolveMapping looks it up in attrs and uses its string value when
+//     present and non-empty.
+//   - An entry not containing "." is treated as a string literal terminal
+//     default and is always selected when reached.
+//
+// If no source resolves to a non-empty value, ("", false) is returned and the
+// caller is expected to omit the destination tag.
+//
+// When sources is nil or empty the function returns ("", false); callers
+// should treat that as "no override configured" and fall back to their
+// historical hardcoded behavior. Validation rejects an explicitly-empty
+// configured slice (see TagMappingsConfig.Validate), so an empty slice at this
+// layer can only originate from a caller that did not configure tag mappings.
+func resolveMapping(attrs pcommon.Map, sources []string) (string, bool) {
+	for _, src := range sources {
+		if !strings.Contains(src, ".") {
+			// Terminal literal default.
+			return src, true
+		}
+		if v, ok := attrs.Get(src); ok {
+			if s := v.Str(); s != "" {
+				return s, true
+			}
+		}
+	}
+	return "", false
+}

--- a/exporter/azuremonitorexporter/contracts_mapping_test.go
+++ b/exporter/azuremonitorexporter/contracts_mapping_test.go
@@ -1,0 +1,192 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuremonitorexporter
+
+import (
+	"testing"
+
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestResolveMapping(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("host.name", "host-1")
+	attrs.PutStr("service.instance.id", "instance-1")
+	attrs.PutStr("empty.value", "")
+
+	tests := []struct {
+		name      string
+		sources   []string
+		wantValue string
+		wantOK    bool
+	}{
+		{
+			name:   "nil sources returns no value",
+			wantOK: false,
+		},
+		{
+			name:    "empty sources returns no value",
+			sources: []string{},
+			wantOK:  false,
+		},
+		{
+			name:      "first source resolves",
+			sources:   []string{"host.name", "service.instance.id"},
+			wantValue: "host-1",
+			wantOK:    true,
+		},
+		{
+			name:      "falls through missing attribute to next source",
+			sources:   []string{"not.present", "service.instance.id"},
+			wantValue: "instance-1",
+			wantOK:    true,
+		},
+		{
+			name:      "skips empty-string attribute value",
+			sources:   []string{"empty.value", "host.name"},
+			wantValue: "host-1",
+			wantOK:    true,
+		},
+		{
+			name:      "all attributes missing, terminal literal selected",
+			sources:   []string{"a.b", "c.d", "unknown-instance"},
+			wantValue: "unknown-instance",
+			wantOK:    true,
+		},
+		{
+			name:      "literal at start short-circuits remaining sources",
+			sources:   []string{"literal", "host.name"},
+			wantValue: "literal",
+			wantOK:    true,
+		},
+		{
+			name:    "no literal, all attributes missing, no value",
+			sources: []string{"a.b", "c.d"},
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveMapping(attrs, tt.sources)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantValue, got)
+		})
+	}
+}
+
+func TestApplyCloudTagsToEnvelope_DefaultBehavior(t *testing.T) {
+	// nil mappings ⇒ historical hardcoded behavior:
+	// service.instance.id alone populates CloudRoleInstance.
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.name", "svc")
+	attrs.PutStr("service.instance.id", "instance-1")
+	attrs.PutStr("host.name", "host-1")
+
+	applyCloudTagsToEnvelope(envelope, attrs, nil)
+
+	assert.Equal(t, "svc", envelope.Tags[contracts.CloudRole])
+	assert.Equal(t, "instance-1", envelope.Tags[contracts.CloudRoleInstance])
+}
+
+func TestApplyCloudTagsToEnvelope_DefaultBehavior_OmitsWhenServiceInstanceIDMissing(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.name", "svc")
+	attrs.PutStr("host.name", "host-1")
+
+	applyCloudTagsToEnvelope(envelope, attrs, nil)
+
+	_, present := envelope.Tags[contracts.CloudRoleInstance]
+	assert.False(t, present, "default behavior must not fall back to host.name silently")
+}
+
+func TestApplyCloudTagsToEnvelope_MappingOverride(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.name", "svc")
+	attrs.PutStr("service.instance.id", "instance-1")
+	attrs.PutStr("host.name", "host-1")
+
+	tagMappings := &TagMappingsConfig{
+		CloudRoleInstance: []string{"host.name", "service.instance.id"},
+	}
+	applyCloudTagsToEnvelope(envelope, attrs, tagMappings)
+
+	assert.Equal(t, "host-1", envelope.Tags[contracts.CloudRoleInstance],
+		"configured precedence must override historical default")
+}
+
+func TestApplyCloudTagsToEnvelope_MappingFallsThroughToLiteral(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.name", "svc")
+
+	tagMappings := &TagMappingsConfig{
+		CloudRoleInstance: []string{"host.name", "service.instance.id", "unknown-instance"},
+	}
+	applyCloudTagsToEnvelope(envelope, attrs, tagMappings)
+
+	assert.Equal(t, "unknown-instance", envelope.Tags[contracts.CloudRoleInstance])
+}
+
+func TestApplyCloudTagsToEnvelope_MappingNoMatchOmitsTag(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+
+	tagMappings := &TagMappingsConfig{
+		CloudRoleInstance: []string{"host.name", "service.instance.id"},
+	}
+	applyCloudTagsToEnvelope(envelope, attrs, tagMappings)
+
+	_, present := envelope.Tags[contracts.CloudRoleInstance]
+	assert.False(t, present)
+}
+
+func TestApplyApplicationTagsToEnvelope_DefaultBehavior(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.version", "1.2.3")
+
+	applyApplicationTagsToEnvelope(envelope, attrs, nil)
+
+	assert.Equal(t, "1.2.3", envelope.Tags[contracts.ApplicationVersion])
+}
+
+func TestApplyApplicationTagsToEnvelope_MappingOverride(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.version", "1.2.3")
+	attrs.PutStr("my.custom.version", "9.9.9")
+
+	tagMappings := &TagMappingsConfig{
+		ApplicationVersion: []string{"my.custom.version", "service.version"},
+	}
+	applyApplicationTagsToEnvelope(envelope, attrs, tagMappings)
+
+	assert.Equal(t, "9.9.9", envelope.Tags[contracts.ApplicationVersion])
+}
+
+func TestApplyApplicationTagsToEnvelope_MappingFallsThroughToLiteral(t *testing.T) {
+	envelope := contracts.NewEnvelope()
+	envelope.Tags = map[string]string{}
+	attrs := pcommon.NewMap()
+
+	tagMappings := &TagMappingsConfig{
+		ApplicationVersion: []string{"service.version", "unknown"},
+	}
+	applyApplicationTagsToEnvelope(envelope, attrs, tagMappings)
+
+	assert.Equal(t, "unknown", envelope.Tags[contracts.ApplicationVersion])
+}

--- a/exporter/azuremonitorexporter/contracts_utils.go
+++ b/exporter/azuremonitorexporter/contracts_utils.go
@@ -22,8 +22,9 @@ func applyResourcesToDataProperties(dataProperties map[string]string, resourceAt
 	}
 }
 
-// Sets important ai.cloud.* tags on the envelope
-func applyCloudTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map) {
+// Sets important ai.cloud.* tags on the envelope. When tagMappings is non-nil it
+// takes precedence over the historical hardcoded ServiceInstanceID source.
+func applyCloudTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map, tagMappings *TagMappingsConfig) {
 	// Extract key service.* labels from the Resource labels and construct CloudRole and CloudRoleInstance envelope tags
 	// https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions
 	if serviceName, serviceNameExists := resourceAttributes.Get(string(conventions.ServiceNameKey)); serviceNameExists {
@@ -36,15 +37,26 @@ func applyCloudTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes p
 		envelope.Tags[contracts.CloudRole] = cloudRole
 	}
 
-	if serviceInstance, exists := resourceAttributes.Get(string(conventions.ServiceInstanceIDKey)); exists {
+	if tagMappings != nil && tagMappings.CloudRoleInstance != nil {
+		if v, ok := resolveMapping(resourceAttributes, tagMappings.CloudRoleInstance); ok {
+			envelope.Tags[contracts.CloudRoleInstance] = v
+		}
+	} else if serviceInstance, exists := resourceAttributes.Get(string(conventions.ServiceInstanceIDKey)); exists {
 		envelope.Tags[contracts.CloudRoleInstance] = serviceInstance.Str()
 	}
 
 	envelope.Tags[contracts.InternalSdkVersion] = getCollectorVersion()
 }
 
-// Sets ai.application.* tags on the envelope
-func applyApplicationTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map) {
+// Sets ai.application.* tags on the envelope. When tagMappings is non-nil it
+// takes precedence over the historical hardcoded ServiceVersion source.
+func applyApplicationTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map, tagMappings *TagMappingsConfig) {
+	if tagMappings != nil && tagMappings.ApplicationVersion != nil {
+		if v, ok := resolveMapping(resourceAttributes, tagMappings.ApplicationVersion); ok {
+			envelope.Tags[contracts.ApplicationVersion] = v
+		}
+		return
+	}
 	if serviceVersion, serviceVersionExists := resourceAttributes.Get(string(conventions.ServiceVersionKey)); serviceVersionExists {
 		envelope.Tags[contracts.ApplicationVersion] = serviceVersion.Str()
 	}

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter/internal/metadata"
@@ -53,6 +54,10 @@ func createDefaultConfig() component.Config {
 		QueueSettings:       configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 		ShutdownTimeout:     1 * time.Second,
 		CustomEventsEnabled: false,
+		TagMappings: TagMappingsConfig{
+			CloudRoleInstance:  []string{string(conventions.ServiceInstanceIDKey)},
+			ApplicationVersion: []string{string(conventions.ServiceVersionKey)},
+		},
 	}
 }
 
@@ -131,7 +136,7 @@ func getOrCreateAzureMonitorExporter(cfg component.Config, set exporter.Settings
 		return &azureMonitorExporter{
 			config:   conf,
 			logger:   set.Logger,
-			packer:   newMetricPacker(set.Logger),
+			packer:   newMetricPacker(set.Logger, conf),
 			settings: set.TelemetrySettings,
 		}
 	})

--- a/exporter/azuremonitorexporter/log_to_envelope.go
+++ b/exporter/azuremonitorexporter/log_to_envelope.go
@@ -64,14 +64,23 @@ func (packer *logPacker) handleMessageData(envelope *contracts.Envelope, data *c
 	resourceAttributes := resource.Attributes()
 	applyResourcesToDataProperties(messageData.Properties, resourceAttributes)
 	applyInstrumentationScopeValueToDataProperties(messageData.Properties, instrumentationScope)
-	applyCloudTagsToEnvelope(envelope, resourceAttributes)
-	applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+	applyCloudTagsToEnvelope(envelope, resourceAttributes, packer.tagMappings())
+	applyApplicationTagsToEnvelope(envelope, resourceAttributes, packer.tagMappings())
 	applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 	applyInternalSdkVersionTagToEnvelope(envelope)
 
 	setAttributesAsProperties(logRecord.Attributes(), messageData.Properties)
 
 	packer.sanitizeAll(envelope, messageData)
+}
+
+// tagMappings returns the configured envelope tag mappings if any, else nil
+// to signal historical hardcoded behavior to the envelope helpers.
+func (packer *logPacker) tagMappings() *TagMappingsConfig {
+	if packer.config == nil {
+		return nil
+	}
+	return &packer.config.TagMappings
 }
 
 func (packer *logPacker) sanitizeAll(envelope *contracts.Envelope, data any) {
@@ -120,8 +129,8 @@ func (packer *logPacker) handleExceptionData(envelope *contracts.Envelope, data 
 	resourceAttributes := resource.Attributes()
 	applyResourcesToDataProperties(exceptionData.Properties, resourceAttributes)
 	applyInstrumentationScopeValueToDataProperties(exceptionData.Properties, instrumentationScope)
-	applyCloudTagsToEnvelope(envelope, resourceAttributes)
-	applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+	applyCloudTagsToEnvelope(envelope, resourceAttributes, packer.tagMappings())
+	applyApplicationTagsToEnvelope(envelope, resourceAttributes, packer.tagMappings())
 	applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 	applyInternalSdkVersionTagToEnvelope(envelope)
 

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -220,7 +220,7 @@ func getLogsExporter(config *Config, transportChannel appinsights.TelemetryChann
 		transportChannel,
 		exportertest.NewNopSettings(metadata.Type).TelemetrySettings,
 		zap.NewNop(),
-		newMetricPacker(zap.NewNop()),
+		newMetricPacker(zap.NewNop(), nil),
 	}
 }
 

--- a/exporter/azuremonitorexporter/metric_to_envelopes.go
+++ b/exporter/azuremonitorexporter/metric_to_envelopes.go
@@ -14,6 +14,7 @@ import (
 
 type metricPacker struct {
 	logger *zap.Logger
+	config *Config
 }
 
 type timedMetricDataPoint struct {
@@ -53,8 +54,8 @@ func (packer *metricPacker) MetricToEnvelopes(metric pmetric.Metric, resource pc
 			resourceAttributes := resource.Attributes()
 			applyResourcesToDataProperties(metricData.Properties, resourceAttributes)
 			applyInstrumentationScopeValueToDataProperties(metricData.Properties, instrumentationScope)
-			applyCloudTagsToEnvelope(envelope, resourceAttributes)
-			applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+			applyCloudTagsToEnvelope(envelope, resourceAttributes, packer.tagMappings())
+			applyApplicationTagsToEnvelope(envelope, resourceAttributes, packer.tagMappings())
 			applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 			applyInternalSdkVersionTagToEnvelope(envelope)
 
@@ -79,11 +80,21 @@ func (packer *metricPacker) sanitize(sanitizeFunc func() []string) {
 	}
 }
 
-func newMetricPacker(logger *zap.Logger) *metricPacker {
+func newMetricPacker(logger *zap.Logger, config *Config) *metricPacker {
 	packer := &metricPacker{
 		logger: logger,
+		config: config,
 	}
 	return packer
+}
+
+// tagMappings returns the configured envelope tag mappings if any, else nil
+// to signal historical hardcoded behavior to the envelope helpers.
+func (packer *metricPacker) tagMappings() *TagMappingsConfig {
+	if packer.config == nil {
+		return nil
+	}
+	return &packer.config.TagMappings
 }
 
 func (packer metricPacker) getMetricTimedData(metric pmetric.Metric) metricTimedData {

--- a/exporter/azuremonitorexporter/metricexporter_test.go
+++ b/exporter/azuremonitorexporter/metricexporter_test.go
@@ -146,12 +146,12 @@ func getAzureMonitorExporter(config *Config, transportChannel appinsights.Teleme
 		transportChannel,
 		exportertest.NewNopSettings(metadata.Type).TelemetrySettings,
 		zap.NewNop(),
-		newMetricPacker(zap.NewNop()),
+		newMetricPacker(zap.NewNop(), nil),
 	}
 }
 
 func getMetricPacker() *metricPacker {
-	return newMetricPacker(zap.NewNop())
+	return newMetricPacker(zap.NewNop(), nil)
 }
 
 func getTestMetrics() pmetric.Metrics {

--- a/exporter/azuremonitorexporter/testdata/config.yaml
+++ b/exporter/azuremonitorexporter/testdata/config.yaml
@@ -20,4 +20,10 @@ azuremonitor/2:
     num_consumers: 10
     storage: disk
 
+azuremonitor/tag_mappings:
+  connection_string: InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/
+  tag_mappings:
+    cloud_role_instance: [host.name, service.instance.id, unknown-instance]
+    application_version: [service.version]
+
 disk/3:

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -55,6 +55,7 @@ func spanToEnvelopes(
 	instrumentationScope pcommon.InstrumentationScope,
 	span ptrace.Span,
 	spanEventsEnabled bool,
+	tagMappings *TagMappingsConfig,
 	logger *zap.Logger,
 ) ([]*contracts.Envelope, error) {
 	spanKind := span.Kind()
@@ -122,8 +123,8 @@ func spanToEnvelopes(
 	resourceAttributes := resource.Attributes()
 	applyResourcesToDataProperties(dataProperties, resourceAttributes)
 	applyInstrumentationScopeValueToDataProperties(dataProperties, instrumentationScope)
-	applyCloudTagsToEnvelope(envelope, resourceAttributes)
-	applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+	applyCloudTagsToEnvelope(envelope, resourceAttributes, tagMappings)
+	applyApplicationTagsToEnvelope(envelope, resourceAttributes, tagMappings)
 	applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 	applyInternalSdkVersionTagToEnvelope(envelope)
 	applyLinksToDataProperties(dataProperties, span.Links(), logger)
@@ -171,8 +172,8 @@ func spanToEnvelopes(
 
 		applyResourcesToDataProperties(dataProperties, resourceAttributes)
 		applyInstrumentationScopeValueToDataProperties(dataProperties, instrumentationScope)
-		applyCloudTagsToEnvelope(spanEventEnvelope, resourceAttributes)
-		applyApplicationTagsToEnvelope(spanEventEnvelope, resourceAttributes)
+		applyCloudTagsToEnvelope(spanEventEnvelope, resourceAttributes, tagMappings)
+		applyApplicationTagsToEnvelope(spanEventEnvelope, resourceAttributes, tagMappings)
 		applyDeviceTagsToEnvelope(spanEventEnvelope, resourceAttributes)
 		applyInternalSdkVersionTagToEnvelope(spanEventEnvelope)
 

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -144,7 +144,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	spanAttributes.PutBool("somebool", false)
 	spanAttributes.PutDouble("somedouble", 0.1)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -177,7 +177,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet2(t *testing.T) {
 
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -205,7 +205,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet3(t *testing.T) {
 	spanAttributes.PutStr("client.address", "127.0.0.2")
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -223,7 +223,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet4(t *testing.T) {
 	spanAttributes.PutInt("http.response.status_code", defaultHTTPStatusCode)
 	spanAttributes.PutStr("url.full", "https://foo:81/bar?biz=baz")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -251,7 +251,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet1(t *testing.T) {
 	spanAttributes.PutStr("url.full", "https://foo:81/bar?biz=baz")
 	spanAttributes.PutInt("http.response.status_code", 400)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -285,7 +285,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet2(t *testing.T) {
 	// A specific http.route
 	spanAttributes.PutStr("http.route", "/bar/:baz_id")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -314,7 +314,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet3(t *testing.T) {
 	// Removing URL Full Key to test fallback although http client span requires url.full see https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/http/http-spans.md
 	spanAttributes.PutStr("url.full", "")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -339,7 +339,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	// Removing URL Full Key to test fallback although http client span requires url.full see https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/http/http-spans.md
 	spanAttributes.PutStr("url.full", "")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -358,7 +358,7 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
@@ -368,7 +368,7 @@ func TestRPCServerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr("server.address", "")
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultRPCRequestDataValidations(t, span, data, "127.0.0.1:81")
@@ -383,7 +383,7 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutInt("client.port", 81)
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -393,7 +393,7 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("client.address", "")
 	spanAttributes.PutStr("network.peer.address", "127.0.0.1")
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "127.0.0.1:81")
@@ -403,7 +403,7 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	span.Status().SetMessage("Resource exhausted")
 	spanAttributes.PutInt("rpc.grpc.status_code", 8)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
@@ -421,7 +421,7 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("client.address", "foo")
 	spanAttributes.PutInt("client.port", 81)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelopes[0], defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -434,7 +434,7 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("db.query.text", "")
 	spanAttributes.PutStr("db.query.text", defaultDBOperation)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	assert.Equal(t, defaultDBOperation, data.Data)
@@ -448,13 +448,13 @@ func TestMessagingConsumerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr("server.address", "foo")
 	spanAttributes.PutInt("server.port", 81)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRequestDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 	defaultMessagingRequestDataValidations(t, span, data)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RequestData)
 
@@ -469,13 +469,13 @@ func TestMessagingProducerSpanToRequestData(t *testing.T) {
 	spanAttributes.PutStr("client.address", "foo")
 	spanAttributes.PutInt("client.port", 81)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultMessagingRemoteDependencyDataValidations(t, span, data)
 
-	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ = spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope = envelopes[0]
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
@@ -490,7 +490,7 @@ func TestUnknownInternalSpanToRemoteDependencyData(t *testing.T) {
 	spanAttributes.PutStr("foo", "bar")
 	spanAttributes.PutStr("enduser.id", "4567")
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -503,7 +503,7 @@ func TestUnspecifiedSpanToInProcRemoteDependencyData(t *testing.T) {
 	span := getDefaultInternalSpan()
 	span.SetKind(ptrace.SpanKindUnspecified)
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 	envelope := envelopes[0]
 	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
 	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
@@ -528,7 +528,7 @@ func TestSpanWithEventsToEnvelopes(t *testing.T) {
 
 	exceptionEvent.CopyTo(span.Events().AppendEmpty())
 
-	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
 
 	assert.NotNil(t, envelopes)
 	assert.Len(t, envelopes, 3)

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -159,6 +159,6 @@ func getExporter(config *Config, transportChannel appinsights.TelemetryChannel) 
 		transportChannel,
 		exportertest.NewNopSettings(metadata.Type).TelemetrySettings,
 		zap.NewNop(),
-		newMetricPacker(zap.NewNop()),
+		newMetricPacker(zap.NewNop(), nil),
 	}
 }


### PR DESCRIPTION
#### Description

   Adds a new optional `tag_mappings:` config block on the `azuremonitor` exporter that lets operators override the resource-attribute precedence used to
  populate selected Application Insights envelope tags.

   Each field accepts an ordered list of **sources**; the first one that resolves to a non-empty string wins:

   - A source containing a `.` is treated as a **resource attribute key** (e.g. `service.instance.id`, `host.name`).
   - A source without a `.` is treated as a **string-literal terminal default** (e.g. `unknown-instance`).

   Supported keys in v1:

   | Mapping key           | AI envelope tag         | Default                  |
   | --------------------- | ----------------------- | ------------------------ |
   | `cloud_role_instance` | `ai.cloud.roleInstance` | `[service.instance.id]`  |
   | `application_version` | `ai.application.ver`    | `[service.version]`      |

   `cloud_role_name` is intentionally **not** configurable in this PR — its hardcoded `service.namespace`/`service.name` concatenation has subtler semantics
  and deserves a separate proposal.

   **Motivation — Azure Container Apps:** ACA sets `service.instance.id` to a random uuid that changes on every revision, which makes the AI "Role Instance"
  facet useless for grouping replicas. With this PR, ACA users can configure:

   ```yaml
   exporters: azuremonitor:
       connection_string: "..."
       tag_mappings:
         cloud_role_instance: [host.name, service.instance.id, unknown-instance]
```
  …and get the stable revision/replica hostname instead.

  Backward compatibility: the new field is optional and defaults to a config that reproduces the exact historical hardcoded behavior. An unset tag_mappings:
  block produces byte-for-byte the same envelope as today. Validation rejects an explicitly empty array (cloud_role_instance: []) at startup so
  misconfiguration fails fast.

  Marked alpha — the schema may evolve before the feature is promoted.

  Link to tracking issue

  Fixes #47657.

#### Testing

   - Added unit tests to validate and make sure backward compatibility 
   - Validated with real application insight instance

####  Documentation

See updates in `README.md`

#### Authorship

- [x] I, a human, wrote this pull request description myself.