### PR TITLE
[processor/resourcedetection] Attach detected entity refs

### DIFF
--- a/.chloggen/resourcedetection-entity-refs.yaml
+++ b/.chloggen/resourcedetection-entity-refs.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: processor/resource_detection
+note: Attach entity refs to resources detected by the `system`, `gcp`, and `k8s_api` detectors.
+issues: [49073]
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/entity_test.go
+++ b/processor/resourcedetectionprocessor/entity_test.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcedetectionprocessor
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	xentity "go.opentelemetry.io/collector/pdata/xpdata/entity"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+)
+
+type entityDetectorStub struct {
+	attrs    map[string]string
+	entities []internal.DetectedEntity
+}
+
+func (d *entityDetectorStub) Detect(context.Context) (pcommon.Resource, string, error) {
+	res := pcommon.NewResource()
+	for k, v := range d.attrs {
+		res.Attributes().PutStr(k, v)
+	}
+	return res, "", nil
+}
+
+func (d *entityDetectorStub) EntityRefs(pcommon.Resource) []internal.DetectedEntity {
+	return d.entities
+}
+
+func TestProcessorAttachesEntityRefs(t *testing.T) {
+	k8sDetector := &entityDetectorStub{
+		attrs: map[string]string{"k8s.node.name": "node-1"},
+		entities: []internal.DetectedEntity{{
+			Type:                    "k8s.node",
+			IDKeys:                  []string{"k8s.node.name"},
+			IDContextTypeCandidates: []string{"k8s.cluster"},
+		}},
+	}
+	cloudDetector := &entityDetectorStub{
+		attrs: map[string]string{"k8s.cluster.name": "cluster-1"},
+		entities: []internal.DetectedEntity{{
+			Type:   "k8s.cluster",
+			IDKeys: []string{"k8s.cluster.name"},
+		}},
+	}
+
+	provider := internal.NewResourceProvider(zap.NewNop(), time.Second, k8sDetector, cloudDetector)
+	require.NoError(t, provider.Refresh(context.Background(), &http.Client{Timeout: time.Second}))
+
+	rdp := &resourceDetectionProcessor{provider: provider}
+	td := ptrace.NewTraces()
+	td.ResourceSpans().AppendEmpty().Resource().Attributes().PutStr("service.name", "svc")
+
+	out, err := rdp.processTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	res := out.ResourceSpans().At(0).Resource()
+	assert.Equal(t, "node-1", mustStr(t, res.Attributes(), "k8s.node.name"))
+
+	refs := xentity.ResourceEntityRefs(res)
+	require.Equal(t, 2, refs.Len())
+	got := map[string]string{}
+	for i := 0; i < refs.Len(); i++ {
+		got[refs.At(i).Type()] = refs.At(i).IdContextType()
+	}
+	assert.Equal(t, map[string]string{
+		"k8s.node":    "k8s.cluster",
+		"k8s.cluster": "",
+	}, got)
+}
+
+func mustStr(t *testing.T, attrs pcommon.Map, key string) string {
+	v, ok := attrs.Get(key)
+	require.True(t, ok, "missing attribute %q", key)
+	return v.Str()
+}

--- a/processor/resourcedetectionprocessor/entity_test.go
+++ b/processor/resourcedetectionprocessor/entity_test.go
@@ -66,11 +66,11 @@ func TestProcessorAttachesEntityRefs(t *testing.T) {
 	res := out.ResourceSpans().At(0).Resource()
 	assert.Equal(t, "node-1", mustStr(t, res.Attributes(), "k8s.node.name"))
 
-	refs := xentity.ResourceEntityRefs(res)
-	require.Equal(t, 2, refs.Len())
+	entities := xentity.ResourceEntities(res)
+	require.Equal(t, 2, entities.Len())
 	got := map[string]string{}
-	for i := 0; i < refs.Len(); i++ {
-		got[refs.At(i).Type()] = refs.At(i).IdContextType()
+	for typ, entity := range entities.All() {
+		got[typ] = entity.IDContextType()
 	}
 	assert.Equal(t, map[string]string{
 		"k8s.node":    "k8s.cluster",

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -40,6 +40,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.154.1-0.20260611154946-8ae0933981eb
 	go.opentelemetry.io/collector/pdata v1.60.1-0.20260611154946-8ae0933981eb
 	go.opentelemetry.io/collector/pdata/pprofile v0.154.1-0.20260611154946-8ae0933981eb
+	go.opentelemetry.io/collector/pdata/xpdata v0.154.1-0.20260611154946-8ae0933981eb
 	go.opentelemetry.io/collector/processor v1.60.1-0.20260611154946-8ae0933981eb
 	go.opentelemetry.io/collector/processor/processorhelper v0.154.1-0.20260611154946-8ae0933981eb
 	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.154.1-0.20260611154946-8ae0933981eb
@@ -176,7 +177,6 @@ require (
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.154.1-0.20260611154946-8ae0933981eb // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.154.1-0.20260611154946-8ae0933981eb // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.154.1-0.20260611154946-8ae0933981eb // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.154.1-0.20260611154946-8ae0933981eb // indirect
 	go.opentelemetry.io/collector/pipeline v1.60.1-0.20260611154946-8ae0933981eb // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.154.1-0.20260611154946-8ae0933981eb // indirect
 	go.opentelemetry.io/collector/receiver v1.60.1-0.20260611154946-8ae0933981eb // indirect

--- a/processor/resourcedetectionprocessor/internal/entities.go
+++ b/processor/resourcedetectionprocessor/internal/entities.go
@@ -106,24 +106,34 @@ func breakContextCycles(entities []DetectedEntity, byType map[string]int, logger
 
 func appendEntityRefs(res pcommon.Resource, entities []DetectedEntity, logger *zap.Logger) {
 	attrs := res.Attributes()
-	entityRefs := xentity.ResourceEntityRefs(res)
+	entityMap := xentity.ResourceEntities(res)
 	for _, ent := range entities {
 		if !hasAllKeys(attrs, ent.IDKeys) {
 			logger.Warn("skipping entity: some id keys are missing in the detected resource",
 				zap.String("entity.type", ent.Type), zap.Strings("entity.id_keys", ent.IDKeys))
 			continue
 		}
-		ref := entityRefs.AppendEmpty()
-		ref.SetSchemaUrl(ent.SchemaURL)
-		ref.SetType(ent.Type)
-		ref.IdKeys().FromRaw(ent.IDKeys)
-		for _, k := range ent.DescriptionKeys {
-			if _, ok := attrs.Get(k); ok {
-				ref.DescriptionKeys().Append(k)
-			}
+		entity := entityMap.PutEmpty(ent.Type)
+		entity.SetSchemaURL(ent.SchemaURL)
+		entity.SetIDContextType(ent.idContextType)
+		for _, k := range ent.IDKeys {
+			copyResourceAttribute(attrs, entity.IdentifyingAttributes(), k)
 		}
-		ref.SetIdContextType(ent.idContextType)
+		for _, k := range ent.DescriptionKeys {
+			copyResourceAttribute(attrs, entity.DescriptiveAttributes(), k)
+		}
 	}
+}
+
+func copyResourceAttribute(attrs pcommon.Map, target xentity.EntityAttributeMap, key string) bool {
+	val, ok := attrs.Get(key)
+	if !ok {
+		return false
+	}
+	copied := pcommon.NewValueEmpty()
+	val.CopyTo(copied)
+	copied.CopyTo(target.PutEmpty(key))
+	return true
 }
 
 // MergeEntityRefs copies entity refs from one resource to another after the

--- a/processor/resourcedetectionprocessor/internal/entities.go
+++ b/processor/resourcedetectionprocessor/internal/entities.go
@@ -1,0 +1,185 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+
+import (
+	"sort"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	xentity "go.opentelemetry.io/collector/pdata/xpdata/entity"
+	"go.uber.org/zap"
+)
+
+// Entity types emitted by detectors. Semantic conventions for entities are
+// still in development; these names follow the current entities draft.
+const (
+	EntityTypeHost         = "host"
+	EntityTypeK8sCluster   = "k8s.cluster"
+	EntityTypeK8sNode      = "k8s.node"
+	EntityTypeCloudAccount = "cloud.account"
+)
+
+// DetectedEntity describes an entity contributed by a detector. The
+// identifying and descriptive attributes are referenced by key and must be
+// present in the resource returned by the same detector.
+type DetectedEntity struct {
+	SchemaURL       string
+	Type            string
+	IDKeys          []string
+	DescriptionKeys []string
+
+	// IDContextTypeCandidates lists, in priority order, the entity types that
+	// can establish the uniqueness context of this entity's ID. It must be
+	// empty for entities with globally unique IDs.
+	IDContextTypeCandidates []string
+
+	idContextType string
+}
+
+// EntityDetector is implemented by detectors that can declare which entities
+// their detected resource attributes describe.
+type EntityDetector interface {
+	Detector
+	EntityRefs(resource pcommon.Resource) []DetectedEntity
+}
+
+func resolveEntities(entities []DetectedEntity, logger *zap.Logger) []DetectedEntity {
+	merged := make([]DetectedEntity, 0, len(entities))
+	byType := make(map[string]int, len(entities))
+	for _, ent := range entities {
+		if ent.Type == "" || len(ent.IDKeys) == 0 {
+			logger.Warn("skipping entity without type or id keys", zap.String("type", ent.Type))
+			continue
+		}
+		i, ok := byType[ent.Type]
+		if !ok {
+			byType[ent.Type] = len(merged)
+			merged = append(merged, ent)
+			continue
+		}
+		// Same entity type from a lower-precedence detector: the first
+		// declaration keeps the identity, description keys are unioned.
+		merged[i].DescriptionKeys = unionKeys(merged[i].DescriptionKeys, ent.DescriptionKeys)
+	}
+
+	for i := range merged {
+		for _, candidate := range merged[i].IDContextTypeCandidates {
+			if _, ok := byType[candidate]; ok && candidate != merged[i].Type {
+				merged[i].idContextType = candidate
+				break
+			}
+		}
+	}
+
+	breakContextCycles(merged, byType, logger)
+	return merged
+}
+
+func breakContextCycles(entities []DetectedEntity, byType map[string]int, logger *zap.Logger) {
+	types := make([]string, 0, len(byType))
+	for t := range byType {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+
+	for _, t := range types {
+		visited := map[string]bool{}
+		i := byType[t]
+		for entities[i].idContextType != "" {
+			if visited[entities[i].Type] {
+				logger.Warn("entity ID context chain forms a cycle, dropping context",
+					zap.String("entity.type", entities[i].Type),
+					zap.String("entity.id_context_type", entities[i].idContextType))
+				entities[i].idContextType = ""
+				break
+			}
+			visited[entities[i].Type] = true
+			next, ok := byType[entities[i].idContextType]
+			if !ok {
+				break
+			}
+			i = next
+		}
+	}
+}
+
+func appendEntityRefs(res pcommon.Resource, entities []DetectedEntity, logger *zap.Logger) {
+	attrs := res.Attributes()
+	entityRefs := xentity.ResourceEntityRefs(res)
+	for _, ent := range entities {
+		if !hasAllKeys(attrs, ent.IDKeys) {
+			logger.Warn("skipping entity: some id keys are missing in the detected resource",
+				zap.String("entity.type", ent.Type), zap.Strings("entity.id_keys", ent.IDKeys))
+			continue
+		}
+		ref := entityRefs.AppendEmpty()
+		ref.SetSchemaUrl(ent.SchemaURL)
+		ref.SetType(ent.Type)
+		ref.IdKeys().FromRaw(ent.IDKeys)
+		for _, k := range ent.DescriptionKeys {
+			if _, ok := attrs.Get(k); ok {
+				ref.DescriptionKeys().Append(k)
+			}
+		}
+		ref.SetIdContextType(ent.idContextType)
+	}
+}
+
+// MergeEntityRefs copies entity refs from one resource to another after the
+// resource attributes have already been merged.
+func MergeEntityRefs(to, from pcommon.Resource, overrideTo bool) {
+	fromRefs := xentity.ResourceEntityRefs(from)
+	if fromRefs.Len() == 0 {
+		return
+	}
+	toRefs := xentity.ResourceEntityRefs(to)
+	if overrideTo {
+		fromTypes := make(map[string]bool, fromRefs.Len())
+		for i := 0; i < fromRefs.Len(); i++ {
+			ref := fromRefs.At(i)
+			if hasAllKeys(to.Attributes(), ref.IdKeys().AsRaw()) {
+				fromTypes[ref.Type()] = true
+			}
+		}
+		toRefs.RemoveIf(func(ref xentity.EntityRef) bool {
+			return fromTypes[ref.Type()]
+		})
+	}
+
+	existing := make(map[string]bool, toRefs.Len())
+	for i := 0; i < toRefs.Len(); i++ {
+		existing[toRefs.At(i).Type()] = true
+	}
+	for i := 0; i < fromRefs.Len(); i++ {
+		ref := fromRefs.At(i)
+		if existing[ref.Type()] || !hasAllKeys(to.Attributes(), ref.IdKeys().AsRaw()) {
+			continue
+		}
+		ref.CopyTo(toRefs.AppendEmpty())
+		existing[ref.Type()] = true
+	}
+}
+
+func hasAllKeys(attrs pcommon.Map, keys []string) bool {
+	for _, k := range keys {
+		if _, ok := attrs.Get(k); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func unionKeys(a, b []string) []string {
+	seen := make(map[string]bool, len(a))
+	for _, k := range a {
+		seen[k] = true
+	}
+	for _, k := range b {
+		if !seen[k] {
+			seen[k] = true
+			a = append(a, k)
+		}
+	}
+	return a
+}

--- a/processor/resourcedetectionprocessor/internal/entities_test.go
+++ b/processor/resourcedetectionprocessor/internal/entities_test.go
@@ -114,47 +114,50 @@ func TestAppendEntityRefs(t *testing.T) {
 		{Type: "host", IDKeys: []string{"host.id"}},
 	}, zap.NewNop())
 
-	refs := xentity.ResourceEntityRefs(res)
-	require.Equal(t, 1, refs.Len())
-	ref := refs.At(0)
-	assert.Equal(t, "k8s.node", ref.Type())
-	assert.Equal(t, "https://test", ref.SchemaUrl())
-	assert.Equal(t, []string{"k8s.node.name"}, ref.IdKeys().AsRaw())
-	assert.Equal(t, []string{"k8s.cluster.name"}, ref.DescriptionKeys().AsRaw())
-	assert.Equal(t, "k8s.cluster", ref.IdContextType())
+	entities := xentity.ResourceEntities(res)
+	require.Equal(t, 1, entities.Len())
+	entity, ok := entities.Get("k8s.node")
+	require.True(t, ok)
+	assert.Equal(t, "https://test", entity.SchemaURL())
+	assert.Equal(t, "k8s.cluster", entity.IDContextType())
+
+	idVal, ok := entity.IdentifyingAttributes().Get("k8s.node.name")
+	require.True(t, ok)
+	assert.Equal(t, "node-1", idVal.Str())
+	descVal, ok := entity.DescriptiveAttributes().Get("k8s.cluster.name")
+	require.True(t, ok)
+	assert.Equal(t, "cluster-1", descVal.Str())
+	_, ok = entity.DescriptiveAttributes().Get("missing")
+	assert.False(t, ok)
 }
 
 func TestMergeEntityRefs(t *testing.T) {
 	from := pcommon.NewResource()
-	from.Attributes().PutStr("k8s.node.name", "node-1")
-	from.Attributes().PutStr("host.id", "host-1")
-	fromRefs := xentity.ResourceEntityRefs(from)
-	node := fromRefs.AppendEmpty()
-	node.SetType("k8s.node")
-	node.IdKeys().Append("k8s.node.name")
-	node.SetIdContextType("k8s.cluster")
-	host := fromRefs.AppendEmpty()
-	host.SetType("host")
-	host.IdKeys().Append("host.id")
+	fromEntities := xentity.ResourceEntities(from)
+	node := fromEntities.PutEmpty("k8s.node")
+	node.IdentifyingAttributes().PutStr("k8s.node.name", "node-1")
+	node.SetIDContextType("k8s.cluster")
+	host := fromEntities.PutEmpty("host")
+	host.IdentifyingAttributes().PutStr("host.id", "host-1")
 
 	to := pcommon.NewResource()
-	to.Attributes().PutStr("k8s.node.name", "node-1")
-	existing := xentity.ResourceEntityRefs(to).AppendEmpty()
-	existing.SetType("k8s.node")
-	existing.IdKeys().Append("k8s.node.name")
+	existing := xentity.ResourceEntities(to).PutEmpty("k8s.node")
+	existing.IdentifyingAttributes().PutStr("k8s.node.name", "node-1")
 
 	MergeEntityRefs(to, from, false)
 
-	toRefs := xentity.ResourceEntityRefs(to)
-	require.Equal(t, 1, toRefs.Len())
-	assert.Equal(t, "k8s.node", toRefs.At(0).Type())
-	assert.Empty(t, toRefs.At(0).IdContextType())
+	toEntities := xentity.ResourceEntities(to)
+	require.Equal(t, 1, toEntities.Len())
+	entity, ok := toEntities.Get("k8s.node")
+	require.True(t, ok)
+	assert.Empty(t, entity.IDContextType())
 
 	MergeEntityRefs(to, from, true)
-	toRefs = xentity.ResourceEntityRefs(to)
-	require.Equal(t, 1, toRefs.Len())
-	assert.Equal(t, "k8s.node", toRefs.At(0).Type())
-	assert.Equal(t, "k8s.cluster", toRefs.At(0).IdContextType())
+	toEntities = xentity.ResourceEntities(to)
+	require.Equal(t, 1, toEntities.Len())
+	entity, ok = toEntities.Get("k8s.node")
+	require.True(t, ok)
+	assert.Equal(t, "k8s.cluster", entity.IDContextType())
 }
 
 func TestDetectResourceEntities(t *testing.T) {
@@ -226,10 +229,10 @@ func contextByType(entities []DetectedEntity) map[string]string {
 }
 
 func contextByRef(res pcommon.Resource) map[string]string {
-	refs := xentity.ResourceEntityRefs(res)
-	got := make(map[string]string, refs.Len())
-	for i := 0; i < refs.Len(); i++ {
-		got[refs.At(i).Type()] = refs.At(i).IdContextType()
+	entities := xentity.ResourceEntities(res)
+	got := make(map[string]string, entities.Len())
+	for typ, entity := range entities.All() {
+		got[typ] = entity.IDContextType()
 	}
 	return got
 }

--- a/processor/resourcedetectionprocessor/internal/entities_test.go
+++ b/processor/resourcedetectionprocessor/internal/entities_test.go
@@ -1,0 +1,260 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	xentity "go.opentelemetry.io/collector/pdata/xpdata/entity"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processortest"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/metadata"
+)
+
+func TestResolveEntities(t *testing.T) {
+	tests := []struct {
+		name     string
+		entities []DetectedEntity
+		want     map[string]string
+	}{
+		{
+			name:     "global entity has no context",
+			entities: []DetectedEntity{{Type: "host", IDKeys: []string{"host.id"}}},
+			want:     map[string]string{"host": ""},
+		},
+		{
+			name: "candidate present",
+			entities: []DetectedEntity{
+				{Type: "k8s.node", IDKeys: []string{"k8s.node.name"}, IDContextTypeCandidates: []string{"k8s.cluster"}},
+				{Type: "k8s.cluster", IDKeys: []string{"k8s.cluster.uid"}},
+			},
+			want: map[string]string{"k8s.node": "k8s.cluster", "k8s.cluster": ""},
+		},
+		{
+			name: "first present candidate wins",
+			entities: []DetectedEntity{
+				{Type: "process", IDKeys: []string{"process.pid"}, IDContextTypeCandidates: []string{"container", "host"}},
+				{Type: "host", IDKeys: []string{"host.id"}},
+			},
+			want: map[string]string{"process": "host", "host": ""},
+		},
+		{
+			name: "same type keeps first identity",
+			entities: []DetectedEntity{
+				{Type: "k8s.cluster", IDKeys: []string{"k8s.cluster.uid"}},
+				{Type: "k8s.cluster", IDKeys: []string{"k8s.cluster.name"}, IDContextTypeCandidates: []string{"cloud.account"}},
+				{Type: "cloud.account", IDKeys: []string{"cloud.account.id"}},
+			},
+			want: map[string]string{"k8s.cluster": "", "cloud.account": ""},
+		},
+		{
+			name: "cycle is broken deterministically",
+			entities: []DetectedEntity{
+				{Type: "a", IDKeys: []string{"a.id"}, IDContextTypeCandidates: []string{"b"}},
+				{Type: "b", IDKeys: []string{"b.id"}, IDContextTypeCandidates: []string{"a"}},
+			},
+			want: map[string]string{"a": "", "b": "a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := contextByType(resolveEntities(tt.entities, zap.NewNop()))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveEntitiesOrderInvariance(t *testing.T) {
+	entities := []DetectedEntity{
+		{Type: "k8s.node", IDKeys: []string{"k8s.node.name"}, IDContextTypeCandidates: []string{"k8s.cluster"}},
+		{Type: "k8s.cluster", IDKeys: []string{"k8s.cluster.name"}, IDContextTypeCandidates: []string{"cloud.account"}},
+		{Type: "cloud.account", IDKeys: []string{"cloud.account.id"}},
+		{Type: "host", IDKeys: []string{"host.id"}},
+	}
+	want := map[string]string{
+		"k8s.node":      "k8s.cluster",
+		"k8s.cluster":   "cloud.account",
+		"cloud.account": "",
+		"host":          "",
+	}
+
+	for _, perm := range permutations(len(entities)) {
+		permuted := make([]DetectedEntity, 0, len(entities))
+		for _, i := range perm {
+			permuted = append(permuted, entities[i])
+		}
+		assert.Equal(t, want, contextByType(resolveEntities(permuted, zap.NewNop())), "permutation %v", perm)
+	}
+}
+
+func TestAppendEntityRefs(t *testing.T) {
+	res := pcommon.NewResource()
+	res.Attributes().PutStr("k8s.node.name", "node-1")
+	res.Attributes().PutStr("k8s.cluster.name", "cluster-1")
+
+	appendEntityRefs(res, []DetectedEntity{
+		{
+			SchemaURL:       "https://test",
+			Type:            "k8s.node",
+			IDKeys:          []string{"k8s.node.name"},
+			DescriptionKeys: []string{"missing", "k8s.cluster.name"},
+			idContextType:   "k8s.cluster",
+		},
+		{Type: "host", IDKeys: []string{"host.id"}},
+	}, zap.NewNop())
+
+	refs := xentity.ResourceEntityRefs(res)
+	require.Equal(t, 1, refs.Len())
+	ref := refs.At(0)
+	assert.Equal(t, "k8s.node", ref.Type())
+	assert.Equal(t, "https://test", ref.SchemaUrl())
+	assert.Equal(t, []string{"k8s.node.name"}, ref.IdKeys().AsRaw())
+	assert.Equal(t, []string{"k8s.cluster.name"}, ref.DescriptionKeys().AsRaw())
+	assert.Equal(t, "k8s.cluster", ref.IdContextType())
+}
+
+func TestMergeEntityRefs(t *testing.T) {
+	from := pcommon.NewResource()
+	from.Attributes().PutStr("k8s.node.name", "node-1")
+	from.Attributes().PutStr("host.id", "host-1")
+	fromRefs := xentity.ResourceEntityRefs(from)
+	node := fromRefs.AppendEmpty()
+	node.SetType("k8s.node")
+	node.IdKeys().Append("k8s.node.name")
+	node.SetIdContextType("k8s.cluster")
+	host := fromRefs.AppendEmpty()
+	host.SetType("host")
+	host.IdKeys().Append("host.id")
+
+	to := pcommon.NewResource()
+	to.Attributes().PutStr("k8s.node.name", "node-1")
+	existing := xentity.ResourceEntityRefs(to).AppendEmpty()
+	existing.SetType("k8s.node")
+	existing.IdKeys().Append("k8s.node.name")
+
+	MergeEntityRefs(to, from, false)
+
+	toRefs := xentity.ResourceEntityRefs(to)
+	require.Equal(t, 1, toRefs.Len())
+	assert.Equal(t, "k8s.node", toRefs.At(0).Type())
+	assert.Empty(t, toRefs.At(0).IdContextType())
+
+	MergeEntityRefs(to, from, true)
+	toRefs = xentity.ResourceEntityRefs(to)
+	require.Equal(t, 1, toRefs.Len())
+	assert.Equal(t, "k8s.node", toRefs.At(0).Type())
+	assert.Equal(t, "k8s.cluster", toRefs.At(0).IdContextType())
+}
+
+func TestDetectResourceEntities(t *testing.T) {
+	newK8sDetector := func() Detector {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr("k8s.node.name", "node-1")
+		return &mockEntityDetector{res: res, entities: []DetectedEntity{{
+			Type:                    "k8s.node",
+			IDKeys:                  []string{"k8s.node.name"},
+			IDContextTypeCandidates: []string{"k8s.cluster"},
+		}}}
+	}
+	newCloudDetector := func() Detector {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr("cloud.account.id", "project-1")
+		res.Attributes().PutStr("k8s.cluster.name", "cluster-1")
+		return &mockEntityDetector{res: res, entities: []DetectedEntity{
+			{Type: "cloud.account", IDKeys: []string{"cloud.account.id"}},
+			{Type: "k8s.cluster", IDKeys: []string{"k8s.cluster.name"}, IDContextTypeCandidates: []string{"cloud.account"}},
+		}}
+	}
+
+	for _, order := range [][]string{{"k8s", "cloud"}, {"cloud", "k8s"}} {
+		t.Run(fmt.Sprintf("order=%v", order), func(t *testing.T) {
+			factories := map[DetectorType]DetectorFactory{
+				"k8s":   func(processor.Settings, DetectorConfig) (Detector, error) { return newK8sDetector(), nil },
+				"cloud": func(processor.Settings, DetectorConfig) (Detector, error) { return newCloudDetector(), nil },
+			}
+			types := make([]DetectorType, len(order))
+			for i, typ := range order {
+				types[i] = DetectorType(typ)
+			}
+
+			provider, err := NewProviderFactory(factories).CreateResourceProvider(
+				processortest.NewNopSettings(metadata.Type), time.Second, &mockDetectorConfig{}, types...)
+			require.NoError(t, err)
+			require.NoError(t, provider.Refresh(context.Background(), &http.Client{Timeout: time.Second}))
+
+			res, _, err := provider.Get(context.Background(), nil)
+			require.NoError(t, err)
+			assert.Equal(t, map[string]string{
+				"k8s.node":      "k8s.cluster",
+				"k8s.cluster":   "cloud.account",
+				"cloud.account": "",
+			}, contextByRef(res))
+		})
+	}
+}
+
+type mockEntityDetector struct {
+	res      pcommon.Resource
+	entities []DetectedEntity
+}
+
+func (d *mockEntityDetector) Detect(context.Context) (pcommon.Resource, string, error) {
+	return d.res, "", nil
+}
+
+func (d *mockEntityDetector) EntityRefs(pcommon.Resource) []DetectedEntity {
+	return d.entities
+}
+
+func contextByType(entities []DetectedEntity) map[string]string {
+	got := make(map[string]string, len(entities))
+	for _, ent := range entities {
+		got[ent.Type] = ent.idContextType
+	}
+	return got
+}
+
+func contextByRef(res pcommon.Resource) map[string]string {
+	refs := xentity.ResourceEntityRefs(res)
+	got := make(map[string]string, refs.Len())
+	for i := 0; i < refs.Len(); i++ {
+		got[refs.At(i).Type()] = refs.At(i).IdContextType()
+	}
+	return got
+}
+
+func permutations(n int) [][]int {
+	var res [][]int
+	perm := make([]int, n)
+	for i := range perm {
+		perm[i] = i
+	}
+	var generate func(int)
+	generate = func(k int) {
+		if k == 1 {
+			res = append(res, append([]int(nil), perm...))
+			return
+		}
+		for i := 0; i < k; i++ {
+			generate(k - 1)
+			if k%2 == 0 {
+				perm[i], perm[k-1] = perm[k-1], perm[i]
+			} else {
+				perm[0], perm[k-1] = perm[k-1], perm[0]
+			}
+		}
+	}
+	generate(n)
+	return res
+}

--- a/processor/resourcedetectionprocessor/internal/gcp/entity_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/entity_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+)
+
+func TestEntityRefs(t *testing.T) {
+	d := &detector{}
+
+	t.Run("gce cloud account", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderGCP.Value.AsString())
+		res.Attributes().PutStr(string(conventions.CloudAccountIDKey), "project-1")
+		res.Attributes().PutStr(string(conventions.CloudPlatformKey), conventions.CloudPlatformGCPComputeEngine.Value.AsString())
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 1)
+		assert.Equal(t, internal.EntityTypeCloudAccount, entities[0].Type)
+		assert.Equal(t, []string{string(conventions.CloudProviderKey), string(conventions.CloudAccountIDKey)}, entities[0].IDKeys)
+		assert.Equal(t, []string{string(conventions.CloudPlatformKey)}, entities[0].DescriptionKeys)
+		assert.Empty(t, entities[0].IDContextTypeCandidates)
+	})
+
+	t.Run("gke cluster scoped to cloud account", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderGCP.Value.AsString())
+		res.Attributes().PutStr(string(conventions.CloudAccountIDKey), "project-1")
+		res.Attributes().PutStr(string(conventions.K8SClusterNameKey), "cluster-1")
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 2)
+		assert.Equal(t, internal.EntityTypeK8sCluster, entities[1].Type)
+		assert.Equal(t, []string{string(conventions.K8SClusterNameKey)}, entities[1].IDKeys)
+		assert.Equal(t, []string{internal.EntityTypeCloudAccount}, entities[1].IDContextTypeCandidates)
+	})
+
+	t.Run("no attributes", func(t *testing.T) {
+		assert.Empty(t, d.EntityRefs(pcommon.NewResource()))
+	})
+
+	t.Run("missing cloud provider", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.CloudAccountIDKey), "project-1")
+		assert.Empty(t, d.EntityRefs(res))
+	})
+}

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -52,6 +52,11 @@ func NewDetector(set processor.Settings, dcfg internal.DetectorConfig) (internal
 	}, nil
 }
 
+var (
+	_ internal.Detector       = (*detector)(nil)
+	_ internal.EntityDetector = (*detector)(nil)
+)
+
 type detector struct {
 	logger           *zap.Logger
 	detector         gcpDetector
@@ -187,6 +192,42 @@ func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		// We don't support this platform yet, so just return with what we have
 	}
 	return d.rb.Emit(), conventions.SchemaURL, errs
+}
+
+// EntityRefs implements internal.EntityDetector.
+func (d *detector) EntityRefs(res pcommon.Resource) []internal.DetectedEntity {
+	attrs := res.Attributes()
+	var entities []internal.DetectedEntity
+
+	if hasAttribute(attrs, string(conventions.CloudProviderKey)) && hasAttribute(attrs, string(conventions.CloudAccountIDKey)) {
+		ent := internal.DetectedEntity{
+			SchemaURL: conventions.SchemaURL,
+			Type:      internal.EntityTypeCloudAccount,
+			IDKeys:    []string{string(conventions.CloudProviderKey), string(conventions.CloudAccountIDKey)},
+		}
+		for _, k := range []string{string(conventions.CloudPlatformKey), string(conventions.CloudRegionKey)} {
+			if _, ok := attrs.Get(k); ok {
+				ent.DescriptionKeys = append(ent.DescriptionKeys, k)
+			}
+		}
+		entities = append(entities, ent)
+	}
+
+	if _, ok := attrs.Get(string(conventions.K8SClusterNameKey)); ok {
+		entities = append(entities, internal.DetectedEntity{
+			SchemaURL:               conventions.SchemaURL,
+			Type:                    internal.EntityTypeK8sCluster,
+			IDKeys:                  []string{string(conventions.K8SClusterNameKey)},
+			IDContextTypeCandidates: []string{internal.EntityTypeCloudAccount},
+		})
+	}
+
+	return entities
+}
+
+func hasAttribute(attrs pcommon.Map, key string) bool {
+	_, ok := attrs.Get(key)
+	return ok
 }
 
 type instancesAPI interface {

--- a/processor/resourcedetectionprocessor/internal/k8sapi/entity_test.go
+++ b/processor/resourcedetectionprocessor/internal/k8sapi/entity_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+)
+
+func TestEntityRefs(t *testing.T) {
+	d := &detector{}
+
+	t.Run("node uid present", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.K8SNodeUIDKey), "node-uid-1")
+		res.Attributes().PutStr(string(conventions.K8SNodeNameKey), "node-1")
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 1)
+		assert.Equal(t, internal.EntityTypeK8sNode, entities[0].Type)
+		assert.Equal(t, []string{string(conventions.K8SNodeUIDKey)}, entities[0].IDKeys)
+		assert.Equal(t, []string{string(conventions.K8SNodeNameKey)}, entities[0].DescriptionKeys)
+		assert.Empty(t, entities[0].IDContextTypeCandidates)
+	})
+
+	t.Run("node name only", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.K8SNodeNameKey), "node-1")
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 1)
+		assert.Equal(t, []string{string(conventions.K8SNodeNameKey)}, entities[0].IDKeys)
+		assert.Equal(t, []string{internal.EntityTypeK8sCluster}, entities[0].IDContextTypeCandidates)
+	})
+
+	t.Run("cluster uid present", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.K8SNodeNameKey), "node-1")
+		res.Attributes().PutStr(string(conventions.K8SClusterUIDKey), "cluster-uid-1")
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 2)
+		assert.Equal(t, internal.EntityTypeK8sCluster, entities[1].Type)
+		assert.Equal(t, []string{string(conventions.K8SClusterUIDKey)}, entities[1].IDKeys)
+		assert.Empty(t, entities[1].IDContextTypeCandidates)
+	})
+}

--- a/processor/resourcedetectionprocessor/internal/k8sapi/k8s.go
+++ b/processor/resourcedetectionprocessor/internal/k8sapi/k8s.go
@@ -24,7 +24,10 @@ const (
 	TypeStrAlias = "k8snode" // Deprecated: use TypeStr
 )
 
-var _ internal.Detector = (*detector)(nil)
+var (
+	_ internal.Detector       = (*detector)(nil)
+	_ internal.EntityDetector = (*detector)(nil)
+)
 
 type detector struct {
 	provider k8snode.Provider
@@ -90,4 +93,43 @@ func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 	}
 
 	return d.rb.Emit(), conventions.SchemaURL, nil
+}
+
+// EntityRefs implements internal.EntityDetector.
+func (d *detector) EntityRefs(res pcommon.Resource) []internal.DetectedEntity {
+	attrs := res.Attributes()
+	var entities []internal.DetectedEntity
+
+	node := internal.DetectedEntity{
+		SchemaURL: conventions.SchemaURL,
+		Type:      internal.EntityTypeK8sNode,
+	}
+	switch {
+	case hasKey(attrs, string(conventions.K8SNodeUIDKey)):
+		node.IDKeys = []string{string(conventions.K8SNodeUIDKey)}
+		if hasKey(attrs, string(conventions.K8SNodeNameKey)) {
+			node.DescriptionKeys = []string{string(conventions.K8SNodeNameKey)}
+		}
+	case hasKey(attrs, string(conventions.K8SNodeNameKey)):
+		node.IDKeys = []string{string(conventions.K8SNodeNameKey)}
+		node.IDContextTypeCandidates = []string{internal.EntityTypeK8sCluster}
+	}
+	if len(node.IDKeys) > 0 {
+		entities = append(entities, node)
+	}
+
+	if hasKey(attrs, string(conventions.K8SClusterUIDKey)) {
+		entities = append(entities, internal.DetectedEntity{
+			SchemaURL: conventions.SchemaURL,
+			Type:      internal.EntityTypeK8sCluster,
+			IDKeys:    []string{string(conventions.K8SClusterUIDKey)},
+		})
+	}
+
+	return entities
+}
+
+func hasKey(attrs pcommon.Map, key string) bool {
+	_, ok := attrs.Get(key)
+	return ok
 }

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -195,7 +195,10 @@ func (p *ResourceProvider) detectResource(ctx context.Context) (pcommon.Resource
 		}(detector, ch)
 	}
 
-	for _, ch := range resultsChan {
+	// Entity declarations are collected in configured detector order so that
+	// entity identity conflicts follow the same precedence rule as attributes.
+	var entities []DetectedEntity
+	for i, ch := range resultsChan {
 		result := <-ch
 		if result.err != nil {
 			joinedErr = errors.Join(joinedErr, result.err)
@@ -204,7 +207,12 @@ func (p *ResourceProvider) detectResource(ctx context.Context) (pcommon.Resource
 		successes++
 		mergedSchemaURL = MergeSchemaURL(mergedSchemaURL, result.schemaURL)
 		MergeResource(res, result.resource, false)
+		if detector, ok := p.detectors[i].(EntityDetector); ok {
+			entities = append(entities, detector.EntityRefs(result.resource)...)
+		}
 	}
+
+	appendEntityRefs(res, resolveEntities(entities, p.logger), p.logger)
 
 	p.logger.Info("detected resource information", zap.Any("resource", res.Attributes().AsRaw()))
 

--- a/processor/resourcedetectionprocessor/internal/system/entity_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/entity_test.go
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+)
+
+func TestEntityRefs(t *testing.T) {
+	d := &Detector{}
+
+	t.Run("host id", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.HostIDKey), "host-id-1")
+		res.Attributes().PutStr(string(conventions.HostNameKey), "host-1")
+		res.Attributes().PutStr(string(conventions.OSTypeKey), "linux")
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 1)
+		assert.Equal(t, internal.EntityTypeHost, entities[0].Type)
+		assert.Equal(t, []string{string(conventions.HostIDKey)}, entities[0].IDKeys)
+		assert.Equal(t, []string{string(conventions.HostNameKey), string(conventions.OSTypeKey)}, entities[0].DescriptionKeys)
+		assert.Empty(t, entities[0].IDContextTypeCandidates)
+	})
+
+	t.Run("host name fallback", func(t *testing.T) {
+		res := pcommon.NewResource()
+		res.Attributes().PutStr(string(conventions.HostNameKey), "host-1")
+
+		entities := d.EntityRefs(res)
+		require.Len(t, entities, 1)
+		assert.Equal(t, []string{string(conventions.HostNameKey)}, entities[0].IDKeys)
+		assert.Empty(t, entities[0].IDContextTypeCandidates)
+	})
+
+	t.Run("no identity", func(t *testing.T) {
+		assert.Empty(t, d.EntityRefs(pcommon.NewResource()))
+	})
+}

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -33,7 +34,10 @@ var hostnameSourcesMap = map[string]func(*Detector) (string, error){
 	"lookup": reverseLookupHost,
 }
 
-var _ internal.Detector = (*Detector)(nil)
+var (
+	_ internal.Detector       = (*Detector)(nil)
+	_ internal.EntityDetector = (*Detector)(nil)
+)
 
 // Detector is a system metadata detector
 type Detector struct {
@@ -178,6 +182,33 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 	}
 
 	return pcommon.NewResource(), "", errors.New("all hostname sources failed to get hostname")
+}
+
+// EntityRefs implements internal.EntityDetector.
+func (d *Detector) EntityRefs(res pcommon.Resource) []internal.DetectedEntity {
+	attrs := res.Attributes()
+	idKey := string(conventions.HostIDKey)
+	if _, ok := attrs.Get(idKey); !ok {
+		idKey = string(conventions.HostNameKey)
+		if _, ok = attrs.Get(idKey); !ok {
+			return nil
+		}
+	}
+
+	descriptionKeys := make([]string, 0, attrs.Len())
+	for k := range attrs.All() {
+		if k != idKey {
+			descriptionKeys = append(descriptionKeys, k)
+		}
+	}
+	sort.Strings(descriptionKeys)
+
+	return []internal.DetectedEntity{{
+		SchemaURL:       conventions.SchemaURL,
+		Type:            internal.EntityTypeHost,
+		IDKeys:          []string{idKey},
+		DescriptionKeys: descriptionKeys,
+	}}
 }
 
 // getHostname returns OS hostname

--- a/processor/resourcedetectionprocessor/resourcedetection_processor.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor.go
@@ -58,6 +58,7 @@ func (rdp *resourceDetectionProcessor) processTraces(ctx context.Context, td ptr
 		rss := rs.At(i)
 		rss.SetSchemaUrl(internal.MergeSchemaURL(rss.SchemaUrl(), schemaURL))
 		internal.MergeResource(rss.Resource(), res, rdp.override)
+		internal.MergeEntityRefs(rss.Resource(), res, rdp.override)
 	}
 	return td, nil
 }
@@ -70,6 +71,7 @@ func (rdp *resourceDetectionProcessor) processMetrics(ctx context.Context, md pm
 		rss := rm.At(i)
 		rss.SetSchemaUrl(internal.MergeSchemaURL(rss.SchemaUrl(), schemaURL))
 		internal.MergeResource(rss.Resource(), res, rdp.override)
+		internal.MergeEntityRefs(rss.Resource(), res, rdp.override)
 	}
 	return md, nil
 }
@@ -82,6 +84,7 @@ func (rdp *resourceDetectionProcessor) processLogs(ctx context.Context, ld plog.
 		rss := rl.At(i)
 		rss.SetSchemaUrl(internal.MergeSchemaURL(rss.SchemaUrl(), schemaURL))
 		internal.MergeResource(rss.Resource(), res, rdp.override)
+		internal.MergeEntityRefs(rss.Resource(), res, rdp.override)
 	}
 	return ld, nil
 }
@@ -94,6 +97,7 @@ func (rdp *resourceDetectionProcessor) processProfiles(ctx context.Context, ld p
 		rss := rl.At(i)
 		rss.SetSchemaUrl(internal.MergeSchemaURL(rss.SchemaUrl(), schemaURL))
 		internal.MergeResource(rss.Resource(), res, rdp.override)
+		internal.MergeEntityRefs(rss.Resource(), res, rdp.override)
 	}
 	return ld, nil
 }


### PR DESCRIPTION
Adds experimental entity refs to resources detected by the `system`, `gcp`, and `k8s_api` detectors. Detectors declare candidate ID context entity types, and the provider resolves `id_context_type` after all detector resources are merged so detector order does not affect context resolution except for same-type identity conflicts.

Depends on open-telemetry/opentelemetry-collector#15441 for the `xpdata/entity.EntityRef.IdContextType` API.
