### PR TITLE
[extensions/encoding/azureencodingextension] Add additional storage mappings for `schemaVersion` & `resourceType`

### DIFF
--- a/.chloggen/dylan_add-additional-mappings-to-azure-encoding.yaml
+++ b/.chloggen/dylan_add-additional-mappings-to-azure-encoding.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: azure_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Map `schemaVersion` and `resourceType` fields of Azure Storage Blob logs to `azure.storage.schema_version` and `azure.resource.type`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48753]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dylan_add-additional-mappings-to-azure-encoding.yaml
+++ b/.chloggen/dylan_add-additional-mappings-to-azure-encoding.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: azure_encoding
+component: extension/azure_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Map `schemaVersion` and `resourceType` fields of Azure Storage Blob logs to `azure.storage.schema_version` and `azure.resource.type`.

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/README.md
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/README.md
@@ -574,6 +574,8 @@ For log categories where the identity structure is not known, the entire identit
 | `statusText`              | `http.response.status_text`                   | Log Attribute |
 | `uri`                     | `url.full` with parsed `url.scheme`, `url.domain`, `url.fragment`, `url.query`, `url.path` and `url.port`. If unparsable - only `url.original`                   | Log Attribute |
 | `protocol`                | `network.protocol.name`                       | Log Attribute |
+| `schemaVersion`           | `azure.storage.schema_version`                | Log Attribute |
+| `resourceType`            | `azure.resource.type`                         | Log Attribute |
 | `accountName`             | `azure.storage.namespace`                     | Log Attribute |
 | `userAgentHeader`         | `user_agent.original`                         | Log Attribute |
 | `clientRequestId`         | `azure.service.request.id`                    | Log Attribute |

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_storage.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/category_storage.go
@@ -41,6 +41,10 @@ const (
 	// OpenTelemetry attribute name for Azure HTTP Response Duration,
 	// this is server-side duration of operation, excluding network time
 	attributeAzureResponseDuration = "azure.response.duration"
+
+	// OpenTelemetry attribute name for the schema version of the Storage log,
+	// from the top-level `schemaVersion` field
+	attributeAzureStorageSchemaVersion = "azure.storage.schema_version"
 )
 
 // ------------------------------------------------------------
@@ -144,10 +148,12 @@ type azureStorageBlobLog struct {
 	Identity *azureIdentityStorage `json:"identity"`
 
 	// Additional fields in common schema
-	StatusCode *json.Number `json:"statusCode"` // int
-	StatusText *string      `json:"statusText"`
-	URI        *string      `json:"uri"`
-	Protocol   *string      `json:"protocol"`
+	StatusCode    *json.Number `json:"statusCode"` // int
+	StatusText    *string      `json:"statusText"`
+	URI           *string      `json:"uri"`
+	Protocol      *string      `json:"protocol"`
+	SchemaVersion *string      `json:"schemaVersion"`
+	ResourceType  *string      `json:"resourceType"`
 
 	Properties struct {
 		AccountName        string      `json:"accountName"`
@@ -188,6 +194,8 @@ func (r *azureStorageBlobLog) PutCommonAttributes(attrs pcommon.Map, body pcommo
 	if r.URI != nil {
 		unmarshaler.AttrPutURLParsed(attrs, *r.URI)
 	}
+	unmarshaler.AttrPutStrPtrIf(attrs, attributeAzureStorageSchemaVersion, r.SchemaVersion)
+	unmarshaler.AttrPutStrPtrIf(attrs, attributeAzureResourceType, r.ResourceType)
 }
 
 func (r *azureStorageBlobLog) PutProperties(attrs pcommon.Map, _ pcommon.Value) error {

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/storage/storage-read-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/storage/storage-read-log_expected.yaml
@@ -114,6 +114,12 @@ resourceLogs:
               - key: url.query
                 value:
                   stringValue: upn=true&action=write&timeout=120&st=2025-09-17T14%3A12%3A45Z&sv=2022-05-01&ske=2025-09-17T16%3A12%3A45Z&sig=RANDOMSIG&sktid=abcdef12-3456-7890-abcd-ef1234567890&se=2025-09-17T15%3A22%3A45Z&sdd=1&skoid=12345678-90ab-cdef-1234-567890abcdef&spr=https&sks=a&skt=2025-09-17T14%3A12%3A45Z&sp=rw&skv=2025-09-17&sr=c
+              - key: azure.storage.schema_version
+                value:
+                  stringValue: "2.1"
+              - key: azure.resource.type
+                value:
+                  stringValue: Microsoft.Storage/storageAccounts/blobServices
               - key: azure.storage.namespace
                 value:
                   stringValue: randomstor


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds 2 missing mappings for the Azure Storage Diagnostic Logs
- `resourceType` -> `azure.resource.type`
- `schemaVersion` -> `azure.storage.schema_version`
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48753

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Manual testing
- Updated tests
<img width="852" height="92" alt="image" src="https://github.com/user-attachments/assets/d9fd0d12-180f-441a-b960-1df3a64ecdb3" />

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
