### PR TITLE
docs: remove outdated warning about GKE host.name and Workload Identity

### DIFF
--- a/.chloggen/docs-gke-metadata.yaml
+++ b/.chloggen/docs-gke-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resource_detection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove outdated warning about GKE host.name not being available with Workload Identity"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48876]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -203,6 +203,11 @@ The list of the populated resource attributes can be found at [GCP Detector Reso
     * host.id (instance id)
     * host.name (instance name)
 
+Support for the instance name in the metadata server when GKE workload identity is enabled depends on the version of GKE being used. On older GKE versions, the GCE metadata endpoints won't be available, thus the GKE resource detector won't be
+able to determine `host.name`. In that case, users are encouraged to set `host.name` from either:
+- `node.name` through the downward API with the `env` detector
+- obtaining the Kubernetes node name from the Kubernetes API (with `k8s.io/client-go`)
+
 #### Google Cloud Run Services Metadata
 
     * cloud.provider ("gcp")

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -201,12 +201,7 @@ The list of the populated resource attributes can be found at [GCP Detector Reso
     * cloud.availability_zone (only for zonal GKE clusters; e.g. "us-central1-c")
     * k8s.cluster.name
     * host.id (instance id)
-    * host.name (instance name; only when workload identity is disabled)
-
-One known issue is when GKE workload identity is enabled, the GCE metadata endpoints won't be available, thus the GKE resource detector won't be
-able to determine `host.name`. In that case, users are encouraged to set `host.name` from either:
-- `node.name` through the downward API with the `env` detector
-- obtaining the Kubernetes node name from the Kubernetes API (with `k8s.io/client-go`)
+    * host.name (instance name)
 
 #### Google Cloud Run Services Metadata
 

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -201,12 +201,7 @@ The list of the populated resource attributes can be found at [GCP Detector Reso
     * cloud.availability_zone (only for zonal GKE clusters; e.g. "us-central1-c")
     * k8s.cluster.name
     * host.id (instance id)
-    * host.name (instance name)
-
-Support for the instance name in the metadata server when GKE workload identity is enabled depends on the version of GKE being used. On older GKE versions, the GCE metadata endpoints won't be available, thus the GKE resource detector won't be
-able to determine `host.name`. In that case, users are encouraged to set `host.name` from either:
-- `node.name` through the downward API with the `env` detector
-- obtaining the Kubernetes node name from the Kubernetes API (with `k8s.io/client-go`)
+    * host.name (instance name; availability with workload identity depends on GKE version)
 
 #### Google Cloud Run Services Metadata
 


### PR DESCRIPTION
#### Description

Update documentation now that GKE workload identity supports the instance name.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48876

#### Testing

Created a new GKE autopilot cluster, which has workload identity enabled.  I verified that `instance/name` metadata is available, and that a collector with the gcp resourcedetection processor is able to obtain it.

#### Documentation

- [x] I, a human, wrote this pull request description myself.
