### PR TITLE
[chore][receiver/prometheusreceiver] Fix TestStaleNaNs flake under load

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -71,6 +71,33 @@ func TestStaleNaNs(t *testing.T) {
 }
 
 func verifyStaleNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {
+	// Drop scrape results that contain only the default scrape metrics.
+	// The receiver emits such entries when a scrape itself fails with no
+	// previously-seen data (e.g. scrape_timeout under load, or once the
+	// expected scrape count is reached but the scrape manager has fired
+	// again before shutdown). They are unrelated to the alternating
+	// success/failure pattern this test validates and would otherwise
+	// race with it on slow CI runners.
+	filtered := resourceMetrics[:0:0]
+	for _, rm := range resourceMetrics {
+		hasAppMetric := false
+		for _, m := range getMetrics(rm) {
+			if !isDefaultMetrics(m) && !isExtraScrapeMetrics(m) {
+				hasAppMetric = true
+				break
+			}
+		}
+		if hasAppMetric {
+			filtered = append(filtered, rm)
+		}
+	}
+	// Trim to the expected count in case the snapshot caught extra real
+	// scrapes appended after the expected count was reached.
+	if len(filtered) > totalScrapes {
+		filtered = filtered[:totalScrapes]
+	}
+	resourceMetrics = filtered
+
 	verifyNumTotalScrapeResults(t, td, resourceMetrics)
 	successfulScrapes := 0
 	failedScrapes := 0


### PR DESCRIPTION
I had to use cross compile to ARM on x86 and run in emulation to reproduce the failures. I got lucky the emulation is so slow.

I think an even better solution would be if we wouldn't use network round trip and the scrape manager for tests that are only interested in the logic , not the e2e round trip.

The rest is generated content:

#### Description

Two distinct timing races make `TestStaleNaNs` flaky on ARM CI and reproducible locally on x86_64 under `qemu-aarch64` at ~20% per run with the existing 100ms scrape interval:

- **Trailing phantom.** The mock server keeps returning the last page (a 500) on requests past page 10, and the scrape ticker keeps firing on its 100ms interval. Between the signalling sink reaching 10 consumed scrapes and the snapshot being taken, an 11th scrape can be appended to `cms.AllMetrics()`. That 11th entry contains only the 5 default scrape metrics with `up=0` (the previous scrape was also a 500, so there is no data to staleness-mark). `verifyStaleNaNs` iterates all entries and fails with `expected 5 failed, got 6` and `expected 9 metrics, got 5`.
- **Leading synthetic.** Under load the HTTP round trip can exceed `scrape_timeout` (which defaults to `min(10s, scrape_interval)` = 100ms here). On timeout the receiver emits a failed-scrape entry containing only the 5 default scrape metrics before any real scrape lands, shifting the subsequent alternation by one or two entries.

Both kinds of unwanted entries share the same shape: only default scrape metrics, no application data. Filter them out at the top of `verifyStaleNaNs` and trim to `totalScrapes`.

The receiver-side helper is left untouched so tests like `TestLabelLimitConfig`, `TestLabelNameLimitConfig`, `TestLabelValueLimitConfig` and `TestOpenMetricsInvalid` — where "default metrics only + up=0" *is* the expected output — keep working unchanged.

#### Link to tracking issue

Fixes #48766.

#### Testing

Reproduced and verified locally on x86_64 via `qemu-aarch64`:

```
sudo apt-get install -y qemu-user-static binfmt-support
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -c -o /tmp/x.arm64.test ./receiver/prometheusreceiver
/tmp/x.arm64.test -test.run '^TestStaleNaNs$' -test.count=1 -test.timeout=60s
```

- Before the fix: ~20% of runs fail (reproduces on the first iteration most of the time).
- After the fix: **200/200 passes** of `TestStaleNaNs` under qemu-aarch64.
- Full `receiver/prometheusreceiver` package: PASS on native amd64 and under qemu-aarch64.

#### Documentation

None — pure test-side change, no user-facing behavior modified.