### PR TITLE
[processor/cumulativetodelta] Fix non-deterministic error message for invalid metric_types config

### DIFF
--- a/.chloggen/49120-cumulativetodelta-deterministic-metric-types-error.yaml
+++ b/.chloggen/49120-cumulativetodelta-deterministic-metric-types-error.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: processor/cumulativetodelta
+
+note: Fix non-deterministic order of valid metric types in error messages for invalid `metric_types` config values.
+
+issues: [49120]
+
+change_logs: [user]

--- a/processor/cumulativetodeltaprocessor/config.go
+++ b/processor/cumulativetodeltaprocessor/config.go
@@ -24,7 +24,11 @@ var validMetricTypes = map[string]bool{
 	strings.ToLower(pmetric.MetricTypeExponentialHistogram.String()): true,
 }
 
-var validMetricTypeList = slices.Collect(maps.Keys(validMetricTypes))
+var validMetricTypeList = func() []string {
+	list := slices.Collect(maps.Keys(validMetricTypes))
+	slices.Sort(list)
+	return list
+}()
 
 // Config defines the configuration for the processor.
 type Config struct {

--- a/processor/cumulativetodeltaprocessor/config.go
+++ b/processor/cumulativetodeltaprocessor/config.go
@@ -6,8 +6,6 @@ package cumulativetodeltaprocessor // import "github.com/open-telemetry/opentele
 import (
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
 	"strings"
 	"time"
 
@@ -24,11 +22,7 @@ var validMetricTypes = map[string]bool{
 	strings.ToLower(pmetric.MetricTypeExponentialHistogram.String()): true,
 }
 
-var validMetricTypeList = func() []string {
-	list := slices.Collect(maps.Keys(validMetricTypes))
-	slices.Sort(list)
-	return list
-}()
+var validMetricTypeList = []string{"exponentialhistogram", "histogram", "sum"}
 
 // Config defines the configuration for the processor.
 type Config struct {

--- a/processor/cumulativetodeltaprocessor/config_test.go
+++ b/processor/cumulativetodeltaprocessor/config_test.go
@@ -4,7 +4,9 @@
 package cumulativetodeltaprocessor
 
 import (
+	"maps"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -18,6 +20,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/tracking"
 )
+
+func TestValidMetricTypeListMatchesMap(t *testing.T) {
+	fromMap := slices.Collect(maps.Keys(validMetricTypes))
+	slices.Sort(fromMap)
+	assert.Equal(t, fromMap, validMetricTypeList)
+}
 
 func TestLoadConfig(t *testing.T) {
 	t.Parallel()

--- a/processor/cumulativetodeltaprocessor/config_test.go
+++ b/processor/cumulativetodeltaprocessor/config_test.go
@@ -4,7 +4,6 @@
 package cumulativetodeltaprocessor
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -117,11 +116,11 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_include_metric_type_filter"),
-			errorMessage: fmt.Sprintf("found invalid metric type in include.metric_types: gauge. Valid values are %s", validMetricTypeList),
+			errorMessage: "found invalid metric type in include.metric_types: gauge. Valid values are [exponentialhistogram histogram sum]",
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_exclude_metric_type_filter"),
-			errorMessage: fmt.Sprintf("found invalid metric type in exclude.metric_types: Invalid. Valid values are %s", validMetricTypeList),
+			errorMessage: "found invalid metric type in exclude.metric_types: Invalid. Valid values are [exponentialhistogram histogram sum]",
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "missing_match_type"),


### PR DESCRIPTION

Sort validMetricTypeList after construction so the "Valid values are" portion of the error message is consistent across runs. Previously, maps.Keys() returned keys in non-deterministic order, causing the message to vary. Tests are updated to assert the exact sorted string rather than using the same variable for both expected and actual.

Fixes: #49120

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
