### PR TITLE
[chore] [receiver/k8sclusterreceiver] Update semconv to v1.40.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -196,7 +196,7 @@ linters:
 
             # Block AWS SDK v1 to prevent new usage while migration to v2 is in progress.
             # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699
-            - pkg: github.com/aws/aws-sdk-go$
+            - pkg: github.com/aws/aws-sdk-go/
               desc: "Use github.com/aws/aws-sdk-go-v2 instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699"
 
         semconv:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -196,7 +196,7 @@ linters:
 
             # Block AWS SDK v1 to prevent new usage while migration to v2 is in progress.
             # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699
-            - pkg: github.com/aws/aws-sdk-go/
+            - pkg: github.com/aws/aws-sdk-go$
               desc: "Use github.com/aws/aws-sdk-go-v2 instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699"
 
         semconv:
@@ -272,12 +272,7 @@ linters:
           files:
             - "!**/*_test.go"
 
-        # Block AWS SDK v1 to prevent new usage while migration to v2 is in progress.
-        # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699
-        aws-sdk-v1:
-          deny:
-            - pkg: github.com/aws/aws-sdk-go
-              desc: "Use github.com/aws/aws-sdk-go-v2 instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699"
+
 
     forbidigo:
       analyze-types: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -272,7 +272,24 @@ linters:
           files:
             - "!**/*_test.go"
 
-
+        # Block AWS SDK v1, with exceptions for components still migrating to v2.
+        # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699
+        aws-sdk-v1:
+          list-mode: lax
+          deny:
+            - pkg: github.com/aws/aws-sdk-go
+              desc: "Use github.com/aws/aws-sdk-go-v2 instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699"
+          allow:
+            # TODO: Remove these exceptions as migration to v2 completes.
+            # Temporary allowances for modules still using SDK v1:
+            - exporter/prometheusexporter
+            - extension/asapauthextension
+            - internal/datadog/e2e
+            - receiver/prometheusreceiver
+            - receiver/simpleprometheusreceiver
+            - receiver/purefbreceiver
+            - receiver/purefareceiver
+            - testbed
 
     forbidigo:
       analyze-types: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -272,24 +272,12 @@ linters:
           files:
             - "!**/*_test.go"
 
-        # Block AWS SDK v1, with exceptions for components still migrating to v2.
+        # Block AWS SDK v1 to prevent new usage while migration to v2 is in progress.
         # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699
         aws-sdk-v1:
-          list-mode: lax
           deny:
             - pkg: github.com/aws/aws-sdk-go
               desc: "Use github.com/aws/aws-sdk-go-v2 instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36699"
-          allow:
-            # TODO: Remove these exceptions as migration to v2 completes.
-            # Temporary allowances for modules still using SDK v1:
-            - exporter/prometheusexporter
-            - extension/asapauthextension
-            - internal/datadog/e2e
-            - receiver/prometheusreceiver
-            - receiver/simpleprometheusreceiver
-            - receiver/purefbreceiver
-            - receiver/purefareceiver
-            - testbed
 
     forbidigo:
       analyze-types: true

--- a/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
@@ -13,7 +13,7 @@ resourceMetrics:
           idKeys:
             - openshift.clusterquota.uid
           type: openshift.clusterquota
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The configured upper limit for a particular resource.

--- a/receiver/k8sclusterreceiver/internal/container/testdata/expected_no_status.yaml
+++ b/receiver/k8sclusterreceiver/internal/container/testdata/expected_no_status.yaml
@@ -33,7 +33,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details

--- a/receiver/k8sclusterreceiver/internal/container/testdata/expected_running.yaml
+++ b/receiver/k8sclusterreceiver/internal/container/testdata/expected_running.yaml
@@ -33,7 +33,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details

--- a/receiver/k8sclusterreceiver/internal/container/testdata/expected_terminated.yaml
+++ b/receiver/k8sclusterreceiver/internal/container/testdata/expected_terminated.yaml
@@ -33,7 +33,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details

--- a/receiver/k8sclusterreceiver/internal/container/testdata/expected_waiting.yaml
+++ b/receiver/k8sclusterreceiver/internal/container/testdata/expected_waiting.yaml
@@ -33,7 +33,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details

--- a/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.cronjob.uid
           type: k8s.cronjob
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running jobs for a cronjob

--- a/receiver/k8sclusterreceiver/internal/daemonset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/daemonset/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.daemonset.uid
           type: k8s.daemonset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod

--- a/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment
-    schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
+    schemaUrl: "https://opentelemetry.io/schemas/1.40.0"
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_logs.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_logs.go
@@ -7,7 +7,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/otel/semconv/v1.18.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // LogsBuilder provides an interface for scrapers to report logs while taking care of all the transformations

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/otel/semconv/v1.18.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 const (

--- a/receiver/k8sclusterreceiver/internal/metadata/metadata.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/metadata.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	conventions "go.opentelemetry.io/otel/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metadataPkg "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"

--- a/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
@@ -13,7 +13,7 @@ resourceMetrics:
           idKeys:
             - k8s.namespace.uid
           type: k8s.namespace
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of namespaces (1 for active and 0 for terminating)

--- a/receiver/k8sclusterreceiver/internal/node/nodes.go
+++ b/receiver/k8sclusterreceiver/internal/node/nodes.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/otel/semconv/v1.18.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected.yaml
@@ -7,7 +7,7 @@ resourceMetrics:
         - key: k8s.node.uid
           value:
             stringValue: test-node-1-uid
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Amount of cpu allocatable on the node

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
@@ -13,7 +13,7 @@ resourceMetrics:
           idKeys:
             - k8s.node.uid
           type: k8s.node
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The condition of a particular Node.

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_optional.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_optional.yaml
@@ -23,7 +23,7 @@ resourceMetrics:
           value:
             stringValue: "linux"
 
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Amount of cpu allocatable on the node

--- a/receiver/k8sclusterreceiver/internal/persistentvolume/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/persistentvolume/testdata/expected.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolume.uid
           type: k8s.persistentvolume
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolume (1 for the current phase, 0 for others).

--- a/receiver/k8sclusterreceiver/internal/persistentvolume/testdata/expected_no_capacity.yaml
+++ b/receiver/k8sclusterreceiver/internal/persistentvolume/testdata/expected_no_capacity.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolume.uid
           type: k8s.persistentvolume
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolume (1 for the current phase, 0 for others).

--- a/receiver/k8sclusterreceiver/internal/persistentvolume/testdata/expected_optional.yaml
+++ b/receiver/k8sclusterreceiver/internal/persistentvolume/testdata/expected_optional.yaml
@@ -21,7 +21,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolume.uid
           type: k8s.persistentvolume
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolume (1 for the current phase, 0 for others).

--- a/receiver/k8sclusterreceiver/internal/persistentvolumeclaim/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/persistentvolumeclaim/testdata/expected.yaml
@@ -19,7 +19,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolumeclaim.uid
           type: k8s.persistentvolumeclaim
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolumeClaim (1 for the current phase, 0 for others).

--- a/receiver/k8sclusterreceiver/internal/persistentvolumeclaim/testdata/expected_pending.yaml
+++ b/receiver/k8sclusterreceiver/internal/persistentvolumeclaim/testdata/expected_pending.yaml
@@ -19,7 +19,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolumeclaim.uid
           type: k8s.persistentvolumeclaim
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolumeClaim (1 for the current phase, 0 for others).

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
@@ -19,7 +19,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -65,7 +65,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_reason.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_reason.yaml
@@ -19,7 +19,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -65,7 +65,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - name: k8s.container.status.reason

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_state.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_container_state.yaml
@@ -19,7 +19,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -65,7 +65,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - name: k8s.container.status.state

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
@@ -23,7 +23,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -79,7 +79,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.

--- a/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Number of desired pods in this replicaset

--- a/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicationcontroller.uid
           type: k8s.replicationcontroller
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this replication_controller

--- a/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.resourcequota.uid
           type: k8s.resourcequota
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The upper limit for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -15,7 +15,7 @@ status:
   codeowners:
     active: [dmitryax, TylerHelmuth, povilasv, ChrsMark]
 
-sem_conv_version: 1.18.0
+sem_conv_version: 1.40.0
 
 reaggregation_enabled: true
 

--- a/receiver/k8sclusterreceiver/testdata/e2e/cluster-scoped/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/cluster-scoped/expected.yaml
@@ -13,7 +13,7 @@ resourceMetrics:
           idKeys:
             - k8s.namespace.uid
           type: k8s.namespace
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of namespaces (1 for active and 0 for terminating)
@@ -40,7 +40,7 @@ resourceMetrics:
           idKeys:
             - k8s.namespace.uid
           type: k8s.namespace
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of namespaces (1 for active and 0 for terminating)
@@ -67,7 +67,7 @@ resourceMetrics:
           idKeys:
             - k8s.namespace.uid
           type: k8s.namespace
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of namespaces (1 for active and 0 for terminating)
@@ -94,7 +94,7 @@ resourceMetrics:
           idKeys:
             - k8s.namespace.uid
           type: k8s.namespace
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of namespaces (1 for active and 0 for terminating)
@@ -121,7 +121,7 @@ resourceMetrics:
           idKeys:
             - k8s.namespace.uid
           type: k8s.namespace
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of namespaces (1 for active and 0 for terminating)
@@ -142,7 +142,7 @@ resourceMetrics:
         - key: k8s.node.uid
           value:
             stringValue: 21a7539e-b949-4dc8-af0f-6aad0cdc675d
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Ready condition status of the node (true=1, false=0, unknown=-1)
@@ -171,7 +171,7 @@ resourceMetrics:
           idKeys:
             - k8s.cronjob.uid
           type: k8s.cronjob
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running jobs for a cronjob
@@ -202,7 +202,7 @@ resourceMetrics:
           idKeys:
             - k8s.daemonset.uid
           type: k8s.daemonset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod
@@ -257,7 +257,7 @@ resourceMetrics:
           idKeys:
             - k8s.daemonset.uid
           type: k8s.daemonset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod
@@ -312,7 +312,7 @@ resourceMetrics:
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment
@@ -351,7 +351,7 @@ resourceMetrics:
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment
@@ -390,7 +390,7 @@ resourceMetrics:
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment
@@ -429,7 +429,7 @@ resourceMetrics:
           idKeys:
             - k8s.hpa.uid
           type: k8s.hpa
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current number of pod replicas managed by this autoscaler.
@@ -484,7 +484,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -547,7 +547,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -610,7 +610,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset
@@ -649,7 +649,7 @@ resourceMetrics:
           idKeys:
             - k8s.statefulset.uid
           type: k8s.statefulset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of pods created by the StatefulSet controller from the StatefulSet version
@@ -704,7 +704,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset
@@ -743,7 +743,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset
@@ -785,7 +785,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -818,7 +818,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -851,7 +851,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -884,7 +884,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -917,7 +917,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolumeclaim.uid
           type: k8s.persistentvolumeclaim
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolumeClaim (1 for the current phase, 0 for others).
@@ -979,7 +979,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolumeclaim.uid
           type: k8s.persistentvolumeclaim
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolumeClaim (1 for the current phase, 0 for others).
@@ -1050,7 +1050,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1083,7 +1083,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1116,7 +1116,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1149,7 +1149,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1182,7 +1182,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1215,7 +1215,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1248,7 +1248,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1281,7 +1281,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1314,7 +1314,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -1349,7 +1349,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolume.uid
           type: k8s.persistentvolume
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolume (1 for the current phase, 0 for others).
@@ -1422,7 +1422,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 025efd12-7d91-44ac-8b1f-c3a39e5fcedc
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -1489,7 +1489,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 0b418ec4-4cb7-4138-a3d4-e6e94492bfc6
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -1556,7 +1556,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 631c98b6-cb40-401c-b997-1c850528621b
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -1623,7 +1623,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 4345f388-1e53-470b-b7b2-5c7d4068ce10
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -1693,7 +1693,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: aadfccda-a1fc-4b36-8ed8-fb86f9e443e2
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of load balancer ingress points (external IPs/hostnames) assigned to the service.
@@ -1741,7 +1741,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -1828,7 +1828,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -1907,7 +1907,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -1962,7 +1962,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -2017,7 +2017,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -2096,7 +2096,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -2151,7 +2151,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -2214,7 +2214,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -2285,7 +2285,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -2348,7 +2348,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -2403,7 +2403,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -2490,7 +2490,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -2545,7 +2545,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details

--- a/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped-multiple-namespaces/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped-multiple-namespaces/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.cronjob.uid
           type: k8s.cronjob
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running jobs for a cronjob
@@ -47,7 +47,7 @@ resourceMetrics:
           idKeys:
             - k8s.cronjob.uid
           type: k8s.cronjob
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running jobs for a cronjob
@@ -78,7 +78,7 @@ resourceMetrics:
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment
@@ -117,7 +117,7 @@ resourceMetrics:
           idKeys:
             - k8s.hpa.uid
           type: k8s.hpa
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current number of pod replicas managed by this autoscaler.
@@ -172,7 +172,7 @@ resourceMetrics:
           idKeys:
             - k8s.hpa.uid
           type: k8s.hpa
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current number of pod replicas managed by this autoscaler.
@@ -227,7 +227,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -290,7 +290,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -353,7 +353,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -416,7 +416,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -479,7 +479,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset
@@ -518,7 +518,7 @@ resourceMetrics:
           idKeys:
             - k8s.statefulset.uid
           type: k8s.statefulset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of pods created by the StatefulSet controller from the StatefulSet version
@@ -573,7 +573,7 @@ resourceMetrics:
           idKeys:
             - k8s.statefulset.uid
           type: k8s.statefulset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of pods created by the StatefulSet controller from the StatefulSet version
@@ -631,7 +631,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -664,7 +664,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -697,7 +697,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -730,7 +730,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -763,7 +763,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -796,7 +796,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -829,7 +829,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -876,7 +876,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -963,7 +963,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -1018,7 +1018,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -1073,7 +1073,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -1128,7 +1128,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -1183,7 +1183,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -1238,7 +1238,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)

--- a/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/namespace-scoped/expected.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
           idKeys:
             - k8s.cronjob.uid
           type: k8s.cronjob
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running jobs for a cronjob
@@ -47,7 +47,7 @@ resourceMetrics:
           idKeys:
             - k8s.deployment.uid
           type: k8s.deployment
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment
@@ -86,7 +86,7 @@ resourceMetrics:
           idKeys:
             - k8s.hpa.uid
           type: k8s.hpa
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current number of pod replicas managed by this autoscaler.
@@ -141,7 +141,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -204,7 +204,7 @@ resourceMetrics:
           idKeys:
             - k8s.job.uid
           type: k8s.job
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of actively running pods for a job
@@ -267,7 +267,7 @@ resourceMetrics:
           idKeys:
             - k8s.replicaset.uid
           type: k8s.replicaset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset
@@ -306,7 +306,7 @@ resourceMetrics:
           idKeys:
             - k8s.statefulset.uid
           type: k8s.statefulset
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of pods created by the StatefulSet controller from the StatefulSet version
@@ -364,7 +364,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -397,7 +397,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -430,7 +430,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -463,7 +463,7 @@ resourceMetrics:
           idKeys:
             - k8s.pod.uid
           type: k8s.pod
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
@@ -496,7 +496,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolumeclaim.uid
           type: k8s.persistentvolumeclaim
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolumeClaim (1 for the current phase, 0 for others).
@@ -558,7 +558,7 @@ resourceMetrics:
           idKeys:
             - k8s.persistentvolumeclaim.uid
           type: k8s.persistentvolumeclaim
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The current phase of the PersistentVolumeClaim (1 for the current phase, 0 for others).
@@ -626,7 +626,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 5cba681a-a612-46b8-80b3-c48bfbd40d72
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -693,7 +693,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 20adec8c-d347-4bf3-a109-405e93063f55
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -763,7 +763,7 @@ resourceMetrics:
         - key: k8s.service.uid
           value:
             stringValue: 2fe6c600-a0e1-434e-ad43-ba2f325c5e23
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: The number of endpoints for a service, broken down by condition, address type, and zone.
@@ -855,7 +855,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -910,7 +910,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -965,7 +965,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -1052,7 +1052,7 @@ resourceMetrics:
           idKeys:
             - container.id
           type: k8s.container
-    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    schemaUrl: https://opentelemetry.io/schemas/1.40.0
     scopeMetrics:
       - metrics:
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Updates receiver/k8sclusterreceiver from semconv v1.9.0 and v1.18.0 to v1.40.0
- 2 manual source files changed: internal/metadata/metadata.go (v1.9.0→v1.40.0), internal/node/nodes.go (v1.18.0→v1.40.0)
- metadata.yaml sem_conv_version updated from 1.18.0 to 1.40.0
- 2 generated files updated to match (generated_metrics.go, generated_logs.go)
- 29 testdata golden files updated: schemaUrl from schemas/1.18.0 to schemas/1.40.0
- The symbols used (K8SNamespaceNameKey, K8SNodeNameKey, K8SNodeUIDKey, SchemaURL) exist identically in both old and new versions - no attribute name or value changes
- The only observable behavioral change is the emitted schemaUrl string

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Updating semconv version for k8sclusterreceiver as listed https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Updated all 29 testdata golden files (expected.yaml) to reflect the new schema URL
- No new tests added - existing tests validate the same attribute names and values


<!--Describe the documentation added.-->
#### Documentation

No documentation changes needed

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
