### PR TITLE
[chore] Remove private link from sentryexporter-validate-slugs.yaml

### DIFF
--- a/.chloggen/sentryexporter-validate-slugs.yaml
+++ b/.chloggen/sentryexporter-validate-slugs.yaml
@@ -18,7 +18,7 @@ issues: [1]
 subtext: |
   The exporter previously interpolated the configured `org_slug` and the runtime-derived
   project slug (from `service.name`) into Sentry API URL paths without validation or
-  escaping. Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/security/advisories/GHSA-4jvg-4jfx-fmhc
+  escaping.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removed private link from `sentryexporter-validate-slugs.yaml`. It's currently breaking the CI (`changelog`) as the link is private.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
