### PR TITLE
exporter/opensearchexporter: Fix silent data loss by correctly classifying transient network errors as retryable in log and trace bulk indexersOpensearch exporter issue

### DIFF
--- a/exporter/opensearchexporter/log_bulk_indexer.go
+++ b/exporter/opensearchexporter/log_bulk_indexer.go
@@ -48,7 +48,8 @@ func (lbi *logBulkIndexer) close(ctx context.Context) {
 
 func (lbi *logBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
 	if indexerErr != nil {
-		lbi.errs = append(lbi.errs, indexerErr) // retryable, not permanent
+		// retryable, not permanent
+		lbi.errs = append(lbi.errs, indexerErr)
 	}
 }
 
@@ -132,9 +133,11 @@ func (lbi *logBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem, i
 		// resp.Status == 0 + itemErr: could be encoding error OR transport error
 		var netErr *net.OpError
 		if errors.As(itemErr, &netErr) {
-			lbi.appendRetryLogError(itemErr, logs) // transport error, retryable
+			// transport error, retryable
+			lbi.appendRetryLogError(itemErr, logs)
 		} else {
-			lbi.appendPermanentError(itemErr) // encoding error, permanent
+			// encoding error, permanent
+			lbi.appendPermanentError(itemErr)
 		}
 	}
 }

--- a/exporter/opensearchexporter/log_bulk_indexer.go
+++ b/exporter/opensearchexporter/log_bulk_indexer.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
@@ -47,7 +48,7 @@ func (lbi *logBulkIndexer) close(ctx context.Context) {
 
 func (lbi *logBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
 	if indexerErr != nil {
-		lbi.appendPermanentError(consumererror.NewPermanent(indexerErr))
+		lbi.errs = append(lbi.errs, indexerErr) // retryable, not permanent
 	}
 }
 
@@ -128,8 +129,13 @@ func (lbi *logBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem, i
 		// Non-recoverable OpenSearch error while indexing document
 		lbi.appendPermanentError(responseAsError(resp))
 	default:
-		// Encoding error. We didn't even attempt to send the event
-		lbi.appendPermanentError(itemErr)
+		// resp.Status == 0 + itemErr: could be encoding error OR transport error
+		var netErr *net.OpError
+		if errors.As(itemErr, &netErr) {
+			lbi.appendRetryLogError(itemErr, logs) // transport error, retryable
+		} else {
+			lbi.appendPermanentError(itemErr) // encoding error, permanent
+		}
 	}
 }
 

--- a/exporter/opensearchexporter/log_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/log_bulk_indexer_test.go
@@ -154,7 +154,7 @@ func TestOnIndexerError_ConnectionRefused_MustBeRetryable(t *testing.T) {
 		Err: errors.New("connection refused"),
 	}
 
-	lbi.onIndexerError(context.Background(), netErr)
+	lbi.onIndexerError(t.Context(), netErr)
 
 	require.Len(t, lbi.errs, 1)
 	assert.True(t, isRetryableError(lbi.errs[0]),
@@ -164,7 +164,7 @@ func TestOnIndexerError_ConnectionRefused_MustBeRetryable(t *testing.T) {
 func TestOnIndexerError_ContextDeadlineExceeded_MustBeRetryable(t *testing.T) {
 	lbi := newTestLogBulkIndexer()
 
-	lbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+	lbi.onIndexerError(t.Context(), context.DeadlineExceeded)
 
 	require.Len(t, lbi.errs, 1)
 	assert.True(t, isRetryableError(lbi.errs[0]),
@@ -180,7 +180,7 @@ func TestOnIndexerError_DNSFailure_MustBeRetryable(t *testing.T) {
 		Err: &net.DNSError{Err: "no such host", Name: "opensearch.example.com"},
 	}
 
-	lbi.onIndexerError(context.Background(), dnsErr)
+	lbi.onIndexerError(t.Context(), dnsErr)
 
 	require.Len(t, lbi.errs, 1)
 	assert.True(t, isRetryableError(lbi.errs[0]),
@@ -190,7 +190,7 @@ func TestOnIndexerError_DNSFailure_MustBeRetryable(t *testing.T) {
 func TestOnIndexerError_GenericNetworkError_MustBeRetryable(t *testing.T) {
 	lbi := newTestLogBulkIndexer()
 
-	lbi.onIndexerError(context.Background(), errors.New("EOF"))
+	lbi.onIndexerError(t.Context(), errors.New("EOF"))
 
 	require.Len(t, lbi.errs, 1)
 	assert.True(t, isRetryableError(lbi.errs[0]),
@@ -200,7 +200,7 @@ func TestOnIndexerError_GenericNetworkError_MustBeRetryable(t *testing.T) {
 func TestOnIndexerError_RetryableError_DoesNotWrapAsNewPermanent(t *testing.T) {
 	lbi := newTestLogBulkIndexer()
 
-	lbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+	lbi.onIndexerError(t.Context(), context.DeadlineExceeded)
 
 	require.Len(t, lbi.errs, 1)
 	assert.False(t, consumererror.IsPermanent(lbi.errs[0]),

--- a/exporter/opensearchexporter/log_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/log_bulk_indexer_test.go
@@ -4,14 +4,31 @@
 package opensearchexporter
 
 import (
+	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newTestLogBulkIndexer() *logBulkIndexer {
+	return &logBulkIndexer{errs: nil}
+}
+
+func isRetryableError(err error) bool {
+	return !consumererror.IsPermanent(err)
+}
 
 func TestJoinedError(t *testing.T) {
 	tests := []struct {
@@ -126,4 +143,83 @@ func TestMakeLog(t *testing.T) {
 	if sl.LogRecords().Len() != 1 {
 		t.Error("expected 1 log record")
 	}
+}
+
+func TestOnIndexerError_ConnectionRefused_MustBeRetryable(t *testing.T) {
+	lbi := newTestLogBulkIndexer()
+
+	netErr := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: errors.New("connection refused"),
+	}
+
+	lbi.onIndexerError(context.Background(), netErr)
+
+	require.Len(t, lbi.errs, 1)
+	assert.True(t, isRetryableError(lbi.errs[0]),
+		"connection refused is transient — must NOT be Permanent; exporterhelper should retry")
+}
+
+func TestOnIndexerError_ContextDeadlineExceeded_MustBeRetryable(t *testing.T) {
+	lbi := newTestLogBulkIndexer()
+
+	lbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+
+	require.Len(t, lbi.errs, 1)
+	assert.True(t, isRetryableError(lbi.errs[0]),
+		"deadline exceeded is transient — must NOT be Permanent; exporterhelper should retry")
+}
+
+func TestOnIndexerError_DNSFailure_MustBeRetryable(t *testing.T) {
+	lbi := newTestLogBulkIndexer()
+
+	dnsErr := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &net.DNSError{Err: "no such host", Name: "opensearch.example.com"},
+	}
+
+	lbi.onIndexerError(context.Background(), dnsErr)
+
+	require.Len(t, lbi.errs, 1)
+	assert.True(t, isRetryableError(lbi.errs[0]),
+		"DNS failure is transient — must NOT be Permanent; exporterhelper should retry")
+}
+
+func TestOnIndexerError_GenericNetworkError_MustBeRetryable(t *testing.T) {
+	lbi := newTestLogBulkIndexer()
+
+	lbi.onIndexerError(context.Background(), errors.New("EOF"))
+
+	require.Len(t, lbi.errs, 1)
+	assert.True(t, isRetryableError(lbi.errs[0]),
+		"generic network-level error from bulk flush must NOT be Permanent")
+}
+
+func TestOnIndexerError_RetryableError_DoesNotWrapAsNewPermanent(t *testing.T) {
+	lbi := newTestLogBulkIndexer()
+
+	lbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+
+	require.Len(t, lbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(lbi.errs[0]),
+		"onIndexerError must never produce a Permanent error — doing so "+
+			"causes exporterhelper to bypass the retry queue and silently drop logs")
+}
+
+func TestProcessItemFailure_Status0_NetOpError_MustBeRetryable(t *testing.T) {
+	lbi := newTestLogBulkIndexer()
+
+	netErr := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: errors.New("connection reset by peer"),
+	}
+
+	lbi.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, netErr, plog.NewLogs())
+
+	require.Len(t, lbi.errs, 1)
+	assert.True(t, isRetryableError(lbi.errs[0]),
+		"status=0 + net.OpError is a transport failure — must NOT be Permanent")
 }

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"slices"
 	"time"
 
@@ -49,7 +50,8 @@ func (tbi *traceBulkIndexer) close(ctx context.Context) {
 
 func (tbi *traceBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
 	if indexerErr != nil {
-		tbi.appendPermanentError(consumererror.NewPermanent(indexerErr))
+		// retryable, not permanent
+		tbi.errs = append(tbi.errs, indexerErr)
 	}
 }
 
@@ -130,8 +132,15 @@ func (tbi *traceBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem,
 		// Non-recoverable OpenSearch error while indexing document
 		tbi.appendPermanentError(responseAsError(resp))
 	default:
-		// Encoding error. We didn't even attempt to send the event
-		tbi.appendPermanentError(itemErr)
+		// resp.Status == 0 + itemErr: could be encoding error OR transport error
+		var netErr *net.OpError
+		if errors.As(itemErr, &netErr) {
+			// transport error, retryable
+			tbi.appendRetryTraceError(itemErr, traces)
+		} else {
+			// encoding error, permanent
+			tbi.appendPermanentError(itemErr)
+		}
 	}
 }
 

--- a/exporter/opensearchexporter/trace_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer_test.go
@@ -4,14 +4,23 @@
 package opensearchexporter
 
 import (
+	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
+
+func newTestTraceBulkIndexer() *traceBulkIndexer {
+	return &traceBulkIndexer{errs: nil}
+}
 
 func TestTraceJoinedError(t *testing.T) {
 	tests := []struct {
@@ -126,4 +135,83 @@ func TestMakeTrace(t *testing.T) {
 	if ss.Spans().Len() != 1 {
 		t.Error("expected 1 span")
 	}
+}
+
+func TestTraceOnIndexerError_ConnectionRefused_MustBeRetryable(t *testing.T) {
+	tbi := newTestTraceBulkIndexer()
+
+	netErr := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: errors.New("connection refused"),
+	}
+
+	tbi.onIndexerError(context.Background(), netErr)
+
+	require.Len(t, tbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
+		"connection refused is transient — must NOT be Permanent; exporterhelper should retry")
+}
+
+func TestTraceOnIndexerError_ContextDeadlineExceeded_MustBeRetryable(t *testing.T) {
+	tbi := newTestTraceBulkIndexer()
+
+	tbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+
+	require.Len(t, tbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
+		"deadline exceeded is transient — must NOT be Permanent; exporterhelper should retry")
+}
+
+func TestTraceOnIndexerError_DNSFailure_MustBeRetryable(t *testing.T) {
+	tbi := newTestTraceBulkIndexer()
+
+	dnsErr := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &net.DNSError{Err: "no such host", Name: "opensearch.example.com"},
+	}
+
+	tbi.onIndexerError(context.Background(), dnsErr)
+
+	require.Len(t, tbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
+		"DNS failure is transient — must NOT be Permanent; exporterhelper should retry")
+}
+
+func TestTraceOnIndexerError_GenericNetworkError_MustBeRetryable(t *testing.T) {
+	tbi := newTestTraceBulkIndexer()
+
+	tbi.onIndexerError(context.Background(), errors.New("EOF"))
+
+	require.Len(t, tbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
+		"generic network-level error from bulk flush must NOT be Permanent")
+}
+
+func TestTraceOnIndexerError_RetryableError_DoesNotWrapAsNewPermanent(t *testing.T) {
+	tbi := newTestTraceBulkIndexer()
+
+	tbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+
+	require.Len(t, tbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
+		"onIndexerError must never produce a Permanent error — doing so "+
+			"causes exporterhelper to bypass the retry queue and silently drop traces")
+}
+
+func TestTraceProcessItemFailure_Status0_NetOpError_MustBeRetryable(t *testing.T) {
+	tbi := newTestTraceBulkIndexer()
+
+	netErr := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: errors.New("connection reset by peer"),
+	}
+
+	tbi.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, netErr, ptrace.NewTraces())
+
+	require.Len(t, tbi.errs, 1)
+	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
+		"status=0 + net.OpError is a transport failure — must NOT be Permanent")
 }

--- a/exporter/opensearchexporter/trace_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer_test.go
@@ -146,7 +146,7 @@ func TestTraceOnIndexerError_ConnectionRefused_MustBeRetryable(t *testing.T) {
 		Err: errors.New("connection refused"),
 	}
 
-	tbi.onIndexerError(context.Background(), netErr)
+	tbi.onIndexerError(t.Context(), netErr)
 
 	require.Len(t, tbi.errs, 1)
 	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
@@ -156,7 +156,7 @@ func TestTraceOnIndexerError_ConnectionRefused_MustBeRetryable(t *testing.T) {
 func TestTraceOnIndexerError_ContextDeadlineExceeded_MustBeRetryable(t *testing.T) {
 	tbi := newTestTraceBulkIndexer()
 
-	tbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+	tbi.onIndexerError(t.Context(), context.DeadlineExceeded)
 
 	require.Len(t, tbi.errs, 1)
 	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
@@ -172,7 +172,7 @@ func TestTraceOnIndexerError_DNSFailure_MustBeRetryable(t *testing.T) {
 		Err: &net.DNSError{Err: "no such host", Name: "opensearch.example.com"},
 	}
 
-	tbi.onIndexerError(context.Background(), dnsErr)
+	tbi.onIndexerError(t.Context(), dnsErr)
 
 	require.Len(t, tbi.errs, 1)
 	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
@@ -182,7 +182,7 @@ func TestTraceOnIndexerError_DNSFailure_MustBeRetryable(t *testing.T) {
 func TestTraceOnIndexerError_GenericNetworkError_MustBeRetryable(t *testing.T) {
 	tbi := newTestTraceBulkIndexer()
 
-	tbi.onIndexerError(context.Background(), errors.New("EOF"))
+	tbi.onIndexerError(t.Context(), errors.New("EOF"))
 
 	require.Len(t, tbi.errs, 1)
 	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),
@@ -192,7 +192,7 @@ func TestTraceOnIndexerError_GenericNetworkError_MustBeRetryable(t *testing.T) {
 func TestTraceOnIndexerError_RetryableError_DoesNotWrapAsNewPermanent(t *testing.T) {
 	tbi := newTestTraceBulkIndexer()
 
-	tbi.onIndexerError(context.Background(), context.DeadlineExceeded)
+	tbi.onIndexerError(t.Context(), context.DeadlineExceeded)
 
 	require.Len(t, tbi.errs, 1)
 	assert.False(t, consumererror.IsPermanent(tbi.errs[0]),


### PR DESCRIPTION
### Summary
**Fixes a data loss bug where transient infrastructure failures were unconditionally classified as Permanent in both logBulkIndexer and traceBulkIndexer, causing exporterhelper to silently drop logs and traces without retrying — even when retry_on_failure is fully configured.**

### **Problem**
onIndexerError fires when the entire bulk flush fails (network down, timeout, DNS failure). Both indexers wrapped every error as Permanent:
go// BEFORE — WRONG (same in both log and trace indexers)
func (lbi *logBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
    if indexerErr != nil {
        lbi.appendPermanentError(consumererror.NewPermanent(indexerErr)) // always dropped, never retried
    }
}
processItemFailure default case also marked transport errors (net.OpError) as Permanent, when they should be retried.

### **Fix**
go// AFTER — onIndexerError: always retryable at infrastructure level
func (lbi *logBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
    if indexerErr != nil {
        lbi.errs = append(lbi.errs, indexerErr) // retryable, not permanent
    }
}

// AFTER — processItemFailure: distinguish transport vs encoding errors
default:
    var netErr *net.OpError
    if errors.As(itemErr, &netErr) {
        lbi.appendRetryLogError(itemErr, logs) // transport error, retryable
    } else {
        lbi.appendPermanentError(itemErr)      // encoding error, permanent
    }
Same fix applied to traceBulkIndexer.

### **Tests**
6 bug-fix tests added to each of log_bulk_indexer_test.go and trace_bulk_indexer_test.go — all fail before the fix, pass after:

onIndexerError with connection refused, deadline exceeded, DNS failure, EOF, generic network error
processItemFailure default case with net.OpError

