### PR TITLE
[exporter/datadogexporter] Split Fargate running metric from host running metric

### DIFF
--- a/.chloggen/split-ddexporter-metrics.yaml
+++ b/.chloggen/split-ddexporter-metrics.yaml
@@ -15,7 +15,9 @@ issues: [49042]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Host-based workloads continue to use `otel.datadog_exporter.metrics.running{host}` unchanged.
+subtext: |
+  Host-based workloads continue to use `otel.datadog_exporter.metrics.running{host}` unchanged.
+  `otel.datadog_exporter.metrics.running` will no longer be tagged with `task_arn`. Fargate workloads will only use `otel.datadog_exporter.metrics.running.fargate{task_arn}`.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/split-ddexporter-metrics.yaml
+++ b/.chloggen/split-ddexporter-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Emit `otel.datadog_exporter.metrics.running.fargate{task_arn}` for AWS ECS Fargate workloads so that each workload has its own metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49042]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Host-based workloads continue to use `otel.datadog_exporter.metrics.running{host}` unchanged.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -5,8 +5,10 @@ package metrics // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	"context"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/quantile"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
@@ -69,11 +71,16 @@ func (c *Consumer) runningMetrics(timestamp uint64, buildInfo component.BuildInf
 	}
 
 	for tag := range c.seenTags {
-		runningMetrics := DefaultMetrics("metrics", "", timestamp, buildTags)
-		for i := range runningMetrics {
-			runningMetrics[i].Tags = append(runningMetrics[i].Tags, tag)
+		var tagSeries []datadogV2.MetricSeries
+		if strings.HasPrefix(tag, string(source.AWSECSFargateKind)+":") {
+			tagSeries = FargateMetrics(timestamp, buildTags)
+		} else {
+			tagSeries = DefaultMetrics("metrics", "", timestamp, buildTags)
 		}
-		series = append(series, runningMetrics...)
+		for i := range tagSeries {
+			tagSeries[i].Tags = append(tagSeries[i].Tags, tag)
+		}
+		series = append(series, tagSeries...)
 	}
 
 	for _, lang := range metadata.Languages {

--- a/exporter/datadogexporter/internal/metrics/consumer_test.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_test.go
@@ -137,4 +137,17 @@ func TestTagsMetrics(t *testing.T) {
 	assert.ElementsMatch(t, runningHostnames, []string{"", "", ""})
 	assert.Len(t, runningMetrics, 3)
 	assert.ElementsMatch(t, runningTags, []string{"task_arn:task-arn-1", "task_arn:task-arn-2", "task_arn:task-arn-3"})
+
+	var runningMetricNames []string
+	for _, metric := range runningMetrics {
+		runningMetricNames = append(runningMetricNames, metric.Metric)
+	}
+	assert.ElementsMatch(t,
+		runningMetricNames,
+		[]string{
+			"otel.datadog_exporter.metrics.running.fargate",
+			"otel.datadog_exporter.metrics.running.fargate",
+			"otel.datadog_exporter.metrics.running.fargate",
+		},
+	)
 }

--- a/exporter/datadogexporter/internal/metrics/series.go
+++ b/exporter/datadogexporter/internal/metrics/series.go
@@ -69,6 +69,22 @@ func DefaultMetrics(exporterType, hostname string, timestamp uint64, tags []stri
 	return metrics
 }
 
+// FargateMetrics creates built-in metrics to report that a Fargate exporter is running.
+func FargateMetrics(timestamp uint64, tags []string) []datadogV2.MetricSeries {
+	metrics := []datadogV2.MetricSeries{
+		NewGauge("otel.datadog_exporter.metrics.running.fargate", timestamp, 0, 1.0, tags),
+	}
+	for i := range metrics {
+		metrics[i].SetResources([]datadogV2.MetricResource{
+			{
+				Name: datadog.PtrString(""),
+				Type: datadog.PtrString("host"),
+			},
+		})
+	}
+	return metrics
+}
+
 // GatewayUsageGauge creates a gauge metric to report if there is a gateway
 func GatewayUsageGauge(timestamp uint64, hostname string, tags []string, gatewayUsage *attributes.GatewayUsage) datadogV2.MetricSeries {
 	series := NewGauge("datadog.otel.gateway", timestamp, 0, gatewayUsage.Gauge(), tags)

--- a/exporter/datadogexporter/internal/metrics/series_test.go
+++ b/exporter/datadogexporter/internal/metrics/series_test.go
@@ -62,6 +62,23 @@ func TestDefaultMetrics(t *testing.T) {
 	assert.ElementsMatch(t, []string{"version:1.0", "command:otelcontribcol"}, ms[0].Tags)
 }
 
+func TestFargateMetrics(t *testing.T) {
+	buildInfo := component.BuildInfo{
+		Version: "1.0",
+		Command: "otelcontribcol",
+	}
+
+	ms := FargateMetrics(uint64(2e9), TagsFromBuildInfo(buildInfo))
+
+	assert.Equal(t, "otel.datadog_exporter.metrics.running.fargate", ms[0].Metric)
+	assert.Len(t, ms, 1)
+	assert.Equal(t, int64(2), *ms[0].Points[0].Timestamp)
+	assert.Equal(t, 1.0, *ms[0].Points[0].Value)
+	// Assert hostname tag is empty
+	assert.Empty(t, *ms[0].Resources[0].Name)
+	assert.ElementsMatch(t, []string{"version:1.0", "command:otelcontribcol"}, ms[0].Tags)
+}
+
 func TestDefaultMetricsWithRuntimeMetrics(t *testing.T) {
 	buildInfo := component.BuildInfo{
 		Version: "1.0",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently, `otel.datadog_exporter.metrics.running` is emitted for both host-based and Fargate workloads. This PR splits the Fargate case into a separate metric `otel.datadog_exporter.metrics.running.fargate`, tagged with `task_arn`, so that each workload type has its own metric. Host-based workloads continue to use `otel.datadog_exporter.metrics.running{host}` unchanged.
- A PR has been merged in [datadog-agent](https://github.com/DataDog/datadog-agent/commit/00f5beb2732b) to update the `serializerexporter` which is active by default. This PR updates that module version to the PR's pseudocommit (`00f5beb2732b`) as well as any other modules needed to get `make otelcontribcol` to pass.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Internal Datadog Jira ticket with screenshots of discussion to split the metric, for context: https://datadoghq.atlassian.net/browse/SVLS-9246

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran locally against a sample app sending Fargate resource attributes and a metric `otel.metric.test.fargate.1` so that the dev collector can pick up the payload as a Fargate app and send `otel.datadog_exporter.metrics.running.fargate`. Verified that the manually set `aws.ecs.task.arn` resource attribute gets converted into a `task_arn` tag and that the `otel.datadog_exporter.metrics.running` metric does not get emitted anymore.
<img width="1318" height="677" alt="image" src="https://github.com/user-attachments/assets/b24a4ce2-1983-41d1-9adb-f8df3f4798c4" />

Ran unit tests for `FargateMetrics()` and updated `TestTagsMetrics` to assert the new metric name.

<!--Describe the documentation added.-->
#### Documentation
No user-facing config changes.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
