### PR TITLE
[chore] Update podman receiver documentation with rootless podman information

### DIFF
--- a/receiver/podmanreceiver/README.md
+++ b/receiver/podmanreceiver/README.md
@@ -26,7 +26,12 @@ the [blkio controller](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-
 
 The following settings are required:
 
-- `endpoint` (default = `unix:///run/podman/podman.sock`): Address to reach the desired Podman daemon.
+- `endpoint` (default = `unix:///run/podman/podman.sock`): Address to reach the Podman service API.
+
+> [!NOTE]
+> Podman runs in rootless mode by default. For rootless Podman, use the user socket path:
+> `unix:///run/user/<UID>/podman/podman.sock` (or `unix://$XDG_RUNTIME_DIR/podman/podman.sock`).
+> The default path `/run/podman/podman.sock` is for rootful (system) Podman and requires elevated permissions.
 
 The following settings are optional:
 
@@ -37,10 +42,11 @@ The following settings are optional:
 
 Example:
 
+### Rootful
 ```yaml
 receivers:
   podman_stats:
-    endpoint: unix://run/podman/podman.sock
+    endpoint: unix:///run/podman/podman.sock
     timeout: 10s
     collection_interval: 10s
     initial_delay: 1s
@@ -48,6 +54,20 @@ receivers:
       container.cpu.usage.system:
         enabled: false
 ```
+
+### Rootless
+```yaml
+receivers:
+  podman_stats:
+    endpoint: unix:///run/user/<UID>/podman/podman.sock
+    timeout: 10s
+    collection_interval: 10s
+    initial_delay: 1s
+    metrics:
+      container.cpu.usage.system:
+        enabled: false
+```
+Where `<UID>` is your user ID.
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go)
 with detailed sample configurations in [testdata/config.yaml](./testdata/config.yaml).
@@ -70,7 +90,7 @@ receiver with an older API version, please set the `api_version` to the desired 
 ```yaml
 receivers:
   podman_stats:
-    endpoint: unix://run/podman/podman.sock
+    endpoint: unix:///run/podman/podman.sock
     api_version: 3.2.0
 ```
 ## Metrics


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Since Podman 2.0, it is installed to run rootless by default. This is one of the huge advantages to running Podman. This change adds rootless information to the podman receiver readme.

Podman can run rootless, on my system if I follow the podman receiver README.md I get this error:

```md
opentelemetry-collector-contrib/bin update-podman-receiver-docs ❯ ./otelcontribcol_linux_amd64 --config=../local/config-podman.yaml
2026-06-02T15:39:08.380+0100	info	otelconftelemetry/tracer.go:47	Internal trace telemetry disabled	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}}
2026-06-02T15:39:08.381+0100	warn	builders/builders.go:40	"otlphttp" alias is deprecated; use "otlp_http" instead	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}, "otelcol.component.id": "otlphttp/prometheus", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics"}
2026-06-02T15:39:08.381+0100	info	service@v0.153.1-0.20260528150546-fe2cf23ff222/service.go:241	Starting otelcontribcol...	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}, "Version": "0.153.0-dev", "NumCPU": 8}
2026-06-02T15:39:08.381+0100	info	extensions/extensions.go:41	Starting extensions...	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}}
2026-06-02T15:39:08.382+0100	error	graph/graph.go:437	Failed to start component	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}, "error": "Get \"http://d/v3.3.1/libpod/containers/json?filters=%7B%22status%22%3A%5B%22running%22%5D%7D\": dial unix /run/podman/podman.sock: connect: permission denied", "type": "Receiver", "id": "podman_stats"}
2026-06-02T15:39:08.382+0100	info	service@v0.153.1-0.20260528150546-fe2cf23ff222/service.go:278	Starting shutdown...	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}}
2026-06-02T15:39:08.382+0100	info	extensions/extensions.go:69	Stopping extensions...	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}}
2026-06-02T15:39:08.382+0100	info	service@v0.153.1-0.20260528150546-fe2cf23ff222/service.go:292	Shutdown complete.	{"resource": {"service.instance.id": "5765f4a6-f3dd-4800-b5f3-974906996398", "service.name": "otelcontribcol", "service.version": "0.153.0-dev"}}
Error: cannot start pipelines: failed to start "podman_stats" receiver: Get "http://d/v3.3.1/libpod/containers/json?filters=%7B%22status%22%3A%5B%22running%22%5D%7D": dial unix /run/podman/podman.sock: connect: permission denied
```

With this config:

```yaml
receivers:
    podman_stats:
      collection_interval: 10s
exporters:
  debug:
    verbosity: detailed
  otlphttp/prometheus:
    endpoint: http://localhost:9090/api/v1/otlp
service:
  pipelines:
    metrics:
      receivers: [podman_stats]
      exporters: [debug, otlphttp/prometheus]
```

My podman config:

```bash
opentelemetry-collector-contrib/bin update-podman-receiver-docs ❯ podman info | grep -i rootless
  rootlessNetworkCmd: pasta
    rootless: true
```

To run the podman receiver I have to add the rootless endpoint to my config:

```yaml
receivers:
    podman_stats:
      endpoint: unix:///run/user/<UID>/podman/podman.sock
      collection_interval: 10s
exporters:
  debug:
    verbosity: detailed
  otlphttp/prometheus:
    endpoint: http://localhost:9090/api/v1/otlp
service:
  pipelines:
    metrics:
      receivers: [podman_stats]
      exporters: [debug, otlphttp/prometheus]
```

<!--Describe the documentation added.-->
#### Documentation

Updated podman receiver README.md with rootless podman information.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
