### PR TITLE
[chore][pkg/stanza] remove references to attributes.time from the container operator docs

### DIFF
--- a/pkg/stanza/docs/operators/container.md
+++ b/pkg/stanza/docs/operators/container.md
@@ -76,7 +76,6 @@ Note: in this example the `format: docker` is optional since formats can be auto
   "timestamp": "2024-03-30 08:31:20.545192187 +0000 UTC",
   "body": "INFO: log line here",
   "attributes": {
-    "time": "2024-03-30T08:31:20.545192187Z", 
     "log.iostream":                "stdout",
     "log.file.path": "/var/log/pods/some_kube-controller-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d6/kube-controller/1.log"
   },
@@ -122,7 +121,6 @@ Configuration:
   "timestamp": "2024-04-13 12:59:37.505201169 +0000 UTC",
   "body": "standalone crio line which is awesome",
   "attributes": {
-    "time": "2024-04-13T07:59:37.505201169-05:00",
     "logtag": "F",
     "log.iostream":                "stdout",
     "log.file.path": "/var/log/pods/some_kube-controller-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d6/kube-controller/1.log"
@@ -169,7 +167,6 @@ Configuration:
   "timestamp": "2023-06-22 10:27:25.813799277 +0000 UTC",
   "body": "standalone containerd line that is super awesome",
   "attributes": {
-    "time": "2023-06-22T10:27:25.813799277Z",
     "logtag": "F", 
     "log.iostream":                "stdout",
     "log.file.path": "/var/log/pods/some_kube-controller-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d6/kube-controller/1.log"
@@ -224,7 +221,6 @@ Configuration:
   "timestamp": "2023-06-22 10:27:25.813799277 +0000 UTC",
   "body": "multiline containerd line that is super awesome",
   "attributes": {
-    "time": "2023-06-22T10:27:25.813799277Z",
     "logtag": "F",
     "log.iostream":                "stdout",
     "log.file.path": "/var/log/pods/some_kube-controller-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d6/kube-controller/1.log"
@@ -291,7 +287,6 @@ receivers:
   "timestamp": "2024-03-30 08:31:20.545192187 +0000 UTC",
   "body": "2024-07-03T13:50:49.526Z  WARN 1 --- [http-nio-8080-exec-6] c.m.antifraud.FraudDetectionController   : checkOrder\njava.net.ConnectException: Failed to connect to",
   "attributes": {
-    "time": "2024-03-30T08:31:20.545192187Z",
     "log.iostream":                "stdout",
     "log.file.path": "/var/log/pods/some_kube-controller-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d6/kube-controller/1.log"
   },
@@ -343,7 +338,6 @@ Configuration:
   "timestamp": "2024-03-30 08:31:20.545192187 +0000 UTC",
   "body": "INFO: log line here",
   "attributes": {
-    "time": "2024-03-30T08:31:20.545192187Z",
     "log.iostream":                "stdout",
     "log.file.path": "/var/log/pods/some_kube-controller-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d6/kube-controller/1.log"
   },


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The output examples in container.md incorrectly showed "time" as present in attributes after parsing phase. In practice, `parseTime` in `parser.go` always deletes the time attribute from the entry after successfully parsing it into `e.Timestamp`. The attribute should never be present in the output of a successfully processed entry.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48885

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
