### PR TITLE
[pkg/ottl] Fix Substring function corrupting multibyte UTF-8 strings

### DIFF
--- a/.chloggen/fix-ottl-substring-utf8.yaml
+++ b/.chloggen/fix-ottl-substring-utf8.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pkg/ottl
+note: Fix Substring function corrupting multibyte UTF-8 strings by using rune-based slicing instead of byte-based slicing.
+issues: [48436]
+change_logs: [user]

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -51,9 +51,10 @@ func substring[K any](target ottl.StringGetter[K], startGetter, lengthGetter ott
 		if err != nil {
 			return nil, err
 		}
-		if start > int64(len(val)) || length > int64(len(val))-start {
-			return nil, fmt.Errorf("invalid range for substring function, start(%d)+length(%d) cannot be greater than the length of target string(%d)", start, length, len(val))
+		runes := []rune(val)
+		if start > int64(len(runes)) || length > int64(len(runes))-start {
+			return nil, fmt.Errorf("invalid range for substring function, start(%d)+length(%d) cannot be greater than the length of target string(%d)", start, length, len(runes))
 		}
-		return val[start : start+length], nil
+		return string(runes[start : start+length]), nil
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -60,6 +60,44 @@ func Test_substring(t *testing.T) {
 			},
 			expected: "123456789",
 		},
+		{
+			name: "substring with multibyte UTF-8 characters",
+			target: &ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return "日本語", nil
+				},
+			},
+			start: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(0), nil
+				},
+			},
+			length: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(1), nil
+				},
+			},
+			expected: "日",
+		},
+		{
+			name: "substring with emoji",
+			target: &ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return "hello🌍world", nil
+				},
+			},
+			start: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(5), nil
+				},
+			},
+			length: &ottl.StandardIntGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return int64(1), nil
+				},
+			},
+			expected: "🌍",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes byte-based slicing in Substring that corrupts CJK/emoji characters. Uses rune-based slicing so start/length refer to character positions. Added tests for Japanese and emoji strings. Fixes #48436