### PR TITLE
fix inaccurate GKE host.name WIF documentation

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -201,10 +201,9 @@ The list of the populated resource attributes can be found at [GCP Detector Reso
     * cloud.availability_zone (only for zonal GKE clusters; e.g. "us-central1-c")
     * k8s.cluster.name
     * host.id (instance id)
-    * host.name (instance name; only when workload identity is disabled)
+    * host.name (instance name; emitted on a best-effort basis; may not be available in all GKE configurations)
 
-One known issue is when GKE workload identity is enabled, the GCE metadata endpoints won't be available, thus the GKE resource detector won't be
-able to determine `host.name`. In that case, users are encouraged to set `host.name` from either:
+`host.name` is fetched from the GCE metadata server on a best-effort basis. It is available in most GKE configurations, including clusters with Workload Identity Federation (WIF) enabled (both Autopilot and Standard mode). If it cannot be retrieved (e.g., the metadata endpoint is not accessible), the attribute will be omitted and an informational message will be logged. In that case, users can set `host.name` from either:
 - `node.name` through the downward API with the `env` detector
 - obtaining the Kubernetes node name from the Kubernetes API (with `k8s.io/client-go`)
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -88,7 +88,7 @@ func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 			d.rb.SetFromCallable(d.rb.SetK8sClusterName, d.detector.GKEClusterName),
 			d.rb.SetFromCallable(d.rb.SetHostID, d.detector.GKEHostID),
 		)
-		// GCEHostname is fallible on GKE, since it's not available when using workload identity.
+		// GCEHostName is fetched on a best-effort basis; it may not be available in all GKE configurations.
 		if v, err := d.detector.GCEHostName(); err == nil {
 			d.rb.SetHostName(v)
 		} else {


### PR DESCRIPTION
The README incorrectly stated that `host.name` is unavailable when GKE
Workload Identity Federation (WIF) is enabled. 
In practice, host.name is
emitted on a best-effort basis and is available in most GKE configurations,
including Autopilot clusters (which always use WIF) and Standard clusters
with WIF manually enabled.
The code already implements the correct behavior: GCEHostName() is called
unconditionally, and host.name is only omitted if the call returns an error.
Update the README to accurately describe host.name as a best-effort attribute
and fix the misleading inline comment in gcp.go.

Fixes: #48876