### PR TITLE
exporter/prometheus: Move 'DisableAddMetricsSuffixes' feature gate to beta

### DIFF
--- a/.chloggen/prometheusexporter-disable-add-metric-suffixes-beta.yaml
+++ b/.chloggen/prometheusexporter-disable-add-metric-suffixes-beta.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Promote the `exporter.prometheusexporter.DisableAddMetricSuffixes` feature gate to beta."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48930]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "The deprecated `add_metric_suffixes` setting is now ignored by default. To preserve the previous no-suffix behavior, set `translation_strategy: UnderscoreEscapingWithoutSuffixes`."
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -739,7 +739,11 @@ func TestCollectMetrics(t *testing.T) {
 						continue
 					}
 
-					require.Contains(t, m.Desc().String(), "fqName: \"test_space_test_metric\"")
+					expectedName := "test_space_test_metric"
+					if tt.metricType == prometheus.CounterValue {
+						expectedName += "_total"
+					}
+					require.Contains(t, m.Desc().String(), `fqName: "`+expectedName+`"`)
 					require.Contains(t, m.Desc().String(), `variableLabels: {label_1,label_2,otel_scope_name,otel_scope_version,otel_scope_schema_url,job,instance}`)
 
 					pbMetric := io_prometheus_client.Metric{}

--- a/exporter/prometheusexporter/documentation.md
+++ b/exporter/prometheusexporter/documentation.md
@@ -8,6 +8,6 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `exporter.prometheusexporter.DisableAddMetricSuffixes` | alpha | When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used | v0.132.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-specification/pull/4533) |
+| `exporter.prometheusexporter.DisableAddMetricSuffixes` | beta | When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used | v0.132.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-specification/pull/4533) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
+++ b/exporter/prometheusexporter/internal/metadata/generated_feature_gates.go
@@ -8,7 +8,7 @@ import (
 
 var ExporterPrometheusexporterDisableAddMetricSuffixesFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"exporter.prometheusexporter.DisableAddMetricSuffixes",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-specification/pull/4533"),
 	featuregate.WithRegisterFromVersion("v0.132.0"),

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -14,7 +14,7 @@ status:
 feature_gates:
   - id: exporter.prometheusexporter.DisableAddMetricSuffixes
     description: When enabled, the deprecated add_metric_suffixes configuration option is ignored and translation_strategy is always used
-    stage: alpha
+    stage: beta
     from_version: "v0.132.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-specification/pull/4533
     skip_strict_validation: true

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -175,10 +175,10 @@ func TestPrometheusExporter_WithTLS(t *testing.T) {
 	_ = rsp.Body.Close()
 
 	want := []string{
-		`# HELP test_counter_int`,
-		`# TYPE test_counter_int counter`,
-		`test_counter_int{code2="one2",foo2="bar2",label_1="label-value-1",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 123 1581452773000`,
-		`test_counter_int{code2="one2",foo2="bar2",label_2="label-value-2",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 456 1581452773000`,
+		`# HELP test_counter_int_total`,
+		`# TYPE test_counter_int_total counter`,
+		`test_counter_int_total{code2="one2",foo2="bar2",label_1="label-value-1",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 123 1581452773000`,
+		`test_counter_int_total{code2="one2",foo2="bar2",label_2="label-value-2",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 456 1581452773000`,
 	}
 
 	for _, w := range want {
@@ -232,18 +232,18 @@ func TestPrometheusExporter_endToEndMultipleTargets(t *testing.T) {
 		blob, _ := io.ReadAll(res.Body)
 		_ = res.Body.Close()
 		want := []string{
-			`# HELP test_metric_1_this_one_there_where Extra ones`,
-			`# TYPE test_metric_1_this_one_there_where counter`,
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+128),
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+128),
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+128),
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+128),
-			`# HELP test_metric_2_this_one_there_where Extra ones`,
-			`# TYPE test_metric_2_this_one_there_where counter`,
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+delta),
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+delta),
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+delta),
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+delta),
+			`# HELP test_metric_1_this_one_there_where_bytes_total Extra ones`,
+			`# TYPE test_metric_1_this_one_there_where_bytes_total counter`,
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+128),
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+128),
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+128),
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+128),
+			`# HELP test_metric_2_this_one_there_where_bytes_total Extra ones`,
+			`# TYPE test_metric_2_this_one_there_where_bytes_total counter`,
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+delta),
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+delta),
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+delta),
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8081",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+delta),
 		}
 
 		for _, w := range want {
@@ -307,14 +307,14 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 		blob, _ := io.ReadAll(res.Body)
 		_ = res.Body.Close()
 		want := []string{
-			`# HELP test_metric_1_this_one_there_where Extra ones`,
-			`# TYPE test_metric_1_this_one_there_where counter`,
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+128),
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+128),
-			`# HELP test_metric_2_this_one_there_where Extra ones`,
-			`# TYPE test_metric_2_this_one_there_where counter`,
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+delta),
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+delta),
+			`# HELP test_metric_1_this_one_there_where_bytes_total Extra ones`,
+			`# TYPE test_metric_1_this_one_there_where_bytes_total counter`,
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+128),
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+128),
+			`# HELP test_metric_2_this_one_there_where_bytes_total Extra ones`,
+			`# TYPE test_metric_2_this_one_there_where_bytes_total counter`,
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 99+delta),
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code1="one1",foo1="bar1",instance="localhost:8080",job="cpu-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v`, 100+delta),
 		}
 
 		for _, w := range want {
@@ -379,14 +379,14 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 		blob, _ := io.ReadAll(res.Body)
 		_ = res.Body.Close()
 		want := []string{
-			`# HELP test_metric_1_this_one_there_where Extra ones`,
-			`# TYPE test_metric_1_this_one_there_where counter`,
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 99+128, 1543160298100+128000),
-			fmt.Sprintf(`test_metric_1_this_one_there_where{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 100+128, 1543160298100),
-			`# HELP test_metric_2_this_one_there_where Extra ones`,
-			`# TYPE test_metric_2_this_one_there_where counter`,
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 99+delta, 1543160298100+delta*1000),
-			fmt.Sprintf(`test_metric_2_this_one_there_where{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 100+delta, 1543160298100),
+			`# HELP test_metric_1_this_one_there_where_bytes_total Extra ones`,
+			`# TYPE test_metric_1_this_one_there_where_bytes_total counter`,
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 99+128, 1543160298100+128000),
+			fmt.Sprintf(`test_metric_1_this_one_there_where_bytes_total{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 100+128, 1543160298100),
+			`# HELP test_metric_2_this_one_there_where_bytes_total Extra ones`,
+			`# TYPE test_metric_2_this_one_there_where_bytes_total counter`,
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="windows",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 99+delta, 1543160298100+delta*1000),
+			fmt.Sprintf(`test_metric_2_this_one_there_where_bytes_total{arch="x86",code2="one2",foo2="bar2",instance="localhost:8080",job="node-exporter",os="linux",otel_scope_name="",otel_scope_schema_url="",otel_scope_version=""} %v %v`, 100+delta, 1543160298100),
 		}
 
 		for _, w := range want {
@@ -454,10 +454,10 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	_ = rsp.Body.Close()
 
 	want := []string{
-		`# HELP test_counter_int`,
-		`# TYPE test_counter_int counter`,
-		`test_counter_int{code2="one2",foo2="bar2",label_1="label-value-1",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 123 1581452773000`,
-		`test_counter_int{code2="one2",foo2="bar2",label_2="label-value-2",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 456 1581452773000`,
+		`# HELP test_counter_int_total`,
+		`# TYPE test_counter_int_total counter`,
+		`test_counter_int_total{code2="one2",foo2="bar2",label_1="label-value-1",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 123 1581452773000`,
+		`test_counter_int_total{code2="one2",foo2="bar2",label_2="label-value-2",otel_scope_name="",otel_scope_schema_url="",otel_scope_version="",resource_attr="resource-attr-val-1"} 456 1581452773000`,
 	}
 
 	for _, w := range want {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Changes the stability of the `DisableAddMetricsSuffixes` feature gate from Alpha to Beta. And, as a consequence, changing the default behavior to add suffixes.
