### PR TITLE
[receiver/hostmetrics/cpu] Make logical CPU attribute opt-in

### DIFF
--- a/.chloggen/49161-hostmetrics-cpu-attribute-opt-in.yaml
+++ b/.chloggen/49161-hostmetrics-cpu-attribute-opt-in.yaml
@@ -1,6 +1,6 @@
 change_type: breaking
 component: receiver/host_metrics
-note: Make the `cpu` attribute opt-in for hostmetrics CPU scraper metrics.
+note: Make the `cpu` attribute opt-in for hostmetrics CPU time and utilization metrics.
 issues: [49161]
 subtext: |
   By default, `system.cpu.time` and `system.cpu.utilization` are now aggregated across logical CPUs and no longer include the `cpu` attribute.
@@ -15,15 +15,5 @@ subtext: |
               attributes: [cpu, state]
             system.cpu.utilization:
               attributes: [cpu, state]
-  ```
-  If `system.cpu.frequency` is enabled and the per-CPU label is required, also configure:
-  ```yaml
-  receivers:
-    hostmetrics:
-      scrapers:
-        cpu:
-          metrics:
-            system.cpu.frequency:
-              attributes: [cpu]
   ```
 change_logs: [user]

--- a/.chloggen/49161-hostmetrics-cpu-attribute-opt-in.yaml
+++ b/.chloggen/49161-hostmetrics-cpu-attribute-opt-in.yaml
@@ -1,0 +1,29 @@
+change_type: breaking
+component: receiver/host_metrics
+note: Make the `cpu` attribute opt-in for hostmetrics CPU scraper metrics.
+issues: [49161]
+subtext: |
+  By default, `system.cpu.time` and `system.cpu.utilization` are now aggregated across logical CPUs and no longer include the `cpu` attribute.
+  To restore the previous per-logical-CPU output, configure:
+  ```yaml
+  receivers:
+    hostmetrics:
+      scrapers:
+        cpu:
+          metrics:
+            system.cpu.time:
+              attributes: [cpu, state]
+            system.cpu.utilization:
+              attributes: [cpu, state]
+  ```
+  If `system.cpu.frequency` is enabled and the per-CPU label is required, also configure:
+  ```yaml
+  receivers:
+    hostmetrics:
+      scrapers:
+        cpu:
+          metrics:
+            system.cpu.frequency:
+              attributes: [cpu]
+  ```
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/e2e_test.go
+++ b/processor/resourcedetectionprocessor/e2e_test.go
@@ -81,7 +81,7 @@ func TestE2EEnvDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -129,7 +129,7 @@ func TestE2ESystemDetector(t *testing.T) {
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		// For system detector, we need to ignore some values that are host-specific
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -197,7 +197,7 @@ func TestE2EDockerDetector(t *testing.T) {
 	require.Truef(t, found, "resource with container.name=%s not found in new metric batches", containerName)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, actual,
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, actual,
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -243,7 +243,7 @@ func TestE2EEKSDetector(t *testing.T) {
 	waitForData(t, metricsConsumer, startEntries, wantEntries)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -287,7 +287,7 @@ func TestE2EGCPDetector(t *testing.T) {
 	waitForData(t, metricsConsumer, startEntries, wantEntries)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -334,7 +334,7 @@ func TestE2EHerokuDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -381,7 +381,7 @@ func TestE2ELambdaDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -445,7 +445,7 @@ func TestE2EConsulDetector(t *testing.T) {
 		require.True(tt, found, "host.id attribute should be present")
 		require.NotEmpty(tt, hostID.Str(), "host.id should not be empty")
 
-		assert.NoError(tt, compareE2EMetrics(expected, metrics,
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metrics,
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -496,7 +496,7 @@ func TestE2EOpenstackNovaDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -544,7 +544,7 @@ func TestE2EUpcloudDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -592,7 +592,7 @@ func TestE2EVultrDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -639,7 +639,7 @@ func TestE2EEC2Detector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -686,7 +686,7 @@ func TestE2EAlibabaECSDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -733,7 +733,7 @@ func TestE2ETencentCVMDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -781,7 +781,7 @@ func TestE2EScalewayDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -829,7 +829,7 @@ func TestE2EDigitalOceanDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -877,7 +877,7 @@ func TestE2EAzureDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -953,7 +953,7 @@ func TestE2EK8sAPIDetector(t *testing.T) {
 				require.True(tt, found, "k8s.cluster.uid attribute should be present")
 				require.NotEmpty(tt, clusterUID.Str(), "k8s.cluster.uid should not be empty")
 
-				assert.NoError(tt, compareE2EMetrics(expected, metrics,
+				assert.NoError(tt, pmetrictest.CompareMetrics(expected, metrics,
 					pmetrictest.IgnoreTimestamp(),
 					pmetrictest.IgnoreStartTimestamp(),
 					pmetrictest.IgnoreScopeVersion(),
@@ -1008,7 +1008,7 @@ func TestE2EAKSDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1056,7 +1056,7 @@ func TestE2EOpenShiftDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1104,7 +1104,7 @@ func TestE2EDynatraceDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1152,7 +1152,7 @@ func TestE2EAkamaiDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1200,7 +1200,7 @@ func TestE2EElasticBeanstalkDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1248,7 +1248,7 @@ func TestE2EHetznerDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1301,7 +1301,7 @@ func TestE2EIBMCloudVPCDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected,
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected,
 			metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
@@ -1355,7 +1355,7 @@ func TestE2EIBMCloudClassicDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected,
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected,
 			metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
@@ -1403,7 +1403,7 @@ func TestE2EECSDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1465,7 +1465,7 @@ func TestE2EKubeadmDetector(t *testing.T) {
 		require.True(tt, found, "k8s.cluster.uid attribute should be present")
 		require.NotEmpty(tt, clusterUID.Str(), "k8s.cluster.uid should not be empty")
 
-		assert.NoError(tt, compareE2EMetrics(expected, metrics,
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metrics,
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1515,7 +1515,7 @@ func TestE2EOracleCloudDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1532,35 +1532,6 @@ func TestE2EOracleCloudDetector(t *testing.T) {
 
 func replaceWithStar(_ string) string {
 	return "*"
-}
-
-func compareE2EMetrics(expected, actual pmetric.Metrics, options ...pmetrictest.CompareMetricsOption) error {
-	exp, act := pmetric.NewMetrics(), pmetric.NewMetrics()
-	expected.CopyTo(exp)
-	actual.CopyTo(act)
-
-	removeDatapointAttribute(exp, "system.cpu.time", "cpu")
-	removeDatapointAttribute(act, "system.cpu.time", "cpu")
-
-	return pmetrictest.CompareMetrics(exp, act, options...)
-}
-
-func removeDatapointAttribute(metrics pmetric.Metrics, metricName, attrName string) {
-	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
-		scopeMetrics := metrics.ResourceMetrics().At(i).ScopeMetrics()
-		for j := 0; j < scopeMetrics.Len(); j++ {
-			metricSlice := scopeMetrics.At(j).Metrics()
-			for k := 0; k < metricSlice.Len(); k++ {
-				metric := metricSlice.At(k)
-				if metric.Name() != metricName {
-					continue
-				}
-				for l := 0; l < metric.Sum().DataPoints().Len(); l++ {
-					metric.Sum().DataPoints().At(l).Attributes().Remove(attrName)
-				}
-			}
-		}
-	}
 }
 
 func startUpSink(t *testing.T, mc *consumertest.MetricsSink) func() {

--- a/processor/resourcedetectionprocessor/e2e_test.go
+++ b/processor/resourcedetectionprocessor/e2e_test.go
@@ -81,7 +81,7 @@ func TestE2EEnvDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -129,7 +129,7 @@ func TestE2ESystemDetector(t *testing.T) {
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		// For system detector, we need to ignore some values that are host-specific
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -197,7 +197,7 @@ func TestE2EDockerDetector(t *testing.T) {
 	require.Truef(t, found, "resource with container.name=%s not found in new metric batches", containerName)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, actual,
+		assert.NoError(tt, compareE2EMetrics(expected, actual,
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -243,7 +243,7 @@ func TestE2EEKSDetector(t *testing.T) {
 	waitForData(t, metricsConsumer, startEntries, wantEntries)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -287,7 +287,7 @@ func TestE2EGCPDetector(t *testing.T) {
 	waitForData(t, metricsConsumer, startEntries, wantEntries)
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -334,7 +334,7 @@ func TestE2EHerokuDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -381,7 +381,7 @@ func TestE2ELambdaDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -445,7 +445,7 @@ func TestE2EConsulDetector(t *testing.T) {
 		require.True(tt, found, "host.id attribute should be present")
 		require.NotEmpty(tt, hostID.Str(), "host.id should not be empty")
 
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metrics,
+		assert.NoError(tt, compareE2EMetrics(expected, metrics,
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -496,7 +496,7 @@ func TestE2EOpenstackNovaDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -544,7 +544,7 @@ func TestE2EUpcloudDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -592,7 +592,7 @@ func TestE2EVultrDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -639,7 +639,7 @@ func TestE2EEC2Detector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -686,7 +686,7 @@ func TestE2EAlibabaECSDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -733,7 +733,7 @@ func TestE2ETencentCVMDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -781,7 +781,7 @@ func TestE2EScalewayDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -829,7 +829,7 @@ func TestE2EDigitalOceanDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -877,7 +877,7 @@ func TestE2EAzureDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -953,7 +953,7 @@ func TestE2EK8sAPIDetector(t *testing.T) {
 				require.True(tt, found, "k8s.cluster.uid attribute should be present")
 				require.NotEmpty(tt, clusterUID.Str(), "k8s.cluster.uid should not be empty")
 
-				assert.NoError(tt, pmetrictest.CompareMetrics(expected, metrics,
+				assert.NoError(tt, compareE2EMetrics(expected, metrics,
 					pmetrictest.IgnoreTimestamp(),
 					pmetrictest.IgnoreStartTimestamp(),
 					pmetrictest.IgnoreScopeVersion(),
@@ -1008,7 +1008,7 @@ func TestE2EAKSDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1056,7 +1056,7 @@ func TestE2EOpenShiftDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1104,7 +1104,7 @@ func TestE2EDynatraceDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1152,7 +1152,7 @@ func TestE2EAkamaiDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1200,7 +1200,7 @@ func TestE2EElasticBeanstalkDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1248,7 +1248,7 @@ func TestE2EHetznerDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1301,7 +1301,7 @@ func TestE2EIBMCloudVPCDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected,
+		assert.NoError(tt, compareE2EMetrics(expected,
 			metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
@@ -1355,7 +1355,7 @@ func TestE2EIBMCloudClassicDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected,
+		assert.NoError(tt, compareE2EMetrics(expected,
 			metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
@@ -1403,7 +1403,7 @@ func TestE2EECSDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1465,7 +1465,7 @@ func TestE2EKubeadmDetector(t *testing.T) {
 		require.True(tt, found, "k8s.cluster.uid attribute should be present")
 		require.NotEmpty(tt, clusterUID.Str(), "k8s.cluster.uid should not be empty")
 
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metrics,
+		assert.NoError(tt, compareE2EMetrics(expected, metrics,
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1515,7 +1515,7 @@ func TestE2EOracleCloudDetector(t *testing.T) {
 	// golden.WriteMetrics(t, expectedFile+".actual", metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1])
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
-		assert.NoError(tt, pmetrictest.CompareMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
+		assert.NoError(tt, compareE2EMetrics(expected, metricsConsumer.AllMetrics()[len(metricsConsumer.AllMetrics())-1],
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreScopeVersion(),
@@ -1532,6 +1532,35 @@ func TestE2EOracleCloudDetector(t *testing.T) {
 
 func replaceWithStar(_ string) string {
 	return "*"
+}
+
+func compareE2EMetrics(expected, actual pmetric.Metrics, options ...pmetrictest.CompareMetricsOption) error {
+	exp, act := pmetric.NewMetrics(), pmetric.NewMetrics()
+	expected.CopyTo(exp)
+	actual.CopyTo(act)
+
+	removeDatapointAttribute(exp, "system.cpu.time", "cpu")
+	removeDatapointAttribute(act, "system.cpu.time", "cpu")
+
+	return pmetrictest.CompareMetrics(exp, act, options...)
+}
+
+func removeDatapointAttribute(metrics pmetric.Metrics, metricName, attrName string) {
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		scopeMetrics := metrics.ResourceMetrics().At(i).ScopeMetrics()
+		for j := 0; j < scopeMetrics.Len(); j++ {
+			metricSlice := scopeMetrics.At(j).Metrics()
+			for k := 0; k < metricSlice.Len(); k++ {
+				metric := metricSlice.At(k)
+				if metric.Name() != metricName {
+					continue
+				}
+				for l := 0; l < metric.Sum().DataPoints().Len(); l++ {
+					metric.Sum().DataPoints().At(l).Attributes().Remove(attrName)
+				}
+			}
+		}
+	}
 }
 
 func startUpSink(t *testing.T, mc *consumertest.MetricsSink) func() {

--- a/processor/resourcedetectionprocessor/testdata/e2e/akamai/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/akamai/expected.yaml
@@ -38,9 +38,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -48,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -58,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -68,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -78,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -88,9 +73,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -98,9 +80,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -108,9 +87,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/aks/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/aks/expected.yaml
@@ -20,9 +20,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -30,9 +27,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -40,9 +34,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -50,9 +41,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -60,9 +48,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -70,9 +55,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -80,9 +62,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -90,9 +69,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/alibaba_ecs/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/alibaba_ecs/expected.yaml
@@ -38,9 +38,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -48,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -58,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -68,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -78,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -88,9 +73,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -98,9 +80,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -108,9 +87,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/azure/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/azure/expected.yaml
@@ -50,9 +50,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -60,9 +57,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -70,9 +64,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -80,9 +71,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -90,9 +78,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -100,9 +85,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -110,9 +92,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -120,9 +99,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/consul/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/consul/expected.yaml
@@ -29,9 +29,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -39,9 +36,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -49,9 +43,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -59,9 +50,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -69,9 +57,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -79,9 +64,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -89,9 +71,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -99,9 +78,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/digitalocean/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/digitalocean/expected.yaml
@@ -23,9 +23,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -33,9 +30,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -43,9 +37,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -53,9 +44,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -63,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -73,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -83,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -93,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/docker/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/docker/expected.yaml
@@ -23,9 +23,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -33,9 +30,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -43,9 +37,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -53,9 +44,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -63,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -73,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -83,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -93,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/dynatrace/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/dynatrace/expected.yaml
@@ -20,9 +20,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -30,9 +27,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -40,9 +34,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -50,9 +41,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -60,9 +48,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -70,9 +55,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -80,9 +62,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -90,9 +69,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/ec2/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ec2/expected.yaml
@@ -44,9 +44,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -54,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -64,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -74,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -84,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -94,9 +79,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -104,9 +86,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -114,9 +93,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/ecs/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ecs/expected.yaml
@@ -64,9 +64,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -74,9 +71,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -84,9 +78,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -94,9 +85,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -104,9 +92,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -114,9 +99,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -124,9 +106,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -134,9 +113,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/eks/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/eks/expected.yaml
@@ -38,9 +38,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -48,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -58,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -68,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -78,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -88,9 +73,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -98,9 +80,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -108,9 +87,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/elasticbeanstalk/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/elasticbeanstalk/expected.yaml
@@ -26,9 +26,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -36,9 +33,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -46,9 +40,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -56,9 +47,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -66,9 +54,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -76,9 +61,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -86,9 +68,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -96,9 +75,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/env/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/env/expected.yaml
@@ -23,9 +23,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -33,9 +30,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -43,9 +37,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -53,9 +44,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -63,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -73,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -83,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -93,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/gcp/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/gcp/expected.yaml
@@ -47,9 +47,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -57,9 +54,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -67,9 +61,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -77,9 +68,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -87,9 +75,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -97,9 +82,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -107,9 +89,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -117,9 +96,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/heroku/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/heroku/expected.yaml
@@ -32,9 +32,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -42,9 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -52,9 +46,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -62,9 +53,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -72,9 +60,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -82,9 +67,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -92,9 +74,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -102,9 +81,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/hetzner/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/hetzner/expected.yaml
@@ -29,9 +29,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -39,9 +36,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -49,9 +43,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -59,9 +50,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -69,9 +57,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -79,9 +64,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -89,9 +71,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -99,9 +78,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_classic/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_classic/expected.yaml
@@ -32,9 +32,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -42,9 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -52,9 +46,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -62,9 +53,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -72,9 +60,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -82,9 +67,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -92,9 +74,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -102,9 +81,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_vpc/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_vpc/expected.yaml
@@ -44,9 +44,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -54,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -64,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -74,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -84,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -94,9 +79,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -104,9 +86,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -114,9 +93,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/k8s_api/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/k8s_api/expected.yaml
@@ -20,9 +20,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -30,9 +27,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -40,9 +34,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -50,9 +41,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -60,9 +48,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -70,9 +55,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -80,9 +62,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -90,9 +69,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/k8snode/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/k8snode/expected.yaml
@@ -20,9 +20,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -30,9 +27,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -40,9 +34,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -50,9 +41,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -60,9 +48,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -70,9 +55,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -80,9 +62,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -90,9 +69,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/kubeadm/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/kubeadm/expected.yaml
@@ -17,9 +17,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -27,9 +24,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -37,9 +31,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -47,9 +38,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -57,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -67,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -77,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -87,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/lambda/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/lambda/expected.yaml
@@ -42,9 +42,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -52,9 +49,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -62,9 +56,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -72,9 +63,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -82,9 +70,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -92,9 +77,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -102,9 +84,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -112,9 +91,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/nova/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/nova/expected.yaml
@@ -38,9 +38,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -48,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -58,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -68,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -78,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -88,9 +73,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -98,9 +80,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -108,9 +87,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/openshift/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/openshift/expected.yaml
@@ -23,9 +23,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -33,9 +30,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -43,9 +37,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -53,9 +44,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -63,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -73,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -83,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -93,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/oraclecloud/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/oraclecloud/expected.yaml
@@ -38,9 +38,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -48,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -58,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -68,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -78,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -88,9 +73,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -98,9 +80,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -108,9 +87,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/scaleway/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/scaleway/expected.yaml
@@ -41,9 +41,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -51,9 +48,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -61,9 +55,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -71,9 +62,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -81,9 +69,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -91,9 +76,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -101,9 +83,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -111,9 +90,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/system/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/system/expected.yaml
@@ -26,9 +26,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -36,9 +33,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -46,9 +40,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -56,9 +47,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -66,9 +54,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -76,9 +61,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -86,9 +68,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -96,9 +75,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/tencent_cvm/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/tencent_cvm/expected.yaml
@@ -38,9 +38,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -48,9 +45,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -58,9 +52,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -68,9 +59,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -78,9 +66,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -88,9 +73,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -98,9 +80,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -108,9 +87,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/upcloud/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/upcloud/expected.yaml
@@ -23,9 +23,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -33,9 +30,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -43,9 +37,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -53,9 +44,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -63,9 +51,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -73,9 +58,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -83,9 +65,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -93,9 +72,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/processor/resourcedetectionprocessor/testdata/e2e/vultr/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/vultr/expected.yaml
@@ -26,9 +26,6 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: idle
@@ -36,9 +33,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: interrupt
@@ -46,9 +40,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: nice
@@ -56,9 +47,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: softirq
@@ -66,9 +54,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: steal
@@ -76,9 +61,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: system
@@ -86,9 +68,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: user
@@ -96,9 +75,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
                 - asDouble: 1.0
                   attributes:
-                    - key: cpu
-                      value:
-                        stringValue: cpu0
                     - key: state
                       value:
                         stringValue: wait

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
@@ -30,14 +30,12 @@ func TestScrape_CpuFrequency(t *testing.T) {
 		{
 			name:             "System CPU Frequency enabled",
 			enabledFrequency: true,
+			expectCPUAttr:    true,
 		},
 		{
-			name:             "System CPU Frequency enabled with CPU attribute",
-			enabledFrequency: true,
-			enabledAttributes: []metadata.SystemCPUFrequencyMetricAttributeKey{
-				metadata.SystemCPUFrequencyMetricAttributeKeyCPU,
-			},
-			expectCPUAttr: true,
+			name:              "System CPU Frequency enabled without CPU attribute",
+			enabledFrequency:  true,
+			enabledAttributes: []metadata.SystemCPUFrequencyMetricAttributeKey{},
 		},
 		{
 			name:             "System CPU Frequency disabled",
@@ -52,7 +50,9 @@ func TestScrape_CpuFrequency(t *testing.T) {
 			cfg := metadata.NewDefaultMetricsBuilderConfig()
 			cfg.Metrics.SystemCPUTime.Enabled = false
 			cfg.Metrics.SystemCPUFrequency.Enabled = test.enabledFrequency
-			cfg.Metrics.SystemCPUFrequency.EnabledAttributes = test.enabledAttributes
+			if test.enabledAttributes != nil {
+				cfg.Metrics.SystemCPUFrequency.EnabledAttributes = test.enabledAttributes
+			}
 
 			scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
 				&Config{MetricsBuilderConfig: cfg})

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
@@ -22,14 +22,12 @@ func TestScrape_CpuFrequency(t *testing.T) {
 	type testCase struct {
 		name             string
 		enabledFrequency bool
-		expectCPUAttr    bool
 	}
 
 	testCases := []testCase{
 		{
 			name:             "System CPU Frequency enabled",
 			enabledFrequency: true,
-			expectCPUAttr:    true,
 		},
 		{
 			name:             "System CPU Frequency disabled",
@@ -68,12 +66,12 @@ func TestScrape_CpuFrequency(t *testing.T) {
 
 			metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 			metric := metrics.At(0)
-			assertCPUFrequencyMetricValid(t, metric, test.expectCPUAttr)
+			assertCPUFrequencyMetricValid(t, metric)
 		})
 	}
 }
 
-func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric, expectCPUAttr bool) {
+func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.frequency")
 	expected.SetDescription("Current frequency of the CPU core in Hz.")
@@ -82,24 +80,15 @@ func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric, expectCP
 	internal.AssertDescriptorEqual(t, expected, metric)
 
 	numCPUs := runtime.NumCPU()
-	if expectCPUAttr {
-		require.GreaterOrEqual(t, metric.Gauge().DataPoints().Len(), numCPUs,
-			"Should have at least one frequency data point per CPU")
-	} else {
-		require.Equal(t, 1, metric.Gauge().DataPoints().Len(),
-			"Should aggregate frequency data points across CPUs by default")
-	}
+	require.GreaterOrEqual(t, metric.Gauge().DataPoints().Len(), numCPUs,
+		"Should have at least one frequency data point per CPU")
 
 	if metric.Gauge().DataPoints().Len() > 0 {
 		dp := metric.Gauge().DataPoints().At(0)
 
 		cpuAttr, exists := dp.Attributes().Get("cpu")
-		if expectCPUAttr {
-			require.True(t, exists, "Data point should have 'cpu' attribute")
-			require.Contains(t, cpuAttr.Str(), "cpu", "CPU attribute should contain 'cpu' prefix")
-		} else {
-			require.False(t, exists, "Data point should not have 'cpu' attribute by default")
-		}
+		require.True(t, exists, "Data point should have 'cpu' attribute")
+		require.Contains(t, cpuAttr.Str(), "cpu", "CPU attribute should contain 'cpu' prefix")
 
 		require.GreaterOrEqual(t, dp.DoubleValue(), 0.0, "CPU frequency should be non-negative")
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
@@ -20,14 +20,24 @@ import (
 
 func TestScrape_CpuFrequency(t *testing.T) {
 	type testCase struct {
-		name             string
-		enabledFrequency bool
+		name              string
+		enabledFrequency  bool
+		enabledAttributes []metadata.SystemCPUFrequencyMetricAttributeKey
+		expectCPUAttr     bool
 	}
 
 	testCases := []testCase{
 		{
 			name:             "System CPU Frequency enabled",
 			enabledFrequency: true,
+		},
+		{
+			name:             "System CPU Frequency enabled with CPU attribute",
+			enabledFrequency: true,
+			enabledAttributes: []metadata.SystemCPUFrequencyMetricAttributeKey{
+				metadata.SystemCPUFrequencyMetricAttributeKeyCPU,
+			},
+			expectCPUAttr: true,
 		},
 		{
 			name:             "System CPU Frequency disabled",
@@ -42,6 +52,7 @@ func TestScrape_CpuFrequency(t *testing.T) {
 			cfg := metadata.NewDefaultMetricsBuilderConfig()
 			cfg.Metrics.SystemCPUTime.Enabled = false
 			cfg.Metrics.SystemCPUFrequency.Enabled = test.enabledFrequency
+			cfg.Metrics.SystemCPUFrequency.EnabledAttributes = test.enabledAttributes
 
 			scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
 				&Config{MetricsBuilderConfig: cfg})
@@ -66,12 +77,12 @@ func TestScrape_CpuFrequency(t *testing.T) {
 
 			metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 			metric := metrics.At(0)
-			assertCPUFrequencyMetricValid(t, metric)
+			assertCPUFrequencyMetricValid(t, metric, test.expectCPUAttr)
 		})
 	}
 }
 
-func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric) {
+func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric, expectCPUAttr bool) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.frequency")
 	expected.SetDescription("Current frequency of the CPU core in Hz.")
@@ -80,15 +91,24 @@ func assertCPUFrequencyMetricValid(t *testing.T, metric pmetric.Metric) {
 	internal.AssertDescriptorEqual(t, expected, metric)
 
 	numCPUs := runtime.NumCPU()
-	require.GreaterOrEqual(t, metric.Gauge().DataPoints().Len(), numCPUs,
-		"Should have at least one frequency data point per CPU")
+	if expectCPUAttr {
+		require.GreaterOrEqual(t, metric.Gauge().DataPoints().Len(), numCPUs,
+			"Should have at least one frequency data point per CPU")
+	} else {
+		require.Equal(t, 1, metric.Gauge().DataPoints().Len(),
+			"Should aggregate frequency data points across CPUs by default")
+	}
 
 	if metric.Gauge().DataPoints().Len() > 0 {
 		dp := metric.Gauge().DataPoints().At(0)
 
 		cpuAttr, exists := dp.Attributes().Get("cpu")
-		require.True(t, exists, "Data point should have 'cpu' attribute")
-		require.Contains(t, cpuAttr.Str(), "cpu", "CPU attribute should contain 'cpu' prefix")
+		if expectCPUAttr {
+			require.True(t, exists, "Data point should have 'cpu' attribute")
+			require.Contains(t, cpuAttr.Str(), "cpu", "CPU attribute should contain 'cpu' prefix")
+		} else {
+			require.False(t, exists, "Data point should not have 'cpu' attribute by default")
+		}
 
 		require.GreaterOrEqual(t, dp.DoubleValue(), 0.0, "CPU frequency should be non-negative")
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
@@ -20,10 +20,9 @@ import (
 
 func TestScrape_CpuFrequency(t *testing.T) {
 	type testCase struct {
-		name              string
-		enabledFrequency  bool
-		enabledAttributes []metadata.SystemCPUFrequencyMetricAttributeKey
-		expectCPUAttr     bool
+		name             string
+		enabledFrequency bool
+		expectCPUAttr    bool
 	}
 
 	testCases := []testCase{
@@ -31,11 +30,6 @@ func TestScrape_CpuFrequency(t *testing.T) {
 			name:             "System CPU Frequency enabled",
 			enabledFrequency: true,
 			expectCPUAttr:    true,
-		},
-		{
-			name:              "System CPU Frequency enabled without CPU attribute",
-			enabledFrequency:  true,
-			enabledAttributes: []metadata.SystemCPUFrequencyMetricAttributeKey{},
 		},
 		{
 			name:             "System CPU Frequency disabled",
@@ -50,9 +44,6 @@ func TestScrape_CpuFrequency(t *testing.T) {
 			cfg := metadata.NewDefaultMetricsBuilderConfig()
 			cfg.Metrics.SystemCPUTime.Enabled = false
 			cfg.Metrics.SystemCPUFrequency.Enabled = test.enabledFrequency
-			if test.enabledAttributes != nil {
-				cfg.Metrics.SystemCPUFrequency.EnabledAttributes = test.enabledAttributes
-			}
 
 			scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),
 				&Config{MetricsBuilderConfig: cfg})

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -355,7 +355,7 @@ func TestScrape_CPUTimeAttributeConfiguration(t *testing.T) {
 			metricsConfig: func() metadata.MetricsBuilderConfig {
 				cfg := metadata.NewDefaultMetricsBuilderConfig()
 				cfg.Metrics.SystemCPUTime.EnabledAttributes = []metadata.SystemCPUTimeMetricAttributeKey{
-					metadata.SystemCPUTimeMetricAttributeKeyCPULogicalNumber,
+					metadata.SystemCPUTimeMetricAttributeKeyCPU,
 					metadata.SystemCPUTimeMetricAttributeKeyState,
 				}
 				return cfg
@@ -460,7 +460,7 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 				cfg.Metrics.SystemCPUUtilization.Enabled = true
 				cfg.Metrics.SystemCPUTime.Enabled = false
 				cfg.Metrics.SystemCPUUtilization.EnabledAttributes = []metadata.SystemCPUUtilizationMetricAttributeKey{
-					metadata.SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber,
+					metadata.SystemCPUUtilizationMetricAttributeKeyCPU,
 					metadata.SystemCPUUtilizationMetricAttributeKeyState,
 				}
 				return cfg

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -330,10 +330,6 @@ func TestScrape_CpuUtilizationError(t *testing.T) {
 func TestScrape_CpuUtilizationStandard(t *testing.T) {
 	overriddenMetricsSettings := metadata.NewDefaultMetricsBuilderConfig()
 	overriddenMetricsSettings.Metrics.SystemCPUUtilization.Enabled = true
-	overriddenMetricsSettings.Metrics.SystemCPUUtilization.EnabledAttributes = []metadata.SystemCPUUtilizationMetricAttributeKey{
-		metadata.SystemCPUUtilizationMetricAttributeKeyCPU,
-		metadata.SystemCPUUtilizationMetricAttributeKeyState,
-	}
 	overriddenMetricsSettings.Metrics.SystemCPUTime.Enabled = false
 
 	// datapoint data
@@ -356,24 +352,18 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 			times:      []cpu.TimesStat{{CPU: "cpu0", User: 2.8, System: 3.9, Idle: 3.3}, {CPU: "cpu1", User: 3.2, System: 5.2, Idle: 2.6}},
 			scrapeTime: "2006-01-02T15:04:10Z",
 			expectedDps: []dpData{
-				{val: 0.26, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-				{val: 0.24, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-				{val: 0.5, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-				{val: 0.24, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-				{val: 0.44, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-				{val: 0.32, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+				{val: 0.25, attrs: map[string]string{"state": "user"}},
+				{val: 0.34, attrs: map[string]string{"state": "system"}},
+				{val: 0.41, attrs: map[string]string{"state": "idle"}},
 			},
 		},
 		{
 			times:      []cpu.TimesStat{{CPU: "cpu0", User: 3.4, System: 5.3, Idle: 6.3}, {CPU: "cpu1", User: 3.7, System: 7.1, Idle: 5.2}},
 			scrapeTime: "2006-01-02T15:04:15Z",
 			expectedDps: []dpData{
-				{val: 0.12, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-				{val: 0.28, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-				{val: 0.6, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-				{val: 0.1, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-				{val: 0.38, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-				{val: 0.52, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+				{val: 0.11, attrs: map[string]string{"state": "user"}},
+				{val: 0.33, attrs: map[string]string{"state": "system"}},
+				{val: 0.56, attrs: map[string]string{"state": "idle"}},
 			},
 		},
 	}
@@ -402,12 +392,12 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 
 		assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 		metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-		assertCPUUtilizationMetricDescriptor(t, metric, 0)
+		assertCPUUtilizationMetricValid(t, metric, 0)
 		dp := metric.Gauge().DataPoints()
 
-		expectedDataPoints := 8
+		expectedDataPoints := 4
 		if runtime.GOOS == "linux" {
-			expectedDataPoints = 16
+			expectedDataPoints = 8
 			assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, metric)
 		}
 		assert.Equal(t, expectedDataPoints, dp.Len())
@@ -500,7 +490,7 @@ func assertCPUPhysicalCountMetricValid(t *testing.T, metric pmetric.Metric) {
 	require.Positive(t, dataPoint.IntValue(), "Physical CPU count should be greater than 0")
 }
 
-func assertCPUUtilizationMetricDescriptor(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
+func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.utilization")
 	expected.SetDescription("Difference in system.cpu.time since the last measurement per logical CPU, divided by the elapsed time (value in interval [0,1]).")
@@ -510,10 +500,6 @@ func assertCPUUtilizationMetricDescriptor(t *testing.T, metric pmetric.Metric, s
 	if startTime != 0 {
 		internal.AssertGaugeMetricStartTimeEquals(t, metric, startTime)
 	}
-}
-
-func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
-	assertCPUUtilizationMetricDescriptor(t, metric, startTime)
 	expectedDataPoints := 4
 	if runtime.GOOS == "linux" {
 		expectedDataPoints = 8

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -327,99 +327,220 @@ func TestScrape_CpuUtilizationError(t *testing.T) {
 	assert.Equal(t, 0, md.MetricCount())
 }
 
-func TestScrape_CpuUtilizationStandard(t *testing.T) {
-	overriddenMetricsSettings := metadata.NewDefaultMetricsBuilderConfig()
-	overriddenMetricsSettings.Metrics.SystemCPUUtilization.Enabled = true
-	overriddenMetricsSettings.Metrics.SystemCPUTime.Enabled = false
+type dpData struct {
+	val   float64
+	attrs map[string]string
+}
 
-	// datapoint data
-	type dpData struct {
-		val   float64
-		attrs map[string]string
-	}
-
-	scrapesData := []struct {
-		times       []cpu.TimesStat
-		scrapeTime  string
-		expectedDps []dpData
+func TestScrape_CPUTimeAttributeConfiguration(t *testing.T) {
+	testCases := []struct {
+		name          string
+		metricsConfig metadata.MetricsBuilderConfig
+		expectedDps   []dpData
 	}{
 		{
-			times:       []cpu.TimesStat{{CPU: "cpu0", User: 1.5, System: 2.7, Idle: 0.8}, {CPU: "cpu1", User: 2, System: 3, Idle: 1}},
-			scrapeTime:  "2006-01-02T15:04:05Z",
-			expectedDps: []dpData{},
+			name: "default attributes aggregate across cpu",
+			metricsConfig: func() metadata.MetricsBuilderConfig {
+				cfg := metadata.NewDefaultMetricsBuilderConfig()
+				return cfg
+			}(),
+			expectedDps: []dpData{
+				{val: 5, attrs: map[string]string{"state": "user"}},
+				{val: 7, attrs: map[string]string{"state": "system"}},
+				{val: 9, attrs: map[string]string{"state": "idle"}},
+			},
+		},
+		{
+			name: "cpu attribute enabled",
+			metricsConfig: func() metadata.MetricsBuilderConfig {
+				cfg := metadata.NewDefaultMetricsBuilderConfig()
+				cfg.Metrics.SystemCPUTime.EnabledAttributes = []metadata.SystemCPUTimeMetricAttributeKey{
+					metadata.SystemCPUTimeMetricAttributeKeyCPULogicalNumber,
+					metadata.SystemCPUTimeMetricAttributeKeyState,
+				}
+				return cfg
+			}(),
+			expectedDps: []dpData{
+				{val: 1, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
+				{val: 2, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
+				{val: 3, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
+				{val: 4, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
+				{val: 5, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
+				{val: 6, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: tt.metricsConfig})
+			cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
+				return []cpu.TimesStat{
+					{CPU: "cpu0", User: 1, System: 2, Idle: 3},
+					{CPU: "cpu1", User: 4, System: 5, Idle: 6},
+				}, nil
+			}
+
+			err := cpuScraper.start(t.Context(), componenttest.NewNopHost())
+			require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
+
+			md, err := cpuScraper.scrape(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, md.MetricCount())
+
+			metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			assertCPUMetricDescriptor(t, metric, 0)
+			dp := metric.Sum().DataPoints()
+			dp.RemoveIf(func(n pmetric.NumberDataPoint) bool {
+				return n.DoubleValue() == 0.0
+			})
+
+			require.Equal(t, len(tt.expectedDps), dp.Len())
+			for idx, expectedDp := range tt.expectedDps {
+				assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
+			}
+		})
+	}
+}
+
+func TestScrape_CpuUtilizationStandard(t *testing.T) {
+	type scrapeData struct {
+		times      []cpu.TimesStat
+		scrapeTime string
+	}
+
+	scrapesData := []scrapeData{
+		{
+			times:      []cpu.TimesStat{{CPU: "cpu0", User: 1.5, System: 2.7, Idle: 0.8}, {CPU: "cpu1", User: 2, System: 3, Idle: 1}},
+			scrapeTime: "2006-01-02T15:04:05Z",
 		},
 		{
 			times:      []cpu.TimesStat{{CPU: "cpu0", User: 2.8, System: 3.9, Idle: 3.3}, {CPU: "cpu1", User: 3.2, System: 5.2, Idle: 2.6}},
 			scrapeTime: "2006-01-02T15:04:10Z",
-			expectedDps: []dpData{
-				{val: 0.26, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-				{val: 0.24, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-				{val: 0.5, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-				{val: 0.24, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-				{val: 0.44, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-				{val: 0.32, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
-			},
 		},
 		{
 			times:      []cpu.TimesStat{{CPU: "cpu0", User: 3.4, System: 5.3, Idle: 6.3}, {CPU: "cpu1", User: 3.7, System: 7.1, Idle: 5.2}},
 			scrapeTime: "2006-01-02T15:04:15Z",
-			expectedDps: []dpData{
-				{val: 0.12, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-				{val: 0.28, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-				{val: 0.6, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-				{val: 0.1, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-				{val: 0.38, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-				{val: 0.52, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+		},
+	}
+
+	testCases := []struct {
+		name                string
+		metricsConfig       metadata.MetricsBuilderConfig
+		perCPU              bool
+		expectedDpsByScrape [][]dpData
+	}{
+		{
+			name: "default attributes aggregate across cpu",
+			metricsConfig: func() metadata.MetricsBuilderConfig {
+				cfg := metadata.NewDefaultMetricsBuilderConfig()
+				cfg.Metrics.SystemCPUUtilization.Enabled = true
+				cfg.Metrics.SystemCPUTime.Enabled = false
+				return cfg
+			}(),
+			expectedDpsByScrape: [][]dpData{
+				{},
+				{
+					{val: 0.25, attrs: map[string]string{"state": "user"}},
+					{val: 0.34, attrs: map[string]string{"state": "system"}},
+					{val: 0.41, attrs: map[string]string{"state": "idle"}},
+				},
+				{
+					{val: 0.11, attrs: map[string]string{"state": "user"}},
+					{val: 0.33, attrs: map[string]string{"state": "system"}},
+					{val: 0.56, attrs: map[string]string{"state": "idle"}},
+				},
+			},
+		},
+		{
+			name:   "cpu attribute enabled",
+			perCPU: true,
+			metricsConfig: func() metadata.MetricsBuilderConfig {
+				cfg := metadata.NewDefaultMetricsBuilderConfig()
+				cfg.Metrics.SystemCPUUtilization.Enabled = true
+				cfg.Metrics.SystemCPUTime.Enabled = false
+				cfg.Metrics.SystemCPUUtilization.EnabledAttributes = []metadata.SystemCPUUtilizationMetricAttributeKey{
+					metadata.SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber,
+					metadata.SystemCPUUtilizationMetricAttributeKeyState,
+				}
+				return cfg
+			}(),
+			expectedDpsByScrape: [][]dpData{
+				{},
+				{
+					{val: 0.26, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
+					{val: 0.24, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
+					{val: 0.5, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
+					{val: 0.24, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
+					{val: 0.44, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
+					{val: 0.32, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+				},
+				{
+					{val: 0.12, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
+					{val: 0.28, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
+					{val: 0.6, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
+					{val: 0.1, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
+					{val: 0.38, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
+					{val: 0.52, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+				},
 			},
 		},
 	}
 
-	cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: overriddenMetricsSettings})
-	for _, scrapeData := range scrapesData {
-		// mock TimeStats and Now
-		cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
-			return scrapeData.times, nil
-		}
-		cpuScraper.now = func() time.Time {
-			now, _ := time.Parse(time.RFC3339, scrapeData.scrapeTime)
-			return now
-		}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: tt.metricsConfig})
+			for scrapeIdx, scrapeData := range scrapesData {
+				// mock TimeStats and Now
+				cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
+					return scrapeData.times, nil
+				}
+				cpuScraper.now = func() time.Time {
+					now, _ := time.Parse(time.RFC3339, scrapeData.scrapeTime)
+					return now
+				}
 
-		err := cpuScraper.start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
+				err := cpuScraper.start(t.Context(), componenttest.NewNopHost())
+				require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
 
-		md, err := cpuScraper.scrape(t.Context())
-		require.NoError(t, err)
-		// no metrics in the first scrape
-		if len(scrapeData.expectedDps) == 0 {
-			assert.Equal(t, 0, md.ResourceMetrics().Len())
-			continue
-		}
+				md, err := cpuScraper.scrape(t.Context())
+				require.NoError(t, err)
+				expectedDps := tt.expectedDpsByScrape[scrapeIdx]
+				// no metrics in the first scrape
+				if len(expectedDps) == 0 {
+					assert.Equal(t, 0, md.ResourceMetrics().Len())
+					continue
+				}
 
-		assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
-		metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-		assertCPUUtilizationMetricValid(t, metric, 0)
-		dp := metric.Gauge().DataPoints()
+				assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+				metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+				assertCPUUtilizationMetricDescriptor(t, metric, 0)
+				dp := metric.Gauge().DataPoints()
 
-		expectedDataPoints := 8
-		if runtime.GOOS == "linux" {
-			expectedDataPoints = 16
-			assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, metric)
-		}
-		assert.Equal(t, expectedDataPoints, dp.Len())
+				expectedDataPoints := expectedCPUStateDataPoints()
+				if tt.perCPU {
+					expectedDataPoints *= len(scrapeData.times)
+				}
+				if runtime.GOOS == "linux" {
+					assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, metric)
+				}
+				assert.Equal(t, expectedDataPoints, dp.Len())
 
-		// remove empty values to make the test more simple
-		dp.RemoveIf(func(n pmetric.NumberDataPoint) bool {
-			return n.DoubleValue() == 0.0
+				// remove empty values to make the test more simple
+				dp.RemoveIf(func(n pmetric.NumberDataPoint) bool {
+					return n.DoubleValue() == 0.0
+				})
+
+				for idx, expectedDp := range expectedDps {
+					assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
+				}
+			}
 		})
-
-		for idx, expectedDp := range scrapeData.expectedDps {
-			assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
-		}
 	}
 }
 
 func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberDataPoint, value float64, attrs map[string]string) {
+	require.Equal(t, len(attrs), dp.Attributes().Len())
 	assert.InDelta(t, value, dp.DoubleValue(), 0.0001)
 	for k, v := range attrs {
 		cpuAttribute, exists := dp.Attributes().Get(k)
@@ -428,7 +549,7 @@ func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberData
 	}
 }
 
-func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
+func assertCPUMetricDescriptor(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.time")
 	expected.SetDescription("Total seconds each logical CPU spent on each mode.")
@@ -438,8 +559,12 @@ func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, metric, startTime)
 	}
-	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 4*runtime.NumCPU())
-	internal.AssertSumMetricHasAttribute(t, metric, 0, "cpu")
+}
+
+func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
+	assertCPUMetricDescriptor(t, metric, startTime)
+	assert.Equal(t, expectedCPUStateDataPoints(), metric.Sum().DataPoints().Len())
+	assertMetricDoesNotHaveAttribute(t, metric.Sum().DataPoints().At(0), "cpu")
 	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueStr(metadata.AttributeStateUser.String()))
 	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "state",
@@ -491,7 +616,7 @@ func assertCPUPhysicalCountMetricValid(t *testing.T, metric pmetric.Metric) {
 	require.Positive(t, dataPoint.IntValue(), "Physical CPU count should be greater than 0")
 }
 
-func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
+func assertCPUUtilizationMetricDescriptor(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.utilization")
 	expected.SetDescription("Difference in system.cpu.time since the last measurement per logical CPU, divided by the elapsed time (value in interval [0,1]).")
@@ -501,7 +626,12 @@ func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startT
 	if startTime != 0 {
 		internal.AssertGaugeMetricStartTimeEquals(t, metric, startTime)
 	}
-	internal.AssertGaugeMetricHasAttribute(t, metric, 0, "cpu")
+}
+
+func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
+	assertCPUUtilizationMetricDescriptor(t, metric, startTime)
+	assert.Equal(t, expectedCPUStateDataPoints(), metric.Gauge().DataPoints().Len())
+	assertMetricDoesNotHaveAttribute(t, metric.Gauge().DataPoints().At(0), "cpu")
 	internal.AssertGaugeMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueStr(metadata.AttributeStateUser.String()))
 	internal.AssertGaugeMetricHasAttributeValue(t, metric, 1, "state",
@@ -510,6 +640,18 @@ func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startT
 		pcommon.NewValueStr(metadata.AttributeStateIdle.String()))
 	internal.AssertGaugeMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueStr(metadata.AttributeStateInterrupt.String()))
+}
+
+func expectedCPUStateDataPoints() int {
+	if runtime.GOOS == "linux" {
+		return 8
+	}
+	return 4
+}
+
+func assertMetricDoesNotHaveAttribute(t *testing.T, dp pmetric.NumberDataPoint, name string) {
+	_, exists := dp.Attributes().Get(name)
+	assert.Falsef(t, exists, "Unexpected attribute %q", name)
 }
 
 func assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Metric) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -327,220 +327,103 @@ func TestScrape_CpuUtilizationError(t *testing.T) {
 	assert.Equal(t, 0, md.MetricCount())
 }
 
-type dpData struct {
-	val   float64
-	attrs map[string]string
-}
+func TestScrape_CpuUtilizationStandard(t *testing.T) {
+	overriddenMetricsSettings := metadata.NewDefaultMetricsBuilderConfig()
+	overriddenMetricsSettings.Metrics.SystemCPUUtilization.Enabled = true
+	overriddenMetricsSettings.Metrics.SystemCPUUtilization.EnabledAttributes = []metadata.SystemCPUUtilizationMetricAttributeKey{
+		metadata.SystemCPUUtilizationMetricAttributeKeyCPU,
+		metadata.SystemCPUUtilizationMetricAttributeKeyState,
+	}
+	overriddenMetricsSettings.Metrics.SystemCPUTime.Enabled = false
 
-func TestScrape_CPUTimeAttributeConfiguration(t *testing.T) {
-	testCases := []struct {
-		name          string
-		metricsConfig metadata.MetricsBuilderConfig
-		expectedDps   []dpData
+	// datapoint data
+	type dpData struct {
+		val   float64
+		attrs map[string]string
+	}
+
+	scrapesData := []struct {
+		times       []cpu.TimesStat
+		scrapeTime  string
+		expectedDps []dpData
 	}{
 		{
-			name: "default attributes aggregate across cpu",
-			metricsConfig: func() metadata.MetricsBuilderConfig {
-				cfg := metadata.NewDefaultMetricsBuilderConfig()
-				return cfg
-			}(),
-			expectedDps: []dpData{
-				{val: 5, attrs: map[string]string{"state": "user"}},
-				{val: 7, attrs: map[string]string{"state": "system"}},
-				{val: 9, attrs: map[string]string{"state": "idle"}},
-			},
-		},
-		{
-			name: "cpu attribute enabled",
-			metricsConfig: func() metadata.MetricsBuilderConfig {
-				cfg := metadata.NewDefaultMetricsBuilderConfig()
-				cfg.Metrics.SystemCPUTime.EnabledAttributes = []metadata.SystemCPUTimeMetricAttributeKey{
-					metadata.SystemCPUTimeMetricAttributeKeyCPU,
-					metadata.SystemCPUTimeMetricAttributeKeyState,
-				}
-				return cfg
-			}(),
-			expectedDps: []dpData{
-				{val: 1, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-				{val: 2, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-				{val: 3, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-				{val: 4, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-				{val: 5, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-				{val: 6, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
-			},
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: tt.metricsConfig})
-			cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
-				return []cpu.TimesStat{
-					{CPU: "cpu0", User: 1, System: 2, Idle: 3},
-					{CPU: "cpu1", User: 4, System: 5, Idle: 6},
-				}, nil
-			}
-
-			err := cpuScraper.start(t.Context(), componenttest.NewNopHost())
-			require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
-
-			md, err := cpuScraper.scrape(t.Context())
-			require.NoError(t, err)
-			require.Equal(t, 1, md.MetricCount())
-
-			metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-			assertCPUMetricDescriptor(t, metric, 0)
-			dp := metric.Sum().DataPoints()
-			dp.RemoveIf(func(n pmetric.NumberDataPoint) bool {
-				return n.DoubleValue() == 0.0
-			})
-
-			require.Equal(t, len(tt.expectedDps), dp.Len())
-			for idx, expectedDp := range tt.expectedDps {
-				assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
-			}
-		})
-	}
-}
-
-func TestScrape_CpuUtilizationStandard(t *testing.T) {
-	type scrapeData struct {
-		times      []cpu.TimesStat
-		scrapeTime string
-	}
-
-	scrapesData := []scrapeData{
-		{
-			times:      []cpu.TimesStat{{CPU: "cpu0", User: 1.5, System: 2.7, Idle: 0.8}, {CPU: "cpu1", User: 2, System: 3, Idle: 1}},
-			scrapeTime: "2006-01-02T15:04:05Z",
+			times:       []cpu.TimesStat{{CPU: "cpu0", User: 1.5, System: 2.7, Idle: 0.8}, {CPU: "cpu1", User: 2, System: 3, Idle: 1}},
+			scrapeTime:  "2006-01-02T15:04:05Z",
+			expectedDps: []dpData{},
 		},
 		{
 			times:      []cpu.TimesStat{{CPU: "cpu0", User: 2.8, System: 3.9, Idle: 3.3}, {CPU: "cpu1", User: 3.2, System: 5.2, Idle: 2.6}},
 			scrapeTime: "2006-01-02T15:04:10Z",
+			expectedDps: []dpData{
+				{val: 0.26, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
+				{val: 0.24, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
+				{val: 0.5, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
+				{val: 0.24, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
+				{val: 0.44, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
+				{val: 0.32, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
+			},
 		},
 		{
 			times:      []cpu.TimesStat{{CPU: "cpu0", User: 3.4, System: 5.3, Idle: 6.3}, {CPU: "cpu1", User: 3.7, System: 7.1, Idle: 5.2}},
 			scrapeTime: "2006-01-02T15:04:15Z",
-		},
-	}
-
-	testCases := []struct {
-		name                string
-		metricsConfig       metadata.MetricsBuilderConfig
-		perCPU              bool
-		expectedDpsByScrape [][]dpData
-	}{
-		{
-			name: "default attributes aggregate across cpu",
-			metricsConfig: func() metadata.MetricsBuilderConfig {
-				cfg := metadata.NewDefaultMetricsBuilderConfig()
-				cfg.Metrics.SystemCPUUtilization.Enabled = true
-				cfg.Metrics.SystemCPUTime.Enabled = false
-				return cfg
-			}(),
-			expectedDpsByScrape: [][]dpData{
-				{},
-				{
-					{val: 0.25, attrs: map[string]string{"state": "user"}},
-					{val: 0.34, attrs: map[string]string{"state": "system"}},
-					{val: 0.41, attrs: map[string]string{"state": "idle"}},
-				},
-				{
-					{val: 0.11, attrs: map[string]string{"state": "user"}},
-					{val: 0.33, attrs: map[string]string{"state": "system"}},
-					{val: 0.56, attrs: map[string]string{"state": "idle"}},
-				},
-			},
-		},
-		{
-			name:   "cpu attribute enabled",
-			perCPU: true,
-			metricsConfig: func() metadata.MetricsBuilderConfig {
-				cfg := metadata.NewDefaultMetricsBuilderConfig()
-				cfg.Metrics.SystemCPUUtilization.Enabled = true
-				cfg.Metrics.SystemCPUTime.Enabled = false
-				cfg.Metrics.SystemCPUUtilization.EnabledAttributes = []metadata.SystemCPUUtilizationMetricAttributeKey{
-					metadata.SystemCPUUtilizationMetricAttributeKeyCPU,
-					metadata.SystemCPUUtilizationMetricAttributeKeyState,
-				}
-				return cfg
-			}(),
-			expectedDpsByScrape: [][]dpData{
-				{},
-				{
-					{val: 0.26, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-					{val: 0.24, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-					{val: 0.5, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-					{val: 0.24, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-					{val: 0.44, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-					{val: 0.32, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
-				},
-				{
-					{val: 0.12, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
-					{val: 0.28, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
-					{val: 0.6, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
-					{val: 0.1, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
-					{val: 0.38, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
-					{val: 0.52, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
-				},
+			expectedDps: []dpData{
+				{val: 0.12, attrs: map[string]string{"cpu": "cpu0", "state": "user"}},
+				{val: 0.28, attrs: map[string]string{"cpu": "cpu0", "state": "system"}},
+				{val: 0.6, attrs: map[string]string{"cpu": "cpu0", "state": "idle"}},
+				{val: 0.1, attrs: map[string]string{"cpu": "cpu1", "state": "user"}},
+				{val: 0.38, attrs: map[string]string{"cpu": "cpu1", "state": "system"}},
+				{val: 0.52, attrs: map[string]string{"cpu": "cpu1", "state": "idle"}},
 			},
 		},
 	}
 
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: tt.metricsConfig})
-			for scrapeIdx, scrapeData := range scrapesData {
-				// mock TimeStats and Now
-				cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
-					return scrapeData.times, nil
-				}
-				cpuScraper.now = func() time.Time {
-					now, _ := time.Parse(time.RFC3339, scrapeData.scrapeTime)
-					return now
-				}
+	cpuScraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: overriddenMetricsSettings})
+	for _, scrapeData := range scrapesData {
+		// mock TimeStats and Now
+		cpuScraper.times = func(context.Context, bool) ([]cpu.TimesStat, error) {
+			return scrapeData.times, nil
+		}
+		cpuScraper.now = func() time.Time {
+			now, _ := time.Parse(time.RFC3339, scrapeData.scrapeTime)
+			return now
+		}
 
-				err := cpuScraper.start(t.Context(), componenttest.NewNopHost())
-				require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
+		err := cpuScraper.start(t.Context(), componenttest.NewNopHost())
+		require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
 
-				md, err := cpuScraper.scrape(t.Context())
-				require.NoError(t, err)
-				expectedDps := tt.expectedDpsByScrape[scrapeIdx]
-				// no metrics in the first scrape
-				if len(expectedDps) == 0 {
-					assert.Equal(t, 0, md.ResourceMetrics().Len())
-					continue
-				}
+		md, err := cpuScraper.scrape(t.Context())
+		require.NoError(t, err)
+		// no metrics in the first scrape
+		if len(scrapeData.expectedDps) == 0 {
+			assert.Equal(t, 0, md.ResourceMetrics().Len())
+			continue
+		}
 
-				assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
-				metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-				assertCPUUtilizationMetricDescriptor(t, metric, 0)
-				dp := metric.Gauge().DataPoints()
+		assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+		metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+		assertCPUUtilizationMetricDescriptor(t, metric, 0)
+		dp := metric.Gauge().DataPoints()
 
-				expectedDataPoints := expectedCPUStateDataPoints()
-				if tt.perCPU {
-					expectedDataPoints *= len(scrapeData.times)
-				}
-				if runtime.GOOS == "linux" {
-					assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, metric)
-				}
-				assert.Equal(t, expectedDataPoints, dp.Len())
+		expectedDataPoints := 8
+		if runtime.GOOS == "linux" {
+			expectedDataPoints = 16
+			assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, metric)
+		}
+		assert.Equal(t, expectedDataPoints, dp.Len())
 
-				// remove empty values to make the test more simple
-				dp.RemoveIf(func(n pmetric.NumberDataPoint) bool {
-					return n.DoubleValue() == 0.0
-				})
-
-				for idx, expectedDp := range expectedDps {
-					assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
-				}
-			}
+		// remove empty values to make the test more simple
+		dp.RemoveIf(func(n pmetric.NumberDataPoint) bool {
+			return n.DoubleValue() == 0.0
 		})
+
+		for idx, expectedDp := range scrapeData.expectedDps {
+			assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
+		}
 	}
 }
 
 func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberDataPoint, value float64, attrs map[string]string) {
-	require.Equal(t, len(attrs), dp.Attributes().Len())
 	assert.InDelta(t, value, dp.DoubleValue(), 0.0001)
 	for k, v := range attrs {
 		cpuAttribute, exists := dp.Attributes().Get(k)
@@ -549,7 +432,7 @@ func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberData
 	}
 }
 
-func assertCPUMetricDescriptor(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
+func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.time")
 	expected.SetDescription("Total seconds each logical CPU spent on each mode.")
@@ -559,12 +442,13 @@ func assertCPUMetricDescriptor(t *testing.T, metric pmetric.Metric, startTime pc
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, metric, startTime)
 	}
-}
-
-func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
-	assertCPUMetricDescriptor(t, metric, startTime)
-	assert.Equal(t, expectedCPUStateDataPoints(), metric.Sum().DataPoints().Len())
-	assertMetricDoesNotHaveAttribute(t, metric.Sum().DataPoints().At(0), "cpu")
+	expectedDataPoints := 4
+	if runtime.GOOS == "linux" {
+		expectedDataPoints = 8
+	}
+	require.Equal(t, expectedDataPoints, metric.Sum().DataPoints().Len())
+	_, exists := metric.Sum().DataPoints().At(0).Attributes().Get("cpu")
+	assert.False(t, exists)
 	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueStr(metadata.AttributeStateUser.String()))
 	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "state",
@@ -630,8 +514,13 @@ func assertCPUUtilizationMetricDescriptor(t *testing.T, metric pmetric.Metric, s
 
 func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	assertCPUUtilizationMetricDescriptor(t, metric, startTime)
-	assert.Equal(t, expectedCPUStateDataPoints(), metric.Gauge().DataPoints().Len())
-	assertMetricDoesNotHaveAttribute(t, metric.Gauge().DataPoints().At(0), "cpu")
+	expectedDataPoints := 4
+	if runtime.GOOS == "linux" {
+		expectedDataPoints = 8
+	}
+	require.Equal(t, expectedDataPoints, metric.Gauge().DataPoints().Len())
+	_, exists := metric.Gauge().DataPoints().At(0).Attributes().Get("cpu")
+	assert.False(t, exists)
 	internal.AssertGaugeMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueStr(metadata.AttributeStateUser.String()))
 	internal.AssertGaugeMetricHasAttributeValue(t, metric, 1, "state",
@@ -640,18 +529,6 @@ func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startT
 		pcommon.NewValueStr(metadata.AttributeStateIdle.String()))
 	internal.AssertGaugeMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueStr(metadata.AttributeStateInterrupt.String()))
-}
-
-func expectedCPUStateDataPoints() int {
-	if runtime.GOOS == "linux" {
-		return 8
-	}
-	return 4
-}
-
-func assertMetricDoesNotHaveAttribute(t *testing.T, dp pmetric.NumberDataPoint, name string) {
-	_, exists := dp.Attributes().Get(name)
-	assert.Falsef(t, exists, "Unexpected attribute %q", name)
 }
 
 func assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Metric) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -24,7 +24,7 @@ Total seconds each logical CPU spent on each mode.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| cpu | Logical CPU number starting at 0. | Any Str | Recommended | - |
+| cpu | Logical CPU number starting at 0. | Any Str | Opt-In | - |
 | state | Breakdown of CPU usage by type. | Str: ``idle``, ``interrupt``, ``nice``, ``softirq``, ``steal``, ``system``, ``user``, ``wait`` | Recommended | - |
 
 ## Optional Metrics
@@ -79,5 +79,5 @@ Difference in system.cpu.time since the last measurement per logical CPU, divide
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| cpu | Logical CPU number starting at 0. | Any Str | Recommended | - |
+| cpu | Logical CPU number starting at 0. | Any Str | Opt-In | - |
 | state | Breakdown of CPU usage by type. | Str: ``idle``, ``interrupt``, ``nice``, ``softirq``, ``steal``, ``system``, ``user``, ``wait`` | Recommended | - |

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -49,7 +49,7 @@ Current frequency of the CPU core in Hz.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| cpu | Logical CPU number starting at 0. | Any Str | Recommended | - |
+| cpu | Logical CPU number starting at 0. | Any Str | Opt-In | - |
 
 ### system.cpu.logical.count
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -49,7 +49,7 @@ Current frequency of the CPU core in Hz.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| cpu | Logical CPU number starting at 0. | Any Str | Opt-In | - |
+| cpu | Logical CPU number starting at 0. | Any Str | Recommended | - |
 
 ### system.cpu.logical.count
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
@@ -100,8 +100,8 @@ func (ms *SystemCPUPhysicalCountMetricConfig) Unmarshal(parser *confmap.Conf) er
 type SystemCPUTimeMetricAttributeKey string
 
 const (
-	SystemCPUTimeMetricAttributeKeyCPULogicalNumber SystemCPUTimeMetricAttributeKey = "cpu"
-	SystemCPUTimeMetricAttributeKeyState            SystemCPUTimeMetricAttributeKey = "state"
+	SystemCPUTimeMetricAttributeKeyCPU   SystemCPUTimeMetricAttributeKey = "cpu"
+	SystemCPUTimeMetricAttributeKeyState SystemCPUTimeMetricAttributeKey = "state"
 )
 
 // SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
@@ -130,7 +130,7 @@ func (ms *SystemCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 func (ms *SystemCPUTimeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemCPUTimeMetricAttributeKeyCPULogicalNumber, SystemCPUTimeMetricAttributeKeyState:
+		case SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState:
 		default:
 			return fmt.Errorf("metric system.cpu.time doesn't have an attribute %v, valid attributes: [cpu, state]", val)
 		}
@@ -149,8 +149,8 @@ func (ms *SystemCPUTimeMetricConfig) Validate() error {
 type SystemCPUUtilizationMetricAttributeKey string
 
 const (
-	SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber SystemCPUUtilizationMetricAttributeKey = "cpu"
-	SystemCPUUtilizationMetricAttributeKeyState            SystemCPUUtilizationMetricAttributeKey = "state"
+	SystemCPUUtilizationMetricAttributeKeyCPU   SystemCPUUtilizationMetricAttributeKey = "cpu"
+	SystemCPUUtilizationMetricAttributeKeyState SystemCPUUtilizationMetricAttributeKey = "state"
 )
 
 // SystemCPUUtilizationMetricConfig provides config for the system.cpu.utilization metric.
@@ -179,7 +179,7 @@ func (ms *SystemCPUUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) erro
 func (ms *SystemCPUUtilizationMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationMetricAttributeKeyState:
+		case SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState:
 		default:
 			return fmt.Errorf("metric system.cpu.utilization doesn't have an attribute %v, valid attributes: [cpu, state]", val)
 		}
@@ -208,7 +208,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		SystemCPUFrequency: SystemCPUFrequencyMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPU},
+			EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{},
 		},
 		SystemCPULogicalCount: SystemCPULogicalCountMetricConfig{
 			Enabled: false,

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
@@ -12,7 +12,7 @@ import (
 type SystemCPUFrequencyMetricAttributeKey string
 
 const (
-	SystemCPUFrequencyMetricAttributeKeyCPU SystemCPUFrequencyMetricAttributeKey = "cpu"
+	SystemCPUFrequencyMetricAttributeKeyCPUFrequency SystemCPUFrequencyMetricAttributeKey = "cpu"
 )
 
 // SystemCPUFrequencyMetricConfig provides config for the system.cpu.frequency metric.
@@ -41,7 +41,7 @@ func (ms *SystemCPUFrequencyMetricConfig) Unmarshal(parser *confmap.Conf) error 
 func (ms *SystemCPUFrequencyMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemCPUFrequencyMetricAttributeKeyCPU:
+		case SystemCPUFrequencyMetricAttributeKeyCPUFrequency:
 		default:
 			return fmt.Errorf("metric system.cpu.frequency doesn't have an attribute %v, valid attributes: [cpu]", val)
 		}
@@ -208,7 +208,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		SystemCPUFrequency: SystemCPUFrequencyMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{},
+			EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPUFrequency},
 		},
 		SystemCPULogicalCount: SystemCPULogicalCountMetricConfig{
 			Enabled: false,

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
@@ -100,8 +100,8 @@ func (ms *SystemCPUPhysicalCountMetricConfig) Unmarshal(parser *confmap.Conf) er
 type SystemCPUTimeMetricAttributeKey string
 
 const (
-	SystemCPUTimeMetricAttributeKeyCPU   SystemCPUTimeMetricAttributeKey = "cpu"
-	SystemCPUTimeMetricAttributeKeyState SystemCPUTimeMetricAttributeKey = "state"
+	SystemCPUTimeMetricAttributeKeyCPULogicalNumber SystemCPUTimeMetricAttributeKey = "cpu"
+	SystemCPUTimeMetricAttributeKeyState            SystemCPUTimeMetricAttributeKey = "state"
 )
 
 // SystemCPUTimeMetricConfig provides config for the system.cpu.time metric.
@@ -130,7 +130,7 @@ func (ms *SystemCPUTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 func (ms *SystemCPUTimeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState:
+		case SystemCPUTimeMetricAttributeKeyCPULogicalNumber, SystemCPUTimeMetricAttributeKeyState:
 		default:
 			return fmt.Errorf("metric system.cpu.time doesn't have an attribute %v, valid attributes: [cpu, state]", val)
 		}
@@ -149,8 +149,8 @@ func (ms *SystemCPUTimeMetricConfig) Validate() error {
 type SystemCPUUtilizationMetricAttributeKey string
 
 const (
-	SystemCPUUtilizationMetricAttributeKeyCPU   SystemCPUUtilizationMetricAttributeKey = "cpu"
-	SystemCPUUtilizationMetricAttributeKeyState SystemCPUUtilizationMetricAttributeKey = "state"
+	SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber SystemCPUUtilizationMetricAttributeKey = "cpu"
+	SystemCPUUtilizationMetricAttributeKeyState            SystemCPUUtilizationMetricAttributeKey = "state"
 )
 
 // SystemCPUUtilizationMetricConfig provides config for the system.cpu.utilization metric.
@@ -179,7 +179,7 @@ func (ms *SystemCPUUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) erro
 func (ms *SystemCPUUtilizationMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState:
+		case SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationMetricAttributeKeyState:
 		default:
 			return fmt.Errorf("metric system.cpu.utilization doesn't have an attribute %v, valid attributes: [cpu, state]", val)
 		}
@@ -219,12 +219,12 @@ func DefaultMetricsConfig() MetricsConfig {
 		SystemCPUTime: SystemCPUTimeMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState},
+			EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyState},
 		},
 		SystemCPUUtilization: SystemCPUUtilizationMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState},
+			EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyState},
 		},
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
@@ -40,12 +40,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPULogicalNumber, SystemCPUTimeMetricAttributeKeyState},
 					},
 					SystemCPUUtilization: SystemCPUUtilizationMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationMetricAttributeKeyState},
 					},
 				},
 			},
@@ -68,12 +68,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPULogicalNumber, SystemCPUTimeMetricAttributeKeyState},
 					},
 					SystemCPUUtilization: SystemCPUUtilizationMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationMetricAttributeKeyState},
 					},
 				},
 			},

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
@@ -40,12 +40,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPULogicalNumber, SystemCPUTimeMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState},
 					},
 					SystemCPUUtilization: SystemCPUUtilizationMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState},
 					},
 				},
 			},
@@ -68,12 +68,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUTime: SystemCPUTimeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPULogicalNumber, SystemCPUTimeMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUTimeMetricAttributeKey{SystemCPUTimeMetricAttributeKeyCPU, SystemCPUTimeMetricAttributeKeyState},
 					},
 					SystemCPUUtilization: SystemCPUUtilizationMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber, SystemCPUUtilizationMetricAttributeKeyState},
+						EnabledAttributes:   []SystemCPUUtilizationMetricAttributeKey{SystemCPUUtilizationMetricAttributeKeyCPU, SystemCPUUtilizationMetricAttributeKeyState},
 					},
 				},
 			},

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
@@ -29,7 +29,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUFrequency: SystemCPUFrequencyMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPU},
+						EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPUFrequency},
 					},
 					SystemCPULogicalCount: SystemCPULogicalCountMetricConfig{
 						Enabled: true,
@@ -57,7 +57,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemCPUFrequency: SystemCPUFrequencyMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPU},
+						EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPUFrequency},
 					},
 					SystemCPULogicalCount: SystemCPULogicalCountMetricConfig{
 						Enabled: false,

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -73,7 +73,7 @@ var MapAttributeState = map[string]AttributeState{
 var MetricsInfo = metricsInfo{
 	SystemCPUFrequency: metricInfo{
 		Name:       "system.cpu.frequency",
-		Attributes: []string{"cpu"},
+		Attributes: []string{"cpu.frequency"},
 	},
 	SystemCPULogicalCount: metricInfo{
 		Name: "system.cpu.logical.count",
@@ -121,7 +121,7 @@ func (m *metricSystemCPUFrequency) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSystemCPUFrequency) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string) {
+func (m *metricSystemCPUFrequency) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuFrequencyAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -129,8 +129,8 @@ func (m *metricSystemCPUFrequency) recordDataPoint(start pcommon.Timestamp, ts p
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemCPUFrequencyMetricAttributeKeyCPU) {
-		dp.Attributes().PutStr("cpu", cpuAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SystemCPUFrequencyMetricAttributeKeyCPUFrequency) {
+		dp.Attributes().PutStr("cpu", cpuFrequencyAttributeValue)
 	}
 
 	var s string
@@ -619,8 +619,8 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordSystemCPUFrequencyDataPoint adds a data point to system.cpu.frequency metric.
-func (mb *MetricsBuilder) RecordSystemCPUFrequencyDataPoint(ts pcommon.Timestamp, val float64, cpuAttributeValue string) {
-	mb.metricSystemCPUFrequency.recordDataPoint(mb.startTime, ts, val, cpuAttributeValue)
+func (mb *MetricsBuilder) RecordSystemCPUFrequencyDataPoint(ts pcommon.Timestamp, val float64, cpuFrequencyAttributeValue string) {
+	mb.metricSystemCPUFrequency.recordDataPoint(mb.startTime, ts, val, cpuFrequencyAttributeValue)
 }
 
 // RecordSystemCPULogicalCountDataPoint adds a data point to system.cpu.logical.count metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -316,7 +316,7 @@ func (m *metricSystemCPUTime) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue string) {
+func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -324,8 +324,8 @@ func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyCPULogicalNumber) {
-		dp.Attributes().PutStr("cpu", cpuLogicalNumberAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyCPU) {
+		dp.Attributes().PutStr("cpu", cpuAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyState) {
 		dp.Attributes().PutStr("state", stateAttributeValue)
@@ -408,7 +408,7 @@ func (m *metricSystemCPUUtilization) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue string) {
+func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -416,8 +416,8 @@ func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber) {
-		dp.Attributes().PutStr("cpu", cpuLogicalNumberAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SystemCPUUtilizationMetricAttributeKeyCPU) {
+		dp.Attributes().PutStr("cpu", cpuAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, SystemCPUUtilizationMetricAttributeKeyState) {
 		dp.Attributes().PutStr("state", stateAttributeValue)
@@ -634,13 +634,13 @@ func (mb *MetricsBuilder) RecordSystemCPUPhysicalCountDataPoint(ts pcommon.Times
 }
 
 // RecordSystemCPUTimeDataPoint adds a data point to system.cpu.time metric.
-func (mb *MetricsBuilder) RecordSystemCPUTimeDataPoint(ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue AttributeState) {
-	mb.metricSystemCPUTime.recordDataPoint(mb.startTime, ts, val, cpuLogicalNumberAttributeValue, stateAttributeValue.String())
+func (mb *MetricsBuilder) RecordSystemCPUTimeDataPoint(ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue AttributeState) {
+	mb.metricSystemCPUTime.recordDataPoint(mb.startTime, ts, val, cpuAttributeValue, stateAttributeValue.String())
 }
 
 // RecordSystemCPUUtilizationDataPoint adds a data point to system.cpu.utilization metric.
-func (mb *MetricsBuilder) RecordSystemCPUUtilizationDataPoint(ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue AttributeState) {
-	mb.metricSystemCPUUtilization.recordDataPoint(mb.startTime, ts, val, cpuLogicalNumberAttributeValue, stateAttributeValue.String())
+func (mb *MetricsBuilder) RecordSystemCPUUtilizationDataPoint(ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue AttributeState) {
+	mb.metricSystemCPUUtilization.recordDataPoint(mb.startTime, ts, val, cpuAttributeValue, stateAttributeValue.String())
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -316,7 +316,7 @@ func (m *metricSystemCPUTime) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
+func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -324,8 +324,8 @@ func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyCPU) {
-		dp.Attributes().PutStr("cpu", cpuAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyCPULogicalNumber) {
+		dp.Attributes().PutStr("cpu", cpuLogicalNumberAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, SystemCPUTimeMetricAttributeKeyState) {
 		dp.Attributes().PutStr("state", stateAttributeValue)
@@ -408,7 +408,7 @@ func (m *metricSystemCPUUtilization) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
+func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -416,8 +416,8 @@ func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemCPUUtilizationMetricAttributeKeyCPU) {
-		dp.Attributes().PutStr("cpu", cpuAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SystemCPUUtilizationMetricAttributeKeyCPULogicalNumber) {
+		dp.Attributes().PutStr("cpu", cpuLogicalNumberAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, SystemCPUUtilizationMetricAttributeKeyState) {
 		dp.Attributes().PutStr("state", stateAttributeValue)
@@ -634,13 +634,13 @@ func (mb *MetricsBuilder) RecordSystemCPUPhysicalCountDataPoint(ts pcommon.Times
 }
 
 // RecordSystemCPUTimeDataPoint adds a data point to system.cpu.time metric.
-func (mb *MetricsBuilder) RecordSystemCPUTimeDataPoint(ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue AttributeState) {
-	mb.metricSystemCPUTime.recordDataPoint(mb.startTime, ts, val, cpuAttributeValue, stateAttributeValue.String())
+func (mb *MetricsBuilder) RecordSystemCPUTimeDataPoint(ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue AttributeState) {
+	mb.metricSystemCPUTime.recordDataPoint(mb.startTime, ts, val, cpuLogicalNumberAttributeValue, stateAttributeValue.String())
 }
 
 // RecordSystemCPUUtilizationDataPoint adds a data point to system.cpu.utilization metric.
-func (mb *MetricsBuilder) RecordSystemCPUUtilizationDataPoint(ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue AttributeState) {
-	mb.metricSystemCPUUtilization.recordDataPoint(mb.startTime, ts, val, cpuAttributeValue, stateAttributeValue.String())
+func (mb *MetricsBuilder) RecordSystemCPUUtilizationDataPoint(ts pcommon.Timestamp, val float64, cpuLogicalNumberAttributeValue string, stateAttributeValue AttributeState) {
+	mb.metricSystemCPUUtilization.recordDataPoint(mb.startTime, ts, val, cpuLogicalNumberAttributeValue, stateAttributeValue.String())
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -71,9 +71,9 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount := 0
 
 			allMetricsCount++
-			mb.RecordSystemCPUFrequencyDataPoint(ts, 1, "cpu-val")
+			mb.RecordSystemCPUFrequencyDataPoint(ts, 1, "cpu.frequency-val")
 			if tt.name == "reaggregate_set" {
-				mb.RecordSystemCPUFrequencyDataPoint(ts, 3, "cpu-val-2")
+				mb.RecordSystemCPUFrequencyDataPoint(ts, 3, "cpu.frequency-val-2")
 			}
 
 			allMetricsCount++
@@ -140,6 +140,9 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						cpuFrequencyAttrVal, ok := dp.Attributes().Get("cpu")
+						assert.True(t, ok)
+						assert.Equal(t, "cpu.frequency-val", cpuFrequencyAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["system.cpu.frequency"], "Found a duplicate in the metrics slice: system.cpu.frequency")
 						validatedMetrics["system.cpu.frequency"] = true

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -83,15 +83,15 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSystemCPUPhysicalCountDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordSystemCPUTimeDataPoint(ts, 1, "cpu.logical_number-val", AttributeStateIdle)
+			mb.RecordSystemCPUTimeDataPoint(ts, 1, "cpu-val", AttributeStateIdle)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSystemCPUTimeDataPoint(ts, 3, "cpu.logical_number-val-2", AttributeStateInterrupt)
+				mb.RecordSystemCPUTimeDataPoint(ts, 3, "cpu-val-2", AttributeStateInterrupt)
 			}
 
 			allMetricsCount++
-			mb.RecordSystemCPUUtilizationDataPoint(ts, 1, "cpu.logical_number-val", AttributeStateIdle)
+			mb.RecordSystemCPUUtilizationDataPoint(ts, 1, "cpu-val", AttributeStateIdle)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSystemCPUUtilizationDataPoint(ts, 3, "cpu.logical_number-val-2", AttributeStateInterrupt)
+				mb.RecordSystemCPUUtilizationDataPoint(ts, 3, "cpu-val-2", AttributeStateInterrupt)
 			}
 
 			res := pcommon.NewResource()
@@ -140,9 +140,6 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						cpuAttrVal, ok := dp.Attributes().Get("cpu")
-						assert.True(t, ok)
-						assert.Equal(t, "cpu-val", cpuAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["system.cpu.frequency"], "Found a duplicate in the metrics slice: system.cpu.frequency")
 						validatedMetrics["system.cpu.frequency"] = true

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -83,15 +83,15 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSystemCPUPhysicalCountDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordSystemCPUTimeDataPoint(ts, 1, "cpu-val", AttributeStateIdle)
+			mb.RecordSystemCPUTimeDataPoint(ts, 1, "cpu.logical_number-val", AttributeStateIdle)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSystemCPUTimeDataPoint(ts, 3, "cpu-val-2", AttributeStateInterrupt)
+				mb.RecordSystemCPUTimeDataPoint(ts, 3, "cpu.logical_number-val-2", AttributeStateInterrupt)
 			}
 
 			allMetricsCount++
-			mb.RecordSystemCPUUtilizationDataPoint(ts, 1, "cpu-val", AttributeStateIdle)
+			mb.RecordSystemCPUUtilizationDataPoint(ts, 1, "cpu.logical_number-val", AttributeStateIdle)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSystemCPUUtilizationDataPoint(ts, 3, "cpu-val-2", AttributeStateInterrupt)
+				mb.RecordSystemCPUUtilizationDataPoint(ts, 3, "cpu.logical_number-val-2", AttributeStateInterrupt)
 			}
 
 			res := pcommon.NewResource()
@@ -210,9 +210,6 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						cpuAttrVal, ok := dp.Attributes().Get("cpu")
-						assert.True(t, ok)
-						assert.Equal(t, "cpu-val", cpuAttrVal.Str())
 						stateAttrVal, ok := dp.Attributes().Get("state")
 						assert.True(t, ok)
 						assert.Equal(t, "idle", stateAttrVal.Str())
@@ -257,9 +254,6 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
-						cpuAttrVal, ok := dp.Attributes().Get("cpu")
-						assert.True(t, ok)
-						assert.Equal(t, "cpu-val", cpuAttrVal.Str())
 						stateAttrVal, ok := dp.Attributes().Get("state")
 						assert.True(t, ok)
 						assert.Equal(t, "idle", stateAttrVal.Str())

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -16,6 +16,11 @@ attributes:
     type: string
     requirement_level: opt_in
 
+  cpu.frequency:
+    name_override: cpu
+    description: Logical CPU number starting at 0.
+    type: string
+
   state:
     description: Breakdown of CPU usage by type.
     type: string
@@ -30,7 +35,7 @@ metrics:
     stability: development
     gauge:
       value_type: double
-    attributes: [cpu]
+    attributes: [cpu.frequency]
 
   system.cpu.logical.count:
     enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -14,12 +14,6 @@ attributes:
   cpu:
     description: Logical CPU number starting at 0.
     type: string
-    requirement_level: recommended
-
-  cpu.logical_number:
-    name_override: cpu
-    description: Logical CPU number starting at 0.
-    type: string
     requirement_level: opt_in
 
   state:
@@ -67,7 +61,7 @@ metrics:
       value_type: double
       aggregation_temporality: cumulative
       monotonic: true
-    attributes: [cpu.logical_number, state]
+    attributes: [cpu, state]
 
   system.cpu.utilization:
     enabled: false
@@ -76,4 +70,4 @@ metrics:
     stability: development
     gauge:
       value_type: double
-    attributes: [cpu.logical_number, state]
+    attributes: [cpu, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -16,6 +16,12 @@ attributes:
     type: string
     requirement_level: recommended
 
+  cpu.logical_number:
+    name_override: cpu
+    description: Logical CPU number starting at 0.
+    type: string
+    requirement_level: opt_in
+
   state:
     description: Breakdown of CPU usage by type.
     type: string
@@ -61,7 +67,7 @@ metrics:
       value_type: double
       aggregation_temporality: cumulative
       monotonic: true
-    attributes: [cpu, state]
+    attributes: [cpu.logical_number, state]
 
   system.cpu.utilization:
     enabled: false
@@ -70,4 +76,4 @@ metrics:
     stability: development
     gauge:
       value_type: double
-    attributes: [cpu, state]
+    attributes: [cpu.logical_number, state]


### PR DESCRIPTION
Marks the host_metrics CPU scraper `cpu` attribute opt-in for `system.cpu.time`, `system.cpu.utilization`, so the default output is aggregated by state.

To restore the previous per-logical-CPU output, re-enable `cpu` attribute by applying the following config:
  ```yaml
  receivers:
    hostmetrics:
      scrapers:
        cpu:
          metrics:
            system.cpu.time:
              attributes: [cpu, state]
            system.cpu.utilization:
              attributes: [cpu, state]
```

Fixes #49161
