### PR TITLE
[chore][extension/pebbletailstorage] Exclude from AIX cross-compile build

### DIFF
--- a/extension/tailstorage/pebbletailstorageextension/config.go
+++ b/extension/tailstorage/pebbletailstorageextension/config.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
 
 import "errors"

--- a/extension/tailstorage/pebbletailstorageextension/extension.go
+++ b/extension/tailstorage/pebbletailstorageextension/extension.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
 
 import (

--- a/extension/tailstorage/pebbletailstorageextension/factory.go
+++ b/extension/tailstorage/pebbletailstorageextension/factory.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
 
 import (

--- a/extension/tailstorage/pebbletailstorageextension/factory_aix.go
+++ b/extension/tailstorage/pebbletailstorageextension/factory_aix.go
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build aix
+
+package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
+
+import "go.opentelemetry.io/collector/extension"
+
+func NewFactory() extension.Factory {
+	panic("aix is not supported")
+}

--- a/extension/tailstorage/pebbletailstorageextension/pebble.go
+++ b/extension/tailstorage/pebbletailstorageextension/pebble.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
 
 import (

--- a/extension/tailstorage/pebbletailstorageextension/storage.go
+++ b/extension/tailstorage/pebbletailstorageextension/storage.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !aix
+
 package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
 
 import (


### PR DESCRIPTION
#### Description
Fix AIX build failure by excluding pebbletailstorage extension from AIX build.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/27136280204/job/80089753527 it has been failing since http://github.com/open-telemetry/opentelemetry-collector-contrib/commit/6004654ac94df40736b67619e00ba7320c2305a

#### Authorship

- [x] I, a human, wrote this pull request description myself.