### PR TITLE
[receiver/netflowreceiver] Add interface index and IP ToS attributes

### DIFF
--- a/.chloggen/feat-netflow-interface-tos.yaml
+++ b/.chloggen/feat-netflow-interface-tos.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/netflowreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add interface index and IP ToS attributes to parsed flow log records
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Added flow.in_if, flow.out_if, and flow.ip_tos attributes. These fields are
+  already decoded by goflow2 but were not previously included in the log record.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/netflowreceiver/README.md
+++ b/receiver/netflowreceiver/README.md
@@ -107,6 +107,9 @@ The log record will have the following attributes (with examples):
 * **flow.sampling_rate**: Int(0)
 * **flow.sampler_address**: Str(172.28.176.1)
 * **flow.tcp_flags**: Int(0)
+* **flow.in_if**: Int(5)
+* **flow.out_if**: Int(10)
+* **flow.ip_tos**: Int(46)
 
 The log record timestamps will be:
 

--- a/receiver/netflowreceiver/parser.go
+++ b/receiver/netflowreceiver/parser.go
@@ -253,6 +253,9 @@ func addMessageAttributes(m producer.ProducerMessage, r *plog.LogRecord) error {
 	r.Attributes().PutInt("flow.sampling_rate", int64(pm.SamplingRate))
 	r.Attributes().PutStr("flow.sampler_address", samplerAddr.String())
 	r.Attributes().PutInt("flow.tcp_flags", int64(pm.TcpFlags))
+	r.Attributes().PutInt("flow.in_if", int64(pm.InIf))
+	r.Attributes().PutInt("flow.out_if", int64(pm.OutIf))
+	r.Attributes().PutInt("flow.ip_tos", int64(pm.IpTos))
 
 	return nil
 }

--- a/receiver/netflowreceiver/parser_test.go
+++ b/receiver/netflowreceiver/parser_test.go
@@ -57,6 +57,9 @@ func TestConvertToOtel(t *testing.T) {
 			SequenceNum:     1,
 			SamplingRate:    1,
 			TcpFlags:        1,
+			InIf:            5,
+			OutIf:           10,
+			IpTos:           46,
 		},
 	}
 
@@ -87,6 +90,9 @@ func TestConvertToOtel(t *testing.T) {
 	expectedAttributes.PutInt("flow.sampling_rate", 1)
 	expectedAttributes.PutStr("flow.sampler_address", "192.168.1.100")
 	expectedAttributes.PutInt("flow.tcp_flags", 1)
+	expectedAttributes.PutInt("flow.in_if", 5)
+	expectedAttributes.PutInt("flow.out_if", 10)
+	expectedAttributes.PutInt("flow.ip_tos", 46)
 
 	assert.Equal(t, expectedAttributes, record.Attributes())
 }
@@ -121,6 +127,9 @@ func TestEmptyConvertToOtel(t *testing.T) {
 	expectedAttributes.PutInt("flow.sampling_rate", 0)
 	expectedAttributes.PutStr("flow.sampler_address", "invalid IP")
 	expectedAttributes.PutInt("flow.tcp_flags", 0)
+	expectedAttributes.PutInt("flow.in_if", 0)
+	expectedAttributes.PutInt("flow.out_if", 0)
+	expectedAttributes.PutInt("flow.ip_tos", 0)
 
 	assert.Equal(t, expectedAttributes, record.Attributes())
 }


### PR DESCRIPTION
Add flow.in_if, flow.out_if, and flow.ip_tos attributes to the parsed log records. These fields are already decoded by goflow2 from netflow/sflow/IPFIX packets but are not currently surfaced in the OTel log attributes.

Our use case involves correlating flows to specific switch interfaces for troubleshooting, and inspecting ToS/DSCP markings to verify QoS policy application. We expect other users with similar network observability needs could benefit from having these fields available without needing to use send_raw mode.

- flow.in_if / flow.out_if: SNMP ifIndex of the input/output interface
  on the sampler where the flow was observed.
- flow.ip_tos: The IP Type of Service byte (contains DSCP + ECN bits).
