### PR TITLE
[receiver/datadog] Enable the Enable128BitTraceID feature gate by default

### DIFF
--- a/.chloggen/datadogreceiver-enable-128bit-traceid.yaml
+++ b/.chloggen/datadogreceiver-enable-128bit-traceid.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable the `receiver.datadogreceiver.Enable128BitTraceID` feature gate by default
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The gate is promoted from alpha to beta (on by default), so spans reconstruct full 128-bit trace ids
+  from `_dd.p.tid` and emit OpenTelemetry-native trace ids that correlate with other OpenTelemetry
+  services. Disable the gate to fall back to 64-bit (zero-padded) trace ids.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/datadogreceiver-enable-128bit-traceid.yaml
+++ b/.chloggen/datadogreceiver-enable-128bit-traceid.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: receiver/datadog
@@ -10,7 +10,7 @@ component: receiver/datadog
 note: Enable the `receiver.datadogreceiver.Enable128BitTraceID` feature gate by default
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [49103]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/datadogreceiver/README.md
+++ b/receiver/datadogreceiver/README.md
@@ -23,10 +23,10 @@ Configuration wise is very simple, just need to specify where the Datadog receiv
 
 Then, the receiver must be configured in the pipeline where it will be used.
 
-The feature gate `receiver.datadogreceiver.Enable128BitTraceID` (disabled by default) enables the receiver to
-reconstruct 128-bit trace ids from spans coming from a datadog instrumented service. This is necessary if a trace is
-initiated with a 128-bit trace id by a service that then calls a datadog instrumented one. Without this, spans from the
-datadog instrumented service will not correlate with the other spans.
+The feature gate `receiver.datadogreceiver.Enable128BitTraceID` (enabled by default) makes the receiver reconstruct
+full 128-bit trace ids from spans coming from a datadog instrumented service, so they correlate with OpenTelemetry
+spans. Datadog splits a 128-bit trace id into a lower 64-bit part (`TraceID`) and an upper 64-bit part (`_dd.p.tid`);
+the receiver concatenates them. Disable the gate to fall back to 64-bit (zero-padded) trace ids.
 
 ```yaml
 receivers:

--- a/receiver/datadogreceiver/documentation.md
+++ b/receiver/datadogreceiver/documentation.md
@@ -8,7 +8,7 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `receiver.datadogreceiver.Enable128BitTraceID` | alpha | When enabled, adds support for 128bits TraceIDs for spans coming from Datadog instrumented services. | v0.125.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36926) |
+| `receiver.datadogreceiver.Enable128BitTraceID` | beta | When enabled, reconstructs full 128-bit TraceIDs for spans coming from Datadog instrumented services so they correlate with OpenTelemetry spans. Enabled by default; disable to fall back to 64-bit (zero-padded) TraceIDs. | v0.125.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36926) |
 | `receiver.datadogreceiver.EnableMultiTagParsing` | alpha | When enabled, parses `key:value` tags with duplicate keys into a slice attribute. | v0.142.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44747) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/receiver/datadogreceiver/internal/metadata/generated_feature_gates.go
+++ b/receiver/datadogreceiver/internal/metadata/generated_feature_gates.go
@@ -8,8 +8,8 @@ import (
 
 var ReceiverDatadogreceiverEnable128BitTraceIDFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"receiver.datadogreceiver.Enable128BitTraceID",
-	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("When enabled, adds support for 128bits TraceIDs for spans coming from Datadog instrumented services."),
+	featuregate.StageBeta,
+	featuregate.WithRegisterDescription("When enabled, reconstructs full 128-bit TraceIDs for spans coming from Datadog instrumented services so they correlate with OpenTelemetry spans. Enabled by default; disable to fall back to 64-bit (zero-padded) TraceIDs."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36926"),
 	featuregate.WithRegisterFromVersion("v0.125.0"),
 )

--- a/receiver/datadogreceiver/metadata.yaml
+++ b/receiver/datadogreceiver/metadata.yaml
@@ -16,8 +16,8 @@ status:
 
 feature_gates:
   - id: receiver.datadogreceiver.Enable128BitTraceID
-    stage: alpha
-    description: When enabled, adds support for 128bits TraceIDs for spans coming from Datadog instrumented services.
+    stage: beta
+    description: When enabled, reconstructs full 128-bit TraceIDs for spans coming from Datadog instrumented services so they correlate with OpenTelemetry spans. Enabled by default; disable to fall back to 64-bit (zero-padded) TraceIDs.
     from_version: v0.125.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36926
     skip_strict_validation: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The Enable128BitTraceID gate reconstructs full 128-bit trace IDs from DataDog's format. The goal is to enable this by default so those using the receiver will have a better transition to OTel semantics and better trace/log correlations for downstream exporters.

<!--Describe the documentation added.-->
#### Documentation

Updated README

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
