### PR TITLE
[receiver/memcached] Add TLS support

### DIFF
--- a/.chloggen/memcached-tls.yaml
+++ b/.chloggen/memcached-tls.yaml
@@ -10,7 +10,7 @@ component: receiver/memcached
 note: Add `tls` configuration to support connecting to memcached over TLS.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0]
+issues: [49146]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/memcached-tls.yaml
+++ b/.chloggen/memcached-tls.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/memcached
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `tls` configuration to support connecting to memcached over TLS.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "TLS is disabled by default (`insecure: true`), so existing plaintext configurations are unaffected."
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -37,6 +37,10 @@ receiver the duration between runs. This value must be a string readable by
 Golang's `ParseDuration` function (example: `1h30m`). Valid time units are
 `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
+- `tls`: configures the TLS settings used to connect to memcached. TLS is
+disabled by default (`insecure: true`), preserving plaintext connections. See
+[TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
+for the full set of supported options.
 
 Example:
 
@@ -46,6 +50,17 @@ receivers:
     endpoint: "localhost:11211"
     collection_interval: 10s
     transport: tcp
+```
+
+Example with TLS enabled:
+
+```yaml
+receivers:
+  memcached:
+    endpoint: "localhost:11211"
+    tls:
+      insecure: false
+      ca_file: /etc/ssl/certs/ca.crt
 ```
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go)

--- a/receiver/memcachedreceiver/client.go
+++ b/receiver/memcachedreceiver/client.go
@@ -4,6 +4,7 @@
 package memcachedreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver"
 
 import (
+	"crypto/tls"
 	"net"
 	"time"
 
@@ -14,14 +15,16 @@ type client interface {
 	Stats() (map[net.Addr]memcache.Stats, error)
 }
 
-type newMemcachedClientFunc func(endpoint string, timeout time.Duration) (client, error)
+type newMemcachedClientFunc func(endpoint string, timeout time.Duration, tlsConfig *tls.Config) (client, error)
 
-func newMemcachedClient(endpoint string, timeout time.Duration) (client, error) {
+func newMemcachedClient(endpoint string, timeout time.Duration, tlsConfig *tls.Config) (client, error) {
 	newClient, err := memcache.New(endpoint)
 	if err != nil {
 		return nil, err
 	}
 
 	newClient.Timeout = timeout
+	// A nil tlsConfig leaves the connection as plaintext (the default).
+	newClient.TlsConfig = tlsConfig
 	return newClient, nil
 }

--- a/receiver/memcachedreceiver/client_test.go
+++ b/receiver/memcachedreceiver/client_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package memcachedreceiver
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/grobie/gomemcache/memcache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMemcachedClientTLS(t *testing.T) {
+	tests := []struct {
+		name      string
+		tlsConfig *tls.Config
+	}{
+		{
+			name:      "plaintext when tls config is nil",
+			tlsConfig: nil,
+		},
+		{
+			name:      "tls config is propagated to the client",
+			tlsConfig: &tls.Config{ServerName: "memcached.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := newMemcachedClient("localhost:11211", 10*time.Second, tt.tlsConfig)
+			require.NoError(t, err)
+
+			mc, ok := c.(*memcache.Client)
+			require.True(t, ok)
+			if tt.tlsConfig == nil {
+				require.Nil(t, mc.TlsConfig)
+			} else {
+				require.Same(t, tt.tlsConfig, mc.TlsConfig)
+			}
+			require.Equal(t, 10*time.Second, mc.Timeout)
+		})
+	}
+}

--- a/receiver/memcachedreceiver/config.go
+++ b/receiver/memcachedreceiver/config.go
@@ -5,6 +5,7 @@ package memcachedreceiver // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver/internal/metadata"
@@ -13,6 +14,10 @@ import (
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	confignet.AddrConfig           `mapstructure:",squash"`
+
+	// TLS controls the TLS settings used to connect to memcached. TLS is
+	// disabled by default (Insecure: true), preserving plaintext connections.
+	TLS configtls.ClientConfig `mapstructure:"tls,omitempty"`
 
 	// MetricsBuilderConfig allows customizing scraped metrics/attributes representation.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`

--- a/receiver/memcachedreceiver/config.schema.yaml
+++ b/receiver/memcachedreceiver/config.schema.yaml
@@ -1,4 +1,8 @@
 type: object
+properties:
+  tls:
+    description: 'TLS controls the TLS settings used to connect to memcached. TLS is disabled by default (Insecure: true), preserving plaintext connections.'
+    $ref: go.opentelemetry.io/collector/config/configtls.client_config
 allOf:
   - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
   - $ref: go.opentelemetry.io/collector/config/confignet.addr_config

--- a/receiver/memcachedreceiver/config_test.go
+++ b/receiver/memcachedreceiver/config_test.go
@@ -19,6 +19,8 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, defaultEndpoint, cfg.Endpoint)
 	require.Equal(t, defaultTimeout, cfg.Timeout)
 	require.Equal(t, defaultCollectionInterval, cfg.CollectionInterval)
+	// TLS is disabled by default to preserve plaintext connections.
+	require.True(t, cfg.TLS.Insecure)
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -32,4 +34,18 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(cfg))
 
 	require.Equal(t, factory.CreateDefaultConfig(), cfg)
+}
+
+func TestLoadConfigTLS(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "tls").String())
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	require.False(t, cfg.(*Config).TLS.Insecure)
+	require.Equal(t, "/etc/ssl/certs/ca.crt", cfg.(*Config).TLS.CAFile)
 }

--- a/receiver/memcachedreceiver/factory.go
+++ b/receiver/memcachedreceiver/factory.go
@@ -9,6 +9,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/scraper"
@@ -40,6 +41,9 @@ func createDefaultConfig() component.Config {
 		ControllerConfig: cfg,
 		AddrConfig: confignet.AddrConfig{
 			Endpoint: defaultEndpoint,
+		},
+		TLS: configtls.ClientConfig{
+			Insecure: true,
 		},
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/collector/component v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/component/componenttest v0.157.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/config/confignet v1.63.1-0.20260723141305-52e6bf4aaaba
+	go.opentelemetry.io/collector/config/configtls v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/confmap v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/consumer v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/consumer/consumertest v0.157.1-0.20260723141305-52e6bf4aaaba
@@ -41,11 +42,14 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250903184740-5d135037bd4d // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -80,6 +84,7 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.63.1-0.20260723141305-52e6bf4aaaba // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.157.1-0.20260723141305-52e6bf4aaaba // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.157.1-0.20260723141305-52e6bf4aaaba // indirect
 	go.opentelemetry.io/collector/featuregate v1.63.1-0.20260723141305-52e6bf4aaaba // indirect

--- a/receiver/memcachedreceiver/go.sum
+++ b/receiver/memcachedreceiver/go.sum
@@ -35,6 +35,12 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/foxboron/go-tpm-keyfiles v0.0.0-20250903184740-5d135037bd4d h1:EdO/NMMuCZfxhdzTZLuKAciQSnI2DV+Ppg8+vAYrnqA=
+github.com/foxboron/go-tpm-keyfiles v0.0.0-20250903184740-5d135037bd4d/go.mod h1:uAyTlAUxchYuiFjTHmuIEJ4nGSm7iOPaGcAyA81fJ80=
+github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006 h1:50sW4r0PcvlpG4PV8tYh2RVCapszJgaOLRCS2subvV4=
+github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006/go.mod h1:eIXCMsMYCaqq9m1KSSxXwQG11krpuNPGP3k0uaWrbas=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -51,6 +57,10 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-tpm v0.9.8 h1:slArAR9Ft+1ybZu0lBwpSmpwhRXaa85hWtMinMyRAWo=
+github.com/google/go-tpm v0.9.8/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
+github.com/google/go-tpm-tools v0.4.7 h1:J3ycC8umYxM9A4eF73EofRZu4BxY0jjQnUnkhIBbvws=
+github.com/google/go-tpm-tools v0.4.7/go.mod h1:gSyXTZHe3fgbzb6WEGd90QucmsnT1SRdlye82gH8QjQ=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -140,6 +150,10 @@ go.opentelemetry.io/collector/component/componenttest v0.157.1-0.20260723141305-
 go.opentelemetry.io/collector/component/componenttest v0.157.1-0.20260723141305-52e6bf4aaaba/go.mod h1:AUzvlwDat8AHaNRDm+dzQ59uaEXQO1qTWccjkRjqq00=
 go.opentelemetry.io/collector/config/confignet v1.63.1-0.20260723141305-52e6bf4aaaba h1:5DbKJbViYzhY8fJ/+pZqAog69G7p7YflpqhkyJWmGT0=
 go.opentelemetry.io/collector/config/confignet v1.63.1-0.20260723141305-52e6bf4aaaba/go.mod h1:Op+r1B/DtzXgIuKEL7/JkTqtJdL9veu2uEXvSxH3lks=
+go.opentelemetry.io/collector/config/configopaque v1.63.1-0.20260723141305-52e6bf4aaaba h1:hyj+gZhABnGnhEwWVRWofEaarPcJSuZ57Jqm3G5+1nk=
+go.opentelemetry.io/collector/config/configopaque v1.63.1-0.20260723141305-52e6bf4aaaba/go.mod h1:GGIOZ5UUlO6+D81QD3DlH4QrjfEUb/wffq351dPtTa4=
+go.opentelemetry.io/collector/config/configtls v1.63.1-0.20260723141305-52e6bf4aaaba h1:/ibEuiAY6skwum/Nz3+pNY9vNXaORAqDTx+eetK29X0=
+go.opentelemetry.io/collector/config/configtls v1.63.1-0.20260723141305-52e6bf4aaaba/go.mod h1:I962r+gFnA6N/U35JR3B0b7gVuprgWsqCjkUdtS7iHA=
 go.opentelemetry.io/collector/confmap v1.63.1-0.20260723141305-52e6bf4aaaba h1:eJbAiR2GK23KtnnwPxMFk5pngmu1V4OG4kMVqOgW+yI=
 go.opentelemetry.io/collector/confmap v1.63.1-0.20260723141305-52e6bf4aaaba/go.mod h1:ksJNAmLTiMkBjMYwXFW1MRRfXYnRsHXA0fW+ZGwb/1U=
 go.opentelemetry.io/collector/consumer v1.63.1-0.20260723141305-52e6bf4aaaba h1:qEPmbmkbG0XhB1AO15y5eSsp3pCeHxA8sE9g4JSnaag=

--- a/receiver/memcachedreceiver/scraper.go
+++ b/receiver/memcachedreceiver/scraper.go
@@ -35,10 +35,16 @@ func newMemcachedScraper(
 	}
 }
 
-func (r *memcachedScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
+func (r *memcachedScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
+	tlsConfig, err := r.config.TLS.LoadTLSConfig(ctx)
+	if err != nil {
+		r.logger.Error("Failed to load TLS config", zap.Error(err))
+		return pmetric.Metrics{}, err
+	}
+
 	// Init client in scrape method in case there are transient errors in the
 	// constructor.
-	statsClient, err := r.newClient(r.config.Endpoint, r.config.Timeout)
+	statsClient, err := r.newClient(r.config.Endpoint, r.config.Timeout, tlsConfig)
 	if err != nil {
 		r.logger.Error("Failed to establish client", zap.Error(err))
 		return pmetric.Metrics{}, err

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -4,11 +4,13 @@
 package memcachedreceiver
 
 import (
+	"crypto/tls"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetricassert"
@@ -19,7 +21,7 @@ func TestScraper(t *testing.T) {
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
 	scraper := newMemcachedScraper(receivertest.NewNopSettings(metadata.Type), cfg)
-	scraper.newClient = func(string, time.Duration) (client, error) {
+	scraper.newClient = func(string, time.Duration, *tls.Config) (client, error) {
 		return &fakeClient{}, nil
 	}
 
@@ -31,4 +33,34 @@ func TestScraper(t *testing.T) {
 	// require.NoError(t, pmetricassert.WriteAssertionFile(t, expectedFile, actualMetrics))
 
 	require.NoError(t, pmetricassert.AssertMetrics(expectedFile, actualMetrics))
+}
+
+func TestScraperTLSConfigPropagated(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.TLS = configtls.ClientConfig{Insecure: false}
+	scraper := newMemcachedScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+	scraper.newClient = func(_ string, _ time.Duration, tlsConfig *tls.Config) (client, error) {
+		require.NotNil(t, tlsConfig)
+		return &fakeClient{}, nil
+	}
+
+	_, err := scraper.scrape(t.Context())
+	require.NoError(t, err)
+}
+
+func TestScraperTLSConfigError(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.TLS = configtls.ClientConfig{
+		Config: configtls.Config{CAFile: filepath.Join(t.TempDir(), "missing-ca.crt")},
+	}
+	scraper := newMemcachedScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+	scraper.newClient = func(string, time.Duration, *tls.Config) (client, error) {
+		t.Fatal("newClient must not be called when TLS config fails to load")
+		return nil, nil
+	}
+
+	_, err := scraper.scrape(t.Context())
+	require.Error(t, err)
 }

--- a/receiver/memcachedreceiver/testdata/config.yaml
+++ b/receiver/memcachedreceiver/testdata/config.yaml
@@ -1,3 +1,9 @@
 memcached:
   endpoint: "localhost:11211"
   collection_interval: 10s
+memcached/tls:
+  endpoint: "localhost:11211"
+  collection_interval: 10s
+  tls:
+    insecure: false
+    ca_file: /etc/ssl/certs/ca.crt


### PR DESCRIPTION
Assisted-by: Claude Opus 4.8

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The redis, mongodb, mysql, and postgresql receivers all expose a `tls` setting,
but the memcached receiver did not. This adds a `tls` option to the memcached
receiver using the same `configtls.ClientConfig` pattern as those receivers.

TLS is disabled by default (`insecure: true`), so existing plaintext
configurations are unaffected. The underlying `grobie/gomemcache` client already
supports TLS via its `TlsConfig` field; the receiver now wires it through from
the loaded TLS config.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests were added covering the new behavior: the TLS-disabled default,
nil tls config -> plaintext, a non-nil *tls.Config being propagated to the
client, decoding a `tls:` block from YAML, and the LoadTLSConfig error path.

Verified locally with `go build`, `go vet`, `go test ./receiver/memcachedreceiver/...`,
`gofmt -l`, and `make chlog-validate` (all passing).

<!--Describe the documentation added.-->
#### Documentation
Updated the receiver README with the new `tls` option and an example showing
TLS enabled with a CA file.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
