### PR TITLE
[chore] [extension/encoding/googlecloudlogentryencoding] added date in the comment

### DIFF
--- a/extension/encoding/googlecloudlogentryencodingextension/internal/auditlog/parser.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/internal/auditlog/parser.go
@@ -248,7 +248,7 @@ func handleStatus(s *status, attr pcommon.Map) {
 	if s == nil {
 		return
 	}
-	// TODO: Remove the old attribute in the future.
+	// TODO(2026-05-26): Remove the old attribute in the future.
 	if s.Code != nil {
 		shared.PutInt(string(conventionsv138.RPCJSONRPCErrorCodeKey), s.Code, attr)
 		shared.PutStr(string(conventions.RPCResponseStatusCodeKey), strconv.FormatInt(*s.Code, 10), attr)

--- a/extension/encoding/googlecloudlogentryencodingextension/internal/auditlog/parser.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/internal/auditlog/parser.go
@@ -248,7 +248,7 @@ func handleStatus(s *status, attr pcommon.Map) {
 	if s == nil {
 		return
 	}
-	// TODO(Created 2026-05-26): Remove the old attribute in the future.
+	// TODO(Created on 2026-05-26): Remove the old attribute in the future.
 	if s.Code != nil {
 		shared.PutInt(string(conventionsv138.RPCJSONRPCErrorCodeKey), s.Code, attr)
 		shared.PutStr(string(conventions.RPCResponseStatusCodeKey), strconv.FormatInt(*s.Code, 10), attr)

--- a/extension/encoding/googlecloudlogentryencodingextension/internal/auditlog/parser.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/internal/auditlog/parser.go
@@ -248,7 +248,7 @@ func handleStatus(s *status, attr pcommon.Map) {
 	if s == nil {
 		return
 	}
-	// TODO(2026-05-26): Remove the old attribute in the future.
+	// TODO(Created 2026-05-26): Remove the old attribute in the future.
 	if s.Code != nil {
 		shared.PutInt(string(conventionsv138.RPCJSONRPCErrorCodeKey), s.Code, attr)
 		shared.PutStr(string(conventions.RPCResponseStatusCodeKey), strconv.FormatInt(*s.Code, 10), attr)


### PR DESCRIPTION
According to this comment (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48080#discussion_r3304492983), I've added a TODO in the same PR, but later I thought it would be better to put a date there too, which would make it easier in the future to have a reference date and get an idea of when to remove those fields.


