### PR TITLE
Revert "[chore]: align check-codeowners with Core's version (#48553)"

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -57,7 +57,8 @@ jobs:
 
       - name: Gen CODEOWNERS
         run: |
-          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=pr" make codeowners
-          if ! git -C pr diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git -C pr diff && exit 1; fi
+          cd pr
+          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} make codeowners
+          if ! git diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git diff && exit 1; fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
This reverts commit a8d26afcf5a3999d947d04eee00eef1267cba092.

Specifying `GITHUBGEN_ARGS="-folder=pr"` prepends `pr` to [component path](https://github.com/open-telemetry/opentelemetry-go-build-tools/blob/fecc61ebcb38377a9bba0bbc3150c2384dac1d01/githubgen/codeowners.go#L47) and it [breaks CI](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/26904407964/job/79365279559?pr=48856) if codeowners are updated. 