### PR TITLE
[cmd/schemagen] Add `-p` flag to schemagen for custom Go package pattern specification

### DIFF
--- a/.chloggen/schemagen_pattern_option.yaml
+++ b/.chloggen/schemagen_pattern_option.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/schemagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `-p` flag to schemagen to allow specifying a custom Go package pattern"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously the parser always loaded the package from the current directory (`.`).
+  The new `-p` flag accepts any pattern accepted by `packages.Load`, including a fully-qualified
+  import path, so that schemagen can target a specific package without changing the working directory.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/schemagen_pattern_option.yaml
+++ b/.chloggen/schemagen_pattern_option.yaml
@@ -10,7 +10,7 @@ component: cmd/schemagen
 note: "Add `-p` flag to schemagen to allow specifying a custom Go package pattern"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [48966]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/schemagen/README.md
+++ b/cmd/schemagen/README.md
@@ -57,6 +57,7 @@ You can also go to specific component folder and run `make schemagen` directly.
 | `-o` | Given directory (or `outputFolder` from `.schemagen.yaml` if provided) | Folder that will receive the generated `*.schema.<ext>` file. |
 | `-t` | `yaml`                                                                 | Output format. Accepts `yaml`, `yml`, or `json`.              |
 | `-r` | `false`                                                                | Resolve `$ref` entries inline (see [Ref resolution](#ref-resolution)). |
+| `-p` | `.`                                                                    | Go package pattern passed to `packages.Load`. Use a fully-qualified import path (e.g. `go.opentelemetry.io/collector/receiver/otlpreceiver`) to target a specific package instead of the current directory. |
 
 The schema `$id` is derived from the Go package import path and the `$title` is the package name with the current
 run mode (`component`/`package`) appended.

--- a/cmd/schemagen/internal/config.go
+++ b/cmd/schemagen/internal/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	ResolveRefs       bool
 	ComponentOverride *ComponentOverride
 	SettingsDir       string
+	Pattern           string
 }
 
 var (
@@ -40,6 +41,7 @@ var (
 	outputFolder = flag.String("o", "", "Output schema folder (defaults to input folder)")
 	fileType     = flag.String("t", "yaml", "Output file type (yaml or json)")
 	resolveRefs  = flag.Bool("r", false, "Resolve external $ref entries inline in the output schema")
+	pattern      = flag.String("p", ".", "Optional pattern to match config struct package, e.g. \"go.opentelemetry.io/collector/receiver/otlpreceiver")
 )
 
 func usage() {
@@ -154,6 +156,7 @@ func ReadConfig() (*Config, error) {
 		ResolveRefs:       *resolveRefs,
 		ComponentOverride: componentOverride,
 		SettingsDir:       settingsDir,
+		Pattern:           *pattern,
 	}, nil
 }
 

--- a/cmd/schemagen/internal/config_test.go
+++ b/cmd/schemagen/internal/config_test.go
@@ -25,6 +25,7 @@ func TestReadConfig(t *testing.T) {
 	require.Equal(t, dir, cfg.DirPath)
 	require.Equal(t, dir, cfg.OutputFolder)
 	require.Empty(t, cfg.ConfigType)
+	require.Equal(t, ".", cfg.Pattern)
 }
 
 func TestReadConfig_Errors(t *testing.T) {
@@ -215,6 +216,7 @@ func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 	origRootType := configType
 	origOutputFolder := outputFolder
 	origFileType := fileType
+	origPattern := pattern
 
 	flag.CommandLine = flag.NewFlagSet(origArgs[0], flag.ContinueOnError)
 	flag.CommandLine.SetOutput(io.Discard)
@@ -222,6 +224,7 @@ func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 	configType = flag.String("r", "", "Root type name (default is derived from file name)")
 	outputFolder = flag.String("o", "", "Output schema folder")
 	fileType = flag.String("t", "yaml", "Output file type (yaml or json)")
+	pattern = flag.String("p", ".", "Optional pattern to match config struct package")
 
 	os.Args = append([]string{origArgs[0]}, args...)
 	t.Cleanup(func() {
@@ -230,6 +233,7 @@ func readConfigForTest(t *testing.T, args ...string) (*Config, error) {
 		configType = origRootType
 		outputFolder = origOutputFolder
 		fileType = origFileType
+		pattern = origPattern
 	})
 
 	return ReadConfig()

--- a/cmd/schemagen/internal/integration_test.go
+++ b/cmd/schemagen/internal/integration_test.go
@@ -70,6 +70,7 @@ func TestFactoryMaps(t *testing.T) {
 				Namespace:         s.Namespace,
 				ComponentOverride: &overrideCopy,
 				SettingsDir:       settingsDir,
+				Pattern:           ".",
 			}
 
 			schema, err := NewParser(cfg).Parse()

--- a/cmd/schemagen/internal/parser.go
+++ b/cmd/schemagen/internal/parser.go
@@ -41,7 +41,7 @@ func NewParser(cfg *Config) *Parser {
 }
 
 func (p *Parser) Parse() (*Schema, error) {
-	return p.ParsePattern(".")
+	return p.ParsePattern(p.config.Pattern)
 }
 
 func (p *Parser) ParsePattern(pattern string) (*Schema, error) {

--- a/cmd/schemagen/internal/parser_test.go
+++ b/cmd/schemagen/internal/parser_test.go
@@ -116,6 +116,7 @@ func TestComponentParser(t *testing.T) {
 					"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/schemagen",
 				},
 				Namespace: "github.com/open-telemetry/opentelemetry-collector-contrib",
+				Pattern:   ".",
 			}
 			if tc.rootType != "" {
 				cfg.ConfigType = tc.rootType


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Previously the parser always loaded the package from the current directory (`.`).  The new `-p` flag accepts any pattern accepted by `packages.Load`, including a fully-qualified import path, so that schemagen can target a specific package without changing the working directory.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests added

<!--Describe the documentation added.-->
#### Documentation

README covers new functionality

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
