### PR TITLE
[exporter/opensearchexporter] Add manage_index_template option for otel-v1 mode

### DIFF
--- a/.chloggen/opensearchexporter-manage-index-template.yaml
+++ b/.chloggen/opensearchexporter-manage-index-template.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/opensearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `mapping.manage_index_template` option for `otel-v1` mode that creates the matching composable index templates on startup.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48585]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When enabled, the exporter creates the `otel-v1-apm-span-index-template` and `otel-v1-logs-index-template` composable index templates idempotently on startup, materializing `date_nanos` timestamp fields and the typed dynamic-attribute mappings before documents are indexed. If templates with the same names already exist (for example, user-customized variants), they are left in place rather than overwritten. Only valid with `mapping.mode: otel-v1`; validation rejects the combination with other modes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/opensearchexporter/README.md
+++ b/exporter/opensearchexporter/README.md
@@ -110,6 +110,7 @@ The OpenSearch exporter supports several document schemas and preprocessing beha
     - `flatten_attributes`: Uses the ECS mapping but flattens all resource and log attributes in the record to the top-level.
     - `bodymap`: uses the "body" of a log record as the exact content of the OpenSearch document, without any transformation. This mapping mode is intended for use cases where the client wishes to have complete control over the OpenSearch document structure.
     - `otel-v1`: exports logs and traces using the Data Prepper OTel v1 schema, compatible with OpenSearch Observability dashboards.
+  - `manage_index_template`: (optional, default=`false`) When `true`, creates composable index templates on startup. Only valid with `otel-v1` mode.
   - `timestamp_field`: (optional) Field to store the timestamp in. If not set, uses the default `@timestamp`.
   - `unix_timestamp`: (optional) Whether to store the timestamp in epoch milliseconds.
   - `dedup`: (optional) removes fields from the document, that have duplicate keys. The filtering only keeps the last value for a key.
@@ -171,6 +172,8 @@ Default index names:
 
 These defaults can be overridden using `traces_index` and `logs_index` configuration options.
 
+The `manage_index_template` option controls whether the exporter automatically creates composable index templates on startup. This ensures correct field mappings (e.g., `date_nanos` timestamps, dynamic attribute typing) are in place before documents are indexed.
+
 | Signal    | `otel-v1`           |
 | --------- | ------------------- |
 | Logs      | :white_check_mark:  |
@@ -181,7 +184,7 @@ Schema references:
 - [logs-otel-v1 index template](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json)
 
 > [!NOTE]
-> The exporter emits nanosecond-precision timestamps in the document body, but to materialize them as `date_nanos` (and apply the rest of the recommended field mappings) you must install the matching index templates before indexing begins. Without a template OpenSearch's dynamic mapping will infer `date` (millisecond precision) for timestamp fields. Install the templates out-of-band for now; see also the schema references above.
+> The exporter emits nanosecond-precision timestamps in the document body, but OpenSearch's dynamic mapping will infer `date` (millisecond precision) unless a matching index template is installed before indexing begins. Set `manage_index_template: true` to have the exporter create the templates on startup, or install them out-of-band — see the schema references above.
 
 ##### Example Configuration
 
@@ -192,6 +195,7 @@ exporters:
       endpoint: http://opensearch.example.com:9200
     mapping:
       mode: "otel-v1"
+      manage_index_template: true
     sending_queue:
       batch:
 ```

--- a/exporter/opensearchexporter/README.md
+++ b/exporter/opensearchexporter/README.md
@@ -174,6 +174,8 @@ These defaults can be overridden using `traces_index` and `logs_index` configura
 
 The `manage_index_template` option controls whether the exporter automatically creates composable index templates on startup. This ensures correct field mappings (e.g., `date_nanos` timestamps, dynamic attribute typing) are in place before documents are indexed.
 
+Template creation is best-effort: if the cluster is temporarily unreachable or rejects the request, the exporter logs a warning and continues — the failure is not propagated through `Start()`. The affected index will then fall back to OpenSearch's dynamic mapping (timestamp fields inferred as `date` rather than `date_nanos`) until the template is installed. If templates with the same names already exist (for example, user-customized variants), they are left in place rather than overwritten.
+
 | Signal    | `otel-v1`           |
 | --------- | ------------------- |
 | Logs      | :white_check_mark:  |

--- a/exporter/opensearchexporter/config.go
+++ b/exporter/opensearchexporter/config.go
@@ -65,14 +65,15 @@ type Config struct {
 }
 
 var (
-	errConfigNoEndpoint             = errors.New("endpoint must be specified")
-	errDatasetNoValue               = errors.New("dataset must be specified")
-	errNamespaceNoValue             = errors.New("namespace must be specified")
-	errBulkActionInvalid            = errors.New("bulk_action can either be `create` or `index`")
-	errMappingModeInvalid           = errors.New("mapping.mode is invalid")
-	errLogsIndexTimeFormatInvalid   = errors.New("logs_index_time_format contains unsupported or invalid tokens")
-	errTracesIndexTimeFormatInvalid = errors.New("traces_index_time_format contains unsupported or invalid tokens")
-	errOTelV1DatasetNamespaceUnused = errors.New(`dataset and namespace are not used by mapping.mode "otel-v1"; remove them or pick a different mode`)
+	errConfigNoEndpoint               = errors.New("endpoint must be specified")
+	errDatasetNoValue                 = errors.New("dataset must be specified")
+	errNamespaceNoValue               = errors.New("namespace must be specified")
+	errBulkActionInvalid              = errors.New("bulk_action can either be `create` or `index`")
+	errMappingModeInvalid             = errors.New("mapping.mode is invalid")
+	errLogsIndexTimeFormatInvalid     = errors.New("logs_index_time_format contains unsupported or invalid tokens")
+	errTracesIndexTimeFormatInvalid   = errors.New("traces_index_time_format contains unsupported or invalid tokens")
+	errOTelV1DatasetNamespaceUnused   = errors.New(`dataset and namespace are not used by mapping.mode "otel-v1"; remove them or pick a different mode`)
+	errManageIndexTemplateInvalidMode = errors.New("mapping.manage_index_template is only supported with mapping.mode \"otel-v1\"")
 )
 
 type MappingsSettings struct {
@@ -102,6 +103,10 @@ type MappingsSettings struct {
 	//     https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json
 	//     https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json
 	Mode string `mapstructure:"mode"`
+
+	// ManageIndexTemplate controls whether the exporter creates index templates on startup.
+	// Only supported when Mode is "otel-v1". Validation will reject this option with other modes.
+	ManageIndexTemplate bool `mapstructure:"manage_index_template"`
 
 	// Additional field mappings.
 	Fields map[string]string `mapstructure:"fields"`
@@ -211,6 +216,10 @@ func (cfg *Config) Validate() error {
 
 	if _, ok := mappingModes[cfg.Mode]; !ok {
 		multiErr = append(multiErr, errMappingModeInvalid)
+	}
+
+	if cfg.ManageIndexTemplate && cfg.Mode != MappingOTelV1.String() {
+		multiErr = append(multiErr, errManageIndexTemplateInvalidMode)
 	}
 
 	return errors.Join(multiErr...)

--- a/exporter/opensearchexporter/config.schema.yaml
+++ b/exporter/opensearchexporter/config.schema.yaml
@@ -15,6 +15,9 @@ $defs:
       file:
         description: File to read additional fields mappings from.
         type: string
+      manage_index_template:
+        description: ManageIndexTemplate controls whether the exporter creates index templates on startup. Only supported when Mode is "otel-v1". Validation will reject this option with other modes.
+        type: boolean
       mode:
         description: 'Mode configures the field mappings. Supported modes are the following: ss4o: exports logs in the Simple Schema for Observability standard. This mode is enabled by default. See: https://opensearch.org/docs/latest/observing-your-data/ss4o/ ecs: maps fields defined in the OpenTelemetry Semantic Conventions to the Elastic Common Schema. See: https://www.elastic.co/guide/en/ecs/current/index.html flatten_attributes: uses the ECS mapping but flattens all resource and log attributes in the record to the top-level. bodymap: supports only logs and uses the "body" of a log record as the exact content of the OpenSearch document, without any transformation. This mapping mode is intended for use cases where the client wishes to have complete control over the OpenSearch document structure. otel-v1: exports logs and traces using the OTel v1 schema published by the OpenSearch Data Prepper project (https://github.com/opensearch-project/data-prepper). Documents are compatible with OpenSearch Observability dashboards that consume Data Prepper indices. See the upstream index templates for the canonical field mappings: https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/logs-otel-v1-index-standard-template.json'
         type: string

--- a/exporter/opensearchexporter/config_test.go
+++ b/exporter/opensearchexporter/config_test.go
@@ -314,3 +314,48 @@ func withDefaultHTTPClientConfig(fns ...func(config *confighttp.ClientConfig)) c
 	}
 	return cfg
 }
+
+func TestOTelV1MappingModeValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		manageTpl   bool
+		expectError string
+	}{
+		{
+			name: "otel-v1 mode valid",
+			mode: "otel-v1",
+		},
+		{
+			name:      "otel-v1 with manage_index_template true",
+			mode:      "otel-v1",
+			manageTpl: true,
+		},
+		{
+			name:        "ss4o with manage_index_template true is invalid",
+			mode:        "ss4o",
+			manageTpl:   true,
+			expectError: errManageIndexTemplateInvalidMode.Error(),
+		},
+		{
+			name: "ss4o with manage_index_template false is valid",
+			mode: "ss4o",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := withDefaultConfig(func(config *Config) {
+				config.Endpoint = "http://localhost:9200"
+				config.Mode = tt.mode
+				config.ManageIndexTemplate = tt.manageTpl
+			})
+			err := cfg.Validate()
+			if tt.expectError != "" {
+				assert.ErrorContains(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/exporter/opensearchexporter/index_template_manager.go
+++ b/exporter/opensearchexporter/index_template_manager.go
@@ -9,94 +9,13 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter/internal/templates"
 )
 
 const (
 	otelV1SpanTemplateName = "otel-v1-apm-span-index-template"
 	otelV1LogsTemplateName = "otel-v1-logs-index-template"
-
-	otelV1SpanTemplateBody = `{
-  "index_patterns": ["otel-v1-apm-span*"],
-  "template": {
-    "mappings": {
-      "date_detection": false,
-      "_source": { "enabled": true },
-      "dynamic_templates": [
-        { "long_resource_attributes": { "mapping": { "type": "long" }, "path_match": "resource.attributes.*", "match_mapping_type": "long" } },
-        { "double_resource_attributes": { "mapping": { "type": "double" }, "path_match": "resource.attributes.*", "match_mapping_type": "double" } },
-        { "string_resource_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "resource.attributes.*", "match_mapping_type": "string" } },
-        { "long_scope_attributes": { "mapping": { "type": "long" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "long" } },
-        { "double_scope_attributes": { "mapping": { "type": "double" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "double" } },
-        { "string_scope_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "string" } },
-        { "long_attributes": { "mapping": { "type": "long" }, "path_match": "attributes.*", "match_mapping_type": "long" } },
-        { "double_attributes": { "mapping": { "type": "double" }, "path_match": "attributes.*", "match_mapping_type": "double" } },
-        { "string_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "attributes.*", "match_mapping_type": "string" } }
-      ],
-      "properties": {
-        "droppedAttributesCount": { "type": "integer" },
-        "instrumentationScope": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 }, "name": { "type": "keyword", "ignore_above": 128 }, "version": { "type": "keyword", "ignore_above": 64 } } },
-        "resource": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 } } },
-        "traceId": { "type": "keyword", "ignore_above": 32 },
-        "spanId": { "type": "keyword", "ignore_above": 16 },
-        "parentSpanId": { "type": "keyword", "ignore_above": 16 },
-        "name": { "ignore_above": 1024, "type": "keyword" },
-        "traceState": { "ignore_above": 1024, "type": "keyword" },
-        "traceGroup": { "ignore_above": 1024, "type": "keyword" },
-        "traceGroupFields": { "properties": { "endTime": { "type": "date_nanos" }, "durationInNanos": { "type": "long" }, "statusCode": { "type": "integer" } } },
-        "kind": { "type": "keyword", "ignore_above": 32 },
-        "serviceName": { "type": "keyword", "ignore_above": 256 },
-        "startTime": { "type": "date_nanos" },
-        "endTime": { "type": "date_nanos" },
-        "@timestamp": { "type": "date_nanos" },
-        "time": { "type": "date_nanos" },
-        "status": { "properties": { "code": { "type": "integer" }, "message": { "type": "keyword", "ignore_above": 2048 } } },
-        "durationInNanos": { "type": "long" },
-        "events": { "type": "nested", "properties": { "name": { "type": "keyword", "ignore_above": 256 }, "attributes": { "type": "object" }, "droppedAttributesCount": { "type": "integer" }, "time": { "type": "date_nanos" } } },
-        "droppedEventsCount": { "type": "integer" },
-        "links": { "type": "nested", "properties": { "traceId": { "type": "keyword", "ignore_above": 32 }, "spanId": { "type": "keyword", "ignore_above": 16 }, "traceState": { "ignore_above": 1024, "type": "keyword" }, "attributes": { "type": "object" }, "droppedAttributesCount": { "type": "integer" } } },
-        "droppedLinksCount": { "type": "integer" }
-      }
-    }
-  },
-  "version": 1,
-  "priority": 100
-}`
-
-	otelV1LogsTemplateBody = `{
-  "index_patterns": ["otel-v1-logs*"],
-  "template": {
-    "mappings": {
-      "date_detection": false,
-      "_source": { "enabled": true },
-      "dynamic_templates": [
-        { "long_resource_attributes": { "mapping": { "type": "long" }, "path_match": "resource.attributes.*", "match_mapping_type": "long" } },
-        { "double_resource_attributes": { "mapping": { "type": "double" }, "path_match": "resource.attributes.*", "match_mapping_type": "double" } },
-        { "string_resource_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "resource.attributes.*", "match_mapping_type": "string" } },
-        { "long_scope_attributes": { "mapping": { "type": "long" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "long" } },
-        { "double_scope_attributes": { "mapping": { "type": "double" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "double" } },
-        { "string_scope_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "string" } },
-        { "long_attributes": { "mapping": { "type": "long" }, "path_match": "attributes.*", "match_mapping_type": "long" } },
-        { "double_attributes": { "mapping": { "type": "double" }, "path_match": "attributes.*", "match_mapping_type": "double" } },
-        { "string_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "attributes.*", "match_mapping_type": "string" } }
-      ],
-      "properties": {
-        "droppedAttributesCount": { "type": "integer" },
-        "instrumentationScope": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 }, "name": { "type": "keyword", "ignore_above": 128 }, "version": { "type": "keyword", "ignore_above": 64 } } },
-        "resource": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 } } },
-        "severity": { "properties": { "number": { "type": "integer" }, "text": { "type": "keyword", "ignore_above": 32 } } },
-        "body": { "type": "text" },
-        "@timestamp": { "type": "date_nanos" },
-        "time": { "type": "date_nanos" },
-        "observedTime": { "type": "date_nanos" },
-        "traceId": { "type": "keyword", "ignore_above": 32 },
-        "spanId": { "type": "keyword", "ignore_above": 16 },
-        "flags": { "type": "long" }
-      }
-    }
-  },
-  "version": 1,
-  "priority": 100
-}`
 )
 
 type templateManager struct {
@@ -108,9 +27,16 @@ func newTemplateManager(client *opensearchapi.Client, logger *zap.Logger) *templ
 	return &templateManager{client: client, logger: logger}
 }
 
+// ensureTemplates is best-effort: it logs and returns on transient cluster
+// errors rather than failing the exporter Start(). A failure means OpenSearch's
+// dynamic mapping will pick up types from the first indexed document
+// (date instead of date_nanos for timestamps); existing documents are
+// unaffected. This matches the Data Prepper sink's posture for the same
+// operation, which logs and retries on IOException rather than blocking
+// pipeline initialization.
 func (tm *templateManager) ensureTemplates(ctx context.Context) {
-	tm.ensureTemplate(ctx, otelV1SpanTemplateName, otelV1SpanTemplateBody)
-	tm.ensureTemplate(ctx, otelV1LogsTemplateName, otelV1LogsTemplateBody)
+	tm.ensureTemplate(ctx, otelV1SpanTemplateName, templates.OtelV1APMSpan)
+	tm.ensureTemplate(ctx, otelV1LogsTemplateName, templates.OtelV1Logs)
 }
 
 func (tm *templateManager) ensureTemplate(ctx context.Context, name, body string) {
@@ -130,7 +56,9 @@ func (tm *templateManager) ensureTemplate(ctx context.Context, name, body string
 	}
 	_, createErr := tm.client.IndexTemplate.Create(ctx, createReq)
 	if createErr != nil {
-		tm.logger.Warn("Failed to create index template", zap.String("template", name), zap.Error(createErr))
+		tm.logger.Warn("Failed to create index template; falling back to dynamic mapping for this index. "+
+			"Timestamp fields may be inferred as `date` (millisecond) instead of `date_nanos` until the template is installed.",
+			zap.String("template", name), zap.Error(createErr))
 		return
 	}
 	tm.logger.Info("Created index template", zap.String("template", name))

--- a/exporter/opensearchexporter/index_template_manager.go
+++ b/exporter/opensearchexporter/index_template_manager.go
@@ -1,0 +1,137 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opensearchexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
+
+import (
+	"context"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"go.uber.org/zap"
+)
+
+const (
+	otelV1SpanTemplateName = "otel-v1-apm-span-index-template"
+	otelV1LogsTemplateName = "otel-v1-logs-index-template"
+
+	otelV1SpanTemplateBody = `{
+  "index_patterns": ["otel-v1-apm-span*"],
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "_source": { "enabled": true },
+      "dynamic_templates": [
+        { "long_resource_attributes": { "mapping": { "type": "long" }, "path_match": "resource.attributes.*", "match_mapping_type": "long" } },
+        { "double_resource_attributes": { "mapping": { "type": "double" }, "path_match": "resource.attributes.*", "match_mapping_type": "double" } },
+        { "string_resource_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "resource.attributes.*", "match_mapping_type": "string" } },
+        { "long_scope_attributes": { "mapping": { "type": "long" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "long" } },
+        { "double_scope_attributes": { "mapping": { "type": "double" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "double" } },
+        { "string_scope_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "string" } },
+        { "long_attributes": { "mapping": { "type": "long" }, "path_match": "attributes.*", "match_mapping_type": "long" } },
+        { "double_attributes": { "mapping": { "type": "double" }, "path_match": "attributes.*", "match_mapping_type": "double" } },
+        { "string_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "attributes.*", "match_mapping_type": "string" } }
+      ],
+      "properties": {
+        "droppedAttributesCount": { "type": "integer" },
+        "instrumentationScope": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 }, "name": { "type": "keyword", "ignore_above": 128 }, "version": { "type": "keyword", "ignore_above": 64 } } },
+        "resource": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 } } },
+        "traceId": { "type": "keyword", "ignore_above": 32 },
+        "spanId": { "type": "keyword", "ignore_above": 16 },
+        "parentSpanId": { "type": "keyword", "ignore_above": 16 },
+        "name": { "ignore_above": 1024, "type": "keyword" },
+        "traceState": { "ignore_above": 1024, "type": "keyword" },
+        "traceGroup": { "ignore_above": 1024, "type": "keyword" },
+        "traceGroupFields": { "properties": { "endTime": { "type": "date_nanos" }, "durationInNanos": { "type": "long" }, "statusCode": { "type": "integer" } } },
+        "kind": { "type": "keyword", "ignore_above": 32 },
+        "serviceName": { "type": "keyword", "ignore_above": 256 },
+        "startTime": { "type": "date_nanos" },
+        "endTime": { "type": "date_nanos" },
+        "@timestamp": { "type": "date_nanos" },
+        "time": { "type": "date_nanos" },
+        "status": { "properties": { "code": { "type": "integer" }, "message": { "type": "keyword", "ignore_above": 2048 } } },
+        "durationInNanos": { "type": "long" },
+        "events": { "type": "nested", "properties": { "name": { "type": "keyword", "ignore_above": 256 }, "attributes": { "type": "object" }, "droppedAttributesCount": { "type": "integer" }, "time": { "type": "date_nanos" } } },
+        "droppedEventsCount": { "type": "integer" },
+        "links": { "type": "nested", "properties": { "traceId": { "type": "keyword", "ignore_above": 32 }, "spanId": { "type": "keyword", "ignore_above": 16 }, "traceState": { "ignore_above": 1024, "type": "keyword" }, "attributes": { "type": "object" }, "droppedAttributesCount": { "type": "integer" } } },
+        "droppedLinksCount": { "type": "integer" }
+      }
+    }
+  },
+  "version": 1,
+  "priority": 100
+}`
+
+	otelV1LogsTemplateBody = `{
+  "index_patterns": ["otel-v1-logs*"],
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "_source": { "enabled": true },
+      "dynamic_templates": [
+        { "long_resource_attributes": { "mapping": { "type": "long" }, "path_match": "resource.attributes.*", "match_mapping_type": "long" } },
+        { "double_resource_attributes": { "mapping": { "type": "double" }, "path_match": "resource.attributes.*", "match_mapping_type": "double" } },
+        { "string_resource_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "resource.attributes.*", "match_mapping_type": "string" } },
+        { "long_scope_attributes": { "mapping": { "type": "long" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "long" } },
+        { "double_scope_attributes": { "mapping": { "type": "double" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "double" } },
+        { "string_scope_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "string" } },
+        { "long_attributes": { "mapping": { "type": "long" }, "path_match": "attributes.*", "match_mapping_type": "long" } },
+        { "double_attributes": { "mapping": { "type": "double" }, "path_match": "attributes.*", "match_mapping_type": "double" } },
+        { "string_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "attributes.*", "match_mapping_type": "string" } }
+      ],
+      "properties": {
+        "droppedAttributesCount": { "type": "integer" },
+        "instrumentationScope": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 }, "name": { "type": "keyword", "ignore_above": 128 }, "version": { "type": "keyword", "ignore_above": 64 } } },
+        "resource": { "properties": { "droppedAttributesCount": { "type": "integer" }, "schemaUrl": { "type": "keyword", "ignore_above": 256 } } },
+        "severity": { "properties": { "number": { "type": "integer" }, "text": { "type": "keyword", "ignore_above": 32 } } },
+        "body": { "type": "text" },
+        "@timestamp": { "type": "date_nanos" },
+        "time": { "type": "date_nanos" },
+        "observedTime": { "type": "date_nanos" },
+        "traceId": { "type": "keyword", "ignore_above": 32 },
+        "spanId": { "type": "keyword", "ignore_above": 16 },
+        "flags": { "type": "long" }
+      }
+    }
+  },
+  "version": 1,
+  "priority": 100
+}`
+)
+
+type templateManager struct {
+	client *opensearchapi.Client
+	logger *zap.Logger
+}
+
+func newTemplateManager(client *opensearchapi.Client, logger *zap.Logger) *templateManager {
+	return &templateManager{client: client, logger: logger}
+}
+
+func (tm *templateManager) ensureTemplates(ctx context.Context) {
+	tm.ensureTemplate(ctx, otelV1SpanTemplateName, otelV1SpanTemplateBody)
+	tm.ensureTemplate(ctx, otelV1LogsTemplateName, otelV1LogsTemplateBody)
+}
+
+func (tm *templateManager) ensureTemplate(ctx context.Context, name, body string) {
+	// Check if template exists
+	existsReq := opensearchapi.IndexTemplateExistsReq{IndexTemplate: name}
+	_, err := tm.client.IndexTemplate.Exists(ctx, existsReq)
+	if err == nil {
+		// Template exists, skip creation
+		tm.logger.Debug("Index template already exists, skipping creation", zap.String("template", name))
+		return
+	}
+
+	// Create template
+	createReq := opensearchapi.IndexTemplateCreateReq{
+		IndexTemplate: name,
+		Body:          strings.NewReader(body),
+	}
+	_, createErr := tm.client.IndexTemplate.Create(ctx, createReq)
+	if createErr != nil {
+		tm.logger.Warn("Failed to create index template", zap.String("template", name), zap.Error(createErr))
+		return
+	}
+	tm.logger.Info("Created index template", zap.String("template", name))
+}

--- a/exporter/opensearchexporter/integration_test.go
+++ b/exporter/opensearchexporter/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -454,5 +455,106 @@ func TestOpenSearchOTelV1_CustomIndex(t *testing.T) {
 	require.NoError(t, exporter.ConsumeTraces(t.Context(), traces))
 
 	assert.Equal(t, "my-custom-traces", bulkIndex)
+	require.NoError(t, exporter.Shutdown(t.Context()))
+}
+
+func TestOpenSearchOTelV1_ManageIndexTemplate(t *testing.T) {
+	var templateRequests []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "_index_template") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "_index_template") {
+			templateRequests = append(templateRequests, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"acknowledged": true}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		response, _ := os.ReadFile("testdata/opensearch-response-no-error.json")
+		_, _ = w.Write(response)
+	}))
+	defer ts.Close()
+
+	cfg := withDefaultConfig(func(config *Config) {
+		config.Endpoint = ts.URL
+		config.TimeoutSettings.Timeout = 0
+		config.Mode = "otel-v1"
+		config.ManageIndexTemplate = true
+	})
+
+	f := NewFactory()
+	exporter, err := f.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+
+	assert.Len(t, templateRequests, 2)
+	assert.Contains(t, templateRequests[0], "otel-v1-apm-span-index-template")
+	assert.Contains(t, templateRequests[1], "otel-v1-logs-index-template")
+
+	require.NoError(t, exporter.Shutdown(t.Context()))
+}
+
+func TestOpenSearchOTelV1_ManageIndexTemplate_Disabled(t *testing.T) {
+	var templateRequests []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "_index_template") {
+			templateRequests = append(templateRequests, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		response, _ := os.ReadFile("testdata/opensearch-response-no-error.json")
+		_, _ = w.Write(response)
+	}))
+	defer ts.Close()
+
+	cfg := withDefaultConfig(func(config *Config) {
+		config.Endpoint = ts.URL
+		config.TimeoutSettings.Timeout = 0
+		config.Mode = "otel-v1"
+		config.ManageIndexTemplate = false
+	})
+
+	f := NewFactory()
+	exporter, err := f.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+
+	assert.Empty(t, templateRequests)
+	require.NoError(t, exporter.Shutdown(t.Context()))
+}
+
+func TestOpenSearchOTelV1_ManageIndexTemplate_AlreadyExists(t *testing.T) {
+	var putRequests []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "_index_template") {
+			w.WriteHeader(http.StatusOK) // already exists
+			return
+		}
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "_index_template") {
+			putRequests = append(putRequests, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		response, _ := os.ReadFile("testdata/opensearch-response-no-error.json")
+		_, _ = w.Write(response)
+	}))
+	defer ts.Close()
+
+	cfg := withDefaultConfig(func(config *Config) {
+		config.Endpoint = ts.URL
+		config.TimeoutSettings.Timeout = 0
+		config.Mode = "otel-v1"
+		config.ManageIndexTemplate = true
+	})
+
+	f := NewFactory()
+	exporter, err := f.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+
+	assert.Empty(t, putRequests)
 	require.NoError(t, exporter.Shutdown(t.Context()))
 }

--- a/exporter/opensearchexporter/internal/templates/embed.go
+++ b/exporter/opensearchexporter/internal/templates/embed.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package templates embeds the composable index templates the exporter installs
+// for the otel-v1 mapping mode. The templates mirror the Data Prepper schemas
+// at https://github.com/opensearch-project/data-prepper/tree/main/data-prepper-plugins/opensearch/src/main/resources/index-template
+// and ensure date_nanos timestamps and typed dynamic-attribute mappings before
+// any documents are indexed.
+package templates // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter/internal/templates"
+
+import _ "embed"
+
+// OtelV1APMSpan is the composable index template body for traces in otel-v1 mode.
+//
+//go:embed otel-v1-apm-span.json
+var OtelV1APMSpan string
+
+// OtelV1Logs is the composable index template body for logs in otel-v1 mode.
+//
+//go:embed otel-v1-logs.json
+var OtelV1Logs string

--- a/exporter/opensearchexporter/internal/templates/otel-v1-apm-span.json
+++ b/exporter/opensearchexporter/internal/templates/otel-v1-apm-span.json
@@ -1,0 +1,86 @@
+{
+  "index_patterns": ["otel-v1-apm-span*"],
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "_source": { "enabled": true },
+      "dynamic_templates": [
+        { "long_resource_attributes": { "mapping": { "type": "long" }, "path_match": "resource.attributes.*", "match_mapping_type": "long" } },
+        { "double_resource_attributes": { "mapping": { "type": "double" }, "path_match": "resource.attributes.*", "match_mapping_type": "double" } },
+        { "string_resource_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "resource.attributes.*", "match_mapping_type": "string" } },
+        { "long_scope_attributes": { "mapping": { "type": "long" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "long" } },
+        { "double_scope_attributes": { "mapping": { "type": "double" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "double" } },
+        { "string_scope_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "string" } },
+        { "long_attributes": { "mapping": { "type": "long" }, "path_match": "attributes.*", "match_mapping_type": "long" } },
+        { "double_attributes": { "mapping": { "type": "double" }, "path_match": "attributes.*", "match_mapping_type": "double" } },
+        { "string_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "attributes.*", "match_mapping_type": "string" } }
+      ],
+      "properties": {
+        "droppedAttributesCount": { "type": "integer" },
+        "instrumentationScope": {
+          "properties": {
+            "droppedAttributesCount": { "type": "integer" },
+            "schemaUrl": { "type": "keyword", "ignore_above": 256 },
+            "name": { "type": "keyword", "ignore_above": 128 },
+            "version": { "type": "keyword", "ignore_above": 64 }
+          }
+        },
+        "resource": {
+          "properties": {
+            "droppedAttributesCount": { "type": "integer" },
+            "schemaUrl": { "type": "keyword", "ignore_above": 256 }
+          }
+        },
+        "traceId": { "type": "keyword", "ignore_above": 32 },
+        "spanId": { "type": "keyword", "ignore_above": 16 },
+        "parentSpanId": { "type": "keyword", "ignore_above": 16 },
+        "name": { "ignore_above": 1024, "type": "keyword" },
+        "traceState": { "ignore_above": 1024, "type": "keyword" },
+        "traceGroup": { "ignore_above": 1024, "type": "keyword" },
+        "traceGroupFields": {
+          "properties": {
+            "endTime": { "type": "date_nanos" },
+            "durationInNanos": { "type": "long" },
+            "statusCode": { "type": "integer" }
+          }
+        },
+        "kind": { "type": "keyword", "ignore_above": 32 },
+        "serviceName": { "type": "keyword", "ignore_above": 256 },
+        "startTime": { "type": "date_nanos" },
+        "endTime": { "type": "date_nanos" },
+        "@timestamp": { "type": "date_nanos" },
+        "time": { "type": "date_nanos" },
+        "status": {
+          "properties": {
+            "code": { "type": "integer" },
+            "message": { "type": "keyword", "ignore_above": 2048 }
+          }
+        },
+        "durationInNanos": { "type": "long" },
+        "events": {
+          "type": "nested",
+          "properties": {
+            "name": { "type": "keyword", "ignore_above": 256 },
+            "attributes": { "type": "object" },
+            "droppedAttributesCount": { "type": "integer" },
+            "time": { "type": "date_nanos" }
+          }
+        },
+        "droppedEventsCount": { "type": "integer" },
+        "links": {
+          "type": "nested",
+          "properties": {
+            "traceId": { "type": "keyword", "ignore_above": 32 },
+            "spanId": { "type": "keyword", "ignore_above": 16 },
+            "traceState": { "ignore_above": 1024, "type": "keyword" },
+            "attributes": { "type": "object" },
+            "droppedAttributesCount": { "type": "integer" }
+          }
+        },
+        "droppedLinksCount": { "type": "integer" }
+      }
+    }
+  },
+  "version": 1,
+  "priority": 100
+}

--- a/exporter/opensearchexporter/internal/templates/otel-v1-logs.json
+++ b/exporter/opensearchexporter/internal/templates/otel-v1-logs.json
@@ -1,0 +1,52 @@
+{
+  "index_patterns": ["otel-v1-logs*"],
+  "template": {
+    "mappings": {
+      "date_detection": false,
+      "_source": { "enabled": true },
+      "dynamic_templates": [
+        { "long_resource_attributes": { "mapping": { "type": "long" }, "path_match": "resource.attributes.*", "match_mapping_type": "long" } },
+        { "double_resource_attributes": { "mapping": { "type": "double" }, "path_match": "resource.attributes.*", "match_mapping_type": "double" } },
+        { "string_resource_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "resource.attributes.*", "match_mapping_type": "string" } },
+        { "long_scope_attributes": { "mapping": { "type": "long" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "long" } },
+        { "double_scope_attributes": { "mapping": { "type": "double" }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "double" } },
+        { "string_scope_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "instrumentationScope.attributes.*", "match_mapping_type": "string" } },
+        { "long_attributes": { "mapping": { "type": "long" }, "path_match": "attributes.*", "match_mapping_type": "long" } },
+        { "double_attributes": { "mapping": { "type": "double" }, "path_match": "attributes.*", "match_mapping_type": "double" } },
+        { "string_attributes": { "mapping": { "type": "keyword", "ignore_above": 256 }, "path_match": "attributes.*", "match_mapping_type": "string" } }
+      ],
+      "properties": {
+        "droppedAttributesCount": { "type": "integer" },
+        "instrumentationScope": {
+          "properties": {
+            "droppedAttributesCount": { "type": "integer" },
+            "schemaUrl": { "type": "keyword", "ignore_above": 256 },
+            "name": { "type": "keyword", "ignore_above": 128 },
+            "version": { "type": "keyword", "ignore_above": 64 }
+          }
+        },
+        "resource": {
+          "properties": {
+            "droppedAttributesCount": { "type": "integer" },
+            "schemaUrl": { "type": "keyword", "ignore_above": 256 }
+          }
+        },
+        "severity": {
+          "properties": {
+            "number": { "type": "integer" },
+            "text": { "type": "keyword", "ignore_above": 32 }
+          }
+        },
+        "body": { "type": "text" },
+        "@timestamp": { "type": "date_nanos" },
+        "time": { "type": "date_nanos" },
+        "observedTime": { "type": "date_nanos" },
+        "traceId": { "type": "keyword", "ignore_above": 32 },
+        "spanId": { "type": "keyword", "ignore_above": 16 },
+        "flags": { "type": "long" }
+      }
+    }
+  },
+  "version": 1,
+  "priority": 100
+}

--- a/exporter/opensearchexporter/sso_log_exporter.go
+++ b/exporter/opensearchexporter/sso_log_exporter.go
@@ -79,6 +79,11 @@ func (l *logExporter) Start(ctx context.Context, host component.Host) error {
 
 	l.client = client
 
+	if l.config.ManageIndexTemplate {
+		tm := newTemplateManager(client, l.telemetry.Logger)
+		tm.ensureTemplates(ctx)
+	}
+
 	return nil
 }
 

--- a/exporter/opensearchexporter/sso_trace_exporter.go
+++ b/exporter/opensearchexporter/sso_trace_exporter.go
@@ -70,6 +70,11 @@ func (s *ssoTracesExporter) Start(ctx context.Context, host component.Host) erro
 
 	s.client = client
 
+	if s.config.ManageIndexTemplate {
+		tm := newTemplateManager(client, s.telemetry.Logger)
+		tm.ensureTemplates(ctx)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

Introduces a new opt-in `mapping.manage_index_template` configuration option for the `otel-v1` mapping mode. When enabled, the exporter automatically provisions the `otel-v1-apm-span-index-template` and `otel-v1-logs-index-template` composable index templates at startup — before any documents are written.

Without these templates, OpenSearch's dynamic mapping downgrades nanosecond-precision timestamps (produced by the encoder) to the `date` type (millisecond precision) — a known limitation already documented in the otel-v1 README.

## Approach

Setting `manage_index_template: true` ensures that from the very first indexed document:

- Timestamps are correctly mapped as `date_nanos` (nanosecond precision)
- `status.code` and `severity.number` are mapped as numeric types
- Typed dynamic-attribute mappings are applied upfront

### Safeguards

- The flag defaults to `false` (no behavior change unless explicitly opted in)
- Validation rejects `manage_index_template: true` for any mode other than `otel-v1`
- If templates with the same names already exist (e.g., user-customized versions), the exporter preserves them without overwriting

## Context

This is the second of three planned PRs from #48585. The third PR (ISM rollover) will follow.

## Tracking Issue

Refs #48585

## Testing

- **Unit tests** — Cover the new config field, validation rule, and the `Start()`-time behavior of the template manager (idempotent creation, skip-if-exists). Three new `_ManageIndexTemplate*` integration tests use `httptest` to verify request shape against a mock OpenSearch.
- **End-to-end smoke tests** — Validated against a live OpenSearch 2.19.5 cluster:
  - Golden path: `date_nanos` materializes correctly
  - Idempotent restart (no duplicate template creation)
  - Pre-existing user-customized templates are preserved
  - Custom `traces_index` matching the wildcard pattern
  - Default behavior unchanged when the flag is `false`
  - Validation rejects the flag when used with `ss4o` mode
  - `ss4o` mode remains unaffected
- **CI checks** — `make test`, `make lint`, and `make chlog-validate` all pass; `config.schema.yaml` regenerated.

## Documentation Updates

- Added a `manage_index_template` entry to the mapping config option list
- Added an explanatory paragraph in the OTel v1 mapping mode section
- Updated the `[!NOTE]` block to recommend the flag (replacing the previous manual out-of-band template instructions)
- Example configuration now includes `manage_index_template: true`