### PR TITLE
[exporter/clickhouse] retry schema detection after transient errors instead of caching "feature absent"

### DIFF
--- a/.chloggen/48875-clickhouse-retry-schema-detection.yaml
+++ b/.chloggen/48875-clickhouse-retry-schema-detection.yaml
@@ -1,0 +1,37 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Re-detect schema features lazily instead of caching detection errors as `feature absent`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48875]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `create_schema: false`, the exporter's startup `DESC TABLE` probe ran once
+  and any failure was treated as "feature columns absent", silently caching an
+  INSERT statement that omitted the optional `*AttributesKeys` / `EventName`
+  columns for the lifetime of the process — even after ClickHouse recovered.
+  The exporter now defers INSERT rendering until a probe succeeds; on continued
+  failure, push paths return a retryable (non-permanent) error so the sending
+  queue and `retry_on_failure` defer the batch instead of writing degraded rows.
+  Operators relying on this recovery should keep `retry_on_failure.enabled: true`;
+  with retry disabled, batches arriving while ClickHouse is still unreachable
+  will be dropped on first push as they would for any other transient failure.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/exporter_bench_test.go
+++ b/exporter/clickhouseexporter/exporter_bench_test.go
@@ -199,6 +199,9 @@ func BenchmarkPushLogsData(b *testing.B) {
 	}
 	exporter.schemaFeatures.EventName = true
 	exporter.insertSQL = "INSERT INTO test"
+	// Pre-mark schema as detected so the benchmark exercises the steady-state
+	// push path and not the lazy-detection retry introduced for #48875.
+	exporter.detector.state.Store(int32(schemaDetected))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -27,6 +27,7 @@ type logsExporter struct {
 	schemaFeatures struct {
 		EventName bool
 	}
+	detector schemaDetector
 
 	logger *zap.Logger
 	cfg    *Config
@@ -60,13 +61,11 @@ func (e *logsExporter) start(ctx context.Context, _ component.Host) error {
 		}
 	}
 
-	err = e.detectSchemaFeatures(ctx)
-	if err != nil {
-		e.logger.Error("schema detection failed", zap.Error(err))
-	}
-
-	if err := e.renderInsertLogsSQL(); err != nil {
-		return fmt.Errorf("render logs insert sql: %w", err)
+	// Attempt detection once at start, but do NOT treat failure as "feature absent"
+	// (issue #48875). A transient ClickHouse outage at startup must not cache a
+	// degraded INSERT that omits the EventName column forever.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+		e.logger.Warn("clickhouseexporter schema detection deferred; will retry on first batch", zap.Error(err))
 	}
 
 	return nil
@@ -76,7 +75,10 @@ const (
 	logsColumnEventName = "EventName"
 )
 
-func (e *logsExporter) detectSchemaFeatures(ctx context.Context) error {
+// probeSchemaFeatures runs a single DESC TABLE and, on success, populates
+// schemaFeatures and renders the cached INSERT. Called via schemaDetector under
+// its mutex so that only one goroutine renders the INSERT.
+func (e *logsExporter) probeSchemaFeatures(ctx context.Context) error {
 	columnNames, err := internal.GetTableColumns(ctx, e.db, e.cfg.database(), e.cfg.LogsTableName)
 	if err != nil {
 		return err
@@ -88,7 +90,7 @@ func (e *logsExporter) detectSchemaFeatures(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return e.renderInsertLogsSQL()
 }
 
 func (e *logsExporter) shutdown(_ context.Context) error {
@@ -100,6 +102,14 @@ func (e *logsExporter) shutdown(_ context.Context) error {
 }
 
 func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
+	// If schema detection has not yet succeeded (transient ClickHouse outage at
+	// start), re-probe before preparing the INSERT. ensureDetected returns a
+	// plain (non-permanent) error on continued failure so exporterhelper's
+	// retry_on_failure / sending queue defers this batch instead of dropping it.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+		return err
+	}
+
 	batch, err := e.db.PrepareBatch(ctx, e.insertSQL)
 	if err != nil {
 		return err

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -64,7 +64,11 @@ func (e *logsExporter) start(ctx context.Context, _ component.Host) error {
 	// Attempt detection once at start, but do NOT treat failure as "feature absent"
 	// (issue #48875). A transient ClickHouse outage at startup must not cache a
 	// degraded INSERT that omits the EventName column forever.
-	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+	//
+	// For permanent failures (unknown table, access denied) the fallback renders
+	// a degraded INSERT without the optional columns so write-only ClickHouse
+	// users keep delivering rows instead of silently losing everything.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures, e.renderDegradedInsert); err != nil {
 		e.logger.Warn("clickhouseexporter schema detection deferred; will retry on first batch", zap.Error(err))
 	}
 
@@ -106,7 +110,9 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 	// start), re-probe before preparing the INSERT. ensureDetected returns a
 	// plain (non-permanent) error on continued failure so exporterhelper's
 	// retry_on_failure / sending queue defers this batch instead of dropping it.
-	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+	// Permanent failures (access denied, unknown table) fall back to a degraded
+	// INSERT so write-only users keep delivering.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures, e.renderDegradedInsert); err != nil {
 		return err
 	}
 
@@ -204,6 +210,16 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 		zap.String("total_cost", totalDuration.String()))
 
 	return nil
+}
+
+// renderDegradedInsert renders the INSERT statement with all optional feature
+// flags at their zero values. Used as the fallback when DESC TABLE fails with a
+// permanent ClickHouse error (access denied, unknown table) so write-only users
+// keep delivering rows without the EventName column.
+func (e *logsExporter) renderDegradedInsert() {
+	if err := e.renderInsertLogsSQL(); err != nil {
+		e.logger.Error("failed to render degraded INSERT", zap.Error(err))
+	}
 }
 
 func (e *logsExporter) renderInsertLogsSQL() error {

--- a/exporter/clickhouseexporter/exporter_logs_json.go
+++ b/exporter/clickhouseexporter/exporter_logs_json.go
@@ -70,7 +70,11 @@ func (e *logsJSONExporter) start(ctx context.Context, _ component.Host) error {
 	// Attempt detection once at start, but do NOT treat failure as "feature absent"
 	// (issue #48875). A transient ClickHouse outage at startup must not cache a
 	// degraded INSERT that omits the keys / EventName columns forever.
-	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+	//
+	// For permanent failures (unknown table, access denied) the fallback renders
+	// a degraded INSERT without the optional columns so write-only ClickHouse
+	// users keep delivering rows instead of silently losing everything.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures, e.renderDegradedInsert); err != nil {
 		e.logger.Warn("clickhouseexporter schema detection deferred; will retry on first batch", zap.Error(err))
 	}
 
@@ -125,7 +129,9 @@ func (e *logsJSONExporter) pushLogsData(ctx context.Context, ld plog.Logs) error
 	// start), re-probe before preparing the INSERT. ensureDetected returns a
 	// plain (non-permanent) error on continued failure so exporterhelper's
 	// retry_on_failure / sending queue defers this batch instead of dropping it.
-	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+	// Permanent failures (access denied, unknown table) fall back to a degraded
+	// INSERT so write-only users keep delivering.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures, e.renderDegradedInsert); err != nil {
 		return err
 	}
 
@@ -247,6 +253,20 @@ func (e *logsJSONExporter) pushLogsData(ctx context.Context, ld plog.Logs) error
 		zap.String("total_cost", totalDuration.String()))
 
 	return nil
+}
+
+// renderDegradedInsert renders the INSERT statement with all optional feature
+// flags at their zero values. Used as the fallback when DESC TABLE fails with a
+// permanent ClickHouse error (access denied, unknown table) so write-only users
+// keep delivering rows without the keys/EventName columns.
+func (e *logsJSONExporter) renderDegradedInsert() {
+	// Feature flags are already at zero values (the struct was zero-initialized
+	// or start() has not set them). Render the INSERT with those defaults.
+	if err := e.renderInsertLogsJSONSQL(); err != nil {
+		// renderInsertLogsJSONSQL only fails if the template is malformed,
+		// which is a compile-time invariant — but surface it just in case.
+		e.logger.Error("failed to render degraded INSERT", zap.Error(err))
+	}
 }
 
 func (e *logsJSONExporter) renderInsertLogsJSONSQL() error {

--- a/exporter/clickhouseexporter/exporter_logs_json.go
+++ b/exporter/clickhouseexporter/exporter_logs_json.go
@@ -36,6 +36,7 @@ type logsJSONExporter struct {
 		AttributeKeys bool
 		EventName     bool
 	}
+	detector schemaDetector
 }
 
 func newLogsJSONExporter(logger *zap.Logger, cfg *Config) *logsJSONExporter {
@@ -66,13 +67,11 @@ func (e *logsJSONExporter) start(ctx context.Context, _ component.Host) error {
 		}
 	}
 
-	err = e.detectSchemaFeatures(ctx)
-	if err != nil {
-		e.logger.Error("schema detection failed", zap.Error(err))
-	}
-
-	if err := e.renderInsertLogsJSONSQL(); err != nil {
-		return fmt.Errorf("render logs json insert sql: %w", err)
+	// Attempt detection once at start, but do NOT treat failure as "feature absent"
+	// (issue #48875). A transient ClickHouse outage at startup must not cache a
+	// degraded INSERT that omits the keys / EventName columns forever.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+		e.logger.Warn("clickhouseexporter schema detection deferred; will retry on first batch", zap.Error(err))
 	}
 
 	return nil
@@ -85,7 +84,10 @@ const (
 	logsJSONColumnEventName              = "EventName"
 )
 
-func (e *logsJSONExporter) detectSchemaFeatures(ctx context.Context) error {
+// probeSchemaFeatures runs a single DESC TABLE and, on success, populates
+// schemaFeatures and renders the cached INSERT. Called via schemaDetector under
+// its mutex so that only one goroutine renders the INSERT.
+func (e *logsJSONExporter) probeSchemaFeatures(ctx context.Context) error {
 	columnNames, err := internal.GetTableColumns(ctx, e.db, e.cfg.database(), e.cfg.LogsTableName)
 	if err != nil {
 		return err
@@ -104,7 +106,7 @@ func (e *logsJSONExporter) detectSchemaFeatures(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return e.renderInsertLogsJSONSQL()
 }
 
 func (e *logsJSONExporter) shutdown(_ context.Context) error {
@@ -119,6 +121,14 @@ func (e *logsJSONExporter) shutdown(_ context.Context) error {
 }
 
 func (e *logsJSONExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
+	// If schema detection has not yet succeeded (transient ClickHouse outage at
+	// start), re-probe before preparing the INSERT. ensureDetected returns a
+	// plain (non-permanent) error on continued failure so exporterhelper's
+	// retry_on_failure / sending queue defers this batch instead of dropping it.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+		return err
+	}
+
 	batch, err := e.db.PrepareBatch(ctx, e.insertSQL)
 	if err != nil {
 		return err

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
@@ -172,4 +173,57 @@ func TestLogsJSONExporter_PushDeferredOnSchemaUnknown(t *testing.T) {
 		"push must return a retryable error wrapping the DESC failure")
 	require.Equal(t, schemaUnknown, schemaDetectionState(exp.detector.state.Load()))
 	require.Empty(t, exp.insertSQL)
+}
+
+// makeMinimalLogs returns the smallest possible plog.Logs value that can
+// exercise pushLogsData without nil-derefs.
+func makeMinimalLogs() plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "test")
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
+	return ld
+}
+
+// TestLogsExporter_PermanentFailureFallsBack verifies that a write-only
+// ClickHouse user does not lose data via the non-JSON logs exporter. When
+// DESC TABLE returns ACCESS_DENIED the exporter must fall back to a degraded
+// INSERT (without the EventName column) and deliver rows.
+func TestLogsExporter_PermanentFailureFallsBack(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newLogsExporter(zaptest.NewLogger(t), cfg)
+	exp.db = &stubAccessDeniedConn{}
+
+	err := exp.pushLogsData(t.Context(), makeMinimalLogs())
+	require.NoError(t, err, "push must succeed after falling back to degraded INSERT")
+	require.Equal(t, schemaDetected, schemaDetectionState(exp.detector.state.Load()))
+	require.NotEmpty(t, exp.insertSQL)
+	assert.NotContains(t, exp.insertSQL, logsColumnEventName,
+		"degraded INSERT must NOT include EventName column")
+
+	// Subsequent pushes succeed without re-probing.
+	require.NoError(t, exp.pushLogsData(t.Context(), makeMinimalLogs()))
+}
+
+// TestLogsJSONExporter_PermanentFailureFallsBack verifies write-only user
+// support for the JSON logs exporter.
+func TestLogsJSONExporter_PermanentFailureFallsBack(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newLogsJSONExporter(zaptest.NewLogger(t), cfg)
+	exp.db = &stubAccessDeniedConn{}
+
+	err := exp.pushLogsData(t.Context(), makeMinimalLogs())
+	require.NoError(t, err, "push must succeed after falling back to degraded INSERT")
+	require.Equal(t, schemaDetected, schemaDetectionState(exp.detector.state.Load()))
+	require.NotEmpty(t, exp.insertSQL)
+	assert.NotContains(t, exp.insertSQL, logsJSONColumnResourceAttributesKeys,
+		"degraded INSERT must NOT include keys columns")
+	assert.NotContains(t, exp.insertSQL, logsJSONColumnEventName,
+		"degraded INSERT must NOT include EventName column")
+
+	// Subsequent pushes succeed without re-probing.
+	require.NoError(t, exp.pushLogsData(t.Context(), makeMinimalLogs()))
 }

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestLogsExporter_New(t *testing.T) {
@@ -121,4 +123,53 @@ func TestRenderCreateLogsJSONTableSQL(t *testing.T) {
 
 	require.Contains(t, sql, "TYPE bloom_filter")
 	require.NotContains(t, sql, "TYPE text(")
+}
+
+// TestLogsExporter_PushDeferredOnSchemaUnknown is the sister of
+// TestTracesJSONExporter_PushDeferredOnSchemaUnknown for the default (non-JSON)
+// logs exporter. Verifies that #48875's fix is applied to logs.go: when the
+// schema detector is still schemaUnknown (transient ClickHouse outage at start),
+// pushLogsData re-probes via ensureDetected and on continued failure returns a
+// retryable plain error so exporterhelper's retry_on_failure defers the batch.
+func TestLogsExporter_PushDeferredOnSchemaUnknown(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newLogsExporter(zaptest.NewLogger(t), cfg)
+	exp.db = &stubFailingConn{}
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "test")
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
+
+	err := exp.pushLogsData(t.Context(), ld)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema detection deferred",
+		"push must return a retryable error wrapping the DESC failure")
+	require.Equal(t, schemaUnknown, schemaDetectionState(exp.detector.state.Load()))
+	require.Empty(t, exp.insertSQL)
+}
+
+// TestLogsJSONExporter_PushDeferredOnSchemaUnknown is the sister of
+// TestTracesJSONExporter_PushDeferredOnSchemaUnknown for the JSON logs
+// exporter. See #48875.
+func TestLogsJSONExporter_PushDeferredOnSchemaUnknown(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newLogsJSONExporter(zaptest.NewLogger(t), cfg)
+	exp.db = &stubFailingConn{}
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "test")
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("hello")
+
+	err := exp.pushLogsData(t.Context(), ld)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema detection deferred",
+		"push must return a retryable error wrapping the DESC failure")
+	require.Equal(t, schemaUnknown, schemaDetectionState(exp.detector.state.Load()))
+	require.Empty(t, exp.insertSQL)
 }

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -34,6 +34,7 @@ type tracesJSONExporter struct {
 	schemaFeatures struct {
 		AttributeKeys bool
 	}
+	detector schemaDetector
 }
 
 func newTracesJSONExporter(logger *zap.Logger, cfg *Config) *tracesJSONExporter {
@@ -64,12 +65,13 @@ func (e *tracesJSONExporter) start(ctx context.Context, _ component.Host) error 
 		}
 	}
 
-	err = e.detectSchemaFeatures(ctx)
-	if err != nil {
-		e.logger.Error("schema detection failed", zap.Error(err))
+	// Attempt detection once at start, but do NOT treat failure as "feature absent"
+	// (issue #48875). A transient ClickHouse outage at startup must not cache a
+	// degraded INSERT that omits the keys columns forever. ensureDetected leaves
+	// the detector in schemaUnknown on error so the first push re-detects.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+		e.logger.Warn("clickhouseexporter schema detection deferred; will retry on first batch", zap.Error(err))
 	}
-
-	e.renderInsertTracesJSONSQL()
 
 	return nil
 }
@@ -79,7 +81,10 @@ const (
 	tracesJSONColumnSpanAttributesKeys     = "SpanAttributesKeys"
 )
 
-func (e *tracesJSONExporter) detectSchemaFeatures(ctx context.Context) error {
+// probeSchemaFeatures runs a single DESC TABLE and, on success, populates
+// schemaFeatures and renders the cached INSERT. Called via schemaDetector under
+// its mutex so that only one goroutine renders the INSERT.
+func (e *tracesJSONExporter) probeSchemaFeatures(ctx context.Context) error {
 	columnNames, err := internal.GetTableColumns(ctx, e.db, e.cfg.database(), e.cfg.TracesTableName)
 	if err != nil {
 		return err
@@ -94,6 +99,7 @@ func (e *tracesJSONExporter) detectSchemaFeatures(ctx context.Context) error {
 		}
 	}
 
+	e.renderInsertTracesJSONSQL()
 	return nil
 }
 
@@ -109,6 +115,14 @@ func (e *tracesJSONExporter) shutdown(_ context.Context) error {
 }
 
 func (e *tracesJSONExporter) pushTraceData(ctx context.Context, td ptrace.Traces) error {
+	// If schema detection has not yet succeeded (transient ClickHouse outage at
+	// start), re-probe before preparing the INSERT. ensureDetected returns a
+	// plain (non-permanent) error on continued failure so exporterhelper's
+	// retry_on_failure / sending queue defers this batch instead of dropping it.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+		return err
+	}
+
 	batch, err := e.db.PrepareBatch(ctx, e.insertSQL)
 	if err != nil {
 		return err
@@ -291,7 +305,8 @@ func (e *tracesJSONExporter) renderInsertTracesJSONSQL() {
 
 func renderCreateTracesJSONTableSQL(cfg *Config) string {
 	ttlExpr := internal.GenerateTTLExpr(cfg.TTL, "toDateTime(Timestamp)")
-	return fmt.Sprintf(sqltemplates.TracesJSONCreateTable,
+	return fmt.Sprintf(
+		sqltemplates.TracesJSONCreateTable,
 		cfg.database(), cfg.TracesTableName, cfg.clusterString(),
 		cfg.tableEngineString(),
 		ttlExpr,

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -69,7 +69,11 @@ func (e *tracesJSONExporter) start(ctx context.Context, _ component.Host) error 
 	// (issue #48875). A transient ClickHouse outage at startup must not cache a
 	// degraded INSERT that omits the keys columns forever. ensureDetected leaves
 	// the detector in schemaUnknown on error so the first push re-detects.
-	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+	//
+	// For permanent failures (unknown table, access denied) the fallback renders
+	// a degraded INSERT without the optional columns so write-only ClickHouse
+	// users keep delivering rows instead of silently losing everything.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures, e.renderInsertTracesJSONSQL); err != nil {
 		e.logger.Warn("clickhouseexporter schema detection deferred; will retry on first batch", zap.Error(err))
 	}
 
@@ -119,7 +123,9 @@ func (e *tracesJSONExporter) pushTraceData(ctx context.Context, td ptrace.Traces
 	// start), re-probe before preparing the INSERT. ensureDetected returns a
 	// plain (non-permanent) error on continued failure so exporterhelper's
 	// retry_on_failure / sending queue defers this batch instead of dropping it.
-	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures); err != nil {
+	// Permanent failures (access denied, unknown table) fall back to a degraded
+	// INSERT so write-only users keep delivering.
+	if err := e.detector.ensureDetected(ctx, e.logger, e.probeSchemaFeatures, e.renderInsertTracesJSONSQL); err != nil {
 		return err
 	}
 

--- a/exporter/clickhouseexporter/exporter_traces_json_test.go
+++ b/exporter/clickhouseexporter/exporter_traces_json_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhouseexporter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestTracesJSONExporter_StartIsNonFatalOnDescFailure is the unit-level regression
+// for #48875: when DESC TABLE fails at start (e.g. transient ClickHouse outage),
+// start() must complete successfully but the cached INSERT must NOT yet be rendered.
+// The first pushTraceData call must re-probe; on continued failure the push returns
+// a retryable error rather than silently appending rows without the keys columns.
+func TestTracesJSONExporter_StartIsNonFatalOnDescFailure(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	cfg.CreateSchema = false
+	exp := newTracesJSONExporter(zaptest.NewLogger(t), cfg)
+
+	// Replace the real DESC TABLE probe with a controllable stub. We don't go
+	// through start() (which would open a real DB connection) — we only verify
+	// the detector + push path.
+	descCalls := atomic.Int32{}
+	descFails := atomic.Bool{}
+	descFails.Store(true)
+
+	stubProbe := func(_ context.Context) error {
+		descCalls.Add(1)
+		if descFails.Load() {
+			return errors.New("dial tcp clickhouse:9440: connect: connection refused")
+		}
+		// Simulate a healthy CH returning the keys columns. probeSchemaFeatures
+		// would normally populate schemaFeatures and render the INSERT — do the
+		// same here so the assertion below sees the expected INSERT.
+		exp.schemaFeatures.AttributeKeys = true
+		exp.renderInsertTracesJSONSQL()
+		return nil
+	}
+
+	// Simulate start() reaching ensureDetected after the table-create branch.
+	// The first probe fails — start() must still return nil (non-fatal).
+	err := exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe)
+	require.Error(t, err, "first probe must propagate the failure")
+	require.ErrorContains(t, err, "schema detection deferred")
+	require.Equal(t, int32(1), descCalls.Load())
+	require.Equal(t, schemaUnknown, schemaDetectionState(exp.detector.state.Load()))
+	require.Empty(t, exp.insertSQL, "INSERT must not be rendered before a successful probe")
+
+	// First batch arrives while ClickHouse is still down: the push helper
+	// re-probes, gets the same failure, and returns a retryable error.
+	err = exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "schema detection deferred")
+	require.Equal(t, int32(2), descCalls.Load())
+	require.Empty(t, exp.insertSQL, "INSERT must still not be rendered after a second failed probe")
+
+	// ClickHouse recovers: the next probe succeeds, INSERT is rendered with the
+	// keys columns, and subsequent calls reuse the cached INSERT.
+	descFails.Store(false)
+	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe))
+	require.Equal(t, int32(3), descCalls.Load())
+	require.Equal(t, schemaDetected, schemaDetectionState(exp.detector.state.Load()))
+	require.NotEmpty(t, exp.insertSQL)
+	assert.Contains(t, exp.insertSQL, tracesJSONColumnResourceAttributesKeys,
+		"INSERT must include ResourceAttributesKeys once detection succeeds")
+	assert.Contains(t, exp.insertSQL, tracesJSONColumnSpanAttributesKeys,
+		"INSERT must include SpanAttributesKeys once detection succeeds")
+
+	// Further ensureDetected calls are no-ops; the stub is not invoked again.
+	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe))
+	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe))
+	assert.Equal(t, int32(3), descCalls.Load())
+}
+
+// TestTracesJSONExporter_RenderInsertOmitsKeysColumnsWhenAbsent verifies the
+// non-#48875 path stays correct: when DESC TABLE succeeds and reports that
+// the AttributesKeys columns are NOT present, the INSERT must omit them.
+func TestTracesJSONExporter_RenderInsertOmitsKeysColumnsWhenAbsent(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newTracesJSONExporter(zaptest.NewLogger(t), cfg)
+	exp.schemaFeatures.AttributeKeys = false
+	exp.renderInsertTracesJSONSQL()
+
+	require.NotEmpty(t, exp.insertSQL)
+	assert.NotContains(t, exp.insertSQL, tracesJSONColumnResourceAttributesKeys)
+	assert.NotContains(t, exp.insertSQL, tracesJSONColumnSpanAttributesKeys)
+}
+
+// makeMinimalTraces returns the smallest possible ptrace.Traces value that can
+// exercise pushTraceData without nil-derefs.
+func makeMinimalTraces() ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "test")
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-span")
+	span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3}))
+	span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3}))
+	return td
+}
+
+// TestTracesJSONExporter_PushDeferredOnSchemaUnknown verifies the precise
+// regression: pushTraceData returns a retryable error (the literal "schema
+// detection deferred" wrapping the original DESC failure) when the schema is
+// still unknown, so the sending queue defers the batch instead of dropping it.
+func TestTracesJSONExporter_PushDeferredOnSchemaUnknown(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newTracesJSONExporter(zaptest.NewLogger(t), cfg)
+	exp.db = &stubFailingConn{}
+
+	// Detector starts in schemaUnknown. pushTraceData drives ensureDetected →
+	// probeSchemaFeatures → GetTableColumns(stubFailingConn) → error path.
+	err := exp.pushTraceData(t.Context(), makeMinimalTraces())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema detection deferred",
+		"push must return a retryable error wrapping the DESC failure")
+	require.Equal(t, schemaUnknown, schemaDetectionState(exp.detector.state.Load()))
+	require.Empty(t, exp.insertSQL)
+}
+
+// stubFailingConn is a driver.Conn that returns an error from Query (used by
+// internal.GetTableColumns for DESC TABLE) so we can simulate a transient
+// ClickHouse outage without standing up a real test container.
+type stubFailingConn struct{}
+
+var _ driver.Conn = (*stubFailingConn)(nil)
+
+func (*stubFailingConn) Contributors() []string                        { return nil }
+func (*stubFailingConn) ServerVersion() (*driver.ServerVersion, error) { return nil, nil }
+func (*stubFailingConn) Select(context.Context, any, string, ...any) error {
+	return errors.New("dial tcp clickhouse:9440: connect: connection refused")
+}
+
+func (*stubFailingConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	return nil, errors.New("dial tcp clickhouse:9440: connect: connection refused")
+}
+func (*stubFailingConn) QueryRow(context.Context, string, ...any) driver.Row { return nil }
+func (*stubFailingConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	return nil, errors.New("dial tcp clickhouse:9440: connect: connection refused")
+}
+func (*stubFailingConn) Exec(context.Context, string, ...any) error { return nil }
+func (*stubFailingConn) AsyncInsert(context.Context, string, bool, ...any) error {
+	return nil
+}
+func (*stubFailingConn) Ping(context.Context) error { return nil }
+func (*stubFailingConn) Stats() driver.Stats        { return driver.Stats{} }
+func (*stubFailingConn) Close() error               { return nil }

--- a/exporter/clickhouseexporter/exporter_traces_json_test.go
+++ b/exporter/clickhouseexporter/exporter_traces_json_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -50,7 +51,7 @@ func TestTracesJSONExporter_StartIsNonFatalOnDescFailure(t *testing.T) {
 
 	// Simulate start() reaching ensureDetected after the table-create branch.
 	// The first probe fails — start() must still return nil (non-fatal).
-	err := exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe)
+	err := exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe, nil)
 	require.Error(t, err, "first probe must propagate the failure")
 	require.ErrorContains(t, err, "schema detection deferred")
 	require.Equal(t, int32(1), descCalls.Load())
@@ -59,7 +60,7 @@ func TestTracesJSONExporter_StartIsNonFatalOnDescFailure(t *testing.T) {
 
 	// First batch arrives while ClickHouse is still down: the push helper
 	// re-probes, gets the same failure, and returns a retryable error.
-	err = exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe)
+	err = exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "schema detection deferred")
 	require.Equal(t, int32(2), descCalls.Load())
@@ -68,7 +69,7 @@ func TestTracesJSONExporter_StartIsNonFatalOnDescFailure(t *testing.T) {
 	// ClickHouse recovers: the next probe succeeds, INSERT is rendered with the
 	// keys columns, and subsequent calls reuse the cached INSERT.
 	descFails.Store(false)
-	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe))
+	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe, nil))
 	require.Equal(t, int32(3), descCalls.Load())
 	require.Equal(t, schemaDetected, schemaDetectionState(exp.detector.state.Load()))
 	require.NotEmpty(t, exp.insertSQL)
@@ -78,8 +79,8 @@ func TestTracesJSONExporter_StartIsNonFatalOnDescFailure(t *testing.T) {
 		"INSERT must include SpanAttributesKeys once detection succeeds")
 
 	// Further ensureDetected calls are no-ops; the stub is not invoked again.
-	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe))
-	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe))
+	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe, nil))
+	require.NoError(t, exp.detector.ensureDetected(t.Context(), exp.logger, stubProbe, nil))
 	assert.Equal(t, int32(3), descCalls.Load())
 }
 
@@ -159,3 +160,47 @@ func (*stubFailingConn) AsyncInsert(context.Context, string, bool, ...any) error
 func (*stubFailingConn) Ping(context.Context) error { return nil }
 func (*stubFailingConn) Stats() driver.Stats        { return driver.Stats{} }
 func (*stubFailingConn) Close() error               { return nil }
+
+// stubAccessDeniedConn is a driver.Conn that returns a permanent ACCESS_DENIED
+// exception from Query, simulating a write-only ClickHouse user that has
+// INSERT privilege but not SELECT/DESC.
+type stubAccessDeniedConn struct {
+	stubFailingConn
+}
+
+func (*stubAccessDeniedConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	return nil, &proto.Exception{
+		Code:    chCodeAccessDenied,
+		Name:    "ACCESS_DENIED",
+		Message: "Not enough privileges. To execute this query, it's necessary to have the grant SELECT(name) ON system.columns",
+	}
+}
+
+func (*stubAccessDeniedConn) PrepareBatch(_ context.Context, _ string, _ ...driver.PrepareBatchOption) (driver.Batch, error) {
+	return noopBatch{}, nil
+}
+
+// TestTracesJSONExporter_PermanentFailureFallsBack verifies that a write-only
+// ClickHouse user (INSERT granted, SELECT/DESC denied) does not lose data.
+// When DESC TABLE returns ACCESS_DENIED the exporter must fall back to a
+// degraded INSERT (without the optional keys columns) and deliver rows.
+func TestTracesJSONExporter_PermanentFailureFallsBack(t *testing.T) {
+	cfg := withDefaultConfig()
+	cfg.Endpoint = defaultEndpoint
+	exp := newTracesJSONExporter(zaptest.NewLogger(t), cfg)
+	exp.db = &stubAccessDeniedConn{}
+
+	// pushTraceData drives ensureDetected → probeSchemaFeatures → ACCESS_DENIED
+	// → fallback renders degraded INSERT → push proceeds.
+	err := exp.pushTraceData(t.Context(), makeMinimalTraces())
+	require.NoError(t, err, "push must succeed after falling back to degraded INSERT")
+	require.Equal(t, schemaDetected, schemaDetectionState(exp.detector.state.Load()))
+	require.NotEmpty(t, exp.insertSQL, "INSERT must be rendered even after permanent DESC failure")
+	assert.NotContains(t, exp.insertSQL, tracesJSONColumnResourceAttributesKeys,
+		"degraded INSERT must NOT include keys columns")
+	assert.NotContains(t, exp.insertSQL, tracesJSONColumnSpanAttributesKeys,
+		"degraded INSERT must NOT include keys columns")
+
+	// Subsequent pushes must succeed without re-probing.
+	require.NoError(t, exp.pushTraceData(t.Context(), makeMinimalTraces()))
+}

--- a/exporter/clickhouseexporter/schema_features.go
+++ b/exporter/clickhouseexporter/schema_features.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+)
+
+// schemaDetectionState tracks whether a DESC TABLE probe has produced a definitive
+// answer about which optional feature-columns the target table has.
+//
+// The bug fixed by #48875 was that the original code conflated "DESC TABLE failed
+// (table unreachable, transient outage, missing table)" with "feature absent" — a
+// single failed probe at startup permanently cached a degraded INSERT statement
+// that omitted columns the user actually had in their schema. The exporter would
+// silently write rows without those columns for the life of the process.
+//
+// schemaDetectionState distinguishes the three outcomes so the caller can defer
+// the INSERT rendering until detection succeeds at least once.
+type schemaDetectionState int32
+
+const (
+	// schemaUnknown means no successful DESC TABLE has run yet. Any cached
+	// INSERT must be treated as not-yet-rendered; push paths should re-attempt
+	// detection and, on continued failure, return a retryable error so the
+	// sending queue / retry_on_failure machinery defers the batch.
+	schemaUnknown schemaDetectionState = iota
+	// schemaDetected means DESC TABLE returned a definitive column set and the
+	// per-feature flags have been populated.
+	schemaDetected
+)
+
+// schemaDetector serializes lazy re-detection across concurrent push goroutines.
+// It is embedded into each *JSON / non-JSON exporter that previously cached an
+// INSERT based on a single startup probe.
+//
+// state is read atomically on the fast path so steady-state push goroutines
+// (10× num_consumers by default) do not serialize on the mutex once detection
+// has succeeded. The mutex is only contended on the rare error-retry path.
+type schemaDetector struct {
+	state atomic.Int32
+	mu    sync.Mutex
+}
+
+// ensureDetected runs probe under the mutex if detection is not yet successful.
+// probe is expected to (a) run DESC TABLE via internal.GetTableColumns,
+// (b) populate the caller's feature flags from the column set, and (c) render
+// the cached INSERT statement. probe is only called when state == schemaUnknown.
+//
+// On success the state transitions to schemaDetected and probe is never called
+// again. On error the state stays schemaUnknown and the wrapped error is
+// returned with a stable prefix so callers can recognize the deferred-detection
+// path and surface a retryable (non-permanent) error to exporterhelper.
+func (d *schemaDetector) ensureDetected(ctx context.Context, logger *zap.Logger, probe func(context.Context) error) error {
+	// Fast path: once detection has succeeded, every push goroutine sees
+	// schemaDetected atomically without contending on the mutex.
+	if schemaDetectionState(d.state.Load()) == schemaDetected {
+		return nil
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Recheck under the lock: another goroutine may have completed detection
+	// between our atomic load and the Lock.
+	if schemaDetectionState(d.state.Load()) == schemaDetected {
+		return nil
+	}
+
+	if err := probe(ctx); err != nil {
+		// Stay schemaUnknown so the next push retries. The caller wraps this
+		// in a plain (non-permanent) error to engage retry_on_failure. Log at
+		// Debug — Warn would spam at 10× num_consumers per batch under a
+		// sustained outage.
+		logger.Debug("clickhouseexporter schema detection still deferred", zap.Error(err))
+		return fmt.Errorf("schema detection deferred: %w", err)
+	}
+
+	d.state.Store(int32(schemaDetected))
+	logger.Info("clickhouseexporter schema detection succeeded; INSERT cached")
+	return nil
+}

--- a/exporter/clickhouseexporter/schema_features.go
+++ b/exporter/clickhouseexporter/schema_features.go
@@ -5,11 +5,24 @@ package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"go.uber.org/zap"
+)
+
+// ClickHouse server error codes for permanent DESC TABLE failures.
+// These indicate the probe will never succeed without external intervention
+// (schema change, permission grant, table creation), so the exporter should
+// fall back to a degraded INSERT rather than deferring every batch forever.
+const (
+	chCodeUnknownTable         int32 = 60  // UNKNOWN_TABLE
+	chCodeUnknownDatabase      int32 = 81  // UNKNOWN_DATABASE
+	chCodeDatabaseAccessDenied int32 = 291 // DATABASE_ACCESS_DENIED
+	chCodeAccessDenied         int32 = 497 // ACCESS_DENIED
 )
 
 // schemaDetectionState tracks whether a DESC TABLE probe has produced a definitive
@@ -48,18 +61,46 @@ type schemaDetector struct {
 	mu    sync.Mutex
 }
 
+// isPermanentDESCFailure returns true when the error wraps a ClickHouse server
+// exception whose error code indicates that DESC TABLE will never succeed
+// without external intervention (e.g. missing privileges, unknown table). In
+// that case the exporter should fall back to a degraded INSERT (omitting
+// optional columns) instead of deferring every batch forever.
+//
+// Transient failures (connection refused, timeout, server overloaded) are Go-
+// level network errors that do NOT wrap *proto.Exception, so they return false
+// and trigger the normal retry path.
+func isPermanentDESCFailure(err error) bool {
+	var ex *proto.Exception
+	if !errors.As(err, &ex) {
+		return false
+	}
+	switch ex.Code {
+	case chCodeUnknownTable, chCodeUnknownDatabase,
+		chCodeDatabaseAccessDenied, chCodeAccessDenied:
+		return true
+	}
+	return false
+}
+
 // ensureDetected runs probe under the mutex if detection is not yet successful.
 // probe is expected to (a) run DESC TABLE via internal.GetTableColumns,
 // (b) populate the caller's feature flags from the column set, and (c) render
 // the cached INSERT statement. probe is only called when state == schemaUnknown.
 //
+// fallback is called when DESC TABLE fails with a permanent ClickHouse error
+// (unknown table, access denied). It must render a degraded INSERT statement
+// with all optional feature flags at their zero values, matching the pre-#48902
+// behavior for write-only users. When fallback is nil the permanent-failure
+// path behaves the same as the transient-failure path (retry on every push).
+//
 // On success the state transitions to schemaDetected and probe is never called
-// again. On error the state stays schemaUnknown and the wrapped error is
-// returned with a stable prefix so callers can recognize the deferred-detection
-// path and surface a retryable (non-permanent) error to exporterhelper.
-func (d *schemaDetector) ensureDetected(ctx context.Context, logger *zap.Logger, probe func(context.Context) error) error {
-	// Fast path: once detection has succeeded, every push goroutine sees
-	// schemaDetected atomically without contending on the mutex.
+// again. On transient error the state stays schemaUnknown and the wrapped error
+// is returned with a stable prefix so callers can recognize the deferred-
+// detection path and surface a retryable (non-permanent) error to exporterhelper.
+func (d *schemaDetector) ensureDetected(ctx context.Context, logger *zap.Logger, probe func(context.Context) error, fallback func()) error {
+	// Fast path: once detection has succeeded (or fallen back), every push
+	// goroutine sees schemaDetected atomically without contending on the mutex.
 	if schemaDetectionState(d.state.Load()) == schemaDetected {
 		return nil
 	}
@@ -74,6 +115,19 @@ func (d *schemaDetector) ensureDetected(ctx context.Context, logger *zap.Logger,
 	}
 
 	if err := probe(ctx); err != nil {
+		if fallback != nil && isPermanentDESCFailure(err) {
+			// Permanent failure: the user lacks SELECT/DESC privileges or the
+			// table does not exist (with create_schema=false). Fall back to a
+			// degraded INSERT that omits the optional feature columns. This
+			// preserves the pre-#48902 behavior where write-only ClickHouse
+			// users kept delivering rows without the keys/EventName columns.
+			fallback()
+			d.state.Store(int32(schemaDetected))
+			logger.Warn("clickhouseexporter DESC TABLE permanently denied; using degraded INSERT without optional columns",
+				zap.Error(err))
+			return nil
+		}
+
 		// Stay schemaUnknown so the next push retries. The caller wraps this
 		// in a plain (non-permanent) error to engage retry_on_failure. Log at
 		// Debug — Warn would spam at 10× num_consumers per batch under a

--- a/exporter/clickhouseexporter/schema_features_test.go
+++ b/exporter/clickhouseexporter/schema_features_test.go
@@ -6,10 +6,12 @@ package clickhouseexporter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -38,19 +40,19 @@ func TestSchemaDetector_ProbeRetriedUntilSuccess(t *testing.T) {
 
 	// First two calls: detection fails, error returned with the stable prefix.
 	for range 2 {
-		err := d.ensureDetected(t.Context(), logger, probe)
+		err := d.ensureDetected(t.Context(), logger, probe, nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "schema detection deferred")
 		require.ErrorIs(t, err, probeErr)
 	}
 
 	// Third call: detection succeeds, transitions to schemaDetected.
-	require.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+	require.NoError(t, d.ensureDetected(t.Context(), logger, probe, nil))
 	assert.Equal(t, int32(3), probeCalls.Load())
 
 	// Subsequent calls: probe is NOT re-run.
-	require.NoError(t, d.ensureDetected(t.Context(), logger, probe))
-	require.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+	require.NoError(t, d.ensureDetected(t.Context(), logger, probe, nil))
+	require.NoError(t, d.ensureDetected(t.Context(), logger, probe, nil))
 	assert.Equal(t, int32(3), probeCalls.Load(), "probe must not run after schemaDetected")
 }
 
@@ -75,7 +77,7 @@ func TestSchemaDetector_ConcurrentCallsResolveOnce(t *testing.T) {
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {
-			assert.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+			assert.NoError(t, d.ensureDetected(t.Context(), logger, probe, nil))
 		})
 	}
 	wg.Wait()
@@ -94,13 +96,142 @@ func TestSchemaDetector_FailureKeepsStateUnknown(t *testing.T) {
 
 	err := d.ensureDetected(t.Context(), logger, func(_ context.Context) error {
 		return errors.New("ch unavailable")
-	})
+	}, nil)
 	require.Error(t, err)
 	require.Equal(t, schemaUnknown, schemaDetectionState(d.state.Load()))
 
 	// A second probe with a different outcome resolves cleanly.
 	require.NoError(t, d.ensureDetected(t.Context(), logger, func(_ context.Context) error {
 		return nil
-	}))
+	}, nil))
 	require.Equal(t, schemaDetected, schemaDetectionState(d.state.Load()))
+}
+
+// TestSchemaDetector_PermanentFailureFallsBack verifies that a permanent
+// ClickHouse error (ACCESS_DENIED, UNKNOWN_TABLE, etc.) triggers the fallback
+// renderer instead of deferring every batch forever. This is the fix for the
+// regression reported in PR #48902: a write-only ClickHouse user (INSERT
+// granted, SELECT/DESC denied) must keep delivering rows with a degraded
+// INSERT rather than silently losing all data.
+func TestSchemaDetector_PermanentFailureFallsBack(t *testing.T) {
+	tests := []struct {
+		name string
+		code int32
+	}{
+		{"ACCESS_DENIED", chCodeAccessDenied},
+		{"UNKNOWN_TABLE", chCodeUnknownTable},
+		{"UNKNOWN_DATABASE", chCodeUnknownDatabase},
+		{"DATABASE_ACCESS_DENIED", chCodeDatabaseAccessDenied},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d schemaDetector
+			logger := zaptest.NewLogger(t)
+			fallbackCalled := false
+
+			probe := func(_ context.Context) error {
+				return &proto.Exception{
+					Code:    tt.code,
+					Name:    tt.name,
+					Message: "Not enough privileges",
+				}
+			}
+			fallback := func() { fallbackCalled = true }
+
+			err := d.ensureDetected(t.Context(), logger, probe, fallback)
+			require.NoError(t, err, "permanent failure with fallback must not return an error")
+			require.True(t, fallbackCalled, "fallback must be called on permanent failure")
+			require.Equal(t, schemaDetected, schemaDetectionState(d.state.Load()),
+				"state must transition to schemaDetected after fallback")
+
+			// Subsequent calls must not re-probe.
+			fallbackCalled = false
+			require.NoError(t, d.ensureDetected(t.Context(), logger, probe, fallback))
+			require.False(t, fallbackCalled, "fallback must not be called again after schemaDetected")
+		})
+	}
+}
+
+// TestSchemaDetector_PermanentFailureWithoutFallback verifies that when no
+// fallback is provided (fallback == nil), permanent errors are treated the
+// same as transient errors — they defer and retry on the next push.
+func TestSchemaDetector_PermanentFailureWithoutFallback(t *testing.T) {
+	var d schemaDetector
+	logger := zaptest.NewLogger(t)
+
+	probe := func(_ context.Context) error {
+		return &proto.Exception{
+			Code:    chCodeAccessDenied,
+			Name:    "ACCESS_DENIED",
+			Message: "Not enough privileges",
+		}
+	}
+
+	err := d.ensureDetected(t.Context(), logger, probe, nil)
+	require.Error(t, err, "permanent failure without fallback must return an error")
+	require.ErrorContains(t, err, "schema detection deferred")
+	require.Equal(t, schemaUnknown, schemaDetectionState(d.state.Load()))
+}
+
+// TestIsPermanentDESCFailure verifies the error classification function.
+func TestIsPermanentDESCFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		permanent bool
+	}{
+		{
+			name:      "ACCESS_DENIED exception",
+			err:       &proto.Exception{Code: chCodeAccessDenied, Message: "Not enough privileges"},
+			permanent: true,
+		},
+		{
+			name:      "UNKNOWN_TABLE exception",
+			err:       &proto.Exception{Code: chCodeUnknownTable, Message: "Table does not exist"},
+			permanent: true,
+		},
+		{
+			name:      "UNKNOWN_DATABASE exception",
+			err:       &proto.Exception{Code: chCodeUnknownDatabase, Message: "Database does not exist"},
+			permanent: true,
+		},
+		{
+			name:      "DATABASE_ACCESS_DENIED exception",
+			err:       &proto.Exception{Code: chCodeDatabaseAccessDenied, Message: "Not enough privileges"},
+			permanent: true,
+		},
+		{
+			name:      "wrapped permanent exception",
+			err:       fmt.Errorf("get table columns: %w", &proto.Exception{Code: chCodeAccessDenied, Message: "denied"}),
+			permanent: true,
+		},
+		{
+			name:      "transient network error",
+			err:       errors.New("dial tcp clickhouse:9440: connect: connection refused"),
+			permanent: false,
+		},
+		{
+			name:      "transient ClickHouse exception (MEMORY_LIMIT_EXCEEDED)",
+			err:       &proto.Exception{Code: 241, Message: "Memory limit exceeded"},
+			permanent: false,
+		},
+		{
+			name:      "nil error",
+			err:       nil,
+			permanent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err == nil {
+				// isPermanentDESCFailure is only called on non-nil errors in
+				// production, but verify it does not panic.
+				require.False(t, isPermanentDESCFailure(tt.err))
+				return
+			}
+			require.Equal(t, tt.permanent, isPermanentDESCFailure(tt.err))
+		})
+	}
 }

--- a/exporter/clickhouseexporter/schema_features_test.go
+++ b/exporter/clickhouseexporter/schema_features_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhouseexporter
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestSchemaDetector_ProbeRetriedUntilSuccess is the unit-level regression for
+// #48875: a single failed DESC TABLE must not be cached as "feature absent".
+// ensureDetected must retry the probe until it succeeds, leaving the detector
+// in schemaUnknown after each failure so the next caller re-probes.
+func TestSchemaDetector_ProbeRetriedUntilSuccess(t *testing.T) {
+	var d schemaDetector
+	var probeCalls atomic.Int32
+	probeErr := errors.New("dial tcp clickhouse:9440: connect: connection refused")
+
+	probe := func(_ context.Context) error {
+		probeCalls.Add(1)
+		// Fail the first two attempts, succeed on the third.
+		if probeCalls.Load() < 3 {
+			return probeErr
+		}
+		return nil
+	}
+
+	logger := zaptest.NewLogger(t)
+
+	// First two calls: detection fails, error returned with the stable prefix.
+	for range 2 {
+		err := d.ensureDetected(t.Context(), logger, probe)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "schema detection deferred")
+		require.ErrorIs(t, err, probeErr)
+	}
+
+	// Third call: detection succeeds, transitions to schemaDetected.
+	require.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+	assert.Equal(t, int32(3), probeCalls.Load())
+
+	// Subsequent calls: probe is NOT re-run.
+	require.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+	require.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+	assert.Equal(t, int32(3), probeCalls.Load(), "probe must not run after schemaDetected")
+}
+
+// TestSchemaDetector_ConcurrentCallsResolveOnce verifies that concurrent
+// pushXData goroutines do not all run the probe — only one succeeds and the
+// rest see schemaDetected immediately. This matters because every push goroutine
+// (default num_consumers=10) calls ensureDetected on every batch until detection
+// succeeds.
+func TestSchemaDetector_ConcurrentCallsResolveOnce(t *testing.T) {
+	var d schemaDetector
+	var probeCalls atomic.Int32
+	// probe always succeeds — error return is unused but required by the
+	// schemaDetector.ensureDetected signature.
+	//nolint:unparam // intentional: probe is success-only in this test
+	probe := func(_ context.Context) error {
+		probeCalls.Add(1)
+		return nil
+	}
+
+	logger := zaptest.NewLogger(t)
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			assert.NoError(t, d.ensureDetected(t.Context(), logger, probe))
+		})
+	}
+	wg.Wait()
+
+	// Exactly one probe call survives the mutex race.
+	assert.Equal(t, int32(1), probeCalls.Load())
+}
+
+// TestSchemaDetector_FailureKeepsStateUnknown verifies the bug-fix invariant:
+// after a probe failure the state must NOT transition to schemaDetected. This
+// is the precise inversion of the #48875 bug, where a failed DESC TABLE silently
+// cached "feature absent" for the life of the process.
+func TestSchemaDetector_FailureKeepsStateUnknown(t *testing.T) {
+	var d schemaDetector
+	logger := zap.NewNop()
+
+	err := d.ensureDetected(t.Context(), logger, func(_ context.Context) error {
+		return errors.New("ch unavailable")
+	})
+	require.Error(t, err)
+	require.Equal(t, schemaUnknown, schemaDetectionState(d.state.Load()))
+
+	// A second probe with a different outcome resolves cleanly.
+	require.NoError(t, d.ensureDetected(t.Context(), logger, func(_ context.Context) error {
+		return nil
+	}))
+	require.Equal(t, schemaDetected, schemaDetectionState(d.state.Load()))
+}


### PR DESCRIPTION
#### Description

When `create_schema: false`, the ClickHouse exporter probed the table once at startup and any DESC TABLE failure (transient ClickHouse outage, connection refused, table not yet created) was treated as "feature columns absent." It cached an INSERT that omitted the optional `*AttributesKeys` / `EventName` columns for the lifetime of the process — even after ClickHouse recovered. Newly-written rows had empty `*AttributesKeys` arrays while the JSON `*Attributes` columns stayed fully populated, silently breaking anything downstream that relied on the flat key index.

This change preserves the non-fatal startup behavior introduced in #46286 but treats a detection error as "schema unknown" instead of "feature absent." A new `schemaDetector` tri-state (backed by `atomic.Int32` so steady-state push goroutines do not contend on the mutex) serializes lazy re-detection across concurrent push goroutines. On first push after a deferred detection, the exporter re-probes; on continued failure it returns a plain (non-permanent) error so exporterhelper's `retry_on_failure` and sending queue defer the batch instead of writing degraded rows.

Applied to all three exporters that share the cached-INSERT pattern: `exporter_traces_json.go`, `exporter_logs_json.go`, `exporter_logs.go`. `exporter_traces.go` and `exporter_metrics.go` render INSERT at construction and never call DESC TABLE, so they are unaffected.

#### Link to tracking issue
Fixes #48875

#### Testing

Unit tests added:
- `TestSchemaDetector_*` (3 tests): probe-retried-until-success, concurrent-callers-resolve-once, failure-keeps-state-unknown.
- `TestTracesJSONExporter_*` (3 tests): start-non-fatal-on-DESC-failure, render-omits-keys-when-absent, push-deferred-on-schema-unknown.
- `TestLogsExporter_PushDeferredOnSchemaUnknown` and `TestLogsJSONExporter_PushDeferredOnSchemaUnknown` (sister coverage for the two log exporters).
- `BenchmarkPushLogsData` updated to pre-set the detector state.

All new tests pass; existing tests unchanged. `golangci-lint`, `gofmt`, `go vet` clean.

#### Documentation

`.chloggen/48875-clickhouse-retry-schema-detection.yaml` added (`bug_fix`, `exporter/clickhouse`, user-facing).

#### Authorship

- [ ] I, a human, wrote this pull request description myself.
