### PR TITLE
[pkg/stanza] Expose remaining go-syslog parser options in syslog_parser

### DIFF
--- a/pkg/stanza/operator/parser/syslog/config.go
+++ b/pkg/stanza/operator/parser/syslog/config.go
@@ -40,6 +40,15 @@ func NewConfig() *Config {
 func NewConfigWithID(operatorID string) *Config {
 	return &Config{
 		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
+		BaseConfig: BaseConfig{
+			EnableLenientDay: true,
+			CiscoIOS: &CiscoIOSConfig{
+				MessageCounter:  true,
+				SequenceNumber:  true,
+				Hostname:        true,
+				SecondFractions: true,
+			},
+		},
 	}
 }
 
@@ -49,14 +58,32 @@ type Config struct {
 	BaseConfig          `mapstructure:",squash"`
 }
 
-// BaseConfig is the detailed configuration of a syslog parser.
+// CiscoIOSConfig defines the configuration for Cisco IOS syslog extensions parser.
+type CiscoIOSConfig struct {
+	Enable          bool `mapstructure:"enable,omitempty"`
+	MessageCounter  bool `mapstructure:"message_counter,omitempty"`
+	SequenceNumber  bool `mapstructure:"sequence_number,omitempty"`
+	Hostname        bool `mapstructure:"hostname,omitempty"`
+	SecondFractions bool `mapstructure:"second_fractions,omitempty"`
+}
+
+// BaseConfig is the detailed configuration of a syslog syslog parser.
 type BaseConfig struct {
-	Protocol                     string  `mapstructure:"protocol,omitempty"`
-	Location                     string  `mapstructure:"location,omitempty"`
-	EnableOctetCounting          bool    `mapstructure:"enable_octet_counting,omitempty"`
-	AllowSkipPriHeader           bool    `mapstructure:"allow_skip_pri_header,omitempty"`
-	NonTransparentFramingTrailer *string `mapstructure:"non_transparent_framing_trailer,omitempty"`
-	MaxOctets                    int     `mapstructure:"max_octets,omitempty"`
+	Protocol                     string          `mapstructure:"protocol,omitempty"`
+	Location                     string          `mapstructure:"location,omitempty"`
+	EnableOctetCounting          bool            `mapstructure:"enable_octet_counting,omitempty"`
+	AllowSkipPriHeader           bool            `mapstructure:"allow_skip_pri_header,omitempty"`
+	NonTransparentFramingTrailer *string         `mapstructure:"non_transparent_framing_trailer,omitempty"`
+	MaxOctets                    int             `mapstructure:"max_octets,omitempty"`
+	EnableCompliantMsg           bool            `mapstructure:"enable_compliant_msg,omitempty"`
+	EnableRFC3339                bool            `mapstructure:"enable_rfc3339,omitempty"`
+	EnableSecondFractions        bool            `mapstructure:"enable_second_fractions,omitempty"`
+	EnableLenientDay             bool            `mapstructure:"enable_lenient_day,omitempty"`
+	EnableEmbeddedNewlines       bool            `mapstructure:"enable_embedded_newlines,omitempty"`
+	EnableCiscoHostname          bool            `mapstructure:"enable_cisco_hostname,omitempty"`
+	CiscoIOS                     *CiscoIOSConfig `mapstructure:"cisco_ios,omitempty"`
+	Year                         *int            `mapstructure:"year,omitempty"`
+	Timezone                     string          `mapstructure:"timezone,omitempty"`
 }
 
 // Build will build a JSON parser operator.
@@ -95,6 +122,16 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		}
 	}
 
+	if proto != RFC5424 && c.EnableCompliantMsg {
+		return nil, errors.New("enable_compliant_msg is only compatible with protocol rfc5424")
+	}
+
+	if proto != RFC3164 && (c.EnableRFC3339 || c.EnableSecondFractions || c.EnableEmbeddedNewlines || c.EnableCiscoHostname ||
+		(c.CiscoIOS != nil && (c.CiscoIOS.Enable || !c.CiscoIOS.MessageCounter || !c.CiscoIOS.SequenceNumber || !c.CiscoIOS.Hostname || !c.CiscoIOS.SecondFractions)) ||
+		c.Year != nil || c.Timezone != "") {
+		return nil, errors.New("rfc3164 options are only compatible with protocol rfc3164")
+	}
+
 	if c.Location == "" {
 		c.Location = "UTC"
 	}
@@ -102,6 +139,14 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 	location, err := time.LoadLocation(c.Location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load location %s: %w", c.Location, err)
+	}
+
+	var timezone *time.Location
+	if c.Timezone != "" {
+		timezone, err = time.LoadLocation(c.Timezone)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load timezone %s: %w", c.Timezone, err)
+		}
 	}
 
 	return &Parser{
@@ -112,5 +157,14 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		allowSkipPriHeader:           c.AllowSkipPriHeader,
 		nonTransparentFramingTrailer: c.NonTransparentFramingTrailer,
 		maxOctets:                    c.MaxOctets,
+		enableCompliantMsg:           c.EnableCompliantMsg,
+		enableRFC3339:                c.EnableRFC3339,
+		enableSecondFractions:        c.EnableSecondFractions,
+		enableLenientDay:             c.EnableLenientDay,
+		enableEmbeddedNewlines:       c.EnableEmbeddedNewlines,
+		enableCiscoHostname:          c.EnableCiscoHostname,
+		ciscoIOS:                     c.CiscoIOS,
+		year:                         c.Year,
+		timezone:                     timezone,
 	}, nil
 }

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -129,6 +129,38 @@ func TestUnmarshal(t *testing.T) {
 					return cfg
 				}(),
 			},
+			{
+				Name: "all_options_rfc3164",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Protocol = RFC3164
+					cfg.EnableRFC3339 = true
+					cfg.EnableSecondFractions = true
+					cfg.EnableLenientDay = false
+					cfg.EnableEmbeddedNewlines = true
+					cfg.EnableCiscoHostname = true
+					cfg.CiscoIOS = &CiscoIOSConfig{
+						Enable:          true,
+						MessageCounter:  false,
+						SequenceNumber:  false,
+						Hostname:        false,
+						SecondFractions: false,
+					}
+					y := 2026
+					cfg.Year = &y
+					cfg.Timezone = "America/New_York"
+					return cfg
+				}(),
+			},
+			{
+				Name: "compliant_msg_rfc5424",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Protocol = RFC5424
+					cfg.EnableCompliantMsg = true
+					return cfg
+				}(),
+			},
 		},
 	}.Run(t)
 }
@@ -240,4 +272,24 @@ func TestParserInvalidLocation(t *testing.T) {
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
 	require.ErrorContains(t, err, "failed to load location "+config.Location)
+}
+
+func TestValidationOptions(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+
+	t.Run("enable_compliant_msg with RFC3164 fails", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.Protocol = RFC3164
+		cfg.EnableCompliantMsg = true
+		_, err := cfg.Build(set)
+		require.ErrorContains(t, err, "enable_compliant_msg is only compatible with protocol rfc5424")
+	})
+
+	t.Run("RFC3164 option with RFC5424 fails", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.Protocol = RFC5424
+		cfg.EnableRFC3339 = true
+		_, err := cfg.Build(set)
+		require.ErrorContains(t, err, "rfc3164 options are only compatible with protocol rfc3164")
+	})
 }

--- a/pkg/stanza/operator/parser/syslog/parser.go
+++ b/pkg/stanza/operator/parser/syslog/parser.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	sl "github.com/leodido/go-syslog/v4"
+	"github.com/leodido/go-syslog/v4/ciscoios"
 	"github.com/leodido/go-syslog/v4/nontransparent"
 	"github.com/leodido/go-syslog/v4/octetcounting"
 	"github.com/leodido/go-syslog/v4/rfc3164"
@@ -56,6 +57,15 @@ type Parser struct {
 	allowSkipPriHeader           bool
 	nonTransparentFramingTrailer *string
 	maxOctets                    int
+	enableCompliantMsg           bool
+	enableRFC3339                bool
+	enableSecondFractions        bool
+	enableLenientDay             bool
+	enableEmbeddedNewlines       bool
+	enableCiscoHostname          bool
+	ciscoIOS                     *CiscoIOSConfig
+	year                         *int
+	timezone                     *time.Location
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
@@ -187,25 +197,69 @@ func (p *Parser) buildParseFunc() (parseFunc, error) {
 			if p.allowSkipPriHeader && !priRegex.Match(input) {
 				input = append([]byte("<0>"), input...)
 			}
-			return rfc3164.NewMachine(rfc3164.WithLocaleTimezone(p.location), rfc3164.WithLenientDay()).Parse(input)
+			opts := []sl.MachineOption{
+				rfc3164.WithLocaleTimezone(p.location),
+			}
+			if p.enableLenientDay {
+				opts = append(opts, rfc3164.WithLenientDay())
+			}
+			if p.enableRFC3339 {
+				opts = append(opts, rfc3164.WithRFC3339())
+			}
+			if p.enableSecondFractions {
+				opts = append(opts, rfc3164.WithSecondFractions())
+			}
+			if p.enableEmbeddedNewlines {
+				opts = append(opts, rfc3164.WithEmbeddedNewlines())
+			}
+			if p.enableCiscoHostname {
+				opts = append(opts, rfc3164.WithCiscoHostname())
+			}
+			if p.ciscoIOS != nil && p.ciscoIOS.Enable {
+				var flags ciscoios.Component
+				if !p.ciscoIOS.MessageCounter {
+					flags |= ciscoios.DisableMessageCounter
+				}
+				if !p.ciscoIOS.SequenceNumber {
+					flags |= ciscoios.DisableSequenceNumber
+				}
+				if !p.ciscoIOS.Hostname {
+					flags |= ciscoios.DisableHostname
+				}
+				if !p.ciscoIOS.SecondFractions {
+					flags |= ciscoios.DisableSecondFractions
+				}
+				opts = append(opts, rfc3164.WithCiscoIOSComponents(flags))
+			}
+			if p.year != nil {
+				opts = append(opts, rfc3164.WithYear(rfc3164.Year{YYYY: *p.year}))
+			}
+			if p.timezone != nil {
+				opts = append(opts, rfc3164.WithTimezone(p.timezone))
+			}
+			return rfc3164.NewMachine(opts...).Parse(input)
 		}, nil
 	case RFC5424:
 		switch {
 		// Octet Counting Parsing RFC6587
 		case p.enableOctetCounting:
-			return newOctetCountingParseFunc(p.maxOctets), nil
+			return p.newOctetCountingParseFunc(p.maxOctets), nil
 		// Non-Transparent-Framing Parsing RFC6587
 		case p.nonTransparentFramingTrailer != nil && *p.nonTransparentFramingTrailer == LFTrailer:
-			return newNonTransparentFramingParseFunc(nontransparent.LF), nil
+			return p.newNonTransparentFramingParseFunc(nontransparent.LF), nil
 		case p.nonTransparentFramingTrailer != nil && *p.nonTransparentFramingTrailer == NULTrailer:
-			return newNonTransparentFramingParseFunc(nontransparent.NUL), nil
+			return p.newNonTransparentFramingParseFunc(nontransparent.NUL), nil
 		// Raw RFC5424 parsing
 		default:
 			return func(input []byte) (sl.Message, error) {
 				if p.allowSkipPriHeader && !priRegex.Match(input) {
 					input = append([]byte("<0>"), input...)
 				}
-				return rfc5424.NewMachine().Parse(input)
+				opts := []sl.MachineOption{}
+				if p.enableCompliantMsg {
+					opts = append(opts, rfc5424.WithCompliantMsg())
+				}
+				return rfc5424.NewMachine(opts...).Parse(input)
 			}, nil
 		}
 	case None:
@@ -456,7 +510,7 @@ func postprocess(e *entry.Entry) error {
 	return cleanupTimestamp(e)
 }
 
-func newOctetCountingParseFunc(maxOctets int) parseFunc {
+func (p *Parser) newOctetCountingParseFunc(maxOctets int) parseFunc {
 	return func(input []byte) (message sl.Message, err error) {
 		listener := func(res *sl.Result) {
 			message = res.Message
@@ -472,6 +526,10 @@ func newOctetCountingParseFunc(maxOctets int) parseFunc {
 			parserOpts = append(parserOpts, sl.WithMaxMessageLength(maxOctets))
 		}
 
+		if p.enableCompliantMsg {
+			parserOpts = append(parserOpts, sl.WithMachineOptions(rfc5424.WithCompliantMsg()))
+		}
+
 		parser := octetcounting.NewParser(parserOpts...)
 		reader := bytes.NewReader(input)
 		parser.Parse(reader)
@@ -479,14 +537,24 @@ func newOctetCountingParseFunc(maxOctets int) parseFunc {
 	}
 }
 
-func newNonTransparentFramingParseFunc(trailerType nontransparent.TrailerType) parseFunc {
+func (p *Parser) newNonTransparentFramingParseFunc(trailerType nontransparent.TrailerType) parseFunc {
 	return func(input []byte) (message sl.Message, err error) {
 		listener := func(res *sl.Result) {
 			message = res.Message
 			err = res.Error
 		}
 
-		parser := nontransparent.NewParser(sl.WithBestEffort(), nontransparent.WithTrailer(trailerType), sl.WithListener(listener))
+		parserOpts := []sl.ParserOption{
+			sl.WithBestEffort(),
+			nontransparent.WithTrailer(trailerType),
+			sl.WithListener(listener),
+		}
+
+		if p.enableCompliantMsg {
+			parserOpts = append(parserOpts, sl.WithMachineOptions(rfc5424.WithCompliantMsg()))
+		}
+
+		parser := nontransparent.NewParser(parserOpts...)
 		reader := bytes.NewReader(input)
 		parser.Parse(reader)
 		return message, err

--- a/pkg/stanza/operator/parser/syslog/parser_test.go
+++ b/pkg/stanza/operator/parser/syslog/parser_test.go
@@ -349,3 +349,212 @@ func TestSyslogQuietModeProcess(t *testing.T) {
 		})
 	}
 }
+
+func TestSyslogParseRFC5424_CompliantMsg(t *testing.T) {
+	cfg := basicConfig()
+	cfg.Protocol = syslog.RFC5424
+	cfg.EnableCompliantMsg = true
+
+	// Strict compliant messages have structured data and VERSION.
+	body := `<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc 8710 - - %% It's time to make the do-nuts.`
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	fake := testutil.NewFakeOutput(t)
+	err = op.SetOutputs([]operator.Operator{fake})
+	require.NoError(t, err)
+
+	newEntry := entry.New()
+	newEntry.Body = body
+	err = op.Process(t.Context(), newEntry)
+	require.NoError(t, err)
+
+	select {
+	case e := <-fake.Received:
+		require.Equal(t, body, e.Body)
+		val, ok := e.Get(entry.NewAttributeField("message"))
+		require.True(t, ok)
+		require.Equal(t, "%% It's time to make the do-nuts.", val)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be processed")
+	}
+}
+
+func TestSyslogParseRFC3164_NewOptions(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+
+	t.Run("RFC3339 timestamp", func(t *testing.T) {
+		cfg := basicConfig()
+		cfg.Protocol = syslog.RFC3164
+		cfg.EnableRFC3339 = true
+
+		body := `<13>2003-10-11T22:14:15Z mymachine su: 'su root' failed`
+
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		fake := testutil.NewFakeOutput(t)
+		require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+		newEntry := entry.New()
+		newEntry.Body = body
+		require.NoError(t, op.Process(t.Context(), newEntry))
+
+		select {
+		case e := <-fake.Received:
+			require.Equal(t, time.Date(2003, time.October, 11, 22, 14, 15, 0, time.UTC), e.Timestamp)
+		case <-time.After(time.Second):
+			require.FailNow(t, "timeout")
+		}
+	})
+
+	t.Run("Second fractions", func(t *testing.T) {
+		cfg := basicConfig()
+		cfg.Protocol = syslog.RFC3164
+		cfg.EnableSecondFractions = true
+
+		body := `<13>Feb  5 17:32:18.123 mymachine su: 'su root' failed`
+
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		fake := testutil.NewFakeOutput(t)
+		require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+		newEntry := entry.New()
+		newEntry.Body = body
+		require.NoError(t, op.Process(t.Context(), newEntry))
+
+		select {
+		case e := <-fake.Received:
+			// Uses current year, let's just check the month/day/time
+			require.Equal(t, time.February, e.Timestamp.Month())
+			require.Equal(t, 5, e.Timestamp.Day())
+			require.Equal(t, 17, e.Timestamp.Hour())
+			require.Equal(t, 32, e.Timestamp.Minute())
+			require.Equal(t, 18, e.Timestamp.Second())
+			require.Equal(t, 123000000, e.Timestamp.Nanosecond())
+		case <-time.After(time.Second):
+			require.FailNow(t, "timeout")
+		}
+	})
+
+	t.Run("Embedded newlines", func(t *testing.T) {
+		cfg := basicConfig()
+		cfg.Protocol = syslog.RFC3164
+		cfg.EnableEmbeddedNewlines = true
+
+		body := "<13>Feb  5 17:32:18 mymachine su: 'su root' failed\nwith embedded\nnewlines"
+
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		fake := testutil.NewFakeOutput(t)
+		require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+		newEntry := entry.New()
+		newEntry.Body = body
+		require.NoError(t, op.Process(t.Context(), newEntry))
+
+		select {
+		case e := <-fake.Received:
+			val, _ := e.Get(entry.NewAttributeField("message"))
+			require.Equal(t, "'su root' failed\nwith embedded\nnewlines", val)
+		case <-time.After(time.Second):
+			require.FailNow(t, "timeout")
+		}
+	})
+
+	t.Run("Cisco IOS options", func(t *testing.T) {
+		cfg := basicConfig()
+		cfg.Protocol = syslog.RFC3164
+		cfg.CiscoIOS = &syslog.CiscoIOSConfig{
+			Enable:          true,
+			MessageCounter:  true,
+			SequenceNumber:  true,
+			Hostname:        true,
+			SecondFractions: true,
+		}
+
+		body := `<189>237: 000485: router1: *Jan  8 19:46:03.295: %SYS-5-CONFIG_I: Configured from console by console`
+
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		fake := testutil.NewFakeOutput(t)
+		require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+		newEntry := entry.New()
+		newEntry.Body = body
+		require.NoError(t, op.Process(t.Context(), newEntry))
+
+		select {
+		case e := <-fake.Received:
+			val, _ := e.Get(entry.NewAttributeField("message"))
+			require.Equal(t, "Configured from console by console", val)
+			appname, _ := e.Get(entry.NewAttributeField("appname"))
+			require.Equal(t, "%SYS-5-CONFIG_I", appname)
+			hostname, _ := e.Get(entry.NewAttributeField("hostname"))
+			require.Equal(t, "router1", hostname)
+			// check that second fractions are parsed
+			require.Equal(t, 295000000, e.Timestamp.Nanosecond())
+		case <-time.After(time.Second):
+			require.FailNow(t, "timeout")
+		}
+	})
+
+	t.Run("Year override", func(t *testing.T) {
+		cfg := basicConfig()
+		cfg.Protocol = syslog.RFC3164
+		y := 2024
+		cfg.Year = &y
+
+		body := `<13>Feb  5 17:32:18 mymachine su: 'su root' failed`
+
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		fake := testutil.NewFakeOutput(t)
+		require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+		newEntry := entry.New()
+		newEntry.Body = body
+		require.NoError(t, op.Process(t.Context(), newEntry))
+
+		select {
+		case e := <-fake.Received:
+			require.Equal(t, 2024, e.Timestamp.Year())
+		case <-time.After(time.Second):
+			require.FailNow(t, "timeout")
+		}
+	})
+
+	t.Run("Timezone Normalization", func(t *testing.T) {
+		cfg := basicConfig()
+		cfg.Protocol = syslog.RFC3164
+		cfg.Timezone = "America/New_York"
+
+		body := `<13>Feb  5 17:32:18 mymachine su: 'su root' failed`
+
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		fake := testutil.NewFakeOutput(t)
+		require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+		newEntry := entry.New()
+		newEntry.Body = body
+		require.NoError(t, op.Process(t.Context(), newEntry))
+
+		select {
+		case e := <-fake.Received:
+			loc, err := time.LoadLocation("America/New_York")
+			require.NoError(t, err)
+			require.Equal(t, loc.String(), e.Timestamp.Location().String())
+		case <-time.After(time.Second):
+			require.FailNow(t, "timeout")
+		}
+	})
+}

--- a/pkg/stanza/operator/parser/syslog/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/syslog/testdata/config.yaml
@@ -47,3 +47,23 @@ timestamp:
     parse_from: body.timestamp_field
     layout_type: strptime
     layout: '%Y-%m-%d'
+all_options_rfc3164:
+  type: syslog_parser
+  protocol: rfc3164
+  enable_rfc3339: true
+  enable_second_fractions: true
+  enable_lenient_day: false
+  enable_embedded_newlines: true
+  enable_cisco_hostname: true
+  cisco_ios:
+    enable: true
+    message_counter: false
+    sequence_number: false
+    hostname: false
+    second_fractions: false
+  year: 2026
+  timezone: America/New_York
+compliant_msg_rfc5424:
+  type: syslog_parser
+  protocol: rfc5424
+  enable_compliant_msg: true


### PR DESCRIPTION
# Expose remaining go-syslog options in syslog_parser

Exposed all the remaining options of `github.com/leodido/go-syslog/v4` (both `rfc3164` and `rfc5424` parsers) as config parameters in `syslog_parser`. This resolves issue #49040.

## Changes Made

### Configuration Options Expose ([config.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog/config.go))
* Added `CiscoIOSConfig` struct containing fields:
  * `Enable`
  * `MessageCounter`
  * `SequenceNumber`
  * `Hostname`
  * `SecondFractions`
* Added new configuration parameters to `BaseConfig`:
  * `EnableCompliantMsg` (for rfc5424 MSG parsing per §6.4)
  * `EnableRFC3339` (for rfc3164 RFC 3339 timestamp parsing)
  * `EnableSecondFractions` (for rfc3164 second fractions support)
  * `EnableLenientDay` (for rfc3164 zero-padded day support, defaulting to `true` to keep backward compatibility)
  * `EnableEmbeddedNewlines` (for rfc3164 embedded newline support)
  * `EnableCiscoHostname` (for rfc3164 hostname parsing in Cisco IOS logs)
  * `CiscoIOS` (`*CiscoIOSConfig` nested structure configuration)
  * `Year` (`*int` fixed year strategy)
  * `Timezone` (output-zone normalization timezone)
* Updated `NewConfigWithID` to initialize default configuration (`EnableLenientDay: true`, and `CiscoIOS` defaults set to `true`).
* Implemented build validation check ensuring `enable_compliant_msg` is only compatible with `rfc5424`, and the other new options are only compatible with `rfc3164`.
* Added output-zone normalization timezone loading.

### Parser Options Wiring ([parser.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog/parser.go))
* Added the new configuration fields to `Parser` struct.
* Imported `github.com/leodido/go-syslog/v4/ciscoios`.
* Wired option checks into `buildParseFunc()`, `newOctetCountingParseFunc()`, and `newNonTransparentFramingParseFunc()` to dynamically instantiate `rfc3164.NewMachine()` and `rfc5424.NewMachine()` with the enabled settings.

### Unit Tests ([config_test.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog/config_test.go) and [parser_test.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog/parser_test.go))
* Added test cases to `config_test.go` verifying YAML unmarshaling and validation behavior.
* Added test cases to `parser_test.go` verifying functionality:
  * RFC 5424 strict compliant MSG parsing.
  * RFC 3164 RFC 3339 timestamp parsing.
  * RFC 3164 second fractions support.
  * RFC 3164 embedded newlines support.
  * RFC 3164 Cisco IOS components parser configuration and fields mapping.
  * RFC 3164 year override.
  * RFC 3164 timezone normalization.

## Verification Results

Successfully ran:
```bash
go test -v ./operator/parser/syslog/...
```
All existing and new tests pass cleanly.
