### PR TITLE
[extension/azureencoding] Support statusMessage on Administrative act…

### DIFF
--- a/.chloggen/azureencoding-status-message.yaml
+++ b/.chloggen/azureencoding-status-message.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/encoding/azureencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`)
+note: Support statusMessage on Administrative Activity Logs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48932]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The properties.statusMessage field on Azure Administrative activity logs is now
+  parsed. When it contains JSON (the common case for VM ScaleSet operations etc.),
+  the structured object is stored under the azure.administrative.status_message
+  attribute. Plain-string values are stored as-is.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/azureencoding-status-message.yaml
+++ b/.chloggen/azureencoding-status-message.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/encoding/azureencodingextension
+component: extension/azure_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`)
 note: Support statusMessage on Administrative Activity Logs

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/README.md
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/README.md
@@ -599,6 +599,7 @@ Activity Logs are a type of Azure platform log that provides insight into subscr
 | `entity`                  | `azure.administrative.entity`       | Log Attribute |
 | `message`                 | `azure.administrative.message`      | Log Attribute |
 | `hierarchy`               | `azure.administrative.hierarchy`    | Log Attribute |
+| `statusMessage`           | `azure.administrative.status_message`| Log Attribute |
 
 #### Administrative — PIM (Privileged Identity Management)
 

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -88,9 +88,10 @@ func (r *activityLogRecordBase) PutCommonAttributes(attrs pcommon.Map, body pcom
 
 // Non-SemConv attributes for Administrative activity logs
 const (
-	attributeAzureAdministrativeEntity    = "azure.administrative.entity"
-	attributeAzureAdministrativeMessage   = "azure.administrative.message"
-	attributeAzureAdministrativeHierarchy = "azure.administrative.hierarchy"
+	attributeAzureAdministrativeEntity        = "azure.administrative.entity"
+	attributeAzureAdministrativeMessage       = "azure.administrative.message"
+	attributeAzureAdministrativeHierarchy     = "azure.administrative.hierarchy"
+	attributeAzureAdministrativeStatusMessage = "azure.administrative.status_message"
 )
 
 // Generic Azure attributes carried by PIM events but not PIM-specific.
@@ -136,9 +137,10 @@ type azureAdministrativeLog struct {
 
 	Properties struct {
 		// Standard Administrative fields
-		Entity    string `json:"entity"`
-		Message   string `json:"message"`
-		Hierarchy string `json:"hierarchy"`
+		Entity        string `json:"entity"`
+		Message       string `json:"message"`
+		Hierarchy     string `json:"hierarchy"`
+		StatusMessage string `json:"statusMessage"`
 
 		// PIM-specific fields (ResourceProviderName=azurerbac)
 		SubscriptionID          *string `json:"SubscriptionID"`
@@ -165,6 +167,7 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeEntity, r.Properties.Entity)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeMessage, r.Properties.Message)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeHierarchy, r.Properties.Hierarchy)
+	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeStatusMessage, r.Properties.StatusMessage)
 
 	// PIM fields
 	// SubscriptionID is also set as a resource attribute (cloud.account.id) by unmarshaler.go from

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -88,10 +88,11 @@ func (r *activityLogRecordBase) PutCommonAttributes(attrs pcommon.Map, body pcom
 
 // Non-SemConv attributes for Administrative activity logs
 const (
-	attributeAzureAdministrativeEntity        = "azure.administrative.entity"
-	attributeAzureAdministrativeMessage       = "azure.administrative.message"
-	attributeAzureAdministrativeHierarchy     = "azure.administrative.hierarchy"
-	attributeAzureAdministrativeStatusMessage = "azure.administrative.status_message"
+	attributeAzureAdministrativeEntity            = "azure.administrative.entity"
+	attributeAzureAdministrativeMessage           = "azure.administrative.message"
+	attributeAzureAdministrativeHierarchy         = "azure.administrative.hierarchy"
+	attributeAzureAdministrativeStatusMessage     = "azure.administrative.status_message"
+	attributeAzureAdministrativeStatusMessageText = "azure.administrative.status_message.text"
 )
 
 // Generic Azure attributes carried by PIM events but not PIM-specific.
@@ -176,7 +177,7 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 			m := attrs.PutEmptyMap(attributeAzureAdministrativeStatusMessage)
 			_ = m.FromRaw(statusMsg)
 		} else {
-			unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeStatusMessage, r.Properties.StatusMessage)
+			unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeStatusMessageText, r.Properties.StatusMessage)
 		}
 	}
 

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_activitylogs.go
@@ -167,7 +167,18 @@ func (r *azureAdministrativeLog) PutProperties(attrs pcommon.Map, _ pcommon.Valu
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeEntity, r.Properties.Entity)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeMessage, r.Properties.Message)
 	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeHierarchy, r.Properties.Hierarchy)
-	unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeStatusMessage, r.Properties.StatusMessage)
+	// statusMessage is typically a JSON-encoded string containing status/error
+	// details (e.g. VM ScaleSet upgrade failures). Attempt to parse it as JSON
+	// and store the structured object; fall back to the raw string if parsing fails.
+	if r.Properties.StatusMessage != "" {
+		var statusMsg map[string]any
+		if err := gojson.Unmarshal([]byte(r.Properties.StatusMessage), &statusMsg); err == nil {
+			m := attrs.PutEmptyMap(attributeAzureAdministrativeStatusMessage)
+			_ = m.FromRaw(statusMsg)
+		} else {
+			unmarshaler.AttrPutStrIf(attrs, attributeAzureAdministrativeStatusMessage, r.Properties.StatusMessage)
+		}
+	}
 
 	// PIM fields
 	// SubscriptionID is also set as a resource attribute (cloud.account.id) by unmarshaler.go from

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
@@ -69,7 +69,7 @@
                 "entity": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs",
                 "message": "microsoft.insights/diagnosticSettings/write",
                 "hierarchy": "22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111",
-                "statusMessage": "some status message"
+                "statusMessage": "{\"status\":\"Failed\",\"error\":{\"code\":\"ResourceOperationFailed\",\"message\":\"The resource operation 'Failed'.\"}}"
             },
             "tenantId": "22222222-2222-2222-2222-222222222222"
         }

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
@@ -72,6 +72,79 @@
                 "statusMessage": "{\"status\":\"Failed\",\"error\":{\"code\":\"ResourceOperationFailed\",\"message\":\"The resource operation 'Failed'.\",\"errorDetails\":[{\"code\":\"MaxUnhealthyUpgradedInstancePercentExceededInRollingUpgrade/ResourceNotFound\",\"message\":\"Rolling Upgrade failed after exceeding the MaxUnhealthyUpgradedInstancePercent value defined in the RollingUpgradePolicy. 100% of instances are in an unhealthy state after being upgraded - more than the threshold of 20%. The most impactful error is: The Resource 'Microsoft.Compute/virtualMachines/<scale_set_name>_07971188' under resource group '<resource_group_name>' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix. First failed instance ID is: <scale_set_name>_07971188.\"}]}}"
             },
             "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        {
+            "RoleLocation": "France South",
+            "Stamp": "FDWeb",
+            "ReleaseVersion": "6.2025.14.4+0123456.release_2025w14",
+            "time": "2025-04-15T10:16:33.9873441Z",
+            "resourceId": "/SUBSCRIPTIONS/11111111-1111-1111-1111-111111111111/PROVIDERS/MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/EXAMPLE-COLLECT-SAMPLE-LOGS",
+            "operationName": "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/WRITE",
+            "category": "Administrative",
+            "resultType": "Start",
+            "resultSignature": "Started.",
+            "durationMs": "0",
+            "callerIpAddress": "203.0.113.10",
+            "correlationId": "aaaaaaaa-bbbb-cccc-dddd-222222222222",
+            "identity": {
+                "authorization": {
+                    "scope": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs",
+                    "action": "microsoft.insights/diagnosticSettings/write",
+                    "evidence": {
+                        "role": "Owner",
+                        "roleAssignmentScope": "/subscriptions/11111111-1111-1111-1111-111111111111",
+                        "roleAssignmentId": "33333333333333333333333333333333",
+                        "roleDefinitionId": "44444444444444444444444444444444",
+                        "principalId": "55555555555555555555555555555555",
+                        "principalType": "User"
+                    }
+                },
+                "claims": {
+                    "aud": "https://management.core.windows.net/",
+                    "iss": "https://sts.windows.net/22222222-2222-2222-2222-222222222222/",
+                    "iat": "1744711621",
+                    "nbf": "1744711621",
+                    "exp": "1744717084",
+                    "http://schemas.microsoft.com/claims/authnclassreference": "1",
+                    "aio": "AaQAW/8ZAAAAZgO/4jIRs/N/KB2dU/OBCRIKqhlJptIDhdwKznsOAvG9l6XBKLVbb3gcOhXy9f7l7PPh72wUbG+ej/8K+eWceVLG+R554s0NPw8+L9LbF/FkzqSnEd3FGiBccK4bL1UbJ0B9ddpT60CbBOgu/xF9JTzYPu3Mtl7em3l+o4oybByk52SljldSN5LizwAmpC0b/rho3D6WMskK7fBotCV3XQ==",
+                    "altsecid": "5::10032001EEC259BA",
+                    "http://schemas.microsoft.com/claims/authnmethodsreferences": "pwd,mfa",
+                    "appid": "66666666-6666-6666-6666-666666666666",
+                    "appidacr": "0",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": "user@example.com",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": "Doe",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname": "John",
+                    "groups": "77777777-7777-7777-7777-777777777777,88888888-8888-8888-8888-888888888888,99999999-9999-9999-9999-999999999999",
+                    "http://schemas.microsoft.com/identity/claims/identityprovider": "https://sts.windows.net/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+                    "idtyp": "user",
+                    "ipaddr": "203.0.113.10",
+                    "name": "John Doe",
+                    "http://schemas.microsoft.com/identity/claims/objectidentifier": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "puid": "100320024FCDB44E",
+                    "rh": "1.AUgAW2hAqn1BZEa07I92QHGa20ZIf3kAutdPukPawfj2MBMLAR1IAA.",
+                    "http://schemas.microsoft.com/identity/claims/scope": "user_impersonation",
+                    "sid": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "8lEWzt6Ed5a3RZMV7p9x6FI31xksIsZsmh09g0Lbdq0",
+                    "http://schemas.microsoft.com/identity/claims/tenantid": "22222222-2222-2222-2222-222222222222",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name": "user@example.com",
+                    "uti": "s4OAwbVGQ0CX8sNFq4tAAA",
+                    "ver": "1.0",
+                    "wids": "dddddddd-dddd-dddd-dddd-dddddddddddd,eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee,ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    "xms_edov": "true",
+                    "xms_idrel": "5 26",
+                    "xms_tcdt": "1391159646"
+                }
+            },
+            "level": "Informational",
+            "properties": {
+                "requestbody": "{\"id\":\"/subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs\",\"name\":\"example-collect-sample-logs\",\"properties\":{\"logs\":[{\"category\":\"Administrative\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"Security\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"ServiceHealth\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"Alert\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"Recommendation\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"Policy\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"Autoscale\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}},{\"category\":\"ResourceHealth\",\"categoryGroup\":null,\"enabled\":true,\"retentionPolicy\":{\"days\":0,\"enabled\":false}}],\"metrics\":[],\"storageAccountId\":\"/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/example-resource-group/providers/Microsoft.Storage/storageAccounts/examplestorageacct\",\"eventHubAuthorizationRuleId\":\"/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/example-resource-group/providers/Microsoft.EventHub/namespaces/exampleeventhubns/authorizationrules/RootManageSharedAccessKey\",\"eventHubName\":\"logs\"}}",
+                "eventCategory": "Administrative",
+                "entity": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs",
+                "message": "microsoft.insights/diagnosticSettings/write",
+                "hierarchy": "22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111",
+                "statusMessage": "some plain text status message"
+            },
+            "tenantId": "22222222-2222-2222-2222-222222222222"
         }
     ]
 }

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
@@ -68,7 +68,8 @@
                 "eventCategory": "Administrative",
                 "entity": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs",
                 "message": "microsoft.insights/diagnosticSettings/write",
-                "hierarchy": "22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111"
+                "hierarchy": "22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111",
+                "statusMessage": "some status message"
             },
             "tenantId": "22222222-2222-2222-2222-222222222222"
         }

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log.json
@@ -69,7 +69,7 @@
                 "entity": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs",
                 "message": "microsoft.insights/diagnosticSettings/write",
                 "hierarchy": "22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111",
-                "statusMessage": "{\"status\":\"Failed\",\"error\":{\"code\":\"ResourceOperationFailed\",\"message\":\"The resource operation 'Failed'.\"}}"
+                "statusMessage": "{\"status\":\"Failed\",\"error\":{\"code\":\"ResourceOperationFailed\",\"message\":\"The resource operation 'Failed'.\",\"errorDetails\":[{\"code\":\"MaxUnhealthyUpgradedInstancePercentExceededInRollingUpgrade/ResourceNotFound\",\"message\":\"Rolling Upgrade failed after exceeding the MaxUnhealthyUpgradedInstancePercent value defined in the RollingUpgradePolicy. 100% of instances are in an unhealthy state after being upgraded - more than the threshold of 20%. The most impactful error is: The Resource 'Microsoft.Compute/virtualMachines/<scale_set_name>_07971188' under resource group '<resource_group_name>' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix. First failed instance ID is: <scale_set_name>_07971188.\"}]}}"
             },
             "tenantId": "22222222-2222-2222-2222-222222222222"
         }

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
@@ -109,6 +109,9 @@ resourceLogs:
               - key: azure.administrative.hierarchy
                 value:
                   stringValue: 22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111
+              - key: azure.administrative.status_message
+                value:
+                  stringValue: some status message
             body: {}
             severityNumber: 9
             severityText: Informational

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
@@ -37,36 +37,36 @@ resourceLogs:
               - key: azure.operation.duration
                 value:
                   intValue: "0"
-              - key: azure.identity.identifier.object
-                value:
-                  stringValue: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
-              - key: user.id
-                value:
-                  stringValue: 8lEWzt6Ed5a3RZMV7p9x6FI31xksIsZsmh09g0Lbdq0
-              - key: azure.identity.application.id
-                value:
-                  stringValue: 66666666-6666-6666-6666-666666666666
-              - key: azure.identity.provider
-                value:
-                  stringValue: https://sts.windows.net/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/
-              - key: user.email
-                value:
-                  stringValue: user@example.com
-              - key: azure.identity.issuer
-                value:
-                  stringValue: https://sts.windows.net/22222222-2222-2222-2222-222222222222/
-              - key: azure.identity.audience
-                value:
-                  stringValue: https://management.core.windows.net/
               - key: azure.identity.scope
                 value:
                   stringValue: user_impersonation
               - key: azure.identity.type
                 value:
                   stringValue: user
+              - key: azure.identity.application.id
+                value:
+                  stringValue: 66666666-6666-6666-6666-666666666666
+              - key: azure.identity.provider
+                value:
+                  stringValue: https://sts.windows.net/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/
+              - key: azure.identity.identifier.object
+                value:
+                  stringValue: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+              - key: user.id
+                value:
+                  stringValue: 8lEWzt6Ed5a3RZMV7p9x6FI31xksIsZsmh09g0Lbdq0
+              - key: azure.identity.issuer
+                value:
+                  stringValue: https://sts.windows.net/22222222-2222-2222-2222-222222222222/
+              - key: azure.identity.audience
+                value:
+                  stringValue: https://management.core.windows.net/
               - key: azure.identity.auth.methods.references
                 value:
                   stringValue: pwd,mfa
+              - key: user.email
+                value:
+                  stringValue: user@example.com
               - key: azure.identity.not_after
                 value:
                   stringValue: "2025-04-15T11:38:04Z"
@@ -123,6 +123,9 @@ resourceLogs:
                               - key: code
                                 value:
                                   stringValue: ResourceOperationFailed
+                              - key: message
+                                value:
+                                  stringValue: The resource operation 'Failed'.
                               - key: errorDetails
                                 value:
                                   arrayValue:
@@ -131,17 +134,115 @@ resourceLogs:
                                           values:
                                             - key: code
                                               value:
-                                                stringValue: "MaxUnhealthyUpgradedInstancePercentExceededInRollingUpgrade/ResourceNotFound"
+                                                stringValue: MaxUnhealthyUpgradedInstancePercentExceededInRollingUpgrade/ResourceNotFound
                                             - key: message
                                               value:
-                                                stringValue: "Rolling Upgrade failed after exceeding the MaxUnhealthyUpgradedInstancePercent value defined in the RollingUpgradePolicy. 100% of instances are in an unhealthy state after being upgraded - more than the threshold of 20%. The most impactful error is: The Resource 'Microsoft.Compute/virtualMachines/<scale_set_name>_07971188' under resource group '<resource_group_name>' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix. First failed instance ID is: <scale_set_name>_07971188."
-                              - key: message
-                                value:
-                                  stringValue: "The resource operation 'Failed'."
+                                                stringValue: 'Rolling Upgrade failed after exceeding the MaxUnhealthyUpgradedInstancePercent value defined in the RollingUpgradePolicy. 100% of instances are in an unhealthy state after being upgraded - more than the threshold of 20%. The most impactful error is: The Resource ''Microsoft.Compute/virtualMachines/<scale_set_name>_07971188'' under resource group ''<resource_group_name>'' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix. First failed instance ID is: <scale_set_name>_07971188.'
             body: {}
             severityNumber: 9
-            severityText: "Informational"
+            severityText: Informational
             timeUnixNano: "1744712192987344100"
+          - attributes:
+              - key: azure.category
+                value:
+                  stringValue: Administrative
+              - key: azure.operation.name
+                value:
+                  stringValue: MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/WRITE
+              - key: azure.result.type
+                value:
+                  stringValue: Start
+              - key: azure.result.signature
+                value:
+                  stringValue: Started.
+              - key: network.peer.address
+                value:
+                  stringValue: 203.0.113.10
+              - key: azure.correlation_id
+                value:
+                  stringValue: aaaaaaaa-bbbb-cccc-dddd-222222222222
+              - key: azure.operation.duration
+                value:
+                  intValue: "0"
+              - key: azure.identity.audience
+                value:
+                  stringValue: https://management.core.windows.net/
+              - key: azure.identity.type
+                value:
+                  stringValue: user
+              - key: azure.identity.application.id
+                value:
+                  stringValue: 66666666-6666-6666-6666-666666666666
+              - key: azure.identity.auth.methods.references
+                value:
+                  stringValue: pwd,mfa
+              - key: azure.identity.provider
+                value:
+                  stringValue: https://sts.windows.net/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/
+              - key: azure.identity.identifier.object
+                value:
+                  stringValue: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+              - key: azure.identity.issuer
+                value:
+                  stringValue: https://sts.windows.net/22222222-2222-2222-2222-222222222222/
+              - key: azure.identity.scope
+                value:
+                  stringValue: user_impersonation
+              - key: user.id
+                value:
+                  stringValue: 8lEWzt6Ed5a3RZMV7p9x6FI31xksIsZsmh09g0Lbdq0
+              - key: user.email
+                value:
+                  stringValue: user@example.com
+              - key: azure.identity.not_after
+                value:
+                  stringValue: "2025-04-15T11:38:04Z"
+              - key: azure.identity.not_before
+                value:
+                  stringValue: "2025-04-15T10:07:01Z"
+              - key: azure.identity.created
+                value:
+                  stringValue: "2025-04-15T10:07:01Z"
+              - key: azure.identity.authorization.scope
+                value:
+                  stringValue: /subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs
+              - key: azure.identity.authorization.action
+                value:
+                  stringValue: microsoft.insights/diagnosticSettings/write
+              - key: azure.identity.authorization.evidence.role
+                value:
+                  stringValue: Owner
+              - key: azure.identity.authorization.evidence.role.assignment.scope
+                value:
+                  stringValue: /subscriptions/11111111-1111-1111-1111-111111111111
+              - key: azure.identity.authorization.evidence.role.assignment.id
+                value:
+                  stringValue: "33333333333333333333333333333333"
+              - key: azure.identity.authorization.evidence.role.definition.id
+                value:
+                  stringValue: "44444444444444444444444444444444"
+              - key: azure.identity.authorization.evidence.principal.id
+                value:
+                  stringValue: "55555555555555555555555555555555"
+              - key: azure.identity.authorization.evidence.principal.type
+                value:
+                  stringValue: User
+              - key: azure.administrative.entity
+                value:
+                  stringValue: /subscriptions/11111111-1111-1111-1111-111111111111/providers/microsoft.insights/diagnosticSettings/example-collect-sample-logs
+              - key: azure.administrative.message
+                value:
+                  stringValue: microsoft.insights/diagnosticSettings/write
+              - key: azure.administrative.hierarchy
+                value:
+                  stringValue: 22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111
+              - key: azure.administrative.status_message.text
+                value:
+                  stringValue: some plain text status message
+            body: {}
+            severityNumber: 9
+            severityText: Informational
+            timeUnixNano: "1744712193987344100"
         scope:
           attributes:
             - key: encoding.format

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
@@ -111,7 +111,21 @@ resourceLogs:
                   stringValue: 22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111
               - key: azure.administrative.status_message
                 value:
-                  stringValue: some status message
+                  kvlistValue:
+                    values:
+                      - key: status
+                        value:
+                          stringValue: Failed
+                      - key: error
+                        value:
+                          kvlistValue:
+                            values:
+                              - key: code
+                                value:
+                                  stringValue: ResourceOperationFailed
+                              - key: message
+                                value:
+                                  stringValue: "The resource operation 'Failed'."
             body: {}
             severityNumber: 9
             severityText: Informational

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/activitylogs/administrative-log_expected.yaml
@@ -123,12 +123,24 @@ resourceLogs:
                               - key: code
                                 value:
                                   stringValue: ResourceOperationFailed
+                              - key: errorDetails
+                                value:
+                                  arrayValue:
+                                    values:
+                                      - kvlistValue:
+                                          values:
+                                            - key: code
+                                              value:
+                                                stringValue: "MaxUnhealthyUpgradedInstancePercentExceededInRollingUpgrade/ResourceNotFound"
+                                            - key: message
+                                              value:
+                                                stringValue: "Rolling Upgrade failed after exceeding the MaxUnhealthyUpgradedInstancePercent value defined in the RollingUpgradePolicy. 100% of instances are in an unhealthy state after being upgraded - more than the threshold of 20%. The most impactful error is: The Resource 'Microsoft.Compute/virtualMachines/<scale_set_name>_07971188' under resource group '<resource_group_name>' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix. First failed instance ID is: <scale_set_name>_07971188."
                               - key: message
                                 value:
                                   stringValue: "The resource operation 'Failed'."
             body: {}
             severityNumber: 9
-            severityText: Informational
+            severityText: "Informational"
             timeUnixNano: "1744712192987344100"
         scope:
           attributes:


### PR DESCRIPTION
fixes; #48932
[extension/azureencoding] Support statusMessage on Azure Administrative Changes Made.

This PR adds support for parsing and mapping the `properties.statusMessage` field on Azure Administrative activity logs. Currently, VM ScaleSet upgrade failures and other operation failures report detailed error reasons inside the `statusMessage` properties field, which was being silently dropped during unmarshaling.
With this change, `statusMessage` is parsed and mapped to the `azure.administrative.status_message` OTel log attribute.

Changes:
Extension Coding Logic
category_activitylogs.go:
- Added the attributeAzureAdministrativeStatusMessage constant mapping to azure.administrative.status_message.
- Added StatusMessage string property to the azureAdministrativeLog.Properties struct.
- Updated PutProperties to map Properties.StatusMessage using AttrPutStrIf.

Tests and Documentation:
- administrative-log.json: Added a sample statusMessage string in the golden test log record's properties.
- administrative-log_expected.yaml: Added the expected azure.administrative.status_message attribute output.
- README.md: Documented statusMessage mapping under the Administrative logs category.
