### PR TITLE
[exporter/elasticsearchexporter] Sanitize elasticsearch.index attribute in dynamic router

### DIFF
--- a/.chloggen/elasticsearchexporter-sanitize-index.yaml
+++ b/.chloggen/elasticsearchexporter-sanitize-index.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: exporter/elasticsearchexporter
+note: "Sanitize `elasticsearch.index` attribute in dynamic router to prevent routing bypasses"
+issues: [49219]

--- a/.chloggen/elasticsearchexporter-sanitize-index.yaml
+++ b/.chloggen/elasticsearchexporter-sanitize-index.yaml
@@ -1,4 +1,4 @@
 change_type: bug_fix
-component: exporter/elasticsearchexporter
+component: exporter/elasticsearch
 note: "Sanitize `elasticsearch.index` attribute in dynamic router to prevent routing bypasses"
 issues: [49219]

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -175,7 +175,7 @@ func routeRecord(
 	if esIndex, esIndexExists := getFromAttributes(elasticsearch.IndexAttributeName, "", recordAttr, scopeAttr, resourceAttr); esIndexExists {
 		// Advanced users can route documents by setting IndexAttributeName in a processor earlier in the pipeline.
 		// If `data_stream.*` needs to be set in the document, users should use `data_stream.*` attributes.
-		return elasticsearch.Index{Index: esIndex}, nil
+		return elasticsearch.Index{Index: sanitizeDataStreamField(esIndex, disallowedNamespaceRunes, "")}, nil
 	}
 
 	dataset, datasetExists := getFromAttributes(elasticsearch.DataStreamDataset, defaultDataStreamDataset, recordAttr, scopeAttr, resourceAttr)

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -190,7 +190,7 @@ func routeRecord(
 	if esIndex, esIndexExists := getFromAttributes(elasticsearch.IndexAttributeName, "", recordAttr, scopeAttr, resourceAttr); esIndexExists {
 		// Advanced users can route documents by setting IndexAttributeName in a processor earlier in the pipeline.
 		// If `data_stream.*` needs to be set in the document, users should use `data_stream.*` attributes.
-		return elasticsearch.Index{Index: esIndex}, nil
+		return elasticsearch.Index{Index: sanitizeDataStreamField(esIndex, disallowedNamespaceRunes, "")}, nil
 	}
 
 	dataset, datasetExists := getFromAttributes(elasticsearch.DataStreamDataset, defaultDataStreamDataset, recordAttr, scopeAttr, resourceAttr)

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -5,6 +5,7 @@ package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -30,8 +31,10 @@ var selfTelemetryScopeNames = map[string]bool{
 
 const (
 	maxDataStreamBytes          = 100
+	maxIndexBytes               = 255
 	disallowedNamespaceRunes    = "\\/*?\"<>| ,#:"
 	disallowedDatasetRunes      = "-\\/*?\"<>| ,#:"
+	disallowedIndexRunes        = "\\/*?\"<>| ,#:"
 	encodingFormatAttributeName = "encoding.format"
 )
 
@@ -52,6 +55,30 @@ func sanitizeDataStreamField(field, disallowed, appendSuffix string) string {
 	field += appendSuffix
 
 	return field
+}
+
+// Sanitize the index name to apply restrictions
+// as outlined in Elasticsearch index naming rules.
+// https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create#operation-indices-create-index
+func sanitizeIndexName(index string) string {
+	index = strings.Map(func(r rune) rune {
+		if strings.ContainsRune(disallowedIndexRunes, r) {
+			return '_'
+		}
+		return unicode.ToLower(r)
+	}, index)
+
+	if len(index) > maxIndexBytes {
+		index = index[:maxIndexBytes]
+	}
+
+	index = strings.TrimLeft(index, "-_+")
+
+	if index == "." || index == ".." {
+		return ""
+	}
+
+	return index
 }
 
 // documentRouter is an interface for routing records to the appropriate
@@ -175,7 +202,11 @@ func routeRecord(
 	if esIndex, esIndexExists := getFromAttributes(elasticsearch.IndexAttributeName, "", recordAttr, scopeAttr, resourceAttr); esIndexExists {
 		// Advanced users can route documents by setting IndexAttributeName in a processor earlier in the pipeline.
 		// If `data_stream.*` needs to be set in the document, users should use `data_stream.*` attributes.
-		return elasticsearch.Index{Index: sanitizeDataStreamField(esIndex, disallowedNamespaceRunes, "")}, nil
+		sanitized := sanitizeIndexName(esIndex)
+		if sanitized == "" {
+			return elasticsearch.Index{}, fmt.Errorf("invalid index name: %q", esIndex)
+		}
+		return elasticsearch.Index{Index: sanitized}, nil
 	}
 
 	dataset, datasetExists := getFromAttributes(elasticsearch.DataStreamDataset, defaultDataStreamDataset, recordAttr, scopeAttr, resourceAttr)

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -30,8 +30,10 @@ var selfTelemetryScopeNames = map[string]bool{
 
 const (
 	maxDataStreamBytes          = 100
+	maxIndexBytes               = 255
 	disallowedNamespaceRunes    = "\\/*?\"<>| ,#:"
 	disallowedDatasetRunes      = "-\\/*?\"<>| ,#:"
+	disallowedIndexRunes        = "\\/*?\"<>| ,#:"
 	encodingFormatAttributeName = "encoding.format"
 )
 
@@ -67,6 +69,30 @@ func sanitizeDataStreamField(field, disallowed, appendSuffix string) string {
 	field += appendSuffix
 
 	return field
+}
+
+// Sanitize the index name to apply restrictions
+// as outlined in Elasticsearch index naming rules.
+// https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create#operation-indices-create-index
+func sanitizeIndexName(index string) string {
+	index = strings.Map(func(r rune) rune {
+		if strings.ContainsRune(disallowedIndexRunes, r) {
+			return '_'
+		}
+		return unicode.ToLower(r)
+	}, index)
+
+	if len(index) > maxIndexBytes {
+		index = index[:maxIndexBytes]
+	}
+
+	index = strings.TrimLeft(index, "-_+")
+
+	if index == "." || index == ".." {
+		return ""
+	}
+
+	return index
 }
 
 // documentRouter is an interface for routing records to the appropriate
@@ -190,7 +216,11 @@ func routeRecord(
 	if esIndex, esIndexExists := getFromAttributes(elasticsearch.IndexAttributeName, "", recordAttr, scopeAttr, resourceAttr); esIndexExists {
 		// Advanced users can route documents by setting IndexAttributeName in a processor earlier in the pipeline.
 		// If `data_stream.*` needs to be set in the document, users should use `data_stream.*` attributes.
-		return elasticsearch.Index{Index: sanitizeDataStreamField(esIndex, disallowedNamespaceRunes, "")}, nil
+		sanitized := sanitizeIndexName(esIndex)
+		if sanitized == "" {
+			return elasticsearch.Index{}, fmt.Errorf("invalid index name: %q", esIndex)
+		}
+		return elasticsearch.Index{Index: sanitized}, nil
 	}
 
 	dataset, datasetExists := getFromAttributes(elasticsearch.DataStreamDataset, defaultDataStreamDataset, recordAttr, scopeAttr, resourceAttr)

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -53,6 +53,17 @@ func createRouteTests(dsType string) []routeTestCase {
 			},
 		},
 		{
+			name:      "otel with elasticsearch.index containing uppercase and disallowed chars",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": "My/Index:Name",
+			},
+			want: elasticsearch.Index{
+				Index: "my_index_name",
+			},
+		},
+		{
 			name:      "otel with data_stream attrs",
 			mode:      MappingOTel,
 			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -4,6 +4,7 @@
 package elasticsearchexporter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,7 @@ type routeTestCase struct {
 	scopeAttrs  map[string]any
 	recordAttrs map[string]any
 	want        elasticsearch.Index
+	wantErr     string
 }
 
 func createRouteTests(dsType string) []routeTestCase {
@@ -61,6 +63,48 @@ func createRouteTests(dsType string) []routeTestCase {
 			},
 			want: elasticsearch.Index{
 				Index: "my_index_name",
+			},
+		},
+		{
+			name:      "otel with elasticsearch.index starting with disallowed chars",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": "-+__my-index",
+			},
+			want: elasticsearch.Index{
+				Index: "my-index",
+			},
+		},
+		{
+			name:      "otel with elasticsearch.index starting with a dot (hidden index)",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": ".my-index",
+			},
+			want: elasticsearch.Index{
+				Index: ".my-index",
+			},
+		},
+		{
+			name:      "otel with elasticsearch.index as dot or dot dot",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": "..",
+			},
+			wantErr: `invalid index name: ".."`,
+		},
+		{
+			name:      "otel with elasticsearch.index exceeding 255 bytes limit",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": strings.Repeat("a", 300),
+			},
+			want: elasticsearch.Index{
+				Index: strings.Repeat("a", 255),
 			},
 		},
 		{
@@ -111,6 +155,10 @@ func TestRouteLogRecord(t *testing.T) {
 			fillAttributeMap(recordAttrMap, tc.recordAttrs)
 
 			ds, err := router.routeLogRecord(pcommon.NewResource(), scope, recordAttrMap)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, ds)
 		})
@@ -170,6 +218,10 @@ func TestRouteDataPoint(t *testing.T) {
 			fillAttributeMap(recordAttrMap, tc.recordAttrs)
 
 			ds, err := router.routeDataPoint(pcommon.NewResource(), scope, recordAttrMap)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, ds)
 		})
@@ -190,6 +242,10 @@ func TestRouteSpan(t *testing.T) {
 			fillAttributeMap(recordAttrMap, tc.recordAttrs)
 
 			ds, err := router.routeSpan(pcommon.NewResource(), scope, recordAttrMap)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, ds)
 		})

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -4,6 +4,7 @@
 package elasticsearchexporter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,7 @@ type routeTestCase struct {
 	scopeAttrs  map[string]any
 	recordAttrs map[string]any
 	want        elasticsearch.Index
+	wantErr     string
 }
 
 func createRouteTests(dsType string) []routeTestCase {
@@ -61,6 +63,48 @@ func createRouteTests(dsType string) []routeTestCase {
 			},
 			want: elasticsearch.Index{
 				Index: "my_index_name",
+			},
+		},
+		{
+			name:      "otel with elasticsearch.index starting with disallowed chars",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": "-+__my-index",
+			},
+			want: elasticsearch.Index{
+				Index: "my-index",
+			},
+		},
+		{
+			name:      "otel with elasticsearch.index starting with a dot (hidden index)",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": ".my-index",
+			},
+			want: elasticsearch.Index{
+				Index: ".my-index",
+			},
+		},
+		{
+			name:      "otel with elasticsearch.index as dot or dot dot",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": "..",
+			},
+			wantErr: `invalid index name: ".."`,
+		},
+		{
+			name:      "otel with elasticsearch.index exceeding 255 bytes limit",
+			mode:      MappingOTel,
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",
+			recordAttrs: map[string]any{
+				"elasticsearch.index": strings.Repeat("a", 300),
+			},
+			want: elasticsearch.Index{
+				Index: strings.Repeat("a", 255),
 			},
 		},
 		{
@@ -111,6 +155,10 @@ func TestRouteLogRecord(t *testing.T) {
 			fillAttributeMap(recordAttrMap, tc.recordAttrs)
 
 			ds, err := router.routeLogRecord(pcommon.NewResource(), scope, recordAttrMap)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, ds)
 		})
@@ -159,6 +207,10 @@ func TestRouteDataPoint(t *testing.T) {
 			fillAttributeMap(recordAttrMap, tc.recordAttrs)
 
 			ds, err := router.routeDataPoint(pcommon.NewResource(), scope, recordAttrMap)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, ds)
 		})
@@ -179,6 +231,10 @@ func TestRouteSpan(t *testing.T) {
 			fillAttributeMap(recordAttrMap, tc.recordAttrs)
 
 			ds, err := router.routeSpan(pcommon.NewResource(), scope, recordAttrMap)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, ds)
 		})


### PR DESCRIPTION
## Description
This PR resolves an input validation vulnerability in the Elasticsearch Exporter. Previously, the `elasticsearch.index` attribute was retrieved dynamically from telemetry record/scope/resource attributes and returned directly without validation, whereas sibling attributes `data_stream.dataset` and `data_stream.namespace` were properly sanitized. 

This fix applies the `sanitizeDataStreamField()` validation to the retrieved `elasticsearch.index` attribute before routing documents to it. Disallowed characters are replaced with underscores, and the name is lowercased and truncated to standard length limits.

Fixes #49219

## Testing
Added unit tests in `data_stream_router_test.go` to verify correct sanitization behavior (replacing invalid runes like `/` and `:` with `_`, converting to lowercase, etc.). Ran all exporter module tests:
```bash
go test -v ./...
