### PR TITLE
Fix broken native histogram link

### DIFF
--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -66,7 +66,7 @@ Given the example, metrics will be available at `https://1.2.3.4:1234/metrics`.
 
 ### Native Histograms
 
-The exporter supports [Prometheus native histograms](https://prometheus.io/docs/concepts/native_histograms/). OpenTelemetry exponential histograms are automatically converted to the Prometheus native histogram format.
+The exporter supports [Prometheus native histograms](https://prometheus.io/docs/specs/native_histograms/). OpenTelemetry exponential histograms are automatically converted to the Prometheus native histogram format.
 
 To scrape native histograms, configure your Prometheus server to [scrape using protobuf format](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-native-histograms) and to accept native histograms.
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

While working on #48922, CI complained about broken links.

Looks like the old page got moved by https://github.com/prometheus/docs/pull/2656