### PR TITLE
[pkg/translator/pprof] Fix the wrong timestamp conversion

### DIFF
--- a/.chloggen/pprof-translator-fix-timestamp.yaml
+++ b/.chloggen/pprof-translator-fix-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/pprof
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the wrong timestamp conversion.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48813]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/pprof/profile"
@@ -636,6 +637,7 @@ func TestGetAttributeStringWithPrefix(t *testing.T) {
 }
 
 func TestConvertMultipleSampleTypes(t *testing.T) {
+	currentTS := time.Now()
 	// Create a pprof profile with multiple sample types
 	prof := &profile.Profile{
 		SampleType: []*profile.ValueType{
@@ -644,7 +646,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"},
 		},
-		TimeNanos:     NanoTimestamp,
+		TimeNanos:     currentTS.UnixNano(),
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},
 		Period:        524288,
@@ -759,7 +761,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 		}
 
 		// Verify profile metadata
-		require.Equal(t, int64(NanoTimestamp), p.Time().AsTime().UnixNano())
+		require.Equal(t, currentTS.UnixNano(), p.Time().AsTime().UnixNano())
 		require.Equal(t, uint64(5000000000), p.DurationNano())
 		require.Equal(t, int64(524288), p.Period())
 	}
@@ -788,6 +790,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 }
 
 func TestDefaultSampleTypeConvention(t *testing.T) {
+	currentTS := time.Now()
 	// Create a pprof profile with multiple sample types.
 	// By convention, the last sample type (inuse_space) is the default in pprof.
 	prof := &profile.Profile{
@@ -797,16 +800,6 @@ func TestDefaultSampleTypeConvention(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"}, // default (last)
 		},
-currentTS := time.Now()
-// Create a pprof profile with multiple sample types.
-// By convention, the last sample type (inuse_space) is the default in pprof.
-prof := &profile.Profile{
-SampleType: []*profile.ValueType{
-{Type: "alloc_objects", Unit: "count"},
-{Type: "alloc_space", Unit: "bytes"},
-{Type: "inuse_objects", Unit: "count"},
-{Type: "inuse_space", Unit: "bytes"}, // default (last)
-},
 		TimeNanos:     currentTS.UnixNano(),
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pprofile"
 )
 
+const NANO_TIMESTAMP = 1780454666123456789
+
 func TestConvertPprofToPprofile(t *testing.T) {
 	tests := map[string]struct {
 		expectedError error
@@ -644,7 +646,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"},
 		},
-		TimeNanos:     1000000000,
+		TimeNanos:     NANO_TIMESTAMP,
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},
 		Period:        524288,
@@ -759,7 +761,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 		}
 
 		// Verify profile metadata
-		require.Equal(t, int64(1000000000), p.Time().AsTime().UnixNano())
+		require.Equal(t, int64(NANO_TIMESTAMP), p.Time().AsTime().UnixNano())
 		require.Equal(t, uint64(5000000000), p.DurationNano())
 		require.Equal(t, int64(524288), p.Period())
 	}
@@ -783,6 +785,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 		for j, val := range sample.Value {
 			require.Equal(t, val, roundTrip.Sample[i].Value[j])
 		}
+		require.Equal(t, prof.TimeNanos, roundTrip.TimeNanos)
 	}
 }
 
@@ -796,7 +799,7 @@ func TestDefaultSampleTypeConvention(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"}, // default (last)
 		},
-		TimeNanos:     1000000000,
+		TimeNanos:     NANO_TIMESTAMP,
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},
 		Period:        524288,
@@ -876,6 +879,7 @@ func TestDefaultSampleTypeConvention(t *testing.T) {
 		for j, val := range sample.Value {
 			require.Equal(t, val, roundTrip.Sample[i].Value[j], "Round-trip should preserve original sample values order")
 		}
+		require.Equal(t, prof.TimeNanos, roundTrip.TimeNanos)
 	}
 }
 

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pprofile"
 )
 
-const NANO_TIMESTAMP = 1780454666123456789
+const NanoTimestamp = 1780454666123456789
 
 func TestConvertPprofToPprofile(t *testing.T) {
 	tests := map[string]struct {
@@ -646,7 +646,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"},
 		},
-		TimeNanos:     NANO_TIMESTAMP,
+		TimeNanos:     NanoTimestamp,
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},
 		Period:        524288,
@@ -761,7 +761,7 @@ func TestConvertMultipleSampleTypes(t *testing.T) {
 		}
 
 		// Verify profile metadata
-		require.Equal(t, int64(NANO_TIMESTAMP), p.Time().AsTime().UnixNano())
+		require.Equal(t, int64(NanoTimestamp), p.Time().AsTime().UnixNano())
 		require.Equal(t, uint64(5000000000), p.DurationNano())
 		require.Equal(t, int64(524288), p.Period())
 	}
@@ -799,7 +799,7 @@ func TestDefaultSampleTypeConvention(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"}, // default (last)
 		},
-		TimeNanos:     NANO_TIMESTAMP,
+		TimeNanos:     NanoTimestamp,
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},
 		Period:        524288,

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -22,8 +22,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pprofile"
 )
 
-const NanoTimestamp = 1780454666123456789
-
 func TestConvertPprofToPprofile(t *testing.T) {
 	tests := map[string]struct {
 		expectedError error
@@ -799,7 +797,17 @@ func TestDefaultSampleTypeConvention(t *testing.T) {
 			{Type: "inuse_objects", Unit: "count"},
 			{Type: "inuse_space", Unit: "bytes"}, // default (last)
 		},
-		TimeNanos:     NanoTimestamp,
+currentTS := time.Now()
+// Create a pprof profile with multiple sample types.
+// By convention, the last sample type (inuse_space) is the default in pprof.
+prof := &profile.Profile{
+SampleType: []*profile.ValueType{
+{Type: "alloc_objects", Unit: "count"},
+{Type: "alloc_space", Unit: "bytes"},
+{Type: "inuse_objects", Unit: "count"},
+{Type: "inuse_space", Unit: "bytes"}, // default (last)
+},
+		TimeNanos:     currentTS.UnixNano(),
 		DurationNanos: 5000000000,
 		PeriodType:    &profile.ValueType{Type: "space", Unit: "bytes"},
 		Period:        524288,

--- a/pkg/translator/pprof/profiles_to_pprof.go
+++ b/pkg/translator/pprof/profiles_to_pprof.go
@@ -181,7 +181,7 @@ func ConvertPprofileToPprof(src *pprofile.Profiles) (*profile.Profile, error) {
 	if attrErr != nil && !errors.Is(attrErr, errNotFound) {
 		return nil, attrErr
 	}
-	dst.TimeNanos = int64(p.Time().AsTime().Nanosecond())
+	dst.TimeNanos = int64(p.Time())
 	dst.DurationNanos = int64(p.DurationNano())
 	dst.Period = p.Period()
 

--- a/pkg/translator/pprof/profiles_to_pprof.go
+++ b/pkg/translator/pprof/profiles_to_pprof.go
@@ -181,7 +181,7 @@ func ConvertPprofileToPprof(src *pprofile.Profiles) (*profile.Profile, error) {
 	if attrErr != nil && !errors.Is(attrErr, errNotFound) {
 		return nil, attrErr
 	}
-	dst.TimeNanos = int64(p.Time())
+	dst.TimeNanos = p.Time().AsTime().UnixNano()
 	dst.DurationNanos = int64(p.DurationNano())
 	dst.Period = p.Period()
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
In `ConvertPprofileToPprof ()`,
```
dst.TimeNanos = int64(p.Time().AsTime().Nanosecond())
```
It returns only the nanosecond offset within the current second (a value between 0 and 999,999,999), discarding the seconds component entirely. This resulted in an incorrect and truncated timestamp being written to `dst.TimeNanos`.

This PR fixes the conversion bug.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48813

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
