### PR TITLE
[receiver/oracledb] Add redo log metrics

### DIFF
--- a/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
@@ -18,7 +18,8 @@ issues: [49060]
 subtext: |
   Adds 7 new metrics under the `oracledb.redo.*` namespace, all disabled by default:
   `oracledb.redo.time` (with the new `oracledb.redo.kind` attribute: write/latching/log_space_wait/synch),
-  `oracledb.redo.size`, `oracledb.redo.operations`, `oracledb.redo.blocks`,
+  `oracledb.redo.size`, `oracledb.redo.operations` and `oracledb.redo.blocks` (both with the
+  reused `disk.io.direction` attribute, currently `write`),
   `oracledb.redo.buffer_allocation.retries`, `oracledb.redo.log_space.requests`, and
   `oracledb.redo.log_switch.interrupts`. These are read from the existing `SELECT * FROM v$sysstat`
   query, so no additional database round-trips are introduced.

--- a/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/oracledb
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add redo log metrics to the oracledb receiver
+note: Add redo log metrics
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49060]

--- a/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/oracledb
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add redo log metrics sourced from v$sysstat
+note: Add redo log metrics to the oracledb receiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49060]
@@ -15,13 +15,7 @@ issues: [49060]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: |
-  Adds 6 new metrics under the `oracledb.redo.*` namespace, all disabled by default:
-  `oracledb.redo.time` (with the new `oracledb.redo.kind` attribute: write/log_space_wait/synch),
-  `oracledb.redo.size`, `oracledb.redo.operations` and `oracledb.redo.blocks` (both with the
-  reused `disk.io.direction` attribute, currently `write`),
-  `oracledb.redo.buffer_allocation.retries`, and `oracledb.redo.log_space.requests`. These are read from the existing `SELECT * FROM v$sysstat`
-  query, so no additional database round-trips are introduced.
+subtext: ""
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
@@ -16,12 +16,11 @@ issues: [49060]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Adds 7 new metrics under the `oracledb.redo.*` namespace, all disabled by default:
-  `oracledb.redo.time` (with the new `oracledb.redo.kind` attribute: write/latching/log_space_wait/synch),
+  Adds 6 new metrics under the `oracledb.redo.*` namespace, all disabled by default:
+  `oracledb.redo.time` (with the new `oracledb.redo.kind` attribute: write/log_space_wait/synch),
   `oracledb.redo.size`, `oracledb.redo.operations` and `oracledb.redo.blocks` (both with the
   reused `disk.io.direction` attribute, currently `write`),
-  `oracledb.redo.buffer_allocation.retries`, `oracledb.redo.log_space.requests`, and
-  `oracledb.redo.log_switch.interrupts`. These are read from the existing `SELECT * FROM v$sysstat`
+  `oracledb.redo.buffer_allocation.retries`, and `oracledb.redo.log_space.requests`. These are read from the existing `SELECT * FROM v$sysstat`
   query, so no additional database round-trips are introduced.
 
 # If your change doesn't affect end users or the exported elements of any package,

--- a/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/oracledb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add redo log metrics sourced from v$sysstat
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49060]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds 7 new metrics under the `oracledb.redo.*` namespace, all disabled by default:
+  `oracledb.redo.time` (with the new `oracledb.redo.kind` attribute: write/latching/log_space_wait/synch),
+  `oracledb.redo.size`, `oracledb.redo.writes`, `oracledb.redo.blocks_written`,
+  `oracledb.redo.buffer_allocation.retries`, `oracledb.redo.log_space.requests`, and
+  `oracledb.redo.log_switch.interrupts`. These are read from the existing `SELECT * FROM v$sysstat`
+  query, so no additional database round-trips are introduced.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-redo-log-metrics.yaml
@@ -18,7 +18,7 @@ issues: [49060]
 subtext: |
   Adds 7 new metrics under the `oracledb.redo.*` namespace, all disabled by default:
   `oracledb.redo.time` (with the new `oracledb.redo.kind` attribute: write/latching/log_space_wait/synch),
-  `oracledb.redo.size`, `oracledb.redo.writes`, `oracledb.redo.blocks_written`,
+  `oracledb.redo.size`, `oracledb.redo.operations`, `oracledb.redo.blocks`,
   `oracledb.redo.buffer_allocation.retries`, `oracledb.redo.log_space.requests`, and
   `oracledb.redo.log_switch.interrupts`. These are read from the existing `SELECT * FROM v$sysstat`
   query, so no additional database round-trips are introduced.

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -507,7 +507,7 @@ Total size of the recycle bin.
 | ---- | ----------- | ---------- | --------- |
 | By | Gauge | Double | Development |
 
-### oracledb.redo.blocks_written
+### oracledb.redo.blocks
 
 Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').
 
@@ -539,6 +539,14 @@ Number of times a redo log switch was interrupted (v$sysstat 'redo log switch in
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {interrupts} | Sum | Int | Cumulative | true | Development |
 
+### oracledb.redo.operations
+
+Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | Development |
+
 ### oracledb.redo.size
 
 Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
@@ -560,14 +568,6 @@ Cumulative time, in seconds, spent in each phase of the redo pipeline (converted
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | oracledb.redo.kind | The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, latching = redo allocation/copy latch waits, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit). | Str: ``write``, ``latching``, ``log_space_wait``, ``synch`` | Recommended | - |
-
-### oracledb.redo.writes
-
-Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {writes} | Sum | Int | Cumulative | true | Development |
 
 ### oracledb.redo_allocation.utilization
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -507,6 +507,68 @@ Total size of the recycle bin.
 | ---- | ----------- | ---------- | --------- |
 | By | Gauge | Double | Development |
 
+### oracledb.redo.blocks_written
+
+Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {blocks} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.redo.buffer_allocation.retries
+
+Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {retries} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.redo.log_space.requests
+
+Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.redo.log_switch.interrupts
+
+Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {interrupts} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.redo.size
+
+Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | Development |
+
+### oracledb.redo.time
+
+Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.redo.kind | The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, latching = redo allocation/copy latch waits, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit). | Str: ``write``, ``latching``, ``log_space_wait``, ``synch`` | Recommended | - |
+
+### oracledb.redo.writes
+
+Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {writes} | Sum | Int | Cumulative | true | Development |
+
 ### oracledb.redo_allocation.utilization
 
 Fraction of redo allocations that succeeded without space contention, as computed by Oracle V$SYSMETRIC (% (#Redo - RedoSpaceReq)/#Redo).

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -521,22 +521,6 @@ Number of redo blocks moved between the redo log and storage, by I/O direction.
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
 
-### oracledb.redo.buffer_allocation_retries
-
-Number of times a process waited and retried to allocate space in the redo buffer.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {retry} | Sum | Int | Cumulative | true | Development |
-
-### oracledb.redo.log_space_requests
-
-Number of times a process requested space in the redo log buffer and had to wait.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {request} | Sum | Int | Cumulative | true | Development |
-
 ### oracledb.redo.operations
 
 Number of redo I/O operations, by I/O direction.
@@ -550,6 +534,34 @@ Number of redo I/O operations, by I/O direction.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
+
+### oracledb.redo.requests
+
+Number of times a process requested space in the redo log buffer and had to wait.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {request} | Sum | Int | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.redo.request.type | The type of redo log buffer space request. | Str: ``log_space`` | Recommended | - |
+
+### oracledb.redo.retries
+
+Number of times a process waited and retried to allocate space in the redo buffer.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {retry} | Sum | Int | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.redo.retry.type | The type of redo buffer allocation retry. | Str: ``buffer_allocation`` | Recommended | - |
 
 ### oracledb.redo.size
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -509,7 +509,7 @@ Total size of the recycle bin.
 
 ### oracledb.redo.blocks
 
-Number of redo blocks moved between the redo log and storage, by I/O direction.
+Number of redo blocks moved between the redo log and storage.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
@@ -523,7 +523,7 @@ Number of redo blocks moved between the redo log and storage, by I/O direction.
 
 ### oracledb.redo.operations
 
-Number of redo I/O operations, by I/O direction.
+Number of redo I/O operations.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
@@ -583,7 +583,7 @@ Time spent in each phase of the redo pipeline.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.redo.type | The phase of the redo pipeline that a redo time measurement is attributed to. | Str: ``write``, ``log_space_wait``, ``synch`` | Recommended | - |
+| oracledb.redo.type | The phase of the redo pipeline that a redo time measurement is attributed to. | Str: ``write``, ``log_space_wait``, ``sync`` | Recommended | - |
 
 ### oracledb.redo_allocation.utilization
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -509,11 +509,11 @@ Total size of the recycle bin.
 
 ### oracledb.redo.blocks
 
-Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').
+Number of redo blocks moved between the redo log and storage, by I/O direction.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {blocks} | Sum | Int | Cumulative | true | Development |
+| {block} | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -521,29 +521,29 @@ Number of redo blocks moved between the redo log and storage, by I/O direction. 
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
 
-### oracledb.redo.buffer_allocation.retries
+### oracledb.redo.buffer_allocation_retries
 
-Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {retries} | Sum | Int | Cumulative | true | Development |
-
-### oracledb.redo.log_space.requests
-
-Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').
+Number of times a process waited and retried to allocate space in the redo buffer.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {requests} | Sum | Int | Cumulative | true | Development |
+| {retry} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.redo.log_space_requests
+
+Number of times a process requested space in the redo log buffer and had to wait.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {request} | Sum | Int | Cumulative | true | Development |
 
 ### oracledb.redo.operations
 
-Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+Number of redo I/O operations, by I/O direction.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {operations} | Sum | Int | Cumulative | true | Development |
+| {operation} | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -553,7 +553,7 @@ Number of redo I/O operations, by direction. disk.io.direction=write counts redo
 
 ### oracledb.redo.size
 
-Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
+Amount of redo generated.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
@@ -561,7 +561,7 @@ Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical 
 
 ### oracledb.redo.time
 
-Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.
+Time spent in each phase of the redo pipeline.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
@@ -571,7 +571,7 @@ Cumulative time, in seconds, spent in each phase of the redo pipeline (converted
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.redo.kind | The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit). | Str: ``write``, ``log_space_wait``, ``synch`` | Recommended | - |
+| oracledb.redo.type | The phase of the redo pipeline that a redo time measurement is attributed to. | Str: ``write``, ``log_space_wait``, ``synch`` | Recommended | - |
 
 ### oracledb.redo_allocation.utilization
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -537,14 +537,6 @@ Number of times a process requested space in the redo log buffer and had to wait
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {requests} | Sum | Int | Cumulative | true | Development |
 
-### oracledb.redo.log_switch.interrupts
-
-Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {interrupts} | Sum | Int | Cumulative | true | Development |
-
 ### oracledb.redo.operations
 
 Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
@@ -579,7 +571,7 @@ Cumulative time, in seconds, spent in each phase of the redo pipeline (converted
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.redo.kind | The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, latching = redo allocation/copy latch waits, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit). | Str: ``write``, ``latching``, ``log_space_wait``, ``synch`` | Recommended | - |
+| oracledb.redo.kind | The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit). | Str: ``write``, ``log_space_wait``, ``synch`` | Recommended | - |
 
 ### oracledb.redo_allocation.utilization
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -509,11 +509,17 @@ Total size of the recycle bin.
 
 ### oracledb.redo.blocks
 
-Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').
+Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {blocks} | Sum | Int | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
 
 ### oracledb.redo.buffer_allocation.retries
 
@@ -541,11 +547,17 @@ Number of times a redo log switch was interrupted (v$sysstat 'redo log switch in
 
 ### oracledb.redo.operations
 
-Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {operations} | Sum | Int | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
 
 ### oracledb.redo.size
 

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -313,8 +313,8 @@ $defs:
           enabled:
             type: boolean
             default: false
-      oracledb.redo.blocks_written:
-        description: "OracledbRedoBlocksWrittenMetricConfig provides config for the oracledb.redo.blocks_written metric."
+      oracledb.redo.blocks:
+        description: "OracledbRedoBlocksMetricConfig provides config for the oracledb.redo.blocks metric."
         type: object
         properties:
           enabled:
@@ -341,6 +341,13 @@ $defs:
           enabled:
             type: boolean
             default: false
+      oracledb.redo.operations:
+        description: "OracledbRedoOperationsMetricConfig provides config for the oracledb.redo.operations metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.redo.size:
         description: "OracledbRedoSizeMetricConfig provides config for the oracledb.redo.size metric."
         type: object
@@ -350,13 +357,6 @@ $defs:
             default: false
       oracledb.redo.time:
         description: "OracledbRedoTimeMetricConfig provides config for the oracledb.redo.time metric."
-        type: object
-        properties:
-          enabled:
-            type: boolean
-            default: false
-      oracledb.redo.writes:
-        description: "OracledbRedoWritesMetricConfig provides config for the oracledb.redo.writes metric."
         type: object
         properties:
           enabled:

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -313,6 +313,55 @@ $defs:
           enabled:
             type: boolean
             default: false
+      oracledb.redo.blocks_written:
+        description: "OracledbRedoBlocksWrittenMetricConfig provides config for the oracledb.redo.blocks_written metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.buffer_allocation.retries:
+        description: "OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation.retries metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.log_space.requests:
+        description: "OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space.requests metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.log_switch.interrupts:
+        description: "OracledbRedoLogSwitchInterruptsMetricConfig provides config for the oracledb.redo.log_switch.interrupts metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.size:
+        description: "OracledbRedoSizeMetricConfig provides config for the oracledb.redo.size metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.time:
+        description: "OracledbRedoTimeMetricConfig provides config for the oracledb.redo.time metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.writes:
+        description: "OracledbRedoWritesMetricConfig provides config for the oracledb.redo.writes metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.sessions.limit:
         description: "OracledbSessionsLimitMetricConfig provides config for the oracledb.sessions.limit metric."
         type: object

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -320,15 +320,15 @@ $defs:
           enabled:
             type: boolean
             default: false
-      oracledb.redo.buffer_allocation.retries:
-        description: "OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation.retries metric."
+      oracledb.redo.buffer_allocation_retries:
+        description: "OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation_retries metric."
         type: object
         properties:
           enabled:
             type: boolean
             default: false
-      oracledb.redo.log_space.requests:
-        description: "OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space.requests metric."
+      oracledb.redo.log_space_requests:
+        description: "OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space_requests metric."
         type: object
         properties:
           enabled:

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -320,22 +320,22 @@ $defs:
           enabled:
             type: boolean
             default: false
-      oracledb.redo.buffer_allocation_retries:
-        description: "OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation_retries metric."
-        type: object
-        properties:
-          enabled:
-            type: boolean
-            default: false
-      oracledb.redo.log_space_requests:
-        description: "OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space_requests metric."
-        type: object
-        properties:
-          enabled:
-            type: boolean
-            default: false
       oracledb.redo.operations:
         description: "OracledbRedoOperationsMetricConfig provides config for the oracledb.redo.operations metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.requests:
+        description: "OracledbRedoRequestsMetricConfig provides config for the oracledb.redo.requests metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.redo.retries:
+        description: "OracledbRedoRetriesMetricConfig provides config for the oracledb.redo.retries metric."
         type: object
         properties:
           enabled:

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -334,13 +334,6 @@ $defs:
           enabled:
             type: boolean
             default: false
-      oracledb.redo.log_switch.interrupts:
-        description: "OracledbRedoLogSwitchInterruptsMetricConfig provides config for the oracledb.redo.log_switch.interrupts metric."
-        type: object
-        properties:
-          enabled:
-            type: boolean
-            default: false
       oracledb.redo.operations:
         description: "OracledbRedoOperationsMetricConfig provides config for the oracledb.redo.operations metric."
         type: object

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1151,26 +1151,6 @@ func (ms *OracledbRedoLogSpaceRequestsMetricConfig) Unmarshal(parser *confmap.Co
 	return nil
 }
 
-// OracledbRedoLogSwitchInterruptsMetricConfig provides config for the oracledb.redo.log_switch.interrupts metric.
-type OracledbRedoLogSwitchInterruptsMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *OracledbRedoLogSwitchInterruptsMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
 // OracledbRedoOperationsMetricAttributeKey specifies the key of an attribute for the oracledb.redo.operations metric.
 type OracledbRedoOperationsMetricAttributeKey string
 
@@ -1781,7 +1761,6 @@ type MetricsConfig struct {
 	OracledbRedoBlocks                            OracledbRedoBlocksMetricConfig                            `mapstructure:"oracledb.redo.blocks"`
 	OracledbRedoBufferAllocationRetries           OracledbRedoBufferAllocationRetriesMetricConfig           `mapstructure:"oracledb.redo.buffer_allocation.retries"`
 	OracledbRedoLogSpaceRequests                  OracledbRedoLogSpaceRequestsMetricConfig                  `mapstructure:"oracledb.redo.log_space.requests"`
-	OracledbRedoLogSwitchInterrupts               OracledbRedoLogSwitchInterruptsMetricConfig               `mapstructure:"oracledb.redo.log_switch.interrupts"`
 	OracledbRedoOperations                        OracledbRedoOperationsMetricConfig                        `mapstructure:"oracledb.redo.operations"`
 	OracledbRedoSize                              OracledbRedoSizeMetricConfig                              `mapstructure:"oracledb.redo.size"`
 	OracledbRedoTime                              OracledbRedoTimeMetricConfig                              `mapstructure:"oracledb.redo.time"`
@@ -1962,9 +1941,6 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
-			Enabled: false,
-		},
-		OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
 			Enabled: false,
 		},
 		OracledbRedoOperations: OracledbRedoOperationsMetricConfig{

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1111,7 +1111,7 @@ func (ms *OracledbRedoBlocksMetricConfig) Validate() error {
 	return nil
 }
 
-// OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation.retries metric.
+// OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation_retries metric.
 type OracledbRedoBufferAllocationRetriesMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
@@ -1131,7 +1131,7 @@ func (ms *OracledbRedoBufferAllocationRetriesMetricConfig) Unmarshal(parser *con
 	return nil
 }
 
-// OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space.requests metric.
+// OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space_requests metric.
 type OracledbRedoLogSpaceRequestsMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
@@ -1223,7 +1223,7 @@ func (ms *OracledbRedoSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 type OracledbRedoTimeMetricAttributeKey string
 
 const (
-	OracledbRedoTimeMetricAttributeKeyOracledbRedoKind OracledbRedoTimeMetricAttributeKey = "oracledb.redo.kind"
+	OracledbRedoTimeMetricAttributeKeyOracledbRedoType OracledbRedoTimeMetricAttributeKey = "oracledb.redo.type"
 )
 
 // OracledbRedoTimeMetricConfig provides config for the oracledb.redo.time metric.
@@ -1252,9 +1252,9 @@ func (ms *OracledbRedoTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 func (ms *OracledbRedoTimeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OracledbRedoTimeMetricAttributeKeyOracledbRedoKind:
+		case OracledbRedoTimeMetricAttributeKeyOracledbRedoType:
 		default:
-			return fmt.Errorf("metric oracledb.redo.time doesn't have an attribute %v, valid attributes: [oracledb.redo.kind]", val)
+			return fmt.Errorf("metric oracledb.redo.time doesn't have an attribute %v, valid attributes: [oracledb.redo.type]", val)
 		}
 	}
 
@@ -1759,8 +1759,8 @@ type MetricsConfig struct {
 	OracledbQueriesParallelized                   OracledbQueriesParallelizedMetricConfig                   `mapstructure:"oracledb.queries_parallelized"`
 	OracledbRecycleBinLimit                       OracledbRecycleBinLimitMetricConfig                       `mapstructure:"oracledb.recycle_bin.limit"`
 	OracledbRedoBlocks                            OracledbRedoBlocksMetricConfig                            `mapstructure:"oracledb.redo.blocks"`
-	OracledbRedoBufferAllocationRetries           OracledbRedoBufferAllocationRetriesMetricConfig           `mapstructure:"oracledb.redo.buffer_allocation.retries"`
-	OracledbRedoLogSpaceRequests                  OracledbRedoLogSpaceRequestsMetricConfig                  `mapstructure:"oracledb.redo.log_space.requests"`
+	OracledbRedoBufferAllocationRetries           OracledbRedoBufferAllocationRetriesMetricConfig           `mapstructure:"oracledb.redo.buffer_allocation_retries"`
+	OracledbRedoLogSpaceRequests                  OracledbRedoLogSpaceRequestsMetricConfig                  `mapstructure:"oracledb.redo.log_space_requests"`
 	OracledbRedoOperations                        OracledbRedoOperationsMetricConfig                        `mapstructure:"oracledb.redo.operations"`
 	OracledbRedoSize                              OracledbRedoSizeMetricConfig                              `mapstructure:"oracledb.redo.size"`
 	OracledbRedoTime                              OracledbRedoTimeMetricConfig                              `mapstructure:"oracledb.redo.time"`
@@ -1954,7 +1954,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbRedoTime: OracledbRedoTimeMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
+			EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoType},
 		},
 		OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 			Enabled: false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1063,10 +1063,20 @@ func (ms *OracledbRecycleBinLimitMetricConfig) Unmarshal(parser *confmap.Conf) e
 	return nil
 }
 
+// OracledbRedoBlocksMetricAttributeKey specifies the key of an attribute for the oracledb.redo.blocks metric.
+type OracledbRedoBlocksMetricAttributeKey string
+
+const (
+	OracledbRedoBlocksMetricAttributeKeyDiskIoDirection OracledbRedoBlocksMetricAttributeKey = "disk.io.direction"
+)
+
 // OracledbRedoBlocksMetricConfig provides config for the oracledb.redo.blocks metric.
 type OracledbRedoBlocksMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbRedoBlocksMetricAttributeKey `mapstructure:"attributes"`
 }
 
 func (ms *OracledbRedoBlocksMetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -1080,6 +1090,24 @@ func (ms *OracledbRedoBlocksMetricConfig) Unmarshal(parser *confmap.Conf) error 
 	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbRedoBlocksMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbRedoBlocksMetricAttributeKeyDiskIoDirection:
+		default:
+			return fmt.Errorf("metric oracledb.redo.blocks doesn't have an attribute %v, valid attributes: [disk.io.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
 	return nil
 }
 
@@ -1143,10 +1171,20 @@ func (ms *OracledbRedoLogSwitchInterruptsMetricConfig) Unmarshal(parser *confmap
 	return nil
 }
 
+// OracledbRedoOperationsMetricAttributeKey specifies the key of an attribute for the oracledb.redo.operations metric.
+type OracledbRedoOperationsMetricAttributeKey string
+
+const (
+	OracledbRedoOperationsMetricAttributeKeyDiskIoDirection OracledbRedoOperationsMetricAttributeKey = "disk.io.direction"
+)
+
 // OracledbRedoOperationsMetricConfig provides config for the oracledb.redo.operations metric.
 type OracledbRedoOperationsMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbRedoOperationsMetricAttributeKey `mapstructure:"attributes"`
 }
 
 func (ms *OracledbRedoOperationsMetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -1160,6 +1198,24 @@ func (ms *OracledbRedoOperationsMetricConfig) Unmarshal(parser *confmap.Conf) er
 	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbRedoOperationsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbRedoOperationsMetricAttributeKeyDiskIoDirection:
+		default:
+			return fmt.Errorf("metric oracledb.redo.operations doesn't have an attribute %v, valid attributes: [disk.io.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
 	return nil
 }
 
@@ -1898,7 +1954,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		OracledbRedoBlocks: OracledbRedoBlocksMetricConfig{
-			Enabled: false,
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []OracledbRedoBlocksMetricAttributeKey{OracledbRedoBlocksMetricAttributeKeyDiskIoDirection},
 		},
 		OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
 			Enabled: false,
@@ -1910,7 +1968,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
-			Enabled: false,
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []OracledbRedoOperationsMetricAttributeKey{OracledbRedoOperationsMetricAttributeKeyDiskIoDirection},
 		},
 		OracledbRedoSize: OracledbRedoSizeMetricConfig{
 			Enabled: false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1111,46 +1111,6 @@ func (ms *OracledbRedoBlocksMetricConfig) Validate() error {
 	return nil
 }
 
-// OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation_retries metric.
-type OracledbRedoBufferAllocationRetriesMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *OracledbRedoBufferAllocationRetriesMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
-// OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space_requests metric.
-type OracledbRedoLogSpaceRequestsMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *OracledbRedoLogSpaceRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
 // OracledbRedoOperationsMetricAttributeKey specifies the key of an attribute for the oracledb.redo.operations metric.
 type OracledbRedoOperationsMetricAttributeKey string
 
@@ -1187,6 +1147,102 @@ func (ms *OracledbRedoOperationsMetricConfig) Validate() error {
 		case OracledbRedoOperationsMetricAttributeKeyDiskIoDirection:
 		default:
 			return fmt.Errorf("metric oracledb.redo.operations doesn't have an attribute %v, valid attributes: [disk.io.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbRedoRequestsMetricAttributeKey specifies the key of an attribute for the oracledb.redo.requests metric.
+type OracledbRedoRequestsMetricAttributeKey string
+
+const (
+	OracledbRedoRequestsMetricAttributeKeyOracledbRedoRequestType OracledbRedoRequestsMetricAttributeKey = "oracledb.redo.request.type"
+)
+
+// OracledbRedoRequestsMetricConfig provides config for the oracledb.redo.requests metric.
+type OracledbRedoRequestsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbRedoRequestsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbRedoRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbRedoRequestsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbRedoRequestsMetricAttributeKeyOracledbRedoRequestType:
+		default:
+			return fmt.Errorf("metric oracledb.redo.requests doesn't have an attribute %v, valid attributes: [oracledb.redo.request.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbRedoRetriesMetricAttributeKey specifies the key of an attribute for the oracledb.redo.retries metric.
+type OracledbRedoRetriesMetricAttributeKey string
+
+const (
+	OracledbRedoRetriesMetricAttributeKeyOracledbRedoRetryType OracledbRedoRetriesMetricAttributeKey = "oracledb.redo.retry.type"
+)
+
+// OracledbRedoRetriesMetricConfig provides config for the oracledb.redo.retries metric.
+type OracledbRedoRetriesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbRedoRetriesMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbRedoRetriesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbRedoRetriesMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbRedoRetriesMetricAttributeKeyOracledbRedoRetryType:
+		default:
+			return fmt.Errorf("metric oracledb.redo.retries doesn't have an attribute %v, valid attributes: [oracledb.redo.retry.type]", val)
 		}
 	}
 
@@ -1759,9 +1815,9 @@ type MetricsConfig struct {
 	OracledbQueriesParallelized                   OracledbQueriesParallelizedMetricConfig                   `mapstructure:"oracledb.queries_parallelized"`
 	OracledbRecycleBinLimit                       OracledbRecycleBinLimitMetricConfig                       `mapstructure:"oracledb.recycle_bin.limit"`
 	OracledbRedoBlocks                            OracledbRedoBlocksMetricConfig                            `mapstructure:"oracledb.redo.blocks"`
-	OracledbRedoBufferAllocationRetries           OracledbRedoBufferAllocationRetriesMetricConfig           `mapstructure:"oracledb.redo.buffer_allocation_retries"`
-	OracledbRedoLogSpaceRequests                  OracledbRedoLogSpaceRequestsMetricConfig                  `mapstructure:"oracledb.redo.log_space_requests"`
 	OracledbRedoOperations                        OracledbRedoOperationsMetricConfig                        `mapstructure:"oracledb.redo.operations"`
+	OracledbRedoRequests                          OracledbRedoRequestsMetricConfig                          `mapstructure:"oracledb.redo.requests"`
+	OracledbRedoRetries                           OracledbRedoRetriesMetricConfig                           `mapstructure:"oracledb.redo.retries"`
 	OracledbRedoSize                              OracledbRedoSizeMetricConfig                              `mapstructure:"oracledb.redo.size"`
 	OracledbRedoTime                              OracledbRedoTimeMetricConfig                              `mapstructure:"oracledb.redo.time"`
 	OracledbRedoAllocationUtilization             OracledbRedoAllocationUtilizationMetricConfig             `mapstructure:"oracledb.redo_allocation.utilization"`
@@ -1937,16 +1993,20 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []OracledbRedoBlocksMetricAttributeKey{OracledbRedoBlocksMetricAttributeKeyDiskIoDirection},
 		},
-		OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
-			Enabled: false,
-		},
-		OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
-			Enabled: false,
-		},
 		OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []OracledbRedoOperationsMetricAttributeKey{OracledbRedoOperationsMetricAttributeKeyDiskIoDirection},
+		},
+		OracledbRedoRequests: OracledbRedoRequestsMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []OracledbRedoRequestsMetricAttributeKey{OracledbRedoRequestsMetricAttributeKeyOracledbRedoRequestType},
+		},
+		OracledbRedoRetries: OracledbRedoRetriesMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []OracledbRedoRetriesMetricAttributeKey{OracledbRedoRetriesMetricAttributeKeyOracledbRedoRetryType},
 		},
 		OracledbRedoSize: OracledbRedoSizeMetricConfig{
 			Enabled: false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1063,13 +1063,13 @@ func (ms *OracledbRecycleBinLimitMetricConfig) Unmarshal(parser *confmap.Conf) e
 	return nil
 }
 
-// OracledbRedoBlocksWrittenMetricConfig provides config for the oracledb.redo.blocks_written metric.
-type OracledbRedoBlocksWrittenMetricConfig struct {
+// OracledbRedoBlocksMetricConfig provides config for the oracledb.redo.blocks metric.
+type OracledbRedoBlocksMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 }
 
-func (ms *OracledbRedoBlocksWrittenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OracledbRedoBlocksMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1130,6 +1130,26 @@ type OracledbRedoLogSwitchInterruptsMetricConfig struct {
 }
 
 func (ms *OracledbRedoLogSwitchInterruptsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbRedoOperationsMetricConfig provides config for the oracledb.redo.operations metric.
+type OracledbRedoOperationsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoOperationsMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1208,26 +1228,6 @@ func (ms *OracledbRedoTimeMetricConfig) Validate() error {
 		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
 	}
 
-	return nil
-}
-
-// OracledbRedoWritesMetricConfig provides config for the oracledb.redo.writes metric.
-type OracledbRedoWritesMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *OracledbRedoWritesMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -1722,13 +1722,13 @@ type MetricsConfig struct {
 	OracledbProcessesUsage                        OracledbProcessesUsageMetricConfig                        `mapstructure:"oracledb.processes.usage"`
 	OracledbQueriesParallelized                   OracledbQueriesParallelizedMetricConfig                   `mapstructure:"oracledb.queries_parallelized"`
 	OracledbRecycleBinLimit                       OracledbRecycleBinLimitMetricConfig                       `mapstructure:"oracledb.recycle_bin.limit"`
-	OracledbRedoBlocksWritten                     OracledbRedoBlocksWrittenMetricConfig                     `mapstructure:"oracledb.redo.blocks_written"`
+	OracledbRedoBlocks                            OracledbRedoBlocksMetricConfig                            `mapstructure:"oracledb.redo.blocks"`
 	OracledbRedoBufferAllocationRetries           OracledbRedoBufferAllocationRetriesMetricConfig           `mapstructure:"oracledb.redo.buffer_allocation.retries"`
 	OracledbRedoLogSpaceRequests                  OracledbRedoLogSpaceRequestsMetricConfig                  `mapstructure:"oracledb.redo.log_space.requests"`
 	OracledbRedoLogSwitchInterrupts               OracledbRedoLogSwitchInterruptsMetricConfig               `mapstructure:"oracledb.redo.log_switch.interrupts"`
+	OracledbRedoOperations                        OracledbRedoOperationsMetricConfig                        `mapstructure:"oracledb.redo.operations"`
 	OracledbRedoSize                              OracledbRedoSizeMetricConfig                              `mapstructure:"oracledb.redo.size"`
 	OracledbRedoTime                              OracledbRedoTimeMetricConfig                              `mapstructure:"oracledb.redo.time"`
-	OracledbRedoWrites                            OracledbRedoWritesMetricConfig                            `mapstructure:"oracledb.redo.writes"`
 	OracledbRedoAllocationUtilization             OracledbRedoAllocationUtilizationMetricConfig             `mapstructure:"oracledb.redo_allocation.utilization"`
 	OracledbSessionsLimit                         OracledbSessionsLimitMetricConfig                         `mapstructure:"oracledb.sessions.limit"`
 	OracledbSessionsUsage                         OracledbSessionsUsageMetricConfig                         `mapstructure:"oracledb.sessions.usage"`
@@ -1897,7 +1897,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbRecycleBinLimit: OracledbRecycleBinLimitMetricConfig{
 			Enabled: false,
 		},
-		OracledbRedoBlocksWritten: OracledbRedoBlocksWrittenMetricConfig{
+		OracledbRedoBlocks: OracledbRedoBlocksMetricConfig{
 			Enabled: false,
 		},
 		OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
@@ -1909,6 +1909,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
 			Enabled: false,
 		},
+		OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
+			Enabled: false,
+		},
 		OracledbRedoSize: OracledbRedoSizeMetricConfig{
 			Enabled: false,
 		},
@@ -1916,9 +1919,6 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
-		},
-		OracledbRedoWrites: OracledbRedoWritesMetricConfig{
-			Enabled: false,
 		},
 		OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 			Enabled: false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -1063,6 +1063,174 @@ func (ms *OracledbRecycleBinLimitMetricConfig) Unmarshal(parser *confmap.Conf) e
 	return nil
 }
 
+// OracledbRedoBlocksWrittenMetricConfig provides config for the oracledb.redo.blocks_written metric.
+type OracledbRedoBlocksWrittenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoBlocksWrittenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbRedoBufferAllocationRetriesMetricConfig provides config for the oracledb.redo.buffer_allocation.retries metric.
+type OracledbRedoBufferAllocationRetriesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoBufferAllocationRetriesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbRedoLogSpaceRequestsMetricConfig provides config for the oracledb.redo.log_space.requests metric.
+type OracledbRedoLogSpaceRequestsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoLogSpaceRequestsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbRedoLogSwitchInterruptsMetricConfig provides config for the oracledb.redo.log_switch.interrupts metric.
+type OracledbRedoLogSwitchInterruptsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoLogSwitchInterruptsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbRedoSizeMetricConfig provides config for the oracledb.redo.size metric.
+type OracledbRedoSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbRedoTimeMetricAttributeKey specifies the key of an attribute for the oracledb.redo.time metric.
+type OracledbRedoTimeMetricAttributeKey string
+
+const (
+	OracledbRedoTimeMetricAttributeKeyOracledbRedoKind OracledbRedoTimeMetricAttributeKey = "oracledb.redo.kind"
+)
+
+// OracledbRedoTimeMetricConfig provides config for the oracledb.redo.time metric.
+type OracledbRedoTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbRedoTimeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbRedoTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbRedoTimeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbRedoTimeMetricAttributeKeyOracledbRedoKind:
+		default:
+			return fmt.Errorf("metric oracledb.redo.time doesn't have an attribute %v, valid attributes: [oracledb.redo.kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbRedoWritesMetricConfig provides config for the oracledb.redo.writes metric.
+type OracledbRedoWritesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbRedoWritesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // OracledbRedoAllocationUtilizationMetricConfig provides config for the oracledb.redo_allocation.utilization metric.
 type OracledbRedoAllocationUtilizationMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -1554,6 +1722,13 @@ type MetricsConfig struct {
 	OracledbProcessesUsage                        OracledbProcessesUsageMetricConfig                        `mapstructure:"oracledb.processes.usage"`
 	OracledbQueriesParallelized                   OracledbQueriesParallelizedMetricConfig                   `mapstructure:"oracledb.queries_parallelized"`
 	OracledbRecycleBinLimit                       OracledbRecycleBinLimitMetricConfig                       `mapstructure:"oracledb.recycle_bin.limit"`
+	OracledbRedoBlocksWritten                     OracledbRedoBlocksWrittenMetricConfig                     `mapstructure:"oracledb.redo.blocks_written"`
+	OracledbRedoBufferAllocationRetries           OracledbRedoBufferAllocationRetriesMetricConfig           `mapstructure:"oracledb.redo.buffer_allocation.retries"`
+	OracledbRedoLogSpaceRequests                  OracledbRedoLogSpaceRequestsMetricConfig                  `mapstructure:"oracledb.redo.log_space.requests"`
+	OracledbRedoLogSwitchInterrupts               OracledbRedoLogSwitchInterruptsMetricConfig               `mapstructure:"oracledb.redo.log_switch.interrupts"`
+	OracledbRedoSize                              OracledbRedoSizeMetricConfig                              `mapstructure:"oracledb.redo.size"`
+	OracledbRedoTime                              OracledbRedoTimeMetricConfig                              `mapstructure:"oracledb.redo.time"`
+	OracledbRedoWrites                            OracledbRedoWritesMetricConfig                            `mapstructure:"oracledb.redo.writes"`
 	OracledbRedoAllocationUtilization             OracledbRedoAllocationUtilizationMetricConfig             `mapstructure:"oracledb.redo_allocation.utilization"`
 	OracledbSessionsLimit                         OracledbSessionsLimitMetricConfig                         `mapstructure:"oracledb.sessions.limit"`
 	OracledbSessionsUsage                         OracledbSessionsUsageMetricConfig                         `mapstructure:"oracledb.sessions.usage"`
@@ -1720,6 +1895,29 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		OracledbRecycleBinLimit: OracledbRecycleBinLimitMetricConfig{
+			Enabled: false,
+		},
+		OracledbRedoBlocksWritten: OracledbRedoBlocksWrittenMetricConfig{
+			Enabled: false,
+		},
+		OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
+			Enabled: false,
+		},
+		OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
+			Enabled: false,
+		},
+		OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
+			Enabled: false,
+		},
+		OracledbRedoSize: OracledbRedoSizeMetricConfig{
+			Enabled: false,
+		},
+		OracledbRedoTime: OracledbRedoTimeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
+		},
+		OracledbRedoWrites: OracledbRedoWritesMetricConfig{
 			Enabled: false,
 		},
 		OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -197,7 +197,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRedoTime: OracledbRedoTimeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
+						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoType},
 					},
 					OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 						Enabled: true,
@@ -442,7 +442,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRedoTime: OracledbRedoTimeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
+						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoType},
 					},
 					OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 						Enabled: false,
@@ -599,7 +599,7 @@ func TestOracledbRedoTimeMetricsConfig_Validate(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cfg.EnabledAttributes = []OracledbRedoTimeMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.time doesn't have an attribute invalid, valid attributes: [oracledb.redo.kind]")
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.time doesn't have an attribute invalid, valid attributes: [oracledb.redo.type]")
 
 	cfg = DefaultMetricsConfig().OracledbRedoTime
 	cfg.AggregationStrategy = "invalid"

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -186,9 +186,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
 						Enabled: true,
 					},
-					OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
-						Enabled: true,
-					},
 					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -434,9 +431,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
 						Enabled: false,
 					},
-					OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
-						Enabled: false,
-					},
 					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -522,7 +516,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoBufferAllocationRetriesMetricConfig{}, OracledbRedoLogSpaceRequestsMetricConfig{}, OracledbRedoLogSwitchInterruptsMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoBufferAllocationRetriesMetricConfig{}, OracledbRedoLogSpaceRequestsMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -572,6 +566,42 @@ func TestOracledbPhysicalIoTransferredMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric oracledb.physical_io.transferred doesn't have an attribute invalid, valid attributes: [disk.io.direction, disk.io.type]")
 
 	cfg = DefaultMetricsConfig().OracledbPhysicalIoTransferred
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbRedoBlocksMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbRedoBlocks
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbRedoBlocksMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.blocks doesn't have an attribute invalid, valid attributes: [disk.io.direction]")
+
+	cfg = DefaultMetricsConfig().OracledbRedoBlocks
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbRedoOperationsMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbRedoOperations
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbRedoOperationsMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.operations doesn't have an attribute invalid, valid attributes: [disk.io.direction]")
+
+	cfg = DefaultMetricsConfig().OracledbRedoOperations
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbRedoTimeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbRedoTime
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbRedoTimeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.time doesn't have an attribute invalid, valid attributes: [oracledb.redo.kind]")
+
+	cfg = DefaultMetricsConfig().OracledbRedoTime
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -175,6 +175,29 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRecycleBinLimit: OracledbRecycleBinLimitMetricConfig{
 						Enabled: true,
 					},
+					OracledbRedoBlocksWritten: OracledbRedoBlocksWrittenMetricConfig{
+						Enabled: true,
+					},
+					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
+						Enabled: true,
+					},
+					OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
+						Enabled: true,
+					},
+					OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
+						Enabled: true,
+					},
+					OracledbRedoSize: OracledbRedoSizeMetricConfig{
+						Enabled: true,
+					},
+					OracledbRedoTime: OracledbRedoTimeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
+					},
+					OracledbRedoWrites: OracledbRedoWritesMetricConfig{
+						Enabled: true,
+					},
 					OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 						Enabled: true,
 					},
@@ -396,6 +419,29 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRecycleBinLimit: OracledbRecycleBinLimitMetricConfig{
 						Enabled: false,
 					},
+					OracledbRedoBlocksWritten: OracledbRedoBlocksWrittenMetricConfig{
+						Enabled: false,
+					},
+					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
+						Enabled: false,
+					},
+					OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
+						Enabled: false,
+					},
+					OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
+						Enabled: false,
+					},
+					OracledbRedoSize: OracledbRedoSizeMetricConfig{
+						Enabled: false,
+					},
+					OracledbRedoTime: OracledbRedoTimeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
+					},
+					OracledbRedoWrites: OracledbRedoWritesMetricConfig{
+						Enabled: false,
+					},
 					OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 						Enabled: false,
 					},
@@ -468,7 +514,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksWrittenMetricConfig{}, OracledbRedoBufferAllocationRetriesMetricConfig{}, OracledbRedoLogSpaceRequestsMetricConfig{}, OracledbRedoLogSwitchInterruptsMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoWritesMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -176,7 +176,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: true,
 					},
 					OracledbRedoBlocks: OracledbRedoBlocksMetricConfig{
-						Enabled: true,
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoBlocksMetricAttributeKey{OracledbRedoBlocksMetricAttributeKeyDiskIoDirection},
 					},
 					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
 						Enabled: true,
@@ -188,7 +190,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: true,
 					},
 					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
-						Enabled: true,
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoOperationsMetricAttributeKey{OracledbRedoOperationsMetricAttributeKeyDiskIoDirection},
 					},
 					OracledbRedoSize: OracledbRedoSizeMetricConfig{
 						Enabled: true,
@@ -420,7 +424,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: false,
 					},
 					OracledbRedoBlocks: OracledbRedoBlocksMetricConfig{
-						Enabled: false,
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoBlocksMetricAttributeKey{OracledbRedoBlocksMetricAttributeKeyDiskIoDirection},
 					},
 					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
 						Enabled: false,
@@ -432,7 +438,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: false,
 					},
 					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
-						Enabled: false,
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoOperationsMetricAttributeKey{OracledbRedoOperationsMetricAttributeKeyDiskIoDirection},
 					},
 					OracledbRedoSize: OracledbRedoSizeMetricConfig{
 						Enabled: false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -175,7 +175,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRecycleBinLimit: OracledbRecycleBinLimitMetricConfig{
 						Enabled: true,
 					},
-					OracledbRedoBlocksWritten: OracledbRedoBlocksWrittenMetricConfig{
+					OracledbRedoBlocks: OracledbRedoBlocksMetricConfig{
 						Enabled: true,
 					},
 					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
@@ -187,6 +187,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
 						Enabled: true,
 					},
+					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
+						Enabled: true,
+					},
 					OracledbRedoSize: OracledbRedoSizeMetricConfig{
 						Enabled: true,
 					},
@@ -194,9 +197,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
-					},
-					OracledbRedoWrites: OracledbRedoWritesMetricConfig{
-						Enabled: true,
 					},
 					OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 						Enabled: true,
@@ -419,7 +419,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRecycleBinLimit: OracledbRecycleBinLimitMetricConfig{
 						Enabled: false,
 					},
-					OracledbRedoBlocksWritten: OracledbRedoBlocksWrittenMetricConfig{
+					OracledbRedoBlocks: OracledbRedoBlocksMetricConfig{
 						Enabled: false,
 					},
 					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
@@ -431,6 +431,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbRedoLogSwitchInterrupts: OracledbRedoLogSwitchInterruptsMetricConfig{
 						Enabled: false,
 					},
+					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
+						Enabled: false,
+					},
 					OracledbRedoSize: OracledbRedoSizeMetricConfig{
 						Enabled: false,
 					},
@@ -438,9 +441,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbRedoTimeMetricAttributeKey{OracledbRedoTimeMetricAttributeKeyOracledbRedoKind},
-					},
-					OracledbRedoWrites: OracledbRedoWritesMetricConfig{
-						Enabled: false,
 					},
 					OracledbRedoAllocationUtilization: OracledbRedoAllocationUtilizationMetricConfig{
 						Enabled: false,
@@ -514,7 +514,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksWrittenMetricConfig{}, OracledbRedoBufferAllocationRetriesMetricConfig{}, OracledbRedoLogSpaceRequestsMetricConfig{}, OracledbRedoLogSwitchInterruptsMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoWritesMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoBufferAllocationRetriesMetricConfig{}, OracledbRedoLogSpaceRequestsMetricConfig{}, OracledbRedoLogSwitchInterruptsMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -180,16 +180,20 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbRedoBlocksMetricAttributeKey{OracledbRedoBlocksMetricAttributeKeyDiskIoDirection},
 					},
-					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
-						Enabled: true,
-					},
-					OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
-						Enabled: true,
-					},
 					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbRedoOperationsMetricAttributeKey{OracledbRedoOperationsMetricAttributeKeyDiskIoDirection},
+					},
+					OracledbRedoRequests: OracledbRedoRequestsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoRequestsMetricAttributeKey{OracledbRedoRequestsMetricAttributeKeyOracledbRedoRequestType},
+					},
+					OracledbRedoRetries: OracledbRedoRetriesMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoRetriesMetricAttributeKey{OracledbRedoRetriesMetricAttributeKeyOracledbRedoRetryType},
 					},
 					OracledbRedoSize: OracledbRedoSizeMetricConfig{
 						Enabled: true,
@@ -425,16 +429,20 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbRedoBlocksMetricAttributeKey{OracledbRedoBlocksMetricAttributeKeyDiskIoDirection},
 					},
-					OracledbRedoBufferAllocationRetries: OracledbRedoBufferAllocationRetriesMetricConfig{
-						Enabled: false,
-					},
-					OracledbRedoLogSpaceRequests: OracledbRedoLogSpaceRequestsMetricConfig{
-						Enabled: false,
-					},
 					OracledbRedoOperations: OracledbRedoOperationsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbRedoOperationsMetricAttributeKey{OracledbRedoOperationsMetricAttributeKeyDiskIoDirection},
+					},
+					OracledbRedoRequests: OracledbRedoRequestsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoRequestsMetricAttributeKey{OracledbRedoRequestsMetricAttributeKeyOracledbRedoRequestType},
+					},
+					OracledbRedoRetries: OracledbRedoRetriesMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbRedoRetriesMetricAttributeKey{OracledbRedoRetriesMetricAttributeKeyOracledbRedoRetryType},
 					},
 					OracledbRedoSize: OracledbRedoSizeMetricConfig{
 						Enabled: false,
@@ -516,7 +524,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoBufferAllocationRetriesMetricConfig{}, OracledbRedoLogSpaceRequestsMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferCacheUtilizationMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -590,6 +598,30 @@ func TestOracledbRedoOperationsMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.operations doesn't have an attribute invalid, valid attributes: [disk.io.direction]")
 
 	cfg = DefaultMetricsConfig().OracledbRedoOperations
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbRedoRequestsMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbRedoRequests
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbRedoRequestsMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.requests doesn't have an attribute invalid, valid attributes: [oracledb.redo.request.type]")
+
+	cfg = DefaultMetricsConfig().OracledbRedoRequests
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbRedoRetriesMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbRedoRetries
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbRedoRetriesMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.redo.retries doesn't have an attribute invalid, valid attributes: [oracledb.redo.retry.type]")
+
+	cfg = DefaultMetricsConfig().OracledbRedoRetries
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -3119,29 +3119,63 @@ func newMetricOracledbRecycleBinLimit(cfg OracledbRecycleBinLimitMetricConfig) m
 }
 
 type metricOracledbRedoBlocks struct {
-	data     pmetric.Metric                 // data buffer for generated metric.
-	config   OracledbRedoBlocksMetricConfig // metric config provided by user.
-	capacity int                            // max observed number of data points added to the metric.
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        OracledbRedoBlocksMetricConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills oracledb.redo.blocks metric with initial data.
 func (m *metricOracledbRedoBlocks) init() {
 	m.data.SetName("oracledb.redo.blocks")
-	m.data.SetDescription("Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').")
+	m.data.SetDescription("Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').")
 	m.data.SetUnit("{blocks}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbRedoBlocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricOracledbRedoBlocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskIoDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbRedoBlocksMetricAttributeKeyDiskIoDirection) {
+		dp.Attributes().PutStr("disk.io.direction", diskIoDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3154,6 +3188,11 @@ func (m *metricOracledbRedoBlocks) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbRedoBlocks) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -3327,29 +3366,63 @@ func newMetricOracledbRedoLogSwitchInterrupts(cfg OracledbRedoLogSwitchInterrupt
 }
 
 type metricOracledbRedoOperations struct {
-	data     pmetric.Metric                     // data buffer for generated metric.
-	config   OracledbRedoOperationsMetricConfig // metric config provided by user.
-	capacity int                                // max observed number of data points added to the metric.
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        OracledbRedoOperationsMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []int64                            // slice containing number of aggregated datapoints at each index
 }
 
 // init fills oracledb.redo.operations metric with initial data.
 func (m *metricOracledbRedoOperations) init() {
 	m.data.SetName("oracledb.redo.operations")
-	m.data.SetDescription("Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').")
+	m.data.SetDescription("Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').")
 	m.data.SetUnit("{operations}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbRedoOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricOracledbRedoOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskIoDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbRedoOperationsMetricAttributeKeyDiskIoDirection) {
+		dp.Attributes().PutStr("disk.io.direction", diskIoDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3362,6 +3435,11 @@ func (m *metricOracledbRedoOperations) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbRedoOperations) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -5287,12 +5365,12 @@ func (mb *MetricsBuilder) RecordOracledbRecycleBinLimitDataPoint(ts pcommon.Time
 }
 
 // RecordOracledbRedoBlocksDataPoint adds a data point to oracledb.redo.blocks metric.
-func (mb *MetricsBuilder) RecordOracledbRedoBlocksDataPoint(ts pcommon.Timestamp, inputVal string) error {
+func (mb *MetricsBuilder) RecordOracledbRedoBlocksDataPoint(ts pcommon.Timestamp, inputVal string, diskIoDirectionAttributeValue AttributeDiskIoDirection) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse int64 for OracledbRedoBlocks, value was %s: %w", inputVal, err)
 	}
-	mb.metricOracledbRedoBlocks.recordDataPoint(mb.startTime, ts, val)
+	mb.metricOracledbRedoBlocks.recordDataPoint(mb.startTime, ts, val, diskIoDirectionAttributeValue.String())
 	return nil
 }
 
@@ -5327,12 +5405,12 @@ func (mb *MetricsBuilder) RecordOracledbRedoLogSwitchInterruptsDataPoint(ts pcom
 }
 
 // RecordOracledbRedoOperationsDataPoint adds a data point to oracledb.redo.operations metric.
-func (mb *MetricsBuilder) RecordOracledbRedoOperationsDataPoint(ts pcommon.Timestamp, inputVal string) error {
+func (mb *MetricsBuilder) RecordOracledbRedoOperationsDataPoint(ts pcommon.Timestamp, inputVal string, diskIoDirectionAttributeValue AttributeDiskIoDirection) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse int64 for OracledbRedoOperations, value was %s: %w", inputVal, err)
 	}
-	mb.metricOracledbRedoOperations.recordDataPoint(mb.startTime, ts, val)
+	mb.metricOracledbRedoOperations.recordDataPoint(mb.startTime, ts, val, diskIoDirectionAttributeValue.String())
 	return nil
 }
 

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -398,8 +398,8 @@ var MetricsInfo = metricsInfo{
 	OracledbRecycleBinLimit: metricInfo{
 		Name: "oracledb.recycle_bin.limit",
 	},
-	OracledbRedoBlocksWritten: metricInfo{
-		Name: "oracledb.redo.blocks_written",
+	OracledbRedoBlocks: metricInfo{
+		Name: "oracledb.redo.blocks",
 	},
 	OracledbRedoBufferAllocationRetries: metricInfo{
 		Name: "oracledb.redo.buffer_allocation.retries",
@@ -410,14 +410,14 @@ var MetricsInfo = metricsInfo{
 	OracledbRedoLogSwitchInterrupts: metricInfo{
 		Name: "oracledb.redo.log_switch.interrupts",
 	},
+	OracledbRedoOperations: metricInfo{
+		Name: "oracledb.redo.operations",
+	},
 	OracledbRedoSize: metricInfo{
 		Name: "oracledb.redo.size",
 	},
 	OracledbRedoTime: metricInfo{
 		Name: "oracledb.redo.time",
-	},
-	OracledbRedoWrites: metricInfo{
-		Name: "oracledb.redo.writes",
 	},
 	OracledbRedoAllocationUtilization: metricInfo{
 		Name: "oracledb.redo_allocation.utilization",
@@ -519,13 +519,13 @@ type metricsInfo struct {
 	OracledbProcessesUsage                        metricInfo
 	OracledbQueriesParallelized                   metricInfo
 	OracledbRecycleBinLimit                       metricInfo
-	OracledbRedoBlocksWritten                     metricInfo
+	OracledbRedoBlocks                            metricInfo
 	OracledbRedoBufferAllocationRetries           metricInfo
 	OracledbRedoLogSpaceRequests                  metricInfo
 	OracledbRedoLogSwitchInterrupts               metricInfo
+	OracledbRedoOperations                        metricInfo
 	OracledbRedoSize                              metricInfo
 	OracledbRedoTime                              metricInfo
-	OracledbRedoWrites                            metricInfo
 	OracledbRedoAllocationUtilization             metricInfo
 	OracledbSessionsLimit                         metricInfo
 	OracledbSessionsUsage                         metricInfo
@@ -3118,15 +3118,15 @@ func newMetricOracledbRecycleBinLimit(cfg OracledbRecycleBinLimitMetricConfig) m
 	return m
 }
 
-type metricOracledbRedoBlocksWritten struct {
-	data     pmetric.Metric                        // data buffer for generated metric.
-	config   OracledbRedoBlocksWrittenMetricConfig // metric config provided by user.
-	capacity int                                   // max observed number of data points added to the metric.
+type metricOracledbRedoBlocks struct {
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   OracledbRedoBlocksMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
 }
 
-// init fills oracledb.redo.blocks_written metric with initial data.
-func (m *metricOracledbRedoBlocksWritten) init() {
-	m.data.SetName("oracledb.redo.blocks_written")
+// init fills oracledb.redo.blocks metric with initial data.
+func (m *metricOracledbRedoBlocks) init() {
+	m.data.SetName("oracledb.redo.blocks")
 	m.data.SetDescription("Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').")
 	m.data.SetUnit("{blocks}")
 	m.data.SetEmptySum()
@@ -3134,7 +3134,7 @@ func (m *metricOracledbRedoBlocksWritten) init() {
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 }
 
-func (m *metricOracledbRedoBlocksWritten) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricOracledbRedoBlocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.config.Enabled {
 		return
 	}
@@ -3145,14 +3145,14 @@ func (m *metricOracledbRedoBlocksWritten) recordDataPoint(start pcommon.Timestam
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbRedoBlocksWritten) updateCapacity() {
+func (m *metricOracledbRedoBlocks) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbRedoBlocksWritten) emit(metrics pmetric.MetricSlice) {
+func (m *metricOracledbRedoBlocks) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -3160,8 +3160,8 @@ func (m *metricOracledbRedoBlocksWritten) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOracledbRedoBlocksWritten(cfg OracledbRedoBlocksWrittenMetricConfig) metricOracledbRedoBlocksWritten {
-	m := metricOracledbRedoBlocksWritten{config: cfg}
+func newMetricOracledbRedoBlocks(cfg OracledbRedoBlocksMetricConfig) metricOracledbRedoBlocks {
+	m := metricOracledbRedoBlocks{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3326,6 +3326,58 @@ func newMetricOracledbRedoLogSwitchInterrupts(cfg OracledbRedoLogSwitchInterrupt
 	return m
 }
 
+type metricOracledbRedoOperations struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   OracledbRedoOperationsMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.operations metric with initial data.
+func (m *metricOracledbRedoOperations) init() {
+	m.data.SetName("oracledb.redo.operations")
+	m.data.SetDescription("Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').")
+	m.data.SetUnit("{operations}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoOperations) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoOperations) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoOperations(cfg OracledbRedoOperationsMetricConfig) metricOracledbRedoOperations {
+	m := metricOracledbRedoOperations{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbRedoSize struct {
 	data     pmetric.Metric               // data buffer for generated metric.
 	config   OracledbRedoSizeMetricConfig // metric config provided by user.
@@ -3461,58 +3513,6 @@ func (m *metricOracledbRedoTime) emit(metrics pmetric.MetricSlice) {
 
 func newMetricOracledbRedoTime(cfg OracledbRedoTimeMetricConfig) metricOracledbRedoTime {
 	m := metricOracledbRedoTime{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricOracledbRedoWrites struct {
-	data     pmetric.Metric                 // data buffer for generated metric.
-	config   OracledbRedoWritesMetricConfig // metric config provided by user.
-	capacity int                            // max observed number of data points added to the metric.
-}
-
-// init fills oracledb.redo.writes metric with initial data.
-func (m *metricOracledbRedoWrites) init() {
-	m.data.SetName("oracledb.redo.writes")
-	m.data.SetDescription("Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').")
-	m.data.SetUnit("{writes}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricOracledbRedoWrites) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbRedoWrites) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbRedoWrites) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricOracledbRedoWrites(cfg OracledbRedoWritesMetricConfig) metricOracledbRedoWrites {
-	m := metricOracledbRedoWrites{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4535,13 +4535,13 @@ type MetricsBuilder struct {
 	metricOracledbProcessesUsage                        metricOracledbProcessesUsage
 	metricOracledbQueriesParallelized                   metricOracledbQueriesParallelized
 	metricOracledbRecycleBinLimit                       metricOracledbRecycleBinLimit
-	metricOracledbRedoBlocksWritten                     metricOracledbRedoBlocksWritten
+	metricOracledbRedoBlocks                            metricOracledbRedoBlocks
 	metricOracledbRedoBufferAllocationRetries           metricOracledbRedoBufferAllocationRetries
 	metricOracledbRedoLogSpaceRequests                  metricOracledbRedoLogSpaceRequests
 	metricOracledbRedoLogSwitchInterrupts               metricOracledbRedoLogSwitchInterrupts
+	metricOracledbRedoOperations                        metricOracledbRedoOperations
 	metricOracledbRedoSize                              metricOracledbRedoSize
 	metricOracledbRedoTime                              metricOracledbRedoTime
-	metricOracledbRedoWrites                            metricOracledbRedoWrites
 	metricOracledbRedoAllocationUtilization             metricOracledbRedoAllocationUtilization
 	metricOracledbSessionsLimit                         metricOracledbSessionsLimit
 	metricOracledbSessionsUsage                         metricOracledbSessionsUsage
@@ -4629,13 +4629,13 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbProcessesUsage:                        newMetricOracledbProcessesUsage(mbc.Metrics.OracledbProcessesUsage),
 		metricOracledbQueriesParallelized:                   newMetricOracledbQueriesParallelized(mbc.Metrics.OracledbQueriesParallelized),
 		metricOracledbRecycleBinLimit:                       newMetricOracledbRecycleBinLimit(mbc.Metrics.OracledbRecycleBinLimit),
-		metricOracledbRedoBlocksWritten:                     newMetricOracledbRedoBlocksWritten(mbc.Metrics.OracledbRedoBlocksWritten),
+		metricOracledbRedoBlocks:                            newMetricOracledbRedoBlocks(mbc.Metrics.OracledbRedoBlocks),
 		metricOracledbRedoBufferAllocationRetries:           newMetricOracledbRedoBufferAllocationRetries(mbc.Metrics.OracledbRedoBufferAllocationRetries),
 		metricOracledbRedoLogSpaceRequests:                  newMetricOracledbRedoLogSpaceRequests(mbc.Metrics.OracledbRedoLogSpaceRequests),
 		metricOracledbRedoLogSwitchInterrupts:               newMetricOracledbRedoLogSwitchInterrupts(mbc.Metrics.OracledbRedoLogSwitchInterrupts),
+		metricOracledbRedoOperations:                        newMetricOracledbRedoOperations(mbc.Metrics.OracledbRedoOperations),
 		metricOracledbRedoSize:                              newMetricOracledbRedoSize(mbc.Metrics.OracledbRedoSize),
 		metricOracledbRedoTime:                              newMetricOracledbRedoTime(mbc.Metrics.OracledbRedoTime),
-		metricOracledbRedoWrites:                            newMetricOracledbRedoWrites(mbc.Metrics.OracledbRedoWrites),
 		metricOracledbRedoAllocationUtilization:             newMetricOracledbRedoAllocationUtilization(mbc.Metrics.OracledbRedoAllocationUtilization),
 		metricOracledbSessionsLimit:                         newMetricOracledbSessionsLimit(mbc.Metrics.OracledbSessionsLimit),
 		metricOracledbSessionsUsage:                         newMetricOracledbSessionsUsage(mbc.Metrics.OracledbSessionsUsage),
@@ -4818,13 +4818,13 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbProcessesUsage.emit(ils.Metrics())
 	mb.metricOracledbQueriesParallelized.emit(ils.Metrics())
 	mb.metricOracledbRecycleBinLimit.emit(ils.Metrics())
-	mb.metricOracledbRedoBlocksWritten.emit(ils.Metrics())
+	mb.metricOracledbRedoBlocks.emit(ils.Metrics())
 	mb.metricOracledbRedoBufferAllocationRetries.emit(ils.Metrics())
 	mb.metricOracledbRedoLogSpaceRequests.emit(ils.Metrics())
 	mb.metricOracledbRedoLogSwitchInterrupts.emit(ils.Metrics())
+	mb.metricOracledbRedoOperations.emit(ils.Metrics())
 	mb.metricOracledbRedoSize.emit(ils.Metrics())
 	mb.metricOracledbRedoTime.emit(ils.Metrics())
-	mb.metricOracledbRedoWrites.emit(ils.Metrics())
 	mb.metricOracledbRedoAllocationUtilization.emit(ils.Metrics())
 	mb.metricOracledbSessionsLimit.emit(ils.Metrics())
 	mb.metricOracledbSessionsUsage.emit(ils.Metrics())
@@ -5286,13 +5286,13 @@ func (mb *MetricsBuilder) RecordOracledbRecycleBinLimitDataPoint(ts pcommon.Time
 	mb.metricOracledbRecycleBinLimit.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordOracledbRedoBlocksWrittenDataPoint adds a data point to oracledb.redo.blocks_written metric.
-func (mb *MetricsBuilder) RecordOracledbRedoBlocksWrittenDataPoint(ts pcommon.Timestamp, inputVal string) error {
+// RecordOracledbRedoBlocksDataPoint adds a data point to oracledb.redo.blocks metric.
+func (mb *MetricsBuilder) RecordOracledbRedoBlocksDataPoint(ts pcommon.Timestamp, inputVal string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
-		return fmt.Errorf("failed to parse int64 for OracledbRedoBlocksWritten, value was %s: %w", inputVal, err)
+		return fmt.Errorf("failed to parse int64 for OracledbRedoBlocks, value was %s: %w", inputVal, err)
 	}
-	mb.metricOracledbRedoBlocksWritten.recordDataPoint(mb.startTime, ts, val)
+	mb.metricOracledbRedoBlocks.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 
@@ -5326,6 +5326,16 @@ func (mb *MetricsBuilder) RecordOracledbRedoLogSwitchInterruptsDataPoint(ts pcom
 	return nil
 }
 
+// RecordOracledbRedoOperationsDataPoint adds a data point to oracledb.redo.operations metric.
+func (mb *MetricsBuilder) RecordOracledbRedoOperationsDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoOperations, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoOperations.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
 // RecordOracledbRedoSizeDataPoint adds a data point to oracledb.redo.size metric.
 func (mb *MetricsBuilder) RecordOracledbRedoSizeDataPoint(ts pcommon.Timestamp, inputVal string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -5339,16 +5349,6 @@ func (mb *MetricsBuilder) RecordOracledbRedoSizeDataPoint(ts pcommon.Timestamp, 
 // RecordOracledbRedoTimeDataPoint adds a data point to oracledb.redo.time metric.
 func (mb *MetricsBuilder) RecordOracledbRedoTimeDataPoint(ts pcommon.Timestamp, val float64, oracledbRedoKindAttributeValue AttributeOracledbRedoKind) {
 	mb.metricOracledbRedoTime.recordDataPoint(mb.startTime, ts, val, oracledbRedoKindAttributeValue.String())
-}
-
-// RecordOracledbRedoWritesDataPoint adds a data point to oracledb.redo.writes metric.
-func (mb *MetricsBuilder) RecordOracledbRedoWritesDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for OracledbRedoWrites, value was %s: %w", inputVal, err)
-	}
-	mb.metricOracledbRedoWrites.recordDataPoint(mb.startTime, ts, val)
-	return nil
 }
 
 // RecordOracledbRedoAllocationUtilizationDataPoint adds a data point to oracledb.redo_allocation.utilization metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -247,7 +247,7 @@ const (
 	_ AttributeOracledbRedoType = iota
 	AttributeOracledbRedoTypeWrite
 	AttributeOracledbRedoTypeLogSpaceWait
-	AttributeOracledbRedoTypeSynch
+	AttributeOracledbRedoTypeSync
 )
 
 // String returns the string representation of the AttributeOracledbRedoType.
@@ -257,8 +257,8 @@ func (av AttributeOracledbRedoType) String() string {
 		return "write"
 	case AttributeOracledbRedoTypeLogSpaceWait:
 		return "log_space_wait"
-	case AttributeOracledbRedoTypeSynch:
-		return "synch"
+	case AttributeOracledbRedoTypeSync:
+		return "sync"
 	}
 	return ""
 }
@@ -267,7 +267,7 @@ func (av AttributeOracledbRedoType) String() string {
 var MapAttributeOracledbRedoType = map[string]AttributeOracledbRedoType{
 	"write":          AttributeOracledbRedoTypeWrite,
 	"log_space_wait": AttributeOracledbRedoTypeLogSpaceWait,
-	"synch":          AttributeOracledbRedoTypeSynch,
+	"sync":           AttributeOracledbRedoTypeSync,
 }
 
 // AttributeOracledbSortType specifies the value oracledb.sort.type attribute.
@@ -3169,7 +3169,7 @@ type metricOracledbRedoBlocks struct {
 // init fills oracledb.redo.blocks metric with initial data.
 func (m *metricOracledbRedoBlocks) init() {
 	m.data.SetName("oracledb.redo.blocks")
-	m.data.SetDescription("Number of redo blocks moved between the redo log and storage, by I/O direction.")
+	m.data.SetDescription("Number of redo blocks moved between the redo log and storage.")
 	m.data.SetUnit("{block}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -3260,7 +3260,7 @@ type metricOracledbRedoOperations struct {
 // init fills oracledb.redo.operations metric with initial data.
 func (m *metricOracledbRedoOperations) init() {
 	m.data.SetName("oracledb.redo.operations")
-	m.data.SetDescription("Number of redo I/O operations, by I/O direction.")
+	m.data.SetDescription("Number of redo I/O operations.")
 	m.data.SetUnit("{operation}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -196,34 +196,34 @@ var MapAttributeOracledbParseType = map[string]AttributeOracledbParseType{
 	"soft": AttributeOracledbParseTypeSoft,
 }
 
-// AttributeOracledbRedoKind specifies the value oracledb.redo.kind attribute.
-type AttributeOracledbRedoKind int
+// AttributeOracledbRedoType specifies the value oracledb.redo.type attribute.
+type AttributeOracledbRedoType int
 
 const (
-	_ AttributeOracledbRedoKind = iota
-	AttributeOracledbRedoKindWrite
-	AttributeOracledbRedoKindLogSpaceWait
-	AttributeOracledbRedoKindSynch
+	_ AttributeOracledbRedoType = iota
+	AttributeOracledbRedoTypeWrite
+	AttributeOracledbRedoTypeLogSpaceWait
+	AttributeOracledbRedoTypeSynch
 )
 
-// String returns the string representation of the AttributeOracledbRedoKind.
-func (av AttributeOracledbRedoKind) String() string {
+// String returns the string representation of the AttributeOracledbRedoType.
+func (av AttributeOracledbRedoType) String() string {
 	switch av {
-	case AttributeOracledbRedoKindWrite:
+	case AttributeOracledbRedoTypeWrite:
 		return "write"
-	case AttributeOracledbRedoKindLogSpaceWait:
+	case AttributeOracledbRedoTypeLogSpaceWait:
 		return "log_space_wait"
-	case AttributeOracledbRedoKindSynch:
+	case AttributeOracledbRedoTypeSynch:
 		return "synch"
 	}
 	return ""
 }
 
-// MapAttributeOracledbRedoKind is a helper map of string to AttributeOracledbRedoKind attribute value.
-var MapAttributeOracledbRedoKind = map[string]AttributeOracledbRedoKind{
-	"write":          AttributeOracledbRedoKindWrite,
-	"log_space_wait": AttributeOracledbRedoKindLogSpaceWait,
-	"synch":          AttributeOracledbRedoKindSynch,
+// MapAttributeOracledbRedoType is a helper map of string to AttributeOracledbRedoType attribute value.
+var MapAttributeOracledbRedoType = map[string]AttributeOracledbRedoType{
+	"write":          AttributeOracledbRedoTypeWrite,
+	"log_space_wait": AttributeOracledbRedoTypeLogSpaceWait,
+	"synch":          AttributeOracledbRedoTypeSynch,
 }
 
 // AttributeOracledbSortType specifies the value oracledb.sort.type attribute.
@@ -399,10 +399,10 @@ var MetricsInfo = metricsInfo{
 		Attributes: []string{"disk.io.direction"},
 	},
 	OracledbRedoBufferAllocationRetries: metricInfo{
-		Name: "oracledb.redo.buffer_allocation.retries",
+		Name: "oracledb.redo.buffer_allocation_retries",
 	},
 	OracledbRedoLogSpaceRequests: metricInfo{
-		Name: "oracledb.redo.log_space.requests",
+		Name: "oracledb.redo.log_space_requests",
 	},
 	OracledbRedoOperations: metricInfo{
 		Name:       "oracledb.redo.operations",
@@ -413,7 +413,7 @@ var MetricsInfo = metricsInfo{
 	},
 	OracledbRedoTime: metricInfo{
 		Name:       "oracledb.redo.time",
-		Attributes: []string{"oracledb.redo.kind"},
+		Attributes: []string{"oracledb.redo.type"},
 	},
 	OracledbRedoAllocationUtilization: metricInfo{
 		Name: "oracledb.redo_allocation.utilization",
@@ -3123,8 +3123,8 @@ type metricOracledbRedoBlocks struct {
 // init fills oracledb.redo.blocks metric with initial data.
 func (m *metricOracledbRedoBlocks) init() {
 	m.data.SetName("oracledb.redo.blocks")
-	m.data.SetDescription("Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').")
-	m.data.SetUnit("{blocks}")
+	m.data.SetDescription("Number of redo blocks moved between the redo log and storage, by I/O direction.")
+	m.data.SetUnit("{block}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -3210,11 +3210,11 @@ type metricOracledbRedoBufferAllocationRetries struct {
 	capacity int                                             // max observed number of data points added to the metric.
 }
 
-// init fills oracledb.redo.buffer_allocation.retries metric with initial data.
+// init fills oracledb.redo.buffer_allocation_retries metric with initial data.
 func (m *metricOracledbRedoBufferAllocationRetries) init() {
-	m.data.SetName("oracledb.redo.buffer_allocation.retries")
-	m.data.SetDescription("Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.")
-	m.data.SetUnit("{retries}")
+	m.data.SetName("oracledb.redo.buffer_allocation_retries")
+	m.data.SetDescription("Number of times a process waited and retried to allocate space in the redo buffer.")
+	m.data.SetUnit("{retry}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -3262,11 +3262,11 @@ type metricOracledbRedoLogSpaceRequests struct {
 	capacity int                                      // max observed number of data points added to the metric.
 }
 
-// init fills oracledb.redo.log_space.requests metric with initial data.
+// init fills oracledb.redo.log_space_requests metric with initial data.
 func (m *metricOracledbRedoLogSpaceRequests) init() {
-	m.data.SetName("oracledb.redo.log_space.requests")
-	m.data.SetDescription("Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').")
-	m.data.SetUnit("{requests}")
+	m.data.SetName("oracledb.redo.log_space_requests")
+	m.data.SetDescription("Number of times a process requested space in the redo log buffer and had to wait.")
+	m.data.SetUnit("{request}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -3318,8 +3318,8 @@ type metricOracledbRedoOperations struct {
 // init fills oracledb.redo.operations metric with initial data.
 func (m *metricOracledbRedoOperations) init() {
 	m.data.SetName("oracledb.redo.operations")
-	m.data.SetDescription("Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').")
-	m.data.SetUnit("{operations}")
+	m.data.SetDescription("Number of redo I/O operations, by I/O direction.")
+	m.data.SetUnit("{operation}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -3408,7 +3408,7 @@ type metricOracledbRedoSize struct {
 // init fills oracledb.redo.size metric with initial data.
 func (m *metricOracledbRedoSize) init() {
 	m.data.SetName("oracledb.redo.size")
-	m.data.SetDescription("Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.")
+	m.data.SetDescription("Amount of redo generated.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -3461,7 +3461,7 @@ type metricOracledbRedoTime struct {
 // init fills oracledb.redo.time metric with initial data.
 func (m *metricOracledbRedoTime) init() {
 	m.data.SetName("oracledb.redo.time")
-	m.data.SetDescription("Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.")
+	m.data.SetDescription("Time spent in each phase of the redo pipeline.")
 	m.data.SetUnit("s")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -3470,7 +3470,7 @@ func (m *metricOracledbRedoTime) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbRedoTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, oracledbRedoKindAttributeValue string) {
+func (m *metricOracledbRedoTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, oracledbRedoTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -3478,8 +3478,8 @@ func (m *metricOracledbRedoTime) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbRedoTimeMetricAttributeKeyOracledbRedoKind) {
-		dp.Attributes().PutStr("oracledb.redo.kind", oracledbRedoKindAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, OracledbRedoTimeMetricAttributeKeyOracledbRedoType) {
+		dp.Attributes().PutStr("oracledb.redo.type", oracledbRedoTypeAttributeValue)
 	}
 
 	var s string
@@ -5314,7 +5314,7 @@ func (mb *MetricsBuilder) RecordOracledbRedoBlocksDataPoint(ts pcommon.Timestamp
 	return nil
 }
 
-// RecordOracledbRedoBufferAllocationRetriesDataPoint adds a data point to oracledb.redo.buffer_allocation.retries metric.
+// RecordOracledbRedoBufferAllocationRetriesDataPoint adds a data point to oracledb.redo.buffer_allocation_retries metric.
 func (mb *MetricsBuilder) RecordOracledbRedoBufferAllocationRetriesDataPoint(ts pcommon.Timestamp, inputVal string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
@@ -5324,7 +5324,7 @@ func (mb *MetricsBuilder) RecordOracledbRedoBufferAllocationRetriesDataPoint(ts 
 	return nil
 }
 
-// RecordOracledbRedoLogSpaceRequestsDataPoint adds a data point to oracledb.redo.log_space.requests metric.
+// RecordOracledbRedoLogSpaceRequestsDataPoint adds a data point to oracledb.redo.log_space_requests metric.
 func (mb *MetricsBuilder) RecordOracledbRedoLogSpaceRequestsDataPoint(ts pcommon.Timestamp, inputVal string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
@@ -5355,8 +5355,8 @@ func (mb *MetricsBuilder) RecordOracledbRedoSizeDataPoint(ts pcommon.Timestamp, 
 }
 
 // RecordOracledbRedoTimeDataPoint adds a data point to oracledb.redo.time metric.
-func (mb *MetricsBuilder) RecordOracledbRedoTimeDataPoint(ts pcommon.Timestamp, val float64, oracledbRedoKindAttributeValue AttributeOracledbRedoKind) {
-	mb.metricOracledbRedoTime.recordDataPoint(mb.startTime, ts, val, oracledbRedoKindAttributeValue.String())
+func (mb *MetricsBuilder) RecordOracledbRedoTimeDataPoint(ts pcommon.Timestamp, val float64, oracledbRedoTypeAttributeValue AttributeOracledbRedoType) {
+	mb.metricOracledbRedoTime.recordDataPoint(mb.startTime, ts, val, oracledbRedoTypeAttributeValue.String())
 }
 
 // RecordOracledbRedoAllocationUtilizationDataPoint adds a data point to oracledb.redo_allocation.utilization metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -196,6 +196,40 @@ var MapAttributeOracledbParseType = map[string]AttributeOracledbParseType{
 	"soft": AttributeOracledbParseTypeSoft,
 }
 
+// AttributeOracledbRedoKind specifies the value oracledb.redo.kind attribute.
+type AttributeOracledbRedoKind int
+
+const (
+	_ AttributeOracledbRedoKind = iota
+	AttributeOracledbRedoKindWrite
+	AttributeOracledbRedoKindLatching
+	AttributeOracledbRedoKindLogSpaceWait
+	AttributeOracledbRedoKindSynch
+)
+
+// String returns the string representation of the AttributeOracledbRedoKind.
+func (av AttributeOracledbRedoKind) String() string {
+	switch av {
+	case AttributeOracledbRedoKindWrite:
+		return "write"
+	case AttributeOracledbRedoKindLatching:
+		return "latching"
+	case AttributeOracledbRedoKindLogSpaceWait:
+		return "log_space_wait"
+	case AttributeOracledbRedoKindSynch:
+		return "synch"
+	}
+	return ""
+}
+
+// MapAttributeOracledbRedoKind is a helper map of string to AttributeOracledbRedoKind attribute value.
+var MapAttributeOracledbRedoKind = map[string]AttributeOracledbRedoKind{
+	"write":          AttributeOracledbRedoKindWrite,
+	"latching":       AttributeOracledbRedoKindLatching,
+	"log_space_wait": AttributeOracledbRedoKindLogSpaceWait,
+	"synch":          AttributeOracledbRedoKindSynch,
+}
+
 // AttributeOracledbSortType specifies the value oracledb.sort.type attribute.
 type AttributeOracledbSortType int
 
@@ -364,6 +398,27 @@ var MetricsInfo = metricsInfo{
 	OracledbRecycleBinLimit: metricInfo{
 		Name: "oracledb.recycle_bin.limit",
 	},
+	OracledbRedoBlocksWritten: metricInfo{
+		Name: "oracledb.redo.blocks_written",
+	},
+	OracledbRedoBufferAllocationRetries: metricInfo{
+		Name: "oracledb.redo.buffer_allocation.retries",
+	},
+	OracledbRedoLogSpaceRequests: metricInfo{
+		Name: "oracledb.redo.log_space.requests",
+	},
+	OracledbRedoLogSwitchInterrupts: metricInfo{
+		Name: "oracledb.redo.log_switch.interrupts",
+	},
+	OracledbRedoSize: metricInfo{
+		Name: "oracledb.redo.size",
+	},
+	OracledbRedoTime: metricInfo{
+		Name: "oracledb.redo.time",
+	},
+	OracledbRedoWrites: metricInfo{
+		Name: "oracledb.redo.writes",
+	},
 	OracledbRedoAllocationUtilization: metricInfo{
 		Name: "oracledb.redo_allocation.utilization",
 	},
@@ -464,6 +519,13 @@ type metricsInfo struct {
 	OracledbProcessesUsage                        metricInfo
 	OracledbQueriesParallelized                   metricInfo
 	OracledbRecycleBinLimit                       metricInfo
+	OracledbRedoBlocksWritten                     metricInfo
+	OracledbRedoBufferAllocationRetries           metricInfo
+	OracledbRedoLogSpaceRequests                  metricInfo
+	OracledbRedoLogSwitchInterrupts               metricInfo
+	OracledbRedoSize                              metricInfo
+	OracledbRedoTime                              metricInfo
+	OracledbRedoWrites                            metricInfo
 	OracledbRedoAllocationUtilization             metricInfo
 	OracledbSessionsLimit                         metricInfo
 	OracledbSessionsUsage                         metricInfo
@@ -3056,6 +3118,409 @@ func newMetricOracledbRecycleBinLimit(cfg OracledbRecycleBinLimitMetricConfig) m
 	return m
 }
 
+type metricOracledbRedoBlocksWritten struct {
+	data     pmetric.Metric                        // data buffer for generated metric.
+	config   OracledbRedoBlocksWrittenMetricConfig // metric config provided by user.
+	capacity int                                   // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.blocks_written metric with initial data.
+func (m *metricOracledbRedoBlocksWritten) init() {
+	m.data.SetName("oracledb.redo.blocks_written")
+	m.data.SetDescription("Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').")
+	m.data.SetUnit("{blocks}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoBlocksWritten) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoBlocksWritten) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoBlocksWritten) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoBlocksWritten(cfg OracledbRedoBlocksWrittenMetricConfig) metricOracledbRedoBlocksWritten {
+	m := metricOracledbRedoBlocksWritten{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoBufferAllocationRetries struct {
+	data     pmetric.Metric                                  // data buffer for generated metric.
+	config   OracledbRedoBufferAllocationRetriesMetricConfig // metric config provided by user.
+	capacity int                                             // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.buffer_allocation.retries metric with initial data.
+func (m *metricOracledbRedoBufferAllocationRetries) init() {
+	m.data.SetName("oracledb.redo.buffer_allocation.retries")
+	m.data.SetDescription("Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.")
+	m.data.SetUnit("{retries}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoBufferAllocationRetries) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoBufferAllocationRetries) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoBufferAllocationRetries) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoBufferAllocationRetries(cfg OracledbRedoBufferAllocationRetriesMetricConfig) metricOracledbRedoBufferAllocationRetries {
+	m := metricOracledbRedoBufferAllocationRetries{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoLogSpaceRequests struct {
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   OracledbRedoLogSpaceRequestsMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.log_space.requests metric with initial data.
+func (m *metricOracledbRedoLogSpaceRequests) init() {
+	m.data.SetName("oracledb.redo.log_space.requests")
+	m.data.SetDescription("Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').")
+	m.data.SetUnit("{requests}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoLogSpaceRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoLogSpaceRequests) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoLogSpaceRequests) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoLogSpaceRequests(cfg OracledbRedoLogSpaceRequestsMetricConfig) metricOracledbRedoLogSpaceRequests {
+	m := metricOracledbRedoLogSpaceRequests{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoLogSwitchInterrupts struct {
+	data     pmetric.Metric                              // data buffer for generated metric.
+	config   OracledbRedoLogSwitchInterruptsMetricConfig // metric config provided by user.
+	capacity int                                         // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.log_switch.interrupts metric with initial data.
+func (m *metricOracledbRedoLogSwitchInterrupts) init() {
+	m.data.SetName("oracledb.redo.log_switch.interrupts")
+	m.data.SetDescription("Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').")
+	m.data.SetUnit("{interrupts}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoLogSwitchInterrupts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoLogSwitchInterrupts) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoLogSwitchInterrupts) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoLogSwitchInterrupts(cfg OracledbRedoLogSwitchInterruptsMetricConfig) metricOracledbRedoLogSwitchInterrupts {
+	m := metricOracledbRedoLogSwitchInterrupts{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoSize struct {
+	data     pmetric.Metric               // data buffer for generated metric.
+	config   OracledbRedoSizeMetricConfig // metric config provided by user.
+	capacity int                          // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.size metric with initial data.
+func (m *metricOracledbRedoSize) init() {
+	m.data.SetName("oracledb.redo.size")
+	m.data.SetDescription("Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoSize) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoSize(cfg OracledbRedoSizeMetricConfig) metricOracledbRedoSize {
+	m := metricOracledbRedoSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoTime struct {
+	data          pmetric.Metric               // data buffer for generated metric.
+	config        OracledbRedoTimeMetricConfig // metric config provided by user.
+	capacity      int                          // max observed number of data points added to the metric.
+	aggDataPoints []float64                    // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.redo.time metric with initial data.
+func (m *metricOracledbRedoTime) init() {
+	m.data.SetName("oracledb.redo.time")
+	m.data.SetDescription("Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.")
+	m.data.SetUnit("s")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbRedoTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, oracledbRedoKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbRedoTimeMetricAttributeKeyOracledbRedoKind) {
+		dp.Attributes().PutStr("oracledb.redo.kind", oracledbRedoKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoTime(cfg OracledbRedoTimeMetricConfig) metricOracledbRedoTime {
+	m := metricOracledbRedoTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoWrites struct {
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   OracledbRedoWritesMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.redo.writes metric with initial data.
+func (m *metricOracledbRedoWrites) init() {
+	m.data.SetName("oracledb.redo.writes")
+	m.data.SetDescription("Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').")
+	m.data.SetUnit("{writes}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricOracledbRedoWrites) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoWrites) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoWrites) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoWrites(cfg OracledbRedoWritesMetricConfig) metricOracledbRedoWrites {
+	m := metricOracledbRedoWrites{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbRedoAllocationUtilization struct {
 	data     pmetric.Metric                                // data buffer for generated metric.
 	config   OracledbRedoAllocationUtilizationMetricConfig // metric config provided by user.
@@ -4070,6 +4535,13 @@ type MetricsBuilder struct {
 	metricOracledbProcessesUsage                        metricOracledbProcessesUsage
 	metricOracledbQueriesParallelized                   metricOracledbQueriesParallelized
 	metricOracledbRecycleBinLimit                       metricOracledbRecycleBinLimit
+	metricOracledbRedoBlocksWritten                     metricOracledbRedoBlocksWritten
+	metricOracledbRedoBufferAllocationRetries           metricOracledbRedoBufferAllocationRetries
+	metricOracledbRedoLogSpaceRequests                  metricOracledbRedoLogSpaceRequests
+	metricOracledbRedoLogSwitchInterrupts               metricOracledbRedoLogSwitchInterrupts
+	metricOracledbRedoSize                              metricOracledbRedoSize
+	metricOracledbRedoTime                              metricOracledbRedoTime
+	metricOracledbRedoWrites                            metricOracledbRedoWrites
 	metricOracledbRedoAllocationUtilization             metricOracledbRedoAllocationUtilization
 	metricOracledbSessionsLimit                         metricOracledbSessionsLimit
 	metricOracledbSessionsUsage                         metricOracledbSessionsUsage
@@ -4157,6 +4629,13 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbProcessesUsage:                        newMetricOracledbProcessesUsage(mbc.Metrics.OracledbProcessesUsage),
 		metricOracledbQueriesParallelized:                   newMetricOracledbQueriesParallelized(mbc.Metrics.OracledbQueriesParallelized),
 		metricOracledbRecycleBinLimit:                       newMetricOracledbRecycleBinLimit(mbc.Metrics.OracledbRecycleBinLimit),
+		metricOracledbRedoBlocksWritten:                     newMetricOracledbRedoBlocksWritten(mbc.Metrics.OracledbRedoBlocksWritten),
+		metricOracledbRedoBufferAllocationRetries:           newMetricOracledbRedoBufferAllocationRetries(mbc.Metrics.OracledbRedoBufferAllocationRetries),
+		metricOracledbRedoLogSpaceRequests:                  newMetricOracledbRedoLogSpaceRequests(mbc.Metrics.OracledbRedoLogSpaceRequests),
+		metricOracledbRedoLogSwitchInterrupts:               newMetricOracledbRedoLogSwitchInterrupts(mbc.Metrics.OracledbRedoLogSwitchInterrupts),
+		metricOracledbRedoSize:                              newMetricOracledbRedoSize(mbc.Metrics.OracledbRedoSize),
+		metricOracledbRedoTime:                              newMetricOracledbRedoTime(mbc.Metrics.OracledbRedoTime),
+		metricOracledbRedoWrites:                            newMetricOracledbRedoWrites(mbc.Metrics.OracledbRedoWrites),
 		metricOracledbRedoAllocationUtilization:             newMetricOracledbRedoAllocationUtilization(mbc.Metrics.OracledbRedoAllocationUtilization),
 		metricOracledbSessionsLimit:                         newMetricOracledbSessionsLimit(mbc.Metrics.OracledbSessionsLimit),
 		metricOracledbSessionsUsage:                         newMetricOracledbSessionsUsage(mbc.Metrics.OracledbSessionsUsage),
@@ -4339,6 +4818,13 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbProcessesUsage.emit(ils.Metrics())
 	mb.metricOracledbQueriesParallelized.emit(ils.Metrics())
 	mb.metricOracledbRecycleBinLimit.emit(ils.Metrics())
+	mb.metricOracledbRedoBlocksWritten.emit(ils.Metrics())
+	mb.metricOracledbRedoBufferAllocationRetries.emit(ils.Metrics())
+	mb.metricOracledbRedoLogSpaceRequests.emit(ils.Metrics())
+	mb.metricOracledbRedoLogSwitchInterrupts.emit(ils.Metrics())
+	mb.metricOracledbRedoSize.emit(ils.Metrics())
+	mb.metricOracledbRedoTime.emit(ils.Metrics())
+	mb.metricOracledbRedoWrites.emit(ils.Metrics())
 	mb.metricOracledbRedoAllocationUtilization.emit(ils.Metrics())
 	mb.metricOracledbSessionsLimit.emit(ils.Metrics())
 	mb.metricOracledbSessionsUsage.emit(ils.Metrics())
@@ -4798,6 +5284,71 @@ func (mb *MetricsBuilder) RecordOracledbQueriesParallelizedDataPoint(ts pcommon.
 // RecordOracledbRecycleBinLimitDataPoint adds a data point to oracledb.recycle_bin.limit metric.
 func (mb *MetricsBuilder) RecordOracledbRecycleBinLimitDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricOracledbRecycleBinLimit.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordOracledbRedoBlocksWrittenDataPoint adds a data point to oracledb.redo.blocks_written metric.
+func (mb *MetricsBuilder) RecordOracledbRedoBlocksWrittenDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoBlocksWritten, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoBlocksWritten.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordOracledbRedoBufferAllocationRetriesDataPoint adds a data point to oracledb.redo.buffer_allocation.retries metric.
+func (mb *MetricsBuilder) RecordOracledbRedoBufferAllocationRetriesDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoBufferAllocationRetries, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoBufferAllocationRetries.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordOracledbRedoLogSpaceRequestsDataPoint adds a data point to oracledb.redo.log_space.requests metric.
+func (mb *MetricsBuilder) RecordOracledbRedoLogSpaceRequestsDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoLogSpaceRequests, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoLogSpaceRequests.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordOracledbRedoLogSwitchInterruptsDataPoint adds a data point to oracledb.redo.log_switch.interrupts metric.
+func (mb *MetricsBuilder) RecordOracledbRedoLogSwitchInterruptsDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoLogSwitchInterrupts, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoLogSwitchInterrupts.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordOracledbRedoSizeDataPoint adds a data point to oracledb.redo.size metric.
+func (mb *MetricsBuilder) RecordOracledbRedoSizeDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoSize.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordOracledbRedoTimeDataPoint adds a data point to oracledb.redo.time metric.
+func (mb *MetricsBuilder) RecordOracledbRedoTimeDataPoint(ts pcommon.Timestamp, val float64, oracledbRedoKindAttributeValue AttributeOracledbRedoKind) {
+	mb.metricOracledbRedoTime.recordDataPoint(mb.startTime, ts, val, oracledbRedoKindAttributeValue.String())
+}
+
+// RecordOracledbRedoWritesDataPoint adds a data point to oracledb.redo.writes metric.
+func (mb *MetricsBuilder) RecordOracledbRedoWritesDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoWrites, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoWrites.recordDataPoint(mb.startTime, ts, val)
+	return nil
 }
 
 // RecordOracledbRedoAllocationUtilizationDataPoint adds a data point to oracledb.redo_allocation.utilization metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -202,7 +202,6 @@ type AttributeOracledbRedoKind int
 const (
 	_ AttributeOracledbRedoKind = iota
 	AttributeOracledbRedoKindWrite
-	AttributeOracledbRedoKindLatching
 	AttributeOracledbRedoKindLogSpaceWait
 	AttributeOracledbRedoKindSynch
 )
@@ -212,8 +211,6 @@ func (av AttributeOracledbRedoKind) String() string {
 	switch av {
 	case AttributeOracledbRedoKindWrite:
 		return "write"
-	case AttributeOracledbRedoKindLatching:
-		return "latching"
 	case AttributeOracledbRedoKindLogSpaceWait:
 		return "log_space_wait"
 	case AttributeOracledbRedoKindSynch:
@@ -225,7 +222,6 @@ func (av AttributeOracledbRedoKind) String() string {
 // MapAttributeOracledbRedoKind is a helper map of string to AttributeOracledbRedoKind attribute value.
 var MapAttributeOracledbRedoKind = map[string]AttributeOracledbRedoKind{
 	"write":          AttributeOracledbRedoKindWrite,
-	"latching":       AttributeOracledbRedoKindLatching,
 	"log_space_wait": AttributeOracledbRedoKindLogSpaceWait,
 	"synch":          AttributeOracledbRedoKindSynch,
 }
@@ -399,7 +395,8 @@ var MetricsInfo = metricsInfo{
 		Name: "oracledb.recycle_bin.limit",
 	},
 	OracledbRedoBlocks: metricInfo{
-		Name: "oracledb.redo.blocks",
+		Name:       "oracledb.redo.blocks",
+		Attributes: []string{"disk.io.direction"},
 	},
 	OracledbRedoBufferAllocationRetries: metricInfo{
 		Name: "oracledb.redo.buffer_allocation.retries",
@@ -407,17 +404,16 @@ var MetricsInfo = metricsInfo{
 	OracledbRedoLogSpaceRequests: metricInfo{
 		Name: "oracledb.redo.log_space.requests",
 	},
-	OracledbRedoLogSwitchInterrupts: metricInfo{
-		Name: "oracledb.redo.log_switch.interrupts",
-	},
 	OracledbRedoOperations: metricInfo{
-		Name: "oracledb.redo.operations",
+		Name:       "oracledb.redo.operations",
+		Attributes: []string{"disk.io.direction"},
 	},
 	OracledbRedoSize: metricInfo{
 		Name: "oracledb.redo.size",
 	},
 	OracledbRedoTime: metricInfo{
-		Name: "oracledb.redo.time",
+		Name:       "oracledb.redo.time",
+		Attributes: []string{"oracledb.redo.kind"},
 	},
 	OracledbRedoAllocationUtilization: metricInfo{
 		Name: "oracledb.redo_allocation.utilization",
@@ -522,7 +518,6 @@ type metricsInfo struct {
 	OracledbRedoBlocks                            metricInfo
 	OracledbRedoBufferAllocationRetries           metricInfo
 	OracledbRedoLogSpaceRequests                  metricInfo
-	OracledbRedoLogSwitchInterrupts               metricInfo
 	OracledbRedoOperations                        metricInfo
 	OracledbRedoSize                              metricInfo
 	OracledbRedoTime                              metricInfo
@@ -3313,58 +3308,6 @@ func newMetricOracledbRedoLogSpaceRequests(cfg OracledbRedoLogSpaceRequestsMetri
 	return m
 }
 
-type metricOracledbRedoLogSwitchInterrupts struct {
-	data     pmetric.Metric                              // data buffer for generated metric.
-	config   OracledbRedoLogSwitchInterruptsMetricConfig // metric config provided by user.
-	capacity int                                         // max observed number of data points added to the metric.
-}
-
-// init fills oracledb.redo.log_switch.interrupts metric with initial data.
-func (m *metricOracledbRedoLogSwitchInterrupts) init() {
-	m.data.SetName("oracledb.redo.log_switch.interrupts")
-	m.data.SetDescription("Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').")
-	m.data.SetUnit("{interrupts}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricOracledbRedoLogSwitchInterrupts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbRedoLogSwitchInterrupts) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbRedoLogSwitchInterrupts) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricOracledbRedoLogSwitchInterrupts(cfg OracledbRedoLogSwitchInterruptsMetricConfig) metricOracledbRedoLogSwitchInterrupts {
-	m := metricOracledbRedoLogSwitchInterrupts{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricOracledbRedoOperations struct {
 	data          pmetric.Metric                     // data buffer for generated metric.
 	config        OracledbRedoOperationsMetricConfig // metric config provided by user.
@@ -4616,7 +4559,6 @@ type MetricsBuilder struct {
 	metricOracledbRedoBlocks                            metricOracledbRedoBlocks
 	metricOracledbRedoBufferAllocationRetries           metricOracledbRedoBufferAllocationRetries
 	metricOracledbRedoLogSpaceRequests                  metricOracledbRedoLogSpaceRequests
-	metricOracledbRedoLogSwitchInterrupts               metricOracledbRedoLogSwitchInterrupts
 	metricOracledbRedoOperations                        metricOracledbRedoOperations
 	metricOracledbRedoSize                              metricOracledbRedoSize
 	metricOracledbRedoTime                              metricOracledbRedoTime
@@ -4710,7 +4652,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbRedoBlocks:                            newMetricOracledbRedoBlocks(mbc.Metrics.OracledbRedoBlocks),
 		metricOracledbRedoBufferAllocationRetries:           newMetricOracledbRedoBufferAllocationRetries(mbc.Metrics.OracledbRedoBufferAllocationRetries),
 		metricOracledbRedoLogSpaceRequests:                  newMetricOracledbRedoLogSpaceRequests(mbc.Metrics.OracledbRedoLogSpaceRequests),
-		metricOracledbRedoLogSwitchInterrupts:               newMetricOracledbRedoLogSwitchInterrupts(mbc.Metrics.OracledbRedoLogSwitchInterrupts),
 		metricOracledbRedoOperations:                        newMetricOracledbRedoOperations(mbc.Metrics.OracledbRedoOperations),
 		metricOracledbRedoSize:                              newMetricOracledbRedoSize(mbc.Metrics.OracledbRedoSize),
 		metricOracledbRedoTime:                              newMetricOracledbRedoTime(mbc.Metrics.OracledbRedoTime),
@@ -4899,7 +4840,6 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbRedoBlocks.emit(ils.Metrics())
 	mb.metricOracledbRedoBufferAllocationRetries.emit(ils.Metrics())
 	mb.metricOracledbRedoLogSpaceRequests.emit(ils.Metrics())
-	mb.metricOracledbRedoLogSwitchInterrupts.emit(ils.Metrics())
 	mb.metricOracledbRedoOperations.emit(ils.Metrics())
 	mb.metricOracledbRedoSize.emit(ils.Metrics())
 	mb.metricOracledbRedoTime.emit(ils.Metrics())
@@ -5391,16 +5331,6 @@ func (mb *MetricsBuilder) RecordOracledbRedoLogSpaceRequestsDataPoint(ts pcommon
 		return fmt.Errorf("failed to parse int64 for OracledbRedoLogSpaceRequests, value was %s: %w", inputVal, err)
 	}
 	mb.metricOracledbRedoLogSpaceRequests.recordDataPoint(mb.startTime, ts, val)
-	return nil
-}
-
-// RecordOracledbRedoLogSwitchInterruptsDataPoint adds a data point to oracledb.redo.log_switch.interrupts metric.
-func (mb *MetricsBuilder) RecordOracledbRedoLogSwitchInterruptsDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for OracledbRedoLogSwitchInterrupts, value was %s: %w", inputVal, err)
-	}
-	mb.metricOracledbRedoLogSwitchInterrupts.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -196,6 +196,50 @@ var MapAttributeOracledbParseType = map[string]AttributeOracledbParseType{
 	"soft": AttributeOracledbParseTypeSoft,
 }
 
+// AttributeOracledbRedoRequestType specifies the value oracledb.redo.request.type attribute.
+type AttributeOracledbRedoRequestType int
+
+const (
+	_ AttributeOracledbRedoRequestType = iota
+	AttributeOracledbRedoRequestTypeLogSpace
+)
+
+// String returns the string representation of the AttributeOracledbRedoRequestType.
+func (av AttributeOracledbRedoRequestType) String() string {
+	switch av {
+	case AttributeOracledbRedoRequestTypeLogSpace:
+		return "log_space"
+	}
+	return ""
+}
+
+// MapAttributeOracledbRedoRequestType is a helper map of string to AttributeOracledbRedoRequestType attribute value.
+var MapAttributeOracledbRedoRequestType = map[string]AttributeOracledbRedoRequestType{
+	"log_space": AttributeOracledbRedoRequestTypeLogSpace,
+}
+
+// AttributeOracledbRedoRetryType specifies the value oracledb.redo.retry.type attribute.
+type AttributeOracledbRedoRetryType int
+
+const (
+	_ AttributeOracledbRedoRetryType = iota
+	AttributeOracledbRedoRetryTypeBufferAllocation
+)
+
+// String returns the string representation of the AttributeOracledbRedoRetryType.
+func (av AttributeOracledbRedoRetryType) String() string {
+	switch av {
+	case AttributeOracledbRedoRetryTypeBufferAllocation:
+		return "buffer_allocation"
+	}
+	return ""
+}
+
+// MapAttributeOracledbRedoRetryType is a helper map of string to AttributeOracledbRedoRetryType attribute value.
+var MapAttributeOracledbRedoRetryType = map[string]AttributeOracledbRedoRetryType{
+	"buffer_allocation": AttributeOracledbRedoRetryTypeBufferAllocation,
+}
+
 // AttributeOracledbRedoType specifies the value oracledb.redo.type attribute.
 type AttributeOracledbRedoType int
 
@@ -398,15 +442,17 @@ var MetricsInfo = metricsInfo{
 		Name:       "oracledb.redo.blocks",
 		Attributes: []string{"disk.io.direction"},
 	},
-	OracledbRedoBufferAllocationRetries: metricInfo{
-		Name: "oracledb.redo.buffer_allocation_retries",
-	},
-	OracledbRedoLogSpaceRequests: metricInfo{
-		Name: "oracledb.redo.log_space_requests",
-	},
 	OracledbRedoOperations: metricInfo{
 		Name:       "oracledb.redo.operations",
 		Attributes: []string{"disk.io.direction"},
+	},
+	OracledbRedoRequests: metricInfo{
+		Name:       "oracledb.redo.requests",
+		Attributes: []string{"oracledb.redo.request.type"},
+	},
+	OracledbRedoRetries: metricInfo{
+		Name:       "oracledb.redo.retries",
+		Attributes: []string{"oracledb.redo.retry.type"},
 	},
 	OracledbRedoSize: metricInfo{
 		Name: "oracledb.redo.size",
@@ -516,9 +562,9 @@ type metricsInfo struct {
 	OracledbQueriesParallelized                   metricInfo
 	OracledbRecycleBinLimit                       metricInfo
 	OracledbRedoBlocks                            metricInfo
-	OracledbRedoBufferAllocationRetries           metricInfo
-	OracledbRedoLogSpaceRequests                  metricInfo
 	OracledbRedoOperations                        metricInfo
+	OracledbRedoRequests                          metricInfo
+	OracledbRedoRetries                           metricInfo
 	OracledbRedoSize                              metricInfo
 	OracledbRedoTime                              metricInfo
 	OracledbRedoAllocationUtilization             metricInfo
@@ -3204,110 +3250,6 @@ func newMetricOracledbRedoBlocks(cfg OracledbRedoBlocksMetricConfig) metricOracl
 	return m
 }
 
-type metricOracledbRedoBufferAllocationRetries struct {
-	data     pmetric.Metric                                  // data buffer for generated metric.
-	config   OracledbRedoBufferAllocationRetriesMetricConfig // metric config provided by user.
-	capacity int                                             // max observed number of data points added to the metric.
-}
-
-// init fills oracledb.redo.buffer_allocation_retries metric with initial data.
-func (m *metricOracledbRedoBufferAllocationRetries) init() {
-	m.data.SetName("oracledb.redo.buffer_allocation_retries")
-	m.data.SetDescription("Number of times a process waited and retried to allocate space in the redo buffer.")
-	m.data.SetUnit("{retry}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricOracledbRedoBufferAllocationRetries) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbRedoBufferAllocationRetries) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbRedoBufferAllocationRetries) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricOracledbRedoBufferAllocationRetries(cfg OracledbRedoBufferAllocationRetriesMetricConfig) metricOracledbRedoBufferAllocationRetries {
-	m := metricOracledbRedoBufferAllocationRetries{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricOracledbRedoLogSpaceRequests struct {
-	data     pmetric.Metric                           // data buffer for generated metric.
-	config   OracledbRedoLogSpaceRequestsMetricConfig // metric config provided by user.
-	capacity int                                      // max observed number of data points added to the metric.
-}
-
-// init fills oracledb.redo.log_space_requests metric with initial data.
-func (m *metricOracledbRedoLogSpaceRequests) init() {
-	m.data.SetName("oracledb.redo.log_space_requests")
-	m.data.SetDescription("Number of times a process requested space in the redo log buffer and had to wait.")
-	m.data.SetUnit("{request}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricOracledbRedoLogSpaceRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbRedoLogSpaceRequests) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbRedoLogSpaceRequests) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricOracledbRedoLogSpaceRequests(cfg OracledbRedoLogSpaceRequestsMetricConfig) metricOracledbRedoLogSpaceRequests {
-	m := metricOracledbRedoLogSpaceRequests{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricOracledbRedoOperations struct {
 	data          pmetric.Metric                     // data buffer for generated metric.
 	config        OracledbRedoOperationsMetricConfig // metric config provided by user.
@@ -3391,6 +3333,188 @@ func (m *metricOracledbRedoOperations) emit(metrics pmetric.MetricSlice) {
 
 func newMetricOracledbRedoOperations(cfg OracledbRedoOperationsMetricConfig) metricOracledbRedoOperations {
 	m := metricOracledbRedoOperations{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoRequests struct {
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        OracledbRedoRequestsMetricConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.redo.requests metric with initial data.
+func (m *metricOracledbRedoRequests) init() {
+	m.data.SetName("oracledb.redo.requests")
+	m.data.SetDescription("Number of times a process requested space in the redo log buffer and had to wait.")
+	m.data.SetUnit("{request}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbRedoRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbRedoRequestTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbRedoRequestsMetricAttributeKeyOracledbRedoRequestType) {
+		dp.Attributes().PutStr("oracledb.redo.request.type", oracledbRedoRequestTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoRequests) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoRequests) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoRequests(cfg OracledbRedoRequestsMetricConfig) metricOracledbRedoRequests {
+	m := metricOracledbRedoRequests{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbRedoRetries struct {
+	data          pmetric.Metric                  // data buffer for generated metric.
+	config        OracledbRedoRetriesMetricConfig // metric config provided by user.
+	capacity      int                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                         // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.redo.retries metric with initial data.
+func (m *metricOracledbRedoRetries) init() {
+	m.data.SetName("oracledb.redo.retries")
+	m.data.SetDescription("Number of times a process waited and retried to allocate space in the redo buffer.")
+	m.data.SetUnit("{retry}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbRedoRetries) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbRedoRetryTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbRedoRetriesMetricAttributeKeyOracledbRedoRetryType) {
+		dp.Attributes().PutStr("oracledb.redo.retry.type", oracledbRedoRetryTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbRedoRetries) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbRedoRetries) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbRedoRetries(cfg OracledbRedoRetriesMetricConfig) metricOracledbRedoRetries {
+	m := metricOracledbRedoRetries{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4557,9 +4681,9 @@ type MetricsBuilder struct {
 	metricOracledbQueriesParallelized                   metricOracledbQueriesParallelized
 	metricOracledbRecycleBinLimit                       metricOracledbRecycleBinLimit
 	metricOracledbRedoBlocks                            metricOracledbRedoBlocks
-	metricOracledbRedoBufferAllocationRetries           metricOracledbRedoBufferAllocationRetries
-	metricOracledbRedoLogSpaceRequests                  metricOracledbRedoLogSpaceRequests
 	metricOracledbRedoOperations                        metricOracledbRedoOperations
+	metricOracledbRedoRequests                          metricOracledbRedoRequests
+	metricOracledbRedoRetries                           metricOracledbRedoRetries
 	metricOracledbRedoSize                              metricOracledbRedoSize
 	metricOracledbRedoTime                              metricOracledbRedoTime
 	metricOracledbRedoAllocationUtilization             metricOracledbRedoAllocationUtilization
@@ -4650,9 +4774,9 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbQueriesParallelized:                   newMetricOracledbQueriesParallelized(mbc.Metrics.OracledbQueriesParallelized),
 		metricOracledbRecycleBinLimit:                       newMetricOracledbRecycleBinLimit(mbc.Metrics.OracledbRecycleBinLimit),
 		metricOracledbRedoBlocks:                            newMetricOracledbRedoBlocks(mbc.Metrics.OracledbRedoBlocks),
-		metricOracledbRedoBufferAllocationRetries:           newMetricOracledbRedoBufferAllocationRetries(mbc.Metrics.OracledbRedoBufferAllocationRetries),
-		metricOracledbRedoLogSpaceRequests:                  newMetricOracledbRedoLogSpaceRequests(mbc.Metrics.OracledbRedoLogSpaceRequests),
 		metricOracledbRedoOperations:                        newMetricOracledbRedoOperations(mbc.Metrics.OracledbRedoOperations),
+		metricOracledbRedoRequests:                          newMetricOracledbRedoRequests(mbc.Metrics.OracledbRedoRequests),
+		metricOracledbRedoRetries:                           newMetricOracledbRedoRetries(mbc.Metrics.OracledbRedoRetries),
 		metricOracledbRedoSize:                              newMetricOracledbRedoSize(mbc.Metrics.OracledbRedoSize),
 		metricOracledbRedoTime:                              newMetricOracledbRedoTime(mbc.Metrics.OracledbRedoTime),
 		metricOracledbRedoAllocationUtilization:             newMetricOracledbRedoAllocationUtilization(mbc.Metrics.OracledbRedoAllocationUtilization),
@@ -4838,9 +4962,9 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbQueriesParallelized.emit(ils.Metrics())
 	mb.metricOracledbRecycleBinLimit.emit(ils.Metrics())
 	mb.metricOracledbRedoBlocks.emit(ils.Metrics())
-	mb.metricOracledbRedoBufferAllocationRetries.emit(ils.Metrics())
-	mb.metricOracledbRedoLogSpaceRequests.emit(ils.Metrics())
 	mb.metricOracledbRedoOperations.emit(ils.Metrics())
+	mb.metricOracledbRedoRequests.emit(ils.Metrics())
+	mb.metricOracledbRedoRetries.emit(ils.Metrics())
 	mb.metricOracledbRedoSize.emit(ils.Metrics())
 	mb.metricOracledbRedoTime.emit(ils.Metrics())
 	mb.metricOracledbRedoAllocationUtilization.emit(ils.Metrics())
@@ -5314,26 +5438,6 @@ func (mb *MetricsBuilder) RecordOracledbRedoBlocksDataPoint(ts pcommon.Timestamp
 	return nil
 }
 
-// RecordOracledbRedoBufferAllocationRetriesDataPoint adds a data point to oracledb.redo.buffer_allocation_retries metric.
-func (mb *MetricsBuilder) RecordOracledbRedoBufferAllocationRetriesDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for OracledbRedoBufferAllocationRetries, value was %s: %w", inputVal, err)
-	}
-	mb.metricOracledbRedoBufferAllocationRetries.recordDataPoint(mb.startTime, ts, val)
-	return nil
-}
-
-// RecordOracledbRedoLogSpaceRequestsDataPoint adds a data point to oracledb.redo.log_space_requests metric.
-func (mb *MetricsBuilder) RecordOracledbRedoLogSpaceRequestsDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for OracledbRedoLogSpaceRequests, value was %s: %w", inputVal, err)
-	}
-	mb.metricOracledbRedoLogSpaceRequests.recordDataPoint(mb.startTime, ts, val)
-	return nil
-}
-
 // RecordOracledbRedoOperationsDataPoint adds a data point to oracledb.redo.operations metric.
 func (mb *MetricsBuilder) RecordOracledbRedoOperationsDataPoint(ts pcommon.Timestamp, inputVal string, diskIoDirectionAttributeValue AttributeDiskIoDirection) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -5341,6 +5445,26 @@ func (mb *MetricsBuilder) RecordOracledbRedoOperationsDataPoint(ts pcommon.Times
 		return fmt.Errorf("failed to parse int64 for OracledbRedoOperations, value was %s: %w", inputVal, err)
 	}
 	mb.metricOracledbRedoOperations.recordDataPoint(mb.startTime, ts, val, diskIoDirectionAttributeValue.String())
+	return nil
+}
+
+// RecordOracledbRedoRequestsDataPoint adds a data point to oracledb.redo.requests metric.
+func (mb *MetricsBuilder) RecordOracledbRedoRequestsDataPoint(ts pcommon.Timestamp, inputVal string, oracledbRedoRequestTypeAttributeValue AttributeOracledbRedoRequestType) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoRequests, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoRequests.recordDataPoint(mb.startTime, ts, val, oracledbRedoRequestTypeAttributeValue.String())
+	return nil
+}
+
+// RecordOracledbRedoRetriesDataPoint adds a data point to oracledb.redo.retries metric.
+func (mb *MetricsBuilder) RecordOracledbRedoRetriesDataPoint(ts pcommon.Timestamp, inputVal string, oracledbRedoRetryTypeAttributeValue AttributeOracledbRedoRetryType) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbRedoRetries, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbRedoRetries.recordDataPoint(mb.startTime, ts, val, oracledbRedoRetryTypeAttributeValue.String())
 	return nil
 }
 

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -1143,7 +1143,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.blocks"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction.", mi.Description())
+						assert.Equal(t, "Number of redo blocks moved between the redo log and storage.", mi.Description())
 						assert.Equal(t, "{block}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1160,7 +1160,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.blocks"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction.", mi.Description())
+						assert.Equal(t, "Number of redo blocks moved between the redo log and storage.", mi.Description())
 						assert.Equal(t, "{block}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1187,7 +1187,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.operations"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo I/O operations, by I/O direction.", mi.Description())
+						assert.Equal(t, "Number of redo I/O operations.", mi.Description())
 						assert.Equal(t, "{operation}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1204,7 +1204,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.operations"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo I/O operations, by I/O direction.", mi.Description())
+						assert.Equal(t, "Number of redo I/O operations.", mi.Description())
 						assert.Equal(t, "{operation}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -71,6 +71,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["oracledb.parse.rate"] = mb.metricOracledbParseRate.config.AggregationStrategy
 			aggMap["oracledb.physical_io.requests"] = mb.metricOracledbPhysicalIoRequests.config.AggregationStrategy
 			aggMap["oracledb.physical_io.transferred"] = mb.metricOracledbPhysicalIoTransferred.config.AggregationStrategy
+			aggMap["oracledb.redo.time"] = mb.metricOracledbRedoTime.config.AggregationStrategy
 			aggMap["oracledb.sessions.usage"] = mb.metricOracledbSessionsUsage.config.AggregationStrategy
 			aggMap["oracledb.sort.ratio"] = mb.metricOracledbSortRatio.config.AggregationStrategy
 			aggMap["oracledb.sqlnet.io.transferred"] = mb.metricOracledbSqlnetIoTransferred.config.AggregationStrategy
@@ -239,6 +240,30 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRecycleBinLimitDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordOracledbRedoBlocksWrittenDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbRedoBufferAllocationRetriesDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbRedoLogSpaceRequestsDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbRedoLogSwitchInterruptsDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbRedoSizeDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbRedoTimeDataPoint(ts, 1, AttributeOracledbRedoKindWrite)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbRedoTimeDataPoint(ts, 3, AttributeOracledbRedoKindLatching)
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbRedoWritesDataPoint(ts, "1")
+
+			allMetricsCount++
 			mb.RecordOracledbRedoAllocationUtilizationDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
@@ -314,6 +339,7 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricOracledbParseRate.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbPhysicalIoRequests.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbPhysicalIoTransferred.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbRedoTime.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSessionsUsage.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSortRatio.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSqlnetIoTransferred.aggDataPoints)
@@ -1094,6 +1120,134 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "oracledb.redo.blocks_written":
+					assert.False(t, validatedMetrics["oracledb.redo.blocks_written"], "Found a duplicate in the metrics slice: oracledb.redo.blocks_written")
+					validatedMetrics["oracledb.redo.blocks_written"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
+					assert.Equal(t, "{blocks}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.redo.buffer_allocation.retries":
+					assert.False(t, validatedMetrics["oracledb.redo.buffer_allocation.retries"], "Found a duplicate in the metrics slice: oracledb.redo.buffer_allocation.retries")
+					validatedMetrics["oracledb.redo.buffer_allocation.retries"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.", mi.Description())
+					assert.Equal(t, "{retries}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.redo.log_space.requests":
+					assert.False(t, validatedMetrics["oracledb.redo.log_space.requests"], "Found a duplicate in the metrics slice: oracledb.redo.log_space.requests")
+					validatedMetrics["oracledb.redo.log_space.requests"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').", mi.Description())
+					assert.Equal(t, "{requests}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.redo.log_switch.interrupts":
+					assert.False(t, validatedMetrics["oracledb.redo.log_switch.interrupts"], "Found a duplicate in the metrics slice: oracledb.redo.log_switch.interrupts")
+					validatedMetrics["oracledb.redo.log_switch.interrupts"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').", mi.Description())
+					assert.Equal(t, "{interrupts}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.redo.size":
+					assert.False(t, validatedMetrics["oracledb.redo.size"], "Found a duplicate in the metrics slice: oracledb.redo.size")
+					validatedMetrics["oracledb.redo.size"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.redo.time":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.redo.time"], "Found a duplicate in the metrics slice: oracledb.redo.time")
+						validatedMetrics["oracledb.redo.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						oracledbRedoKindAttrVal, ok := dp.Attributes().Get("oracledb.redo.kind")
+						assert.True(t, ok)
+						assert.Equal(t, "write", oracledbRedoKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.redo.time"], "Found a duplicate in the metrics slice: oracledb.redo.time")
+						validatedMetrics["oracledb.redo.time"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["oracledb.redo.time"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("oracledb.redo.kind")
+						assert.False(t, ok)
+					}
+				case "oracledb.redo.writes":
+					assert.False(t, validatedMetrics["oracledb.redo.writes"], "Found a duplicate in the metrics slice: oracledb.redo.writes")
+					validatedMetrics["oracledb.redo.writes"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
+					assert.Equal(t, "{writes}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "oracledb.redo_allocation.utilization":
 					assert.False(t, validatedMetrics["oracledb.redo_allocation.utilization"], "Found a duplicate in the metrics slice: oracledb.redo_allocation.utilization")
 					validatedMetrics["oracledb.redo_allocation.utilization"] = true

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -254,9 +254,6 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRedoLogSpaceRequestsDataPoint(ts, "1")
 
 			allMetricsCount++
-			mb.RecordOracledbRedoLogSwitchInterruptsDataPoint(ts, "1")
-
-			allMetricsCount++
 			mb.RecordOracledbRedoOperationsDataPoint(ts, "1", AttributeDiskIoDirectionRead)
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbRedoOperationsDataPoint(ts, "3", AttributeDiskIoDirectionWrite)
@@ -268,7 +265,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordOracledbRedoTimeDataPoint(ts, 1, AttributeOracledbRedoKindWrite)
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbRedoTimeDataPoint(ts, 3, AttributeOracledbRedoKindLatching)
+				mb.RecordOracledbRedoTimeDataPoint(ts, 3, AttributeOracledbRedoKindLogSpaceWait)
 			}
 
 			allMetricsCount++
@@ -1195,20 +1192,6 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 					assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').", mi.Description())
 					assert.Equal(t, "{requests}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-				case "oracledb.redo.log_switch.interrupts":
-					assert.False(t, validatedMetrics["oracledb.redo.log_switch.interrupts"], "Found a duplicate in the metrics slice: oracledb.redo.log_switch.interrupts")
-					validatedMetrics["oracledb.redo.log_switch.interrupts"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').", mi.Description())
-					assert.Equal(t, "{interrupts}", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -73,6 +73,8 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["oracledb.physical_io.transferred"] = mb.metricOracledbPhysicalIoTransferred.config.AggregationStrategy
 			aggMap["oracledb.redo.blocks"] = mb.metricOracledbRedoBlocks.config.AggregationStrategy
 			aggMap["oracledb.redo.operations"] = mb.metricOracledbRedoOperations.config.AggregationStrategy
+			aggMap["oracledb.redo.requests"] = mb.metricOracledbRedoRequests.config.AggregationStrategy
+			aggMap["oracledb.redo.retries"] = mb.metricOracledbRedoRetries.config.AggregationStrategy
 			aggMap["oracledb.redo.time"] = mb.metricOracledbRedoTime.config.AggregationStrategy
 			aggMap["oracledb.sessions.usage"] = mb.metricOracledbSessionsUsage.config.AggregationStrategy
 			aggMap["oracledb.sort.ratio"] = mb.metricOracledbSortRatio.config.AggregationStrategy
@@ -248,15 +250,21 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
-			mb.RecordOracledbRedoBufferAllocationRetriesDataPoint(ts, "1")
-
-			allMetricsCount++
-			mb.RecordOracledbRedoLogSpaceRequestsDataPoint(ts, "1")
-
-			allMetricsCount++
 			mb.RecordOracledbRedoOperationsDataPoint(ts, "1", AttributeDiskIoDirectionRead)
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbRedoOperationsDataPoint(ts, "3", AttributeDiskIoDirectionWrite)
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbRedoRequestsDataPoint(ts, "1", AttributeOracledbRedoRequestTypeLogSpace)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbRedoRequestsDataPoint(ts, "3", AttributeOracledbRedoRequestTypeLogSpace)
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbRedoRetriesDataPoint(ts, "1", AttributeOracledbRedoRetryTypeBufferAllocation)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbRedoRetriesDataPoint(ts, "3", AttributeOracledbRedoRetryTypeBufferAllocation)
 			}
 
 			allMetricsCount++
@@ -346,6 +354,8 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricOracledbPhysicalIoTransferred.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbRedoBlocks.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbRedoOperations.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbRedoRequests.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbRedoRetries.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbRedoTime.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSessionsUsage.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSortRatio.aggDataPoints)
@@ -1171,34 +1181,6 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("disk.io.direction")
 						assert.False(t, ok)
 					}
-				case "oracledb.redo.buffer_allocation_retries":
-					assert.False(t, validatedMetrics["oracledb.redo.buffer_allocation_retries"], "Found a duplicate in the metrics slice: oracledb.redo.buffer_allocation_retries")
-					validatedMetrics["oracledb.redo.buffer_allocation_retries"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of times a process waited and retried to allocate space in the redo buffer.", mi.Description())
-					assert.Equal(t, "{retry}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-				case "oracledb.redo.log_space_requests":
-					assert.False(t, validatedMetrics["oracledb.redo.log_space_requests"], "Found a duplicate in the metrics slice: oracledb.redo.log_space_requests")
-					validatedMetrics["oracledb.redo.log_space_requests"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait.", mi.Description())
-					assert.Equal(t, "{request}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
 				case "oracledb.redo.operations":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["oracledb.redo.operations"], "Found a duplicate in the metrics slice: oracledb.redo.operations")
@@ -1241,6 +1223,94 @@ func TestMetricsBuilder(t *testing.T) {
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
 						_, ok := dp.Attributes().Get("disk.io.direction")
+						assert.False(t, ok)
+					}
+				case "oracledb.redo.requests":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.redo.requests"], "Found a duplicate in the metrics slice: oracledb.redo.requests")
+						validatedMetrics["oracledb.redo.requests"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait.", mi.Description())
+						assert.Equal(t, "{request}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbRedoRequestTypeAttrVal, ok := dp.Attributes().Get("oracledb.redo.request.type")
+						assert.True(t, ok)
+						assert.Equal(t, "log_space", oracledbRedoRequestTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.redo.requests"], "Found a duplicate in the metrics slice: oracledb.redo.requests")
+						validatedMetrics["oracledb.redo.requests"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait.", mi.Description())
+						assert.Equal(t, "{request}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.redo.requests"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.redo.request.type")
+						assert.False(t, ok)
+					}
+				case "oracledb.redo.retries":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.redo.retries"], "Found a duplicate in the metrics slice: oracledb.redo.retries")
+						validatedMetrics["oracledb.redo.retries"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of times a process waited and retried to allocate space in the redo buffer.", mi.Description())
+						assert.Equal(t, "{retry}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbRedoRetryTypeAttrVal, ok := dp.Attributes().Get("oracledb.redo.retry.type")
+						assert.True(t, ok)
+						assert.Equal(t, "buffer_allocation", oracledbRedoRetryTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.redo.retries"], "Found a duplicate in the metrics slice: oracledb.redo.retries")
+						validatedMetrics["oracledb.redo.retries"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of times a process waited and retried to allocate space in the redo buffer.", mi.Description())
+						assert.Equal(t, "{retry}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.redo.retries"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.redo.retry.type")
 						assert.False(t, ok)
 					}
 				case "oracledb.redo.size":

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -71,6 +71,8 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["oracledb.parse.rate"] = mb.metricOracledbParseRate.config.AggregationStrategy
 			aggMap["oracledb.physical_io.requests"] = mb.metricOracledbPhysicalIoRequests.config.AggregationStrategy
 			aggMap["oracledb.physical_io.transferred"] = mb.metricOracledbPhysicalIoTransferred.config.AggregationStrategy
+			aggMap["oracledb.redo.blocks"] = mb.metricOracledbRedoBlocks.config.AggregationStrategy
+			aggMap["oracledb.redo.operations"] = mb.metricOracledbRedoOperations.config.AggregationStrategy
 			aggMap["oracledb.redo.time"] = mb.metricOracledbRedoTime.config.AggregationStrategy
 			aggMap["oracledb.sessions.usage"] = mb.metricOracledbSessionsUsage.config.AggregationStrategy
 			aggMap["oracledb.sort.ratio"] = mb.metricOracledbSortRatio.config.AggregationStrategy
@@ -240,7 +242,10 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRecycleBinLimitDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordOracledbRedoBlocksDataPoint(ts, "1")
+			mb.RecordOracledbRedoBlocksDataPoint(ts, "1", AttributeDiskIoDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbRedoBlocksDataPoint(ts, "3", AttributeDiskIoDirectionWrite)
+			}
 
 			allMetricsCount++
 			mb.RecordOracledbRedoBufferAllocationRetriesDataPoint(ts, "1")
@@ -252,7 +257,10 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRedoLogSwitchInterruptsDataPoint(ts, "1")
 
 			allMetricsCount++
-			mb.RecordOracledbRedoOperationsDataPoint(ts, "1")
+			mb.RecordOracledbRedoOperationsDataPoint(ts, "1", AttributeDiskIoDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbRedoOperationsDataPoint(ts, "3", AttributeDiskIoDirectionWrite)
+			}
 
 			allMetricsCount++
 			mb.RecordOracledbRedoSizeDataPoint(ts, "1")
@@ -339,6 +347,8 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricOracledbParseRate.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbPhysicalIoRequests.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbPhysicalIoTransferred.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbRedoBlocks.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbRedoOperations.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbRedoTime.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSessionsUsage.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbSortRatio.aggDataPoints)
@@ -1121,19 +1131,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.redo.blocks":
-					assert.False(t, validatedMetrics["oracledb.redo.blocks"], "Found a duplicate in the metrics slice: oracledb.redo.blocks")
-					validatedMetrics["oracledb.redo.blocks"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
-					assert.Equal(t, "{blocks}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.redo.blocks"], "Found a duplicate in the metrics slice: oracledb.redo.blocks")
+						validatedMetrics["oracledb.redo.blocks"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
+						assert.Equal(t, "{blocks}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						diskIoDirectionAttrVal, ok := dp.Attributes().Get("disk.io.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskIoDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.redo.blocks"], "Found a duplicate in the metrics slice: oracledb.redo.blocks")
+						validatedMetrics["oracledb.redo.blocks"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
+						assert.Equal(t, "{blocks}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.redo.blocks"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("disk.io.direction")
+						assert.False(t, ok)
+					}
 				case "oracledb.redo.buffer_allocation.retries":
 					assert.False(t, validatedMetrics["oracledb.redo.buffer_allocation.retries"], "Found a duplicate in the metrics slice: oracledb.redo.buffer_allocation.retries")
 					validatedMetrics["oracledb.redo.buffer_allocation.retries"] = true
@@ -1177,19 +1217,49 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
 				case "oracledb.redo.operations":
-					assert.False(t, validatedMetrics["oracledb.redo.operations"], "Found a duplicate in the metrics slice: oracledb.redo.operations")
-					validatedMetrics["oracledb.redo.operations"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
-					assert.Equal(t, "{operations}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.redo.operations"], "Found a duplicate in the metrics slice: oracledb.redo.operations")
+						validatedMetrics["oracledb.redo.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						diskIoDirectionAttrVal, ok := dp.Attributes().Get("disk.io.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskIoDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.redo.operations"], "Found a duplicate in the metrics slice: oracledb.redo.operations")
+						validatedMetrics["oracledb.redo.operations"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
+						assert.Equal(t, "{operations}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.redo.operations"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("disk.io.direction")
+						assert.False(t, ok)
+					}
 				case "oracledb.redo.size":
 					assert.False(t, validatedMetrics["oracledb.redo.size"], "Found a duplicate in the metrics slice: oracledb.redo.size")
 					validatedMetrics["oracledb.redo.size"] = true

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -263,9 +263,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRedoSizeDataPoint(ts, "1")
 
 			allMetricsCount++
-			mb.RecordOracledbRedoTimeDataPoint(ts, 1, AttributeOracledbRedoKindWrite)
+			mb.RecordOracledbRedoTimeDataPoint(ts, 1, AttributeOracledbRedoTypeWrite)
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbRedoTimeDataPoint(ts, 3, AttributeOracledbRedoKindLogSpaceWait)
+				mb.RecordOracledbRedoTimeDataPoint(ts, 3, AttributeOracledbRedoTypeLogSpaceWait)
 			}
 
 			allMetricsCount++
@@ -1133,8 +1133,8 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.blocks"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
-						assert.Equal(t, "{blocks}", mi.Unit())
+						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction.", mi.Description())
+						assert.Equal(t, "{block}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 						dp := mi.Sum().DataPoints().At(0)
@@ -1150,8 +1150,8 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.blocks"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
-						assert.Equal(t, "{blocks}", mi.Unit())
+						assert.Equal(t, "Number of redo blocks moved between the redo log and storage, by I/O direction.", mi.Description())
+						assert.Equal(t, "{block}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 						dp := mi.Sum().DataPoints().At(0)
@@ -1171,13 +1171,13 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("disk.io.direction")
 						assert.False(t, ok)
 					}
-				case "oracledb.redo.buffer_allocation.retries":
-					assert.False(t, validatedMetrics["oracledb.redo.buffer_allocation.retries"], "Found a duplicate in the metrics slice: oracledb.redo.buffer_allocation.retries")
-					validatedMetrics["oracledb.redo.buffer_allocation.retries"] = true
+				case "oracledb.redo.buffer_allocation_retries":
+					assert.False(t, validatedMetrics["oracledb.redo.buffer_allocation_retries"], "Found a duplicate in the metrics slice: oracledb.redo.buffer_allocation_retries")
+					validatedMetrics["oracledb.redo.buffer_allocation_retries"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.", mi.Description())
-					assert.Equal(t, "{retries}", mi.Unit())
+					assert.Equal(t, "Number of times a process waited and retried to allocate space in the redo buffer.", mi.Description())
+					assert.Equal(t, "{retry}", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)
@@ -1185,13 +1185,13 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-				case "oracledb.redo.log_space.requests":
-					assert.False(t, validatedMetrics["oracledb.redo.log_space.requests"], "Found a duplicate in the metrics slice: oracledb.redo.log_space.requests")
-					validatedMetrics["oracledb.redo.log_space.requests"] = true
+				case "oracledb.redo.log_space_requests":
+					assert.False(t, validatedMetrics["oracledb.redo.log_space_requests"], "Found a duplicate in the metrics slice: oracledb.redo.log_space_requests")
+					validatedMetrics["oracledb.redo.log_space_requests"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').", mi.Description())
-					assert.Equal(t, "{requests}", mi.Unit())
+					assert.Equal(t, "Number of times a process requested space in the redo log buffer and had to wait.", mi.Description())
+					assert.Equal(t, "{request}", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)
@@ -1205,8 +1205,8 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.operations"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
-						assert.Equal(t, "{operations}", mi.Unit())
+						assert.Equal(t, "Number of redo I/O operations, by I/O direction.", mi.Description())
+						assert.Equal(t, "{operation}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 						dp := mi.Sum().DataPoints().At(0)
@@ -1222,8 +1222,8 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.operations"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
-						assert.Equal(t, "{operations}", mi.Unit())
+						assert.Equal(t, "Number of redo I/O operations, by I/O direction.", mi.Description())
+						assert.Equal(t, "{operation}", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 						dp := mi.Sum().DataPoints().At(0)
@@ -1248,7 +1248,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["oracledb.redo.size"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.", mi.Description())
+					assert.Equal(t, "Amount of redo generated.", mi.Description())
 					assert.Equal(t, "By", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1263,7 +1263,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.redo.time"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.", mi.Description())
+						assert.Equal(t, "Time spent in each phase of the redo pipeline.", mi.Description())
 						assert.Equal(t, "s", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1272,15 +1272,15 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						oracledbRedoKindAttrVal, ok := dp.Attributes().Get("oracledb.redo.kind")
+						oracledbRedoTypeAttrVal, ok := dp.Attributes().Get("oracledb.redo.type")
 						assert.True(t, ok)
-						assert.Equal(t, "write", oracledbRedoKindAttrVal.Str())
+						assert.Equal(t, "write", oracledbRedoTypeAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["oracledb.redo.time"], "Found a duplicate in the metrics slice: oracledb.redo.time")
 						validatedMetrics["oracledb.redo.time"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.", mi.Description())
+						assert.Equal(t, "Time spent in each phase of the redo pipeline.", mi.Description())
 						assert.Equal(t, "s", mi.Unit())
 						assert.True(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1298,7 +1298,7 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
 						}
-						_, ok := dp.Attributes().Get("oracledb.redo.kind")
+						_, ok := dp.Attributes().Get("oracledb.redo.type")
 						assert.False(t, ok)
 					}
 				case "oracledb.redo_allocation.utilization":

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -240,7 +240,7 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRecycleBinLimitDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordOracledbRedoBlocksWrittenDataPoint(ts, "1")
+			mb.RecordOracledbRedoBlocksDataPoint(ts, "1")
 
 			allMetricsCount++
 			mb.RecordOracledbRedoBufferAllocationRetriesDataPoint(ts, "1")
@@ -252,6 +252,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbRedoLogSwitchInterruptsDataPoint(ts, "1")
 
 			allMetricsCount++
+			mb.RecordOracledbRedoOperationsDataPoint(ts, "1")
+
+			allMetricsCount++
 			mb.RecordOracledbRedoSizeDataPoint(ts, "1")
 
 			allMetricsCount++
@@ -259,9 +262,6 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbRedoTimeDataPoint(ts, 3, AttributeOracledbRedoKindLatching)
 			}
-
-			allMetricsCount++
-			mb.RecordOracledbRedoWritesDataPoint(ts, "1")
 
 			allMetricsCount++
 			mb.RecordOracledbRedoAllocationUtilizationDataPoint(ts, 1)
@@ -1120,9 +1120,9 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-				case "oracledb.redo.blocks_written":
-					assert.False(t, validatedMetrics["oracledb.redo.blocks_written"], "Found a duplicate in the metrics slice: oracledb.redo.blocks_written")
-					validatedMetrics["oracledb.redo.blocks_written"] = true
+				case "oracledb.redo.blocks":
+					assert.False(t, validatedMetrics["oracledb.redo.blocks"], "Found a duplicate in the metrics slice: oracledb.redo.blocks")
+					validatedMetrics["oracledb.redo.blocks"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 					assert.Equal(t, "Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').", mi.Description())
@@ -1169,6 +1169,20 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 					assert.Equal(t, "Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').", mi.Description())
 					assert.Equal(t, "{interrupts}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.redo.operations":
+					assert.False(t, validatedMetrics["oracledb.redo.operations"], "Found a duplicate in the metrics slice: oracledb.redo.operations")
+					validatedMetrics["oracledb.redo.operations"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
+					assert.Equal(t, "{operations}", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)
@@ -1234,20 +1248,6 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("oracledb.redo.kind")
 						assert.False(t, ok)
 					}
-				case "oracledb.redo.writes":
-					assert.False(t, validatedMetrics["oracledb.redo.writes"], "Found a duplicate in the metrics slice: oracledb.redo.writes")
-					validatedMetrics["oracledb.redo.writes"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').", mi.Description())
-					assert.Equal(t, "{writes}", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
 				case "oracledb.redo_allocation.utilization":
 					assert.False(t, validatedMetrics["oracledb.redo_allocation.utilization"], "Found a duplicate in the metrics slice: oracledb.redo_allocation.utilization")
 					validatedMetrics["oracledb.redo_allocation.utilization"] = true

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -99,6 +99,21 @@ all_set:
       enabled: true
     oracledb.recycle_bin.limit:
       enabled: true
+    oracledb.redo.blocks_written:
+      enabled: true
+    oracledb.redo.buffer_allocation.retries:
+      enabled: true
+    oracledb.redo.log_space.requests:
+      enabled: true
+    oracledb.redo.log_switch.interrupts:
+      enabled: true
+    oracledb.redo.size:
+      enabled: true
+    oracledb.redo.time:
+      enabled: true
+      attributes: ["oracledb.redo.kind"]
+    oracledb.redo.writes:
+      enabled: true
     oracledb.redo_allocation.utilization:
       enabled: true
     oracledb.sessions.limit:
@@ -258,6 +273,21 @@ reaggregate_set:
       enabled: true
     oracledb.recycle_bin.limit:
       enabled: true
+    oracledb.redo.blocks_written:
+      enabled: true
+    oracledb.redo.buffer_allocation.retries:
+      enabled: true
+    oracledb.redo.log_space.requests:
+      enabled: true
+    oracledb.redo.log_switch.interrupts:
+      enabled: true
+    oracledb.redo.size:
+      enabled: true
+    oracledb.redo.time:
+      enabled: true
+      attributes: []
+    oracledb.redo.writes:
+      enabled: true
     oracledb.redo_allocation.utilization:
       enabled: true
     oracledb.sessions.limit:
@@ -416,6 +446,21 @@ none_set:
     oracledb.queries_parallelized:
       enabled: false
     oracledb.recycle_bin.limit:
+      enabled: false
+    oracledb.redo.blocks_written:
+      enabled: false
+    oracledb.redo.buffer_allocation.retries:
+      enabled: false
+    oracledb.redo.log_space.requests:
+      enabled: false
+    oracledb.redo.log_switch.interrupts:
+      enabled: false
+    oracledb.redo.size:
+      enabled: false
+    oracledb.redo.time:
+      enabled: false
+      attributes: ["oracledb.redo.kind"]
+    oracledb.redo.writes:
       enabled: false
     oracledb.redo_allocation.utilization:
       enabled: false

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -99,7 +99,7 @@ all_set:
       enabled: true
     oracledb.recycle_bin.limit:
       enabled: true
-    oracledb.redo.blocks_written:
+    oracledb.redo.blocks:
       enabled: true
     oracledb.redo.buffer_allocation.retries:
       enabled: true
@@ -107,13 +107,13 @@ all_set:
       enabled: true
     oracledb.redo.log_switch.interrupts:
       enabled: true
+    oracledb.redo.operations:
+      enabled: true
     oracledb.redo.size:
       enabled: true
     oracledb.redo.time:
       enabled: true
       attributes: ["oracledb.redo.kind"]
-    oracledb.redo.writes:
-      enabled: true
     oracledb.redo_allocation.utilization:
       enabled: true
     oracledb.sessions.limit:
@@ -273,7 +273,7 @@ reaggregate_set:
       enabled: true
     oracledb.recycle_bin.limit:
       enabled: true
-    oracledb.redo.blocks_written:
+    oracledb.redo.blocks:
       enabled: true
     oracledb.redo.buffer_allocation.retries:
       enabled: true
@@ -281,13 +281,13 @@ reaggregate_set:
       enabled: true
     oracledb.redo.log_switch.interrupts:
       enabled: true
+    oracledb.redo.operations:
+      enabled: true
     oracledb.redo.size:
       enabled: true
     oracledb.redo.time:
       enabled: true
       attributes: []
-    oracledb.redo.writes:
-      enabled: true
     oracledb.redo_allocation.utilization:
       enabled: true
     oracledb.sessions.limit:
@@ -447,7 +447,7 @@ none_set:
       enabled: false
     oracledb.recycle_bin.limit:
       enabled: false
-    oracledb.redo.blocks_written:
+    oracledb.redo.blocks:
       enabled: false
     oracledb.redo.buffer_allocation.retries:
       enabled: false
@@ -455,13 +455,13 @@ none_set:
       enabled: false
     oracledb.redo.log_switch.interrupts:
       enabled: false
+    oracledb.redo.operations:
+      enabled: false
     oracledb.redo.size:
       enabled: false
     oracledb.redo.time:
       enabled: false
       attributes: ["oracledb.redo.kind"]
-    oracledb.redo.writes:
-      enabled: false
     oracledb.redo_allocation.utilization:
       enabled: false
     oracledb.sessions.limit:

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -102,13 +102,15 @@ all_set:
     oracledb.redo.blocks:
       enabled: true
       attributes: ["disk.io.direction"]
-    oracledb.redo.buffer_allocation_retries:
-      enabled: true
-    oracledb.redo.log_space_requests:
-      enabled: true
     oracledb.redo.operations:
       enabled: true
       attributes: ["disk.io.direction"]
+    oracledb.redo.requests:
+      enabled: true
+      attributes: ["oracledb.redo.request.type"]
+    oracledb.redo.retries:
+      enabled: true
+      attributes: ["oracledb.redo.retry.type"]
     oracledb.redo.size:
       enabled: true
     oracledb.redo.time:
@@ -276,11 +278,13 @@ reaggregate_set:
     oracledb.redo.blocks:
       enabled: true
       attributes: []
-    oracledb.redo.buffer_allocation_retries:
-      enabled: true
-    oracledb.redo.log_space_requests:
-      enabled: true
     oracledb.redo.operations:
+      enabled: true
+      attributes: []
+    oracledb.redo.requests:
+      enabled: true
+      attributes: []
+    oracledb.redo.retries:
       enabled: true
       attributes: []
     oracledb.redo.size:
@@ -450,13 +454,15 @@ none_set:
     oracledb.redo.blocks:
       enabled: false
       attributes: ["disk.io.direction"]
-    oracledb.redo.buffer_allocation_retries:
-      enabled: false
-    oracledb.redo.log_space_requests:
-      enabled: false
     oracledb.redo.operations:
       enabled: false
       attributes: ["disk.io.direction"]
+    oracledb.redo.requests:
+      enabled: false
+      attributes: ["oracledb.redo.request.type"]
+    oracledb.redo.retries:
+      enabled: false
+      attributes: ["oracledb.redo.retry.type"]
     oracledb.redo.size:
       enabled: false
     oracledb.redo.time:

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -101,6 +101,7 @@ all_set:
       enabled: true
     oracledb.redo.blocks:
       enabled: true
+      attributes: ["disk.io.direction"]
     oracledb.redo.buffer_allocation.retries:
       enabled: true
     oracledb.redo.log_space.requests:
@@ -109,6 +110,7 @@ all_set:
       enabled: true
     oracledb.redo.operations:
       enabled: true
+      attributes: ["disk.io.direction"]
     oracledb.redo.size:
       enabled: true
     oracledb.redo.time:
@@ -275,6 +277,7 @@ reaggregate_set:
       enabled: true
     oracledb.redo.blocks:
       enabled: true
+      attributes: []
     oracledb.redo.buffer_allocation.retries:
       enabled: true
     oracledb.redo.log_space.requests:
@@ -283,6 +286,7 @@ reaggregate_set:
       enabled: true
     oracledb.redo.operations:
       enabled: true
+      attributes: []
     oracledb.redo.size:
       enabled: true
     oracledb.redo.time:
@@ -449,6 +453,7 @@ none_set:
       enabled: false
     oracledb.redo.blocks:
       enabled: false
+      attributes: ["disk.io.direction"]
     oracledb.redo.buffer_allocation.retries:
       enabled: false
     oracledb.redo.log_space.requests:
@@ -457,6 +462,7 @@ none_set:
       enabled: false
     oracledb.redo.operations:
       enabled: false
+      attributes: ["disk.io.direction"]
     oracledb.redo.size:
       enabled: false
     oracledb.redo.time:

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -102,9 +102,9 @@ all_set:
     oracledb.redo.blocks:
       enabled: true
       attributes: ["disk.io.direction"]
-    oracledb.redo.buffer_allocation.retries:
+    oracledb.redo.buffer_allocation_retries:
       enabled: true
-    oracledb.redo.log_space.requests:
+    oracledb.redo.log_space_requests:
       enabled: true
     oracledb.redo.operations:
       enabled: true
@@ -113,7 +113,7 @@ all_set:
       enabled: true
     oracledb.redo.time:
       enabled: true
-      attributes: ["oracledb.redo.kind"]
+      attributes: ["oracledb.redo.type"]
     oracledb.redo_allocation.utilization:
       enabled: true
     oracledb.sessions.limit:
@@ -276,9 +276,9 @@ reaggregate_set:
     oracledb.redo.blocks:
       enabled: true
       attributes: []
-    oracledb.redo.buffer_allocation.retries:
+    oracledb.redo.buffer_allocation_retries:
       enabled: true
-    oracledb.redo.log_space.requests:
+    oracledb.redo.log_space_requests:
       enabled: true
     oracledb.redo.operations:
       enabled: true
@@ -450,9 +450,9 @@ none_set:
     oracledb.redo.blocks:
       enabled: false
       attributes: ["disk.io.direction"]
-    oracledb.redo.buffer_allocation.retries:
+    oracledb.redo.buffer_allocation_retries:
       enabled: false
-    oracledb.redo.log_space.requests:
+    oracledb.redo.log_space_requests:
       enabled: false
     oracledb.redo.operations:
       enabled: false
@@ -461,7 +461,7 @@ none_set:
       enabled: false
     oracledb.redo.time:
       enabled: false
-      attributes: ["oracledb.redo.kind"]
+      attributes: ["oracledb.redo.type"]
     oracledb.redo_allocation.utilization:
       enabled: false
     oracledb.sessions.limit:

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -106,8 +106,6 @@ all_set:
       enabled: true
     oracledb.redo.log_space.requests:
       enabled: true
-    oracledb.redo.log_switch.interrupts:
-      enabled: true
     oracledb.redo.operations:
       enabled: true
       attributes: ["disk.io.direction"]
@@ -282,8 +280,6 @@ reaggregate_set:
       enabled: true
     oracledb.redo.log_space.requests:
       enabled: true
-    oracledb.redo.log_switch.interrupts:
-      enabled: true
     oracledb.redo.operations:
       enabled: true
       attributes: []
@@ -457,8 +453,6 @@ none_set:
     oracledb.redo.buffer_allocation.retries:
       enabled: false
     oracledb.redo.log_space.requests:
-      enabled: false
-    oracledb.redo.log_switch.interrupts:
       enabled: false
     oracledb.redo.operations:
       enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -235,6 +235,10 @@ attributes:
   oracledb.query_plan:
     description: The query execution plan used by the SQL Server.
     type: string
+  oracledb.redo.kind:
+    description: The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, latching = redo allocation/copy latch waits, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit).
+    type: string
+    enum: [write, latching, log_space_wait, synch]
   oracledb.rows_processed:
     description: The total number of rows that a query has read, returned, or affected during its execution (reporting delta).
     type: int
@@ -821,6 +825,76 @@ metrics:
     gauge:
       value_type: double
     unit: By
+  oracledb.redo.blocks_written:
+    description: Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{blocks}"
+  oracledb.redo.buffer_allocation.retries:
+    description: Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{retries}"
+  oracledb.redo.log_space.requests:
+    description: Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{requests}"
+  oracledb.redo.log_switch.interrupts:
+    description: Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{interrupts}"
+  oracledb.redo.size:
+    description: Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: By
+  oracledb.redo.time:
+    description: Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    unit: s
+    attributes: [oracledb.redo.kind]
+  oracledb.redo.writes:
+    description: Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{writes}"
   oracledb.redo_allocation.utilization:
     description: Fraction of redo allocations that succeeded without space contention, as computed by Oracle V$SYSMETRIC (% (#Redo - RedoSpaceReq)/#Redo).
     enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -825,7 +825,7 @@ metrics:
     gauge:
       value_type: double
     unit: By
-  oracledb.redo.blocks_written:
+  oracledb.redo.blocks:
     description: Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').
     enabled: false
     stability: development
@@ -865,6 +865,16 @@ metrics:
       value_type: int
       input_type: string
     unit: "{interrupts}"
+  oracledb.redo.operations:
+    description: Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{operations}"
   oracledb.redo.size:
     description: Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
     enabled: false
@@ -885,16 +895,6 @@ metrics:
       value_type: double
     unit: s
     attributes: [oracledb.redo.kind]
-  oracledb.redo.writes:
-    description: Number of writes by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
-    enabled: false
-    stability: development
-    sum:
-      aggregation_temporality: cumulative
-      monotonic: true
-      value_type: int
-      input_type: string
-    unit: "{writes}"
   oracledb.redo_allocation.utilization:
     description: Fraction of redo allocations that succeeded without space contention, as computed by Oracle V$SYSMETRIC (% (#Redo - RedoSpaceReq)/#Redo).
     enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -246,7 +246,7 @@ attributes:
   oracledb.redo.type:
     description: The phase of the redo pipeline that a redo time measurement is attributed to.
     type: string
-    enum: [write, log_space_wait, synch]
+    enum: [write, log_space_wait, sync]
   oracledb.rows_processed:
     description: The total number of rows that a query has read, returned, or affected during its execution (reporting delta).
     type: int
@@ -834,7 +834,7 @@ metrics:
       value_type: double
     unit: By
   oracledb.redo.blocks:
-    description: Number of redo blocks moved between the redo log and storage, by I/O direction.
+    description: Number of redo blocks moved between the redo log and storage.
     enabled: false
     stability: development
     sum:
@@ -845,7 +845,7 @@ metrics:
     unit: "{block}"
     attributes: [disk.io.direction]
   oracledb.redo.operations:
-    description: Number of redo I/O operations, by I/O direction.
+    description: Number of redo I/O operations.
     enabled: false
     stability: development
     sum:

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -826,7 +826,7 @@ metrics:
       value_type: double
     unit: By
   oracledb.redo.blocks:
-    description: Number of redo blocks written to the redo log (v$sysstat 'redo blocks written').
+    description: Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').
     enabled: false
     stability: development
     sum:
@@ -835,6 +835,7 @@ metrics:
       value_type: int
       input_type: string
     unit: "{blocks}"
+    attributes: [disk.io.direction]
   oracledb.redo.buffer_allocation.retries:
     description: Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.
     enabled: false
@@ -866,7 +867,7 @@ metrics:
       input_type: string
     unit: "{interrupts}"
   oracledb.redo.operations:
-    description: Number of redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+    description: Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
     enabled: false
     stability: development
     sum:
@@ -875,6 +876,7 @@ metrics:
       value_type: int
       input_type: string
     unit: "{operations}"
+    attributes: [disk.io.direction]
   oracledb.redo.size:
     description: Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
     enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -236,9 +236,9 @@ attributes:
     description: The query execution plan used by the SQL Server.
     type: string
   oracledb.redo.kind:
-    description: The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, latching = redo allocation/copy latch waits, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit).
+    description: The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit).
     type: string
-    enum: [write, latching, log_space_wait, synch]
+    enum: [write, log_space_wait, synch]
   oracledb.rows_processed:
     description: The total number of rows that a query has read, returned, or affected during its execution (reporting delta).
     type: int
@@ -856,16 +856,6 @@ metrics:
       value_type: int
       input_type: string
     unit: "{requests}"
-  oracledb.redo.log_switch.interrupts:
-    description: Number of times a redo log switch was interrupted (v$sysstat 'redo log switch interrupts').
-    enabled: false
-    stability: development
-    sum:
-      aggregation_temporality: cumulative
-      monotonic: true
-      value_type: int
-      input_type: string
-    unit: "{interrupts}"
   oracledb.redo.operations:
     description: Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
     enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -235,8 +235,8 @@ attributes:
   oracledb.query_plan:
     description: The query execution plan used by the SQL Server.
     type: string
-  oracledb.redo.kind:
-    description: The redo-pipeline phase that a redo time measurement is attributed to (write = redo writer I/O, log_space_wait = waits for available redo log space, synch = foreground redo synch on commit).
+  oracledb.redo.type:
+    description: The phase of the redo pipeline that a redo time measurement is attributed to.
     type: string
     enum: [write, log_space_wait, synch]
   oracledb.rows_processed:
@@ -826,7 +826,7 @@ metrics:
       value_type: double
     unit: By
   oracledb.redo.blocks:
-    description: Number of redo blocks moved between the redo log and storage, by I/O direction. disk.io.direction=write counts redo blocks written to the redo log (v$sysstat 'redo blocks written').
+    description: Number of redo blocks moved between the redo log and storage, by I/O direction.
     enabled: false
     stability: development
     sum:
@@ -834,10 +834,10 @@ metrics:
       monotonic: true
       value_type: int
       input_type: string
-    unit: "{blocks}"
+    unit: "{block}"
     attributes: [disk.io.direction]
-  oracledb.redo.buffer_allocation.retries:
-    description: Number of times a process waited and retried to allocate space in the redo buffer because the log writer had not finished flushing it (v$sysstat 'redo buffer allocation retries'). A rising value indicates redo buffer or log writer contention.
+  oracledb.redo.buffer_allocation_retries:
+    description: Number of times a process waited and retried to allocate space in the redo buffer.
     enabled: false
     stability: development
     sum:
@@ -845,9 +845,9 @@ metrics:
       monotonic: true
       value_type: int
       input_type: string
-    unit: "{retries}"
-  oracledb.redo.log_space.requests:
-    description: Number of times a process requested space in the redo log buffer and had to wait for a log switch or available space (v$sysstat 'redo log space requests').
+    unit: "{retry}"
+  oracledb.redo.log_space_requests:
+    description: Number of times a process requested space in the redo log buffer and had to wait.
     enabled: false
     stability: development
     sum:
@@ -855,9 +855,9 @@ metrics:
       monotonic: true
       value_type: int
       input_type: string
-    unit: "{requests}"
+    unit: "{request}"
   oracledb.redo.operations:
-    description: Number of redo I/O operations, by direction. disk.io.direction=write counts redo write operations performed by the log writer (LGWR) to the redo log files (v$sysstat 'redo writes').
+    description: Number of redo I/O operations, by I/O direction.
     enabled: false
     stability: development
     sum:
@@ -865,10 +865,10 @@ metrics:
       monotonic: true
       value_type: int
       input_type: string
-    unit: "{operations}"
+    unit: "{operation}"
     attributes: [disk.io.direction]
   oracledb.redo.size:
-    description: Total amount of redo generated, in bytes (v$sysstat 'redo size'). The canonical redo write-throughput baseline.
+    description: Amount of redo generated.
     enabled: false
     stability: development
     sum:
@@ -878,7 +878,7 @@ metrics:
       input_type: string
     unit: By
   oracledb.redo.time:
-    description: Cumulative time, in seconds, spent in each phase of the redo pipeline (converted from v$sysstat centiseconds). High write/synch time directly raises commit latency.
+    description: Time spent in each phase of the redo pipeline.
     enabled: false
     stability: development
     sum:
@@ -886,7 +886,7 @@ metrics:
       monotonic: true
       value_type: double
     unit: s
-    attributes: [oracledb.redo.kind]
+    attributes: [oracledb.redo.type]
   oracledb.redo_allocation.utilization:
     description: Fraction of redo allocations that succeeded without space contention, as computed by Oracle V$SYSMETRIC (% (#Redo - RedoSpaceReq)/#Redo).
     enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -235,6 +235,14 @@ attributes:
   oracledb.query_plan:
     description: The query execution plan used by the SQL Server.
     type: string
+  oracledb.redo.request.type:
+    description: The type of redo log buffer space request.
+    type: string
+    enum: [log_space]
+  oracledb.redo.retry.type:
+    description: The type of redo buffer allocation retry.
+    type: string
+    enum: [buffer_allocation]
   oracledb.redo.type:
     description: The phase of the redo pipeline that a redo time measurement is attributed to.
     type: string
@@ -836,26 +844,6 @@ metrics:
       input_type: string
     unit: "{block}"
     attributes: [disk.io.direction]
-  oracledb.redo.buffer_allocation_retries:
-    description: Number of times a process waited and retried to allocate space in the redo buffer.
-    enabled: false
-    stability: development
-    sum:
-      aggregation_temporality: cumulative
-      monotonic: true
-      value_type: int
-      input_type: string
-    unit: "{retry}"
-  oracledb.redo.log_space_requests:
-    description: Number of times a process requested space in the redo log buffer and had to wait.
-    enabled: false
-    stability: development
-    sum:
-      aggregation_temporality: cumulative
-      monotonic: true
-      value_type: int
-      input_type: string
-    unit: "{request}"
   oracledb.redo.operations:
     description: Number of redo I/O operations, by I/O direction.
     enabled: false
@@ -867,6 +855,28 @@ metrics:
       input_type: string
     unit: "{operation}"
     attributes: [disk.io.direction]
+  oracledb.redo.requests:
+    description: Number of times a process requested space in the redo log buffer and had to wait.
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{request}"
+    attributes: [oracledb.redo.request.type]
+  oracledb.redo.retries:
+    description: Number of times a process waited and retried to allocate space in the redo buffer.
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{retry}"
+    attributes: [oracledb.redo.retry.type]
   oracledb.redo.size:
     description: Amount of redo generated.
     enabled: false

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -82,6 +82,18 @@ const (
 	dbBlockGets                    = "db block gets"
 	consistentGets                 = "consistent gets"
 
+	// Redo log v$sysstat names (PR4a)
+	redoWriteTime           = "redo write time"
+	redoWriterLatchingTime  = "redo writer latching time"
+	redoLogSpaceWaitTime    = "redo log space wait time"
+	redoSynchTime           = "redo synch time"
+	redoSize                = "redo size"
+	redoWrites              = "redo writes"
+	redoBlocksWritten       = "redo blocks written"
+	redoBufferAllocRetries  = "redo buffer allocation retries"
+	redoLogSpaceRequests    = "redo log space requests"
+	redoLogSwitchInterrupts = "redo log switch interrupts"
+
 	// I/O performance v$sysstat names
 	physicalReadBytesStat            = "physical read bytes"
 	physicalWriteBytesStat           = "physical write bytes"
@@ -311,7 +323,14 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.metricsBuilderConfig.Metrics.OracledbPhysicalIoCacheWrites.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbPhysicalIoRequests.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbPhysicalIoTransferred.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbSqlnetIoTransferred.Enabled
+		s.metricsBuilderConfig.Metrics.OracledbSqlnetIoTransferred.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoTime.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoSize.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoWrites.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoBlocksWritten.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoBufferAllocationRetries.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoLogSpaceRequests.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoLogSwitchInterrupts.Enabled
 	if runStats {
 		now := pcommon.NewTimestampFromTime(time.Now())
 		rows, execError := s.statsClient.metricRows(ctx)
@@ -517,6 +536,47 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				if err := s.mb.RecordOracledbSqlnetIoTransferredDataPoint(now, row["VALUE"], metadata.AttributeNetworkIoDirectionTransmit, metadata.AttributeDestinationTypeDblink); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
+			// Redo log v$sysstat statistics (PR4a)
+			case redoWriteTime:
+				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindWrite); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoWriterLatchingTime:
+				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindLatching); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoLogSpaceWaitTime:
+				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindLogSpaceWait); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoSynchTime:
+				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindSynch); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoSize:
+				if err := s.mb.RecordOracledbRedoSizeDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoWrites:
+				if err := s.mb.RecordOracledbRedoWritesDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoBlocksWritten:
+				if err := s.mb.RecordOracledbRedoBlocksWrittenDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoBufferAllocRetries:
+				if err := s.mb.RecordOracledbRedoBufferAllocationRetriesDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoLogSpaceRequests:
+				if err := s.mb.RecordOracledbRedoLogSpaceRequestsDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoLogSwitchInterrupts:
+				if err := s.mb.RecordOracledbRedoLogSwitchInterruptsDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
 			}
 		}
 	}
@@ -663,6 +723,19 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		return out, scrapererror.NewPartialScrapeError(multierr.Combine(scrapeErrors...), len(scrapeErrors))
 	}
 	return out, nil
+}
+
+// recordRedoTime parses a v$sysstat redo-time value (expressed in centiseconds)
+// and records it as oracledb.redo.time in seconds for the given redo-pipeline phase.
+func (s *oracleScraper) recordRedoTime(ts pcommon.Timestamp, rawValue string, kind metadata.AttributeOracledbRedoKind) error {
+	value, err := strconv.ParseFloat(rawValue, 64)
+	if err != nil {
+		return fmt.Errorf("oracledb.redo.time value: %q, %w", rawValue, err)
+	}
+	// divide by 100 as the value is expressed in centiseconds
+	value /= 100
+	s.mb.RecordOracledbRedoTimeDataPoint(ts, value, kind)
+	return nil
 }
 
 func (s *oracleScraper) collectDataDictHitRatio(ctx context.Context, scrapeErrors *[]error) {

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -326,8 +326,8 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.metricsBuilderConfig.Metrics.OracledbRedoSize.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoOperations.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoBlocks.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoBufferAllocationRetries.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoLogSpaceRequests.Enabled
+		s.metricsBuilderConfig.Metrics.OracledbRedoRequests.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoRetries.Enabled
 	if runStats {
 		now := pcommon.NewTimestampFromTime(time.Now())
 		rows, execError := s.statsClient.metricRows(ctx)
@@ -539,11 +539,11 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoBufferAllocRetries:
-				if err := s.mb.RecordOracledbRedoBufferAllocationRetriesDataPoint(now, row["VALUE"]); err != nil {
+				if err := s.mb.RecordOracledbRedoRetriesDataPoint(now, row["VALUE"], metadata.AttributeOracledbRedoRetryTypeBufferAllocation); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoLogSpaceRequests:
-				if err := s.mb.RecordOracledbRedoLogSpaceRequestsDataPoint(now, row["VALUE"]); err != nil {
+				if err := s.mb.RecordOracledbRedoRequestsDataPoint(now, row["VALUE"], metadata.AttributeOracledbRedoRequestTypeLogSpace); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoLogSpaceWaitTime:

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -562,7 +562,7 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				if value, err := parseFloat("oracledb.redo.time", row["VALUE"]); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				} else {
-					s.mb.RecordOracledbRedoTimeDataPoint(now, value/100, metadata.AttributeOracledbRedoTypeSynch)
+					s.mb.RecordOracledbRedoTimeDataPoint(now, value/100, metadata.AttributeOracledbRedoTypeSync)
 				}
 			case redoWriteTime:
 				// redo time is reported in centiseconds; convert to seconds.
@@ -723,8 +723,6 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	return out, nil
 }
 
-// parseFloat converts a raw v$sysstat string value to a float64, wrapping parse
-// errors with the metric name for context.
 func parseFloat(metricName, rawValue string) (float64, error) {
 	value, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -82,7 +82,7 @@ const (
 	dbBlockGets                    = "db block gets"
 	consistentGets                 = "consistent gets"
 
-	// Redo log v$sysstat names (PR4a)
+	// Redo log v$sysstat names
 	redoWriteTime           = "redo write time"
 	redoWriterLatchingTime  = "redo writer latching time"
 	redoLogSpaceWaitTime    = "redo log space wait time"
@@ -326,8 +326,8 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.metricsBuilderConfig.Metrics.OracledbSqlnetIoTransferred.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoTime.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoSize.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoWrites.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoBlocksWritten.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoOperations.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbRedoBlocks.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoBufferAllocationRetries.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoLogSpaceRequests.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoLogSwitchInterrupts.Enabled
@@ -536,7 +536,7 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				if err := s.mb.RecordOracledbSqlnetIoTransferredDataPoint(now, row["VALUE"], metadata.AttributeNetworkIoDirectionTransmit, metadata.AttributeDestinationTypeDblink); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
-			// Redo log v$sysstat statistics (PR4a)
+			// Redo log v$sysstat statistics
 			case redoWriteTime:
 				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindWrite); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
@@ -558,11 +558,11 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoWrites:
-				if err := s.mb.RecordOracledbRedoWritesDataPoint(now, row["VALUE"]); err != nil {
+				if err := s.mb.RecordOracledbRedoOperationsDataPoint(now, row["VALUE"]); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoBlocksWritten:
-				if err := s.mb.RecordOracledbRedoBlocksWrittenDataPoint(now, row["VALUE"]); err != nil {
+				if err := s.mb.RecordOracledbRedoBlocksDataPoint(now, row["VALUE"]); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoBufferAllocRetries:

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -83,14 +83,14 @@ const (
 	consistentGets                 = "consistent gets"
 
 	// Redo log v$sysstat names
-	redoWriteTime          = "redo write time"
-	redoLogSpaceWaitTime   = "redo log space wait time"
-	redoSynchTime          = "redo synch time"
-	redoSize               = "redo size"
-	redoWrites             = "redo writes"
 	redoBlocksWritten      = "redo blocks written"
 	redoBufferAllocRetries = "redo buffer allocation retries"
 	redoLogSpaceRequests   = "redo log space requests"
+	redoLogSpaceWaitTime   = "redo log space wait time"
+	redoSize               = "redo size"
+	redoSynchTime          = "redo synch time"
+	redoWriteTime          = "redo write time"
+	redoWrites             = "redo writes"
 
 	// I/O performance v$sysstat names
 	physicalReadBytesStat            = "physical read bytes"
@@ -534,26 +534,6 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			// Redo log v$sysstat statistics
-			case redoWriteTime:
-				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindWrite); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
-			case redoLogSpaceWaitTime:
-				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindLogSpaceWait); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
-			case redoSynchTime:
-				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindSynch); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
-			case redoSize:
-				if err := s.mb.RecordOracledbRedoSizeDataPoint(now, row["VALUE"]); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
-			case redoWrites:
-				if err := s.mb.RecordOracledbRedoOperationsDataPoint(now, row["VALUE"], metadata.AttributeDiskIoDirectionWrite); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
 			case redoBlocksWritten:
 				if err := s.mb.RecordOracledbRedoBlocksDataPoint(now, row["VALUE"], metadata.AttributeDiskIoDirectionWrite); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
@@ -564,6 +544,35 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				}
 			case redoLogSpaceRequests:
 				if err := s.mb.RecordOracledbRedoLogSpaceRequestsDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoLogSpaceWaitTime:
+				// redo time is reported in centiseconds; convert to seconds.
+				if value, err := parseFloat("oracledb.redo.time", row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				} else {
+					s.mb.RecordOracledbRedoTimeDataPoint(now, value/100, metadata.AttributeOracledbRedoTypeLogSpaceWait)
+				}
+			case redoSize:
+				if err := s.mb.RecordOracledbRedoSizeDataPoint(now, row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				}
+			case redoSynchTime:
+				// redo time is reported in centiseconds; convert to seconds.
+				if value, err := parseFloat("oracledb.redo.time", row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				} else {
+					s.mb.RecordOracledbRedoTimeDataPoint(now, value/100, metadata.AttributeOracledbRedoTypeSynch)
+				}
+			case redoWriteTime:
+				// redo time is reported in centiseconds; convert to seconds.
+				if value, err := parseFloat("oracledb.redo.time", row["VALUE"]); err != nil {
+					scrapeErrors = append(scrapeErrors, err)
+				} else {
+					s.mb.RecordOracledbRedoTimeDataPoint(now, value/100, metadata.AttributeOracledbRedoTypeWrite)
+				}
+			case redoWrites:
+				if err := s.mb.RecordOracledbRedoOperationsDataPoint(now, row["VALUE"], metadata.AttributeDiskIoDirectionWrite); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			}
@@ -714,17 +723,14 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	return out, nil
 }
 
-// recordRedoTime parses a v$sysstat redo-time value (expressed in centiseconds)
-// and records it as oracledb.redo.time in seconds for the given redo-pipeline phase.
-func (s *oracleScraper) recordRedoTime(ts pcommon.Timestamp, rawValue string, kind metadata.AttributeOracledbRedoKind) error {
+// parseFloat converts a raw v$sysstat string value to a float64, wrapping parse
+// errors with the metric name for context.
+func parseFloat(metricName, rawValue string) (float64, error) {
 	value, err := strconv.ParseFloat(rawValue, 64)
 	if err != nil {
-		return fmt.Errorf("oracledb.redo.time value: %q, %w", rawValue, err)
+		return 0, fmt.Errorf("%s value: %q, %w", metricName, rawValue, err)
 	}
-	// divide by 100 as the value is expressed in centiseconds
-	value /= 100
-	s.mb.RecordOracledbRedoTimeDataPoint(ts, value, kind)
-	return nil
+	return value, nil
 }
 
 func (s *oracleScraper) collectDataDictHitRatio(ctx context.Context, scrapeErrors *[]error) {

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -83,16 +83,14 @@ const (
 	consistentGets                 = "consistent gets"
 
 	// Redo log v$sysstat names
-	redoWriteTime           = "redo write time"
-	redoWriterLatchingTime  = "redo writer latching time"
-	redoLogSpaceWaitTime    = "redo log space wait time"
-	redoSynchTime           = "redo synch time"
-	redoSize                = "redo size"
-	redoWrites              = "redo writes"
-	redoBlocksWritten       = "redo blocks written"
-	redoBufferAllocRetries  = "redo buffer allocation retries"
-	redoLogSpaceRequests    = "redo log space requests"
-	redoLogSwitchInterrupts = "redo log switch interrupts"
+	redoWriteTime          = "redo write time"
+	redoLogSpaceWaitTime   = "redo log space wait time"
+	redoSynchTime          = "redo synch time"
+	redoSize               = "redo size"
+	redoWrites             = "redo writes"
+	redoBlocksWritten      = "redo blocks written"
+	redoBufferAllocRetries = "redo buffer allocation retries"
+	redoLogSpaceRequests   = "redo log space requests"
 
 	// I/O performance v$sysstat names
 	physicalReadBytesStat            = "physical read bytes"
@@ -329,8 +327,7 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.metricsBuilderConfig.Metrics.OracledbRedoOperations.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoBlocks.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbRedoBufferAllocationRetries.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoLogSpaceRequests.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoLogSwitchInterrupts.Enabled
+		s.metricsBuilderConfig.Metrics.OracledbRedoLogSpaceRequests.Enabled
 	if runStats {
 		now := pcommon.NewTimestampFromTime(time.Now())
 		rows, execError := s.statsClient.metricRows(ctx)
@@ -541,10 +538,6 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindWrite); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
-			case redoWriterLatchingTime:
-				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindLatching); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
 			case redoLogSpaceWaitTime:
 				if err := s.recordRedoTime(now, row["VALUE"], metadata.AttributeOracledbRedoKindLogSpaceWait); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
@@ -571,10 +564,6 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				}
 			case redoLogSpaceRequests:
 				if err := s.mb.RecordOracledbRedoLogSpaceRequestsDataPoint(now, row["VALUE"]); err != nil {
-					scrapeErrors = append(scrapeErrors, err)
-				}
-			case redoLogSwitchInterrupts:
-				if err := s.mb.RecordOracledbRedoLogSwitchInterruptsDataPoint(now, row["VALUE"]); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			}

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -558,11 +558,11 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoWrites:
-				if err := s.mb.RecordOracledbRedoOperationsDataPoint(now, row["VALUE"]); err != nil {
+				if err := s.mb.RecordOracledbRedoOperationsDataPoint(now, row["VALUE"], metadata.AttributeDiskIoDirectionWrite); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoBlocksWritten:
-				if err := s.mb.RecordOracledbRedoBlocksDataPoint(now, row["VALUE"]); err != nil {
+				if err := s.mb.RecordOracledbRedoBlocksDataPoint(now, row["VALUE"], metadata.AttributeDiskIoDirectionWrite); err != nil {
 					scrapeErrors = append(scrapeErrors, err)
 				}
 			case redoBufferAllocRetries:

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -76,7 +76,6 @@ var queryResponses = map[string][]metricRow{
 		{"NAME": sqlnetBytesSentToDBLink, "VALUE": "75000"},
 		// Redo log v$sysstat rows (redo time values are in centiseconds)
 		{"NAME": redoWriteTime, "VALUE": "1500"},
-		{"NAME": redoWriterLatchingTime, "VALUE": "300"},
 		{"NAME": redoLogSpaceWaitTime, "VALUE": "250"},
 		{"NAME": redoSynchTime, "VALUE": "900"},
 		{"NAME": redoSize, "VALUE": "104857600"},
@@ -84,7 +83,6 @@ var queryResponses = map[string][]metricRow{
 		{"NAME": redoBlocksWritten, "VALUE": "210000"},
 		{"NAME": redoBufferAllocRetries, "VALUE": "12"},
 		{"NAME": redoLogSpaceRequests, "VALUE": "34"},
-		{"NAME": redoLogSwitchInterrupts, "VALUE": "5"},
 	},
 	sessionCountSQL: {{"VALUE": "1"}},
 	systemResourceLimitsSQL: {
@@ -419,7 +417,6 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 	cfg.Metrics.OracledbRedoBlocks.Enabled = true
 	cfg.Metrics.OracledbRedoBufferAllocationRetries.Enabled = true
 	cfg.Metrics.OracledbRedoLogSpaceRequests.Enabled = true
-	cfg.Metrics.OracledbRedoLogSwitchInterrupts.Enabled = true
 
 	scrpr := oracleScraper{
 		logger: zap.NewNop(),
@@ -469,7 +466,6 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 
 	// oracledb.redo.time: centiseconds converted to seconds (value / 100), one data point per redo.kind.
 	assert.InDelta(t, 15.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=write"], floatDelta)
-	assert.InDelta(t, 3.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=latching"], floatDelta)
 	assert.InDelta(t, 2.5, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=log_space_wait"], floatDelta)
 	assert.InDelta(t, 9.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=synch"], floatDelta)
 
@@ -480,7 +476,6 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks"]["disk.io.direction=write"])
 	assert.Equal(t, int64(12), intVals["oracledb.redo.buffer_allocation.retries"][""])
 	assert.Equal(t, int64(34), intVals["oracledb.redo.log_space.requests"][""])
-	assert.Equal(t, int64(5), intVals["oracledb.redo.log_switch.interrupts"][""])
 }
 
 func TestScraper_ScrapeTopNLogs(t *testing.T) {

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -415,8 +415,8 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 	cfg.Metrics.OracledbRedoSize.Enabled = true
 	cfg.Metrics.OracledbRedoOperations.Enabled = true
 	cfg.Metrics.OracledbRedoBlocks.Enabled = true
-	cfg.Metrics.OracledbRedoBufferAllocationRetries.Enabled = true
-	cfg.Metrics.OracledbRedoLogSpaceRequests.Enabled = true
+	cfg.Metrics.OracledbRedoRequests.Enabled = true
+	cfg.Metrics.OracledbRedoRetries.Enabled = true
 
 	scrpr := oracleScraper{
 		logger: zap.NewNop(),
@@ -474,8 +474,9 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 	// redo.operations and redo.blocks carry disk.io.direction=write.
 	assert.Equal(t, int64(45000), intVals[metadata.MetricsInfo.OracledbRedoOperations.Name]["disk.io.direction=write"])
 	assert.Equal(t, int64(210000), intVals[metadata.MetricsInfo.OracledbRedoBlocks.Name]["disk.io.direction=write"])
-	assert.Equal(t, int64(12), intVals[metadata.MetricsInfo.OracledbRedoBufferAllocationRetries.Name][""])
-	assert.Equal(t, int64(34), intVals[metadata.MetricsInfo.OracledbRedoLogSpaceRequests.Name][""])
+	// redo.requests and redo.retries each carry a single-value type attribute.
+	assert.Equal(t, int64(34), intVals[metadata.MetricsInfo.OracledbRedoRequests.Name]["oracledb.redo.request.type=log_space"])
+	assert.Equal(t, int64(12), intVals[metadata.MetricsInfo.OracledbRedoRetries.Name]["oracledb.redo.retry.type=buffer_allocation"])
 }
 
 func TestScraper_ScrapeTopNLogs(t *testing.T) {

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -74,7 +74,7 @@ var queryResponses = map[string][]metricRow{
 		{"NAME": sqlnetBytesSentToClient, "VALUE": "600000"},
 		{"NAME": sqlnetBytesRecvFromDBLink, "VALUE": "150000"},
 		{"NAME": sqlnetBytesSentToDBLink, "VALUE": "75000"},
-		// PR4a: redo log v$sysstat rows (redo time values are in centiseconds)
+		// Redo log v$sysstat rows (redo time values are in centiseconds)
 		{"NAME": redoWriteTime, "VALUE": "1500"},
 		{"NAME": redoWriterLatchingTime, "VALUE": "300"},
 		{"NAME": redoLogSpaceWaitTime, "VALUE": "250"},
@@ -415,8 +415,8 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 	cfg := metadata.NewDefaultMetricsBuilderConfig()
 	cfg.Metrics.OracledbRedoTime.Enabled = true
 	cfg.Metrics.OracledbRedoSize.Enabled = true
-	cfg.Metrics.OracledbRedoWrites.Enabled = true
-	cfg.Metrics.OracledbRedoBlocksWritten.Enabled = true
+	cfg.Metrics.OracledbRedoOperations.Enabled = true
+	cfg.Metrics.OracledbRedoBlocks.Enabled = true
 	cfg.Metrics.OracledbRedoBufferAllocationRetries.Enabled = true
 	cfg.Metrics.OracledbRedoLogSpaceRequests.Enabled = true
 	cfg.Metrics.OracledbRedoLogSwitchInterrupts.Enabled = true
@@ -475,8 +475,8 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 
 	// Standalone redo counters pass v$sysstat VALUE straight through.
 	assert.Equal(t, int64(104857600), intVals["oracledb.redo.size"][""])
-	assert.Equal(t, int64(45000), intVals["oracledb.redo.writes"][""])
-	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks_written"][""])
+	assert.Equal(t, int64(45000), intVals["oracledb.redo.operations"][""])
+	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks"][""])
 	assert.Equal(t, int64(12), intVals["oracledb.redo.buffer_allocation.retries"][""])
 	assert.Equal(t, int64(34), intVals["oracledb.redo.log_space.requests"][""])
 	assert.Equal(t, int64(5), intVals["oracledb.redo.log_switch.interrupts"][""])

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -475,8 +475,9 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 
 	// Standalone redo counters pass v$sysstat VALUE straight through.
 	assert.Equal(t, int64(104857600), intVals["oracledb.redo.size"][""])
-	assert.Equal(t, int64(45000), intVals["oracledb.redo.operations"][""])
-	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks"][""])
+	// redo.operations and redo.blocks carry disk.io.direction=write.
+	assert.Equal(t, int64(45000), intVals["oracledb.redo.operations"]["disk.io.direction=write"])
+	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks"]["disk.io.direction=write"])
 	assert.Equal(t, int64(12), intVals["oracledb.redo.buffer_allocation.retries"][""])
 	assert.Equal(t, int64(34), intVals["oracledb.redo.log_space.requests"][""])
 	assert.Equal(t, int64(5), intVals["oracledb.redo.log_switch.interrupts"][""])

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -464,18 +464,18 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 		}
 	}
 
-	// oracledb.redo.time: centiseconds converted to seconds (value / 100), one data point per redo.kind.
-	assert.InDelta(t, 15.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=write"], floatDelta)
-	assert.InDelta(t, 2.5, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=log_space_wait"], floatDelta)
-	assert.InDelta(t, 9.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=synch"], floatDelta)
+	// oracledb.redo.time: centiseconds converted to seconds (value / 100), one data point per redo.type.
+	assert.InDelta(t, 15.0, doubleVals[metadata.MetricsInfo.OracledbRedoTime.Name]["oracledb.redo.type=write"], floatDelta)
+	assert.InDelta(t, 2.5, doubleVals[metadata.MetricsInfo.OracledbRedoTime.Name]["oracledb.redo.type=log_space_wait"], floatDelta)
+	assert.InDelta(t, 9.0, doubleVals[metadata.MetricsInfo.OracledbRedoTime.Name]["oracledb.redo.type=synch"], floatDelta)
 
 	// Standalone redo counters pass v$sysstat VALUE straight through.
-	assert.Equal(t, int64(104857600), intVals["oracledb.redo.size"][""])
+	assert.Equal(t, int64(104857600), intVals[metadata.MetricsInfo.OracledbRedoSize.Name][""])
 	// redo.operations and redo.blocks carry disk.io.direction=write.
-	assert.Equal(t, int64(45000), intVals["oracledb.redo.operations"]["disk.io.direction=write"])
-	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks"]["disk.io.direction=write"])
-	assert.Equal(t, int64(12), intVals["oracledb.redo.buffer_allocation.retries"][""])
-	assert.Equal(t, int64(34), intVals["oracledb.redo.log_space.requests"][""])
+	assert.Equal(t, int64(45000), intVals[metadata.MetricsInfo.OracledbRedoOperations.Name]["disk.io.direction=write"])
+	assert.Equal(t, int64(210000), intVals[metadata.MetricsInfo.OracledbRedoBlocks.Name]["disk.io.direction=write"])
+	assert.Equal(t, int64(12), intVals[metadata.MetricsInfo.OracledbRedoBufferAllocationRetries.Name][""])
+	assert.Equal(t, int64(34), intVals[metadata.MetricsInfo.OracledbRedoLogSpaceRequests.Name][""])
 }
 
 func TestScraper_ScrapeTopNLogs(t *testing.T) {

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -74,6 +74,17 @@ var queryResponses = map[string][]metricRow{
 		{"NAME": sqlnetBytesSentToClient, "VALUE": "600000"},
 		{"NAME": sqlnetBytesRecvFromDBLink, "VALUE": "150000"},
 		{"NAME": sqlnetBytesSentToDBLink, "VALUE": "75000"},
+		// PR4a: redo log v$sysstat rows (redo time values are in centiseconds)
+		{"NAME": redoWriteTime, "VALUE": "1500"},
+		{"NAME": redoWriterLatchingTime, "VALUE": "300"},
+		{"NAME": redoLogSpaceWaitTime, "VALUE": "250"},
+		{"NAME": redoSynchTime, "VALUE": "900"},
+		{"NAME": redoSize, "VALUE": "104857600"},
+		{"NAME": redoWrites, "VALUE": "45000"},
+		{"NAME": redoBlocksWritten, "VALUE": "210000"},
+		{"NAME": redoBufferAllocRetries, "VALUE": "12"},
+		{"NAME": redoLogSpaceRequests, "VALUE": "34"},
+		{"NAME": redoLogSwitchInterrupts, "VALUE": "5"},
 	},
 	sessionCountSQL: {{"VALUE": "1"}},
 	systemResourceLimitsSQL: {
@@ -396,6 +407,79 @@ func TestScraper_ScrapeIOPerformanceMetrics(t *testing.T) {
 	assert.Equal(t, int64(600000), got["oracledb.sqlnet.io.transferred"]["destination.type=client,network.io.direction=transmit"])
 	assert.Equal(t, int64(150000), got["oracledb.sqlnet.io.transferred"]["destination.type=dblink,network.io.direction=receive"])
 	assert.Equal(t, int64(75000), got["oracledb.sqlnet.io.transferred"]["destination.type=dblink,network.io.direction=transmit"])
+}
+
+func TestScraper_ScrapeRedoMetrics(t *testing.T) {
+	const floatDelta = 0.0001
+
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	cfg.Metrics.OracledbRedoTime.Enabled = true
+	cfg.Metrics.OracledbRedoSize.Enabled = true
+	cfg.Metrics.OracledbRedoWrites.Enabled = true
+	cfg.Metrics.OracledbRedoBlocksWritten.Enabled = true
+	cfg.Metrics.OracledbRedoBufferAllocationRetries.Enabled = true
+	cfg.Metrics.OracledbRedoLogSpaceRequests.Enabled = true
+	cfg.Metrics.OracledbRedoLogSwitchInterrupts.Enabled = true
+
+	scrpr := oracleScraper{
+		logger: zap.NewNop(),
+		mb:     metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		dbProviderFunc: func() (*sql.DB, error) {
+			return nil, nil
+		},
+		clientProviderFunc: func(_ *sql.DB, s string, _ *zap.Logger) dbClient {
+			return &fakeDbClient{Responses: [][]metricRow{queryResponses[s]}}
+		},
+		id:                   component.ID{},
+		metricsBuilderConfig: cfg,
+	}
+	require.NoError(t, scrpr.start(t.Context(), componenttest.NewNopHost()))
+	defer func() { assert.NoError(t, scrpr.shutdown(t.Context())) }()
+
+	m, err := scrpr.scrape(t.Context())
+	require.NoError(t, err)
+
+	// metricName -> attrSignature -> data point (int and double accessors)
+	intVals := map[string]map[string]int64{}
+	doubleVals := map[string]map[string]float64{}
+	metrics := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		me := metrics.At(i)
+		if me.Type() != pmetric.MetricTypeSum {
+			continue
+		}
+		dps := me.Sum().DataPoints()
+		for j := 0; j < dps.Len(); j++ {
+			dp := dps.At(j)
+			var keys []string
+			dp.Attributes().Range(func(k string, v pcommon.Value) bool {
+				keys = append(keys, k+"="+v.AsString())
+				return true
+			})
+			sort.Strings(keys)
+			sig := strings.Join(keys, ",")
+			if _, ok := intVals[me.Name()]; !ok {
+				intVals[me.Name()] = map[string]int64{}
+				doubleVals[me.Name()] = map[string]float64{}
+			}
+			intVals[me.Name()][sig] = dp.IntValue()
+			doubleVals[me.Name()][sig] = dp.DoubleValue()
+		}
+	}
+
+	// oracledb.redo.time: centiseconds converted to seconds (value / 100), one data point per redo.kind.
+	assert.InDelta(t, 15.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=write"], floatDelta)
+	assert.InDelta(t, 3.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=latching"], floatDelta)
+	assert.InDelta(t, 2.5, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=log_space_wait"], floatDelta)
+	assert.InDelta(t, 9.0, doubleVals["oracledb.redo.time"]["oracledb.redo.kind=synch"], floatDelta)
+
+	// Standalone redo counters pass v$sysstat VALUE straight through.
+	assert.Equal(t, int64(104857600), intVals["oracledb.redo.size"][""])
+	assert.Equal(t, int64(45000), intVals["oracledb.redo.writes"][""])
+	assert.Equal(t, int64(210000), intVals["oracledb.redo.blocks_written"][""])
+	assert.Equal(t, int64(12), intVals["oracledb.redo.buffer_allocation.retries"][""])
+	assert.Equal(t, int64(34), intVals["oracledb.redo.log_space.requests"][""])
+	assert.Equal(t, int64(5), intVals["oracledb.redo.log_switch.interrupts"][""])
 }
 
 func TestScraper_ScrapeTopNLogs(t *testing.T) {

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -436,47 +436,64 @@ func TestScraper_ScrapeRedoMetrics(t *testing.T) {
 	m, err := scrpr.scrape(t.Context())
 	require.NoError(t, err)
 
-	// metricName -> attrSignature -> data point (int and double accessors)
-	intVals := map[string]map[string]int64{}
-	doubleVals := map[string]map[string]float64{}
+	// Loop the scraped metrics and switch on the metric name; assert each metric's value(s) and
+	// attribute(s) in place, using the mdatagen-generated name/attribute constants.
 	metrics := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	seen := 0
 	for i := 0; i < metrics.Len(); i++ {
 		me := metrics.At(i)
 		if me.Type() != pmetric.MetricTypeSum {
 			continue
 		}
 		dps := me.Sum().DataPoints()
-		for j := 0; j < dps.Len(); j++ {
-			dp := dps.At(j)
-			var keys []string
-			dp.Attributes().Range(func(k string, v pcommon.Value) bool {
-				keys = append(keys, k+"="+v.AsString())
-				return true
-			})
-			sort.Strings(keys)
-			sig := strings.Join(keys, ",")
-			if _, ok := intVals[me.Name()]; !ok {
-				intVals[me.Name()] = map[string]int64{}
-				doubleVals[me.Name()] = map[string]float64{}
+		switch me.Name() {
+		case metadata.MetricsInfo.OracledbRedoTime.Name:
+			// centiseconds converted to seconds (value / 100), one data point per redo.type.
+			for j := 0; j < dps.Len(); j++ {
+				dp := dps.At(j)
+				redoType, _ := dp.Attributes().Get("oracledb.redo.type")
+				switch redoType.Str() {
+				case metadata.AttributeOracledbRedoTypeWrite.String():
+					assert.InDelta(t, 15.0, dp.DoubleValue(), floatDelta)
+				case metadata.AttributeOracledbRedoTypeLogSpaceWait.String():
+					assert.InDelta(t, 2.5, dp.DoubleValue(), floatDelta)
+				case metadata.AttributeOracledbRedoTypeSync.String():
+					assert.InDelta(t, 9.0, dp.DoubleValue(), floatDelta)
+				default:
+					t.Errorf("unexpected oracledb.redo.type: %q", redoType.Str())
+				}
 			}
-			intVals[me.Name()][sig] = dp.IntValue()
-			doubleVals[me.Name()][sig] = dp.DoubleValue()
+			seen++
+		case metadata.MetricsInfo.OracledbRedoSize.Name:
+			assert.Equal(t, int64(104857600), dps.At(0).IntValue())
+			seen++
+		case metadata.MetricsInfo.OracledbRedoOperations.Name:
+			dp := dps.At(0)
+			dir, _ := dp.Attributes().Get("disk.io.direction")
+			assert.Equal(t, metadata.AttributeDiskIoDirectionWrite.String(), dir.Str())
+			assert.Equal(t, int64(45000), dp.IntValue())
+			seen++
+		case metadata.MetricsInfo.OracledbRedoBlocks.Name:
+			dp := dps.At(0)
+			dir, _ := dp.Attributes().Get("disk.io.direction")
+			assert.Equal(t, metadata.AttributeDiskIoDirectionWrite.String(), dir.Str())
+			assert.Equal(t, int64(210000), dp.IntValue())
+			seen++
+		case metadata.MetricsInfo.OracledbRedoRequests.Name:
+			dp := dps.At(0)
+			reqType, _ := dp.Attributes().Get("oracledb.redo.request.type")
+			assert.Equal(t, metadata.AttributeOracledbRedoRequestTypeLogSpace.String(), reqType.Str())
+			assert.Equal(t, int64(34), dp.IntValue())
+			seen++
+		case metadata.MetricsInfo.OracledbRedoRetries.Name:
+			dp := dps.At(0)
+			retryType, _ := dp.Attributes().Get("oracledb.redo.retry.type")
+			assert.Equal(t, metadata.AttributeOracledbRedoRetryTypeBufferAllocation.String(), retryType.Str())
+			assert.Equal(t, int64(12), dp.IntValue())
+			seen++
 		}
 	}
-
-	// oracledb.redo.time: centiseconds converted to seconds (value / 100), one data point per redo.type.
-	assert.InDelta(t, 15.0, doubleVals[metadata.MetricsInfo.OracledbRedoTime.Name]["oracledb.redo.type=write"], floatDelta)
-	assert.InDelta(t, 2.5, doubleVals[metadata.MetricsInfo.OracledbRedoTime.Name]["oracledb.redo.type=log_space_wait"], floatDelta)
-	assert.InDelta(t, 9.0, doubleVals[metadata.MetricsInfo.OracledbRedoTime.Name]["oracledb.redo.type=synch"], floatDelta)
-
-	// Standalone redo counters pass v$sysstat VALUE straight through.
-	assert.Equal(t, int64(104857600), intVals[metadata.MetricsInfo.OracledbRedoSize.Name][""])
-	// redo.operations and redo.blocks carry disk.io.direction=write.
-	assert.Equal(t, int64(45000), intVals[metadata.MetricsInfo.OracledbRedoOperations.Name]["disk.io.direction=write"])
-	assert.Equal(t, int64(210000), intVals[metadata.MetricsInfo.OracledbRedoBlocks.Name]["disk.io.direction=write"])
-	// redo.requests and redo.retries each carry a single-value type attribute.
-	assert.Equal(t, int64(34), intVals[metadata.MetricsInfo.OracledbRedoRequests.Name]["oracledb.redo.request.type=log_space"])
-	assert.Equal(t, int64(12), intVals[metadata.MetricsInfo.OracledbRedoRetries.Name]["oracledb.redo.retry.type=buffer_allocation"])
+	assert.Equal(t, 6, seen, "expected all 6 redo metrics to be emitted")
 }
 
 func TestScraper_ScrapeTopNLogs(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The Oracle DB receiver scrapes `v$sysstat` with `SELECT * FROM v$sysstat`, which returns all system-statistics rows. However, the scraper only processes a subset of those rows in its `switch` block and silently discards the rest -- including every redo-log statistic. This PR surfaces **8 discarded redo rows** as **6 new opt-in metrics** under the `oracledb.redo.*` namespace, giving operators visibility into redo write latency, redo throughput, and redo-log sizing pressure -- the foundation of Oracle's durability and recovery story (the equivalent of PostgreSQL's WAL).

Because the data is already being fetched, the implementation is purely additive Go code:
- **No new SQL queries**
- **No new database round-trips**
- **Zero additional load on the Oracle instance**

Related statistics are consolidated under a single metric name with an OTel attribute rather than mapping each flat statistic to its own metric name, following the receiver's existing attributed-metric convention. The redo-pipeline timing statistics share one metric (`oracledb.redo.time`) differentiated by the `oracledb.redo.type` attribute; the redo space requests and buffer-allocation retries each share one metric (`oracledb.redo.requests` / `oracledb.redo.retries`) differentiated by a `oracledb.redo.request.type` / `oracledb.redo.retry.type` attribute; and the write-direction counters reuse the existing `disk.io.direction` attribute (introduced for `oracledb.physical_io.*`).

This PR adds 6 new opt-in metrics (disabled by default, stability: development):

* `oracledb.redo.time` -- Time spent in each phase of the redo pipeline. Attribute: `oracledb.redo.type` (write|log_space_wait|sync). Covers `v$sysstat`: `redo write time`, `redo log space wait time`, `redo synch time` (the raw centisecond value is divided by 100 in the scraper).
* `oracledb.redo.size` -- Amount of redo generated. No attributes. Covers `v$sysstat`: `redo size`.
* `oracledb.redo.operations` -- Number of redo I/O operations. Attribute: `disk.io.direction` (write). Covers `v$sysstat`: `redo writes`.
* `oracledb.redo.blocks` -- Number of redo blocks moved between the redo log and storage. Attribute: `disk.io.direction` (write). Covers `v$sysstat`: `redo blocks written`.
* `oracledb.redo.requests` -- Number of times a process requested space in the redo log buffer and had to wait. Attribute: `oracledb.redo.request.type` (log_space). Covers `v$sysstat`: `redo log space requests`.
* `oracledb.redo.retries` -- Number of times a process waited and retried to allocate space in the redo buffer. Attribute: `oracledb.redo.retry.type` (buffer_allocation). Covers `v$sysstat`: `redo buffer allocation retries`.

`oracledb.redo.time` is emitted as a `Sum` with `aggregation_temporality: cumulative`, `monotonic: true`, value type `double`, unit `s`. The other five are emitted as `Sum` with `aggregation_temporality: cumulative`, `monotonic: true`, value type `int`. Per-metric units: `s` (`oracledb.redo.time`); `By` (`oracledb.redo.size`); `{operation}` (`oracledb.redo.operations`); `{block}` (`oracledb.redo.blocks`); `{request}` (`oracledb.redo.requests`); `{retry}` (`oracledb.redo.retries`).

`oracledb.redo.time` reports seconds (`s`) rather than the raw `cs` (centisecond) units that Oracle exposes via `v$sysstat`. The scraper divides the raw value by 100 before recording, matching the conversion already in place for the existing `oracledb.cpu_time` metric.

The new attributes `oracledb.redo.type`, `oracledb.redo.request.type`, and `oracledb.redo.retry.type` use dotted-namespaced receiver-scoped keys, as no OTel semantic-convention attribute covers Oracle's redo-pipeline phases or space-request/retry kinds. `oracledb.redo.operations` and `oracledb.redo.blocks` reuse the existing `disk.io.direction` attribute (currently `write`), which also leaves room for a future read counterpart without a schema change.

The metric set covers the redo statistics present on currently-supported Oracle (12c+); statistics that were removed in 12c (e.g. `redo writer latching time`) or that are not exposed by `v$sysstat` are intentionally excluded.

These metrics can be enabled in the collector configuration:

```yaml
receivers:
  oracledb:
    datasource: "oracle://user:password@host:1521/service"
    metrics:
      oracledb.redo.time:
        enabled: true
      oracledb.redo.size:
        enabled: true
      oracledb.redo.operations:
        enabled: true
      oracledb.redo.blocks:
        enabled: true
      oracledb.redo.requests:
        enabled: true
      oracledb.redo.retries:
        enabled: true
 ```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49060

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests added in scraper_test.go:

- TestScraper_ScrapeRedoMetrics exercises all 6 new metrics end-to-end through the scraper using the existing fake DB client. It loops over the scraped metrics and switches on the metric name, asserting each metric's value(s) and attribute(s) in place using the mdatagen-generated `metadata.MetricsInfo.*.Name` and `Attribute*.String()` constants (3 `oracledb.redo.time` data points -- one per `oracledb.redo.type` -- plus one data point for each of the other five metrics).
- The shared queryResponses[statsSQL] fixture is extended with 8 new fake `v$sysstat` rows (one per covered NAME), so the existing scraper tests continue to pass unchanged.
The test verifies the centiseconds -> seconds conversion on oracledb.redo.time (raw redo write time / redo log space wait time / redo synch time produce the expected write/log_space_wait/sync values), asserts disk.io.direction=write on `oracledb.redo.operations` and `oracledb.redo.blocks`, and asserts the single-value `request.type`/`retry.type` attributes on `oracledb.redo.requests` / `oracledb.redo.retries`.
- Auto-generated tests in internal/metadata/generated_metrics_test.go and generated_config_test.go are regenerated by make generate and cover the new metric configs / metric builders.

<!--Describe the documentation added.-->
#### Documentation
Auto-generated documentation.md updated with descriptions and metadata for the 6 new metrics and the new `oracledb.redo.type`, `oracledb.redo.request.type`, and `oracledb.redo.retry.type` attributes (`oracledb.redo.operations` and `oracledb.redo.blocks` reuse the existing `disk.io.direction` attribute). internal/metadata/generated_*.go and internal/metadata/testdata/config.yaml regenerated via make generate. internal/metadata/config.schema.yaml was manually updated for the 6 new metric stanzas, as that file is not regenerated by mdatagen.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
