### PR TITLE
[exporter/elasticsearch]Drop scripted error.grouping_name field for error docs

### DIFF
--- a/.chloggen/49216.yaml
+++ b/.chloggen/49216.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip `error.grouping_name` when encoding ECS span events, as it is a scripted field in the `logs-apm.error` index template and cannot be indexed directly.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49216]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -124,6 +124,7 @@ var (
 		elasticsearch.DataStreamType:                {skip: true}, // routing only, written by addDataStreamAttributes
 		elasticsearch.DataStreamDataset:             {skip: true},
 		elasticsearch.DataStreamNamespace:           {skip: true},
+		"error.grouping_name":                       {skip: true}, // scripted field in logs-apm.error; cannot be indexed directly
 	}
 
 	// Precomputed protected fields for performance

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1652,7 +1652,9 @@ func TestECSSpanEventEncoder(t *testing.T) {
 				assert.Equal(t, "at com.example.Foo.bar(Foo.java:42)", gjson.Get(body, "error.stack_trace").String())
 				assert.Equal(t, "abcdef1234567890abcdef1234567890", gjson.Get(body, "error.id").String())
 				assert.Equal(t, "abcdef1234567890", gjson.Get(body, "error.grouping_key").String())
-				assert.Equal(t, "null pointer", gjson.Get(body, "error.grouping_name").String())
+				// error.grouping_name is a scripted field in the logs-apm.error index template and
+				// cannot be indexed directly; the conversion map skips it.
+				assert.False(t, gjson.Get(body, "error.grouping_name").Exists())
 				assert.Equal(t, txnID, gjson.Get(body, "parent.id").String())
 				assert.Equal(t, txnID, gjson.Get(body, "span.id").String())
 				assert.Equal(t, txnID, gjson.Get(body, "transaction.id").String())


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`error.grouping_name` is a scripted field in ES mappings for APM and should be dropped in ECS mode explicitly


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Test cases are updated

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
