### PR TITLE
Support prob head based sampling for DD Connector stats calculation

### DIFF
--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -235,6 +235,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.155.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.155.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.155.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.155.0 // indirect
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/outcaste-io/ristretto v0.2.3 // indirect
@@ -407,3 +408,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/e
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => ../../pkg/datadog
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog => ../../internal/datadog
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -478,8 +478,6 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0 h1:BwhW8UIDFuhPMK9CvkFKANDwpZj8PUWrMbJCVk5uLPg=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0/go.mod h1:BkZ/+Z2dxFPSB0d/uyGmtlMFmkn/q1HURhfSg/HAiAk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0 h1:vt7mupvepVIO4XlZrJ+8yFECWxIqHMTAuEYFmsCbXao=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0/go.mod h1:xRRQmHi6lbHw3rxl94RpKM5nttEV5D2uTOO9fj9YUk4=
 github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 h1:Ot2fbEEPmF3WlPQkyEW/bUCV38GMugH/UmZvxpWceNc=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -346,3 +346,5 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -444,8 +444,6 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0 h1:BwhW8UIDFuhPMK9CvkFKANDwpZj8PUWrMbJCVk5uLPg=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0/go.mod h1:BkZ/+Z2dxFPSB0d/uyGmtlMFmkn/q1HURhfSg/HAiAk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0 h1:vt7mupvepVIO4XlZrJ+8yFECWxIqHMTAuEYFmsCbXao=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0/go.mod h1:xRRQmHi6lbHw3rxl94RpKM5nttEV5D2uTOO9fj9YUk4=
 github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 h1:Ot2fbEEPmF3WlPQkyEW/bUCV38GMugH/UmZvxpWceNc=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -246,6 +246,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.155.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.155.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.155.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.155.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.155.0 // indirect
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
@@ -432,3 +433,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog =>
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog => ../../../internal/datadog
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv => ../../../internal/gopsutilenv
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../../pkg/sampling

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -516,8 +516,6 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0 h1:BwhW8UIDFuhPMK9CvkFKANDwpZj8PUWrMbJCVk5uLPg=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0/go.mod h1:BkZ/+Z2dxFPSB0d/uyGmtlMFmkn/q1HURhfSg/HAiAk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0 h1:vt7mupvepVIO4XlZrJ+8yFECWxIqHMTAuEYFmsCbXao=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0/go.mod h1:xRRQmHi6lbHw3rxl94RpKM5nttEV5D2uTOO9fj9YUk4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -322,3 +322,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/commo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil => ../../internal/aws/ecsutil
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog => ../../internal/datadog
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling

--- a/pkg/datadog/apmstats/connector.go
+++ b/pkg/datadog/apmstats/connector.go
@@ -194,35 +194,17 @@ func (*traceToMetricConnector) Capabilities() consumer.Capabilities {
 }
 
 func (c *traceToMetricConnector) ConsumeTraces(_ context.Context, traces ptrace.Traces) error {
-	// Build a spanID→probability map from W3C tracestate values so we can
-	// inject _sample_rate into DD spans for correct Concentrator weighting.
-	sampleProbs := samplingProbsFromTraces(traces, c.logger)
-
-	c.logger.Debug("sampling probs from tracestate", zap.Int("span_count", len(sampleProbs)))
+	// Collect raw W3C tracestate strings keyed by span ID. No parsing happens
+	// here; tracestates are only parsed for spans that turn out to be chunk
+	// roots (see injectSampleRates).
+	rawTracestates := rawTracestatesBySpanID(traces)
 
 	inputs := otelstats.OTLPTracesToConcentratorInputsWithObfuscation(traces, c.tcfg, c.ctagKeys, c.peerTagKeys, c.obfuscator)
 
-	// Inject _sample_rate onto the root DD span of each trace chunk.
-	// The Concentrator reads weight only from pt.Root, so child spans are irrelevant.
-	if len(sampleProbs) > 0 {
-		for i := range inputs {
-			for j := range inputs[i].Traces {
-				root := inputs[i].Traces[j].Root
-				if root == nil {
-					continue
-				}
-				prob, ok := sampleProbs[root.SpanID]
-				if !ok {
-					continue
-				}
-				if _, exists := root.Metrics[keySamplingRateGlobal]; exists {
-					continue // preserve an explicitly set value from upstream
-				}
-				if root.Metrics == nil {
-					root.Metrics = make(map[string]float64)
-				}
-				root.Metrics[keySamplingRateGlobal] = prob
-			}
+	if len(rawTracestates) > 0 {
+		injected := injectSampleRates(inputs, rawTracestates, c.logger)
+		if injected > 0 {
+			c.logger.Debug("injected sampling probs from tracestate", zap.Int("root_count", injected))
 		}
 	}
 
@@ -230,6 +212,39 @@ func (c *traceToMetricConnector) ConsumeTraces(_ context.Context, traces ptrace.
 		c.concentrator.Add(input)
 	}
 	return nil
+}
+
+// injectSampleRates injects _sample_rate onto the root DD span of each trace
+// chunk whose root has a supported W3C tracestate sampling encoding. The
+// Concentrator reads weight only from pt.Root, so child spans are irrelevant
+// and only root tracestates are parsed. Returns the number of roots injected.
+func injectSampleRates(inputs []stats.Input, rawTracestates map[uint64]string, logger *zap.Logger) int {
+	injected := 0
+	for i := range inputs {
+		for j := range inputs[i].Traces {
+			root := inputs[i].Traces[j].Root
+			if root == nil {
+				continue
+			}
+			raw, ok := rawTracestates[root.SpanID]
+			if !ok {
+				continue
+			}
+			prob, ok := samplingProbFromTracestate(raw, logger)
+			if !ok {
+				continue
+			}
+			if _, exists := root.Metrics[keySamplingRateGlobal]; exists {
+				continue // preserve an explicitly set value from upstream
+			}
+			if root.Metrics == nil {
+				root.Metrics = make(map[string]float64)
+			}
+			root.Metrics[keySamplingRateGlobal] = prob
+			injected++
+		}
+	}
+	return injected
 }
 
 // run awaits incoming stats resulting from the agent's ingestion, converts them

--- a/pkg/datadog/apmstats/connector.go
+++ b/pkg/datadog/apmstats/connector.go
@@ -194,7 +194,38 @@ func (*traceToMetricConnector) Capabilities() consumer.Capabilities {
 }
 
 func (c *traceToMetricConnector) ConsumeTraces(_ context.Context, traces ptrace.Traces) error {
+	// Build a spanID→probability map from W3C tracestate values so we can
+	// inject _sample_rate into DD spans for correct Concentrator weighting.
+	sampleProbs := samplingProbsFromTraces(traces, c.logger)
+
+	c.logger.Debug("sampling probs from tracestate", zap.Int("span_count", len(sampleProbs)))
+
 	inputs := otelstats.OTLPTracesToConcentratorInputsWithObfuscation(traces, c.tcfg, c.ctagKeys, c.peerTagKeys, c.obfuscator)
+
+	// Inject _sample_rate onto the root DD span of each trace chunk.
+	// The Concentrator reads weight only from pt.Root, so child spans are irrelevant.
+	if len(sampleProbs) > 0 {
+		for i := range inputs {
+			for j := range inputs[i].Traces {
+				root := inputs[i].Traces[j].Root
+				if root == nil {
+					continue
+				}
+				prob, ok := sampleProbs[root.SpanID]
+				if !ok {
+					continue
+				}
+				if _, exists := root.Metrics[keySamplingRateGlobal]; exists {
+					continue // preserve an explicitly set value from upstream
+				}
+				if root.Metrics == nil {
+					root.Metrics = make(map[string]float64)
+				}
+				root.Metrics[keySamplingRateGlobal] = prob
+			}
+		}
+	}
+
 	for _, input := range inputs {
 		c.concentrator.Add(input)
 	}

--- a/pkg/datadog/apmstats/connector_test.go
+++ b/pkg/datadog/apmstats/connector_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 	otlpmetrics "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	otelstats "github.com/DataDog/datadog-agent/pkg/trace/otel/stats"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,8 +31,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
-
-	otelstats "github.com/DataDog/datadog-agent/pkg/trace/otel/stats"
 
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/internal/metadata"

--- a/pkg/datadog/apmstats/connector_test.go
+++ b/pkg/datadog/apmstats/connector_test.go
@@ -31,6 +31,8 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	otelstats "github.com/DataDog/datadog-agent/pkg/trace/otel/stats"
+
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/internal/metadata"
 )
@@ -533,6 +535,160 @@ func (es *errorSink) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) err
 		return es.err
 	}
 	return es.MetricsSink.ConsumeMetrics(ctx, md)
+}
+
+// TestSamplingWeightFromTracestate verifies that W3C tracestate th values drive
+// Concentrator weighting. The Concentrator reads _sample_rate from the root span
+// of each trace chunk and applies that weight to every span in the chunk, so the
+// th value on the root span controls the Hits count for the whole trace.
+func TestSamplingWeightFromTracestate(t *testing.T) {
+	if err := featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", true); err != nil {
+		t.Fatal(err)
+	}
+	cfg := NewConnectorFactory(datadogComponentType, component.StabilityLevelBeta, component.StabilityLevelBeta, nil, nil, nil).CreateDefaultConfig().(*datadogconfig.ConnectorComponentConfig)
+	cfg.Traces.ComputeTopLevelBySpanKind = true
+	connector, metricsSink := createConnectorCfg(t, cfg)
+	err := connector.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, connector.Shutdown(t.Context()))
+	}()
+
+	// Trace A: single root Server span with ot=th:8 (50% sampling).
+	// weight = 1/0.5 = 2, so Hits should be 2.
+	traceA := ptrace.NewTraces()
+	resA := traceA.ResourceSpans().AppendEmpty().Resource()
+	resA.Attributes().PutStr("service.name", "weight-test-svc")
+	resA.Attributes().PutStr("deployment.environment.name", "test-env")
+	ssA := traceA.ResourceSpans().At(0).ScopeSpans().AppendEmpty().Spans()
+	spanA := ssA.AppendEmpty()
+	spanA.SetName("sampled-op")
+	spanA.SetKind(ptrace.SpanKindServer)
+	spanA.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	spanA.SetSpanID(pcommon.SpanID([8]byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22}))
+	spanA.SetStartTimestamp(spanStartTimestamp)
+	spanA.SetEndTimestamp(spanEndTimestamp)
+	spanA.TraceState().FromRaw("ot=th:8") // 50% sampling → weight=2
+
+	// Trace B: single root Server span with no tracestate.
+	// weight = 1, so Hits should be 1.
+	traceB := ptrace.NewTraces()
+	resB := traceB.ResourceSpans().AppendEmpty().Resource()
+	resB.Attributes().PutStr("service.name", "weight-test-svc")
+	resB.Attributes().PutStr("deployment.environment.name", "test-env")
+	ssB := traceB.ResourceSpans().At(0).ScopeSpans().AppendEmpty().Spans()
+	spanB := ssB.AppendEmpty()
+	spanB.SetName("unsampled-op")
+	spanB.SetKind(ptrace.SpanKindServer)
+	spanB.SetTraceID(pcommon.TraceID([16]byte{2, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	spanB.SetSpanID(pcommon.SpanID([8]byte{0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA}))
+	spanB.SetStartTimestamp(spanStartTimestamp)
+	spanB.SetEndTimestamp(spanEndTimestamp)
+	// no tracestate
+
+	err = connector.ConsumeTraces(t.Context(), traceA)
+	require.NoError(t, err)
+	err = connector.ConsumeTraces(t.Context(), traceB)
+	require.NoError(t, err)
+
+	timeout := time.Now().Add(1 * time.Minute)
+	for time.Now().Before(timeout) {
+		if len(metricsSink.AllMetrics()) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	metrics := metricsSink.AllMetrics()
+	require.NotEmpty(t, metrics)
+
+	ch := make(chan []byte, 100)
+	tr := newTranslatorWithStatsChannel(t, zap.NewNop(), ch)
+	_, err = tr.MapMetrics(t.Context(), metrics[0], nil, nil)
+	require.NoError(t, err)
+	msg := <-ch
+	sp := &pb.StatsPayload{}
+	require.NoError(t, proto.Unmarshal(msg, sp))
+
+	require.NotEmpty(t, sp.Stats)
+	require.NotEmpty(t, sp.Stats[0].Stats)
+
+	hitsByResource := make(map[string]uint64)
+	for _, bucket := range sp.Stats[0].Stats {
+		for _, cgs := range bucket.Stats {
+			hitsByResource[cgs.Resource] += cgs.Hits
+		}
+	}
+
+	// Trace A root has th:8 → _sample_rate=0.5 → weight=2 → Hits=2.
+	assert.Equal(t, uint64(2), hitsByResource["sampled-op"], "span with th:8 tracestate should have Hits=2 (weight=2)")
+	// Trace B root has no tracestate → weight=1 → Hits=1.
+	assert.Equal(t, uint64(1), hitsByResource["unsampled-op"], "span with no tracestate should have Hits=1 (weight=1)")
+}
+
+// TestSampleRateInjectedOnRoot checks that ConsumeTraces injects _sample_rate
+// onto the root DD span for both the th (threshold) and p (power-of-two)
+// tracestate encodings so the Concentrator computes the correct weight.
+// This exercises the full path: OTel tracestate → sampleProbs map → DD span
+// Metrics → Root.Metrics, without requiring the Concentrator to flush.
+func TestSampleRateInjectedOnRoot(t *testing.T) {
+	tests := []struct {
+		name       string
+		traceState string
+		wantRate   float64
+	}{
+		{"th encoding 50%", "ot=th:8", 0.5},
+		{"p encoding 50%", "ot=p:1;r:1", 0.5},
+		{"p encoding 6.25%", "ot=p:4;r:4", 0.0625},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+			traceID := pcommon.TraceID([16]byte{1})
+
+			td := ptrace.NewTraces()
+			rs := td.ResourceSpans().AppendEmpty()
+			rs.Resource().Attributes().PutStr("service.name", "svc")
+			ss := rs.ScopeSpans().AppendEmpty()
+			span := ss.Spans().AppendEmpty()
+			span.SetTraceID(traceID)
+			span.SetSpanID(rootID)
+			span.SetKind(ptrace.SpanKindServer)
+			span.SetStartTimestamp(spanStartTimestamp)
+			span.SetEndTimestamp(spanEndTimestamp)
+			span.TraceState().FromRaw(tt.traceState)
+
+			connector, _ := createConnector(t)
+
+			sampleProbs := samplingProbsFromTraces(td, nil)
+			require.NotEmpty(t, sampleProbs, "sampleProbs must contain an entry for tracestate %q", tt.traceState)
+
+			inputs := otelstats.OTLPTracesToConcentratorInputsWithObfuscation(
+				td, connector.tcfg, connector.ctagKeys, connector.peerTagKeys, connector.obfuscator,
+			)
+			require.Len(t, inputs, 1)
+			require.Len(t, inputs[0].Traces, 1)
+
+			// Run the injection logic from ConsumeTraces.
+			for _, ddSpan := range inputs[0].Traces[0].TraceChunk.Spans {
+				prob, ok := sampleProbs[ddSpan.SpanID]
+				if !ok {
+					continue
+				}
+				if ddSpan.Metrics == nil {
+					ddSpan.Metrics = make(map[string]float64)
+				}
+				ddSpan.Metrics[keySamplingRateGlobal] = prob
+			}
+
+			root := inputs[0].Traces[0].Root
+			require.NotNil(t, root)
+			rate, ok := root.Metrics[keySamplingRateGlobal]
+			require.True(t, ok, "root span must have _sample_rate set after injection")
+			assert.InDelta(t, tt.wantRate, rate, 1e-9)
+		})
+	}
 }
 
 func TestError(t *testing.T) {

--- a/pkg/datadog/apmstats/connector_test.go
+++ b/pkg/datadog/apmstats/connector_test.go
@@ -625,11 +625,12 @@ func TestSamplingWeightFromTracestate(t *testing.T) {
 	assert.Equal(t, uint64(1), hitsByResource["unsampled-op"], "span with no tracestate should have Hits=1 (weight=1)")
 }
 
-// TestSampleRateInjectedOnRoot checks that ConsumeTraces injects _sample_rate
-// onto the root DD span for both the th (threshold) and p (power-of-two)
-// tracestate encodings so the Concentrator computes the correct weight.
-// This exercises the full path: OTel tracestate → sampleProbs map → DD span
-// Metrics → Root.Metrics, without requiring the Concentrator to flush.
+// TestSampleRateInjectedOnRoot checks that injectSampleRates (the same helper
+// ConsumeTraces uses) injects _sample_rate onto the root DD span for both the
+// th (threshold) and p (power-of-two) tracestate encodings so the Concentrator
+// computes the correct weight. This exercises the full path: OTel tracestate →
+// raw tracestate map → DD span Metrics → Root.Metrics, without requiring the
+// Concentrator to flush.
 func TestSampleRateInjectedOnRoot(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -660,8 +661,8 @@ func TestSampleRateInjectedOnRoot(t *testing.T) {
 
 			connector, _ := createConnector(t)
 
-			sampleProbs := samplingProbsFromTraces(td, nil)
-			require.NotEmpty(t, sampleProbs, "sampleProbs must contain an entry for tracestate %q", tt.traceState)
+			rawTracestates := rawTracestatesBySpanID(td)
+			require.NotEmpty(t, rawTracestates, "rawTracestates must contain an entry for tracestate %q", tt.traceState)
 
 			inputs := otelstats.OTLPTracesToConcentratorInputsWithObfuscation(
 				td, connector.tcfg, connector.ctagKeys, connector.peerTagKeys, connector.obfuscator,
@@ -669,17 +670,8 @@ func TestSampleRateInjectedOnRoot(t *testing.T) {
 			require.Len(t, inputs, 1)
 			require.Len(t, inputs[0].Traces, 1)
 
-			// Run the injection logic from ConsumeTraces.
-			for _, ddSpan := range inputs[0].Traces[0].TraceChunk.Spans {
-				prob, ok := sampleProbs[ddSpan.SpanID]
-				if !ok {
-					continue
-				}
-				if ddSpan.Metrics == nil {
-					ddSpan.Metrics = make(map[string]float64)
-				}
-				ddSpan.Metrics[keySamplingRateGlobal] = prob
-			}
+			injected := injectSampleRates(inputs, rawTracestates, nil)
+			assert.Equal(t, 1, injected)
 
 			root := inputs[0].Traces[0].Root
 			require.NotNil(t, root)
@@ -688,6 +680,103 @@ func TestSampleRateInjectedOnRoot(t *testing.T) {
 			assert.InDelta(t, tt.wantRate, rate, 1e-9)
 		})
 	}
+}
+
+// TestSampleRatePreservesUpstreamValue verifies that injectSampleRates does not
+// overwrite an explicitly set upstream _sample_rate on the root span.
+func TestSampleRatePreservesUpstreamValue(t *testing.T) {
+	rootID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	traceID := pcommon.TraceID([16]byte{1})
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "svc")
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(traceID)
+	span.SetSpanID(rootID)
+	span.SetKind(ptrace.SpanKindServer)
+	span.SetStartTimestamp(spanStartTimestamp)
+	span.SetEndTimestamp(spanEndTimestamp)
+	span.TraceState().FromRaw("ot=th:8") // 50% → 0.5
+
+	connector, _ := createConnector(t)
+
+	rawTracestates := rawTracestatesBySpanID(td)
+	require.NotEmpty(t, rawTracestates)
+
+	inputs := otelstats.OTLPTracesToConcentratorInputsWithObfuscation(
+		td, connector.tcfg, connector.ctagKeys, connector.peerTagKeys, connector.obfuscator,
+	)
+	require.Len(t, inputs, 1)
+	require.Len(t, inputs[0].Traces, 1)
+
+	root := inputs[0].Traces[0].Root
+	require.NotNil(t, root)
+	if root.Metrics == nil {
+		root.Metrics = make(map[string]float64)
+	}
+	root.Metrics[keySamplingRateGlobal] = 0.25 // pre-existing upstream value
+
+	injected := injectSampleRates(inputs, rawTracestates, nil)
+	assert.Equal(t, 0, injected)
+
+	rate, ok := root.Metrics[keySamplingRateGlobal]
+	require.True(t, ok)
+	assert.InDelta(t, 0.25, rate, 1e-9, "upstream _sample_rate must be preserved")
+}
+
+// TestSampleRateIgnoresNonRootTracestate verifies that a tracestate on a child
+// span does not cause any _sample_rate injection. Only the root span's weight
+// matters to the Concentrator.
+func TestSampleRateIgnoresNonRootTracestate(t *testing.T) {
+	traceID := pcommon.TraceID([16]byte{1})
+	rootID := pcommon.SpanID(testSpanID1)
+	childID := pcommon.SpanID(testSpanID2)
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "svc")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	// Root span: no tracestate.
+	root := ss.Spans().AppendEmpty()
+	root.SetName("parent")
+	root.SetTraceID(traceID)
+	root.SetSpanID(rootID)
+	root.SetKind(ptrace.SpanKindServer)
+	root.SetStartTimestamp(spanStartTimestamp)
+	root.SetEndTimestamp(spanEndTimestamp)
+
+	// Child span: has a tracestate that should be ignored.
+	child := ss.Spans().AppendEmpty()
+	child.SetName("child")
+	child.SetTraceID(traceID)
+	child.SetSpanID(childID)
+	child.SetParentSpanID(rootID)
+	child.SetKind(ptrace.SpanKindClient)
+	child.SetStartTimestamp(spanStartTimestamp)
+	child.SetEndTimestamp(spanEndTimestamp)
+	child.TraceState().FromRaw("ot=th:8")
+
+	connector, _ := createConnector(t)
+
+	rawTracestates := rawTracestatesBySpanID(td)
+	require.NotEmpty(t, rawTracestates, "child tracestate should be collected into the map")
+
+	inputs := otelstats.OTLPTracesToConcentratorInputsWithObfuscation(
+		td, connector.tcfg, connector.ctagKeys, connector.peerTagKeys, connector.obfuscator,
+	)
+	require.Len(t, inputs, 1)
+	require.Len(t, inputs[0].Traces, 1)
+
+	injected := injectSampleRates(inputs, rawTracestates, nil)
+	assert.Equal(t, 0, injected)
+
+	ddRoot := inputs[0].Traces[0].Root
+	require.NotNil(t, ddRoot)
+	_, ok := ddRoot.Metrics[keySamplingRateGlobal]
+	assert.False(t, ok, "root must not have _sample_rate set from a child tracestate")
 }
 
 func TestError(t *testing.T) {

--- a/pkg/datadog/apmstats/sampling.go
+++ b/pkg/datadog/apmstats/sampling.go
@@ -21,7 +21,7 @@ const keySamplingRateGlobal = "_sample_rate"
 
 // samplingProbsFromTraces returns a map of DD span ID (uint64) to sampling
 // probability for each OTel span whose W3C tracestate contains a supported
-// sampling probability encoding (ot=th: or ot=p:). Spans without a recognised
+// sampling probability encoding (ot=th: or ot=p:). Spans without a recognized
 // encoding are omitted; the Concentrator defaults their weight to 1.
 func samplingProbsFromTraces(traces ptrace.Traces, logger *zap.Logger) map[uint64]float64 {
 	result := make(map[uint64]float64)

--- a/pkg/datadog/apmstats/sampling.go
+++ b/pkg/datadog/apmstats/sampling.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package apmstats // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/apmstats"
+
+import (
+	"math"
+	"strconv"
+
+	traceutilotel "github.com/DataDog/datadog-agent/pkg/trace/otel/traceutil"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+)
+
+// keySamplingRateGlobal mirrors the unexported constant in
+// github.com/DataDog/datadog-agent/pkg/trace/stats (weight.go).
+// Must stay in sync: the Concentrator reads this key to compute span weight.
+const keySamplingRateGlobal = "_sample_rate"
+
+// samplingProbsFromTraces returns a map of DD span ID (uint64) to sampling
+// probability for each OTel span whose W3C tracestate contains a supported
+// sampling probability encoding (ot=th: or ot=p:). Spans without a recognised
+// encoding are omitted; the Concentrator defaults their weight to 1.
+func samplingProbsFromTraces(traces ptrace.Traces, logger *zap.Logger) map[uint64]float64 {
+	result := make(map[uint64]float64)
+	rss := traces.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		sss := rss.At(i).ScopeSpans()
+		for j := 0; j < sss.Len(); j++ {
+			spans := sss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				prob, ok := samplingProbFromSpan(span, logger)
+				if ok {
+					result[traceutilotel.OTelSpanIDToUint64(span.SpanID())] = prob
+				}
+			}
+		}
+	}
+	return result
+}
+
+// samplingProbFromSpan extracts the sampling probability from a span's W3C
+// tracestate. Returns (probability, true) on success, (0, false) otherwise.
+//
+// Two encodings are supported:
+//   - th (threshold): OTel collector-contrib pkg/sampling samplers.
+//     e.g. "ot=th:8" → probability 0.5
+//   - p (power-of-two): go.opentelemetry.io/contrib/samplers/probability/consistent.
+//     e.g. "ot=p:1;r:1" → probability 2^-1 = 0.5
+func samplingProbFromSpan(span ptrace.Span, logger *zap.Logger) (float64, bool) {
+	raw := span.TraceState().AsRaw()
+	if raw == "" {
+		return 0, false
+	}
+	w3c, err := sampling.NewW3CTraceState(raw)
+	if err != nil {
+		// Malformed tracestate — log at debug so misconfigured tracers are
+		// diagnosable without being noisy in healthy pipelines.
+		if logger != nil {
+			logger.Debug("Failed to parse W3C tracestate for sampling probability",
+				zap.String("tracestate", raw), zap.Error(err))
+		}
+		return 0, false
+	}
+	otel := w3c.OTelValue()
+
+	// th encoding: used by the OTel collector-contrib pkg/sampling samplers.
+	if th, ok := otel.TValueThreshold(); ok {
+		return th.Probability(), true
+	}
+
+	// p encoding: used by go.opentelemetry.io/contrib/samplers/probability/consistent.
+	// p:N means sampling probability = 2^-N (e.g. p:1 → 0.5, p:4 → 1/16).
+	// Valid range is [0, 62]; p:63 is the reserved "not sampled" sentinel and
+	// carries no meaningful probability, so we skip it.
+	for _, kv := range otel.ExtraValues() {
+		if kv.Key != "p" {
+			continue
+		}
+		pVal, err := strconv.ParseUint(kv.Value, 10, 64)
+		if err != nil {
+			break
+		}
+		if pVal == 63 {
+			// Sentinel value meaning "not sampled"; no probability to extract.
+			break
+		}
+		if pVal > 63 {
+			break
+		}
+		if pVal == 0 {
+			return 1.0, true
+		}
+		return math.Pow(2, -float64(pVal)), true
+	}
+
+	return 0, false
+}

--- a/pkg/datadog/apmstats/sampling.go
+++ b/pkg/datadog/apmstats/sampling.go
@@ -4,7 +4,6 @@
 package apmstats // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/apmstats"
 
 import (
-	"math"
 	"strconv"
 
 	traceutilotel "github.com/DataDog/datadog-agent/pkg/trace/otel/traceutil"
@@ -19,12 +18,16 @@ import (
 // Must stay in sync: the Concentrator reads this key to compute span weight.
 const keySamplingRateGlobal = "_sample_rate"
 
-// samplingProbsFromTraces returns a map of DD span ID (uint64) to sampling
-// probability for each OTel span whose W3C tracestate contains a supported
-// sampling probability encoding (ot=th: or ot=p:). Spans without a recognized
-// encoding are omitted; the Concentrator defaults their weight to 1.
-func samplingProbsFromTraces(traces ptrace.Traces, logger *zap.Logger) map[uint64]float64 {
-	result := make(map[uint64]float64)
+// pValueNotSampled is the reserved p-value sentinel meaning "not sampled"
+// in the consistent-probability sampling encoding (p:63 has no probability).
+const pValueNotSampled = 63
+
+// rawTracestatesBySpanID returns a map of DD span ID (uint64) to the raw W3C
+// tracestate string for each OTel span that has a non-empty tracestate. No
+// parsing happens here; the tracestate is only parsed later for spans that
+// are actually chunk roots (see samplingProbFromTracestate).
+func rawTracestatesBySpanID(traces ptrace.Traces) map[uint64]string {
+	result := make(map[uint64]string)
 	rss := traces.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
 		sss := rss.At(i).ScopeSpans()
@@ -32,10 +35,11 @@ func samplingProbsFromTraces(traces ptrace.Traces, logger *zap.Logger) map[uint6
 			spans := sss.At(j).Spans()
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
-				prob, ok := samplingProbFromSpan(span, logger)
-				if ok {
-					result[traceutilotel.OTelSpanIDToUint64(span.SpanID())] = prob
+				raw := span.TraceState().AsRaw()
+				if raw == "" {
+					continue
 				}
+				result[traceutilotel.OTelSpanIDToUint64(span.SpanID())] = raw
 			}
 		}
 	}
@@ -51,7 +55,13 @@ func samplingProbsFromTraces(traces ptrace.Traces, logger *zap.Logger) map[uint6
 //   - p (power-of-two): go.opentelemetry.io/contrib/samplers/probability/consistent.
 //     e.g. "ot=p:1;r:1" → probability 2^-1 = 0.5
 func samplingProbFromSpan(span ptrace.Span, logger *zap.Logger) (float64, bool) {
-	raw := span.TraceState().AsRaw()
+	return samplingProbFromTracestate(span.TraceState().AsRaw(), logger)
+}
+
+// samplingProbFromTracestate extracts the sampling probability from a raw W3C
+// tracestate string. Returns (probability, true) on success, (0, false)
+// otherwise. See samplingProbFromSpan for the supported encodings.
+func samplingProbFromTracestate(raw string, logger *zap.Logger) (float64, bool) {
 	if raw == "" {
 		return 0, false
 	}
@@ -84,17 +94,14 @@ func samplingProbFromSpan(span ptrace.Span, logger *zap.Logger) (float64, bool) 
 		if err != nil {
 			break
 		}
-		if pVal == 63 {
+		if pVal >= pValueNotSampled {
 			// Sentinel value meaning "not sampled"; no probability to extract.
-			break
-		}
-		if pVal > 63 {
 			break
 		}
 		if pVal == 0 {
 			return 1.0, true
 		}
-		return math.Pow(2, -float64(pVal)), true
+		return 1.0 / float64(uint64(1)<<pVal), true
 	}
 
 	return 0, false

--- a/pkg/datadog/apmstats/sampling_test.go
+++ b/pkg/datadog/apmstats/sampling_test.go
@@ -102,7 +102,7 @@ func TestSamplingProbFromSpan_MalformedTracestate(t *testing.T) {
 	})
 }
 
-func TestSamplingProbsFromTraces(t *testing.T) {
+func TestRawTracestatesBySpanID(t *testing.T) {
 	spanID1 := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 	spanID2 := [8]byte{9, 10, 11, 12, 13, 14, 15, 16}
 
@@ -110,7 +110,7 @@ func TestSamplingProbsFromTraces(t *testing.T) {
 	rs := td.ResourceSpans().AppendEmpty()
 	ss := rs.ScopeSpans().AppendEmpty()
 
-	// Span 1: 50% sampling via th:8
+	// Span 1: has a tracestate
 	s1 := ss.Spans().AppendEmpty()
 	s1.SetSpanID(pcommon.SpanID(spanID1))
 	s1.TraceState().FromRaw("ot=th:8")
@@ -119,15 +119,15 @@ func TestSamplingProbsFromTraces(t *testing.T) {
 	s2 := ss.Spans().AppendEmpty()
 	s2.SetSpanID(pcommon.SpanID(spanID2))
 
-	result := samplingProbsFromTraces(td, nil)
+	result := rawTracestatesBySpanID(td)
 
 	require.Len(t, result, 1)
 
 	// The key must match the DD uint64 span ID used by OtelSpanToDDSpanMinimal.
 	expectedKey := traceutilotel.OTelSpanIDToUint64(pcommon.SpanID(spanID1))
-	prob, ok := result[expectedKey]
+	raw, ok := result[expectedKey]
 	require.True(t, ok)
-	assert.InDelta(t, 0.5, prob, 1e-9)
+	assert.Equal(t, "ot=th:8", raw)
 
 	// Span 2 must not appear.
 	_, ok = result[traceutilotel.OTelSpanIDToUint64(pcommon.SpanID(spanID2))]

--- a/pkg/datadog/apmstats/sampling_test.go
+++ b/pkg/datadog/apmstats/sampling_test.go
@@ -1,0 +1,135 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package apmstats // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/apmstats"
+
+import (
+	"testing"
+
+	traceutilotel "github.com/DataDog/datadog-agent/pkg/trace/otel/traceutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func newSpanWithTraceState(spanID [8]byte, traceState string) ptrace.Span {
+	span := ptrace.NewSpan()
+	span.SetSpanID(pcommon.SpanID(spanID))
+	span.TraceState().FromRaw(traceState)
+	return span
+}
+
+func TestSamplingProbFromSpan(t *testing.T) {
+	tests := []struct {
+		name       string
+		traceState string
+		wantProb   float64
+		wantOK     bool
+	}{
+		{
+			name:       "50% sampling (th:8)",
+			traceState: "ot=th:8",
+			wantProb:   0.5,
+			wantOK:     true,
+		},
+		{
+			name:       "100% sampling (th:0)",
+			traceState: "ot=th:0",
+			wantProb:   1.0,
+			wantOK:     true,
+		},
+		{
+			name:       "p-encoding 50% (p:1)",
+			traceState: "ot=p:1;r:1",
+			wantProb:   0.5,
+			wantOK:     true,
+		},
+		{
+			name:       "p-encoding 6.25% (p:4)",
+			traceState: "ot=p:4;r:4",
+			wantProb:   0.0625,
+			wantOK:     true,
+		},
+		{
+			name:       "p-encoding 100% (p:0)",
+			traceState: "ot=p:0",
+			wantProb:   1.0,
+			wantOK:     true,
+		},
+		{
+			name:       "th absent rv present",
+			traceState: "ot=rv:abcdefabcdefab",
+			wantProb:   0,
+			wantOK:     false,
+		},
+		{
+			name:       "no tracestate",
+			traceState: "",
+			wantProb:   0,
+			wantOK:     false,
+		},
+		{
+			name:       "non-ot vendor field only",
+			traceState: "zz=vendorcontent",
+			wantProb:   0,
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := newSpanWithTraceState([8]byte{1, 2, 3, 4, 5, 6, 7, 8}, tt.traceState)
+			prob, ok := samplingProbFromSpan(span, nil)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.InDelta(t, tt.wantProb, prob, 1e-9)
+			}
+		})
+	}
+}
+
+func TestSamplingProbFromSpan_MalformedTracestate(t *testing.T) {
+	// Malformed tracestate — must not panic and must return (0, false).
+	// The value "ot=th:zz" is invalid hex for the th field.
+	// Note: "ot=th:zz" parses the ot field but "zz" is not valid hex, so
+	// NewW3CTraceState may return an error or silently skip; either way ok=false.
+	span := newSpanWithTraceState([8]byte{1}, "ot=th:zz")
+	assert.NotPanics(t, func() {
+		prob, ok := samplingProbFromSpan(span, nil)
+		assert.False(t, ok)
+		assert.Equal(t, float64(0), prob)
+	})
+}
+
+func TestSamplingProbsFromTraces(t *testing.T) {
+	spanID1 := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	spanID2 := [8]byte{9, 10, 11, 12, 13, 14, 15, 16}
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	// Span 1: 50% sampling via th:8
+	s1 := ss.Spans().AppendEmpty()
+	s1.SetSpanID(pcommon.SpanID(spanID1))
+	s1.TraceState().FromRaw("ot=th:8")
+
+	// Span 2: no tracestate — should not appear in the map
+	s2 := ss.Spans().AppendEmpty()
+	s2.SetSpanID(pcommon.SpanID(spanID2))
+
+	result := samplingProbsFromTraces(td, nil)
+
+	require.Len(t, result, 1)
+
+	// The key must match the DD uint64 span ID used by OtelSpanToDDSpanMinimal.
+	expectedKey := traceutilotel.OTelSpanIDToUint64(pcommon.SpanID(spanID1))
+	prob, ok := result[expectedKey]
+	require.True(t, ok)
+	assert.InDelta(t, 0.5, prob, 1e-9)
+
+	// Span 2 must not appear.
+	_, ok = result[traceutilotel.OTelSpanIDToUint64(pcommon.SpanID(spanID2))]
+	assert.False(t, ok)
+}

--- a/pkg/datadog/go.mod
+++ b/pkg/datadog/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.8.3
 	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog v0.155.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.155.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.61.0
 	go.opentelemetry.io/collector/component/componenttest v0.155.0
@@ -284,6 +285,8 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog => ../../internal/datadog
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders => ../../internal/metadataproviders
 

--- a/pkg/datadog/go.sum
+++ b/pkg/datadog/go.sum
@@ -403,8 +403,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.154.0
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.154.0/go.mod h1:bsRfkHYRXlU21zhPQeEh0TTRswNzBcKWMJtb7gzscZQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.154.0 h1:Kda+8F8o5QATBLP5K2MKmI2t7ddr7sBaV0EhZpjlvB0=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.154.0/go.mod h1:iVnoGSVXYhnyuQ6TQNhBIHqtu7h0LTXbSyWy584eBjg=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0 h1:BwhW8UIDFuhPMK9CvkFKANDwpZj8PUWrMbJCVk5uLPg=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0/go.mod h1:BkZ/+Z2dxFPSB0d/uyGmtlMFmkn/q1HURhfSg/HAiAk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0 h1:vt7mupvepVIO4XlZrJ+8yFECWxIqHMTAuEYFmsCbXao=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0/go.mod h1:xRRQmHi6lbHw3rxl94RpKM5nttEV5D2uTOO9fj9YUk4=
 github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 h1:Ot2fbEEPmF3WlPQkyEW/bUCV38GMugH/UmZvxpWceNc=

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -175,3 +175,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sco
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil => ../../internal/aws/ecsutil
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling

--- a/receiver/datadogreceiver/go.sum
+++ b/receiver/datadogreceiver/go.sum
@@ -142,8 +142,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0 h1:BwhW8UIDFuhPMK9CvkFKANDwpZj8PUWrMbJCVk5uLPg=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.152.0/go.mod h1:BkZ/+Z2dxFPSB0d/uyGmtlMFmkn/q1HURhfSg/HAiAk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0 h1:vt7mupvepVIO4XlZrJ+8yFECWxIqHMTAuEYFmsCbXao=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.152.0/go.mod h1:xRRQmHi6lbHw3rxl94RpKM5nttEV5D2uTOO9fj9YUk4=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The DD Connector calculated trace metrics from OTLP Traces, previously it ignored sampling weights that were present from any head based sampling that occurred. This change extracts those sampling weights and applies them to the resulting DD Span calculations ensuring that trace metrics are appropriately scaled when OTEL head based sampling has taken place.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added additional unit tests
Also did a local manual test with a small test application emitting 50% sampled traces and viewed the resulting stats in the DD UI, validating the correct hits metrics are there.

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
