### PR TITLE
[receiver/hostmetrics] Add process.network.connection.count metric to process scraper

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	// If neither `include` or `exclude` are set, process metrics will be generated for all processes.
 	Include MatchConfig `mapstructure:"include"`
 	Exclude MatchConfig `mapstructure:"exclude"`
+	// Connections specifies process network connection metric settings.
+	Connections ConnectionConfig `mapstructure:"connections"`
 
 	// MuteProcessAllErrors is a flag that will mute all the errors encountered when trying to read metrics of a process.
 	// When this flag is enabled, there is no need to activate any other error suppression flags.
@@ -59,4 +61,15 @@ type MatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
 
 	Names []string `mapstructure:"names"`
+}
+
+type ConnectionConfig struct {
+	// IncludePorts specifies remote ports that should be included in process connection metrics.
+	IncludePorts []uint32 `mapstructure:"include_ports"`
+	// ExcludePorts specifies remote ports that should be excluded from process connection metrics.
+	ExcludePorts []uint32 `mapstructure:"exclude_ports"`
+	// ExcludeLocalhost specifies whether to exclude local and loopback remote addresses from process connection metrics.
+	ExcludeLocalhost bool `mapstructure:"exclude_localhost"`
+	// ExcludeListenPorts specifies whether to exclude connections from local listening ports from process connection metrics.
+	ExcludeListenPorts bool `mapstructure:"exclude_listen_ports"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -128,6 +128,21 @@ Percentage of total physical memory that is used by the process.
 | ---- | ----------- | ---------- | --------- |
 | 1 | Gauge | Double | Development |
 
+### process.network.connection.count
+
+The number of established network connections opened by the process, grouped by remote endpoint.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {connections} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| server.address | The remote address of the network connection. | Any Str | Recommended | - |
+| server.port | The remote port of the network connection. | Any Int | Recommended | - |
+
 ### process.open_file_descriptors
 
 Number of file descriptors in use by the process.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/generated_package_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/generated_package_test.go
@@ -3,9 +3,8 @@
 package processscraper
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config.go
@@ -329,6 +329,55 @@ func (ms *ProcessMemoryVirtualMetricConfig) Unmarshal(parser *confmap.Conf) erro
 	return nil
 }
 
+// ProcessNetworkConnectionCountMetricAttributeKey specifies the key of an attribute for the process.network.connection.count metric.
+type ProcessNetworkConnectionCountMetricAttributeKey string
+
+const (
+	ProcessNetworkConnectionCountMetricAttributeKeyServerAddress ProcessNetworkConnectionCountMetricAttributeKey = "server.address"
+	ProcessNetworkConnectionCountMetricAttributeKeyServerPort    ProcessNetworkConnectionCountMetricAttributeKey = "server.port"
+)
+
+// ProcessNetworkConnectionCountMetricConfig provides config for the process.network.connection.count metric.
+type ProcessNetworkConnectionCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []ProcessNetworkConnectionCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *ProcessNetworkConnectionCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *ProcessNetworkConnectionCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case ProcessNetworkConnectionCountMetricAttributeKeyServerAddress, ProcessNetworkConnectionCountMetricAttributeKeyServerPort:
+		default:
+			return fmt.Errorf("metric process.network.connection.count doesn't have an attribute %v, valid attributes: [server.address, server.port]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // ProcessOpenFileDescriptorsMetricConfig provides config for the process.open_file_descriptors metric.
 type ProcessOpenFileDescriptorsMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -459,20 +508,21 @@ func (ms *ProcessUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for process metrics.
 type MetricsConfig struct {
-	ProcessContextSwitches     ProcessContextSwitchesMetricConfig     `mapstructure:"process.context_switches"`
-	ProcessCPUTime             ProcessCPUTimeMetricConfig             `mapstructure:"process.cpu.time"`
-	ProcessCPUUtilization      ProcessCPUUtilizationMetricConfig      `mapstructure:"process.cpu.utilization"`
-	ProcessDiskIo              ProcessDiskIoMetricConfig              `mapstructure:"process.disk.io"`
-	ProcessDiskOperations      ProcessDiskOperationsMetricConfig      `mapstructure:"process.disk.operations"`
-	ProcessHandles             ProcessHandlesMetricConfig             `mapstructure:"process.handles"`
-	ProcessMemoryUsage         ProcessMemoryUsageMetricConfig         `mapstructure:"process.memory.usage"`
-	ProcessMemoryUtilization   ProcessMemoryUtilizationMetricConfig   `mapstructure:"process.memory.utilization"`
-	ProcessMemoryVirtual       ProcessMemoryVirtualMetricConfig       `mapstructure:"process.memory.virtual"`
-	ProcessOpenFileDescriptors ProcessOpenFileDescriptorsMetricConfig `mapstructure:"process.open_file_descriptors"`
-	ProcessPagingFaults        ProcessPagingFaultsMetricConfig        `mapstructure:"process.paging.faults"`
-	ProcessSignalsPending      ProcessSignalsPendingMetricConfig      `mapstructure:"process.signals_pending"`
-	ProcessThreads             ProcessThreadsMetricConfig             `mapstructure:"process.threads"`
-	ProcessUptime              ProcessUptimeMetricConfig              `mapstructure:"process.uptime"`
+	ProcessContextSwitches        ProcessContextSwitchesMetricConfig        `mapstructure:"process.context_switches"`
+	ProcessCPUTime                ProcessCPUTimeMetricConfig                `mapstructure:"process.cpu.time"`
+	ProcessCPUUtilization         ProcessCPUUtilizationMetricConfig         `mapstructure:"process.cpu.utilization"`
+	ProcessDiskIo                 ProcessDiskIoMetricConfig                 `mapstructure:"process.disk.io"`
+	ProcessDiskOperations         ProcessDiskOperationsMetricConfig         `mapstructure:"process.disk.operations"`
+	ProcessHandles                ProcessHandlesMetricConfig                `mapstructure:"process.handles"`
+	ProcessMemoryUsage            ProcessMemoryUsageMetricConfig            `mapstructure:"process.memory.usage"`
+	ProcessMemoryUtilization      ProcessMemoryUtilizationMetricConfig      `mapstructure:"process.memory.utilization"`
+	ProcessMemoryVirtual          ProcessMemoryVirtualMetricConfig          `mapstructure:"process.memory.virtual"`
+	ProcessNetworkConnectionCount ProcessNetworkConnectionCountMetricConfig `mapstructure:"process.network.connection.count"`
+	ProcessOpenFileDescriptors    ProcessOpenFileDescriptorsMetricConfig    `mapstructure:"process.open_file_descriptors"`
+	ProcessPagingFaults           ProcessPagingFaultsMetricConfig           `mapstructure:"process.paging.faults"`
+	ProcessSignalsPending         ProcessSignalsPendingMetricConfig         `mapstructure:"process.signals_pending"`
+	ProcessThreads                ProcessThreadsMetricConfig                `mapstructure:"process.threads"`
+	ProcessUptime                 ProcessUptimeMetricConfig                 `mapstructure:"process.uptime"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -513,6 +563,11 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		ProcessMemoryVirtual: ProcessMemoryVirtualMetricConfig{
 			Enabled: true,
+		},
+		ProcessNetworkConnectionCount: ProcessNetworkConnectionCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []ProcessNetworkConnectionCountMetricAttributeKey{ProcessNetworkConnectionCountMetricAttributeKeyServerAddress, ProcessNetworkConnectionCountMetricAttributeKeyServerPort},
 		},
 		ProcessOpenFileDescriptors: ProcessOpenFileDescriptorsMetricConfig{
 			Enabled: false,

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_config_test.go
@@ -63,6 +63,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					ProcessMemoryVirtual: ProcessMemoryVirtualMetricConfig{
 						Enabled: true,
 					},
+					ProcessNetworkConnectionCount: ProcessNetworkConnectionCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ProcessNetworkConnectionCountMetricAttributeKey{ProcessNetworkConnectionCountMetricAttributeKeyServerAddress, ProcessNetworkConnectionCountMetricAttributeKeyServerPort},
+					},
 					ProcessOpenFileDescriptors: ProcessOpenFileDescriptorsMetricConfig{
 						Enabled: true,
 					},
@@ -134,6 +139,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					ProcessMemoryVirtual: ProcessMemoryVirtualMetricConfig{
 						Enabled: false,
 					},
+					ProcessNetworkConnectionCount: ProcessNetworkConnectionCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []ProcessNetworkConnectionCountMetricAttributeKey{ProcessNetworkConnectionCountMetricAttributeKeyServerAddress, ProcessNetworkConnectionCountMetricAttributeKeyServerPort},
+					},
 					ProcessOpenFileDescriptors: ProcessOpenFileDescriptorsMetricConfig{
 						Enabled: false,
 					},
@@ -168,7 +178,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ProcessContextSwitchesMetricConfig{}, ProcessCPUTimeMetricConfig{}, ProcessCPUUtilizationMetricConfig{}, ProcessDiskIoMetricConfig{}, ProcessDiskOperationsMetricConfig{}, ProcessHandlesMetricConfig{}, ProcessMemoryUsageMetricConfig{}, ProcessMemoryUtilizationMetricConfig{}, ProcessMemoryVirtualMetricConfig{}, ProcessOpenFileDescriptorsMetricConfig{}, ProcessPagingFaultsMetricConfig{}, ProcessSignalsPendingMetricConfig{}, ProcessThreadsMetricConfig{}, ProcessUptimeMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ProcessContextSwitchesMetricConfig{}, ProcessCPUTimeMetricConfig{}, ProcessCPUUtilizationMetricConfig{}, ProcessDiskIoMetricConfig{}, ProcessDiskOperationsMetricConfig{}, ProcessHandlesMetricConfig{}, ProcessMemoryUsageMetricConfig{}, ProcessMemoryUtilizationMetricConfig{}, ProcessMemoryVirtualMetricConfig{}, ProcessNetworkConnectionCountMetricConfig{}, ProcessOpenFileDescriptorsMetricConfig{}, ProcessPagingFaultsMetricConfig{}, ProcessSignalsPendingMetricConfig{}, ProcessThreadsMetricConfig{}, ProcessUptimeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -157,6 +157,9 @@ var MetricsInfo = metricsInfo{
 	ProcessMemoryVirtual: metricInfo{
 		Name: "process.memory.virtual",
 	},
+	ProcessNetworkConnectionCount: metricInfo{
+		Name: "process.network.connection.count",
+	},
 	ProcessOpenFileDescriptors: metricInfo{
 		Name: "process.open_file_descriptors",
 	},
@@ -175,20 +178,21 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	ProcessContextSwitches     metricInfo
-	ProcessCPUTime             metricInfo
-	ProcessCPUUtilization      metricInfo
-	ProcessDiskIo              metricInfo
-	ProcessDiskOperations      metricInfo
-	ProcessHandles             metricInfo
-	ProcessMemoryUsage         metricInfo
-	ProcessMemoryUtilization   metricInfo
-	ProcessMemoryVirtual       metricInfo
-	ProcessOpenFileDescriptors metricInfo
-	ProcessPagingFaults        metricInfo
-	ProcessSignalsPending      metricInfo
-	ProcessThreads             metricInfo
-	ProcessUptime              metricInfo
+	ProcessContextSwitches        metricInfo
+	ProcessCPUTime                metricInfo
+	ProcessCPUUtilization         metricInfo
+	ProcessDiskIo                 metricInfo
+	ProcessDiskOperations         metricInfo
+	ProcessHandles                metricInfo
+	ProcessMemoryUsage            metricInfo
+	ProcessMemoryUtilization      metricInfo
+	ProcessMemoryVirtual          metricInfo
+	ProcessNetworkConnectionCount metricInfo
+	ProcessOpenFileDescriptors    metricInfo
+	ProcessPagingFaults           metricInfo
+	ProcessSignalsPending         metricInfo
+	ProcessThreads                metricInfo
+	ProcessUptime                 metricInfo
 }
 
 type metricInfo struct {
@@ -854,6 +858,98 @@ func newMetricProcessMemoryVirtual(cfg ProcessMemoryVirtualMetricConfig) metricP
 	return m
 }
 
+type metricProcessNetworkConnectionCount struct {
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        ProcessNetworkConnectionCountMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills process.network.connection.count metric with initial data.
+func (m *metricProcessNetworkConnectionCount) init() {
+	m.data.SetName("process.network.connection.count")
+	m.data.SetDescription("The number of established network connections opened by the process, grouped by remote endpoint.")
+	m.data.SetUnit("{connections}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricProcessNetworkConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serverAddressAttributeValue string, serverPortAttributeValue int64) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, ProcessNetworkConnectionCountMetricAttributeKeyServerAddress) {
+		dp.Attributes().PutStr("server.address", serverAddressAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, ProcessNetworkConnectionCountMetricAttributeKeyServerPort) {
+		dp.Attributes().PutInt("server.port", serverPortAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricProcessNetworkConnectionCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricProcessNetworkConnectionCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricProcessNetworkConnectionCount(cfg ProcessNetworkConnectionCountMetricConfig) metricProcessNetworkConnectionCount {
+	m := metricProcessNetworkConnectionCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricProcessOpenFileDescriptors struct {
 	data     pmetric.Metric                         // data buffer for generated metric.
 	config   ProcessOpenFileDescriptorsMetricConfig // metric config provided by user.
@@ -1154,27 +1250,28 @@ func newMetricProcessUptime(cfg ProcessUptimeMetricConfig) metricProcessUptime {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                           MetricsBuilderConfig // config of the metrics builder.
-	startTime                        pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                  int                  // maximum observed number of metrics per resource.
-	metricsBuffer                    pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                        component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter   map[string]filter.Filter
-	resourceAttributeExcludeFilter   map[string]filter.Filter
-	metricProcessContextSwitches     metricProcessContextSwitches
-	metricProcessCPUTime             metricProcessCPUTime
-	metricProcessCPUUtilization      metricProcessCPUUtilization
-	metricProcessDiskIo              metricProcessDiskIo
-	metricProcessDiskOperations      metricProcessDiskOperations
-	metricProcessHandles             metricProcessHandles
-	metricProcessMemoryUsage         metricProcessMemoryUsage
-	metricProcessMemoryUtilization   metricProcessMemoryUtilization
-	metricProcessMemoryVirtual       metricProcessMemoryVirtual
-	metricProcessOpenFileDescriptors metricProcessOpenFileDescriptors
-	metricProcessPagingFaults        metricProcessPagingFaults
-	metricProcessSignalsPending      metricProcessSignalsPending
-	metricProcessThreads             metricProcessThreads
-	metricProcessUptime              metricProcessUptime
+	config                              MetricsBuilderConfig // config of the metrics builder.
+	startTime                           pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                     int                  // maximum observed number of metrics per resource.
+	metricsBuffer                       pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                           component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter      map[string]filter.Filter
+	resourceAttributeExcludeFilter      map[string]filter.Filter
+	metricProcessContextSwitches        metricProcessContextSwitches
+	metricProcessCPUTime                metricProcessCPUTime
+	metricProcessCPUUtilization         metricProcessCPUUtilization
+	metricProcessDiskIo                 metricProcessDiskIo
+	metricProcessDiskOperations         metricProcessDiskOperations
+	metricProcessHandles                metricProcessHandles
+	metricProcessMemoryUsage            metricProcessMemoryUsage
+	metricProcessMemoryUtilization      metricProcessMemoryUtilization
+	metricProcessMemoryVirtual          metricProcessMemoryVirtual
+	metricProcessNetworkConnectionCount metricProcessNetworkConnectionCount
+	metricProcessOpenFileDescriptors    metricProcessOpenFileDescriptors
+	metricProcessPagingFaults           metricProcessPagingFaults
+	metricProcessSignalsPending         metricProcessSignalsPending
+	metricProcessThreads                metricProcessThreads
+	metricProcessUptime                 metricProcessUptime
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -1196,26 +1293,27 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings scraper.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                           mbc,
-		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                    pmetric.NewMetrics(),
-		buildInfo:                        settings.BuildInfo,
-		metricProcessContextSwitches:     newMetricProcessContextSwitches(mbc.Metrics.ProcessContextSwitches),
-		metricProcessCPUTime:             newMetricProcessCPUTime(mbc.Metrics.ProcessCPUTime),
-		metricProcessCPUUtilization:      newMetricProcessCPUUtilization(mbc.Metrics.ProcessCPUUtilization),
-		metricProcessDiskIo:              newMetricProcessDiskIo(mbc.Metrics.ProcessDiskIo),
-		metricProcessDiskOperations:      newMetricProcessDiskOperations(mbc.Metrics.ProcessDiskOperations),
-		metricProcessHandles:             newMetricProcessHandles(mbc.Metrics.ProcessHandles),
-		metricProcessMemoryUsage:         newMetricProcessMemoryUsage(mbc.Metrics.ProcessMemoryUsage),
-		metricProcessMemoryUtilization:   newMetricProcessMemoryUtilization(mbc.Metrics.ProcessMemoryUtilization),
-		metricProcessMemoryVirtual:       newMetricProcessMemoryVirtual(mbc.Metrics.ProcessMemoryVirtual),
-		metricProcessOpenFileDescriptors: newMetricProcessOpenFileDescriptors(mbc.Metrics.ProcessOpenFileDescriptors),
-		metricProcessPagingFaults:        newMetricProcessPagingFaults(mbc.Metrics.ProcessPagingFaults),
-		metricProcessSignalsPending:      newMetricProcessSignalsPending(mbc.Metrics.ProcessSignalsPending),
-		metricProcessThreads:             newMetricProcessThreads(mbc.Metrics.ProcessThreads),
-		metricProcessUptime:              newMetricProcessUptime(mbc.Metrics.ProcessUptime),
-		resourceAttributeIncludeFilter:   make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:   make(map[string]filter.Filter),
+		config:                              mbc,
+		startTime:                           pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                       pmetric.NewMetrics(),
+		buildInfo:                           settings.BuildInfo,
+		metricProcessContextSwitches:        newMetricProcessContextSwitches(mbc.Metrics.ProcessContextSwitches),
+		metricProcessCPUTime:                newMetricProcessCPUTime(mbc.Metrics.ProcessCPUTime),
+		metricProcessCPUUtilization:         newMetricProcessCPUUtilization(mbc.Metrics.ProcessCPUUtilization),
+		metricProcessDiskIo:                 newMetricProcessDiskIo(mbc.Metrics.ProcessDiskIo),
+		metricProcessDiskOperations:         newMetricProcessDiskOperations(mbc.Metrics.ProcessDiskOperations),
+		metricProcessHandles:                newMetricProcessHandles(mbc.Metrics.ProcessHandles),
+		metricProcessMemoryUsage:            newMetricProcessMemoryUsage(mbc.Metrics.ProcessMemoryUsage),
+		metricProcessMemoryUtilization:      newMetricProcessMemoryUtilization(mbc.Metrics.ProcessMemoryUtilization),
+		metricProcessMemoryVirtual:          newMetricProcessMemoryVirtual(mbc.Metrics.ProcessMemoryVirtual),
+		metricProcessNetworkConnectionCount: newMetricProcessNetworkConnectionCount(mbc.Metrics.ProcessNetworkConnectionCount),
+		metricProcessOpenFileDescriptors:    newMetricProcessOpenFileDescriptors(mbc.Metrics.ProcessOpenFileDescriptors),
+		metricProcessPagingFaults:           newMetricProcessPagingFaults(mbc.Metrics.ProcessPagingFaults),
+		metricProcessSignalsPending:         newMetricProcessSignalsPending(mbc.Metrics.ProcessSignalsPending),
+		metricProcessThreads:                newMetricProcessThreads(mbc.Metrics.ProcessThreads),
+		metricProcessUptime:                 newMetricProcessUptime(mbc.Metrics.ProcessUptime),
+		resourceAttributeIncludeFilter:      make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:      make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.ProcessCgroup.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["process.cgroup"] = filter.CreateFilter(mbc.ResourceAttributes.ProcessCgroup.MetricsInclude)
@@ -1344,6 +1442,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricProcessMemoryUsage.emit(ils.Metrics())
 	mb.metricProcessMemoryUtilization.emit(ils.Metrics())
 	mb.metricProcessMemoryVirtual.emit(ils.Metrics())
+	mb.metricProcessNetworkConnectionCount.emit(ils.Metrics())
 	mb.metricProcessOpenFileDescriptors.emit(ils.Metrics())
 	mb.metricProcessPagingFaults.emit(ils.Metrics())
 	mb.metricProcessSignalsPending.emit(ils.Metrics())
@@ -1423,6 +1522,11 @@ func (mb *MetricsBuilder) RecordProcessMemoryUtilizationDataPoint(ts pcommon.Tim
 // RecordProcessMemoryVirtualDataPoint adds a data point to process.memory.virtual metric.
 func (mb *MetricsBuilder) RecordProcessMemoryVirtualDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricProcessMemoryVirtual.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordProcessNetworkConnectionCountDataPoint adds a data point to process.network.connection.count metric.
+func (mb *MetricsBuilder) RecordProcessNetworkConnectionCountDataPoint(ts pcommon.Timestamp, val int64, serverAddressAttributeValue string, serverPortAttributeValue int64) {
+	mb.metricProcessNetworkConnectionCount.recordDataPoint(mb.startTime, ts, val, serverAddressAttributeValue, serverPortAttributeValue)
 }
 
 // RecordProcessOpenFileDescriptorsDataPoint adds a data point to process.open_file_descriptors metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
@@ -72,6 +72,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["process.cpu.utilization"] = mb.metricProcessCPUUtilization.config.AggregationStrategy
 			aggMap["process.disk.io"] = mb.metricProcessDiskIo.config.AggregationStrategy
 			aggMap["process.disk.operations"] = mb.metricProcessDiskOperations.config.AggregationStrategy
+			aggMap["process.network.connection.count"] = mb.metricProcessNetworkConnectionCount.config.AggregationStrategy
 			aggMap["process.paging.faults"] = mb.metricProcessPagingFaults.config.AggregationStrategy
 
 			expectedWarnings := 0
@@ -129,6 +130,12 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordProcessMemoryVirtualDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordProcessNetworkConnectionCountDataPoint(ts, 1, "server.address-val", 11)
+			if tt.name == "reaggregate_set" {
+				mb.RecordProcessNetworkConnectionCountDataPoint(ts, 3, "server.address-val-2", 12)
+			}
+
+			allMetricsCount++
 			mb.RecordProcessOpenFileDescriptorsDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -163,6 +170,7 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricProcessCPUUtilization.aggDataPoints)
 				assert.Empty(t, mb.metricProcessDiskIo.aggDataPoints)
 				assert.Empty(t, mb.metricProcessDiskOperations.aggDataPoints)
+				assert.Empty(t, mb.metricProcessNetworkConnectionCount.aggDataPoints)
 				assert.Empty(t, mb.metricProcessPagingFaults.aggDataPoints)
 			}
 
@@ -461,6 +469,51 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "process.network.connection.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["process.network.connection.count"], "Found a duplicate in the metrics slice: process.network.connection.count")
+						validatedMetrics["process.network.connection.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of established network connections opened by the process, grouped by remote endpoint.", mi.Description())
+						assert.Equal(t, "{connections}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						serverAddressAttrVal, ok := dp.Attributes().Get("server.address")
+						assert.True(t, ok)
+						assert.Equal(t, "server.address-val", serverAddressAttrVal.Str())
+						serverPortAttrVal, ok := dp.Attributes().Get("server.port")
+						assert.True(t, ok)
+						assert.EqualValues(t, 11, serverPortAttrVal.Int())
+					} else {
+						assert.False(t, validatedMetrics["process.network.connection.count"], "Found a duplicate in the metrics slice: process.network.connection.count")
+						validatedMetrics["process.network.connection.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of established network connections opened by the process, grouped by remote endpoint.", mi.Description())
+						assert.Equal(t, "{connections}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["process.network.connection.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("server.address")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("server.port")
+						assert.False(t, ok)
+					}
 				case "process.open_file_descriptors":
 					assert.False(t, validatedMetrics["process.open_file_descriptors"], "Found a duplicate in the metrics slice: process.open_file_descriptors")
 					validatedMetrics["process.open_file_descriptors"] = true

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/testdata/config.yaml
@@ -24,6 +24,9 @@ all_set:
       enabled: true
     process.memory.virtual:
       enabled: true
+    process.network.connection.count:
+      enabled: true
+      attributes: ["server.address","server.port"]
     process.open_file_descriptors:
       enabled: true
     process.paging.faults:
@@ -77,6 +80,9 @@ reaggregate_set:
       enabled: true
     process.memory.virtual:
       enabled: true
+    process.network.connection.count:
+      enabled: true
+      attributes: []
     process.open_file_descriptors:
       enabled: true
     process.paging.faults:
@@ -130,6 +136,9 @@ none_set:
       enabled: false
     process.memory.virtual:
       enabled: false
+    process.network.connection.count:
+      enabled: false
+      attributes: ["server.address","server.port"]
     process.open_file_descriptors:
       enabled: false
     process.paging.faults:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -71,13 +71,20 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [read, write]
-
   paging_fault_type:
     name_override: type
     description: Type of memory paging fault.
     type: string
     requirement_level: recommended
     enum: [major, minor]
+  server.address:
+    description: The remote address of the network connection.
+    type: string
+    requirement_level: recommended
+  server.port:
+    description: The remote port of the network connection.
+    type: int
+    requirement_level: recommended
   state:
     description: Breakdown of CPU usage by type.
     type: string
@@ -177,6 +184,15 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
       monotonic: false
+
+  process.network.connection.count:
+    enabled: false
+    description: The number of established network connections opened by the process, grouped by remote endpoint.
+    unit: "{connections}"
+    stability: development
+    gauge:
+      value_type: int
+    attributes: [server.address, server.port]
 
   process.open_file_descriptors:
     enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -5,6 +5,7 @@ package processscraper // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"context"
+	gopsnet "github.com/shirou/gopsutil/v4/net"
 	"os"
 	"runtime"
 	"strconv"
@@ -86,6 +87,7 @@ type processHandle interface {
 	MemoryInfoWithContext(context.Context) (*process.MemoryInfoStat, error)
 	MemoryPercentWithContext(context.Context) (float32, error)
 	IOCountersWithContext(context.Context) (*process.IOCountersStat, error)
+	ConnectionsWithContext(context.Context) ([]gopsnet.ConnectionStat, error)
 	NumThreadsWithContext(context.Context) (int32, error)
 	ThreadsWithContext(context.Context) (map[int32]*cpu.TimesStat, error)
 	CreateTimeWithContext(context.Context) (int64, error)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	stdnet "net"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/host"
+	gopsnet "github.com/shirou/gopsutil/v4/net"
 	"github.com/shirou/gopsutil/v4/process"
 	"github.com/tilinna/clock"
 	"go.opentelemetry.io/collector/component"
@@ -36,6 +39,7 @@ const (
 	contextSwitchMetricsLen     = 1
 	fileDescriptorMetricsLen    = 1
 	handleMetricsLen            = 1
+	networkConnectionMetricsLen = 1
 	signalMetricsLen            = 1
 	uptimeMetricsLen            = 1
 
@@ -56,6 +60,7 @@ type processScraper struct {
 	// for mocking
 	getProcessCreateTime func(p processHandle, ctx context.Context) (int64, error)
 	getProcessHandles    func(context.Context) (processHandles, error)
+	interfaceAddrs       func() ([]stdnet.Addr, error)
 }
 
 // newProcessScraper creates a Process Scraper
@@ -65,6 +70,7 @@ func newProcessScraper(settings scraper.Settings, cfg *Config) (*processScraper,
 		config:               cfg,
 		getProcessCreateTime: processHandle.CreateTimeWithContext,
 		getProcessHandles:    getGopsutilProcessHandles,
+		interfaceAddrs:       stdnet.InterfaceAddrs,
 		scrapeProcessDelay:   cfg.ScrapeProcessDelay,
 		ucals:                make(map[int32]*ucal.CPUUtilizationCalculator),
 	}
@@ -167,6 +173,10 @@ func (s *processScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 		if err = s.scrapeAndAppendHandlesMetric(ctx, now, md.handle); err != nil {
 			errs.AddPartial(handleMetricsLen, fmt.Errorf("error reading handle count for process %q (pid %v): %w", md.executable.name, md.pid, err))
+		}
+
+		if err = s.scrapeAndAppendNetworkConnectionCountMetric(ctx, now, md.handle); err != nil {
+			errs.AddPartial(networkConnectionMetricsLen, fmt.Errorf("error reading network connections for process %q (pid %v): %w", md.executable.name, md.pid, err))
 		}
 
 		if err = s.scrapeAndAppendSignalsPendingMetric(ctx, now, md.handle); err != nil {
@@ -484,6 +494,125 @@ func (s *processScraper) scrapeAndAppendHandlesMetric(ctx context.Context, now p
 	s.mb.RecordProcessHandlesDataPoint(now, handleCount)
 
 	return nil
+}
+
+type processNetworkConnectionKey struct {
+	serverAddress string
+	serverPort    int64
+}
+
+func (s *processScraper) scrapeAndAppendNetworkConnectionCountMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
+	if !s.config.Metrics.ProcessNetworkConnectionCount.Enabled {
+		return nil
+	}
+
+	connections, err := handle.ConnectionsWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	listenPorts := map[uint32]struct{}{}
+	if s.config.Connections.ExcludeListenPorts {
+		listenPorts = buildListenPortSet(connections)
+	}
+
+	var localIPs map[string]struct{}
+	if s.config.Connections.ExcludeLocalhost {
+		localIPs = s.localIPSet()
+	}
+
+	counts := make(map[processNetworkConnectionKey]int64)
+	for _, connection := range connections {
+		if !strings.EqualFold(connection.Status, "ESTABLISHED") {
+			continue
+		}
+		if connection.Raddr.IP == "" || connection.Raddr.Port == 0 {
+			continue
+		}
+		if _, ok := listenPorts[connection.Laddr.Port]; ok {
+			continue
+		}
+		if !s.isConnectionPortAllowed(connection.Raddr.Port) {
+			continue
+		}
+		if s.config.Connections.ExcludeLocalhost && isLocalIP(connection.Raddr.IP, localIPs) {
+			continue
+		}
+
+		key := processNetworkConnectionKey{
+			serverAddress: connection.Raddr.IP,
+			serverPort:    int64(connection.Raddr.Port),
+		}
+		counts[key]++
+	}
+
+	for key, count := range counts {
+		s.mb.RecordProcessNetworkConnectionCountDataPoint(now, count, key.serverAddress, key.serverPort)
+	}
+
+	return nil
+}
+
+func buildListenPortSet(connections []gopsnet.ConnectionStat) map[uint32]struct{} {
+	ports := make(map[uint32]struct{})
+	for _, connection := range connections {
+		if strings.EqualFold(connection.Status, "LISTEN") {
+			ports[connection.Laddr.Port] = struct{}{}
+		}
+	}
+	return ports
+}
+
+func (s *processScraper) isConnectionPortAllowed(port uint32) bool {
+	if len(s.config.Connections.IncludePorts) > 0 {
+		matched := false
+		for _, includePort := range s.config.Connections.IncludePorts {
+			if includePort == port {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	for _, excludePort := range s.config.Connections.ExcludePorts {
+		if excludePort == port {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *processScraper) localIPSet() map[string]struct{} {
+	ips := map[string]struct{}{
+		"127.0.0.1": {},
+		"::1":       {},
+		"localhost": {},
+	}
+
+	addrs, err := s.interfaceAddrs()
+	if err != nil {
+		return ips
+	}
+	for _, addr := range addrs {
+		switch typedAddr := addr.(type) {
+		case *stdnet.IPNet:
+			ips[typedAddr.IP.String()] = struct{}{}
+		case *stdnet.IPAddr:
+			ips[typedAddr.IP.String()] = struct{}{}
+		}
+	}
+	return ips
+}
+
+func isLocalIP(ip string, localIPs map[string]struct{}) bool {
+	if _, ok := localIPs[ip]; ok {
+		return true
+	}
+	parsed := stdnet.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
 }
 
 func (s *processScraper) scrapeAndAppendSignalsPendingMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	stdnet "net"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/common"
 	"github.com/shirou/gopsutil/v4/cpu"
+	gopsnet "github.com/shirou/gopsutil/v4/net"
 	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -484,6 +486,11 @@ func (p *processHandleMock) IOCountersWithContext(ctx context.Context) (*process
 	return args.Get(0).(*process.IOCountersStat), args.Error(1)
 }
 
+func (p *processHandleMock) ConnectionsWithContext(ctx context.Context) ([]gopsnet.ConnectionStat, error) {
+	args := p.MethodCalled("ConnectionsWithContext", ctx)
+	return args.Get(0).([]gopsnet.ConnectionStat), args.Error(1)
+}
+
 func (p *processHandleMock) NumThreadsWithContext(ctx context.Context) (int32, error) {
 	args := p.MethodCalled("NumThreadsWithContext", ctx)
 	return args.Get(0).(int32), args.Error(1)
@@ -553,6 +560,9 @@ func initDefaultsHandleMock(t mock.TestingT, handleMock *processHandleMock) {
 	}
 	if !handleMock.IsMethodCallable(t, "IOCountersWithContext", mock.Anything) {
 		handleMock.On("IOCountersWithContext", mock.Anything).Return(&process.IOCountersStat{}, nil)
+	}
+	if !handleMock.IsMethodCallable(t, "ConnectionsWithContext", mock.Anything) {
+		handleMock.On("ConnectionsWithContext", mock.Anything).Return([]gopsnet.ConnectionStat{}, nil)
 	}
 	if !handleMock.IsMethodCallable(t, "PpidWithContext", mock.Anything) {
 		handleMock.On("PpidWithContext", mock.Anything).Return(int32(2), nil)
@@ -1389,6 +1399,80 @@ func TestScrapeMetrics_CpuUtilizationWhenCpuTimesIsDisabled(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestScrapeProcessNetworkConnectionCountMetric(t *testing.T) {
+	metricsBuilderConfig := metadata.NewDefaultMetricsBuilderConfig()
+	metricsBuilderConfig.Metrics.ProcessCPUTime.Enabled = false
+	metricsBuilderConfig.Metrics.ProcessDiskIo.Enabled = false
+	metricsBuilderConfig.Metrics.ProcessMemoryUsage.Enabled = false
+	metricsBuilderConfig.Metrics.ProcessMemoryVirtual.Enabled = false
+	metricsBuilderConfig.Metrics.ProcessNetworkConnectionCount.Enabled = true
+
+	config := &Config{
+		MetricsBuilderConfig: metricsBuilderConfig,
+		Connections: ConnectionConfig{
+			IncludePorts:       []uint32{443, 8443},
+			ExcludePorts:       []uint32{8443},
+			ExcludeLocalhost:   true,
+			ExcludeListenPorts: true,
+		},
+	}
+
+	scraper, err := newProcessScraper(scrapertest.NewNopSettings(metadata.Type), config)
+	require.NoError(t, err)
+	scraper.interfaceAddrs = func() ([]stdnet.Addr, error) {
+		return []stdnet.Addr{&stdnet.IPNet{IP: stdnet.ParseIP("10.0.0.2")}}, nil
+	}
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
+
+	handleMock := &processHandleMock{}
+	handleMock.On("NameWithContext", mock.Anything).Return("app", nil)
+	handleMock.On("ExeWithContext", mock.Anything).Return("app", nil)
+	handleMock.On("CreateTimeWithContext", mock.Anything).Return(int64(100), nil)
+	handleMock.On("ConnectionsWithContext", mock.Anything).Return([]gopsnet.ConnectionStat{
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50001}, Raddr: gopsnet.Addr{IP: "203.0.113.10", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50002}, Raddr: gopsnet.Addr{IP: "203.0.113.10", Port: 443}},
+		{Status: "SYN_SENT", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50003}, Raddr: gopsnet.Addr{IP: "203.0.113.10", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50004}, Raddr: gopsnet.Addr{}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50005}, Raddr: gopsnet.Addr{IP: "203.0.113.10"}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50006}, Raddr: gopsnet.Addr{IP: "127.0.0.1", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50007}, Raddr: gopsnet.Addr{IP: "10.0.0.2", Port: 443}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 50008}, Raddr: gopsnet.Addr{IP: "203.0.113.10", Port: 8443}},
+		{Status: "LISTEN", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 60000}},
+		{Status: "ESTABLISHED", Laddr: gopsnet.Addr{IP: "10.0.0.1", Port: 60000}, Raddr: gopsnet.Addr{IP: "203.0.113.10", Port: 443}},
+	}, nil)
+	initDefaultsHandleMock(t, handleMock)
+
+	scraper.getProcessHandles = func(context.Context) (processHandles, error) {
+		return &processHandlesMock{handles: []*processHandleMock{handleMock}}, nil
+	}
+
+	md, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, md.ResourceMetrics().Len())
+	resourceAttrs := md.ResourceMetrics().At(0).Resource().Attributes()
+	processName, ok := resourceAttrs.Get("process.executable.name")
+	require.True(t, ok)
+	assert.Equal(t, "app", processName.Str())
+
+	require.Equal(t, 1, md.MetricCount())
+	metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(t, "process.network.connection.count", metric.Name())
+	dps := metric.Gauge().DataPoints()
+	require.Equal(t, 1, dps.Len())
+	dp := dps.At(0)
+	assert.Equal(t, int64(2), dp.IntValue())
+	assertAttributeValue(t, dp.Attributes(), "server.address", "203.0.113.10")
+	serverPort, ok := dp.Attributes().Get("server.port")
+	require.True(t, ok)
+	assert.Equal(t, int64(443), serverPort.Int())
+}
+
+func assertAttributeValue(t *testing.T, attrs pcommon.Map, name string, expected string) {
+	value, ok := attrs.Get(name)
+	require.True(t, ok)
+	assert.Equal(t, expected, value.Str())
 }
 
 func handleCountErrorIfSupportedOnPlatform() error {


### PR DESCRIPTION
#### Description

Adds a new `process.network.connection.count` metric to the `hostmetricsreceiver` process scraper.

The metric is a gauge that reports the number of established TCP connections per process,
grouped by remote endpoint (`server.address`, `server.port`). It is opt-in (disabled by
default, `stability: development`) and complements the existing system-level
`system.network.connections` metric by providing per-process granularity.

Key implementation details:
- Uses `gopsutil` `ConnectionsWithContext` on the per-process handle to list TCP connections
- Filters to `ESTABLISHED` state only; skips connections with empty remote address/port
- Two optional filtering flags added to `Config.Connections`:
  - `exclude_listen_ports`: excludes connections where the local port is a listen port of the same process
  - `exclude_localhost`: excludes connections to local interface addresses (resolved via `net.InterfaceAddrs`)
- `server.address` and `server.port` attributes added to `metadata.yaml`
- All `generated_*.go` files and `documentation.md` regenerated via `mdatagen`

#### Testing

Added unit tests in `process_scraper_test.go` covering:
- Metric disabled by default (no data points emitted)
- ESTABLISHED connections are counted and grouped by remote endpoint
- `exclude_listen_ports` filter correctly drops server-side connections
- `exclude_localhost` filter correctly drops loopback/local-interface connections

Existing tests continue to pass:
go test ./receiver/hostmetricsreceiver/...

#### Documentation
`documentation.md` was regenerated by `mdatagen` from the `metadata.yaml` updates.