### PR TITLE
Stop using deprecated config module from the Datadog Agent

### DIFF
--- a/exporter/datadogexporter/internal/logs/package_test.go
+++ b/exporter/datadogexporter/internal/logs/package_test.go
@@ -14,8 +14,5 @@ func TestMain(m *testing.M) {
 		// We have to ignore seelog because of upstream issue
 		// https://github.com/cihub/seelog/issues/182
 		goleak.IgnoreAnyFunction("github.com/cihub/seelog.(*asyncLoopLogger).processQueue"),
-
-		// known goroutine leak http://github.com/DataDog/datadog-agent/issues/40071
-		goleak.IgnoreAnyFunction("github.com/DataDog/datadog-agent/pkg/config/viperconfig.(*safeConfig).processNotifications"),
 	)
 }

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -14,10 +14,10 @@ import (
 	corelog "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigcreate "github.com/DataDog/datadog-agent/pkg/config/create"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	zlib "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zlib"
@@ -142,7 +142,7 @@ func NewSerializerComponent(cfg coreconfig.Component, logger corelog.Component, 
 // This function uses the options pattern to allow different modules to configure
 // the component with their specific needs.
 func NewConfigComponent(options ...ConfigOption) coreconfig.Component {
-	pkgconfig := viperconfig.NewConfig("DD", "DD", strings.NewReplacer(".", "_"))
+	pkgconfig := pkgconfigcreate.NewConfig(name, "")
 
 	// Apply all configuration options
 	for _, opt := range options {

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -142,7 +142,7 @@ func NewSerializerComponent(cfg coreconfig.Component, logger corelog.Component, 
 // This function uses the options pattern to allow different modules to configure
 // the component with their specific needs.
 func NewConfigComponent(options ...ConfigOption) coreconfig.Component {
-	pkgconfig := pkgconfigcreate.NewConfig(name, "")
+	pkgconfig := pkgconfigcreate.NewConfig("DD", "")
 
 	// Apply all configuration options
 	for _, opt := range options {

--- a/pkg/datadog/go.mod
+++ b/pkg/datadog/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.77.0-devel.0.20260213154712-e02b9359151a
+	github.com/DataDog/datadog-agent/pkg/config/create v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.77.0-devel.0.20260213154712-e02b9359151a
-	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/metrics v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.81.0-devel.0.20260515214905-7c02565fb890
@@ -75,13 +75,13 @@ require (
 	github.com/DataDog/datadog-agent/pkg/api v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260213154712-e02b9359151a // indirect
-	github.com/DataDog/datadog-agent/pkg/config/create v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
+	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.81.0-devel.0.20260515214905-7c02565fb890 // indirect


### PR DESCRIPTION
#### Description

This PR use the dedicated `create` package to handle the Datadog config. `viperconfig` will soon be removed from the Agent repo.

#### Testing

There is no change in behavior introduced here. Running the CI will be enough.