### PR TITLE
[chore][tiny] Add `windows_services` receiver to contrib local build

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -256,6 +256,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.154.0


### PR DESCRIPTION
This is a follow-up to PR #48176 that change the stability of the receiver to `alpha`.

The `windows_services` receiver was moved to `alpha` stability, but was not added to the collector built locally. 

I will open a PR on releases to also include this component.