### PR TITLE
[receiver/vcenterreceiver] Fix vcenter.vm.cpu.readiness always report…

### DIFF
--- a/.chloggen/fix-vcenter-vm-cpu-readiness.yaml
+++ b/.chloggen/fix-vcenter-vm-cpu-readiness.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/vcenter
+
+note: Fix `vcenter.vm.cpu.readiness` always reporting 0 by adding the missing `summary.quickStats.overallCpuReadiness` property to the vSphere Retrieve call in `VMs()`
+
+issues: [48487]
+
+subtext:
+
+change_logs: [user]

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -242,6 +242,7 @@ func (vc *vcenterClient) VMs(ctx context.Context, containerMoRef vt.ManagedObjec
 		"summary.quickStats.swappedMemory",
 		"summary.quickStats.ssdSwappedMemory",
 		"summary.quickStats.overallCpuUsage",
+		"summary.quickStats.overallCpuReadiness",
 		"summary.overallStatus",
 		"summary.config.memorySizeMB",
 		"summary.storage.committed",

--- a/receiver/vcenterreceiver/internal/mockserver/responses/vm-default-properties.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/vm-default-properties.xml
@@ -54,6 +54,10 @@
                         <val xsi:type="xsd:int">12</val>
                     </propSet>
                     <propSet>
+                        <name>summary.quickStats.overallCpuReadiness</name>
+                        <val xsi:type="xsd:int">225</val>
+                    </propSet>
+                    <propSet>
                         <name>summary.quickStats.ssdSwappedMemory</name>
                         <val xsi:type="xsd:long">0</val>
                     </propSet>
@@ -127,6 +131,10 @@
                         <val xsi:type="xsd:int">12</val>
                     </propSet>
                     <propSet>
+                        <name>summary.quickStats.overallCpuReadiness</name>
+                        <val xsi:type="xsd:int">225</val>
+                    </propSet>
+                    <propSet>
                         <name>summary.quickStats.ssdSwappedMemory</name>
                         <val xsi:type="xsd:long">0</val>
                     </propSet>
@@ -198,6 +206,10 @@
                     <propSet>
                         <name>summary.quickStats.overallCpuUsage</name>
                         <val xsi:type="xsd:int">12</val>
+                    </propSet>
+                    <propSet>
+                        <name>summary.quickStats.overallCpuReadiness</name>
+                        <val xsi:type="xsd:int">225</val>
                     </propSet>
                     <propSet>
                         <name>summary.quickStats.ssdSwappedMemory</name>

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -2162,7 +2162,7 @@ resourceMetrics:
           - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "225"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: vcenter.vm.cpu.readiness
@@ -2993,7 +2993,7 @@ resourceMetrics:
           - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "225"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: vcenter.vm.cpu.readiness
@@ -3923,7 +3923,7 @@ resourceMetrics:
           - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "225"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: vcenter.vm.cpu.readiness

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -2106,7 +2106,7 @@ resourceMetrics:
           - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "225"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: vcenter.vm.cpu.readiness
@@ -2743,7 +2743,7 @@ resourceMetrics:
           - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "225"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: vcenter.vm.cpu.readiness
@@ -3479,7 +3479,7 @@ resourceMetrics:
           - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "225"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: vcenter.vm.cpu.readiness


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
vcenter.vm.cpu.readiness has always reported 0 for every VM since it was introduced. 
The root cause is that "**summary.quickStats.overallCpuReadiness**" was never included in the vSphere property list passed to Retrieve() in the VMs() function in client.go. Since vSphere only returns explicitly requested properties, the Go struct field vm.Summary.QuickStats.OverallCpuReadiness was never populated and stayed at its zero value. The fix adds the missing property to the list alongside the existing "summary.quickStats.overallCpuUsage". The mock server test data and golden files were updated accordingly.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48487
<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added the missing property to the mock server XML (vm-default-properties.xml) with a non-zero value and updated the golden test files (expected.yaml, expected-all-enabled.yaml) to reflect the correct value. 
Ran go test ./... in receiver/vcenterreceiver/ — all tests pass. Ran make lint and passed too.
<!--Describe the documentation added.-->
#### Documentation
None
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
