### PR TITLE
[processor/tailsamplingprocessor] move spans during ingest instead of copying

### DIFF
--- a/.chloggen/tailsampling-movespans.yaml
+++ b/.chloggen/tailsampling-movespans.yaml
@@ -1,0 +1,16 @@
+change_type: enhancement
+
+component: tailsamplingprocessor
+
+note: Move spans into the per-trace ResourceSpans during ingest instead of deep-copying them, reducing per-span allocations.
+
+issues: []
+
+subtext: |
+  The processor now declares `MutatesData: true`. Pipelines that fan the input out
+  to multiple consumers will see one extra clone at the fanoutconsumer boundary
+  (which already happened internally inside this processor); in the typical
+  single-consumer load-balanced topology there is no additional copy and the
+  per-span deep copy is replaced with a pointer swap.
+
+change_logs: [user]

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -162,7 +162,7 @@ func newTracesProcessor(ctx context.Context, set processor.Settings, nextConsume
 }
 
 func (*tailSamplingSpanProcessor) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+	return consumer.Capabilities{MutatesData: true}
 }
 
 // Start is invoked during service startup.
@@ -1180,7 +1180,7 @@ func newResourceSpanFromSpanAndScopes(rss ptrace.ResourceSpans, spanAndScopes []
 			sp = scope.Spans().AppendEmpty()
 		}
 
-		spanAndScope.span.CopyTo(sp)
+		spanAndScope.span.MoveTo(sp)
 		if sp.ParentSpanID().IsEmpty() {
 			rootSpan = &sp
 		}

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -223,8 +223,12 @@ func TestTraceIntegrity(t *testing.T) {
 
 	mpe1.SetDecision(samplingpolicy.Sampled)
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), traces))
+	// Generate and deliver first span. ConsumeTraces declares MutatesData=true,
+	// so clone before the call to keep the captured `spans` references intact
+	// for the post-consume assertions below.
+	tracesIn := ptrace.NewTraces()
+	traces.CopyTo(tracesIn)
+	require.NoError(t, p.ConsumeTraces(t.Context(), tracesIn))
 
 	// The first tick won't do anything
 	controller.waitForTick()
@@ -335,7 +339,10 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	concurrencyLimiter := make(chan struct{}, 128)
 	defer close(concurrencyLimiter)
 	for _, batch := range batches {
-		// Add the same traceId twice.
+		// Add the same traceId twice. ConsumeTraces declares MutatesData=true,
+		// so each goroutine needs its own copy to race over.
+		batchClone := ptrace.NewTraces()
+		batch.CopyTo(batchClone)
 		wg.Add(2)
 		concurrencyLimiter <- struct{}{}
 		go func(td ptrace.Traces) {
@@ -348,7 +355,7 @@ func TestConcurrentTraceArrival(t *testing.T) {
 			assert.NoError(t, sp.ConsumeTraces(t.Context(), td))
 			wg.Done()
 			<-concurrencyLimiter
-		}(batch)
+		}(batchClone)
 	}
 
 	wg.Wait()
@@ -397,15 +404,22 @@ func TestConcurrentArrivalAndEvaluation(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
+	cloneTraces := func(td ptrace.Traces) ptrace.Traces {
+		out := ptrace.NewTraces()
+		td.CopyTo(out)
+		return out
+	}
 	for _, batch := range batches {
 		wg.Add(1)
 		go func(td ptrace.Traces) {
+			// ConsumeTraces declares MutatesData=true, so each call needs its
+			// own copy or only the first one would carry data.
 			for range 10 {
-				assert.NoError(t, sp.ConsumeTraces(t.Context(), td))
+				assert.NoError(t, sp.ConsumeTraces(t.Context(), cloneTraces(td)))
 			}
 			controller.concurrentWithTick(func() {
 				for range 10 {
-					assert.NoError(t, sp.ConsumeTraces(t.Context(), td))
+					assert.NoError(t, sp.ConsumeTraces(t.Context(), cloneTraces(td)))
 				}
 			})
 			wg.Done()
@@ -543,8 +557,12 @@ func TestConsumptionDuringPolicyEvaluation(t *testing.T) {
 			// know exactly when that will happen, so we just write in a loop
 			// until the time must have passed.
 			for time.Since(start) < 2*cfg.DecisionWait {
-				expectedSpans.Add(int64(batch.SpanCount()))
-				err := tsp.ConsumeTraces(t.Context(), batch)
+				// ConsumeTraces declares MutatesData=true, so clone before
+				// each call to keep delivering data on subsequent iterations.
+				clone := ptrace.NewTraces()
+				batch.CopyTo(clone)
+				expectedSpans.Add(int64(clone.SpanCount()))
+				err := tsp.ConsumeTraces(t.Context(), clone)
 				if err != nil {
 					errCh <- err
 				}


### PR DESCRIPTION
#### Description

Reduce the amount of allocations done by the tail sampling processor by using MoveTo when possible. This requires marking the processor as mutating data which will cause any fanout setups to still copy the data but shows ~10-15% improvement in allocations for users without a fanout.

#### Link to tracking issue

#### Testing

this change is transparent so all existing tests need to pass

#### Documentation

no documentation

#### Authorship

- [x] I, a human, wrote this pull request description myself.