### PR TITLE
[chore][govuln] pin Go version in govuln check for now

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,7 +208,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
-          go-version: oldstable
+          go-version: 1.25.11 # TODO: revert to oldstable when actions/setup-go reliably resolves oldstable to 1.25.11
       - name: Run `govulncheck`
         run: make gogovulncheck GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
#### Description
Pin Go version to 1.25.11 in govuln check  to fix CI failures. Right now actions/setup-go resolves oldstable to 1.25.10 which has known vulns. E.g http://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/26897577744/job/79341230054

```
Setup go version spec oldstable
oldstable version resolved as 1.25.10
...
Vulnerabilities need attention: GO-2026-5037 GO-2026-5039
```

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
