### PR TITLE
exporter/prometheus: Add config option 'resource_constant_labels'

### DIFF
--- a/.chloggen/prometheusexporter-resource-constant-labels.yaml
+++ b/.chloggen/prometheusexporter-resource-constant-labels.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `resource_to_telemetry_conversion` in favor of `resource_constant_labels` for selecting resource attributes to copy as metric labels.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48861]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new `resource_constant_labels` setting is guarded by the `exporter.prometheusexporter.ResourceConstantLabels` feature gate. When the gate is enabled, the deprecated `resource_to_telemetry_conversion` setting is disabled. The deprecated setting adds every resource attribute to every exported metric label set, while `resource_constant_labels` lets users choose which resource attributes are added by using `included` and `excluded` lists. Copied resource attributes are still exported on `target_info`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -27,8 +27,11 @@ The following settings can be optionally configured:
 - `namespace` (no default): if set, exports metrics under the provided value.
 - `send_timestamps` (default = `false`): if true, sends the timestamp of the underlying metric sample in the response.
 - `metric_expiration` (default = `5m`): defines how long metrics are exposed without updates
-- `resource_to_telemetry_conversion`
+- `resource_to_telemetry_conversion` (**Deprecated**: use `resource_constant_labels` with the `exporter.prometheusexporter.ResourceConstantLabels` feature gate instead.)
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
+- `resource_constant_labels`: Defines resource attributes to add to metric labels. This option requires the `exporter.prometheusexporter.ResourceConstantLabels` feature gate.
+  - `included`: List of resource attributes to add to metric labels. If empty, all resource attributes except excluded attributes are added.
+  - `excluded`: List of resource attributes not to add to metric labels.
 - `enable_open_metrics`: (default = `false`): If true, metrics will be exported using the OpenMetrics format. Exemplars are only exported in the OpenMetrics format, and only for histogram and monotonic sum (i.e. counter) metrics.
 - `without_scope_info`: (default = `false`): If true, metrics will be exported without scope name, version, schemaURL, and attributes encoded as labels.
 - `add_metric_suffixes`: (default = `true`): If false, addition of type and unit suffixes is disabled. **Deprecated**: Use `translation_strategy` instead. This setting is ignored when `translation_strategy` is explicitly set.
@@ -58,8 +61,12 @@ exporters:
     # Legacy configuration - deprecated, ignored when translation_strategy is set
     add_metric_suffixes: false
     translation_strategy: "UnderscoreEscapingWithoutSuffixes"
-    resource_to_telemetry_conversion:
-      enabled: true
+    resource_constant_labels:
+      included:
+        - service.name
+        - k8s.namespace.name
+      excluded:
+        - service.instance.id
 ```
 
 Given the example, metrics will be available at `https://1.2.3.4:1234/metrics`.
@@ -96,23 +103,22 @@ Or to group by a particular attribute (for ex. `k8s_namespace_name`):
 sum by (k8s_namespace_name) (app_ads_ad_requests_total * on (job, instance) group_left(k8s_namespace_name) target_info)
 ```
 
-This is not a common pattern, and we recommend copying the most common resource attributes into metric labels. You can do this through the transform processor:
+This is not a common pattern, and we recommend copying the most common resource attributes into metric labels. You can do this through `resource_constant_labels`:
 
 ```yaml
-processor:
-  transform:
-    metric_statements:
-      - context: datapoint
-        statements:
-        - set(attributes["namespace"], resource.attributes["k8s.namespace.name"])
-        - set(attributes["container"], resource.attributes["k8s.container.name"])
-        - set(attributes["pod"], resource.attributes["k8s.pod.name"])
+exporters:
+  prometheus:
+    resource_constant_labels:
+      included:
+        - k8s.namespace.name
+        - k8s.container.name
+        - k8s.pod.name
 ```
 
-After this, grouping or selecting becomes as simple as:
+Copied resource attributes remain on `target_info`. After this, grouping or selecting becomes as simple as:
 
 ```promql
-app_ads_ad_requests_total{namespace="my-namespace"}
+app_ads_ad_requests_total{k8s_namespace_name="my-namespace"}
 
-sum by (namespace) (app_ads_ad_requests_total)
+sum by (k8s_namespace_name) (app_ads_ad_requests_total)
 ```

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -27,9 +27,9 @@ The following settings can be optionally configured:
 - `namespace` (no default): if set, exports metrics under the provided value.
 - `send_timestamps` (default = `false`): if true, sends the timestamp of the underlying metric sample in the response.
 - `metric_expiration` (default = `5m`): defines how long metrics are exposed without updates
-- `resource_to_telemetry_conversion` (**Deprecated**: use `resource_constant_labels` with the `exporter.prometheusexporter.ResourceConstantLabels` feature gate instead.)
+- `resource_to_telemetry_conversion` (**Deprecated**: use `resource_constant_labels` instead. The `exporter.prometheusexporter.RemoveResourceToTelemetry` feature gate disables this setting.)
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
-- `resource_constant_labels`: Defines resource attributes to add to metric labels. This option requires the `exporter.prometheusexporter.ResourceConstantLabels` feature gate.
+- `resource_constant_labels`: Defines resource attributes to add to metric labels.
   - `included`: List of resource attributes to add to metric labels. If empty, all resource attributes except excluded attributes are added.
   - `excluded`: List of resource attributes not to add to metric labels.
 - `enable_open_metrics`: (default = `false`): If true, metrics will be exported using the OpenMetrics format. Exemplars are only exported in the OpenMetrics format, and only for histogram and monotonic sum (i.e. counter) metrics.

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -381,6 +381,11 @@ func (c *collector) shouldAddResourceLabel(key string) bool {
 	return false
 }
 
+// upsertLabel keeps the variable label list unique while preserving the first
+// label position. Later sources, such as resource attributes, can override
+// earlier datapoint attributes after label-name translation.
+//
+// The later caller can override the earlier value by calling upsertLabel again.
 func upsertLabel(keys, values *[]string, labelIndex map[string]int, key, value string) {
 	if index, ok := labelIndex[key]; ok {
 		(*values)[index] = value

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -320,7 +320,7 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 		upsertLabel(&keys, &values, labelIndex, labelName, v.AsString())
 	}
 
-	if c.resourceLabelsConfigured() {
+	if c.resourceLabels != nil {
 		for k, v := range resourceAttrs.All() {
 			if !c.shouldAddResourceLabel(k) {
 				continue
@@ -362,10 +362,6 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 		return nil, nil, multiErrs
 	}
 	return prometheus.NewDesc(name, help, keys, c.constLabels), values, nil
-}
-
-func (c *collector) resourceLabelsConfigured() bool {
-	return c.resourceLabels != nil
 }
 
 func (c *collector) shouldAddResourceLabel(key string) bool {

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -39,6 +39,7 @@ type collector struct {
 	metricFamilies   sync.Map
 	metricExpiration time.Duration
 	withoutScopeInfo bool
+	resourceLabels   *ResourceConstantLabels
 
 	metricNamer otlptranslator.MetricNamer
 	labelNamer  otlptranslator.LabelNamer
@@ -52,7 +53,7 @@ type metricFamily struct {
 func newCollector(config *Config, logger *zap.Logger) *collector {
 	labelNamer := configureLabelNamer(config)
 
-	return &collector{
+	c := &collector{
 		accumulator:      newAccumulator(logger, config.MetricExpiration),
 		logger:           logger,
 		namespace:        normalizeNamespace(config.Namespace, labelNamer, logger),
@@ -63,6 +64,10 @@ func newCollector(config *Config, logger *zap.Logger) *collector {
 		metricNamer:      configureMetricNamer(config),
 		labelNamer:       labelNamer,
 	}
+	if config.ResourceConstantLabels.HasValue() {
+		c.resourceLabels = config.ResourceConstantLabels.Get()
+	}
+	return c
 }
 
 // normalizeNamespace builds and returns the namespace if specified in the config
@@ -301,8 +306,9 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 		return nil, nil, err
 	}
 
-	keys := make([]string, 0, attributes.Len()+scopeAttributes.Len()+5) // +2 for job and instance labels, +3 for scope name, version and schema url
-	values := make([]string, 0, attributes.Len()+scopeAttributes.Len()+5)
+	keys := make([]string, 0, attributes.Len()+scopeAttributes.Len()+resourceAttrs.Len()+5) // +2 for job and instance labels, +3 for scope name, version and schema url
+	values := make([]string, 0, attributes.Len()+scopeAttributes.Len()+resourceAttrs.Len()+5)
+	labelIndex := make(map[string]int, attributes.Len()+scopeAttributes.Len()+resourceAttrs.Len()+5)
 
 	var multiErrs error
 	for k, v := range attributes.All() {
@@ -311,8 +317,21 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 			multiErrs = multierr.Append(multiErrs, err)
 			continue
 		}
-		keys = append(keys, labelName)
-		values = append(values, v.AsString())
+		upsertLabel(&keys, &values, labelIndex, labelName, v.AsString())
+	}
+
+	if c.resourceLabelsConfigured() {
+		for k, v := range resourceAttrs.All() {
+			if !c.shouldAddResourceLabel(k) {
+				continue
+			}
+			labelName, err := c.labelNamer.Build(k)
+			if err != nil {
+				multiErrs = multierr.Append(multiErrs, err)
+				continue
+			}
+			upsertLabel(&keys, &values, labelIndex, labelName, v.AsString())
+		}
 	}
 
 	if !c.withoutScopeInfo {
@@ -325,30 +344,55 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 				multiErrs = multierr.Append(multiErrs, err)
 				continue
 			}
-			keys = append(keys, labelName)
-			values = append(values, v.AsString())
+			upsertLabel(&keys, &values, labelIndex, labelName, v.AsString())
 		}
 
-		keys = append(keys, "otel_scope_name")
-		values = append(values, scopeName)
-		keys = append(keys, "otel_scope_version")
-		values = append(values, scopeVersion)
-		keys = append(keys, "otel_scope_schema_url")
-		values = append(values, scopeSchemaURL)
+		upsertLabel(&keys, &values, labelIndex, "otel_scope_name", scopeName)
+		upsertLabel(&keys, &values, labelIndex, "otel_scope_version", scopeVersion)
+		upsertLabel(&keys, &values, labelIndex, "otel_scope_schema_url", scopeSchemaURL)
 	}
 
 	if job, ok := extractJob(resourceAttrs); ok {
-		keys = append(keys, model.JobLabel)
-		values = append(values, job)
+		upsertLabel(&keys, &values, labelIndex, model.JobLabel, job)
 	}
 	if instance, ok := extractInstance(resourceAttrs); ok {
-		keys = append(keys, model.InstanceLabel)
-		values = append(values, instance)
+		upsertLabel(&keys, &values, labelIndex, model.InstanceLabel, instance)
 	}
 	if multiErrs != nil {
 		return nil, nil, multiErrs
 	}
 	return prometheus.NewDesc(name, help, keys, c.constLabels), values, nil
+}
+
+func (c *collector) resourceLabelsConfigured() bool {
+	return c.resourceLabels != nil
+}
+
+func (c *collector) shouldAddResourceLabel(key string) bool {
+	for _, excluded := range c.resourceLabels.Excluded {
+		if key == excluded {
+			return false
+		}
+	}
+	if len(c.resourceLabels.Included) == 0 {
+		return true
+	}
+	for _, included := range c.resourceLabels.Included {
+		if key == included {
+			return true
+		}
+	}
+	return false
+}
+
+func upsertLabel(keys, values *[]string, labelIndex map[string]int, key, value string) {
+	if index, ok := labelIndex[key]; ok {
+		(*values)[index] = value
+		return
+	}
+	labelIndex[key] = len(*keys)
+	*keys = append(*keys, key)
+	*values = append(*values, value)
 }
 
 func isReservedScopeAttribute(k string) bool {

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -33,15 +33,15 @@ type collector struct {
 	accumulator accumulator
 	logger      *zap.Logger
 
-	sendTimestamps   bool
-	namespace        string
-	constLabels      prometheus.Labels
-	metricFamilies   sync.Map
-	metricExpiration time.Duration
-	withoutScopeInfo bool
-	resourceLabels   *ResourceConstantLabels
-	includedLabels   map[string]struct{}
-	excludedLabels   map[string]struct{}
+	sendTimestamps        bool
+	namespace             string
+	constLabels           prometheus.Labels
+	metricFamilies        sync.Map
+	metricExpiration      time.Duration
+	withoutScopeInfo      bool
+	resourceLabelsEnabled bool
+	includedLabelNames    []string
+	excludedLabels        map[string]struct{}
 
 	metricNamer otlptranslator.MetricNamer
 	labelNamer  otlptranslator.LabelNamer
@@ -67,9 +67,10 @@ func newCollector(config *Config, logger *zap.Logger) *collector {
 		labelNamer:       labelNamer,
 	}
 	if config.ResourceConstantLabels.HasValue() {
-		c.resourceLabels = config.ResourceConstantLabels.Get()
-		c.includedLabels = labelSet(c.resourceLabels.Included)
-		c.excludedLabels = labelSet(c.resourceLabels.Excluded)
+		resourceLabels := config.ResourceConstantLabels.Get()
+		c.resourceLabelsEnabled = true
+		c.includedLabelNames = resourceLabels.Included
+		c.excludedLabels = labelSet(resourceLabels.Excluded)
 	}
 	return c
 }
@@ -335,7 +336,7 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 		upsertLabel(&keys, &values, labelIndex, labelName, v.AsString())
 	}
 
-	if c.resourceLabels != nil {
+	if c.resourceLabelsEnabled {
 		multiErrs = multierr.Append(multiErrs, c.addResourceLabels(resourceAttrs, &keys, &values, labelIndex))
 	}
 
@@ -371,8 +372,8 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 
 func (c *collector) addResourceLabels(resourceAttrs pcommon.Map, keys, values *[]string, labelIndex map[string]int) error {
 	var multiErrs error
-	if len(c.resourceLabels.Included) > 0 {
-		for _, key := range c.resourceLabels.Included {
+	if len(c.includedLabelNames) > 0 {
+		for _, key := range c.includedLabelNames {
 			if _, excluded := c.excludedLabels[key]; excluded {
 				continue
 			}

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -40,6 +40,8 @@ type collector struct {
 	metricExpiration time.Duration
 	withoutScopeInfo bool
 	resourceLabels   *ResourceConstantLabels
+	includedLabels   map[string]struct{}
+	excludedLabels   map[string]struct{}
 
 	metricNamer otlptranslator.MetricNamer
 	labelNamer  otlptranslator.LabelNamer
@@ -66,8 +68,21 @@ func newCollector(config *Config, logger *zap.Logger) *collector {
 	}
 	if config.ResourceConstantLabels.HasValue() {
 		c.resourceLabels = config.ResourceConstantLabels.Get()
+		c.includedLabels = labelSet(c.resourceLabels.Included)
+		c.excludedLabels = labelSet(c.resourceLabels.Excluded)
 	}
 	return c
+}
+
+func labelSet(labels []string) map[string]struct{} {
+	if len(labels) == 0 {
+		return nil
+	}
+	result := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		result[label] = struct{}{}
+	}
+	return result
 }
 
 // normalizeNamespace builds and returns the namespace if specified in the config
@@ -321,17 +336,7 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 	}
 
 	if c.resourceLabels != nil {
-		for k, v := range resourceAttrs.All() {
-			if !c.shouldAddResourceLabel(k) {
-				continue
-			}
-			labelName, err := c.labelNamer.Build(k)
-			if err != nil {
-				multiErrs = multierr.Append(multiErrs, err)
-				continue
-			}
-			upsertLabel(&keys, &values, labelIndex, labelName, v.AsString())
-		}
+		multiErrs = multierr.Append(multiErrs, c.addResourceLabels(resourceAttrs, &keys, &values, labelIndex))
 	}
 
 	if !c.withoutScopeInfo {
@@ -364,21 +369,42 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 	return prometheus.NewDesc(name, help, keys, c.constLabels), values, nil
 }
 
-func (c *collector) shouldAddResourceLabel(key string) bool {
-	for _, excluded := range c.resourceLabels.Excluded {
-		if key == excluded {
-			return false
+func (c *collector) addResourceLabels(resourceAttrs pcommon.Map, keys, values *[]string, labelIndex map[string]int) error {
+	var multiErrs error
+	if len(c.resourceLabels.Included) > 0 {
+		for _, key := range c.resourceLabels.Included {
+			if _, excluded := c.excludedLabels[key]; excluded {
+				continue
+			}
+			value, ok := resourceAttrs.Get(key)
+			if !ok {
+				continue
+			}
+			if err := c.upsertResourceLabel(keys, values, labelIndex, key, value); err != nil {
+				multiErrs = multierr.Append(multiErrs, err)
+			}
+		}
+		return multiErrs
+	}
+
+	for key, value := range resourceAttrs.All() {
+		if _, excluded := c.excludedLabels[key]; excluded {
+			continue
+		}
+		if err := c.upsertResourceLabel(keys, values, labelIndex, key, value); err != nil {
+			multiErrs = multierr.Append(multiErrs, err)
 		}
 	}
-	if len(c.resourceLabels.Included) == 0 {
-		return true
+	return multiErrs
+}
+
+func (c *collector) upsertResourceLabel(keys, values *[]string, labelIndex map[string]int, key string, value pcommon.Value) error {
+	labelName, err := c.labelNamer.Build(key)
+	if err != nil {
+		return err
 	}
-	for _, included := range c.resourceLabels.Included {
-		if key == included {
-			return true
-		}
-	}
-	return false
+	upsertLabel(keys, values, labelIndex, labelName, value.AsString())
+	return nil
 }
 
 // upsertLabel keeps the variable label list unique while preserving the first

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -201,6 +201,37 @@ func TestResourceConstantLabels(t *testing.T) {
 	}, labelsToMap(pbMetric.Label))
 }
 
+func TestResourceConstantLabelsWithoutIncludedAttributes(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("test_metric")
+	metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+
+	resourceAttrs := pcommon.NewMap()
+	resourceAttrs.PutStr("resource.attr", "from-resource")
+	resourceAttrs.PutStr("k8s.namespace.name", "default")
+	resourceAttrs.PutStr("excluded.attr", "excluded")
+
+	c := newCollector(&Config{
+		ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
+			Excluded: []string{"excluded.attr"},
+		}),
+	}, zap.NewNop())
+
+	promMetric, err := c.convertGauge(metric, resourceAttrs, "", "", "", pcommon.NewMap())
+	require.NoError(t, err)
+
+	pbMetric := io_prometheus_client.Metric{}
+	require.NoError(t, promMetric.Write(&pbMetric))
+
+	require.Equal(t, map[string]string{
+		"k8s_namespace_name":    "default",
+		"otel_scope_name":       "",
+		"otel_scope_schema_url": "",
+		"otel_scope_version":    "",
+		"resource_attr":         "from-resource",
+	}, labelsToMap(pbMetric.Label))
+}
+
 func labelsToMap(labels []*io_prometheus_client.LabelPair) map[string]string {
 	result := make(map[string]string, len(labels))
 	for _, label := range labels {

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -13,6 +13,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/otlptranslator"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
@@ -161,6 +162,51 @@ func TestConvertMetric(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestResourceConstantLabels(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("test_metric")
+	metric.SetEmptyGauge()
+	dp := metric.Gauge().DataPoints().AppendEmpty()
+	dp.Attributes().PutStr("resource.attr", "from-datapoint")
+	dp.Attributes().PutStr("datapoint.attr", "from-datapoint")
+	dp.SetIntValue(1)
+
+	resourceAttrs := pcommon.NewMap()
+	resourceAttrs.PutStr("resource.attr", "from-resource")
+	resourceAttrs.PutStr("k8s.namespace.name", "default")
+	resourceAttrs.PutStr("excluded.attr", "excluded")
+
+	c := newCollector(&Config{
+		ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
+			Included: []string{"resource.attr", "k8s.namespace.name", "excluded.attr"},
+			Excluded: []string{"excluded.attr"},
+		}),
+	}, zap.NewNop())
+
+	promMetric, err := c.convertGauge(metric, resourceAttrs, "", "", "", pcommon.NewMap())
+	require.NoError(t, err)
+
+	pbMetric := io_prometheus_client.Metric{}
+	require.NoError(t, promMetric.Write(&pbMetric))
+
+	require.Equal(t, map[string]string{
+		"datapoint_attr":        "from-datapoint",
+		"k8s_namespace_name":    "default",
+		"otel_scope_name":       "",
+		"otel_scope_schema_url": "",
+		"otel_scope_version":    "",
+		"resource_attr":         "from-resource",
+	}, labelsToMap(pbMetric.Label))
+}
+
+func labelsToMap(labels []*io_prometheus_client.LabelPair) map[string]string {
+	result := make(map[string]string, len(labels))
+	for _, label := range labels {
+		result[label.GetName()] = label.GetValue()
+	}
+	return result
 }
 
 func setUpTestExemplar(exemplar pmetric.Exemplar) {

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -4,6 +4,7 @@
 package prometheusexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -94,7 +95,7 @@ func (cfg *Config) Validate() error {
 		}
 	}
 	if cfg.ResourceConstantLabels.HasValue() && cfg.resourceToTelemetryConfigured() {
-		return fmt.Errorf("resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time")
+		return errors.New("resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time")
 	}
 	if metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() {
 		if cfg.resourceToTelemetryConfigured() {

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -97,12 +97,10 @@ func (cfg *Config) Validate() error {
 	if cfg.ResourceConstantLabels.HasValue() && cfg.resourceToTelemetryConfigured() {
 		return errors.New("resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time")
 	}
-	if metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() {
+	if metadata.ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate.IsEnabled() {
 		if cfg.resourceToTelemetryConfigured() {
-			return fmt.Errorf("resource_to_telemetry_conversion is disabled by feature gate %q; use resource_constant_labels instead", "exporter.prometheusexporter.ResourceConstantLabels")
+			return fmt.Errorf("resource_to_telemetry_conversion is disabled by feature gate %q; use resource_constant_labels instead", "exporter.prometheusexporter.RemoveResourceToTelemetry")
 		}
-	} else if cfg.ResourceConstantLabels.HasValue() {
-		return fmt.Errorf("resource_constant_labels requires feature gate %q", "exporter.prometheusexporter.ResourceConstantLabels")
 	}
 	return nil
 }

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -11,8 +11,10 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
 )
 
@@ -36,7 +38,12 @@ type Config struct {
 	MetricExpiration time.Duration `mapstructure:"metric_expiration"`
 
 	// ResourceToTelemetrySettings defines configuration for converting resource attributes to metric labels.
+	//
+	// Deprecated: Use ResourceConstantLabels instead.
 	ResourceToTelemetrySettings resourcetotelemetry.Settings `mapstructure:"resource_to_telemetry_conversion"`
+
+	// ResourceConstantLabels defines resource attributes to add to metric labels.
+	ResourceConstantLabels configoptional.Optional[ResourceConstantLabels] `mapstructure:"resource_constant_labels"`
 
 	// EnableOpenMetrics enables the use of the OpenMetrics encoding option for the prometheus exporter.
 	EnableOpenMetrics bool `mapstructure:"enable_open_metrics"`
@@ -52,9 +59,29 @@ type Config struct {
 	// TranslationStrategy controls how OTLP metric and attribute names are translated into Prometheus metric and label names.
 	// When set, this takes precedence over AddMetricSuffixes.
 	TranslationStrategy translationStrategy `mapstructure:"translation_strategy"`
+
+	resourceToTelemetrySettingsConfigured bool
 }
 
 var _ component.Config = (*Config)(nil)
+
+// ResourceConstantLabels defines which resource attributes are copied to metric labels.
+type ResourceConstantLabels struct {
+	// Included resource attributes are copied to metric labels.
+	// If empty, all resource attributes except excluded attributes are copied.
+	Included []string `mapstructure:"included"`
+
+	// Excluded resource attributes are not copied to metric labels.
+	Excluded []string `mapstructure:"excluded"`
+}
+
+func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
+	if err := conf.Unmarshal(cfg); err != nil {
+		return err
+	}
+	cfg.resourceToTelemetrySettingsConfigured = conf.IsSet("resource_to_telemetry_conversion")
+	return nil
+}
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
@@ -66,7 +93,25 @@ func (cfg *Config) Validate() error {
 			return fmt.Errorf("invalid translation_strategy: %s", cfg.TranslationStrategy)
 		}
 	}
+	if cfg.resourceConstantLabelsConfigured() && cfg.resourceToTelemetryConfigured() {
+		return fmt.Errorf("resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time")
+	}
+	if metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() {
+		if cfg.resourceToTelemetryConfigured() {
+			return fmt.Errorf("resource_to_telemetry_conversion is disabled by feature gate %q; use resource_constant_labels instead", "exporter.prometheusexporter.ResourceConstantLabels")
+		}
+	} else if cfg.resourceConstantLabelsConfigured() {
+		return fmt.Errorf("resource_constant_labels requires feature gate %q", "exporter.prometheusexporter.ResourceConstantLabels")
+	}
 	return nil
+}
+
+func (cfg *Config) resourceConstantLabelsConfigured() bool {
+	return cfg.ResourceConstantLabels.HasValue()
+}
+
+func (cfg *Config) resourceToTelemetryConfigured() bool {
+	return cfg.resourceToTelemetrySettingsConfigured || cfg.ResourceToTelemetrySettings.Enabled || cfg.ResourceToTelemetrySettings.ExcludeServiceAttributes
 }
 
 type translationStrategy string

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -93,21 +93,17 @@ func (cfg *Config) Validate() error {
 			return fmt.Errorf("invalid translation_strategy: %s", cfg.TranslationStrategy)
 		}
 	}
-	if cfg.resourceConstantLabelsConfigured() && cfg.resourceToTelemetryConfigured() {
+	if cfg.ResourceConstantLabels.HasValue() && cfg.resourceToTelemetryConfigured() {
 		return fmt.Errorf("resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time")
 	}
 	if metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() {
 		if cfg.resourceToTelemetryConfigured() {
 			return fmt.Errorf("resource_to_telemetry_conversion is disabled by feature gate %q; use resource_constant_labels instead", "exporter.prometheusexporter.ResourceConstantLabels")
 		}
-	} else if cfg.resourceConstantLabelsConfigured() {
+	} else if cfg.ResourceConstantLabels.HasValue() {
 		return fmt.Errorf("resource_constant_labels requires feature gate %q", "exporter.prometheusexporter.ResourceConstantLabels")
 	}
 	return nil
-}
-
-func (cfg *Config) resourceConstantLabelsConfigured() bool {
-	return cfg.ResourceConstantLabels.HasValue()
 }
 
 func (cfg *Config) resourceToTelemetryConfigured() bool {

--- a/exporter/prometheusexporter/config.schema.yaml
+++ b/exporter/prometheusexporter/config.schema.yaml
@@ -32,13 +32,13 @@ properties:
   namespace:
     description: Namespace if set, exports metrics under the provided value.
     type: string
-  resource_to_telemetry_conversion:
-    description: 'ResourceToTelemetrySettings defines configuration for converting resource attributes to metric labels. Deprecated: Use ResourceConstantLabels instead.'
-    $ref: /pkg/resourcetotelemetry.settings
   resource_constant_labels:
     description: ResourceConstantLabels defines resource attributes to add to metric labels.
     x-optional: true
     $ref: resource_constant_labels
+  resource_to_telemetry_conversion:
+    description: 'ResourceToTelemetrySettings defines configuration for converting resource attributes to metric labels. Deprecated: Use ResourceConstantLabels instead.'
+    $ref: /pkg/resourcetotelemetry.settings
   send_timestamps:
     description: SendTimestamps will send the underlying scrape timestamp with the export
     type: boolean

--- a/exporter/prometheusexporter/config.schema.yaml
+++ b/exporter/prometheusexporter/config.schema.yaml
@@ -1,3 +1,18 @@
+$defs:
+  resource_constant_labels:
+    description: ResourceConstantLabels defines which resource attributes are copied to metric labels.
+    type: object
+    properties:
+      excluded:
+        description: Excluded resource attributes are not copied to metric labels.
+        type: array
+        items:
+          type: string
+      included:
+        description: Included resource attributes are copied to metric labels. If empty, all resource attributes except excluded attributes are copied.
+        type: array
+        items:
+          type: string
 description: Config defines configuration for Prometheus exporter.
 type: object
 properties:
@@ -18,8 +33,12 @@ properties:
     description: Namespace if set, exports metrics under the provided value.
     type: string
   resource_to_telemetry_conversion:
-    description: ResourceToTelemetrySettings defines configuration for converting resource attributes to metric labels.
+    description: 'ResourceToTelemetrySettings defines configuration for converting resource attributes to metric labels. Deprecated: Use ResourceConstantLabels instead.'
     $ref: /pkg/resourcetotelemetry.settings
+  resource_constant_labels:
+    description: ResourceConstantLabels defines resource attributes to add to metric labels.
+    x-optional: true
+    $ref: resource_constant_labels
   send_timestamps:
     description: SendTimestamps will send the underlying scrape timestamp with the export
     type: boolean

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -27,9 +27,8 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		id                component.ID
-		enableFeatureGate bool
-		expected          component.Config
+		id       component.ID
+		expected component.Config
 	}{
 		{
 			id:       component.NewIDWithName(metadata.Type, ""),
@@ -62,8 +61,7 @@ func TestLoadConfig(t *testing.T) {
 			}(),
 		},
 		{
-			id:                component.NewIDWithName(metadata.Type, "resource_constant_labels"),
-			enableFeatureGate: true,
+			id: component.NewIDWithName(metadata.Type, "resource_constant_labels"),
 			expected: func() component.Config {
 				cfg := createDefaultConfig().(*Config)
 				cfg.ResourceConstantLabels = configoptional.Some(ResourceConstantLabels{
@@ -89,10 +87,6 @@ func TestLoadConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
-			oldValue := metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled()
-			testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, tt.enableFeatureGate)
-			defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, oldValue)
-
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 
@@ -106,7 +100,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
-func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
+func TestValidateRemoveResourceToTelemetryFeatureGate(t *testing.T) {
 	tests := []struct {
 		name              string
 		enableFeatureGate bool
@@ -114,14 +108,13 @@ func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
 		wantErr           string
 	}{
 		{
-			name:              "resource constant labels require feature gate",
+			name:              "resource constant labels allowed without feature gate",
 			enableFeatureGate: false,
 			cfg: &Config{
 				ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
 					Included: []string{"service.name"},
 				}),
 			},
-			wantErr: `resource_constant_labels requires feature gate "exporter.prometheusexporter.ResourceConstantLabels"`,
 		},
 		{
 			name:              "legacy disabled by feature gate",
@@ -129,7 +122,7 @@ func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
 			cfg: &Config{
 				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
 			},
-			wantErr: `resource_to_telemetry_conversion is disabled by feature gate "exporter.prometheusexporter.ResourceConstantLabels"; use resource_constant_labels instead`,
+			wantErr: `resource_to_telemetry_conversion is disabled by feature gate "exporter.prometheusexporter.RemoveResourceToTelemetry"; use resource_constant_labels instead`,
 		},
 		{
 			name:              "legacy block presence disabled by feature gate",
@@ -137,7 +130,7 @@ func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
 			cfg: &Config{
 				resourceToTelemetrySettingsConfigured: true,
 			},
-			wantErr: `resource_to_telemetry_conversion is disabled by feature gate "exporter.prometheusexporter.ResourceConstantLabels"; use resource_constant_labels instead`,
+			wantErr: `resource_to_telemetry_conversion is disabled by feature gate "exporter.prometheusexporter.RemoveResourceToTelemetry"; use resource_constant_labels instead`,
 		},
 		{
 			name:              "legacy and new are mutually exclusive",
@@ -151,7 +144,7 @@ func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
 			wantErr: "resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time",
 		},
 		{
-			name:              "new config allowed with feature gate",
+			name:              "resource constant labels allowed with feature gate",
 			enableFeatureGate: true,
 			cfg: &Config{
 				ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
@@ -170,9 +163,9 @@ func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldValue := metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled()
-			testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, tt.enableFeatureGate)
-			defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, oldValue)
+			oldValue := metadata.ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate.IsEnabled()
+			testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate, tt.enableFeatureGate)
+			defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate, oldValue)
 
 			err := tt.cfg.Validate()
 			if tt.wantErr != "" {

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -18,17 +18,18 @@ import (
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
 )
 
 func TestLoadConfig(t *testing.T) {
-	t.Parallel()
-
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
 	tests := []struct {
-		id       component.ID
-		expected component.Config
+		id                component.ID
+		enableFeatureGate bool
+		expected          component.Config
 	}{
 		{
 			id:       component.NewIDWithName(metadata.Type, ""),
@@ -60,10 +61,38 @@ func TestLoadConfig(t *testing.T) {
 				}
 			}(),
 		},
+		{
+			id:                component.NewIDWithName(metadata.Type, "resource_constant_labels"),
+			enableFeatureGate: true,
+			expected: func() component.Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.ResourceConstantLabels = configoptional.Some(ResourceConstantLabels{
+					Included: []string{"service.name", "k8s.namespace.name"},
+					Excluded: []string{"service.instance.id"},
+				})
+				return cfg
+			}(),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "legacy_resource_to_telemetry"),
+			expected: func() component.Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.ResourceToTelemetrySettings = resourcetotelemetry.Settings{
+					Enabled:                  true,
+					ExcludeServiceAttributes: true,
+				}
+				cfg.resourceToTelemetrySettingsConfigured = true
+				return cfg
+			}(),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
+			oldValue := metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled()
+			testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, tt.enableFeatureGate)
+			defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, oldValue)
+
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 
@@ -73,6 +102,84 @@ func TestLoadConfig(t *testing.T) {
 
 			assert.NoError(t, xconfmap.Validate(cfg))
 			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestValidateResourceConstantLabelsFeatureGate(t *testing.T) {
+	tests := []struct {
+		name              string
+		enableFeatureGate bool
+		cfg               *Config
+		wantErr           string
+	}{
+		{
+			name:              "resource constant labels require feature gate",
+			enableFeatureGate: false,
+			cfg: &Config{
+				ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
+					Included: []string{"service.name"},
+				}),
+			},
+			wantErr: `resource_constant_labels requires feature gate "exporter.prometheusexporter.ResourceConstantLabels"`,
+		},
+		{
+			name:              "legacy disabled by feature gate",
+			enableFeatureGate: true,
+			cfg: &Config{
+				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
+			},
+			wantErr: `resource_to_telemetry_conversion is disabled by feature gate "exporter.prometheusexporter.ResourceConstantLabels"; use resource_constant_labels instead`,
+		},
+		{
+			name:              "legacy block presence disabled by feature gate",
+			enableFeatureGate: true,
+			cfg: &Config{
+				resourceToTelemetrySettingsConfigured: true,
+			},
+			wantErr: `resource_to_telemetry_conversion is disabled by feature gate "exporter.prometheusexporter.ResourceConstantLabels"; use resource_constant_labels instead`,
+		},
+		{
+			name:              "legacy and new are mutually exclusive",
+			enableFeatureGate: true,
+			cfg: &Config{
+				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
+				ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
+					Included: []string{"service.name"},
+				}),
+			},
+			wantErr: "resource_constant_labels and resource_to_telemetry_conversion cannot be configured at the same time",
+		},
+		{
+			name:              "new config allowed with feature gate",
+			enableFeatureGate: true,
+			cfg: &Config{
+				ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
+					Included: []string{"service.name"},
+				}),
+			},
+		},
+		{
+			name:              "legacy config allowed without feature gate",
+			enableFeatureGate: false,
+			cfg: &Config{
+				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldValue := metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled()
+			testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, tt.enableFeatureGate)
+			defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, oldValue)
+
+			err := tt.cfg.Validate()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/exporter/prometheusexporter/documentation.md
+++ b/exporter/prometheusexporter/documentation.md
@@ -9,6 +9,6 @@ This component has the following feature gates:
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
 | `exporter.prometheusexporter.DisableAddMetricSuffixes` | alpha | When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used | v0.132.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-specification/pull/4533) |
-| `exporter.prometheusexporter.ResourceConstantLabels` | alpha | When enabled, resource_constant_labels is available and the deprecated resource_to_telemetry_conversion configuration option is disabled | v0.153.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861) |
+| `exporter.prometheusexporter.RemoveResourceToTelemetry` | alpha | When enabled, the deprecated resource_to_telemetry_conversion configuration option is disabled | v0.153.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/exporter/prometheusexporter/documentation.md
+++ b/exporter/prometheusexporter/documentation.md
@@ -9,5 +9,6 @@ This component has the following feature gates:
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
 | `exporter.prometheusexporter.DisableAddMetricSuffixes` | alpha | When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used | v0.132.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-specification/pull/4533) |
+| `exporter.prometheusexporter.ResourceConstantLabels` | alpha | When enabled, resource_constant_labels is available and the deprecated resource_to_telemetry_conversion configuration option is disabled | v0.153.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -45,8 +45,8 @@ func createMetricsExporter(
 	if err := pcfg.Validate(); err != nil {
 		return nil, err
 	}
-	if !metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() && pcfg.resourceToTelemetryConfigured() {
-		set.Logger.Warn("`resource_to_telemetry_conversion` is deprecated. Please enable the `exporter.prometheusexporter.ResourceConstantLabels` feature gate and use `resource_constant_labels` instead.")
+	if !metadata.ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate.IsEnabled() && pcfg.resourceToTelemetryConfigured() {
+		set.Logger.Warn("`resource_to_telemetry_conversion` is deprecated. Please enable the `exporter.prometheusexporter.RemoveResourceToTelemetry` feature gate and use `resource_constant_labels` instead.")
 	}
 
 	prometheus, err := newPrometheusExporter(pcfg, set)
@@ -68,7 +68,7 @@ func createMetricsExporter(
 		return nil, err
 	}
 	metricsExporter := exporter
-	if !metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() {
+	if !metadata.ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate.IsEnabled() {
 		metricsExporter = resourcetotelemetry.WrapMetricsExporter(pcfg.ResourceToTelemetrySettings, exporter)
 	}
 

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -42,6 +42,12 @@ func createMetricsExporter(
 	cfg component.Config,
 ) (exporter.Metrics, error) {
 	pcfg := cfg.(*Config)
+	if err := pcfg.Validate(); err != nil {
+		return nil, err
+	}
+	if !metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() && pcfg.ResourceToTelemetrySettings.Enabled {
+		set.Logger.Warn("`resource_to_telemetry_conversion` is deprecated. Please enable the `exporter.prometheusexporter.ResourceConstantLabels` feature gate and use `resource_constant_labels` instead.")
+	}
 
 	prometheus, err := newPrometheusExporter(pcfg, set)
 	if err != nil {
@@ -61,9 +67,13 @@ func createMetricsExporter(
 	if err != nil {
 		return nil, err
 	}
+	metricsExporter := exporter
+	if !metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() {
+		metricsExporter = resourcetotelemetry.WrapMetricsExporter(pcfg.ResourceToTelemetrySettings, exporter)
+	}
 
 	return &wrapMetricsExporter{
-		Metrics:  resourcetotelemetry.WrapMetricsExporter(pcfg.ResourceToTelemetrySettings, exporter),
+		Metrics:  metricsExporter,
 		exporter: prometheus,
 	}, nil
 }

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -45,7 +45,7 @@ func createMetricsExporter(
 	if err := pcfg.Validate(); err != nil {
 		return nil, err
 	}
-	if !metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() && pcfg.ResourceToTelemetrySettings.Enabled {
+	if !metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled() && pcfg.resourceToTelemetryConfigured() {
 		set.Logger.Warn("`resource_to_telemetry_conversion` is deprecated. Please enable the `exporter.prometheusexporter.ResourceConstantLabels` feature gate and use `resource_constant_labels` instead.")
 	}
 

--- a/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
+++ b/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
@@ -13,3 +13,11 @@ var ExporterPrometheusexporterDisableAddMetricSuffixesFeatureGate = featuregate.
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-specification/pull/4533"),
 	featuregate.WithRegisterFromVersion("v0.132.0"),
 )
+
+var ExporterPrometheusexporterResourceConstantLabelsFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.prometheusexporter.ResourceConstantLabels",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, resource_constant_labels is available and the deprecated resource_to_telemetry_conversion configuration option is disabled"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861"),
+	featuregate.WithRegisterFromVersion("v0.153.0"),
+)

--- a/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
+++ b/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
@@ -14,10 +14,10 @@ var ExporterPrometheusexporterDisableAddMetricSuffixesFeatureGate = featuregate.
 	featuregate.WithRegisterFromVersion("v0.132.0"),
 )
 
-var ExporterPrometheusexporterResourceConstantLabelsFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"exporter.prometheusexporter.ResourceConstantLabels",
+var ExporterPrometheusexporterRemoveResourceToTelemetryFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.prometheusexporter.RemoveResourceToTelemetry",
 	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("When enabled, resource_constant_labels is available and the deprecated resource_to_telemetry_conversion configuration option is disabled"),
+	featuregate.WithRegisterDescription("When enabled, the deprecated resource_to_telemetry_conversion configuration option is disabled"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861"),
 	featuregate.WithRegisterFromVersion("v0.153.0"),
 )

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -18,8 +18,8 @@ feature_gates:
     from_version: "v0.132.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-specification/pull/4533
     skip_strict_validation: true
-  - id: exporter.prometheusexporter.ResourceConstantLabels
-    description: When enabled, resource_constant_labels is available and the deprecated resource_to_telemetry_conversion configuration option is disabled
+  - id: exporter.prometheusexporter.RemoveResourceToTelemetry
+    description: When enabled, the deprecated resource_to_telemetry_conversion configuration option is disabled
     stage: alpha
     from_version: "v0.153.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -18,6 +18,12 @@ feature_gates:
     from_version: "v0.132.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-specification/pull/4533
     skip_strict_validation: true
+  - id: exporter.prometheusexporter.ResourceConstantLabels
+    description: When enabled, resource_constant_labels is available and the deprecated resource_to_telemetry_conversion configuration option is disabled
+    stage: alpha
+    from_version: "v0.153.0"
+    reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48861
+    skip_strict_validation: true
 
 tests:
   config:

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -466,10 +466,6 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 }
 
 func TestPrometheusExporter_endToEndWithResourceConstantLabels(t *testing.T) {
-	oldValue := metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled()
-	testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, true)
-	defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, oldValue)
-
 	addr := testutil.GetAvailableLocalAddress(t)
 	cfg := &Config{
 		Namespace: "test",

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -465,6 +465,75 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	}
 }
 
+func TestPrometheusExporter_endToEndWithResourceConstantLabels(t *testing.T) {
+	oldValue := metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate.IsEnabled()
+	testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, true)
+	defer testutil.SetFeatureGateForTest(t, metadata.ExporterPrometheusexporterResourceConstantLabelsFeatureGate, oldValue)
+
+	addr := testutil.GetAvailableLocalAddress(t)
+	cfg := &Config{
+		Namespace: "test",
+		ConstLabels: map[string]string{
+			"foo2":  "bar2",
+			"code2": "one2",
+		},
+		ServerConfig: confighttp.ServerConfig{
+			NetAddr: confignet.AddrConfig{
+				Transport: "tcp",
+				Endpoint:  addr,
+			},
+		},
+		SendTimestamps:   true,
+		MetricExpiration: 120 * time.Minute,
+		ResourceConstantLabels: configoptional.Some(ResourceConstantLabels{
+			Included: []string{"resource-attr", "service.name", "excluded.attr"},
+			Excluded: []string{"excluded.attr"},
+		}),
+	}
+
+	factory := NewFactory()
+	set := exportertest.NewNopSettings(metadata.Type)
+	exp, err := factory.CreateMetrics(t.Context(), set, cfg)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, exp.Shutdown(t.Context()))
+	}()
+
+	require.NotNil(t, exp)
+	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+
+	md := testdata.GenerateMetricsOneMetric()
+	resourceAttrs := md.ResourceMetrics().At(0).Resource().Attributes()
+	resourceAttrs.PutStr("service.name", "test-service")
+	resourceAttrs.PutStr("service.instance.id", "test-instance")
+	resourceAttrs.PutStr("excluded.attr", "kept-on-target-info")
+
+	require.NoError(t, exp.ConsumeMetrics(t.Context(), md))
+
+	rsp, err := http.Get("http://" + addr + "/metrics")
+	require.NoError(t, err, "Failed to perform a scrape")
+
+	require.Equal(t, http.StatusOK, rsp.StatusCode, "Mismatched HTTP response status code")
+
+	blob, _ := io.ReadAll(rsp.Body)
+	_ = rsp.Body.Close()
+
+	want := []string{
+		`# HELP test_target_info Target metadata`,
+		`# TYPE test_target_info gauge`,
+		`test_target_info{excluded_attr="kept-on-target-info",instance="test-instance",job="test-service",resource_attr="resource-attr-val-1"} 1`,
+		`# HELP test_counter_int`,
+		`# TYPE test_counter_int counter`,
+		`test_counter_int{code2="one2",foo2="bar2",instance="test-instance",job="test-service",label_1="label-value-1",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1",service_name="test-service"} 123 1581452773000`,
+		`test_counter_int{code2="one2",foo2="bar2",instance="test-instance",job="test-service",label_2="label-value-2",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1",service_name="test-service"} 456 1581452773000`,
+	}
+	for _, w := range want {
+		assert.Contains(t, string(blob), w, "Missing %v from response:\n%v", w, string(blob))
+	}
+	assert.NotContains(t, string(blob), `test_counter_int{code2="one2",excluded_attr=`)
+}
+
 func metricBuilder(delta int64, prefix, job, instance string) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	rms := md.ResourceMetrics().AppendEmpty()

--- a/exporter/prometheusexporter/testdata/config.yaml
+++ b/exporter/prometheusexporter/testdata/config.yaml
@@ -12,3 +12,14 @@ prometheus/2:
   send_timestamps: true
   metric_expiration: 60m
   add_metric_suffixes: false
+prometheus/resource_constant_labels:
+  resource_constant_labels:
+    included:
+      - service.name
+      - k8s.namespace.name
+    excluded:
+      - service.instance.id
+prometheus/legacy_resource_to_telemetry:
+  resource_to_telemetry_conversion:
+    enabled: true
+    exclude_service_attributes: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds the config option `resource_constant_labels` with two arrays `include` and `exclude`, to select which resource attributes are translated to labels during exposition. 

The new config is hidden behind a feature gate that, once enabled, will also disable the deprecated config option `resource_to_telemetry_conversion`, which uses an "all or nothing" approach. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48861 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.
- AI wrote the code though :)

<!--Please delete paragraphs that you did not use before submitting.-->
