### PR TITLE
[receiver/hostmetrics] Add system.network.connection.count metric to network scraper

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/config.go
@@ -15,10 +15,23 @@ type Config struct {
 	Include MatchConfig `mapstructure:"include"`
 	// Exclude specifies a filter on the network interfaces that should be excluded from the generated metrics.
 	Exclude MatchConfig `mapstructure:"exclude"`
+	// Connections specifies detailed network connection metric settings.
+	Connections ConnectionConfig `mapstructure:"connections"`
 }
 
 type MatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
 
 	Interfaces []string `mapstructure:"interfaces"`
+}
+
+type ConnectionConfig struct {
+	// IncludePorts specifies remote ports that should be included in detailed connection metrics.
+	IncludePorts []uint32 `mapstructure:"include_ports"`
+	// ExcludePorts specifies remote ports that should be excluded from detailed connection metrics.
+	ExcludePorts []uint32 `mapstructure:"exclude_ports"`
+	// ExcludeLocalhost specifies whether to exclude local and loopback remote addresses from detailed connection metrics.
+	ExcludeLocalhost bool `mapstructure:"exclude_localhost"`
+	// ExcludeListenPorts specifies whether to exclude connections from local listening ports from detailed connection metrics.
+	ExcludeListenPorts bool `mapstructure:"exclude_listen_ports"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
@@ -97,6 +97,21 @@ metrics:
     enabled: true
 ```
 
+### system.network.connection.count
+
+The number of established network connections, grouped by remote endpoint.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {connections} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| server.address | The remote address of the network connection. | Any Str | Recommended | - |
+| server.port | The remote port of the network connection. | Any Int | Recommended | - |
+
 ### system.network.conntrack.count
 
 The count of entries in conntrack table.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/generated_package_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/generated_package_test.go
@@ -3,9 +3,8 @@
 package networkscraper
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config.go
@@ -8,6 +8,55 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 )
 
+// SystemNetworkConnectionCountMetricAttributeKey specifies the key of an attribute for the system.network.connection.count metric.
+type SystemNetworkConnectionCountMetricAttributeKey string
+
+const (
+	SystemNetworkConnectionCountMetricAttributeKeyServerAddress SystemNetworkConnectionCountMetricAttributeKey = "server.address"
+	SystemNetworkConnectionCountMetricAttributeKeyServerPort    SystemNetworkConnectionCountMetricAttributeKey = "server.port"
+)
+
+// SystemNetworkConnectionCountMetricConfig provides config for the system.network.connection.count metric.
+type SystemNetworkConnectionCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SystemNetworkConnectionCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SystemNetworkConnectionCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SystemNetworkConnectionCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SystemNetworkConnectionCountMetricAttributeKeyServerAddress, SystemNetworkConnectionCountMetricAttributeKeyServerPort:
+		default:
+			return fmt.Errorf("metric system.network.connection.count doesn't have an attribute %v, valid attributes: [server.address, server.port]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SystemNetworkConnectionsMetricAttributeKey specifies the key of an attribute for the system.network.connections metric.
 type SystemNetworkConnectionsMetricAttributeKey string
 
@@ -295,17 +344,23 @@ func (ms *SystemNetworkPacketsMetricConfig) Validate() error {
 
 // MetricsConfig provides config for network metrics.
 type MetricsConfig struct {
-	SystemNetworkConnections    SystemNetworkConnectionsMetricConfig    `mapstructure:"system.network.connections"`
-	SystemNetworkConntrackCount SystemNetworkConntrackCountMetricConfig `mapstructure:"system.network.conntrack.count"`
-	SystemNetworkConntrackMax   SystemNetworkConntrackMaxMetricConfig   `mapstructure:"system.network.conntrack.max"`
-	SystemNetworkDropped        SystemNetworkDroppedMetricConfig        `mapstructure:"system.network.dropped"`
-	SystemNetworkErrors         SystemNetworkErrorsMetricConfig         `mapstructure:"system.network.errors"`
-	SystemNetworkIo             SystemNetworkIoMetricConfig             `mapstructure:"system.network.io"`
-	SystemNetworkPackets        SystemNetworkPacketsMetricConfig        `mapstructure:"system.network.packets"`
+	SystemNetworkConnectionCount SystemNetworkConnectionCountMetricConfig `mapstructure:"system.network.connection.count"`
+	SystemNetworkConnections     SystemNetworkConnectionsMetricConfig     `mapstructure:"system.network.connections"`
+	SystemNetworkConntrackCount  SystemNetworkConntrackCountMetricConfig  `mapstructure:"system.network.conntrack.count"`
+	SystemNetworkConntrackMax    SystemNetworkConntrackMaxMetricConfig    `mapstructure:"system.network.conntrack.max"`
+	SystemNetworkDropped         SystemNetworkDroppedMetricConfig         `mapstructure:"system.network.dropped"`
+	SystemNetworkErrors          SystemNetworkErrorsMetricConfig          `mapstructure:"system.network.errors"`
+	SystemNetworkIo              SystemNetworkIoMetricConfig              `mapstructure:"system.network.io"`
+	SystemNetworkPackets         SystemNetworkPacketsMetricConfig         `mapstructure:"system.network.packets"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		SystemNetworkConnectionCount: SystemNetworkConnectionCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SystemNetworkConnectionCountMetricAttributeKey{SystemNetworkConnectionCountMetricAttributeKeyServerAddress, SystemNetworkConnectionCountMetricAttributeKeyServerPort},
+		},
 		SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config_test.go
@@ -26,6 +26,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					SystemNetworkConnectionCount: SystemNetworkConnectionCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemNetworkConnectionCountMetricAttributeKey{SystemNetworkConnectionCountMetricAttributeKeyServerAddress, SystemNetworkConnectionCountMetricAttributeKeyServerPort},
+					},
 					SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -64,6 +69,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					SystemNetworkConnectionCount: SystemNetworkConnectionCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemNetworkConnectionCountMetricAttributeKey{SystemNetworkConnectionCountMetricAttributeKeyServerAddress, SystemNetworkConnectionCountMetricAttributeKeyServerPort},
+					},
 					SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -102,7 +112,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SystemNetworkConnectionsMetricConfig{}, SystemNetworkConntrackCountMetricConfig{}, SystemNetworkConntrackMaxMetricConfig{}, SystemNetworkDroppedMetricConfig{}, SystemNetworkErrorsMetricConfig{}, SystemNetworkIoMetricConfig{}, SystemNetworkPacketsMetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SystemNetworkConnectionCountMetricConfig{}, SystemNetworkConnectionsMetricConfig{}, SystemNetworkConntrackCountMetricConfig{}, SystemNetworkConntrackMaxMetricConfig{}, SystemNetworkDroppedMetricConfig{}, SystemNetworkErrorsMetricConfig{}, SystemNetworkIoMetricConfig{}, SystemNetworkPacketsMetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -69,6 +69,9 @@ var MapAttributeProtocol = map[string]AttributeProtocol{
 }
 
 var MetricsInfo = metricsInfo{
+	SystemNetworkConnectionCount: metricInfo{
+		Name: "system.network.connection.count",
+	},
 	SystemNetworkConnections: metricInfo{
 		Name: "system.network.connections",
 	},
@@ -93,17 +96,110 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	SystemNetworkConnections    metricInfo
-	SystemNetworkConntrackCount metricInfo
-	SystemNetworkConntrackMax   metricInfo
-	SystemNetworkDropped        metricInfo
-	SystemNetworkErrors         metricInfo
-	SystemNetworkIo             metricInfo
-	SystemNetworkPackets        metricInfo
+	SystemNetworkConnectionCount metricInfo
+	SystemNetworkConnections     metricInfo
+	SystemNetworkConntrackCount  metricInfo
+	SystemNetworkConntrackMax    metricInfo
+	SystemNetworkDropped         metricInfo
+	SystemNetworkErrors          metricInfo
+	SystemNetworkIo              metricInfo
+	SystemNetworkPackets         metricInfo
 }
 
 type metricInfo struct {
 	Name string
+}
+
+type metricSystemNetworkConnectionCount struct {
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        SystemNetworkConnectionCountMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills system.network.connection.count metric with initial data.
+func (m *metricSystemNetworkConnectionCount) init() {
+	m.data.SetName("system.network.connection.count")
+	m.data.SetDescription("The number of established network connections, grouped by remote endpoint.")
+	m.data.SetUnit("{connections}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSystemNetworkConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serverAddressAttributeValue string, serverPortAttributeValue int64) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SystemNetworkConnectionCountMetricAttributeKeyServerAddress) {
+		dp.Attributes().PutStr("server.address", serverAddressAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemNetworkConnectionCountMetricAttributeKeyServerPort) {
+		dp.Attributes().PutInt("server.port", serverPortAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemNetworkConnectionCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemNetworkConnectionCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemNetworkConnectionCount(cfg SystemNetworkConnectionCountMetricConfig) metricSystemNetworkConnectionCount {
+	m := metricSystemNetworkConnectionCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
 }
 
 type metricSystemNetworkConnections struct {
@@ -683,18 +779,19 @@ func newMetricSystemNetworkPackets(cfg SystemNetworkPacketsMetricConfig) metricS
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                            MetricsBuilderConfig // config of the metrics builder.
-	startTime                         pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                   int                  // maximum observed number of metrics per resource.
-	metricsBuffer                     pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                         component.BuildInfo  // contains version information.
-	metricSystemNetworkConnections    metricSystemNetworkConnections
-	metricSystemNetworkConntrackCount metricSystemNetworkConntrackCount
-	metricSystemNetworkConntrackMax   metricSystemNetworkConntrackMax
-	metricSystemNetworkDropped        metricSystemNetworkDropped
-	metricSystemNetworkErrors         metricSystemNetworkErrors
-	metricSystemNetworkIo             metricSystemNetworkIo
-	metricSystemNetworkPackets        metricSystemNetworkPackets
+	config                             MetricsBuilderConfig // config of the metrics builder.
+	startTime                          pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                    int                  // maximum observed number of metrics per resource.
+	metricsBuffer                      pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                          component.BuildInfo  // contains version information.
+	metricSystemNetworkConnectionCount metricSystemNetworkConnectionCount
+	metricSystemNetworkConnections     metricSystemNetworkConnections
+	metricSystemNetworkConntrackCount  metricSystemNetworkConntrackCount
+	metricSystemNetworkConntrackMax    metricSystemNetworkConntrackMax
+	metricSystemNetworkDropped         metricSystemNetworkDropped
+	metricSystemNetworkErrors          metricSystemNetworkErrors
+	metricSystemNetworkIo              metricSystemNetworkIo
+	metricSystemNetworkPackets         metricSystemNetworkPackets
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -716,17 +813,18 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings scraper.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                            mbc,
-		startTime:                         pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                     pmetric.NewMetrics(),
-		buildInfo:                         settings.BuildInfo,
-		metricSystemNetworkConnections:    newMetricSystemNetworkConnections(mbc.Metrics.SystemNetworkConnections),
-		metricSystemNetworkConntrackCount: newMetricSystemNetworkConntrackCount(mbc.Metrics.SystemNetworkConntrackCount),
-		metricSystemNetworkConntrackMax:   newMetricSystemNetworkConntrackMax(mbc.Metrics.SystemNetworkConntrackMax),
-		metricSystemNetworkDropped:        newMetricSystemNetworkDropped(mbc.Metrics.SystemNetworkDropped),
-		metricSystemNetworkErrors:         newMetricSystemNetworkErrors(mbc.Metrics.SystemNetworkErrors),
-		metricSystemNetworkIo:             newMetricSystemNetworkIo(mbc.Metrics.SystemNetworkIo),
-		metricSystemNetworkPackets:        newMetricSystemNetworkPackets(mbc.Metrics.SystemNetworkPackets),
+		config:                             mbc,
+		startTime:                          pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                      pmetric.NewMetrics(),
+		buildInfo:                          settings.BuildInfo,
+		metricSystemNetworkConnectionCount: newMetricSystemNetworkConnectionCount(mbc.Metrics.SystemNetworkConnectionCount),
+		metricSystemNetworkConnections:     newMetricSystemNetworkConnections(mbc.Metrics.SystemNetworkConnections),
+		metricSystemNetworkConntrackCount:  newMetricSystemNetworkConntrackCount(mbc.Metrics.SystemNetworkConntrackCount),
+		metricSystemNetworkConntrackMax:    newMetricSystemNetworkConntrackMax(mbc.Metrics.SystemNetworkConntrackMax),
+		metricSystemNetworkDropped:         newMetricSystemNetworkDropped(mbc.Metrics.SystemNetworkDropped),
+		metricSystemNetworkErrors:          newMetricSystemNetworkErrors(mbc.Metrics.SystemNetworkErrors),
+		metricSystemNetworkIo:              newMetricSystemNetworkIo(mbc.Metrics.SystemNetworkIo),
+		metricSystemNetworkPackets:         newMetricSystemNetworkPackets(mbc.Metrics.SystemNetworkPackets),
 	}
 
 	for _, op := range options {
@@ -793,6 +891,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetName(ScopeName)
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemNetworkConnectionCount.emit(ils.Metrics())
 	mb.metricSystemNetworkConnections.emit(ils.Metrics())
 	mb.metricSystemNetworkConntrackCount.emit(ils.Metrics())
 	mb.metricSystemNetworkConntrackMax.emit(ils.Metrics())
@@ -819,6 +918,11 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 	metrics := mb.metricsBuffer
 	mb.metricsBuffer = pmetric.NewMetrics()
 	return metrics
+}
+
+// RecordSystemNetworkConnectionCountDataPoint adds a data point to system.network.connection.count metric.
+func (mb *MetricsBuilder) RecordSystemNetworkConnectionCountDataPoint(ts pcommon.Timestamp, val int64, serverAddressAttributeValue string, serverPortAttributeValue int64) {
+	mb.metricSystemNetworkConnectionCount.recordDataPoint(mb.startTime, ts, val, serverAddressAttributeValue, serverPortAttributeValue)
 }
 
 // RecordSystemNetworkConnectionsDataPoint adds a data point to system.network.connections metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
@@ -58,6 +58,7 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["system.network.connection.count"] = mb.metricSystemNetworkConnectionCount.config.AggregationStrategy
 			aggMap["system.network.connections"] = mb.metricSystemNetworkConnections.config.AggregationStrategy
 			aggMap["system.network.dropped"] = mb.metricSystemNetworkDropped.config.AggregationStrategy
 			aggMap["system.network.errors"] = mb.metricSystemNetworkErrors.config.AggregationStrategy
@@ -71,6 +72,12 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
+
+			allMetricsCount++
+			mb.RecordSystemNetworkConnectionCountDataPoint(ts, 1, "server.address-val", 11)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemNetworkConnectionCountDataPoint(ts, 3, "server.address-val-2", 12)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -116,6 +123,7 @@ func TestMetricsBuilder(t *testing.T) {
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricSystemNetworkConnectionCount.aggDataPoints)
 				assert.Empty(t, mb.metricSystemNetworkConnections.aggDataPoints)
 				assert.Empty(t, mb.metricSystemNetworkDropped.aggDataPoints)
 				assert.Empty(t, mb.metricSystemNetworkErrors.aggDataPoints)
@@ -148,6 +156,51 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
+				case "system.network.connection.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.network.connection.count"], "Found a duplicate in the metrics slice: system.network.connection.count")
+						validatedMetrics["system.network.connection.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of established network connections, grouped by remote endpoint.", mi.Description())
+						assert.Equal(t, "{connections}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						serverAddressAttrVal, ok := dp.Attributes().Get("server.address")
+						assert.True(t, ok)
+						assert.Equal(t, "server.address-val", serverAddressAttrVal.Str())
+						serverPortAttrVal, ok := dp.Attributes().Get("server.port")
+						assert.True(t, ok)
+						assert.EqualValues(t, 11, serverPortAttrVal.Int())
+					} else {
+						assert.False(t, validatedMetrics["system.network.connection.count"], "Found a duplicate in the metrics slice: system.network.connection.count")
+						validatedMetrics["system.network.connection.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of established network connections, grouped by remote endpoint.", mi.Description())
+						assert.Equal(t, "{connections}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.network.connection.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("server.address")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("server.port")
+						assert.False(t, ok)
+					}
 				case "system.network.connections":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["system.network.connections"], "Found a duplicate in the metrics slice: system.network.connections")

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
@@ -1,6 +1,9 @@
 default:
 all_set:
   metrics:
+    system.network.connection.count:
+      enabled: true
+      attributes: ["server.address","server.port"]
     system.network.connections:
       enabled: true
       attributes: ["protocol","state"]
@@ -22,6 +25,9 @@ all_set:
       attributes: ["device","direction"]
 reaggregate_set:
   metrics:
+    system.network.connection.count:
+      enabled: true
+      attributes: []
     system.network.connections:
       enabled: true
       attributes: []
@@ -43,6 +49,9 @@ reaggregate_set:
       attributes: []
 none_set:
   metrics:
+    system.network.connection.count:
+      enabled: false
+      attributes: ["server.address","server.port"]
     system.network.connections:
       enabled: false
       attributes: ["protocol","state"]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -27,12 +27,28 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [tcp]
+  server.address:
+    description: The remote address of the network connection.
+    type: string
+    requirement_level: recommended
+  server.port:
+    description: The remote port of the network connection.
+    type: int
+    requirement_level: recommended
   state:
     description: State of the network connection.
     type: string
     requirement_level: recommended
 
 metrics:
+  system.network.connection.count:
+    enabled: false
+    description: The number of established network connections, grouped by remote endpoint.
+    unit: "{connections}"
+    stability: development
+    gauge:
+      value_type: int
+    attributes: [server.address, server.port]
   system.network.connections:
     enabled: true
     description: The number of connections.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -6,6 +6,8 @@ package networkscraper // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 	"fmt"
+	stdnet "net"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/host"
@@ -35,21 +37,23 @@ type networkScraper struct {
 	excludeFS filterset.FilterSet
 
 	// for mocking
-	bootTime    func(context.Context) (uint64, error)
-	ioCounters  func(context.Context, bool) ([]net.IOCountersStat, error)
-	connections func(context.Context, string) ([]net.ConnectionStat, error)
-	conntrack   func(context.Context) ([]net.FilterStat, error)
+	bootTime       func(context.Context) (uint64, error)
+	ioCounters     func(context.Context, bool) ([]net.IOCountersStat, error)
+	connections    func(context.Context, string) ([]net.ConnectionStat, error)
+	conntrack      func(context.Context) ([]net.FilterStat, error)
+	interfaceAddrs func() ([]stdnet.Addr, error)
 }
 
 // newNetworkScraper creates a set of Network related metrics
 func newNetworkScraper(_ context.Context, settings scraper.Settings, cfg *Config) (*networkScraper, error) {
 	scraper := &networkScraper{
-		settings:    settings,
-		config:      cfg,
-		bootTime:    host.BootTimeWithContext,
-		ioCounters:  net.IOCountersWithContext,
-		connections: net.ConnectionsWithContext,
-		conntrack:   net.FilterCountersWithContext,
+		settings:       settings,
+		config:         cfg,
+		bootTime:       host.BootTimeWithContext,
+		ioCounters:     net.IOCountersWithContext,
+		connections:    net.ConnectionsWithContext,
+		conntrack:      net.FilterCountersWithContext,
+		interfaceAddrs: stdnet.InterfaceAddrs,
 	}
 
 	var err error
@@ -92,7 +96,7 @@ func (s *networkScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	err = s.recordNetworkConnectionsMetrics(ctx)
 	if err != nil {
-		errors.AddPartial(connectionsMetricsLen, err)
+		errors.AddPartial(s.enabledConnectionMetricsLen(), err)
 	}
 
 	err = s.recordNetworkConntrackMetrics(ctx)
@@ -154,7 +158,7 @@ func (s *networkScraper) recordNetworkIOMetric(now pcommon.Timestamp, ioCounters
 }
 
 func (s *networkScraper) recordNetworkConnectionsMetrics(ctx context.Context) error {
-	if !s.config.Metrics.SystemNetworkConnections.Enabled {
+	if s.enabledConnectionMetricsLen() == 0 {
 		return nil
 	}
 
@@ -165,10 +169,27 @@ func (s *networkScraper) recordNetworkConnectionsMetrics(ctx context.Context) er
 		return fmt.Errorf("failed to read TCP connections: %w", err)
 	}
 
-	tcpConnectionStatusCounts := getTCPConnectionStatusCounts(connections)
+	if s.config.Metrics.SystemNetworkConnections.Enabled {
+		tcpConnectionStatusCounts := getTCPConnectionStatusCounts(connections)
+		s.recordNetworkConnectionsMetric(now, tcpConnectionStatusCounts)
+	}
 
-	s.recordNetworkConnectionsMetric(now, tcpConnectionStatusCounts)
+	if s.config.Metrics.SystemNetworkConnectionCount.Enabled {
+		s.recordNetworkConnectionCountMetric(now, connections)
+	}
+
 	return nil
+}
+
+func (s *networkScraper) enabledConnectionMetricsLen() int {
+	count := 0
+	if s.config.Metrics.SystemNetworkConnections.Enabled {
+		count++
+	}
+	if s.config.Metrics.SystemNetworkConnectionCount.Enabled {
+		count++
+	}
+	return count
 }
 
 func getTCPConnectionStatusCounts(connections []net.ConnectionStat) map[string]int64 {
@@ -187,6 +208,114 @@ func (s *networkScraper) recordNetworkConnectionsMetric(now pcommon.Timestamp, c
 	for connectionState, count := range connectionStateCounts {
 		s.mb.RecordSystemNetworkConnectionsDataPoint(now, count, metadata.AttributeProtocolTcp, connectionState)
 	}
+}
+
+type networkConnectionKey struct {
+	serverAddress string
+	serverPort    int64
+}
+
+func (s *networkScraper) recordNetworkConnectionCountMetric(now pcommon.Timestamp, connections []net.ConnectionStat) {
+	listenPorts := map[uint32]struct{}{}
+	if s.config.Connections.ExcludeListenPorts {
+		listenPorts = buildListenPortSet(connections)
+	}
+
+	var localIPs map[string]struct{}
+	if s.config.Connections.ExcludeLocalhost {
+		localIPs = s.localIPSet()
+	}
+
+	counts := make(map[networkConnectionKey]int64)
+	for _, connection := range connections {
+		if !strings.EqualFold(connection.Status, "ESTABLISHED") {
+			continue
+		}
+		if connection.Raddr.IP == "" || connection.Raddr.Port == 0 {
+			continue
+		}
+		if _, ok := listenPorts[connection.Laddr.Port]; ok {
+			continue
+		}
+		if !s.isConnectionPortAllowed(connection.Raddr.Port) {
+			continue
+		}
+		if s.config.Connections.ExcludeLocalhost && isLocalIP(connection.Raddr.IP, localIPs) {
+			continue
+		}
+
+		key := networkConnectionKey{
+			serverAddress: connection.Raddr.IP,
+			serverPort:    int64(connection.Raddr.Port),
+		}
+		counts[key]++
+	}
+
+	for key, count := range counts {
+		s.mb.RecordSystemNetworkConnectionCountDataPoint(now, count, key.serverAddress, key.serverPort)
+	}
+}
+
+func buildListenPortSet(connections []net.ConnectionStat) map[uint32]struct{} {
+	ports := make(map[uint32]struct{})
+	for _, connection := range connections {
+		if strings.EqualFold(connection.Status, "LISTEN") {
+			ports[connection.Laddr.Port] = struct{}{}
+		}
+	}
+	return ports
+}
+
+func (s *networkScraper) isConnectionPortAllowed(port uint32) bool {
+	if len(s.config.Connections.IncludePorts) > 0 {
+		matched := false
+		for _, includePort := range s.config.Connections.IncludePorts {
+			if includePort == port {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	for _, excludePort := range s.config.Connections.ExcludePorts {
+		if excludePort == port {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *networkScraper) localIPSet() map[string]struct{} {
+	ips := map[string]struct{}{
+		"127.0.0.1": {},
+		"::1":       {},
+		"localhost": {},
+	}
+
+	addrs, err := s.interfaceAddrs()
+	if err != nil {
+		return ips
+	}
+	for _, addr := range addrs {
+		switch typedAddr := addr.(type) {
+		case *stdnet.IPNet:
+			ips[typedAddr.IP.String()] = struct{}{}
+		case *stdnet.IPAddr:
+			ips[typedAddr.IP.String()] = struct{}{}
+		}
+	}
+	return ips
+}
+
+func isLocalIP(ip string, localIPs map[string]struct{}) bool {
+	if _, ok := localIPs[ip]; ok {
+		return true
+	}
+	parsed := stdnet.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
 }
 
 func (s *networkScraper) filterByInterface(ioCounters []net.IOCountersStat) []net.IOCountersStat {

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -6,6 +6,7 @@ package networkscraper
 import (
 	"context"
 	"errors"
+	stdnet "net"
 	"testing"
 
 	"github.com/shirou/gopsutil/v4/net"
@@ -130,6 +131,7 @@ func TestScrape(t *testing.T) {
 			config: func() *Config {
 				cfg := Config{MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig()}
 				cfg.Metrics.SystemNetworkConnections.Enabled = false
+				cfg.Metrics.SystemNetworkConnectionCount.Enabled = false
 				return &cfg
 			}(),
 			connectionsFunc: func(context.Context, string) ([]net.ConnectionStat, error) {
@@ -164,6 +166,7 @@ func TestScrape(t *testing.T) {
 			if test.conntrackFunc != nil {
 				scraper.conntrack = test.conntrackFunc
 			}
+			scraper.interfaceAddrs = func() ([]stdnet.Addr, error) { return nil, nil }
 
 			err = scraper.start(t.Context(), componenttest.NewNopHost())
 			if test.initializationErr != "" {
@@ -214,6 +217,109 @@ func TestScrape(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestScrapeNetworkConnectionCountMetric(t *testing.T) {
+	cfg := Config{
+		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		Connections: ConnectionConfig{
+			IncludePorts:       []uint32{443, 8443},
+			ExcludePorts:       []uint32{8443},
+			ExcludeLocalhost:   true,
+			ExcludeListenPorts: true,
+		},
+	}
+	cfg.Metrics.SystemNetworkConnections.Enabled = false
+	cfg.Metrics.SystemNetworkConnectionCount.Enabled = true
+
+	md := scrapeConnectionCountMetric(t, &cfg, []net.ConnectionStat{
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50001}, Raddr: net.Addr{IP: "203.0.113.10", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50002}, Raddr: net.Addr{IP: "203.0.113.10", Port: 443}},
+		{Status: "SYN_SENT", Laddr: net.Addr{IP: "10.0.0.1", Port: 50003}, Raddr: net.Addr{IP: "203.0.113.10", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50004}, Raddr: net.Addr{}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50005}, Raddr: net.Addr{IP: "203.0.113.10"}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50006}, Raddr: net.Addr{IP: "127.0.0.1", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50007}, Raddr: net.Addr{IP: "10.0.0.2", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 50008}, Raddr: net.Addr{IP: "203.0.113.10", Port: 8443}},
+		{Status: "LISTEN", Laddr: net.Addr{IP: "10.0.0.1", Port: 60000}},
+		{Status: "ESTABLISHED", Laddr: net.Addr{IP: "10.0.0.1", Port: 60000}, Raddr: net.Addr{IP: "203.0.113.10", Port: 443}},
+	})
+
+	require.Equal(t, 1, md.MetricCount())
+	metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(t, "system.network.connection.count", metric.Name())
+	dps := metric.Gauge().DataPoints()
+	require.Equal(t, 1, dps.Len())
+	dp := dps.At(0)
+	assert.Equal(t, int64(2), dp.IntValue())
+	assertAttributeValue(t, dp.Attributes(), "server.address", "203.0.113.10")
+	serverPort, ok := dp.Attributes().Get("server.port")
+	require.True(t, ok)
+	assert.Equal(t, int64(443), serverPort.Int())
+}
+
+func TestScrapeNetworkConnectionCountDisabledSkipsDetailLookups(t *testing.T) {
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	cfg.Metrics.SystemNetworkConnectionCount.Enabled = false
+
+	scraper, err := newNetworkScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: cfg})
+	require.NoError(t, err)
+	scraper.bootTime = func(context.Context) (uint64, error) { return 100, nil }
+	scraper.ioCounters = func(context.Context, bool) ([]net.IOCountersStat, error) { return nil, nil }
+	scraper.conntrack = func(context.Context) ([]net.FilterStat, error) { return nil, nil }
+	scraper.connections = func(context.Context, string) ([]net.ConnectionStat, error) {
+		return []net.ConnectionStat{{Status: "ESTABLISHED", Raddr: net.Addr{IP: "203.0.113.10", Port: 443}}}, nil
+	}
+	scraper.interfaceAddrs = func() ([]stdnet.Addr, error) { panic("interfaceAddrs should not be called") }
+
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
+	md, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, md.MetricCount())
+	assert.Equal(t, "system.network.connections", md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestScrapeNetworkConnectionsErrorCountsEnabledMetrics(t *testing.T) {
+	cfg := Config{MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig()}
+	cfg.Metrics.SystemNetworkConnectionCount.Enabled = true
+
+	scraper, err := newNetworkScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &cfg)
+	require.NoError(t, err)
+	scraper.bootTime = func(context.Context) (uint64, error) { return 100, nil }
+	scraper.ioCounters = func(context.Context, bool) ([]net.IOCountersStat, error) { return nil, nil }
+	scraper.conntrack = func(context.Context) ([]net.FilterStat, error) { return nil, nil }
+	scraper.connections = func(context.Context, string) ([]net.ConnectionStat, error) { return nil, errors.New("err3") }
+
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
+	_, err = scraper.scrape(t.Context())
+	require.EqualError(t, err, "failed to read TCP connections: err3")
+	var scraperErr scrapererror.PartialScrapeError
+	require.ErrorAs(t, err, &scraperErr)
+	assert.Equal(t, 2, scraperErr.Failed)
+}
+
+func scrapeConnectionCountMetric(t *testing.T, cfg *Config, connections []net.ConnectionStat) pmetric.Metrics {
+	scraper, err := newNetworkScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+
+	scraper.bootTime = func(context.Context) (uint64, error) { return 100, nil }
+	scraper.ioCounters = func(context.Context, bool) ([]net.IOCountersStat, error) { return nil, nil }
+	scraper.conntrack = func(context.Context) ([]net.FilterStat, error) { return nil, nil }
+	scraper.connections = func(context.Context, string) ([]net.ConnectionStat, error) { return connections, nil }
+	scraper.interfaceAddrs = func() ([]stdnet.Addr, error) {
+		return []stdnet.Addr{&stdnet.IPNet{IP: stdnet.ParseIP("10.0.0.2")}}, nil
+	}
+
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
+	md, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+	return md
+}
+
+func assertAttributeValue(t *testing.T, attrs pcommon.Map, name string, expected string) {
+	value, ok := attrs.Get(name)
+	require.True(t, ok)
+	assert.Equal(t, expected, value.Str())
 }
 
 func assertNetworkIOMetricValid(t *testing.T, metric pmetric.Metric, expectedName string, startTime pcommon.Timestamp) {


### PR DESCRIPTION
Adds a new system.network.connection.count metric to the hostmetricsreceiver network scraper.

The metric is a gauge that reports the number of established TCP connections grouped by remote endpoint (server.address, server.port). It is opt-in (disabled by default, stability: development) and is independent of the existing system.network.connections metric, which aggregates connections by state.

Changes:

Added system.network.connection.count metric definition to metadata.yaml with two new attributes: server.address and server.port
Implemented collection logic in network_scraper.go using net.InterfaceAddrs to resolve local interface addresses and gopsutil TCP connections
Regenerated documentation.md and all generated_*.go files via mdatagen
Added unit tests covering the new metric
Link to tracking issue
Fixes

Testing
Added unit tests in network_scraper_test.go covering the new metric with mock connections
Ran make mdatagen in the scraper directory to validate metadata → generated code pipeline
Verified existing tests continue to pass: go test ./receiver/hostmetricsreceiver/...
Documentation
documentation.md was regenerated by mdatagen from the metadata.yaml updates.