### PR TITLE
[receiver/aws_lambda] feat: Add custom handler to lambda receiver

### DIFF
--- a/.chloggen/feat_aws-lambda-receiver-custom-handler.yaml
+++ b/.chloggen/feat_aws-lambda-receiver-custom-handler.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/.chloggen/feat_aws-lambda-receiver-custom-handler.yaml
+++ b/.chloggen/feat_aws-lambda-receiver-custom-handler.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/aws_lambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce Custom Handler support for AWS Lambda Receiver. The custom handler allows the receiver to bind a signal-agnostic extension.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49160]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -99,13 +99,14 @@ This metadata is added to the request context and can be accessed by any downstr
 ### Custom event handling
 
 Events that are not recognized as S3 or CloudWatch Logs events are handled as custom events.
+For custom events, only the logs signal is supported.
 
 Custom events are handled in the following manner:
 
 - Receive the Lambda invocation payload
-- Decode the payload using the configured encoding extension
-  - Default encoding: Preserve the payload content as-is
-  - Custom encoding: Use the specified encoding extension via `custom::encoding`
+- Decode the payload using the configured encoding extension 
+
+If an encoding extension is not configured, then the receiver will error out and return the error.
 
 The encoding used for custom events is configured through the `custom::encoding` option.
 See the [Configurations](#configurations) section for details.

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -41,10 +41,10 @@ The `awslambdareceiver` operates as follows:
 The receiver automatically detects the event source based on the Lambda invocation message format.
 Table below summarizes supported signals and their sources:
 
-| Signal  | Sources                          |
-|---------|----------------------------------|
-| Logs    | S3, CloudWatch Logs subscription |
-| Metrics | S3                               |
+| Signal  | Sources                                  |
+|---------|------------------------------------------|
+| Logs    | S3, CloudWatch Logs subscription, Custom |
+| Metrics | S3                                       |
 
 Sections below summarize how each event source is handled.
 
@@ -95,6 +95,20 @@ This metadata is added to the request context and can be accessed by any downstr
 > [!NOTE]
 > Static metadata such as `cloud.provider` are not available through `client.Info`.
 > These can be added using processors (for example, the resource processor).
+
+### Custom event handling
+
+Events that are not recognized as S3 or CloudWatch Logs events are handled as custom events.
+
+Custom events are handled in the following manner:
+
+- Receive the Lambda invocation payload
+- Decode the payload using the configured encoding extension
+  - Default encoding: Preserve the payload content as-is
+  - Custom encoding: Use the specified encoding extension via `custom::encoding`
+
+The encoding used for custom events is configured through the `custom::encoding` option.
+See the [Configurations](#configurations) section for details.
 
 ## Deployment
 
@@ -228,6 +242,7 @@ The following receiver configuration parameters are supported.
 |:-----------------------|:--------------------------------------------------------|
 | `s3::encoding`         | Optional encoder to use for S3 event processing         | 
 | `cloudwatch::encoding` | Optional encoder to use for CloudWatch event processing | 
+| `custom::encoding`     | Optional encoder to use for custom event processing     | 
 
 Consider following notes on default behaviors:
 

--- a/receiver/awslambdareceiver/config.go
+++ b/receiver/awslambdareceiver/config.go
@@ -144,6 +144,9 @@ type Config struct {
 	// CloudWatch defines configuration for the CloudWatch Logs Lambda trigger.
 	CloudWatch sharedConfig `mapstructure:"cloudwatch"`
 
+	// Custom defines configurations for custom trigger
+	Custom sharedConfig `mapstructure:"custom"`
+
 	// FailureBucketARN is the ARN of the S3 bucket used to store failed Lambda event records.
 	FailureBucketARN string `mapstructure:"failure_bucket_arn"`
 

--- a/receiver/awslambdareceiver/config.schema.yaml
+++ b/receiver/awslambdareceiver/config.schema.yaml
@@ -34,6 +34,13 @@ properties:
       encoding:
         description: Encoding defines the encoding to decode incoming Lambda invocation data.
         type: string
+  custom:
+    description: Custom defines configurations for custom trigger
+    type: object
+    properties:
+      encoding:
+        description: Encoding defines the encoding to decode incoming Lambda invocation data.
+        type: string
   failure_bucket_arn:
     description: FailureBucketARN is the ARN of the S3 bucket used to store failed Lambda event records.
     type: string

--- a/receiver/awslambdareceiver/config_test.go
+++ b/receiver/awslambdareceiver/config_test.go
@@ -74,6 +74,15 @@ func TestLoadConfig(t *testing.T) {
 				CloudWatch: sharedConfig{},
 			},
 		},
+		{
+			name:              "Config with custom trigger encoding",
+			componentIDToLoad: component.NewIDWithName(metadata.Type, "custom_event"),
+			expected: &Config{
+				S3:         S3Config{},
+				CloudWatch: sharedConfig{},
+				Custom:     sharedConfig{Encoding: "custom_encoding"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -74,7 +74,6 @@ func (h *handlerProviderImpl) getHandler(eventType eventType) (lambdaEventHandle
 
 // lambdaEventHandler defines the contract for AWS Lambda event handlers
 type lambdaEventHandler interface {
-	handlerType() eventType
 	handle(ctx context.Context, event json.RawMessage) error
 }
 
@@ -183,10 +182,6 @@ func newS3MetricsHandler(
 	}
 }
 
-func (*s3Handler) handlerType() eventType {
-	return s3Event
-}
-
 func (s *s3Handler) handle(ctx context.Context, event json.RawMessage) error {
 	var err error
 	parsedEvent, err := parseS3Event(event)
@@ -260,10 +255,6 @@ func newCWLogsSubscriptionHandler(
 	}
 }
 
-func (*cwLogsSubscriptionHandler) handlerType() eventType {
-	return cwEvent
-}
-
 func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMessage) error {
 	var log events.CloudwatchLogsEvent
 	if err := gojson.Unmarshal(event, &log); err != nil {
@@ -312,6 +303,45 @@ func (c *cwLogsSubscriptionHandler) handle(ctx context.Context, event json.RawMe
 
 		getEnrichedCWLog(logs, mData)
 		if err = c.consumer.ConsumeLogs(getEnrichedCtxForCWLogs(ctx, mData), logs); err != nil {
+			return checkConsumerErrorAndWrap(err)
+		}
+	}
+
+	return nil
+}
+
+// customHandler implements the custom event handling.
+type customHandler struct {
+	logsDecoder encoding.LogsDecoderFactory
+	consumer    consumer.Logs
+}
+
+func newCustomHandler(logsDecoder encoding.LogsDecoderFactory, consumer consumer.Logs) *customHandler {
+	return &customHandler{
+		logsDecoder: logsDecoder,
+		consumer:    consumer,
+	}
+}
+
+func (c *customHandler) handle(ctx context.Context, event json.RawMessage) error {
+	decoder, err := c.logsDecoder.NewLogsDecoder(bytes.NewReader(event))
+	if err != nil {
+		return fmt.Errorf("failed to create decoder for the Custom event: %w", err)
+	}
+
+	for {
+		var logs plog.Logs
+		logs, err = decoder.DecodeLogs()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return fmt.Errorf("failed to decode the Custom event: %w", err)
+		}
+
+		err = c.consumer.ConsumeLogs(ctx, logs)
+		if err != nil {
 			return checkConsumerErrorAndWrap(err)
 		}
 	}

--- a/receiver/awslambdareceiver/handler_test.go
+++ b/receiver/awslambdareceiver/handler_test.go
@@ -134,7 +134,7 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 				objectKey:  "test-file.txt",
 				data:       []byte("Some log in S3 object"),
 			},
-			extension:     internal.NewDefaultS3LogsDecoder(),
+			extension:     internal.NewDefaultBlobDecoder(),
 			eventConsumer: &logConsumerWithGoldenValidation{logsExpectedPath: filepath.Join(testDataDirectory, "s3_log_expected_string.yaml")},
 		},
 		{
@@ -160,7 +160,7 @@ func TestProcessLambdaEvent_S3LogNotification(t *testing.T) {
 				objectKey:  "test-file.txt.gz",
 				data:       compressData(t, []byte("Logs in Gzip S3 object")),
 			},
-			extension:     internal.NewDefaultS3LogsDecoder(),
+			extension:     internal.NewDefaultBlobDecoder(),
 			eventConsumer: &logConsumerWithGoldenValidation{logsExpectedPath: filepath.Join(testDataDirectory, "s3_log_expected_gzip.yaml")},
 		},
 		{
@@ -384,6 +384,52 @@ func TestHandleCloudwatchLogEvent(t *testing.T) {
 			handler := newCWLogsSubscriptionHandler(test.extension, test.eventConsumer)
 
 			err = handler.handle(t.Context(), lambdaEvent)
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHandleCustomEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		event         string
+		extension     encoding.LogsDecoderFactory
+		eventConsumer consumer.Logs
+		expectedErr   string
+	}{
+		{
+			name:          "Valid custom event is decoded and consumed",
+			event:         `{"custom":"payload"}`,
+			extension:     &customLogUnmarshaler{},
+			eventConsumer: &noOpLogsConsumer{},
+		},
+		{
+			name:          "Decoder error is propagated",
+			event:         `{"custom":"payload"}`,
+			extension:     &customLogUnmarshaler{error: errors.New("failed to build decoder")},
+			eventConsumer: &noOpLogsConsumer{},
+			expectedErr:   "failed to build decoder",
+		},
+		{
+			name:          "Consumer error is propagated",
+			event:         `{"custom":"payload"}`,
+			extension:     &customLogUnmarshaler{},
+			eventConsumer: &noOpLogsConsumer{err: errors.New("failed to consume")},
+			expectedErr:   "failed to consume",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := newCustomHandler(test.extension, test.eventConsumer)
+
+			err := handler.handle(t.Context(), json.RawMessage(test.event))
 			if test.expectedErr != "" {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {
@@ -700,10 +746,6 @@ type mockPlogEventHandler struct {
 	event       eventType
 }
 
-func (n *mockPlogEventHandler) handlerType() eventType {
-	return n.event
-}
-
 func (n *mockPlogEventHandler) handle(context.Context, json.RawMessage) error {
 	n.handleCount++
 	return nil
@@ -834,7 +876,7 @@ func TestMultiFormatS3LogsHandler(t *testing.T) {
 			},
 			decoders: map[string]encoding.LogsDecoderFactory{
 				"vpcflow":  &customLogUnmarshaler{},
-				"catchall": internal.NewDefaultS3LogsDecoder(),
+				"catchall": internal.NewDefaultBlobDecoder(),
 			},
 		},
 		{

--- a/receiver/awslambdareceiver/internal/default_decoders.go
+++ b/receiver/awslambdareceiver/internal/default_decoders.go
@@ -18,16 +18,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver/internal/metadata"
 )
 
-// NewDefaultS3LogsDecoder returns a defaultS3Unmarshaler wrapped as an encoding.LogsDecoderFactory.
-func NewDefaultS3LogsDecoder() encoding.LogsDecoderFactory {
-	return xstreamencoding.NewLogsUnmarshalerDecoderFactory(&defaultS3Unmarshaler{})
+// NewDefaultBlobDecoder returns a defaultBlobDecoder wrapped as an encoding.LogsDecoderFactory.
+func NewDefaultBlobDecoder() encoding.LogsDecoderFactory {
+	return xstreamencoding.NewLogsUnmarshalerDecoderFactory(&defaultBlobDecoder{})
 }
 
-// defaultS3Unmarshaler defines the default S3 logs decoder for AWS Lambda receiver.
-type defaultS3Unmarshaler struct{}
+// defaultBlobDecoder defines a blob decoder for AWS Lambda receiver.
+type defaultBlobDecoder struct{}
 
-// UnmarshalLogs defines the built-in behavior for S3 events when no encoding extension is provided.
-func (*defaultS3Unmarshaler) UnmarshalLogs(data []byte) (plog.Logs, error) {
+// UnmarshalLogs defines the built-in behavior for .
+func (*defaultBlobDecoder) UnmarshalLogs(data []byte) (plog.Logs, error) {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()

--- a/receiver/awslambdareceiver/internal/default_decoders_test.go
+++ b/receiver/awslambdareceiver/internal/default_decoders_test.go
@@ -36,7 +36,7 @@ func TestDefaultS3LogsDecoder_NewLogsDecoder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			decoder := NewDefaultS3LogsDecoder()
+			decoder := NewDefaultBlobDecoder()
 			logsDecoder, err := decoder.NewLogsDecoder(tt.input())
 			require.NoError(t, err)
 			require.NotNil(t, logsDecoder)

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -262,16 +262,16 @@ func newLogsHandler(
 	}
 	registry[cwEvent] = newCWLogsSubscriptionHandler(cwDecoder, next)
 
-	customDecoder := internal.NewDefaultBlobDecoder()
+	// Customer handler: register only if provided.
 	if cfg.Custom.Encoding != "" {
 		logger.Info("Using configured encoding for custom logs trigger", zap.String("encoding", cfg.Custom.Encoding))
-		customDecoder, err = resolveLogsDecoder(host, cfg.Custom.Encoding)
+		customDecoder, err := resolveLogsDecoder(host, cfg.Custom.Encoding)
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	registry[customEvent] = newCustomHandler(customDecoder, next)
+		registry[customEvent] = newCustomHandler(customDecoder, next)
+	}
 
 	return newHandlerProvider(registry), nil
 }
@@ -401,10 +401,10 @@ func loadEncodingExtension[T any](host component.Host, encoding, signalType stri
 // - CloudWatchEvent
 // - CustomEvent
 // See payload content at official documentation,
-//   - For S3: https://pkg.go.dev/github.com/aws/aws-lambda-go/events#S3Event
-//   - For CloudWatch: https://pkg.go.dev/github.com/aws/aws-lambda-go/events#CloudwatchLogsEvent
+// - For S3: https://pkg.go.dev/github.com/aws/aws-lambda-go/events#S3Event
+// - For CloudWatch: https://pkg.go.dev/github.com/aws/aws-lambda-go/events#CloudwatchLogsEvent
 //
-// Suppoerted custom trigger type:
+// Supported custom trigger type:
 // - replayFailedEvents
 // Beyond these, all other events will be fall through to CustomEvent category.
 func detectTriggerType(data []byte) eventType {
@@ -426,7 +426,7 @@ func detectTriggerType(data []byte) eventType {
 		return replayEvent
 	}
 
-	// fallback to handle as a custom event
+	// Fallback to handle as a custom event
 	return customEvent
 }
 

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -28,9 +28,10 @@ import (
 type eventType string
 
 const (
-	s3Event           eventType = "S3Event"
-	cwEvent           eventType = "CloudWatchEvent"
-	customReplayEvent eventType = "replayFailedEvents"
+	s3Event     eventType = "S3Event"
+	cwEvent     eventType = "CloudWatchEvent"
+	customEvent eventType = "CustomEvent"
+	replayEvent eventType = "replayFailedEvents"
 
 	// defaultMetricsEncodingExtension defines the default encoding extension ID for metrics when none is specified
 	defaultMetricsEncodingExtension = "awscloudwatchmetricstreams_encoding"
@@ -113,14 +114,9 @@ func (a *awsLambdaReceiver) Start(ctx context.Context, host component.Host) erro
 
 // processLambdaEvent filters trigger events and forward to dedicated processors
 func (a *awsLambdaReceiver) processLambdaEvent(ctx context.Context, event json.RawMessage) error {
-	triggerType, err := detectTriggerType(event)
-	if err != nil {
-		// Unknown or invalid event triggers are suppressed so that they do not get replayed by the lambda framework.
-		a.logger.Error("Received an event with invalid or unsupported trigger type", zap.Error(err))
-		return nil
-	}
+	triggerType := detectTriggerType(event)
 
-	if triggerType == customReplayEvent {
+	if triggerType == replayEvent {
 		a.logger.Info("Running custom event", zap.String(logInvokedTrigger, string(triggerType)))
 		service, err := a.s3Provider.GetService(ctx)
 		if err != nil {
@@ -159,13 +155,7 @@ func (a *awsLambdaReceiver) handleCustomTriggers(ctx context.Context, customEven
 			continue
 		}
 
-		tType, err := detectTriggerType(content)
-		if err != nil {
-			// Note - Manual triggers are synchronous.
-			// Errors for synchronous invocations are not retried by Lambda & not stored at error destination.
-			return fmt.Errorf("invalid lambda trigger event from custom trigger: %w", err)
-		}
-
+		tType := detectTriggerType(content)
 		err = a.handleEvent(ctx, content, tType)
 		if err != nil {
 			a.logger.Error("error while processing content of the custom trigger", zap.Error(err))
@@ -246,7 +236,7 @@ func newLogsHandler(
 		}
 		getLogsDecoder = s3Router.GetDecoder
 	} else {
-		s3LogsDecoder := internal.NewDefaultS3LogsDecoder()
+		s3LogsDecoder := internal.NewDefaultBlobDecoder()
 		if cfg.S3.Encoding != "" {
 			logger.Info("Using configured S3 encoding for logs", zap.String("encoding", cfg.S3.Encoding))
 			s3LogsDecoder, err = resolveLogsDecoder(host, cfg.S3.Encoding)
@@ -272,6 +262,17 @@ func newLogsHandler(
 	}
 	registry[cwEvent] = newCWLogsSubscriptionHandler(cwDecoder, next)
 
+	customDecoder := internal.NewDefaultBlobDecoder()
+	if cfg.Custom.Encoding != "" {
+		logger.Info("Using configured encoding for custom logs trigger", zap.String("encoding", cfg.Custom.Encoding))
+		customDecoder, err = resolveLogsDecoder(host, cfg.Custom.Encoding)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	registry[customEvent] = newCustomHandler(customDecoder, next)
+
 	return newHandlerProvider(registry), nil
 }
 
@@ -281,7 +282,7 @@ func buildS3LogsRouter(host component.Host, cfg S3Config, logger *zap.Logger) (*
 	sortedEncodings := cfg.sortedEncodings()
 	decoders := make(map[string]encoding.LogsDecoderFactory, len(sortedEncodings))
 
-	defaultDecoder := internal.NewDefaultS3LogsDecoder()
+	defaultDecoder := internal.NewDefaultBlobDecoder()
 	for _, enc := range sortedEncodings {
 		if enc.Encoding == "" {
 			// No extension configured: use the raw-passthrough decoder.
@@ -398,31 +399,35 @@ func loadEncodingExtension[T any](host component.Host, encoding, signalType stri
 // Supported trigger types are:
 // - S3Event
 // - CloudWatchEvent
+// - CustomEvent
 // See payload content at official documentation,
 //   - For S3: https://pkg.go.dev/github.com/aws/aws-lambda-go/events#S3Event
 //   - For CloudWatch: https://pkg.go.dev/github.com/aws/aws-lambda-go/events#CloudwatchLogsEvent
 //
 // Suppoerted custom trigger type:
 // - replayFailedEvents
-func detectTriggerType(data []byte) (eventType, error) {
+// Beyond these, all other events will be fall through to CustomEvent category.
+func detectTriggerType(data []byte) eventType {
 	switch {
 	case bytes.HasPrefix(data, []byte(`{"Records"`)):
-		return s3Event, nil
+		return s3Event
 	case bytes.HasPrefix(data, []byte(`{"awslogs"`)):
-		return cwEvent, nil
+		return cwEvent
 	}
 
 	// fallback for possible manual trigger cases
 	key, err := extractFirstKey(data)
 	if err != nil {
-		return "", err
+		// Note errors are intentionally ignored. Return as a custom event
+		return customEvent
 	}
 
-	if key == string(customReplayEvent) {
-		return customReplayEvent, nil
+	if key == string(replayEvent) {
+		return replayEvent
 	}
 
-	return "", fmt.Errorf("unknown event type with key: %s", key)
+	// fallback to handle as a custom event
+	return customEvent
 }
 
 // extractFirstKey extracts the first JSON key from byte array without parsing it.

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -406,11 +406,9 @@ func TestExtractFirstKey(t *testing.T) {
 
 func TestDetectTriggerType(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        []byte
-		want         eventType
-		isError      bool
-		errorContent string
+		name  string
+		input []byte
+		want  eventType
 	}{
 		{
 			name:  "Parse S3 event",
@@ -418,26 +416,19 @@ func TestDetectTriggerType(t *testing.T) {
 			want:  s3Event,
 		},
 		{
-			name:         "Invalid event - unknown json",
-			input:        []byte(`{"key": "value"}`),
-			isError:      true,
-			errorContent: "unknown event type",
+			name:  "Invalid event - unknown json",
+			input: []byte(`{"key": "value"}`),
+			want:  customEvent,
 		},
 		{
-			name:         "Invalid event - no JSON key",
-			input:        []byte(`invalid content`),
-			isError:      true,
-			errorContent: "invalid JSON payload",
+			name:  "Invalid event - no JSON key",
+			input: []byte(`invalid content`),
+			want:  customEvent,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := detectTriggerType(tt.input)
-			if tt.errorContent != "" {
-				require.ErrorContains(t, err, tt.errorContent)
-				return
-			}
-			require.NoError(t, err)
+			got := detectTriggerType(tt.input)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -496,22 +487,22 @@ func TestHandleCustomTrigger(t *testing.T) {
 			expectHandleCount: 0,
 		},
 		{
-			name: "Event handling fails for unknown event type",
+			name: "Custom trigger for custom event",
 			handlerFunc: func() internal.CustomTriggerHandler {
 				handler := internal.NewMockCustomTriggerHandler(goMock)
 				handler.EXPECT().HasNext(t.Context()).Times(1).Return(true)
+				handler.EXPECT().HasNext(t.Context()).Times(1).Return(false)
 				handler.EXPECT().PostProcess(gomock.Any()).AnyTimes()
 				handler.EXPECT().IsDryRun().AnyTimes().Return(false)
 				handler.EXPECT().Error().AnyTimes().Return(nil)
 
 				handler.EXPECT().
 					GetNext(gomock.Any()).Times(1).
-					Return([]byte(`{"test": "unknown trigger"}`), nil)
+					Return([]byte(`{"test": "someMessage"}`), nil)
 
 				return handler
 			},
-			expectHandleCount: 0,
-			expectError:       "unknown event type with key: test",
+			expectHandleCount: 1,
 		},
 		{
 			name: "Event handling ends with error when handler returns error",

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -179,6 +179,73 @@ func TestCreateMetrics(t *testing.T) {
 	require.Contains(t, m.Get("aws.s3.key"), "test-file.txt")
 }
 
+func TestCustomHandlerRegistration(t *testing.T) {
+	// Set Lambda environment variables required by Start()
+	t.Setenv("AWS_EXECUTION_ENV", "AWS_Lambda_python3.12")
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+
+	goMock := gomock.NewController(t)
+	s3Service := internal.NewMockS3Service(goMock)
+	s3Provider := internal.NewMockS3Provider(goMock)
+	s3Provider.EXPECT().GetService(gomock.Any()).AnyTimes().Return(s3Service, nil)
+
+	// A custom event payload that detectTriggerType classifies as customEvent.
+	customEventPayload := []byte(`{"custom":"payload"}`)
+
+	t.Run("custom handler is not registered by default", func(t *testing.T) {
+		factory := NewFactory()
+		cfg := factory.CreateDefaultConfig().(*Config)
+
+		sink := consumertest.LogsSink{}
+		receiver, err := factory.CreateLogs(t.Context(), settings, cfg, &sink)
+		require.NoError(t, err)
+
+		host := mockHost{GetFunc: func() map[component.ID]component.Component {
+			return map[component.ID]component.Component{}
+		}}
+
+		// Initialize the handlerProvider manually (without starting Lambda runtime to avoid goroutine leaks in tests)
+		awsReceiver := receiver.(*awsLambdaReceiver)
+		awsReceiver.hp, err = newLogsHandler(t.Context(), cfg, settings, host, &sink, s3Provider)
+		require.NoError(t, err)
+
+		// Processing fails fast since no custom handler is registered by default.
+		err = awsReceiver.processLambdaEvent(t.Context(), customEventPayload)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "cannot handle event type")
+		require.Zero(t, sink.LogRecordCount())
+	})
+
+	t.Run("registered custom extension processes log content", func(t *testing.T) {
+		customEncoding := "custom_encoding"
+
+		factory := NewFactory()
+		cfg := factory.CreateDefaultConfig().(*Config)
+		cfg.Custom.Encoding = customEncoding
+
+		sink := consumertest.LogsSink{}
+		receiver, err := factory.CreateLogs(t.Context(), settings, cfg, &sink)
+		require.NoError(t, err)
+
+		host := mockHost{GetFunc: func() map[component.ID]component.Component {
+			return map[component.ID]component.Component{
+				component.MustNewID(customEncoding): &mockExtensionWithPLogUnmarshaler{},
+			}
+		}}
+
+		// Initialize the handlerProvider manually (without starting Lambda runtime to avoid goroutine leaks in tests)
+		awsReceiver := receiver.(*awsLambdaReceiver)
+		awsReceiver.hp, err = newLogsHandler(t.Context(), cfg, settings, host, &sink, s3Provider)
+		require.NoError(t, err)
+
+		// The custom extension decodes the raw event into log records.
+		err = awsReceiver.processLambdaEvent(t.Context(), customEventPayload)
+		require.NoError(t, err)
+		require.NotZero(t, sink.LogRecordCount(), "Expected logs to be sent to sink")
+	})
+}
+
 func TestStartRequiresLambdaEnvironment(t *testing.T) {
 	// Ensure Lambda environment variables are not set
 	t.Setenv("AWS_EXECUTION_ENV", "")

--- a/receiver/awslambdareceiver/router_test.go
+++ b/receiver/awslambdareceiver/router_test.go
@@ -16,9 +16,9 @@ import (
 func TestLogsDecoderRouter_GetDecoder(t *testing.T) {
 	t.Parallel()
 
-	defaultDecoder := internal.NewDefaultS3LogsDecoder()
-	vpcDecoder := internal.NewDefaultS3LogsDecoder()
-	ctDecoder := internal.NewDefaultS3LogsDecoder()
+	defaultDecoder := internal.NewDefaultBlobDecoder()
+	vpcDecoder := internal.NewDefaultBlobDecoder()
+	ctDecoder := internal.NewDefaultBlobDecoder()
 
 	tests := []struct {
 		name           string
@@ -124,8 +124,8 @@ func TestLogsDecoderRouter_GetDecoder(t *testing.T) {
 func TestLogsDecoderRouter_PatternPriority(t *testing.T) {
 	t.Parallel()
 
-	vpcDecoder := internal.NewDefaultS3LogsDecoder()
-	catchallDecoder := internal.NewDefaultS3LogsDecoder()
+	vpcDecoder := internal.NewDefaultBlobDecoder()
+	catchallDecoder := internal.NewDefaultBlobDecoder()
 
 	// Formats passed in already sorted (as sortedEncodings() would return).
 	encodings := []S3Encoding{

--- a/receiver/awslambdareceiver/testdata/config.yaml
+++ b/receiver/awslambdareceiver/testdata/config.yaml
@@ -22,3 +22,7 @@ aws_lambda/s3_multi_encoding:
         encoding: awslogs_encoding/cloudtrail
       - name: catchall
         path_pattern: "*"
+
+aws_lambda/custom_event:
+  custom:
+    encoding: custom_encoding


### PR DESCRIPTION
#### Description
This PR adds `custom` handler to lambda receiver.

```yaml
aws_lambda/custom_event:
  custom:
    encoding: custom_encoding
```

This allows this receiver to receive any arbitrary signal and bind a custom encoder as needed. This is extra to existing S3 & CloudWatch handlers. 

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49160 

#### Testing

Added unit tests to test the new path and updated existing ones to reflect changes.
#### Documentation

Updated the documentation to reflect the new feature

#### Authorship

- [x] I, a human, wrote this pull request description myself.

