### PR TITLE
[cmd/schemagen] Ensure schemaElement is not nil before accessing communications

### DIFF
--- a/.chloggen/schemagen_parser_nilguard.yaml
+++ b/.chloggen/schemagen_parser_nilguard.yaml
@@ -10,7 +10,7 @@ component: cmd/schemagen
 note: Fix nil pointer dereference in parser when a type produces no schema element.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48789]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/schemagen_parser_nilguard.yaml
+++ b/.chloggen/schemagen_parser_nilguard.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/schemagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil pointer dereference in parser when a type produces no schema element.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/schemagen/internal/parser.go
+++ b/cmd/schemagen/internal/parser.go
@@ -194,7 +194,7 @@ func (p *Parser) parseType(typeInfo *TypeInfo) (SchemaElement, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(typeInfo.comms) > 0 {
+	if schemaElement != nil && len(typeInfo.comms) > 0 {
 		if desc, ok := ExtractDescriptionFromComment(typeInfo.comms[0]); ok {
 			schemaElement.setDescription(desc)
 		}

--- a/cmd/schemagen/internal/parser_test.go
+++ b/cmd/schemagen/internal/parser_test.go
@@ -5,6 +5,9 @@
 package internal
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"testing"
@@ -170,4 +173,52 @@ func testMappings() Mappings {
 			},
 		},
 	}
+}
+
+func TestParseTypeNilGuard(t *testing.T) {
+	src := `package test
+
+// MyConfig is a config type backed by an unrecognized generic.
+type MyConfig pkg.Unknown[string]
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	cmap := ast.NewCommentMap(fset, file, file.Comments)
+	var typeInfo *TypeInfo
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if ts.Name.Name == "MyConfig" {
+				typeInfo = &TypeInfo{
+					spec:     ts,
+					comms:    cmap[genDecl],
+					typeName: ts.Name.Name,
+					imports:  map[string]string{},
+				}
+			}
+		}
+	}
+	require.NotNil(t, typeInfo, "TypeInfo for MyConfig not found")
+	require.NotEmpty(t, typeInfo.comms, "expected doc comment to be present")
+
+	p := &Parser{
+		config: &Config{
+			Mode:     Component,
+			Mappings: testMappings(),
+		},
+		types: map[string]*TypeInfo{},
+	}
+
+	elem, err := p.parseType(typeInfo)
+	require.NoError(t, err)
+	require.Nil(t, elem)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix nil pointer dereference in parser when a type produces no schema element.