### PR TITLE
[receiver/azureeventhub] Add encoding extension support

### DIFF
--- a/.chloggen/dylan_azure-event-hub-encoding-extension.yaml
+++ b/.chloggen/dylan_azure-event-hub-encoding-extension.yaml
@@ -4,7 +4,7 @@
 change_type: "enhancement"
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: reciever/azure_event_hub
+component: receiver/azure_event_hub
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add the ability to use encoding extensions to the Azure Event Hub receiver.

--- a/.chloggen/dylan_azure-event-hub-encoding-extension.yaml
+++ b/.chloggen/dylan_azure-event-hub-encoding-extension.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: reciever/azure_event_hub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the ability to use encoding extensions to the Azure Event Hub receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48753]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -74,7 +74,8 @@ When `blob_checkpoint_store` is set, the receiver uses the Azure SDK [Processor]
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `format` | string | No | `azure` | Message format: `azure`, `raw`, or `""`. See [Format](#format) section. |
+| `format` | string | No | `azure` | Message format: `azure`, `raw`, or `""`. Mutually exclusive with `encoding`. See [Format](#format) section. |
+| `encoding` | string | No | | ID of an [encoding extension] used to unmarshal the message body. Mutually exclusive with `format`. See [Encoding](#encoding) section. |
 | `apply_semantic_conventions` | bool | No | `false` | Translate Azure Resource Logs using OpenTelemetry semantic convention attribute names. |
 | `time_formats.logs` | []string | No | | Custom time formats for logs. Uses [Go time layout](https://pkg.go.dev/time#Layout). Falls back to ISO8601. |
 | `time_formats.metrics` | []string | No | | Custom time formats for metrics. |
@@ -294,4 +295,26 @@ Traces based on Azure Application Insights array of records from `AppRequests` &
 | Id          | span.id                                               |
 | AppRoleName | service.name                                          |
 
+## Encoding
+
+As an alternative to the built-in `format`, the `encoding` option delegates
+unmarshaling of the message body to an [encoding extension]. This is mutually
+exclusive with `format`.
+
+```yaml
+extensions:
+  azure_encoding:
+
+receivers:
+  azure_event_hub:
+    connection: Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<hub-name>
+    encoding: azure_encoding
+```
+
+> [!NOTE]
+> The encoding extension only receives the message body. AMQP properties and
+> enqueued time (which the `raw` format maps onto the LogRecord) are not applied
+> on the encoding path. Use `format: raw` if you need those.
+
 [storage extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage
+[encoding extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding

--- a/receiver/azureeventhubreceiver/config.go
+++ b/receiver/azureeventhubreceiver/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Offset                   string         `mapstructure:"offset"`
 	StorageID                *component.ID  `mapstructure:"storage"`
 	Auth                     *component.ID  `mapstructure:"auth"`
+	Encoding                 *component.ID  `mapstructure:"encoding"`
 	Format                   string         `mapstructure:"format"`
 	ConsumerGroup            string         `mapstructure:"group"`
 	ApplySemanticConventions bool           `mapstructure:"apply_semantic_conventions"`
@@ -102,10 +103,16 @@ func (config *Config) Validate() error {
 		}
 	}
 
-	switch logFormat(config.Format) {
-	case defaultLogFormat, rawLogFormat, azureLogFormat: // valid
-	default:
-		return fmt.Errorf("invalid format; must be one of %#v", validFormats)
+	if config.Encoding != nil {
+		if config.Format != "" {
+			return errors.New("format and encoding are mutually exclusive")
+		}
+	} else {
+		switch logFormat(config.Format) {
+		case defaultLogFormat, rawLogFormat, azureLogFormat: // valid
+		default:
+			return fmt.Errorf("invalid format; must be one of %#v", validFormats)
+		}
 	}
 
 	if config.Partition == "" && config.Offset != "" {

--- a/receiver/azureeventhubreceiver/config.schema.yaml
+++ b/receiver/azureeventhubreceiver/config.schema.yaml
@@ -51,6 +51,10 @@ properties:
     $ref: blob_checkpoint_store_config
   connection:
     type: string
+  encoding:
+    x-pointer: true
+    type: string
+    x-customType: go.opentelemetry.io/collector/component.ID
   event_hub:
     $ref: event_hub_config
   format:

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -23,6 +23,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	authID := component.MustNewID("azureauth")
+	encodingID := component.MustNewID("azure_encoding")
 
 	tests := []struct {
 		id                  component.ID
@@ -120,6 +121,17 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:                  component.NewIDWithName(metadata.Type, "blob_checkpoint_store_with_storage"),
 			expectedErrContains: "blob_checkpoint_store is mutually exclusive with storage",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "encoding"),
+			expected: &Config{
+				Connection: "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName",
+				Encoding:   &encodingID,
+			},
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "format_and_encoding"),
+			expectedErrContains: "format and encoding are mutually exclusive",
 		},
 	}
 

--- a/receiver/azureeventhubreceiver/factory.go
+++ b/receiver/azureeventhubreceiver/factory.go
@@ -107,37 +107,40 @@ func (f *eventhubReceiverFactory) getReceiver(
 		var logsUnmarshaler eventLogsUnmarshaler
 		var metricsUnmarshaler eventMetricsUnmarshaler
 		var tracesUnmarshaler eventTracesUnmarshaler
-		switch signal {
-		case pipeline.SignalLogs:
-			if logFormat(receiverConfig.Format) == rawLogFormat {
-				logsUnmarshaler = newRawLogsUnmarshaler(settings.Logger)
-			} else {
-				logsUnmarshaler = newAzureResourceLogsUnmarshaler(settings.BuildInfo, settings.Logger, receiverConfig.ApplySemanticConventions, receiverConfig.TimeFormats.Logs)
+		// With an encoding extension, the unmarshaler is resolved from the host at Start time.
+		if receiverConfig.Encoding == nil {
+			switch signal {
+			case pipeline.SignalLogs:
+				if logFormat(receiverConfig.Format) == rawLogFormat {
+					logsUnmarshaler = newRawLogsUnmarshaler(settings.Logger)
+				} else {
+					logsUnmarshaler = newAzureResourceLogsUnmarshaler(settings.BuildInfo, settings.Logger, receiverConfig.ApplySemanticConventions, receiverConfig.TimeFormats.Logs)
+				}
+			case pipeline.SignalMetrics:
+				if logFormat(receiverConfig.Format) == rawLogFormat {
+					metricsUnmarshaler = nil
+					err = errors.New("raw format not supported for Metrics")
+				} else {
+					metricsUnmarshaler = newAzureResourceMetricsUnmarshaler(settings.BuildInfo, settings.Logger, receiverConfig)
+				}
+			case pipeline.SignalTraces:
+				if logFormat(receiverConfig.Format) == rawLogFormat {
+					tracesUnmarshaler = nil
+					err = errors.New("raw format not supported for Traces")
+				} else {
+					tracesUnmarshaler = newAzureTracesUnmarshaler(settings.BuildInfo, settings.Logger, receiverConfig.TimeFormats.Traces)
+				}
 			}
-		case pipeline.SignalMetrics:
-			if logFormat(receiverConfig.Format) == rawLogFormat {
-				metricsUnmarshaler = nil
-				err = errors.New("raw format not supported for Metrics")
-			} else {
-				metricsUnmarshaler = newAzureResourceMetricsUnmarshaler(settings.BuildInfo, settings.Logger, receiverConfig)
-			}
-		case pipeline.SignalTraces:
-			if logFormat(receiverConfig.Format) == rawLogFormat {
-				tracesUnmarshaler = nil
-				err = errors.New("raw format not supported for Traces")
-			} else {
-				tracesUnmarshaler = newAzureTracesUnmarshaler(settings.BuildInfo, settings.Logger, receiverConfig.TimeFormats.Traces)
-			}
-		}
 
-		if err != nil {
-			return nil
+			if err != nil {
+				return nil
+			}
 		}
 
 		eventHandler := newEventhubHandler(receiverConfig, settings)
 
 		var rcvr component.Component
-		rcvr, err = newReceiver(signal, logsUnmarshaler, metricsUnmarshaler, tracesUnmarshaler, eventHandler, settings)
+		rcvr, err = newReceiver(signal, receiverConfig.Encoding, logsUnmarshaler, metricsUnmarshaler, tracesUnmarshaler, eventHandler, settings)
 		return rcvr
 	})
 

--- a/receiver/azureeventhubreceiver/factory_test.go
+++ b/receiver/azureeventhubreceiver/factory_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -30,4 +32,27 @@ func Test_NewMetricsReceiver(t *testing.T) {
 	receiver, err := f.CreateMetrics(t.Context(), receivertest.NewNopSettings(metadata.Type), f.CreateDefaultConfig(), consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, receiver)
+}
+
+func TestFactoryWithEncodingSkipsFormatUnmarshaler(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+
+	config := createDefaultConfig().(*Config)
+	config.Connection = testConnection
+	config.Encoding = &encodingID
+
+	f := NewFactory()
+	settings := receivertest.NewNopSettings(metadata.Type)
+
+	logs, err := f.CreateLogs(t.Context(), settings, config, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.Nil(t, logs.(*eventhubReceiver).logsUnmarshaler)
+
+	metrics, err := f.CreateMetrics(t.Context(), settings, config, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.Nil(t, metrics.(*eventhubReceiver).metricsUnmarshaler)
+
+	traces, err := f.CreateTraces(t.Context(), settings, config, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.Nil(t, traces.(*eventhubReceiver).tracesUnmarshaler)
 }

--- a/receiver/azureeventhubreceiver/receiver.go
+++ b/receiver/azureeventhubreceiver/receiver.go
@@ -40,9 +40,34 @@ type eventTracesUnmarshaler interface {
 	UnmarshalTraces(event *azureEvent) (ptrace.Traces, error)
 }
 
+type encodingLogsUnmarshaler struct {
+	unmarshaler plog.Unmarshaler
+}
+
+func (e encodingLogsUnmarshaler) UnmarshalLogs(event *azureEvent) (plog.Logs, error) {
+	return e.unmarshaler.UnmarshalLogs(event.Data())
+}
+
+type encodingMetricsUnmarshaler struct {
+	unmarshaler pmetric.Unmarshaler
+}
+
+func (e encodingMetricsUnmarshaler) UnmarshalMetrics(event *azureEvent) (pmetric.Metrics, error) {
+	return e.unmarshaler.UnmarshalMetrics(event.Data())
+}
+
+type encodingTracesUnmarshaler struct {
+	unmarshaler ptrace.Unmarshaler
+}
+
+func (e encodingTracesUnmarshaler) UnmarshalTraces(event *azureEvent) (ptrace.Traces, error) {
+	return e.unmarshaler.UnmarshalTraces(event.Data())
+}
+
 type eventhubReceiver struct {
 	eventHandler        *eventhubHandler
 	signal              pipeline.Signal
+	encodingID          *component.ID
 	logger              *zap.Logger
 	logsUnmarshaler     eventLogsUnmarshaler
 	metricsUnmarshaler  eventMetricsUnmarshaler
@@ -54,7 +79,44 @@ type eventhubReceiver struct {
 }
 
 func (receiver *eventhubReceiver) Start(ctx context.Context, host component.Host) error {
+	if receiver.encodingID != nil {
+		if err := receiver.setEncodingUnmarshaler(host); err != nil {
+			return err
+		}
+	}
 	return receiver.eventHandler.run(ctx, host)
+}
+
+func (receiver *eventhubReceiver) setEncodingUnmarshaler(host component.Host) error {
+	ext, ok := host.GetExtensions()[*receiver.encodingID]
+	if !ok {
+		return fmt.Errorf("encoding extension %q not found", receiver.encodingID)
+	}
+
+	switch receiver.signal {
+	case pipeline.SignalLogs:
+		unmarshaler, ok := ext.(plog.Unmarshaler)
+		if !ok {
+			return fmt.Errorf("extension %q is not a logs unmarshaler", receiver.encodingID)
+		}
+		receiver.logsUnmarshaler = encodingLogsUnmarshaler{unmarshaler}
+	case pipeline.SignalMetrics:
+		unmarshaler, ok := ext.(pmetric.Unmarshaler)
+		if !ok {
+			return fmt.Errorf("extension %q is not a metrics unmarshaler", receiver.encodingID)
+		}
+		receiver.metricsUnmarshaler = encodingMetricsUnmarshaler{unmarshaler}
+	case pipeline.SignalTraces:
+		unmarshaler, ok := ext.(ptrace.Unmarshaler)
+		if !ok {
+			return fmt.Errorf("extension %q is not a traces unmarshaler", receiver.encodingID)
+		}
+		receiver.tracesUnmarshaler = encodingTracesUnmarshaler{unmarshaler}
+	default:
+		return fmt.Errorf("invalid data type: %v", receiver.signal)
+	}
+
+	return nil
 }
 
 func (receiver *eventhubReceiver) Shutdown(ctx context.Context) error {
@@ -159,6 +221,7 @@ func (receiver *eventhubReceiver) consumeTraces(ctx context.Context, event *azur
 
 func newReceiver(
 	signal pipeline.Signal,
+	encodingID *component.ID,
 	logsUnmarshaler eventLogsUnmarshaler,
 	metricsUnmarshaler eventMetricsUnmarshaler,
 	tracesUnmarshaler eventTracesUnmarshaler,
@@ -176,6 +239,7 @@ func newReceiver(
 
 	eventhubReceiver := &eventhubReceiver{
 		signal:             signal,
+		encodingID:         encodingID,
 		eventHandler:       eventHandler,
 		logger:             settings.Logger,
 		logsUnmarshaler:    logsUnmarshaler,

--- a/receiver/azureeventhubreceiver/receiver_test.go
+++ b/receiver/azureeventhubreceiver/receiver_test.go
@@ -1,0 +1,248 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azureeventhubreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pipeline"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver/internal/metadata"
+)
+
+const testConnection = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
+
+type mockEncodingExtension struct{}
+
+func (mockEncodingExtension) Start(context.Context, component.Host) error { return nil }
+func (mockEncodingExtension) Shutdown(context.Context) error              { return nil }
+
+func (mockEncodingExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr(string(buf))
+	return logs, nil
+}
+
+func (mockEncodingExtension) UnmarshalMetrics(buf []byte) (pmetric.Metrics, error) {
+	metrics := pmetric.NewMetrics()
+	metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName(string(buf))
+	return metrics, nil
+}
+
+func (mockEncodingExtension) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName(string(buf))
+	return traces, nil
+}
+
+type mockBareExtension struct{}
+
+func (mockBareExtension) Start(context.Context, component.Host) error { return nil }
+func (mockBareExtension) Shutdown(context.Context) error              { return nil }
+
+type mockEncodingHost struct {
+	component.Host
+	extensions map[component.ID]component.Component
+}
+
+func (h mockEncodingHost) GetExtensions() map[component.ID]component.Component {
+	return h.extensions
+}
+
+func newTestEvent(data string) *azureEvent {
+	return &azureEvent{
+		AzEventData: &azeventhubs.ReceivedEventData{
+			EventData: azeventhubs.EventData{
+				Body: []byte(data),
+			},
+		},
+	}
+}
+
+func TestEncodingLogsUnmarshaler(t *testing.T) {
+	u := encodingLogsUnmarshaler{unmarshaler: mockEncodingExtension{}}
+	logs, err := u.UnmarshalLogs(newTestEvent("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 1, logs.LogRecordCount())
+	assert.Equal(t, "hello", logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+}
+
+func TestEncodingMetricsUnmarshaler(t *testing.T) {
+	u := encodingMetricsUnmarshaler{unmarshaler: mockEncodingExtension{}}
+	metrics, err := u.UnmarshalMetrics(newTestEvent("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 1, metrics.MetricCount())
+	assert.Equal(t, "hello", metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestEncodingTracesUnmarshaler(t *testing.T) {
+	u := encodingTracesUnmarshaler{unmarshaler: mockEncodingExtension{}}
+	traces, err := u.UnmarshalTraces(newTestEvent("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 1, traces.SpanCount())
+	assert.Equal(t, "hello", traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+}
+
+func TestSetEncodingUnmarshaler(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+
+	host := mockEncodingHost{
+		extensions: map[component.ID]component.Component{
+			encodingID: mockEncodingExtension{},
+		},
+	}
+
+	t.Run("logs", func(t *testing.T) {
+		r := &eventhubReceiver{signal: pipeline.SignalLogs, encodingID: &encodingID}
+		require.NoError(t, r.setEncodingUnmarshaler(host))
+		assert.IsType(t, encodingLogsUnmarshaler{}, r.logsUnmarshaler)
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		r := &eventhubReceiver{signal: pipeline.SignalMetrics, encodingID: &encodingID}
+		require.NoError(t, r.setEncodingUnmarshaler(host))
+		assert.IsType(t, encodingMetricsUnmarshaler{}, r.metricsUnmarshaler)
+	})
+
+	t.Run("traces", func(t *testing.T) {
+		r := &eventhubReceiver{signal: pipeline.SignalTraces, encodingID: &encodingID}
+		require.NoError(t, r.setEncodingUnmarshaler(host))
+		assert.IsType(t, encodingTracesUnmarshaler{}, r.tracesUnmarshaler)
+	})
+}
+
+func TestSetEncodingUnmarshaler_ExtensionNotFound(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+	host := mockEncodingHost{extensions: map[component.ID]component.Component{}}
+
+	r := &eventhubReceiver{signal: pipeline.SignalLogs, encodingID: &encodingID}
+	err := r.setEncodingUnmarshaler(host)
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestSetEncodingUnmarshaler_WrongType(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+	host := mockEncodingHost{
+		extensions: map[component.ID]component.Component{
+			encodingID: mockBareExtension{},
+		},
+	}
+
+	tests := []struct {
+		signal      pipeline.Signal
+		expectedErr string
+	}{
+		{pipeline.SignalLogs, "is not a logs unmarshaler"},
+		{pipeline.SignalMetrics, "is not a metrics unmarshaler"},
+		{pipeline.SignalTraces, "is not a traces unmarshaler"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.signal.String(), func(t *testing.T) {
+			r := &eventhubReceiver{signal: tt.signal, encodingID: &encodingID}
+			assert.ErrorContains(t, r.setEncodingUnmarshaler(host), tt.expectedErr)
+		})
+	}
+}
+
+func TestSetEncodingUnmarshaler_InvalidSignal(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+	host := mockEncodingHost{
+		extensions: map[component.ID]component.Component{
+			encodingID: mockEncodingExtension{},
+		},
+	}
+
+	r := &eventhubReceiver{signal: pipeline.Signal{}, encodingID: &encodingID}
+	assert.ErrorContains(t, r.setEncodingUnmarshaler(host), "invalid data type")
+}
+
+func TestStartResolvesEncodingExtension(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+	host := mockEncodingHost{
+		extensions: map[component.ID]component.Component{
+			encodingID: mockEncodingExtension{},
+		},
+	}
+
+	config := createDefaultConfig().(*Config)
+	config.Connection = testConnection
+	config.Encoding = &encodingID
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	eventHandler := newEventhubHandler(config, settings)
+	eventHandler.hub = &mockHubWrapper{}
+
+	rcvr, err := newReceiver(pipeline.SignalLogs, &encodingID, nil, nil, nil, eventHandler, settings)
+	require.NoError(t, err)
+
+	r := rcvr.(*eventhubReceiver)
+	require.Nil(t, r.logsUnmarshaler)
+
+	require.NoError(t, r.Start(t.Context(), host))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(t.Context())) })
+
+	assert.IsType(t, encodingLogsUnmarshaler{}, r.logsUnmarshaler)
+}
+
+func TestStartWithMissingEncodingExtensionFails(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+	host := mockEncodingHost{extensions: map[component.ID]component.Component{}}
+
+	config := createDefaultConfig().(*Config)
+	config.Connection = testConnection
+	config.Encoding = &encodingID
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	eventHandler := newEventhubHandler(config, settings)
+	eventHandler.hub = &mockHubWrapper{}
+
+	rcvr, err := newReceiver(pipeline.SignalLogs, &encodingID, nil, nil, nil, eventHandler, settings)
+	require.NoError(t, err)
+
+	assert.Error(t, rcvr.(*eventhubReceiver).Start(t.Context(), host))
+}
+
+func TestConsumeWithEncodingDecodesBody(t *testing.T) {
+	encodingID := component.MustNewID("myencoding")
+	host := mockEncodingHost{
+		extensions: map[component.ID]component.Component{
+			encodingID: mockEncodingExtension{},
+		},
+	}
+
+	config := createDefaultConfig().(*Config)
+	config.Connection = testConnection
+	config.Encoding = &encodingID
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	eventHandler := newEventhubHandler(config, settings)
+	eventHandler.hub = &mockHubWrapper{}
+
+	sink := new(consumertest.LogsSink)
+	rcvr, err := newReceiver(pipeline.SignalLogs, &encodingID, nil, nil, nil, eventHandler, settings)
+	require.NoError(t, err)
+	r := rcvr.(*eventhubReceiver)
+	r.setNextLogsConsumer(sink)
+
+	require.NoError(t, r.Start(t.Context(), host))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(t.Context())) })
+
+	require.NoError(t, r.consume(t.Context(), newTestEvent("payload")))
+
+	require.Len(t, sink.AllLogs(), 1)
+	got := sink.AllLogs()[0]
+	require.Equal(t, 1, got.LogRecordCount())
+	assert.Equal(t, "payload", got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+}

--- a/receiver/azureeventhubreceiver/testdata/config.yaml
+++ b/receiver/azureeventhubreceiver/testdata/config.yaml
@@ -81,3 +81,12 @@ azure_event_hub/blob_checkpoint_store_with_storage:
   blob_checkpoint_store:
     connection: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net
     container_name: eventhub-checkpoints
+
+azure_event_hub/encoding:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  encoding: azure_encoding
+
+azure_event_hub/format_and_encoding:
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+  format: raw
+  encoding: azure_encoding


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds support for encoding extensions to be used with the receiver instead of the `format` option.

There are plans to deprecate `pkg/translator/azurelogs` and multiple issues have been opened regarding this package. This will allow any bug fixes to be done in the new azure encoding extension. This extension already has some improvements over the translator package that partially solve #48753

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Partially solves #48753

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tests written, manual testing done as well

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
