### PR TITLE
fix(fluentforwardreceiver): correct tag attribute key in README

### DIFF
--- a/receiver/fluentforwardreceiver/README.md
+++ b/receiver/fluentforwardreceiver/README.md
@@ -46,7 +46,7 @@ receivers:
 
 The receiver converts Fluentd events to OpenTelemetry logs. Each Fluentd event
 is converted to a single OpenTelemetry log record and packets are stored as LogRecordSlice.
-The FluentD `tag` is stored as an attribute with key `fluentd.tag`.
+The FluentD `tag` is stored as an attribute with key `fluent.tag`.
 The FluentD event timestamp is used as the log record timestamp.
 The record `message` or `log` field is stored as the body of the log record. If both are present,
 it just takes the field that comes last in the message stream.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The Data Conversion section documents the tag attribute key as `fluentd.tag`, but `conversion.go` defines it as `fluent.tag`:

    const tagAttributeKey = "fluent.tag"

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48910

<!--Describe what testing was performed and which tests were added.-->
#### Testing

No code changes.

<!--Describe the documentation added.-->
#### Documentation

Updated the README to match the actual behavior

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
