### PR TITLE
Fix UDP log receiver newline tokenization

### DIFF
--- a/pkg/stanza/operator/input/udp/config.go
+++ b/pkg/stanza/operator/input/udp/config.go
@@ -45,9 +45,6 @@ func NewConfigWithID(operatorID string) *Config {
 		BaseConfig: BaseConfig{
 			Encoding:        "utf-8",
 			OneLogPerPacket: false,
-			SplitConfig: split.Config{
-				LineEndPattern: ".^", // Use never matching regex to not split data by default
-			},
 		},
 	}
 }

--- a/pkg/stanza/operator/input/udp/input_test.go
+++ b/pkg/stanza/operator/input/udp/input_test.go
@@ -146,7 +146,12 @@ func TestInput(t *testing.T) {
 	t.Run("Simple", udpInputTest([]byte("message1"), []string{"message1"}, cfg))
 	t.Run("TrailingNewlines", udpInputTest([]byte("message1\n"), []string{"message1"}, cfg))
 	t.Run("TrailingCRNewlines", udpInputTest([]byte("message1\r\n"), []string{"message1"}, cfg))
-	t.Run("NewlineInMessage", udpInputTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}, cfg))
+	t.Run("NewlineInMessage", udpInputTest([]byte("message1\nmessage2\n"), []string{"message1", "message2"}, cfg))
+
+	oneLogPerPacketCfg := NewConfigWithID("test_input")
+	oneLogPerPacketCfg.ListenAddress = ":0"
+	oneLogPerPacketCfg.OneLogPerPacket = true
+	t.Run("OneLogPerPacket", udpInputTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}, oneLogPerPacketCfg))
 
 	cfg.AsyncConfig = &AsyncConfig{
 		Readers:        2,
@@ -160,7 +165,7 @@ func TestInputAttributes(t *testing.T) {
 	t.Run("Simple", udpInputAttributesTest([]byte("message1"), []string{"message1"}))
 	t.Run("TrailingNewlines", udpInputAttributesTest([]byte("message1\n"), []string{"message1"}))
 	t.Run("TrailingCRNewlines", udpInputAttributesTest([]byte("message1\r\n"), []string{"message1"}))
-	t.Run("NewlineInMessage", udpInputAttributesTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}))
+	t.Run("NewlineInMessage", udpInputAttributesTest([]byte("message1\nmessage2\n"), []string{"message1", "message2"}))
 }
 
 func TestFailToBind(t *testing.T) {

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -47,7 +47,7 @@ Many parsers operators can be configured to embed certain followup operations su
 
 If set, the `multiline` configuration block instructs the `udp_log` receiver to split log entries on a pattern other than newlines.
 
-**note** If `multiline` is not set at all, it won't split log entries at all. Every UDP packet is going to be treated as log.
+**note** If `multiline` is not set at all, log entries are split on newlines unless `one_log_per_packet` is set to `true`.
 **note** `multiline` detection works per UDP packet due to protocol limitations.
 
 The `multiline` configuration block must contain exactly one of `line_start_pattern` or `line_end_pattern`. These are regex patterns that


### PR DESCRIPTION
#### Description
Fixes the UDP log receiver so `one_log_per_packet: false` uses the default newline splitter when no explicit `multiline` config is provided. Previously the UDP input defaulted `multiline.line_end_pattern` to a never-matching regex, so packets containing multiple newline-delimited log records were emitted as a single log even when tokenization was enabled.

This also keeps coverage for `one_log_per_packet: true`, where a UDP packet should still be emitted as one log record.

Fixes #49054.

#### Testing
- `git diff --check`
- Not run: `go test ./pkg/stanza/operator/input/udp` because Go is not installed in this local environment.