### PR TITLE
[receiver/apache] add request rate, transmitted-bytes rate, and worker limit metrics

### DIFF
--- a/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
+++ b/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/apache
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `apache.request.rate`, `apache.request.bandwidth.rate`, and `apache.worker.limit` metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47061]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `apache.request.rate` and `apache.request.bandwidth.rate` expose the request and transmitted-bytes
+  rates that Apache reports natively via the `ReqPerSec` and `BytesPerSec` fields of
+  `server-status?auto`, so users no longer have to derive them from the cumulative
+  `apache.requests`/`apache.traffic` counters. `apache.worker.limit` reports the total configured
+  worker slots (derived from the scoreboard length), enabling worker-utilization calculations.
+  All three are enabled by default with `development` stability.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
+++ b/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
@@ -12,17 +12,6 @@ note: Add `apache.request.rate`, `apache.request.bandwidth.rate`, and `apache.wo
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [47061]
 
-# (Optional) One or more lines of additional information to render under the primary note.
-# These lines will be padded with 2 spaces and then inserted directly into the document.
-# Use pipe (|) for multiline entries.
-subtext: |
-  `apache.request.rate` and `apache.request.bandwidth.rate` expose the request and transmitted-bytes
-  rates that Apache reports natively via the `ReqPerSec` and `BytesPerSec` fields of
-  `server-status?auto`, so users no longer have to derive them from the cumulative
-  `apache.requests`/`apache.traffic` counters. `apache.worker.limit` reports the total configured
-  worker slots (derived from the scoreboard length), enabling worker-utilization calculations.
-  All three are enabled by default with `development` stability.
-
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.

--- a/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
+++ b/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/apache
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `apache.request.rate`, `apache.request.bandwidth.rate`, and `apache.worker.limit` metrics
+note: Add `apache.request.rate`, `apache.traffic.rate`, and `apache.worker.limit` metrics
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [47061]

--- a/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
+++ b/.chloggen/47061-apache-rate-and-max-workers-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/apache
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `apache.request.rate`, `apache.traffic.rate`, and `apache.worker.limit` metrics
+note: Add `apache.request.rate`, `apache.traffic.rate` (disabled by default), and `apache.worker.limit` metrics
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [47061]

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -81,14 +81,6 @@ The average server load during the last 5 minutes.
 | ---- | ----------- | ---------- | --------- |
 | % | Gauge | Double | Development |
 
-### apache.request.bandwidth.rate
-
-Average number of bytes transmitted per second since the server was started, as reported by mod_status.
-
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| By/s | Gauge | Double | Development |
-
 ### apache.request.rate
 
 Average number of requests served per second since the server was started, as reported by mod_status.
@@ -136,6 +128,14 @@ Total HTTP server traffic.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | By | Sum | Int | Cumulative | true | Development |
+
+### apache.traffic.rate
+
+Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | Development |
 
 ### apache.uptime
 

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -81,6 +81,22 @@ The average server load during the last 5 minutes.
 | ---- | ----------- | ---------- | --------- |
 | % | Gauge | Double | Development |
 
+### apache.request.bandwidth.rate
+
+Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | Development |
+
+### apache.request.rate
+
+Average number of requests served per second since the server was started, as reported by mod_status.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {request}/s | Gauge | Double | Development |
+
 ### apache.request.time
 
 Total time spent on handling requests.
@@ -128,6 +144,14 @@ The amount of time that the server has been running in seconds.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Int | Cumulative | true | Development |
+
+### apache.worker.limit
+
+The maximum number of worker slots configured for the HTTP server, derived from the scoreboard length.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {worker} | Gauge | Int | Development |
 
 ### apache.workers
 

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -81,14 +81,6 @@ The average server load during the last 5 minutes.
 | ---- | ----------- | ---------- | --------- |
 | % | Gauge | Double | Development |
 
-### apache.request.rate
-
-Average number of requests served per second since the server was started, as reported by mod_status.
-
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| {request}/s | Gauge | Double | Development |
-
 ### apache.request.time
 
 Total time spent on handling requests.
@@ -129,14 +121,6 @@ Total HTTP server traffic.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | By | Sum | Int | Cumulative | true | Development |
 
-### apache.traffic.rate
-
-Average number of bytes transmitted per second since the server was started, as reported by mod_status.
-
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| By/s | Gauge | Double | Development |
-
 ### apache.uptime
 
 The amount of time that the server has been running in seconds.
@@ -166,6 +150,32 @@ The number of workers currently attached to the HTTP server.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | state | The state of workers. | Str: ``busy``, ``idle`` | Recommended | - |
+
+## Optional Metrics
+
+The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+metrics:
+  <metric_name>:
+    enabled: true
+```
+
+### apache.request.rate
+
+Average number of requests served per second since the server was started, as reported by mod_status.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {request}/s | Gauge | Double | Development |
+
+### apache.traffic.rate
+
+Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | Development |
 
 ## Resource Attributes
 

--- a/receiver/apachereceiver/generated_package_test.go
+++ b/receiver/apachereceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package apachereceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/apachereceiver/generated_package_test.go
+++ b/receiver/apachereceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package apachereceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/apachereceiver/internal/metadata/generated_config.go
+++ b/receiver/apachereceiver/internal/metadata/generated_config.go
@@ -206,26 +206,6 @@ func (ms *ApacheLoad5MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// ApacheRequestBandwidthRateMetricConfig provides config for the apache.request.bandwidth.rate metric.
-type ApacheRequestBandwidthRateMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *ApacheRequestBandwidthRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
 // ApacheRequestRateMetricConfig provides config for the apache.request.rate metric.
 type ApacheRequestRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -354,6 +334,26 @@ func (ms *ApacheTrafficMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+// ApacheTrafficRateMetricConfig provides config for the apache.traffic.rate metric.
+type ApacheTrafficRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ApacheTrafficRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // ApacheUptimeMetricConfig provides config for the apache.uptime metric.
 type ApacheUptimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -444,22 +444,22 @@ func (ms *ApacheWorkersMetricConfig) Validate() error {
 
 // MetricsConfig provides config for apache metrics.
 type MetricsConfig struct {
-	ApacheConnectionsAsync     ApacheConnectionsAsyncMetricConfig     `mapstructure:"apache.connections.async"`
-	ApacheCPULoad              ApacheCPULoadMetricConfig              `mapstructure:"apache.cpu.load"`
-	ApacheCPUTime              ApacheCPUTimeMetricConfig              `mapstructure:"apache.cpu.time"`
-	ApacheCurrentConnections   ApacheCurrentConnectionsMetricConfig   `mapstructure:"apache.current_connections"`
-	ApacheLoad1                ApacheLoad1MetricConfig                `mapstructure:"apache.load.1"`
-	ApacheLoad15               ApacheLoad15MetricConfig               `mapstructure:"apache.load.15"`
-	ApacheLoad5                ApacheLoad5MetricConfig                `mapstructure:"apache.load.5"`
-	ApacheRequestBandwidthRate ApacheRequestBandwidthRateMetricConfig `mapstructure:"apache.request.bandwidth.rate"`
-	ApacheRequestRate          ApacheRequestRateMetricConfig          `mapstructure:"apache.request.rate"`
-	ApacheRequestTime          ApacheRequestTimeMetricConfig          `mapstructure:"apache.request.time"`
-	ApacheRequests             ApacheRequestsMetricConfig             `mapstructure:"apache.requests"`
-	ApacheScoreboard           ApacheScoreboardMetricConfig           `mapstructure:"apache.scoreboard"`
-	ApacheTraffic              ApacheTrafficMetricConfig              `mapstructure:"apache.traffic"`
-	ApacheUptime               ApacheUptimeMetricConfig               `mapstructure:"apache.uptime"`
-	ApacheWorkerLimit          ApacheWorkerLimitMetricConfig          `mapstructure:"apache.worker.limit"`
-	ApacheWorkers              ApacheWorkersMetricConfig              `mapstructure:"apache.workers"`
+	ApacheConnectionsAsync   ApacheConnectionsAsyncMetricConfig   `mapstructure:"apache.connections.async"`
+	ApacheCPULoad            ApacheCPULoadMetricConfig            `mapstructure:"apache.cpu.load"`
+	ApacheCPUTime            ApacheCPUTimeMetricConfig            `mapstructure:"apache.cpu.time"`
+	ApacheCurrentConnections ApacheCurrentConnectionsMetricConfig `mapstructure:"apache.current_connections"`
+	ApacheLoad1              ApacheLoad1MetricConfig              `mapstructure:"apache.load.1"`
+	ApacheLoad15             ApacheLoad15MetricConfig             `mapstructure:"apache.load.15"`
+	ApacheLoad5              ApacheLoad5MetricConfig              `mapstructure:"apache.load.5"`
+	ApacheRequestRate        ApacheRequestRateMetricConfig        `mapstructure:"apache.request.rate"`
+	ApacheRequestTime        ApacheRequestTimeMetricConfig        `mapstructure:"apache.request.time"`
+	ApacheRequests           ApacheRequestsMetricConfig           `mapstructure:"apache.requests"`
+	ApacheScoreboard         ApacheScoreboardMetricConfig         `mapstructure:"apache.scoreboard"`
+	ApacheTraffic            ApacheTrafficMetricConfig            `mapstructure:"apache.traffic"`
+	ApacheTrafficRate        ApacheTrafficRateMetricConfig        `mapstructure:"apache.traffic.rate"`
+	ApacheUptime             ApacheUptimeMetricConfig             `mapstructure:"apache.uptime"`
+	ApacheWorkerLimit        ApacheWorkerLimitMetricConfig        `mapstructure:"apache.worker.limit"`
+	ApacheWorkers            ApacheWorkersMetricConfig            `mapstructure:"apache.workers"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -489,9 +489,6 @@ func DefaultMetricsConfig() MetricsConfig {
 		ApacheLoad5: ApacheLoad5MetricConfig{
 			Enabled: true,
 		},
-		ApacheRequestBandwidthRate: ApacheRequestBandwidthRateMetricConfig{
-			Enabled: true,
-		},
 		ApacheRequestRate: ApacheRequestRateMetricConfig{
 			Enabled: true,
 		},
@@ -507,6 +504,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			EnabledAttributes:   []ApacheScoreboardMetricAttributeKey{ApacheScoreboardMetricAttributeKeyScoreboardState},
 		},
 		ApacheTraffic: ApacheTrafficMetricConfig{
+			Enabled: true,
+		},
+		ApacheTrafficRate: ApacheTrafficRateMetricConfig{
 			Enabled: true,
 		},
 		ApacheUptime: ApacheUptimeMetricConfig{

--- a/receiver/apachereceiver/internal/metadata/generated_config.go
+++ b/receiver/apachereceiver/internal/metadata/generated_config.go
@@ -206,6 +206,46 @@ func (ms *ApacheLoad5MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+// ApacheRequestBandwidthRateMetricConfig provides config for the apache.request.bandwidth.rate metric.
+type ApacheRequestBandwidthRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ApacheRequestBandwidthRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// ApacheRequestRateMetricConfig provides config for the apache.request.rate metric.
+type ApacheRequestRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ApacheRequestRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // ApacheRequestTimeMetricConfig provides config for the apache.request.time metric.
 type ApacheRequestTimeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -334,6 +374,26 @@ func (ms *ApacheUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+// ApacheWorkerLimitMetricConfig provides config for the apache.worker.limit metric.
+type ApacheWorkerLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *ApacheWorkerLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // ApacheWorkersMetricAttributeKey specifies the key of an attribute for the apache.workers metric.
 type ApacheWorkersMetricAttributeKey string
 
@@ -384,19 +444,22 @@ func (ms *ApacheWorkersMetricConfig) Validate() error {
 
 // MetricsConfig provides config for apache metrics.
 type MetricsConfig struct {
-	ApacheConnectionsAsync   ApacheConnectionsAsyncMetricConfig   `mapstructure:"apache.connections.async"`
-	ApacheCPULoad            ApacheCPULoadMetricConfig            `mapstructure:"apache.cpu.load"`
-	ApacheCPUTime            ApacheCPUTimeMetricConfig            `mapstructure:"apache.cpu.time"`
-	ApacheCurrentConnections ApacheCurrentConnectionsMetricConfig `mapstructure:"apache.current_connections"`
-	ApacheLoad1              ApacheLoad1MetricConfig              `mapstructure:"apache.load.1"`
-	ApacheLoad15             ApacheLoad15MetricConfig             `mapstructure:"apache.load.15"`
-	ApacheLoad5              ApacheLoad5MetricConfig              `mapstructure:"apache.load.5"`
-	ApacheRequestTime        ApacheRequestTimeMetricConfig        `mapstructure:"apache.request.time"`
-	ApacheRequests           ApacheRequestsMetricConfig           `mapstructure:"apache.requests"`
-	ApacheScoreboard         ApacheScoreboardMetricConfig         `mapstructure:"apache.scoreboard"`
-	ApacheTraffic            ApacheTrafficMetricConfig            `mapstructure:"apache.traffic"`
-	ApacheUptime             ApacheUptimeMetricConfig             `mapstructure:"apache.uptime"`
-	ApacheWorkers            ApacheWorkersMetricConfig            `mapstructure:"apache.workers"`
+	ApacheConnectionsAsync     ApacheConnectionsAsyncMetricConfig     `mapstructure:"apache.connections.async"`
+	ApacheCPULoad              ApacheCPULoadMetricConfig              `mapstructure:"apache.cpu.load"`
+	ApacheCPUTime              ApacheCPUTimeMetricConfig              `mapstructure:"apache.cpu.time"`
+	ApacheCurrentConnections   ApacheCurrentConnectionsMetricConfig   `mapstructure:"apache.current_connections"`
+	ApacheLoad1                ApacheLoad1MetricConfig                `mapstructure:"apache.load.1"`
+	ApacheLoad15               ApacheLoad15MetricConfig               `mapstructure:"apache.load.15"`
+	ApacheLoad5                ApacheLoad5MetricConfig                `mapstructure:"apache.load.5"`
+	ApacheRequestBandwidthRate ApacheRequestBandwidthRateMetricConfig `mapstructure:"apache.request.bandwidth.rate"`
+	ApacheRequestRate          ApacheRequestRateMetricConfig          `mapstructure:"apache.request.rate"`
+	ApacheRequestTime          ApacheRequestTimeMetricConfig          `mapstructure:"apache.request.time"`
+	ApacheRequests             ApacheRequestsMetricConfig             `mapstructure:"apache.requests"`
+	ApacheScoreboard           ApacheScoreboardMetricConfig           `mapstructure:"apache.scoreboard"`
+	ApacheTraffic              ApacheTrafficMetricConfig              `mapstructure:"apache.traffic"`
+	ApacheUptime               ApacheUptimeMetricConfig               `mapstructure:"apache.uptime"`
+	ApacheWorkerLimit          ApacheWorkerLimitMetricConfig          `mapstructure:"apache.worker.limit"`
+	ApacheWorkers              ApacheWorkersMetricConfig              `mapstructure:"apache.workers"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -426,6 +489,12 @@ func DefaultMetricsConfig() MetricsConfig {
 		ApacheLoad5: ApacheLoad5MetricConfig{
 			Enabled: true,
 		},
+		ApacheRequestBandwidthRate: ApacheRequestBandwidthRateMetricConfig{
+			Enabled: true,
+		},
+		ApacheRequestRate: ApacheRequestRateMetricConfig{
+			Enabled: true,
+		},
 		ApacheRequestTime: ApacheRequestTimeMetricConfig{
 			Enabled: true,
 		},
@@ -441,6 +510,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		ApacheUptime: ApacheUptimeMetricConfig{
+			Enabled: true,
+		},
+		ApacheWorkerLimit: ApacheWorkerLimitMetricConfig{
 			Enabled: true,
 		},
 		ApacheWorkers: ApacheWorkersMetricConfig{

--- a/receiver/apachereceiver/internal/metadata/generated_config.go
+++ b/receiver/apachereceiver/internal/metadata/generated_config.go
@@ -490,7 +490,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		ApacheRequestRate: ApacheRequestRateMetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		ApacheRequestTime: ApacheRequestTimeMetricConfig{
 			Enabled: true,
@@ -507,7 +507,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		ApacheTrafficRate: ApacheTrafficRateMetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		ApacheUptime: ApacheUptimeMetricConfig{
 			Enabled: true,

--- a/receiver/apachereceiver/internal/metadata/generated_config_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_config_test.go
@@ -51,6 +51,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					ApacheLoad5: ApacheLoad5MetricConfig{
 						Enabled: true,
 					},
+					ApacheRequestBandwidthRate: ApacheRequestBandwidthRateMetricConfig{
+						Enabled: true,
+					},
+					ApacheRequestRate: ApacheRequestRateMetricConfig{
+						Enabled: true,
+					},
 					ApacheRequestTime: ApacheRequestTimeMetricConfig{
 						Enabled: true,
 					},
@@ -66,6 +72,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: true,
 					},
 					ApacheUptime: ApacheUptimeMetricConfig{
+						Enabled: true,
+					},
+					ApacheWorkerLimit: ApacheWorkerLimitMetricConfig{
 						Enabled: true,
 					},
 					ApacheWorkers: ApacheWorkersMetricConfig{
@@ -109,6 +118,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					ApacheLoad5: ApacheLoad5MetricConfig{
 						Enabled: false,
 					},
+					ApacheRequestBandwidthRate: ApacheRequestBandwidthRateMetricConfig{
+						Enabled: false,
+					},
+					ApacheRequestRate: ApacheRequestRateMetricConfig{
+						Enabled: false,
+					},
 					ApacheRequestTime: ApacheRequestTimeMetricConfig{
 						Enabled: false,
 					},
@@ -124,6 +139,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: false,
 					},
 					ApacheUptime: ApacheUptimeMetricConfig{
+						Enabled: false,
+					},
+					ApacheWorkerLimit: ApacheWorkerLimitMetricConfig{
 						Enabled: false,
 					},
 					ApacheWorkers: ApacheWorkersMetricConfig{
@@ -142,7 +160,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ApacheConnectionsAsyncMetricConfig{}, ApacheCPULoadMetricConfig{}, ApacheCPUTimeMetricConfig{}, ApacheCurrentConnectionsMetricConfig{}, ApacheLoad1MetricConfig{}, ApacheLoad15MetricConfig{}, ApacheLoad5MetricConfig{}, ApacheRequestTimeMetricConfig{}, ApacheRequestsMetricConfig{}, ApacheScoreboardMetricConfig{}, ApacheTrafficMetricConfig{}, ApacheUptimeMetricConfig{}, ApacheWorkersMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ApacheConnectionsAsyncMetricConfig{}, ApacheCPULoadMetricConfig{}, ApacheCPUTimeMetricConfig{}, ApacheCurrentConnectionsMetricConfig{}, ApacheLoad1MetricConfig{}, ApacheLoad15MetricConfig{}, ApacheLoad5MetricConfig{}, ApacheRequestBandwidthRateMetricConfig{}, ApacheRequestRateMetricConfig{}, ApacheRequestTimeMetricConfig{}, ApacheRequestsMetricConfig{}, ApacheScoreboardMetricConfig{}, ApacheTrafficMetricConfig{}, ApacheUptimeMetricConfig{}, ApacheWorkerLimitMetricConfig{}, ApacheWorkersMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/apachereceiver/internal/metadata/generated_config_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_config_test.go
@@ -51,9 +51,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					ApacheLoad5: ApacheLoad5MetricConfig{
 						Enabled: true,
 					},
-					ApacheRequestBandwidthRate: ApacheRequestBandwidthRateMetricConfig{
-						Enabled: true,
-					},
 					ApacheRequestRate: ApacheRequestRateMetricConfig{
 						Enabled: true,
 					},
@@ -69,6 +66,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						EnabledAttributes:   []ApacheScoreboardMetricAttributeKey{ApacheScoreboardMetricAttributeKeyScoreboardState},
 					},
 					ApacheTraffic: ApacheTrafficMetricConfig{
+						Enabled: true,
+					},
+					ApacheTrafficRate: ApacheTrafficRateMetricConfig{
 						Enabled: true,
 					},
 					ApacheUptime: ApacheUptimeMetricConfig{
@@ -118,9 +118,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					ApacheLoad5: ApacheLoad5MetricConfig{
 						Enabled: false,
 					},
-					ApacheRequestBandwidthRate: ApacheRequestBandwidthRateMetricConfig{
-						Enabled: false,
-					},
 					ApacheRequestRate: ApacheRequestRateMetricConfig{
 						Enabled: false,
 					},
@@ -136,6 +133,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						EnabledAttributes:   []ApacheScoreboardMetricAttributeKey{ApacheScoreboardMetricAttributeKeyScoreboardState},
 					},
 					ApacheTraffic: ApacheTrafficMetricConfig{
+						Enabled: false,
+					},
+					ApacheTrafficRate: ApacheTrafficRateMetricConfig{
 						Enabled: false,
 					},
 					ApacheUptime: ApacheUptimeMetricConfig{
@@ -160,7 +160,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ApacheConnectionsAsyncMetricConfig{}, ApacheCPULoadMetricConfig{}, ApacheCPUTimeMetricConfig{}, ApacheCurrentConnectionsMetricConfig{}, ApacheLoad1MetricConfig{}, ApacheLoad15MetricConfig{}, ApacheLoad5MetricConfig{}, ApacheRequestBandwidthRateMetricConfig{}, ApacheRequestRateMetricConfig{}, ApacheRequestTimeMetricConfig{}, ApacheRequestsMetricConfig{}, ApacheScoreboardMetricConfig{}, ApacheTrafficMetricConfig{}, ApacheUptimeMetricConfig{}, ApacheWorkerLimitMetricConfig{}, ApacheWorkersMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ApacheConnectionsAsyncMetricConfig{}, ApacheCPULoadMetricConfig{}, ApacheCPUTimeMetricConfig{}, ApacheCurrentConnectionsMetricConfig{}, ApacheLoad1MetricConfig{}, ApacheLoad15MetricConfig{}, ApacheLoad5MetricConfig{}, ApacheRequestRateMetricConfig{}, ApacheRequestTimeMetricConfig{}, ApacheRequestsMetricConfig{}, ApacheScoreboardMetricConfig{}, ApacheTrafficMetricConfig{}, ApacheTrafficRateMetricConfig{}, ApacheUptimeMetricConfig{}, ApacheWorkerLimitMetricConfig{}, ApacheWorkersMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/apachereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics.go
@@ -4,14 +4,15 @@ package metadata
 
 import (
 	"fmt"
+	"slices"
+	"strconv"
+	"time"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	"slices"
-	"strconv"
-	"time"
 )
 
 const (

--- a/receiver/apachereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics.go
@@ -220,9 +220,6 @@ var MetricsInfo = metricsInfo{
 	ApacheLoad5: metricInfo{
 		Name: "apache.load.5",
 	},
-	ApacheRequestBandwidthRate: metricInfo{
-		Name: "apache.request.bandwidth.rate",
-	},
 	ApacheRequestRate: metricInfo{
 		Name: "apache.request.rate",
 	},
@@ -239,6 +236,9 @@ var MetricsInfo = metricsInfo{
 	ApacheTraffic: metricInfo{
 		Name: "apache.traffic",
 	},
+	ApacheTrafficRate: metricInfo{
+		Name: "apache.traffic.rate",
+	},
 	ApacheUptime: metricInfo{
 		Name: "apache.uptime",
 	},
@@ -252,22 +252,22 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	ApacheConnectionsAsync     metricInfo
-	ApacheCPULoad              metricInfo
-	ApacheCPUTime              metricInfo
-	ApacheCurrentConnections   metricInfo
-	ApacheLoad1                metricInfo
-	ApacheLoad15               metricInfo
-	ApacheLoad5                metricInfo
-	ApacheRequestBandwidthRate metricInfo
-	ApacheRequestRate          metricInfo
-	ApacheRequestTime          metricInfo
-	ApacheRequests             metricInfo
-	ApacheScoreboard           metricInfo
-	ApacheTraffic              metricInfo
-	ApacheUptime               metricInfo
-	ApacheWorkerLimit          metricInfo
-	ApacheWorkers              metricInfo
+	ApacheConnectionsAsync   metricInfo
+	ApacheCPULoad            metricInfo
+	ApacheCPUTime            metricInfo
+	ApacheCurrentConnections metricInfo
+	ApacheLoad1              metricInfo
+	ApacheLoad15             metricInfo
+	ApacheLoad5              metricInfo
+	ApacheRequestRate        metricInfo
+	ApacheRequestTime        metricInfo
+	ApacheRequests           metricInfo
+	ApacheScoreboard         metricInfo
+	ApacheTraffic            metricInfo
+	ApacheTrafficRate        metricInfo
+	ApacheUptime             metricInfo
+	ApacheWorkerLimit        metricInfo
+	ApacheWorkers            metricInfo
 }
 
 type metricInfo struct {
@@ -710,56 +710,6 @@ func newMetricApacheLoad5(cfg ApacheLoad5MetricConfig) metricApacheLoad5 {
 	return m
 }
 
-type metricApacheRequestBandwidthRate struct {
-	data     pmetric.Metric                         // data buffer for generated metric.
-	config   ApacheRequestBandwidthRateMetricConfig // metric config provided by user.
-	capacity int                                    // max observed number of data points added to the metric.
-}
-
-// init fills apache.request.bandwidth.rate metric with initial data.
-func (m *metricApacheRequestBandwidthRate) init() {
-	m.data.SetName("apache.request.bandwidth.rate")
-	m.data.SetDescription("Average number of bytes transmitted per second since the server was started, as reported by mod_status.")
-	m.data.SetUnit("By/s")
-	m.data.SetEmptyGauge()
-}
-
-func (m *metricApacheRequestBandwidthRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetDoubleValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricApacheRequestBandwidthRate) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricApacheRequestBandwidthRate) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricApacheRequestBandwidthRate(cfg ApacheRequestBandwidthRateMetricConfig) metricApacheRequestBandwidthRate {
-	m := metricApacheRequestBandwidthRate{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricApacheRequestRate struct {
 	data     pmetric.Metric                // data buffer for generated metric.
 	config   ApacheRequestRateMetricConfig // metric config provided by user.
@@ -1057,6 +1007,56 @@ func newMetricApacheTraffic(cfg ApacheTrafficMetricConfig) metricApacheTraffic {
 	return m
 }
 
+type metricApacheTrafficRate struct {
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   ApacheTrafficRateMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
+}
+
+// init fills apache.traffic.rate metric with initial data.
+func (m *metricApacheTrafficRate) init() {
+	m.data.SetName("apache.traffic.rate")
+	m.data.SetDescription("Average number of bytes transmitted per second since the server was started, as reported by mod_status.")
+	m.data.SetUnit("By/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricApacheTrafficRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricApacheTrafficRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricApacheTrafficRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricApacheTrafficRate(cfg ApacheTrafficRateMetricConfig) metricApacheTrafficRate {
+	m := metricApacheTrafficRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricApacheUptime struct {
 	data     pmetric.Metric           // data buffer for generated metric.
 	config   ApacheUptimeMetricConfig // metric config provided by user.
@@ -1253,29 +1253,29 @@ func newMetricApacheWorkers(cfg ApacheWorkersMetricConfig) metricApacheWorkers {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                           MetricsBuilderConfig // config of the metrics builder.
-	startTime                        pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                  int                  // maximum observed number of metrics per resource.
-	metricsBuffer                    pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                        component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter   map[string]filter.Filter
-	resourceAttributeExcludeFilter   map[string]filter.Filter
-	metricApacheConnectionsAsync     metricApacheConnectionsAsync
-	metricApacheCPULoad              metricApacheCPULoad
-	metricApacheCPUTime              metricApacheCPUTime
-	metricApacheCurrentConnections   metricApacheCurrentConnections
-	metricApacheLoad1                metricApacheLoad1
-	metricApacheLoad15               metricApacheLoad15
-	metricApacheLoad5                metricApacheLoad5
-	metricApacheRequestBandwidthRate metricApacheRequestBandwidthRate
-	metricApacheRequestRate          metricApacheRequestRate
-	metricApacheRequestTime          metricApacheRequestTime
-	metricApacheRequests             metricApacheRequests
-	metricApacheScoreboard           metricApacheScoreboard
-	metricApacheTraffic              metricApacheTraffic
-	metricApacheUptime               metricApacheUptime
-	metricApacheWorkerLimit          metricApacheWorkerLimit
-	metricApacheWorkers              metricApacheWorkers
+	config                         MetricsBuilderConfig // config of the metrics builder.
+	startTime                      pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                int                  // maximum observed number of metrics per resource.
+	metricsBuffer                  pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                      component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter map[string]filter.Filter
+	resourceAttributeExcludeFilter map[string]filter.Filter
+	metricApacheConnectionsAsync   metricApacheConnectionsAsync
+	metricApacheCPULoad            metricApacheCPULoad
+	metricApacheCPUTime            metricApacheCPUTime
+	metricApacheCurrentConnections metricApacheCurrentConnections
+	metricApacheLoad1              metricApacheLoad1
+	metricApacheLoad15             metricApacheLoad15
+	metricApacheLoad5              metricApacheLoad5
+	metricApacheRequestRate        metricApacheRequestRate
+	metricApacheRequestTime        metricApacheRequestTime
+	metricApacheRequests           metricApacheRequests
+	metricApacheScoreboard         metricApacheScoreboard
+	metricApacheTraffic            metricApacheTraffic
+	metricApacheTrafficRate        metricApacheTrafficRate
+	metricApacheUptime             metricApacheUptime
+	metricApacheWorkerLimit        metricApacheWorkerLimit
+	metricApacheWorkers            metricApacheWorkers
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -1297,28 +1297,28 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                           mbc,
-		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                    pmetric.NewMetrics(),
-		buildInfo:                        settings.BuildInfo,
-		metricApacheConnectionsAsync:     newMetricApacheConnectionsAsync(mbc.Metrics.ApacheConnectionsAsync),
-		metricApacheCPULoad:              newMetricApacheCPULoad(mbc.Metrics.ApacheCPULoad),
-		metricApacheCPUTime:              newMetricApacheCPUTime(mbc.Metrics.ApacheCPUTime),
-		metricApacheCurrentConnections:   newMetricApacheCurrentConnections(mbc.Metrics.ApacheCurrentConnections),
-		metricApacheLoad1:                newMetricApacheLoad1(mbc.Metrics.ApacheLoad1),
-		metricApacheLoad15:               newMetricApacheLoad15(mbc.Metrics.ApacheLoad15),
-		metricApacheLoad5:                newMetricApacheLoad5(mbc.Metrics.ApacheLoad5),
-		metricApacheRequestBandwidthRate: newMetricApacheRequestBandwidthRate(mbc.Metrics.ApacheRequestBandwidthRate),
-		metricApacheRequestRate:          newMetricApacheRequestRate(mbc.Metrics.ApacheRequestRate),
-		metricApacheRequestTime:          newMetricApacheRequestTime(mbc.Metrics.ApacheRequestTime),
-		metricApacheRequests:             newMetricApacheRequests(mbc.Metrics.ApacheRequests),
-		metricApacheScoreboard:           newMetricApacheScoreboard(mbc.Metrics.ApacheScoreboard),
-		metricApacheTraffic:              newMetricApacheTraffic(mbc.Metrics.ApacheTraffic),
-		metricApacheUptime:               newMetricApacheUptime(mbc.Metrics.ApacheUptime),
-		metricApacheWorkerLimit:          newMetricApacheWorkerLimit(mbc.Metrics.ApacheWorkerLimit),
-		metricApacheWorkers:              newMetricApacheWorkers(mbc.Metrics.ApacheWorkers),
-		resourceAttributeIncludeFilter:   make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:   make(map[string]filter.Filter),
+		config:                         mbc,
+		startTime:                      pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                  pmetric.NewMetrics(),
+		buildInfo:                      settings.BuildInfo,
+		metricApacheConnectionsAsync:   newMetricApacheConnectionsAsync(mbc.Metrics.ApacheConnectionsAsync),
+		metricApacheCPULoad:            newMetricApacheCPULoad(mbc.Metrics.ApacheCPULoad),
+		metricApacheCPUTime:            newMetricApacheCPUTime(mbc.Metrics.ApacheCPUTime),
+		metricApacheCurrentConnections: newMetricApacheCurrentConnections(mbc.Metrics.ApacheCurrentConnections),
+		metricApacheLoad1:              newMetricApacheLoad1(mbc.Metrics.ApacheLoad1),
+		metricApacheLoad15:             newMetricApacheLoad15(mbc.Metrics.ApacheLoad15),
+		metricApacheLoad5:              newMetricApacheLoad5(mbc.Metrics.ApacheLoad5),
+		metricApacheRequestRate:        newMetricApacheRequestRate(mbc.Metrics.ApacheRequestRate),
+		metricApacheRequestTime:        newMetricApacheRequestTime(mbc.Metrics.ApacheRequestTime),
+		metricApacheRequests:           newMetricApacheRequests(mbc.Metrics.ApacheRequests),
+		metricApacheScoreboard:         newMetricApacheScoreboard(mbc.Metrics.ApacheScoreboard),
+		metricApacheTraffic:            newMetricApacheTraffic(mbc.Metrics.ApacheTraffic),
+		metricApacheTrafficRate:        newMetricApacheTrafficRate(mbc.Metrics.ApacheTrafficRate),
+		metricApacheUptime:             newMetricApacheUptime(mbc.Metrics.ApacheUptime),
+		metricApacheWorkerLimit:        newMetricApacheWorkerLimit(mbc.Metrics.ApacheWorkerLimit),
+		metricApacheWorkers:            newMetricApacheWorkers(mbc.Metrics.ApacheWorkers),
+		resourceAttributeIncludeFilter: make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter: make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.ApacheServerName.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["apache.server.name"] = filter.CreateFilter(mbc.ResourceAttributes.ApacheServerName.MetricsInclude)
@@ -1408,12 +1408,12 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricApacheLoad1.emit(ils.Metrics())
 	mb.metricApacheLoad15.emit(ils.Metrics())
 	mb.metricApacheLoad5.emit(ils.Metrics())
-	mb.metricApacheRequestBandwidthRate.emit(ils.Metrics())
 	mb.metricApacheRequestRate.emit(ils.Metrics())
 	mb.metricApacheRequestTime.emit(ils.Metrics())
 	mb.metricApacheRequests.emit(ils.Metrics())
 	mb.metricApacheScoreboard.emit(ils.Metrics())
 	mb.metricApacheTraffic.emit(ils.Metrics())
+	mb.metricApacheTrafficRate.emit(ils.Metrics())
 	mb.metricApacheUptime.emit(ils.Metrics())
 	mb.metricApacheWorkerLimit.emit(ils.Metrics())
 	mb.metricApacheWorkers.emit(ils.Metrics())
@@ -1518,16 +1518,6 @@ func (mb *MetricsBuilder) RecordApacheLoad5DataPoint(ts pcommon.Timestamp, input
 	return nil
 }
 
-// RecordApacheRequestBandwidthRateDataPoint adds a data point to apache.request.bandwidth.rate metric.
-func (mb *MetricsBuilder) RecordApacheRequestBandwidthRateDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseFloat(inputVal, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse float64 for ApacheRequestBandwidthRate, value was %s: %w", inputVal, err)
-	}
-	mb.metricApacheRequestBandwidthRate.recordDataPoint(mb.startTime, ts, val)
-	return nil
-}
-
 // RecordApacheRequestRateDataPoint adds a data point to apache.request.rate metric.
 func (mb *MetricsBuilder) RecordApacheRequestRateDataPoint(ts pcommon.Timestamp, inputVal string) error {
 	val, err := strconv.ParseFloat(inputVal, 64)
@@ -1566,6 +1556,16 @@ func (mb *MetricsBuilder) RecordApacheScoreboardDataPoint(ts pcommon.Timestamp, 
 // RecordApacheTrafficDataPoint adds a data point to apache.traffic metric.
 func (mb *MetricsBuilder) RecordApacheTrafficDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricApacheTraffic.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordApacheTrafficRateDataPoint adds a data point to apache.traffic.rate metric.
+func (mb *MetricsBuilder) RecordApacheTrafficRateDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseFloat(inputVal, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse float64 for ApacheTrafficRate, value was %s: %w", inputVal, err)
+	}
+	mb.metricApacheTrafficRate.recordDataPoint(mb.startTime, ts, val)
+	return nil
 }
 
 // RecordApacheUptimeDataPoint adds a data point to apache.uptime metric.

--- a/receiver/apachereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics.go
@@ -220,6 +220,12 @@ var MetricsInfo = metricsInfo{
 	ApacheLoad5: metricInfo{
 		Name: "apache.load.5",
 	},
+	ApacheRequestBandwidthRate: metricInfo{
+		Name: "apache.request.bandwidth.rate",
+	},
+	ApacheRequestRate: metricInfo{
+		Name: "apache.request.rate",
+	},
 	ApacheRequestTime: metricInfo{
 		Name: "apache.request.time",
 	},
@@ -236,6 +242,9 @@ var MetricsInfo = metricsInfo{
 	ApacheUptime: metricInfo{
 		Name: "apache.uptime",
 	},
+	ApacheWorkerLimit: metricInfo{
+		Name: "apache.worker.limit",
+	},
 	ApacheWorkers: metricInfo{
 		Name:       "apache.workers",
 		Attributes: []string{"workers_state"},
@@ -243,19 +252,22 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	ApacheConnectionsAsync   metricInfo
-	ApacheCPULoad            metricInfo
-	ApacheCPUTime            metricInfo
-	ApacheCurrentConnections metricInfo
-	ApacheLoad1              metricInfo
-	ApacheLoad15             metricInfo
-	ApacheLoad5              metricInfo
-	ApacheRequestTime        metricInfo
-	ApacheRequests           metricInfo
-	ApacheScoreboard         metricInfo
-	ApacheTraffic            metricInfo
-	ApacheUptime             metricInfo
-	ApacheWorkers            metricInfo
+	ApacheConnectionsAsync     metricInfo
+	ApacheCPULoad              metricInfo
+	ApacheCPUTime              metricInfo
+	ApacheCurrentConnections   metricInfo
+	ApacheLoad1                metricInfo
+	ApacheLoad15               metricInfo
+	ApacheLoad5                metricInfo
+	ApacheRequestBandwidthRate metricInfo
+	ApacheRequestRate          metricInfo
+	ApacheRequestTime          metricInfo
+	ApacheRequests             metricInfo
+	ApacheScoreboard           metricInfo
+	ApacheTraffic              metricInfo
+	ApacheUptime               metricInfo
+	ApacheWorkerLimit          metricInfo
+	ApacheWorkers              metricInfo
 }
 
 type metricInfo struct {
@@ -698,6 +710,106 @@ func newMetricApacheLoad5(cfg ApacheLoad5MetricConfig) metricApacheLoad5 {
 	return m
 }
 
+type metricApacheRequestBandwidthRate struct {
+	data     pmetric.Metric                         // data buffer for generated metric.
+	config   ApacheRequestBandwidthRateMetricConfig // metric config provided by user.
+	capacity int                                    // max observed number of data points added to the metric.
+}
+
+// init fills apache.request.bandwidth.rate metric with initial data.
+func (m *metricApacheRequestBandwidthRate) init() {
+	m.data.SetName("apache.request.bandwidth.rate")
+	m.data.SetDescription("Average number of bytes transmitted per second since the server was started, as reported by mod_status.")
+	m.data.SetUnit("By/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricApacheRequestBandwidthRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricApacheRequestBandwidthRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricApacheRequestBandwidthRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricApacheRequestBandwidthRate(cfg ApacheRequestBandwidthRateMetricConfig) metricApacheRequestBandwidthRate {
+	m := metricApacheRequestBandwidthRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricApacheRequestRate struct {
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   ApacheRequestRateMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
+}
+
+// init fills apache.request.rate metric with initial data.
+func (m *metricApacheRequestRate) init() {
+	m.data.SetName("apache.request.rate")
+	m.data.SetDescription("Average number of requests served per second since the server was started, as reported by mod_status.")
+	m.data.SetUnit("{request}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricApacheRequestRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricApacheRequestRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricApacheRequestRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricApacheRequestRate(cfg ApacheRequestRateMetricConfig) metricApacheRequestRate {
+	m := metricApacheRequestRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricApacheRequestTime struct {
 	data     pmetric.Metric                // data buffer for generated metric.
 	config   ApacheRequestTimeMetricConfig // metric config provided by user.
@@ -997,6 +1109,56 @@ func newMetricApacheUptime(cfg ApacheUptimeMetricConfig) metricApacheUptime {
 	return m
 }
 
+type metricApacheWorkerLimit struct {
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   ApacheWorkerLimitMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
+}
+
+// init fills apache.worker.limit metric with initial data.
+func (m *metricApacheWorkerLimit) init() {
+	m.data.SetName("apache.worker.limit")
+	m.data.SetDescription("The maximum number of worker slots configured for the HTTP server, derived from the scoreboard length.")
+	m.data.SetUnit("{worker}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricApacheWorkerLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricApacheWorkerLimit) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricApacheWorkerLimit) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricApacheWorkerLimit(cfg ApacheWorkerLimitMetricConfig) metricApacheWorkerLimit {
+	m := metricApacheWorkerLimit{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricApacheWorkers struct {
 	data          pmetric.Metric            // data buffer for generated metric.
 	config        ApacheWorkersMetricConfig // metric config provided by user.
@@ -1091,26 +1253,29 @@ func newMetricApacheWorkers(cfg ApacheWorkersMetricConfig) metricApacheWorkers {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                         MetricsBuilderConfig // config of the metrics builder.
-	startTime                      pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                int                  // maximum observed number of metrics per resource.
-	metricsBuffer                  pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                      component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter map[string]filter.Filter
-	resourceAttributeExcludeFilter map[string]filter.Filter
-	metricApacheConnectionsAsync   metricApacheConnectionsAsync
-	metricApacheCPULoad            metricApacheCPULoad
-	metricApacheCPUTime            metricApacheCPUTime
-	metricApacheCurrentConnections metricApacheCurrentConnections
-	metricApacheLoad1              metricApacheLoad1
-	metricApacheLoad15             metricApacheLoad15
-	metricApacheLoad5              metricApacheLoad5
-	metricApacheRequestTime        metricApacheRequestTime
-	metricApacheRequests           metricApacheRequests
-	metricApacheScoreboard         metricApacheScoreboard
-	metricApacheTraffic            metricApacheTraffic
-	metricApacheUptime             metricApacheUptime
-	metricApacheWorkers            metricApacheWorkers
+	config                           MetricsBuilderConfig // config of the metrics builder.
+	startTime                        pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                  int                  // maximum observed number of metrics per resource.
+	metricsBuffer                    pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                        component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter   map[string]filter.Filter
+	resourceAttributeExcludeFilter   map[string]filter.Filter
+	metricApacheConnectionsAsync     metricApacheConnectionsAsync
+	metricApacheCPULoad              metricApacheCPULoad
+	metricApacheCPUTime              metricApacheCPUTime
+	metricApacheCurrentConnections   metricApacheCurrentConnections
+	metricApacheLoad1                metricApacheLoad1
+	metricApacheLoad15               metricApacheLoad15
+	metricApacheLoad5                metricApacheLoad5
+	metricApacheRequestBandwidthRate metricApacheRequestBandwidthRate
+	metricApacheRequestRate          metricApacheRequestRate
+	metricApacheRequestTime          metricApacheRequestTime
+	metricApacheRequests             metricApacheRequests
+	metricApacheScoreboard           metricApacheScoreboard
+	metricApacheTraffic              metricApacheTraffic
+	metricApacheUptime               metricApacheUptime
+	metricApacheWorkerLimit          metricApacheWorkerLimit
+	metricApacheWorkers              metricApacheWorkers
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -1132,25 +1297,28 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                         mbc,
-		startTime:                      pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                  pmetric.NewMetrics(),
-		buildInfo:                      settings.BuildInfo,
-		metricApacheConnectionsAsync:   newMetricApacheConnectionsAsync(mbc.Metrics.ApacheConnectionsAsync),
-		metricApacheCPULoad:            newMetricApacheCPULoad(mbc.Metrics.ApacheCPULoad),
-		metricApacheCPUTime:            newMetricApacheCPUTime(mbc.Metrics.ApacheCPUTime),
-		metricApacheCurrentConnections: newMetricApacheCurrentConnections(mbc.Metrics.ApacheCurrentConnections),
-		metricApacheLoad1:              newMetricApacheLoad1(mbc.Metrics.ApacheLoad1),
-		metricApacheLoad15:             newMetricApacheLoad15(mbc.Metrics.ApacheLoad15),
-		metricApacheLoad5:              newMetricApacheLoad5(mbc.Metrics.ApacheLoad5),
-		metricApacheRequestTime:        newMetricApacheRequestTime(mbc.Metrics.ApacheRequestTime),
-		metricApacheRequests:           newMetricApacheRequests(mbc.Metrics.ApacheRequests),
-		metricApacheScoreboard:         newMetricApacheScoreboard(mbc.Metrics.ApacheScoreboard),
-		metricApacheTraffic:            newMetricApacheTraffic(mbc.Metrics.ApacheTraffic),
-		metricApacheUptime:             newMetricApacheUptime(mbc.Metrics.ApacheUptime),
-		metricApacheWorkers:            newMetricApacheWorkers(mbc.Metrics.ApacheWorkers),
-		resourceAttributeIncludeFilter: make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter: make(map[string]filter.Filter),
+		config:                           mbc,
+		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                    pmetric.NewMetrics(),
+		buildInfo:                        settings.BuildInfo,
+		metricApacheConnectionsAsync:     newMetricApacheConnectionsAsync(mbc.Metrics.ApacheConnectionsAsync),
+		metricApacheCPULoad:              newMetricApacheCPULoad(mbc.Metrics.ApacheCPULoad),
+		metricApacheCPUTime:              newMetricApacheCPUTime(mbc.Metrics.ApacheCPUTime),
+		metricApacheCurrentConnections:   newMetricApacheCurrentConnections(mbc.Metrics.ApacheCurrentConnections),
+		metricApacheLoad1:                newMetricApacheLoad1(mbc.Metrics.ApacheLoad1),
+		metricApacheLoad15:               newMetricApacheLoad15(mbc.Metrics.ApacheLoad15),
+		metricApacheLoad5:                newMetricApacheLoad5(mbc.Metrics.ApacheLoad5),
+		metricApacheRequestBandwidthRate: newMetricApacheRequestBandwidthRate(mbc.Metrics.ApacheRequestBandwidthRate),
+		metricApacheRequestRate:          newMetricApacheRequestRate(mbc.Metrics.ApacheRequestRate),
+		metricApacheRequestTime:          newMetricApacheRequestTime(mbc.Metrics.ApacheRequestTime),
+		metricApacheRequests:             newMetricApacheRequests(mbc.Metrics.ApacheRequests),
+		metricApacheScoreboard:           newMetricApacheScoreboard(mbc.Metrics.ApacheScoreboard),
+		metricApacheTraffic:              newMetricApacheTraffic(mbc.Metrics.ApacheTraffic),
+		metricApacheUptime:               newMetricApacheUptime(mbc.Metrics.ApacheUptime),
+		metricApacheWorkerLimit:          newMetricApacheWorkerLimit(mbc.Metrics.ApacheWorkerLimit),
+		metricApacheWorkers:              newMetricApacheWorkers(mbc.Metrics.ApacheWorkers),
+		resourceAttributeIncludeFilter:   make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:   make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.ApacheServerName.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["apache.server.name"] = filter.CreateFilter(mbc.ResourceAttributes.ApacheServerName.MetricsInclude)
@@ -1240,11 +1408,14 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricApacheLoad1.emit(ils.Metrics())
 	mb.metricApacheLoad15.emit(ils.Metrics())
 	mb.metricApacheLoad5.emit(ils.Metrics())
+	mb.metricApacheRequestBandwidthRate.emit(ils.Metrics())
+	mb.metricApacheRequestRate.emit(ils.Metrics())
 	mb.metricApacheRequestTime.emit(ils.Metrics())
 	mb.metricApacheRequests.emit(ils.Metrics())
 	mb.metricApacheScoreboard.emit(ils.Metrics())
 	mb.metricApacheTraffic.emit(ils.Metrics())
 	mb.metricApacheUptime.emit(ils.Metrics())
+	mb.metricApacheWorkerLimit.emit(ils.Metrics())
 	mb.metricApacheWorkers.emit(ils.Metrics())
 
 	for _, op := range options {
@@ -1347,6 +1518,26 @@ func (mb *MetricsBuilder) RecordApacheLoad5DataPoint(ts pcommon.Timestamp, input
 	return nil
 }
 
+// RecordApacheRequestBandwidthRateDataPoint adds a data point to apache.request.bandwidth.rate metric.
+func (mb *MetricsBuilder) RecordApacheRequestBandwidthRateDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseFloat(inputVal, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse float64 for ApacheRequestBandwidthRate, value was %s: %w", inputVal, err)
+	}
+	mb.metricApacheRequestBandwidthRate.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordApacheRequestRateDataPoint adds a data point to apache.request.rate metric.
+func (mb *MetricsBuilder) RecordApacheRequestRateDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseFloat(inputVal, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse float64 for ApacheRequestRate, value was %s: %w", inputVal, err)
+	}
+	mb.metricApacheRequestRate.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
 // RecordApacheRequestTimeDataPoint adds a data point to apache.request.time metric.
 func (mb *MetricsBuilder) RecordApacheRequestTimeDataPoint(ts pcommon.Timestamp, inputVal string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -1385,6 +1576,11 @@ func (mb *MetricsBuilder) RecordApacheUptimeDataPoint(ts pcommon.Timestamp, inpu
 	}
 	mb.metricApacheUptime.recordDataPoint(mb.startTime, ts, val)
 	return nil
+}
+
+// RecordApacheWorkerLimitDataPoint adds a data point to apache.worker.limit metric.
+func (mb *MetricsBuilder) RecordApacheWorkerLimitDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricApacheWorkerLimit.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordApacheWorkersDataPoint adds a data point to apache.workers metric.

--- a/receiver/apachereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics.go
@@ -4,15 +4,14 @@ package metadata
 
 import (
 	"fmt"
-	"slices"
-	"strconv"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"slices"
+	"strconv"
+	"time"
 )
 
 const (

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
@@ -108,6 +108,14 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordApacheLoad5DataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
+			mb.RecordApacheRequestBandwidthRateDataPoint(ts, "1")
+
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordApacheRequestRateDataPoint(ts, "1")
+
+			defaultMetricsCount++
+			allMetricsCount++
 			mb.RecordApacheRequestTimeDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
@@ -124,6 +132,10 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheUptimeDataPoint(ts, "1")
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordApacheWorkerLimitDataPoint(ts, 1)
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheWorkersDataPoint(ts, "1", AttributeWorkersStateBusy)
@@ -319,6 +331,30 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "apache.request.bandwidth.rate":
+					assert.False(t, validatedMetrics["apache.request.bandwidth.rate"], "Found a duplicate in the metrics slice: apache.request.bandwidth.rate")
+					validatedMetrics["apache.request.bandwidth.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Average number of bytes transmitted per second since the server was started, as reported by mod_status.", mi.Description())
+					assert.Equal(t, "By/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "apache.request.rate":
+					assert.False(t, validatedMetrics["apache.request.rate"], "Found a duplicate in the metrics slice: apache.request.rate")
+					validatedMetrics["apache.request.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Average number of requests served per second since the server was started, as reported by mod_status.", mi.Description())
+					assert.Equal(t, "{request}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "apache.request.time":
 					assert.False(t, validatedMetrics["apache.request.time"], "Found a duplicate in the metrics slice: apache.request.time")
 					validatedMetrics["apache.request.time"] = true
@@ -415,6 +451,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "apache.worker.limit":
+					assert.False(t, validatedMetrics["apache.worker.limit"], "Found a duplicate in the metrics slice: apache.worker.limit")
+					validatedMetrics["apache.worker.limit"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "The maximum number of worker slots configured for the HTTP server, derived from the scoreboard length.", mi.Description())
+					assert.Equal(t, "{worker}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
@@ -108,10 +108,6 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordApacheLoad5DataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordApacheRequestBandwidthRateDataPoint(ts, "1")
-
-			defaultMetricsCount++
-			allMetricsCount++
 			mb.RecordApacheRequestRateDataPoint(ts, "1")
 
 			defaultMetricsCount++
@@ -129,6 +125,10 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheTrafficDataPoint(ts, 1)
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordApacheTrafficRateDataPoint(ts, "1")
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheUptimeDataPoint(ts, "1")
@@ -331,18 +331,6 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-				case "apache.request.bandwidth.rate":
-					assert.False(t, validatedMetrics["apache.request.bandwidth.rate"], "Found a duplicate in the metrics slice: apache.request.bandwidth.rate")
-					validatedMetrics["apache.request.bandwidth.rate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-					assert.Equal(t, "Average number of bytes transmitted per second since the server was started, as reported by mod_status.", mi.Description())
-					assert.Equal(t, "By/s", mi.Unit())
-					dp := mi.Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "apache.request.rate":
 					assert.False(t, validatedMetrics["apache.request.rate"], "Found a duplicate in the metrics slice: apache.request.rate")
 					validatedMetrics["apache.request.rate"] = true
@@ -441,6 +429,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "apache.traffic.rate":
+					assert.False(t, validatedMetrics["apache.traffic.rate"], "Found a duplicate in the metrics slice: apache.traffic.rate")
+					validatedMetrics["apache.traffic.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Average number of bytes transmitted per second since the server was started, as reported by mod_status.", mi.Description())
+					assert.Equal(t, "By/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "apache.uptime":
 					assert.False(t, validatedMetrics["apache.uptime"], "Found a duplicate in the metrics slice: apache.uptime")
 					validatedMetrics["apache.uptime"] = true

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
@@ -109,7 +109,6 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheRequestRateDataPoint(ts, "1")
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheRequestTimeDataPoint(ts, "1")
@@ -128,14 +127,12 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheTrafficRateDataPoint(ts, "1")
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheUptimeDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheWorkerLimitDataPoint(ts, 1)
-
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheWorkersDataPoint(ts, "1", AttributeWorkersStateBusy)

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
@@ -106,7 +106,7 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheLoad5DataPoint(ts, "1")
-			defaultMetricsCount++
+
 			allMetricsCount++
 			mb.RecordApacheRequestRateDataPoint(ts, "1")
 			defaultMetricsCount++
@@ -124,7 +124,7 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordApacheTrafficDataPoint(ts, 1)
-			defaultMetricsCount++
+
 			allMetricsCount++
 			mb.RecordApacheTrafficRateDataPoint(ts, "1")
 			defaultMetricsCount++

--- a/receiver/apachereceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/apachereceiver/internal/metadata/testdata/config.yaml
@@ -17,6 +17,10 @@ all_set:
       enabled: true
     apache.load.5:
       enabled: true
+    apache.request.bandwidth.rate:
+      enabled: true
+    apache.request.rate:
+      enabled: true
     apache.request.time:
       enabled: true
     apache.requests:
@@ -27,6 +31,8 @@ all_set:
     apache.traffic:
       enabled: true
     apache.uptime:
+      enabled: true
+    apache.worker.limit:
       enabled: true
     apache.workers:
       enabled: true
@@ -54,6 +60,10 @@ reaggregate_set:
       enabled: true
     apache.load.5:
       enabled: true
+    apache.request.bandwidth.rate:
+      enabled: true
+    apache.request.rate:
+      enabled: true
     apache.request.time:
       enabled: true
     apache.requests:
@@ -64,6 +74,8 @@ reaggregate_set:
     apache.traffic:
       enabled: true
     apache.uptime:
+      enabled: true
+    apache.worker.limit:
       enabled: true
     apache.workers:
       enabled: true
@@ -91,6 +103,10 @@ none_set:
       enabled: false
     apache.load.5:
       enabled: false
+    apache.request.bandwidth.rate:
+      enabled: false
+    apache.request.rate:
+      enabled: false
     apache.request.time:
       enabled: false
     apache.requests:
@@ -101,6 +117,8 @@ none_set:
     apache.traffic:
       enabled: false
     apache.uptime:
+      enabled: false
+    apache.worker.limit:
       enabled: false
     apache.workers:
       enabled: false

--- a/receiver/apachereceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/apachereceiver/internal/metadata/testdata/config.yaml
@@ -17,8 +17,6 @@ all_set:
       enabled: true
     apache.load.5:
       enabled: true
-    apache.request.bandwidth.rate:
-      enabled: true
     apache.request.rate:
       enabled: true
     apache.request.time:
@@ -29,6 +27,8 @@ all_set:
       enabled: true
       attributes: ["state"]
     apache.traffic:
+      enabled: true
+    apache.traffic.rate:
       enabled: true
     apache.uptime:
       enabled: true
@@ -60,8 +60,6 @@ reaggregate_set:
       enabled: true
     apache.load.5:
       enabled: true
-    apache.request.bandwidth.rate:
-      enabled: true
     apache.request.rate:
       enabled: true
     apache.request.time:
@@ -72,6 +70,8 @@ reaggregate_set:
       enabled: true
       attributes: []
     apache.traffic:
+      enabled: true
+    apache.traffic.rate:
       enabled: true
     apache.uptime:
       enabled: true
@@ -103,8 +103,6 @@ none_set:
       enabled: false
     apache.load.5:
       enabled: false
-    apache.request.bandwidth.rate:
-      enabled: false
     apache.request.rate:
       enabled: false
     apache.request.time:
@@ -115,6 +113,8 @@ none_set:
       enabled: false
       attributes: ["state"]
     apache.traffic:
+      enabled: false
+    apache.traffic.rate:
       enabled: false
     apache.uptime:
       enabled: false

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -143,15 +143,6 @@ metrics:
       value_type: double
       input_type: string
     attributes: []
-  apache.request.bandwidth.rate:
-    enabled: true
-    stability: development
-    description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
-    unit: "By/s"
-    gauge:
-      value_type: double
-      input_type: string
-    attributes: []
   apache.request.rate:
     enabled: true
     stability: development
@@ -206,6 +197,15 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
+    attributes: []
+  apache.traffic.rate:
+    enabled: true
+    stability: development
+    description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+    unit: "By/s"
+    gauge:
+      value_type: double
+      input_type: string
     attributes: []
   apache.uptime:
     enabled: true

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -143,6 +143,24 @@ metrics:
       value_type: double
       input_type: string
     attributes: []
+  apache.request.bandwidth.rate:
+    enabled: true
+    stability: development
+    description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+    unit: "By/s"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+  apache.request.rate:
+    enabled: true
+    stability: development
+    description: Average number of requests served per second since the server was started, as reported by mod_status.
+    unit: "{request}/s"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
   apache.request.time:
     enabled: true
     stability: development
@@ -199,6 +217,14 @@ metrics:
       input_type: string
       monotonic: true
       aggregation_temporality: cumulative
+    attributes: []
+  apache.worker.limit:
+    enabled: true
+    stability: development
+    description: The maximum number of worker slots configured for the HTTP server, derived from the scoreboard length.
+    unit: "{worker}"
+    gauge:
+      value_type: int
     attributes: []
   apache.workers:
     enabled: true

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -144,7 +144,7 @@ metrics:
       input_type: string
     attributes: []
   apache.request.rate:
-    enabled: true
+    enabled: false
     stability: development
     description: Average number of requests served per second since the server was started, as reported by mod_status.
     unit: "{request}/s"
@@ -199,7 +199,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes: []
   apache.traffic.rate:
-    enabled: true
+    enabled: false
     stability: development
     description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
     unit: "By/s"

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -125,7 +125,12 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 			addPartialIfError(errs, r.mb.RecordApacheLoad15DataPoint(now, metricValue))
 		case "Total Duration":
 			addPartialIfError(errs, r.mb.RecordApacheRequestTimeDataPoint(now, metricValue))
+		case "ReqPerSec":
+			addPartialIfError(errs, r.mb.RecordApacheRequestRateDataPoint(now, metricValue))
+		case "BytesPerSec":
+			addPartialIfError(errs, r.mb.RecordApacheRequestBandwidthRateDataPoint(now, metricValue))
 		case "Scoreboard":
+			r.mb.RecordApacheWorkerLimitDataPoint(now, int64(len(metricValue)))
 			scoreboardMap := parseScoreboard(metricValue)
 			for state, score := range scoreboardMap {
 				r.mb.RecordApacheScoreboardDataPoint(now, score, state)

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -128,7 +128,7 @@ func (r *apacheScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		case "ReqPerSec":
 			addPartialIfError(errs, r.mb.RecordApacheRequestRateDataPoint(now, metricValue))
 		case "BytesPerSec":
-			addPartialIfError(errs, r.mb.RecordApacheRequestBandwidthRateDataPoint(now, metricValue))
+			addPartialIfError(errs, r.mb.RecordApacheTrafficRateDataPoint(now, metricValue))
 		case "Scoreboard":
 			r.mb.RecordApacheWorkerLimitDataPoint(now, int64(len(metricValue)))
 			scoreboardMap := parseScoreboard(metricValue)

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -179,6 +179,8 @@ CPUChildrenUser: 0.02
 CPUSystem: 0.03
 CPUUser: 0.04
 CPULoad: 0.66
+ReqPerSec: 719.771
+BytesPerSec: 73.12
 Load1: 0.9
 Load5: 0.4
 Load15: 0.3

--- a/receiver/apachereceiver/testdata/integration/expected.yaml
+++ b/receiver/apachereceiver/testdata/integration/expected.yaml
@@ -111,6 +111,22 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
             name: apache.load.5
             unit: '%'
+          - description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+            gauge:
+              dataPoints:
+                - asDouble: 512
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1632495518500962000"
+            name: apache.request.bandwidth.rate
+            unit: By/s
+          - description: Average number of requests served per second since the server was started, as reported by mod_status.
+            gauge:
+              dataPoints:
+                - asDouble: 1.5
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1632495518500962000"
+            name: apache.request.rate
+            unit: '{request}/s'
           - description: Total time spent on handling requests.
             name: apache.request.time
             sum:
@@ -219,6 +235,14 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
               isMonotonic: true
             unit: s
+          - description: The maximum number of worker slots configured for the HTTP server, derived from the scoreboard length.
+            gauge:
+              dataPoints:
+                - asInt: "400"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1632495518500962000"
+            name: apache.worker.limit
+            unit: '{worker}'
           - description: The number of workers currently attached to the HTTP server.
             name: apache.workers
             sum:

--- a/receiver/apachereceiver/testdata/integration/expected.yaml
+++ b/receiver/apachereceiver/testdata/integration/expected.yaml
@@ -117,7 +117,7 @@ resourceMetrics:
                 - asDouble: 512
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "1632495518500962000"
-            name: apache.request.bandwidth.rate
+            name: apache.traffic.rate
             unit: By/s
           - description: Average number of requests served per second since the server was started, as reported by mod_status.
             gauge:

--- a/receiver/apachereceiver/testdata/integration/expected.yaml
+++ b/receiver/apachereceiver/testdata/integration/expected.yaml
@@ -111,14 +111,6 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
             name: apache.load.5
             unit: '%'
-          - description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
-            gauge:
-              dataPoints:
-                - asDouble: 512
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1632495518500962000"
-            name: apache.traffic.rate
-            unit: By/s
           - description: Average number of requests served per second since the server was started, as reported by mod_status.
             gauge:
               dataPoints:
@@ -226,6 +218,14 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
               isMonotonic: true
             unit: By
+          - description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
+            gauge:
+              dataPoints:
+                - asDouble: 512
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1632495518500962000"
+            name: apache.traffic.rate
+            unit: By/s
           - description: The amount of time that the server has been running in seconds.
             name: apache.uptime
             sum:

--- a/receiver/apachereceiver/testdata/integration/expected.yaml
+++ b/receiver/apachereceiver/testdata/integration/expected.yaml
@@ -111,14 +111,6 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
             name: apache.load.5
             unit: '%'
-          - description: Average number of requests served per second since the server was started, as reported by mod_status.
-            gauge:
-              dataPoints:
-                - asDouble: 1.5
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1632495518500962000"
-            name: apache.request.rate
-            unit: '{request}/s'
           - description: Total time spent on handling requests.
             name: apache.request.time
             sum:
@@ -218,14 +210,6 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
               isMonotonic: true
             unit: By
-          - description: Average number of bytes transmitted per second since the server was started, as reported by mod_status.
-            gauge:
-              dataPoints:
-                - asDouble: 512
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "1632495518500962000"
-            name: apache.traffic.rate
-            unit: By/s
           - description: The amount of time that the server has been running in seconds.
             name: apache.uptime
             sum:

--- a/receiver/apachereceiver/testdata/scraper/metrics.assert.yaml
+++ b/receiver/apachereceiver/testdata/scraper/metrics.assert.yaml
@@ -44,7 +44,7 @@ resources:
               unit: '{connections}'
               temporality: cumulative
               monotonic: false
-            - name: apache.request.bandwidth.rate
+            - name: apache.traffic.rate
               type: gauge
               unit: By/s
             - name: apache.load.1

--- a/receiver/apachereceiver/testdata/scraper/metrics.assert.yaml
+++ b/receiver/apachereceiver/testdata/scraper/metrics.assert.yaml
@@ -44,6 +44,9 @@ resources:
               unit: '{connections}'
               temporality: cumulative
               monotonic: false
+            - name: apache.request.bandwidth.rate
+              type: gauge
+              unit: By/s
             - name: apache.load.1
               type: gauge
               unit: '%'
@@ -53,6 +56,9 @@ resources:
             - name: apache.load.5
               type: gauge
               unit: '%'
+            - name: apache.request.rate
+              type: gauge
+              unit: '{request}/s'
             - name: apache.request.time
               type: sum
               unit: ms
@@ -101,6 +107,9 @@ resources:
               unit: s
               temporality: cumulative
               monotonic: true
+            - name: apache.worker.limit
+              type: gauge
+              unit: '{worker}'
             - name: apache.workers
               type: sum
               unit: '{workers}'

--- a/receiver/apachereceiver/testdata/scraper/metrics.assert.yaml
+++ b/receiver/apachereceiver/testdata/scraper/metrics.assert.yaml
@@ -44,9 +44,6 @@ resources:
               unit: '{connections}'
               temporality: cumulative
               monotonic: false
-            - name: apache.traffic.rate
-              type: gauge
-              unit: By/s
             - name: apache.load.1
               type: gauge
               unit: '%'
@@ -56,9 +53,6 @@ resources:
             - name: apache.load.5
               type: gauge
               unit: '%'
-            - name: apache.request.rate
-              type: gauge
-              unit: '{request}/s'
             - name: apache.request.time
               type: sum
               unit: ms


### PR DESCRIPTION
#### Description

Add three new metrics to the Apache receiver:

1. `apache.workers.limit` (gauge, int) [disabled by default] - The total number of worker slots configured.
2. `apache.traffic.rate` (gauge, double, `By/s`) [disabled by default] - The server's average bytes served per second since the server was started.
3. `apache.request.rate` (gauge, double, `{request}/s`)- The server's average requests served per second since the server was started.

#### Link to tracking issue

Fixes #47061

#### Testing

- Added `ReqPerSec`, `BytesPerSec` to the unit test mock server and updated the scraper assertion fixture in `testdata/scraper/metrics.assert.yaml`.
- Updated `testdata/integration/expected.yaml` to  include the three new metrics.

#### Documentation

- Added attribute definitions in metadata.yaml.
- Auto-generated `documentation.md` updated to reflect three new metrics.
- Added changelog entry in  `.chloggen/47061-apache-rate-and-max-workers-metrics.yaml`.

#### Authorship

- [x] I, a human, wrote this pull request description myself.