### PR TITLE
[chore][receiver/pprofreceiver] Fix t.Cleanup shutdown context cancellation

### DIFF
--- a/receiver/pprofreceiver/internal/http_server_test.go
+++ b/receiver/pprofreceiver/internal/http_server_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -45,7 +46,7 @@ func TestHTTPServerPush(t *testing.T) {
 	}
 	require.NoError(t, srv.Start(t.Context(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		require.NoError(t, srv.Shutdown(t.Context()))
+		require.NoError(t, srv.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	pprofBody := generatePprofBody(t)
@@ -102,7 +103,7 @@ func TestHTTPServerPush_BodySizeLimit(t *testing.T) {
 	}
 	require.NoError(t, srv.Start(t.Context(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		require.NoError(t, srv.Shutdown(t.Context()))
+		require.NoError(t, srv.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	url := fmt.Sprintf("http://%s%s", addr, PushPath)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

t.Context may already be canceled when t.Cleanup is executed.
Therefore, wrap it with context.WithoutCancel to ensure that shutdown at the end of the test is not affected by a canceled context.

https://pkg.go.dev/testing#T.Context

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes: #48671

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
