### PR TITLE
[processor/spanpruning] Add random exemplar sampling

### DIFF
--- a/.chloggen/49167-spanpruning-exemplar-sampling.yaml
+++ b/.chloggen/49167-spanpruning-exemplar-sampling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/span_pruning
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add random exemplar sampling. When enabled, ceil(precision_multiplier * sqrt(N)) spans are sampled from the top-level group of each aggregation tree and kept as whole subtrees (siblings of the summary span) with their CPS sampling threshold updated so cross-trace consumers can extrapolate via adjusted counts.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49167]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/spanpruningprocessor/README.md
+++ b/processor/spanpruningprocessor/README.md
@@ -32,6 +32,8 @@ The processor can also apply **selective pruning** with OTTL conditions so only 
 
 Optionally, the processor can detect **duration outliers** using statistical methods (IQR or MAD) and either annotate summary spans with outlier correlations or **preserve outlier subtrees** for debugging while still aggregating normal spans. Detection runs at every aggregation level, so a slow interior span (for example one slow `handler` among many) is caught and its whole subtree is kept intact.
 
+Optionally, the processor can also randomly preserve a small sub-linear number of **exemplar subtrees** at the top of each aggregation tree. Each sampled span is kept whole (with its descendants) as a sibling of the summary span.
+
 This processor is useful for reducing trace data volume while preserving meaningful information about repeated operations.
 
 ## Use Cases
@@ -173,6 +175,21 @@ processors:
       # Range: [0.0, 1.0+]
       # Default: 0.1 (10%)
       min_outlier_threshold_percent: 0.1
+
+    # Enable random exemplar sampling. When enabled, ceil(precision_multiplier * sqrt(N))
+    # spans are sampled from the top-level group of each aggregation tree and kept as
+    # whole subtrees (siblings of the summary), with their TraceState threshold updated
+    # so consumers can extrapolate.
+    # Default: false
+    enable_exemplar_sampling: false
+
+    # Exemplar sampling configuration (optional)
+    exemplar_sampling:
+      # Multiplier applied to the sqrt(N) sample size. Standard error of cross-trace
+      # estimators scales as 1/sqrt(precision_multiplier). This is a precision knob,
+      # not a strict confidence-interval level.
+      # Default: 1.0
+      precision_multiplier: 1.0
 ```
 
 ## Configuration Options
@@ -200,6 +217,8 @@ processors:
 | `outlier_analysis.max_preserved_outliers` | int | 2 | Max outlier subtrees to preserve per group (0=preserve all) |
 | `outlier_analysis.preserve_only_with_correlation` | bool | false | Only preserve outliers if a strong correlation is found |
 | `outlier_analysis.min_outlier_threshold_percent` | float64 | 0.1 | Minimum percentage above median required before a span is considered an outlier |
+| `enable_exemplar_sampling` | bool | false | Enable random exemplar sampling |
+| `exemplar_sampling.precision_multiplier` | float64 | 1.0 | Multiplier applied to `sqrt(N)` sample size |
 
 ### Glob Pattern Support
 
@@ -484,6 +503,82 @@ handler
 - **Skip aggregation**: if protection leaves a group below `min_spans_to_aggregate`, that group is left unchanged.
 - **Selection order**: outliers are preserved starting with the most extreme (longest duration) first, capped by `max_preserved_outliers` subtrees per group.
 
+### Random Exemplar Sampling (Optional)
+
+When `enable_exemplar_sampling: true`, the processor preserves a randomly
+selected, sub-linear sample of **exemplars** at the top of each aggregation
+tree. Sampling runs only on the top-level group (the spans closest to the root
+that would aggregate); each sampled span is kept as a whole subtree, so an
+exemplar is a complete representative tree rather than an isolated span. Lower
+groups in the same tree are not sampled separately. Exemplar roots are kept as
+siblings of the summary span (same parent) and their TraceState threshold is
+updated to reflect the additional sampling step.
+
+This is complementary to outlier preservation: outliers ensure the tail of the
+duration distribution is represented, while exemplars sample the body.
+Cross-trace consumers can then estimate properties of the aggregated-away
+population (e.g. attribute-value frequencies) by pooling exemplars across many
+traces.
+
+#### Sample Size
+
+For a top-level group of `N` spans, the processor draws
+`D = ceil(precision_multiplier * sqrt(N))` spans without replacement and keeps
+each drawn span's whole subtree. `sqrt(N)` is sub-linear in storage and gives
+bounded relative error for cross-trace analysis. The draw is taken over the full
+group (see *Interaction with outliers* below), so the number of spans that
+become exemplars may be slightly below `D` when some draws land on spans already
+preserved as outliers.
+
+#### Configuration
+
+```yaml
+processors:
+  spanpruning:
+    enable_exemplar_sampling: true
+    exemplar_sampling:
+      precision_multiplier: 1.0
+```
+
+#### Exemplar Span Attributes
+
+The root of each preserved exemplar subtree is annotated with:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `<prefix>is_exemplar` | bool | Identifies span as a sampled exemplar (root of a kept subtree) |
+| `<prefix>summary_span_id` | string | SpanID of the associated summary span |
+
+#### Summary Span Attributes (When Sampling Exemplars)
+
+When at least one exemplar is preserved, the summary span gets:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `<prefix>exemplar_count` | int64 | Number of exemplar subtrees preserved |
+| `<prefix>exemplar_span_ids` | []string | SpanIDs of the preserved exemplar roots |
+
+#### Behavior Notes
+
+- **Top level only**: Sampling runs once per aggregation tree, on its top-level
+  group. A group is top-level when none of its members' parents are themselves
+  aggregated into a higher group.
+- **Whole subtree**: Each sampled span keeps its entire subtree; nothing beneath
+  an exemplar is aggregated, and deeper outlier detection skips the protected
+  subtree.
+- **Parent aggregation**: The remaining (non-exemplar) top-level spans still
+  aggregate, and exemplar roots become siblings of that summary.
+- **Small groups**: For `N <= 1` no exemplars are sampled. For small `N` where
+  `D >= N`, the whole group is kept and aggregation is skipped.
+- **Interaction with outliers**: When both features are enabled, a span is kept
+  individually if it is a preserved outlier **OR** it is sampled. Outliers in the
+  top-level group are protected first; the draw is then taken over the full group
+  (outliers included), but the keep is an OR: a span that is both an outlier and
+  drawn is kept once, tagged only as an outlier, and its threshold is left
+  untouched (it is kept deterministically, so its effective keep-probability is
+  1). Non-outlier exemplars compose their threshold by `D/N` over the full group,
+  so adjusted counts remain consistent.
+
 ## Pipeline Placement
 
 This processor is designed to work best when placed after processors that ensure complete traces are available:
@@ -702,6 +797,7 @@ The processor emits the following metrics to help monitor its operation:
 | `otelcol_processor_spanpruning_bytes_processed_input` | Total bytes of serialized traces in the matched subset, measured before pruning (when `enable_bytes_metrics: true`) |
 | `otelcol_processor_spanpruning_bytes_processed_output` | Total bytes of serialized traces in the matched subset, measured after pruning (when `enable_bytes_metrics: true`) |
 | `otelcol_processor_spanpruning_bytes_emitted` | Total bytes of serialized traces emitted after pruning (when `enable_bytes_metrics: true`) |
+| `otelcol_processor_spanpruning_exemplars_sampled` | Total spans randomly sampled as exemplars (when `enable_exemplar_sampling: true`) |
 
 ### Byte metrics semantics
 

--- a/processor/spanpruningprocessor/aggregation.go
+++ b/processor/spanpruningprocessor/aggregation.go
@@ -16,13 +16,16 @@ import (
 // aggregationGroup captures the spans to aggregate along with execution
 // metadata (tree depth, preassigned summary ID, and attribute loss info).
 type aggregationGroup struct {
-	nodes             []*spanNode            // nodes to aggregate (replaces []spanInfo for efficiency)
-	depth             int                    // tree depth (0 = leaf, 1 = parent of leaf, etc.)
-	summarySpanID     pcommon.SpanID         // SpanID of the summary span (assigned before creation)
-	lossInfo          attributeLossSummary   // attribute loss info (diverse + missing)
-	templateNode      *spanNode              // node to use as summary template (longest duration)
-	outlierAnalysis   *outlierAnalysisResult // outlier analysis results
-	preservedOutliers []*spanNode            // outliers to keep as individual spans
+	nodes                  []*spanNode            // nodes to aggregate (replaces []spanInfo for efficiency)
+	depth                  int                    // tree depth (0 = leaf, 1 = parent of leaf, etc.)
+	summarySpanID          pcommon.SpanID         // SpanID of the summary span (assigned before creation)
+	lossInfo               attributeLossSummary   // attribute loss info (diverse + missing)
+	templateNode           *spanNode              // node to use as summary template (longest duration)
+	outlierAnalysis        *outlierAnalysisResult // outlier analysis results
+	preservedOutliers      []*spanNode            // outliers to keep as individual spans
+	exemplars              []*spanNode            // randomly sampled exemplars to keep as siblings of the summary
+	exemplarPopulationSize int                    // full group size (N), denominator for exemplar threshold composition
+	exemplarSampleSize     int                    // trees drawn from the group (D), numerator for exemplar threshold composition
 }
 
 // aggregationPlan orders aggregation groups for top-down execution and
@@ -109,6 +112,17 @@ func (p *spanPruningProcessor) executeAggregations(plan aggregationPlan, tree *t
 			outlier.span.SetParentSpanID(summaryParentID)
 			outlier.span.Attributes().PutBool(prefix+"is_preserved_outlier", true)
 			outlier.span.Attributes().PutStr(prefix+"summary_span_id", group.summarySpanID.String())
+		}
+
+		// Mark randomly sampled exemplars with reference to summary span and
+		// update their CPS sampling threshold to reflect the additional
+		// sampling step (K kept of N).
+		for _, exemplar := range group.exemplars {
+			// Exemplars become siblings of the summary span.
+			exemplar.span.SetParentSpanID(summaryParentID)
+			updateExemplarThreshold(exemplar.span, group.exemplarSampleSize, group.exemplarPopulationSize)
+			exemplar.span.Attributes().PutBool(prefix+"is_exemplar", true)
+			exemplar.span.Attributes().PutStr(prefix+"summary_span_id", group.summarySpanID.String())
 		}
 
 		// Record replacement span ID on each node so child groups can find it
@@ -200,6 +214,16 @@ func (p *spanPruningProcessor) createSummarySpanWithParent(group aggregationGrou
 			for _, outlier := range group.preservedOutliers {
 				outlierIDs.AppendEmpty().SetStr(outlier.span.SpanID().String())
 			}
+		}
+	}
+
+	// Track sampled exemplars.
+	if len(group.exemplars) > 0 {
+		newSpan.Attributes().PutInt(prefix+"exemplar_count", int64(len(group.exemplars)))
+
+		exemplarIDs := newSpan.Attributes().PutEmptySlice(prefix + "exemplar_span_ids")
+		for _, exemplar := range group.exemplars {
+			exemplarIDs.AppendEmpty().SetStr(exemplar.span.SpanID().String())
 		}
 	}
 

--- a/processor/spanpruningprocessor/config.go
+++ b/processor/spanpruningprocessor/config.go
@@ -6,6 +6,7 @@ package spanpruningprocessor // import "github.com/open-telemetry/opentelemetry-
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -95,6 +96,22 @@ type OutlierAnalysisConfig struct {
 	MinOutlierThresholdPercent float64 `mapstructure:"min_outlier_threshold_percent"`
 }
 
+// ExemplarSamplingConfig controls random exemplar selection. Sampling runs once
+// per aggregation tree, on its top-level group of N spans, drawing D =
+// ceil(PrecisionMultiplier * sqrt(N)) spans without replacement and keeping each
+// as a whole subtree.
+type ExemplarSamplingConfig struct {
+	// PrecisionMultiplier scales the top-level sample count.
+	// Samples per top-level group = ceil(PrecisionMultiplier * sqrt(N)). Standard
+	// error of cross-trace estimators built from exemplars scales as
+	// 1/sqrt(PrecisionMultiplier). This is a precision knob, not a
+	// confidence-interval level.
+	// Default: 1.0
+	PrecisionMultiplier float64 `mapstructure:"precision_multiplier"`
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
 // Config defines the configuration options for the span pruning processor
 // and the rules used to identify and aggregate similar spans.
 type Config struct {
@@ -163,6 +180,17 @@ type Config struct {
 	// OutlierAnalysis configures IQR-based outlier detection and
 	// attribute correlation for aggregation groups.
 	OutlierAnalysis OutlierAnalysisConfig `mapstructure:"outlier_analysis"`
+
+	// EnableExemplarSampling toggles preservation of randomly sampled spans
+	// from each aggregation group as exemplars. Exemplars are kept as siblings
+	// of the summary span and have their TraceState threshold updated so
+	// downstream consumers can extrapolate via CPS adjusted-count semantics.
+	// Default: false
+	EnableExemplarSampling bool `mapstructure:"enable_exemplar_sampling"`
+
+	// ExemplarSampling configures random exemplar selection per aggregation
+	// group.
+	ExemplarSampling ExemplarSamplingConfig `mapstructure:"exemplar_sampling"`
 }
 
 var _ component.Config = (*Config)(nil)
@@ -224,6 +252,21 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
+	if err := cfg.ExemplarSampling.Validate(cfg.EnableExemplarSampling); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate checks ExemplarSamplingConfig for invalid values.
+func (cfg *ExemplarSamplingConfig) Validate(enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	if math.IsNaN(cfg.PrecisionMultiplier) || math.IsInf(cfg.PrecisionMultiplier, 0) || cfg.PrecisionMultiplier <= 0 {
+		return errors.New("exemplar_sampling.precision_multiplier must be a positive, finite number")
+	}
 	return nil
 }
 

--- a/processor/spanpruningprocessor/config_test.go
+++ b/processor/spanpruningprocessor/config_test.go
@@ -4,6 +4,7 @@
 package spanpruningprocessor
 
 import (
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -71,6 +72,10 @@ func TestLoadConfig(t *testing.T) {
 					PreserveOnlyWithCorrelation:    false,
 					MinOutlierThresholdPercent:     0.1,
 				},
+				EnableExemplarSampling: false,
+				ExemplarSampling: ExemplarSamplingConfig{
+					PrecisionMultiplier: 1.0,
+				},
 			},
 		},
 		{
@@ -97,6 +102,10 @@ func TestLoadConfig(t *testing.T) {
 					MaxPreservedOutliers:           2,
 					PreserveOnlyWithCorrelation:    false,
 					MinOutlierThresholdPercent:     0.1,
+				},
+				EnableExemplarSampling: false,
+				ExemplarSampling: ExemplarSamplingConfig{
+					PrecisionMultiplier: 1.0,
 				},
 			},
 		},
@@ -588,6 +597,72 @@ func TestConfig_Validate(t *testing.T) {
 				AggregationHistogramBuckets: []time.Duration{},
 			},
 			expectError: false,
+		},
+		{
+			name: "exemplar sampling disabled skips validation",
+			config: &Config{
+				MinSpansToAggregate:        2,
+				AggregationAttributePrefix: "aggregation.",
+				GroupByAttributes:          []string{"db.operation"},
+				EnableExemplarSampling:     false,
+				ExemplarSampling:           ExemplarSamplingConfig{PrecisionMultiplier: -1},
+			},
+			expectError: false,
+		},
+		{
+			name: "exemplar sampling precision_multiplier positive",
+			config: &Config{
+				MinSpansToAggregate:        2,
+				AggregationAttributePrefix: "aggregation.",
+				GroupByAttributes:          []string{"db.operation"},
+				EnableExemplarSampling:     true,
+				ExemplarSampling:           ExemplarSamplingConfig{PrecisionMultiplier: 1.0},
+			},
+			expectError: false,
+		},
+		{
+			name: "exemplar sampling precision_multiplier zero",
+			config: &Config{
+				MinSpansToAggregate:        2,
+				AggregationAttributePrefix: "aggregation.",
+				GroupByAttributes:          []string{"db.operation"},
+				EnableExemplarSampling:     true,
+				ExemplarSampling:           ExemplarSamplingConfig{PrecisionMultiplier: 0},
+			},
+			expectError: true,
+		},
+		{
+			name: "exemplar sampling precision_multiplier negative",
+			config: &Config{
+				MinSpansToAggregate:        2,
+				AggregationAttributePrefix: "aggregation.",
+				GroupByAttributes:          []string{"db.operation"},
+				EnableExemplarSampling:     true,
+				ExemplarSampling:           ExemplarSamplingConfig{PrecisionMultiplier: -0.5},
+			},
+			expectError: true,
+		},
+		{
+			name: "exemplar sampling precision_multiplier NaN",
+			config: &Config{
+				MinSpansToAggregate:        2,
+				AggregationAttributePrefix: "aggregation.",
+				GroupByAttributes:          []string{"db.operation"},
+				EnableExemplarSampling:     true,
+				ExemplarSampling:           ExemplarSamplingConfig{PrecisionMultiplier: math.NaN()},
+			},
+			expectError: true,
+		},
+		{
+			name: "exemplar sampling precision_multiplier +Inf",
+			config: &Config{
+				MinSpansToAggregate:        2,
+				AggregationAttributePrefix: "aggregation.",
+				GroupByAttributes:          []string{"db.operation"},
+				EnableExemplarSampling:     true,
+				ExemplarSampling:           ExemplarSamplingConfig{PrecisionMultiplier: math.Inf(1)},
+			},
+			expectError: true,
 		},
 	}
 	for _, tt := range tests {

--- a/processor/spanpruningprocessor/documentation.md
+++ b/processor/spanpruningprocessor/documentation.md
@@ -22,6 +22,14 @@ Total aggregation summary spans created
 | ---- | ----------- | ---------- | --------- | --------- |
 | {spans} | Sum | Int | true | Development |
 
+### otelcol_processor_spanpruning_exemplars_sampled
+
+Spans randomly sampled as exemplars (excluded from aggregation)
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {spans} | Sum | Int | true | Development |
+
 ### otelcol_processor_spanpruning_outliers_correlations_detected
 
 Groups where outliers had correlated attributes

--- a/processor/spanpruningprocessor/exemplar.go
+++ b/processor/spanpruningprocessor/exemplar.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package spanpruningprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor"
+
+import (
+	"math"
+	"math/rand/v2"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+)
+
+// exemplarSampleSize returns the number of exemplars to draw from a group of
+// the given size: ceil(multiplier * sqrt(groupSize)), clamped to [0, groupSize].
+func exemplarSampleSize(groupSize int, multiplier float64) int {
+	if groupSize <= 0 || multiplier <= 0 {
+		return 0
+	}
+	return min(int(math.Ceil(multiplier*math.Sqrt(float64(groupSize)))), groupSize)
+}
+
+// sampleExemplars selects ceil(multiplier * sqrt(len(nodes))) nodes uniformly
+// at random without replacement and returns (remaining, exemplars). When the
+// computed sample size equals or exceeds len(nodes) the entire input becomes
+// exemplars and remaining is nil. The remaining slice preserves the input
+// order, matching filterOutlierNodes.
+func sampleExemplars(nodes []*spanNode, multiplier float64) (remaining, exemplars []*spanNode) {
+	groupSize := len(nodes)
+	sampleSize := exemplarSampleSize(groupSize, multiplier)
+	if sampleSize == 0 {
+		return nodes, nil
+	}
+	if sampleSize >= groupSize {
+		return nil, nodes
+	}
+
+	// Partial Fisher-Yates over an index slice: pick sampleSize distinct
+	// indices in O(sampleSize) swaps without materializing a full permutation.
+	indices := make([]int, groupSize)
+	for i := range indices {
+		indices[i] = i
+	}
+	for i := range sampleSize {
+		j := i + rand.IntN(groupSize-i)
+		indices[i], indices[j] = indices[j], indices[i]
+	}
+
+	exemplarSet := make(map[int]struct{}, sampleSize)
+	for _, idx := range indices[:sampleSize] {
+		exemplarSet[idx] = struct{}{}
+	}
+
+	remaining = make([]*spanNode, 0, groupSize-sampleSize)
+	exemplars = make([]*spanNode, 0, sampleSize)
+	for i, node := range nodes {
+		if _, ok := exemplarSet[i]; ok {
+			exemplars = append(exemplars, node)
+		} else {
+			remaining = append(remaining, node)
+		}
+	}
+	return remaining, exemplars
+}
+
+// updateExemplarThreshold composes the exemplar span's CPS sampling threshold
+// to account for the additional sampling step (sampleSize kept out of
+// groupSize). The new probability encodes p_old * sampleSize/groupSize so
+// consumers can extrapolate via adjusted counts.
+//
+// If the span carries no prior th-value, the TraceState is left untouched —
+// we do not fabricate CPS context where the upstream provided none.
+func updateExemplarThreshold(span ptrace.Span, sampleSize, groupSize int) {
+	if sampleSize <= 0 || groupSize <= 0 {
+		return
+	}
+	raw := span.TraceState().AsRaw()
+	w3c, err := sampling.NewW3CTraceState(raw)
+	if err != nil {
+		return
+	}
+	otts := w3c.OTelValue()
+	priorThreshold, hasPriorTh := otts.TValueThreshold()
+	if !hasPriorTh {
+		return
+	}
+
+	composedProbability := priorThreshold.Probability() * float64(sampleSize) / float64(groupSize)
+	// ProbabilityToThreshold rejects values below MinSamplingProbability. If
+	// the composed probability is unrepresentable in 56-bit threshold encoding,
+	// leave the prior th untouched — consumers will slightly undercount, which
+	// is far better than clamping (which would massively overcount via an
+	// inflated adjusted count).
+	newThreshold, err := sampling.ProbabilityToThreshold(composedProbability)
+	if err != nil {
+		return
+	}
+	if err := otts.UpdateTValueWithSampling(newThreshold); err != nil {
+		// ErrInconsistentSampling cannot occur here since sampleSize/groupSize
+		// is at most 1, so the new threshold is never smaller than the prior.
+		// Any other error indicates a malformed tracestate we don't want to
+		// overwrite.
+		return
+	}
+
+	var serialized strings.Builder
+	if err := w3c.Serialize(&serialized); err != nil {
+		return
+	}
+	span.TraceState().FromRaw(serialized.String())
+}

--- a/processor/spanpruningprocessor/exemplar_test.go
+++ b/processor/spanpruningprocessor/exemplar_test.go
@@ -1,0 +1,171 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package spanpruningprocessor
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+)
+
+func TestExemplarSampleSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		n          int
+		multiplier float64
+		want       int
+	}{
+		{name: "zero population", n: 0, multiplier: 1.0, want: 0},
+		{name: "zero multiplier", n: 100, multiplier: 0, want: 0},
+		{name: "negative multiplier", n: 100, multiplier: -1, want: 0},
+		{name: "small N=4 multiplier=1", n: 4, multiplier: 1.0, want: 2},
+		{name: "N=100 multiplier=1", n: 100, multiplier: 1.0, want: 10},
+		{name: "N=100 multiplier=2", n: 100, multiplier: 2.0, want: 20},
+		{name: "N=100 multiplier=0.5", n: 100, multiplier: 0.5, want: 5},
+		{name: "N=10000 multiplier=1", n: 10000, multiplier: 1.0, want: 100},
+		{name: "clamped: K>N", n: 4, multiplier: 5.0, want: 4},
+		{name: "ceil rounds up: N=10 multiplier=1", n: 10, multiplier: 1.0, want: int(math.Ceil(math.Sqrt(10)))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := exemplarSampleSize(tt.n, tt.multiplier)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSampleExemplars_CountAndNoReplacement(t *testing.T) {
+	nodes := makeNodes(100)
+
+	remaining, exemplars := sampleExemplars(nodes, 1.0)
+
+	wantK := exemplarSampleSize(100, 1.0)
+	require.Len(t, exemplars, wantK)
+	require.Len(t, remaining, 100-wantK)
+
+	// Combined slices must cover the original set with no duplicates.
+	seen := make(map[*spanNode]struct{}, 100)
+	for _, n := range exemplars {
+		_, dup := seen[n]
+		require.False(t, dup, "duplicate exemplar selected")
+		seen[n] = struct{}{}
+	}
+	for _, n := range remaining {
+		_, dup := seen[n]
+		require.False(t, dup, "node appears in both remaining and exemplars")
+		seen[n] = struct{}{}
+	}
+	assert.Len(t, seen, 100)
+}
+
+func TestSampleExemplars_KGreaterOrEqualN(t *testing.T) {
+	nodes := makeNodes(4)
+	// multiplier=5 forces K to clamp to N.
+	remaining, exemplars := sampleExemplars(nodes, 5.0)
+	assert.Nil(t, remaining)
+	assert.Len(t, exemplars, 4)
+}
+
+func TestSampleExemplars_ZeroK(t *testing.T) {
+	nodes := makeNodes(10)
+	remaining, exemplars := sampleExemplars(nodes, 0)
+	assert.Equal(t, nodes, remaining)
+	assert.Nil(t, exemplars)
+}
+
+func TestSampleExemplars_PreservesOrderOfRemaining(t *testing.T) {
+	nodes := makeNodes(50)
+	remaining, _ := sampleExemplars(nodes, 1.0)
+
+	// Build a position map from the original ordering and verify remaining
+	// slice is monotonically increasing by original index.
+	pos := make(map[*spanNode]int, len(nodes))
+	for i, n := range nodes {
+		pos[n] = i
+	}
+	last := -1
+	for _, n := range remaining {
+		p := pos[n]
+		require.Greater(t, p, last, "remaining slice not in original order")
+		last = p
+	}
+}
+
+func TestUpdateExemplarThreshold_ComposesWhenPriorThExists(t *testing.T) {
+	// Construct a span whose TraceState declares 1/2 sampling (th encodes
+	// rejection probability 1/2 -> sampling probability 1/2).
+	priorTh, err := sampling.ProbabilityToThreshold(0.5)
+	require.NoError(t, err)
+
+	span := ptrace.NewSpan()
+	span.TraceState().FromRaw("ot=th:" + priorTh.TValue())
+
+	// Group of N=100, K=10 exemplars: new probability = 0.5 * 10/100 = 0.05.
+	updateExemplarThreshold(span, 10, 100)
+
+	w3c, err := sampling.NewW3CTraceState(span.TraceState().AsRaw())
+	require.NoError(t, err)
+	newTh, hasTh := w3c.OTelValue().TValueThreshold()
+	require.True(t, hasTh, "expected th to remain present after composition")
+
+	wantTh, err := sampling.ProbabilityToThreshold(0.05)
+	require.NoError(t, err)
+	assert.Equal(t, wantTh.TValue(), newTh.TValue())
+}
+
+func TestUpdateExemplarThreshold_NoopWhenNoPriorTh(t *testing.T) {
+	span := ptrace.NewSpan()
+	const original = "vendor=abc"
+	span.TraceState().FromRaw(original)
+
+	updateExemplarThreshold(span, 10, 100)
+
+	assert.Equal(t, original, span.TraceState().AsRaw(), "TraceState should be unchanged when no prior th is present")
+}
+
+func TestUpdateExemplarThreshold_NoopWhenEmptyTraceState(t *testing.T) {
+	span := ptrace.NewSpan()
+	updateExemplarThreshold(span, 10, 100)
+	assert.Empty(t, span.TraceState().AsRaw())
+}
+
+func TestUpdateExemplarThreshold_NoopWhenMalformed(t *testing.T) {
+	span := ptrace.NewSpan()
+	const broken = "ot=garbage:!!!"
+	span.TraceState().FromRaw(broken)
+	updateExemplarThreshold(span, 10, 100)
+	assert.Equal(t, broken, span.TraceState().AsRaw())
+}
+
+// TestUpdateExemplarThreshold_NoopWhenUnrepresentable ensures we leave the
+// prior threshold untouched when p_old * K/N would fall below MinSamplingProbability.
+// Clamping would have catastrophically inflated the consumer-side adjusted count.
+func TestUpdateExemplarThreshold_NoopWhenUnrepresentable(t *testing.T) {
+	// Prior th encoding the smallest representable sampling probability.
+	priorTh, err := sampling.ProbabilityToThreshold(sampling.MinSamplingProbability)
+	require.NoError(t, err)
+
+	span := ptrace.NewSpan()
+	priorTS := "ot=th:" + priorTh.TValue()
+	span.TraceState().FromRaw(priorTS)
+
+	// Any further sub-sampling makes p_new < MinSamplingProbability.
+	updateExemplarThreshold(span, 1, 100)
+
+	assert.Equal(t, priorTS, span.TraceState().AsRaw(), "threshold should be unchanged when composed probability is unrepresentable")
+}
+
+// makeNodes returns n spanNodes with unique identity for set-membership tests.
+func makeNodes(n int) []*spanNode {
+	nodes := make([]*spanNode, n)
+	for i := range nodes {
+		nodes[i] = &spanNode{}
+	}
+	return nodes
+}

--- a/processor/spanpruningprocessor/factory.go
+++ b/processor/spanpruningprocessor/factory.go
@@ -64,6 +64,10 @@ func createDefaultConfig() component.Config {
 			PreserveOnlyWithCorrelation:    false,
 			MinOutlierThresholdPercent:     0.1,
 		},
+		EnableExemplarSampling: false,
+		ExemplarSampling: ExemplarSamplingConfig{
+			PrecisionMultiplier: 1.0,
+		},
 	}
 }
 

--- a/processor/spanpruningprocessor/go.mod
+++ b/processor/spanpruningprocessor/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.159.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.159.0
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/collector/component v1.65.1-0.20260824174011-67fef8cb7049
 	go.opentelemetry.io/collector/component/componenttest v0.159.1-0.20260824174011-67fef8cb7049
@@ -88,3 +89,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter => ../../internal/filter
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling

--- a/processor/spanpruningprocessor/go.mod
+++ b/processor/spanpruningprocessor/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.157.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.157.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.154.1-0.20260612191519-af182d232650
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/component/componenttest v0.157.1-0.20260723141305-52e6bf4aaaba
@@ -90,3 +91,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter => ../../internal/filter
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling => ../../pkg/sampling

--- a/processor/spanpruningprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/spanpruningprocessor/internal/metadata/generated_telemetry.go
@@ -31,6 +31,7 @@ type TelemetryBuilder struct {
 	ProcessorSpanpruningBytesProcessedInput          metric.Int64Counter
 	ProcessorSpanpruningBytesProcessedOutput         metric.Int64Counter
 	ProcessorSpanpruningBytesReceived                metric.Int64Counter
+	ProcessorSpanpruningExemplarsSampled             metric.Int64Counter
 	ProcessorSpanpruningLeafAttributeDiversityLoss   metric.Int64Histogram
 	ProcessorSpanpruningLeafAttributeLoss            metric.Int64Histogram
 	ProcessorSpanpruningOutliersCorrelationsDetected metric.Int64Counter
@@ -108,6 +109,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_processor_spanpruning_bytes_received",
 		metric.WithDescription("Total bytes of serialized traces received before pruning [Development]"),
 		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorSpanpruningExemplarsSampled, err = builder.meter.Int64Counter(
+		"otelcol_processor_spanpruning_exemplars_sampled",
+		metric.WithDescription("Spans randomly sampled as exemplars (excluded from aggregation) [Development]"),
+		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorSpanpruningLeafAttributeDiversityLoss, err = builder.meter.Int64Histogram(

--- a/processor/spanpruningprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/spanpruningprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -116,6 +116,22 @@ func AssertEqualProcessorSpanpruningBytesReceived(t *testing.T, tt *componenttes
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualProcessorSpanpruningExemplarsSampled(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_spanpruning_exemplars_sampled",
+		Description: "Spans randomly sampled as exemplars (excluded from aggregation) [Development]",
+		Unit:        "{spans}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_spanpruning_exemplars_sampled")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualProcessorSpanpruningLeafAttributeDiversityLoss(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_spanpruning_leaf_attribute_diversity_loss",

--- a/processor/spanpruningprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/spanpruningprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -25,6 +25,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ProcessorSpanpruningBytesProcessedInput.Add(context.Background(), 1)
 	tb.ProcessorSpanpruningBytesProcessedOutput.Add(context.Background(), 1)
 	tb.ProcessorSpanpruningBytesReceived.Add(context.Background(), 1)
+	tb.ProcessorSpanpruningExemplarsSampled.Add(context.Background(), 1)
 	tb.ProcessorSpanpruningLeafAttributeDiversityLoss.Record(context.Background(), 1)
 	tb.ProcessorSpanpruningLeafAttributeLoss.Record(context.Background(), 1)
 	tb.ProcessorSpanpruningOutliersCorrelationsDetected.Add(context.Background(), 1)
@@ -53,6 +54,9 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorSpanpruningBytesReceived(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorSpanpruningExemplarsSampled(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorSpanpruningLeafAttributeDiversityLoss(t, testTel,

--- a/processor/spanpruningprocessor/metadata.yaml
+++ b/processor/spanpruningprocessor/metadata.yaml
@@ -65,6 +65,15 @@ telemetry:
         value_type: int
         monotonic: true
 
+    processor_spanpruning_exemplars_sampled:
+      enabled: true
+      description: Spans randomly sampled as exemplars (excluded from aggregation)
+      unit: "{spans}"
+      stability: development
+      sum:
+        value_type: int
+        monotonic: true
+
     processor_spanpruning_leaf_attribute_diversity_loss:
       enabled: false
       description: Attribute values lost due to diversity per leaf aggregation

--- a/processor/spanpruningprocessor/processor.go
+++ b/processor/spanpruningprocessor/processor.go
@@ -313,23 +313,22 @@ func (p *spanPruningProcessor) analyzeAggregationsWithTree(ctx context.Context, 
 		return nil
 	}
 
-	// Step 2: detect outliers over those groups and protect their subtrees
-	// before any aggregation runs.
-	outlierResultByKey, protectedRootsByKey := p.detectAndProtectOutliers(ctx, groups)
+	// Step 2: detect outliers at every level and sample exemplars at the top of
+	// each aggregation tree, protecting both as whole subtrees before any
+	// aggregation runs.
+	outlierResultByKey, protectedRootsByKey, exemplarByKey := p.detectAndProtect(ctx, groups)
 
 	// Step 3: aggregate. planCandidateGroups returns groups bottom-up (leaves
 	// first, then parents by increasing depth), so processing them in order
 	// marks a group's children before the parent group is evaluated.
 	aggregationGroups := make(map[string]aggregationGroup, len(groups))
-	preserving := p.config.EnableOutlierAnalysis && p.config.OutlierAnalysis.PreserveOutliers
 
 	for _, g := range groups {
 		nodes := g.nodes
 		if g.depth == 0 {
-			// Leaf group: drop preserved-outlier subtrees, then re-check the floor.
-			if preserving {
-				nodes = excludeProtectedNodes(nodes)
-			}
+			// Leaf group: drop protected (preserved outlier or exemplar) subtrees,
+			// then re-check the floor.
+			nodes = excludeProtectedNodes(nodes)
 			if len(nodes) < p.config.MinSpansToAggregate {
 				continue
 			}
@@ -347,18 +346,23 @@ func (p *spanPruningProcessor) analyzeAggregationsWithTree(ctx context.Context, 
 		lossInfo := p.recordAttributeLoss(ctx, g.depth == 0, nodes, templateNode)
 
 		preserved := protectedRootsByKey[g.key]
+		sel := exemplarByKey[g.key]
 		aggregationGroups[g.key] = aggregationGroup{
-			nodes:             nodes,
-			depth:             g.depth,
-			lossInfo:          lossInfo,
-			templateNode:      templateNode,
-			outlierAnalysis:   outlierResultByKey[g.key],
-			preservedOutliers: preserved,
+			nodes:                  nodes,
+			depth:                  g.depth,
+			lossInfo:               lossInfo,
+			templateNode:           templateNode,
+			outlierAnalysis:        outlierResultByKey[g.key],
+			preservedOutliers:      preserved,
+			exemplars:              sel.roots,
+			exemplarPopulationSize: sel.populationSize,
+			exemplarSampleSize:     sel.sampleSize,
 		}
 		for _, n := range nodes {
 			n.markedForRemoval = true
 		}
 		p.recordPreserved(ctx, preserved)
+		p.recordExemplars(ctx, sel.roots)
 	}
 
 	return aggregationGroups
@@ -406,69 +410,173 @@ func (p *spanPruningProcessor) recordAttributeLoss(ctx context.Context, isLeaf b
 	return lossInfo
 }
 
-// detectAndProtectOutliers runs outlier detection over the planned groups and,
-// when preservation is enabled, protects each preserved outlier's whole subtree
-// so it is kept instead of aggregated. It returns per-group detection results (to
-// annotate the matching summary) and the preserved-outlier roots grouped by group
-// key (to link them to their summary during execution).
-func (p *spanPruningProcessor) detectAndProtectOutliers(ctx context.Context, groups []candidateGroup) (map[string]*outlierAnalysisResult, map[string][]*spanNode) {
-	if !p.config.EnableOutlierAnalysis {
-		return nil, nil
+// detectAndProtect runs outlier detection at every level and exemplar sampling
+// at the top of each aggregation tree, protecting both as whole subtrees before
+// aggregation. It returns per-group outlier detection results (to annotate the
+// matching summary), the preserved-outlier roots grouped by key, and the
+// exemplar selection grouped by key (both linked to their summary during
+// execution).
+//
+// Groups are processed shallowest-first so a higher group's protected subtrees
+// land before any deeper group is examined. Top-level groups (closest to the
+// root) sort first, so each exemplar's whole subtree is protected before deeper
+// outlier detection runs and skips it. Within a top-level group, that group's
+// outliers are protected before exemplars are drawn, so exemplars come from the
+// remaining (non-outlier) spans and the two never overlap.
+func (p *spanPruningProcessor) detectAndProtect(ctx context.Context, groups []candidateGroup) (map[string]*outlierAnalysisResult, map[string][]*spanNode, map[string]exemplarSelection) {
+	outliersEnabled := p.config.EnableOutlierAnalysis
+	exemplarsEnabled := p.config.EnableExemplarSampling
+	if !outliersEnabled && !exemplarsEnabled {
+		return nil, nil, nil
+	}
+
+	var inGroup map[*spanNode]struct{}
+	if exemplarsEnabled {
+		inGroup = make(map[*spanNode]struct{})
+		for _, g := range groups {
+			for _, n := range g.nodes {
+				inGroup[n] = struct{}{}
+			}
+		}
 	}
 
 	outlierResultByKey := make(map[string]*outlierAnalysisResult)
 	protectedRootsByKey := make(map[string][]*spanNode)
-	preserve := p.config.OutlierAnalysis.PreserveOutliers
+	exemplarByKey := make(map[string]exemplarSelection)
+	preserve := outliersEnabled && p.config.OutlierAnalysis.PreserveOutliers
 
-	// Process groups shallowest-first (by tree depth) so an interior outlier's
-	// subtree protection lands before any group nested beneath it; a leaf outlier
-	// inside an already-protected subtree is then skipped rather than preserved
-	// (and counted) twice. Sort a copy so the caller keeps its bottom-up order.
 	ordered := append([]candidateGroup(nil), groups...)
 	sort.SliceStable(ordered, func(i, j int) bool {
 		return ordered[i].nodes[0].depth() < ordered[j].nodes[0].depth()
 	})
 
 	for _, group := range ordered {
-		res := analyzeOutliers(group.nodes, p.config.OutlierAnalysis)
-		if res == nil {
+		// Groups whose spans are all inside an already-protected subtree have
+		// nothing left to aggregate or preserve; skip them so detection metrics
+		// don't count spans that are already kept.
+		if !anyUnprotected(group.nodes) {
 			continue
 		}
-		outlierResultByKey[group.key] = res
 
-		if res.hasOutliers {
-			p.telemetryBuilder.ProcessorSpanpruningOutliersDetected.Add(ctx, int64(len(res.outlierIndices)))
-			if len(res.correlations) > 0 {
-				p.telemetryBuilder.ProcessorSpanpruningOutliersCorrelationsDetected.Add(ctx, 1)
+		if outliersEnabled {
+			if res := analyzeOutliers(group.nodes, p.config.OutlierAnalysis); res != nil {
+				outlierResultByKey[group.key] = res
+				if res.hasOutliers {
+					p.telemetryBuilder.ProcessorSpanpruningOutliersDetected.Add(ctx, int64(len(res.outlierIndices)))
+					if len(res.correlations) > 0 {
+						p.telemetryBuilder.ProcessorSpanpruningOutliersCorrelationsDetected.Add(ctx, 1)
+					}
+				}
+				if preserve {
+					p.protectOutliers(group, res, protectedRootsByKey)
+				}
 			}
 		}
 
-		if !preserve {
-			continue
-		}
-		// filterOutlierNodes applies correlation gating and orders outliers most
-		// extreme first. Ask it for all of them (cap 0) and apply
-		// MaxPreservedOutliers here, after dropping outliers already kept by an
-		// enclosing protected subtree. Letting filterOutlierNodes cap first would
-		// spend a budget slot on an already-covered outlier and starve a
-		// not-yet-preserved one further down the order.
-		unlimited := p.config.OutlierAnalysis
-		unlimited.MaxPreservedOutliers = 0
-		_, outliers := filterOutlierNodes(group.nodes, res, unlimited)
-		limit := p.config.OutlierAnalysis.MaxPreservedOutliers
-		for _, o := range outliers {
-			// Skip outliers already kept by an enclosing protected subtree.
-			if o.protected {
-				continue
+		// Exemplar sampling runs only at the top of each aggregation tree, after
+		// that group's outliers are protected. The draw is taken over the full
+		// group (outliers included) but the kept exemplar roots exclude any draw
+		// that is already a protected outlier. Doing it here, before any deeper
+		// group is examined, protects each exemplar's whole subtree so deeper
+		// detection skips it.
+		if exemplarsEnabled && isTopLevelGroup(group, inGroup) {
+			if sel, ok := p.sampleExemplarsFromGroup(group.nodes); ok {
+				exemplarByKey[group.key] = sel
 			}
-			if limit > 0 && len(protectedRootsByKey[group.key]) >= limit {
-				break
-			}
-			markOutlierSubtree(o)
-			protectedRootsByKey[group.key] = append(protectedRootsByKey[group.key], o)
 		}
 	}
-	return outlierResultByKey, protectedRootsByKey
+	return outlierResultByKey, protectedRootsByKey, exemplarByKey
+}
+
+// protectOutliers selects and protects the outlier subtrees for a single group,
+// appending the preserved roots to protectedRootsByKey under the group key.
+func (p *spanPruningProcessor) protectOutliers(group candidateGroup, res *outlierAnalysisResult, protectedRootsByKey map[string][]*spanNode) {
+	// filterOutlierNodes applies correlation gating and orders outliers most
+	// extreme first. Ask it for all of them (cap 0) and apply
+	// MaxPreservedOutliers here, after dropping outliers already kept by an
+	// enclosing protected subtree. Letting filterOutlierNodes cap first would
+	// spend a budget slot on an already-covered outlier and starve a
+	// not-yet-preserved one further down the order.
+	unlimited := p.config.OutlierAnalysis
+	unlimited.MaxPreservedOutliers = 0
+	_, outliers := filterOutlierNodes(group.nodes, res, unlimited)
+	limit := p.config.OutlierAnalysis.MaxPreservedOutliers
+	for _, o := range outliers {
+		// Skip outliers already kept by an enclosing protected subtree.
+		if o.protected {
+			continue
+		}
+		if limit > 0 && len(protectedRootsByKey[group.key]) >= limit {
+			break
+		}
+		markOutlierSubtree(o)
+		protectedRootsByKey[group.key] = append(protectedRootsByKey[group.key], o)
+	}
+}
+
+// exemplarSelection is the result of sampling exemplars from one top-level
+// group: the sampled subtree roots plus the population size (N) and draw size
+// (D) the executor uses to compose each exemplar's CPS threshold (D/N).
+type exemplarSelection struct {
+	roots          []*spanNode
+	populationSize int
+	sampleSize     int
+}
+
+// sampleExemplarsFromGroup draws random exemplars over the full top-level group
+// (keeping is "outlier OR sampled") and protects each sampled span's whole
+// subtree so it is kept intact instead of aggregated. A drawn span that is
+// already a preserved outlier is kept via the outlier rule (deterministic, so
+// its threshold is left untouched) and is not additionally treated as an
+// exemplar. The draw size D is taken over the full group N and reported as the
+// threshold numerator, because a non-outlier's inclusion probability is D/N
+// regardless of how many draws land on outliers. Lower groups are never
+// sampled: an exemplar is a complete representative tree, taken once at the top.
+func (p *spanPruningProcessor) sampleExemplarsFromGroup(nodes []*spanNode) (exemplarSelection, bool) {
+	if len(nodes) < 2 {
+		return exemplarSelection{}, false
+	}
+	_, sampled := sampleExemplars(nodes, p.config.ExemplarSampling.PrecisionMultiplier)
+	if len(sampled) == 0 {
+		return exemplarSelection{}, false
+	}
+	roots := make([]*spanNode, 0, len(sampled))
+	for _, s := range sampled {
+		// A drawn outlier is already kept deterministically; don't double-tag it.
+		if s.protected {
+			continue
+		}
+		markExemplarSubtree(s)
+		roots = append(roots, s)
+	}
+	if len(roots) == 0 {
+		return exemplarSelection{}, false
+	}
+	return exemplarSelection{roots: roots, populationSize: len(nodes), sampleSize: len(sampled)}, true
+}
+
+// isTopLevelGroup reports whether a candidate group sits at the top of its
+// aggregation tree: none of its members' parents are themselves members of a
+// candidate group, so no higher group aggregates above it.
+func isTopLevelGroup(g candidateGroup, inGroup map[*spanNode]struct{}) bool {
+	for _, n := range g.nodes {
+		if n.parent == nil {
+			continue
+		}
+		if _, ok := inGroup[n.parent]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+// recordExemplars emits exemplar telemetry: one count per sampled exemplar
+// subtree kept in the output.
+func (p *spanPruningProcessor) recordExemplars(ctx context.Context, roots []*spanNode) {
+	if len(roots) == 0 {
+		return
+	}
+	p.telemetryBuilder.ProcessorSpanpruningExemplarsSampled.Add(ctx, int64(len(roots)))
 }
 
 // candidateGroup is a group of sibling spans that would aggregate, paired with
@@ -575,6 +683,16 @@ func planEligibleForParentAggregation(node *spanNode, would map[*spanNode]bool) 
 		}
 	}
 	return true
+}
+
+// anyUnprotected reports whether at least one node is not protected.
+func anyUnprotected(nodes []*spanNode) bool {
+	for _, n := range nodes {
+		if !n.protected {
+			return true
+		}
+	}
+	return false
 }
 
 // excludeProtectedNodes returns the subset of nodes that are not protected,

--- a/processor/spanpruningprocessor/processor_test.go
+++ b/processor/spanpruningprocessor/processor_test.go
@@ -5,6 +5,7 @@ package spanpruningprocessor
 
 import (
 	"context"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor/internal/metadatatest"
 )
@@ -934,6 +936,463 @@ func TestProcessorSkipsAggregationWhenTooFewNormalSpans(t *testing.T) {
 	assert.False(t, found, "summary span should not be created when normal spans drop below threshold")
 }
 
+// TestProcessorSamplesExemplars verifies that random exemplar sampling keeps
+// ceil(multiplier * sqrt(N)) spans as siblings of the summary, annotates them,
+// records summary-level exemplar attributes, and leaves the summary's
+// TraceState untouched.
+func TestProcessorSamplesExemplars(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableExemplarSampling = true
+	cfg.ExemplarSampling.PrecisionMultiplier = 1.0
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	const n = 100
+	td := createTestTraceWithLeafSpans(t, n, map[string]string{"db.operation": "SELECT"})
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	summary, found := findSummarySpanByName(td, "SELECT")
+	require.True(t, found, "summary span should be created")
+
+	wantK := int(math.Ceil(math.Sqrt(float64(n))))
+	wantAggregated := n - wantK
+
+	spanCount, exists := summary.Attributes().Get("aggregation.span_count")
+	require.True(t, exists)
+	assert.Equal(t, int64(wantAggregated), spanCount.Int(), "summary aggregates N-K spans")
+
+	exemplarCount, exists := summary.Attributes().Get("aggregation.exemplar_count")
+	require.True(t, exists)
+	assert.Equal(t, int64(wantK), exemplarCount.Int())
+
+	exemplarIDsAttr, exists := summary.Attributes().Get("aggregation.exemplar_span_ids")
+	require.True(t, exists)
+	require.Equal(t, wantK, exemplarIDsAttr.Slice().Len())
+
+	// Each preserved exemplar must be a sibling of the summary, carry the
+	// is_exemplar marker, and reference the summary span.
+	allLeaves := findAllSpansByExactName(td, "SELECT")
+	var exemplars []ptrace.Span
+	for _, leaf := range allLeaves {
+		if isEx, ok := leaf.Attributes().Get("aggregation.is_exemplar"); ok && isEx.Bool() {
+			exemplars = append(exemplars, leaf)
+		}
+	}
+	require.Len(t, exemplars, wantK)
+
+	summaryIDStr := summary.SpanID().String()
+	for _, ex := range exemplars {
+		assert.Equal(t, summary.ParentSpanID(), ex.ParentSpanID(), "exemplar should be a sibling of the summary")
+		summaryRef, hasRef := ex.Attributes().Get("aggregation.summary_span_id")
+		require.True(t, hasRef)
+		assert.Equal(t, summaryIDStr, summaryRef.Str())
+	}
+
+	// Summary span TraceState must not be modified by exemplar sampling.
+	assert.Empty(t, summary.TraceState().AsRaw())
+}
+
+// TestProcessorExemplarThreshold verifies that exemplar spans with an existing
+// CPS th-value get their threshold composed multiplicatively, while spans
+// without a prior th retain their original TraceState.
+func TestProcessorExemplarThreshold(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableExemplarSampling = true
+	cfg.ExemplarSampling.PrecisionMultiplier = 1.0
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	const n = 100
+	td := createTestTraceWithLeafSpans(t, n, map[string]string{"db.operation": "SELECT"})
+
+	// Stamp prior th encoding p=0.5 on every leaf span.
+	priorTh, err := sampling.ProbabilityToThreshold(0.5)
+	require.NoError(t, err)
+	priorTS := "ot=th:" + priorTh.TValue()
+	rs := td.ResourceSpans().At(0)
+	ss := rs.ScopeSpans().At(0)
+	for i := 0; i < ss.Spans().Len(); i++ {
+		span := ss.Spans().At(i)
+		if span.Name() == "SELECT" {
+			span.TraceState().FromRaw(priorTS)
+		}
+	}
+
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	wantK := int(math.Ceil(math.Sqrt(float64(n))))
+	wantNewTh, err := sampling.ProbabilityToThreshold(0.5 * float64(wantK) / float64(n))
+	require.NoError(t, err)
+	wantTS := "ot=th:" + wantNewTh.TValue()
+
+	leaves := findAllSpansByExactName(td, "SELECT")
+	var exemplars []ptrace.Span
+	for _, leaf := range leaves {
+		if isEx, ok := leaf.Attributes().Get("aggregation.is_exemplar"); ok && isEx.Bool() {
+			exemplars = append(exemplars, leaf)
+		}
+	}
+	require.Len(t, exemplars, wantK)
+
+	for _, ex := range exemplars {
+		assert.Equal(t, wantTS, ex.TraceState().AsRaw(), "exemplar th should be composed to p_old * K/N")
+	}
+
+	// Summary span keeps the template's TraceState verbatim (the prior th).
+	summary, found := findSummarySpanByName(td, "SELECT")
+	require.True(t, found)
+	assert.Equal(t, priorTS, summary.TraceState().AsRaw())
+}
+
+// TestProcessorExemplarThresholdNoPrior verifies that exemplars without a prior
+// th retain their original TraceState (no fabricated CPS context).
+func TestProcessorExemplarThresholdNoPrior(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableExemplarSampling = true
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	td := createTestTraceWithLeafSpans(t, 50, map[string]string{"db.operation": "SELECT"})
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	leaves := findAllSpansByExactName(td, "SELECT")
+	exemplarCount := 0
+	for _, leaf := range leaves {
+		if isEx, ok := leaf.Attributes().Get("aggregation.is_exemplar"); ok && isEx.Bool() {
+			exemplarCount++
+			assert.Empty(t, leaf.TraceState().AsRaw(), "no prior th means no synthesized CPS state")
+		}
+	}
+	assert.Equal(t, int(math.Ceil(math.Sqrt(50))), exemplarCount)
+}
+
+// TestProcessorOutlierAndExemplarCoexist verifies that outlier preservation and
+// exemplar sampling coexist under "keep if outlier OR sampled" semantics:
+// exemplars are drawn from the FULL group (outliers included), an outlier that
+// is drawn is kept once via the outlier rule (never tagged as both), preserved
+// outliers retain their prior threshold verbatim, and exemplars compose their
+// threshold by D/N where D is the draw size over the full group N.
+//
+// Counts are asserted as invariants rather than exact values: the overlap
+// between the draw and the outlier set is random (the math/rand/v2 global RNG
+// cannot be seeded), so exemplar_count varies run-to-run by the overlap.
+func TestProcessorOutlierAndExemplarCoexist(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableOutlierAnalysis = true
+	cfg.OutlierAnalysis.PreserveOutliers = true
+	cfg.OutlierAnalysis.MaxPreservedOutliers = 10
+	cfg.OutlierAnalysis.IQRMultiplier = 1.5
+	cfg.OutlierAnalysis.MinGroupSize = 7
+	cfg.EnableExemplarSampling = true
+	cfg.ExemplarSampling.PrecisionMultiplier = 1.0
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	const (
+		numNormal   = 100
+		numOutliers = 5
+		n           = numNormal + numOutliers // full group size N
+	)
+	d := int(math.Ceil(math.Sqrt(float64(n)))) // draw size D = ceil(1.0 * sqrt(N))
+
+	// Stamp prior th encoding p=0.5 on every SELECT span.
+	priorTh, err := sampling.ProbabilityToThreshold(0.5)
+	require.NoError(t, err)
+	priorTS := "ot=th:" + priorTh.TValue()
+
+	td := createTestTraceWithOutliersCount(t, numNormal, numOutliers, priorTS)
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	summary, found := findSummarySpanByName(td, "SELECT")
+	require.True(t, found)
+
+	// Expected composed threshold for non-outlier exemplars: p_old * D/N.
+	wantExTh, err := sampling.ProbabilityToThreshold(0.5 * float64(d) / float64(n))
+	require.NoError(t, err)
+	wantExTS := "ot=th:" + wantExTh.TValue()
+
+	leaves := findAllSpansByExactName(td, "SELECT")
+	var outliers, exemplars []ptrace.Span
+	for _, leaf := range leaves {
+		isOutlier, _ := leaf.Attributes().Get("aggregation.is_preserved_outlier")
+		isEx, _ := leaf.Attributes().Get("aggregation.is_exemplar")
+		// OR semantics: no span is kept as both an outlier and an exemplar.
+		assert.False(t, isOutlier.Bool() && isEx.Bool(), "span tagged as both outlier and exemplar")
+		switch {
+		case isOutlier.Bool():
+			outliers = append(outliers, leaf)
+		case isEx.Bool():
+			exemplars = append(exemplars, leaf)
+		}
+	}
+
+	// The 5 long spans are detected and preserved deterministically.
+	require.Len(t, outliers, numOutliers, "all outliers should be preserved")
+
+	// Preserved outliers keep their prior threshold verbatim — being drawn into
+	// the exemplar sample must NOT recompose an outlier's threshold (OR).
+	for _, o := range outliers {
+		assert.Equal(t, priorTS, o.TraceState().AsRaw(), "preserved outlier threshold must be untouched")
+	}
+
+	// Exemplars are non-outlier draws; their threshold is composed by D/N.
+	for _, ex := range exemplars {
+		assert.Equal(t, wantExTS, ex.TraceState().AsRaw(), "exemplar th should be composed to p_old * D/N")
+	}
+
+	// exemplar_count = D minus any draws that landed on outliers, so it is in
+	// [D - numOutliers, D] and never exceeds the non-outlier population.
+	exemplarCountAttr, ok := summary.Attributes().Get("aggregation.exemplar_count")
+	require.True(t, ok)
+	exemplarCount := int(exemplarCountAttr.Int())
+	assert.Equal(t, len(exemplars), exemplarCount)
+	assert.GreaterOrEqual(t, exemplarCount, d-numOutliers)
+	assert.LessOrEqual(t, exemplarCount, d)
+
+	preservedCount, ok := summary.Attributes().Get("aggregation.preserved_outlier_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(numOutliers), preservedCount.Int())
+
+	// Conservation: every span is either a preserved outlier, an exemplar, or
+	// aggregated into the summary.
+	spanCount, ok := summary.Attributes().Get("aggregation.span_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(n), preservedCount.Int()+exemplarCountAttr.Int()+spanCount.Int(),
+		"preserved + exemplars + aggregated must equal the full group")
+}
+
+// TestProcessorExemplarSkipsWhenBelowMinSpansToAggregate verifies that when
+// exemplar sampling would drop the aggregated set below MinSpansToAggregate,
+// the entire leaf group is left unchanged: no summary, no exemplar markers,
+// and the exemplars_sampled counter is not incremented.
+func TestProcessorExemplarSkipsWhenBelowMinSpansToAggregate(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	// 10 leaf spans, K = ceil(sqrt(10)) = 4 exemplars, aggregate = 6.
+	// MinSpansToAggregate = 7 means the floor check should reject this group.
+	cfg.MinSpansToAggregate = 7
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableExemplarSampling = true
+	cfg.ExemplarSampling.PrecisionMultiplier = 1.0
+
+	tel := componenttest.NewTelemetry()
+	t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) }) //nolint:usetesting
+
+	settings := metadatatest.NewSettings(tel)
+	tp, err := factory.CreateTraces(t.Context(), settings, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	const n = 10
+	td := createTestTraceWithLeafSpans(t, n, map[string]string{"db.operation": "SELECT"})
+	initialCount := countSpans(td)
+
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	assert.Equal(t, initialCount, countSpans(td), "no spans should be added or removed")
+	_, found := findSummarySpanByName(td, "SELECT")
+	assert.False(t, found, "no summary should be created")
+
+	for _, leaf := range findAllSpansByExactName(td, "SELECT") {
+		_, hasMarker := leaf.Attributes().Get("aggregation.is_exemplar")
+		assert.False(t, hasMarker, "no exemplar markers should leak when the group is skipped")
+	}
+
+	// exemplars_sampled counter must not be incremented for skipped groups.
+	_, err = tel.GetMetric("otelcol_processor_spanpruning_exemplars_sampled")
+	assert.Error(t, err, "exemplars_sampled should not be recorded when the group is skipped")
+}
+
+// TestProcessorExemplarPreservesTopLevelSubtree verifies that exemplar sampling
+// runs only at the top of an aggregation tree and keeps each sampled span's
+// whole subtree: the chosen handlers are preserved intact (their SELECT children
+// are not aggregated), the remaining handlers aggregate normally, and no leaf
+// span is independently sampled.
+func TestProcessorExemplarPreservesTopLevelSubtree(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.MaxParentDepth = -1
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableExemplarSampling = true
+	cfg.ExemplarSampling.PrecisionMultiplier = 1.0
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	// 10 handlers under the root, each with 5 SELECT children. The top of the
+	// tree is the handler group, so exemplars are drawn there: ceil(sqrt(10)) = 4
+	// handlers are kept whole, the other 6 aggregate.
+	const (
+		numHandlers       = 10
+		selectsPerHandler = 5
+	)
+	td := createTraceHandlersEachWithSelects(t, numHandlers, selectsPerHandler)
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	wantExemplars := int(math.Ceil(math.Sqrt(float64(numHandlers))))
+
+	exemplars := findExemplarSpans(td)
+	require.Len(t, exemplars, wantExemplars)
+
+	// Every exemplar is a top-level handler, never a leaf.
+	for _, ex := range exemplars {
+		assert.Equal(t, "handler", ex.Name(), "exemplars must be sampled at the top (handler) level")
+	}
+
+	// No SELECT leaf is independently sampled: sampling happens only at the top.
+	for _, leaf := range findAllSpansByExactName(td, "SELECT") {
+		isEx, _ := leaf.Attributes().Get("aggregation.is_exemplar")
+		assert.False(t, isEx.Bool(), "leaf groups below the top must not be sampled")
+	}
+
+	// The remaining handlers aggregate into a single handler summary, and the
+	// exemplar handlers become its siblings (reparented to the root).
+	handlerSummary, found := findSummarySpanByName(td, "handler")
+	require.True(t, found, "non-exemplar handlers should aggregate")
+	handlerSpanCount, ok := handlerSummary.Attributes().Get("aggregation.span_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(numHandlers-wantExemplars), handlerSpanCount.Int())
+	for _, ex := range exemplars {
+		assert.Equal(t, handlerSummary.ParentSpanID(), ex.ParentSpanID(), "exemplar reparented as a sibling of the handler summary")
+	}
+
+	// Each exemplar handler's whole subtree is preserved: its SELECT children are
+	// still present and none were aggregated into a summary.
+	bySpanID := indexSpansByID(td)
+	for _, ex := range exemplars {
+		children := childSpans(td, ex.SpanID())
+		require.Len(t, children, selectsPerHandler, "exemplar subtree should keep all its children")
+		for _, child := range children {
+			assert.Equal(t, "SELECT", child.Name())
+			isSummary, _ := child.Attributes().Get("aggregation.is_summary")
+			assert.False(t, isSummary.Bool(), "children of an exemplar must not be aggregated")
+			_, stillPresent := bySpanID[child.SpanID()]
+			assert.True(t, stillPresent)
+		}
+	}
+}
+
+// indexSpansByID returns every span in the trace keyed by its SpanID.
+func indexSpansByID(td ptrace.Traces) map[pcommon.SpanID]ptrace.Span {
+	out := make(map[pcommon.SpanID]ptrace.Span)
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		ilss := rss.At(i).ScopeSpans()
+		for j := 0; j < ilss.Len(); j++ {
+			spans := ilss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				out[span.SpanID()] = span
+			}
+		}
+	}
+	return out
+}
+
+// childSpans returns all spans whose parent is the given SpanID.
+func childSpans(td ptrace.Traces, parentID pcommon.SpanID) []ptrace.Span {
+	var out []ptrace.Span
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		ilss := rss.At(i).ScopeSpans()
+		for j := 0; j < ilss.Len(); j++ {
+			spans := ilss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				if span.ParentSpanID() == parentID {
+					out = append(out, span)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// findExemplarSpans returns all spans with the is_exemplar marker.
+func findExemplarSpans(td ptrace.Traces) []ptrace.Span {
+	var out []ptrace.Span
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		ilss := rss.At(i).ScopeSpans()
+		for j := 0; j < ilss.Len(); j++ {
+			spans := ilss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				if isEx, ok := span.Attributes().Get("aggregation.is_exemplar"); ok && isEx.Bool() {
+					out = append(out, span)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// createTraceHandlersEachWithSelects builds a trace where each of numHandlers
+// handler spans has selectsPerHandler SELECT children that all share the same
+// leaf group key. Used to exercise parent aggregation interacting with
+// exemplar sampling.
+func createTraceHandlersEachWithSelects(t *testing.T, numHandlers, selectsPerHandler int) ptrace.Traces {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	rootID := pcommon.SpanID([8]byte{1, 0, 0, 0, 0, 0, 0, 0})
+
+	root := ss.Spans().AppendEmpty()
+	root.SetTraceID(traceID)
+	root.SetSpanID(rootID)
+	root.SetName("root")
+	root.SetStartTimestamp(pcommon.Timestamp(1000000000))
+	root.SetEndTimestamp(pcommon.Timestamp(2000000000))
+
+	for h := range numHandlers {
+		handlerID := pcommon.SpanID([8]byte{2, byte(h), 0, 0, 0, 0, 0, 0})
+		handler := ss.Spans().AppendEmpty()
+		handler.SetTraceID(traceID)
+		handler.SetSpanID(handlerID)
+		handler.SetParentSpanID(rootID)
+		handler.SetName("handler")
+		handler.SetStartTimestamp(pcommon.Timestamp(1000000000))
+		handler.SetEndTimestamp(pcommon.Timestamp(1500000000))
+
+		for i := range selectsPerHandler {
+			leaf := ss.Spans().AppendEmpty()
+			leaf.SetTraceID(traceID)
+			leaf.SetSpanID(pcommon.SpanID([8]byte{3, byte(h), byte(i), 0, 0, 0, 0, 0}))
+			leaf.SetParentSpanID(handlerID)
+			leaf.SetName("SELECT")
+			leaf.SetStartTimestamp(pcommon.Timestamp(1000000000 + int64(i)*100))
+			leaf.SetEndTimestamp(pcommon.Timestamp(1000000200 + int64(i)*100))
+			leaf.Attributes().PutStr("db.operation", "SELECT")
+		}
+	}
+	return td
+}
+
 // Helper functions
 
 func assertHistogramRecordedOnceWithSum(t *testing.T, tel *componenttest.Telemetry, metricName string) {
@@ -1050,6 +1509,56 @@ func createTestTraceWithOutliers(t *testing.T) ptrace.Traces {
 		span.SetEndTimestamp(pcommon.Timestamp(baseTime + dur*ms))
 		span.Attributes().PutStr("db.operation", "SELECT")
 		span.Attributes().PutStr("cache_hit", "false")
+	}
+
+	return td
+}
+
+// createTestTraceWithOutliersCount builds a single SELECT leaf group with
+// numNormal short spans and numOutliers very long spans (clear duration
+// outliers), all sharing db.operation=SELECT. Outliers carry cache_hit=false to
+// drive correlation detection. The prior TraceState (if non-empty) is stamped on
+// every SELECT span so exemplar/outlier threshold composition can be asserted.
+func createTestTraceWithOutliersCount(t *testing.T, numNormal, numOutliers int, priorTS string) ptrace.Traces {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	parentSpanID := pcommon.SpanID([8]byte{1, 0, 0, 0, 0, 0, 0, 0})
+
+	parentSpan := ss.Spans().AppendEmpty()
+	parentSpan.SetTraceID(traceID)
+	parentSpan.SetSpanID(parentSpanID)
+	parentSpan.SetName("handler")
+	parentSpan.SetStartTimestamp(pcommon.Timestamp(1000000000))
+	parentSpan.SetEndTimestamp(pcommon.Timestamp(1001000000))
+
+	baseTime := int64(1000000000)
+	ms := int64(1000000)
+
+	addSpan := func(prefix byte, i int, durMS int64, cacheHit string) {
+		span := ss.Spans().AppendEmpty()
+		span.SetTraceID(traceID)
+		span.SetSpanID(pcommon.SpanID([8]byte{prefix, byte(i), byte(i >> 8), 0, 0, 0, 0, 0}))
+		span.SetParentSpanID(parentSpanID)
+		span.SetName("SELECT")
+		span.SetStartTimestamp(pcommon.Timestamp(baseTime))
+		span.SetEndTimestamp(pcommon.Timestamp(baseTime + durMS*ms))
+		span.Attributes().PutStr("db.operation", "SELECT")
+		span.Attributes().PutStr("cache_hit", cacheHit)
+		if priorTS != "" {
+			span.TraceState().FromRaw(priorTS)
+		}
+	}
+
+	for i := range numNormal {
+		// Tight spread (5..14ms) so normals never trip outlier detection.
+		addSpan(2, i, 5+int64(i%10), "true")
+	}
+	for i := range numOutliers {
+		addSpan(3, i, 500+int64(i)*10, "false")
 	}
 
 	return td

--- a/processor/spanpruningprocessor/tree.go
+++ b/processor/spanpruningprocessor/tree.go
@@ -24,7 +24,8 @@ type spanNode struct {
 	isLeaf             bool           // true if node has no children
 	markedForRemoval   bool           // true if node will be aggregated
 	isPreservedOutlier bool           // true if this node is the root of a preserved outlier subtree
-	protected          bool           // true if this node is within a preserved outlier subtree (never aggregated)
+	isExemplar         bool           // true if this node is the root of a sampled exemplar subtree
+	protected          bool           // true if this node is within a preserved outlier or exemplar subtree (never aggregated)
 }
 
 // traceTree holds span nodes indexed by ID plus quick leaf/orphan lists for
@@ -150,6 +151,18 @@ func markOutlierSubtree(root *spanNode) {
 	}
 }
 
+// markExemplarSubtree records root as a sampled-exemplar root and marks every
+// node in its subtree (root included) as protected, so the whole subtree is kept
+// intact (never aggregated). It is exemplar-specific (it sets isExemplar); it
+// deliberately does not reuse markOutlierSubtree so exemplars never acquire an
+// outlier flag.
+func markExemplarSubtree(root *spanNode) {
+	root.isExemplar = true
+	for _, n := range subtreeNodes(root) {
+		n.protected = true
+	}
+}
+
 // subtreeNodes returns root and all of its descendants.
 func subtreeNodes(root *spanNode) []*spanNode {
 	nodes := []*spanNode{root}
@@ -208,13 +221,15 @@ func (*spanPruningProcessor) isEligibleForParentAggregation(node *spanNode) bool
 		return false
 	}
 
-	// Must not already be marked for removal, and must not itself be a protected
-	// outlier subtree (those are preserved, not aggregated).
+	// Must not already be marked for removal, and must not itself be within a
+	// protected subtree (preserved outliers and sampled exemplars are kept, not
+	// aggregated).
 	if node.markedForRemoval || node.protected {
 		return false
 	}
 
-	// All children must be aggregated or part of a preserved outlier subtree.
+	// All children must be aggregated or part of a protected (preserved outlier
+	// or sampled exemplar) subtree.
 	for _, child := range node.children {
 		if !child.markedForRemoval && !child.protected {
 			return false


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The idea of this change is to sample a random selection of pruned paths instead of just outliers. This will allow more information to users of span pruning at the cost of slightly more space consumed. The number of kept paths scales with $`\sqrt{n}`$ to balance out information we keep vs pruning efficiency.

In order to accurately calculate metrics afterwards the trace state thresholds are updated (when present) to account for the sampling being done and resulting partial traces. Users would likely want to exclude summary spans when doing analytics as they could skew the results.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->