### PR TITLE
[chore][cmd/schemagen] Add type mapping for `SizerType` to prevent unresolved `$ref` entries in generated schemas.

### DIFF
--- a/.schemagen.yaml
+++ b/.schemagen.yaml
@@ -21,6 +21,9 @@ mappings:
   k8s.io/apimachinery/pkg/watch:
     EventType:
       schemaType: string
+  go.opentelemetry.io/collector/exporter/exporterhelper/internal/request:
+    SizerType:
+      schemaType: string
 allowedRefs:
   - go.opentelemetry.io/collector
   - github.com/open-telemetry/opentelemetry-collector-contrib


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add type mapping for `SizerType` from `go.opentelemetry.io/collector/exporter/exporterhelper/internal/request` to prevent unresolved `$ref` entries in generated schemas.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
