### PR TITLE
[extension/datadog] Skip source provider when hostname is set in config

### DIFF
--- a/.chloggen/datadogextension-skip-source-provider-when-hostname-configured.yaml
+++ b/.chloggen/datadogextension-skip-source-provider-when-hostname-configured.yaml
@@ -1,10 +1,10 @@
 change_type: bug_fix
 
-component: extension/datadog
+component: internal/datadog/hostmetadata
 
-note: Skip cloud metadata source provider probe when hostname is already set in config, avoiding spurious GCP metadata server requests on non-GCP hosts.
+note: Skip building the cloud metadata provider chain when hostname is already set in config, avoiding spurious GCP metadata server requests on non-GCP hosts.
 
-issues: [OTAGENT-1062]
+issues: [49241]
 
 subtext:
 

--- a/.chloggen/datadogextension-skip-source-provider-when-hostname-configured.yaml
+++ b/.chloggen/datadogextension-skip-source-provider-when-hostname-configured.yaml
@@ -1,8 +1,8 @@
 change_type: bug_fix
 
-component: internal/datadog/hostmetadata
+component: extension/datadog
 
-note: Skip building the cloud metadata provider chain when hostname is already set in config, avoiding spurious GCP metadata server requests on non-GCP hosts.
+note: Skip cloud metadata source provider probe when hostname is already set in config, avoiding spurious GCP metadata server requests on non-GCP hosts.
 
 issues: [49241]
 

--- a/.chloggen/datadogextension-skip-source-provider-when-hostname-configured.yaml
+++ b/.chloggen/datadogextension-skip-source-provider-when-hostname-configured.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: extension/datadog
+
+note: Skip cloud metadata source provider probe when hostname is already set in config, avoiding spurious GCP metadata server requests on non-GCP hosts.
+
+issues: [OTAGENT-1062]
+
+subtext:
+
+change_logs: [user]

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -386,20 +386,15 @@ func newExtension(
 	hostProvider source.Provider,
 	uuidProvider uuidProvider,
 ) (*datadogExtension, error) {
-	var host source.Source
+	host, err := hostProvider.Source(context.Background())
+	if err != nil {
+		return nil, err
+	}
 	var hostnameSource string
 	if cfg.Hostname != "" {
-		// Hostname is already known from config; skip the source provider to avoid
-		// unnecessary cloud metadata probes (e.g. GCP metadata server on non-GCP hosts).
 		hostnameSource = "config"
-		host = source.Source{Kind: source.HostnameKind, Identifier: cfg.Hostname}
 	} else {
 		hostnameSource = "inferred"
-		var err error
-		host, err = hostProvider.Source(context.Background())
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// Create agent components

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -386,15 +386,20 @@ func newExtension(
 	hostProvider source.Provider,
 	uuidProvider uuidProvider,
 ) (*datadogExtension, error) {
-	host, err := hostProvider.Source(context.Background())
-	if err != nil {
-		return nil, err
-	}
+	var host source.Source
 	var hostnameSource string
 	if cfg.Hostname != "" {
+		// Hostname is already known from config; skip the source provider to avoid
+		// unnecessary cloud metadata probes (e.g. GCP metadata server on non-GCP hosts).
 		hostnameSource = "config"
+		host = source.Source{Kind: source.HostnameKind, Identifier: cfg.Hostname}
 	} else {
 		hostnameSource = "inferred"
+		var err error
+		host, err = hostProvider.Source(context.Background())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create agent components

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -72,20 +72,6 @@ func TestNewExtension(t *testing.T) {
 		assert.Equal(t, "host error", err.Error())
 	})
 
-	t.Run("config hostname skips source provider", func(t *testing.T) {
-		cfgWithHostname := &Config{
-			API:      datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Site: "datadoghq.com"},
-			Hostname: "my-configured-host",
-		}
-		// Provider returns an error; if it were called the test would fail.
-		hostProvider := &mockSourceProvider{err: errors.New("provider should not be called")}
-		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
-		ext, err := newExtension(t.Context(), cfgWithHostname, set, hostProvider, uuidProvider)
-		require.NoError(t, err)
-		assert.False(t, hostProvider.called, "source provider must not be called when hostname is set in config")
-		assert.Equal(t, "my-configured-host", ext.info.host.Identifier)
-		assert.Equal(t, "config", ext.info.hostnameSource)
-	})
 }
 
 func TestExtensionLifecycle(t *testing.T) {
@@ -835,11 +821,9 @@ var _ source.Provider = (*mockSourceProvider)(nil)
 type mockSourceProvider struct {
 	source source.Source
 	err    error
-	called bool
 }
 
 func (m *mockSourceProvider) Source(_ context.Context) (source.Source, error) {
-	m.called = true
 	if m.err != nil {
 		return source.Source{}, m.err
 	}

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -71,6 +71,21 @@ func TestNewExtension(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, "host error", err.Error())
 	})
+
+	t.Run("config hostname skips source provider", func(t *testing.T) {
+		cfgWithHostname := &Config{
+			API:      datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Site: "datadoghq.com"},
+			Hostname: "my-configured-host",
+		}
+		// Provider returns an error; if it were called the test would fail.
+		hostProvider := &mockSourceProvider{err: errors.New("provider should not be called")}
+		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
+		ext, err := newExtension(t.Context(), cfgWithHostname, set, hostProvider, uuidProvider)
+		require.NoError(t, err)
+		assert.False(t, hostProvider.called, "source provider must not be called when hostname is set in config")
+		assert.Equal(t, "my-configured-host", ext.info.host.Identifier)
+		assert.Equal(t, "config", ext.info.hostnameSource)
+	})
 }
 
 func TestExtensionLifecycle(t *testing.T) {
@@ -820,9 +835,11 @@ var _ source.Provider = (*mockSourceProvider)(nil)
 type mockSourceProvider struct {
 	source source.Source
 	err    error
+	called bool
 }
 
 func (m *mockSourceProvider) Source(_ context.Context) (source.Source, error) {
+	m.called = true
 	if m.err != nil {
 		return source.Source{}, m.err
 	}

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -72,6 +72,20 @@ func TestNewExtension(t *testing.T) {
 		assert.Equal(t, "host error", err.Error())
 	})
 
+	t.Run("config hostname skips source provider", func(t *testing.T) {
+		cfgWithHostname := &Config{
+			API:      datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Site: "datadoghq.com"},
+			Hostname: "my-configured-host",
+		}
+		// Provider returns an error; if it were called the test would fail.
+		hostProvider := &mockSourceProvider{err: errors.New("provider should not be called")}
+		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
+		ext, err := newExtension(t.Context(), cfgWithHostname, set, hostProvider, uuidProvider)
+		require.NoError(t, err)
+		assert.False(t, hostProvider.called, "source provider must not be called when hostname is set in config")
+		assert.Equal(t, "my-configured-host", ext.info.host.Identifier)
+		assert.Equal(t, "config", ext.info.hostnameSource)
+	})
 }
 
 func TestExtensionLifecycle(t *testing.T) {
@@ -821,9 +835,11 @@ var _ source.Provider = (*mockSourceProvider)(nil)
 type mockSourceProvider struct {
 	source source.Source
 	err    error
+	called bool
 }
 
 func (m *mockSourceProvider) Source(_ context.Context) (source.Source, error) {
+	m.called = true
 	if m.err != nil {
 		return source.Source{}, m.err
 	}

--- a/internal/datadog/hostmetadata/host.go
+++ b/internal/datadog/hostmetadata/host.go
@@ -20,7 +20,13 @@ import (
 )
 
 // GetSourceProvider builds the hostname resolution chain.
+// If configHostname is non-empty the chain is skipped entirely and a fixed config provider is returned,
+// avoiding unnecessary cloud metadata probes on non-matching cloud environments.
 func GetSourceProvider(set component.TelemetrySettings, configHostname string, timeout time.Duration) (source.Provider, error) {
+	if configHostname != "" {
+		return provider.Config(configHostname), nil
+	}
+
 	ecsProvider, err := ecs.NewProvider(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build ECS Fargate provider: %w", err)

--- a/internal/datadog/hostmetadata/host.go
+++ b/internal/datadog/hostmetadata/host.go
@@ -20,13 +20,7 @@ import (
 )
 
 // GetSourceProvider builds the hostname resolution chain.
-// If configHostname is non-empty the chain is skipped entirely and a fixed config provider is returned,
-// avoiding unnecessary cloud metadata probes on non-matching cloud environments.
 func GetSourceProvider(set component.TelemetrySettings, configHostname string, timeout time.Duration) (source.Provider, error) {
-	if configHostname != "" {
-		return provider.Config(configHostname), nil
-	}
-
 	ecsProvider, err := ecs.NewProvider(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build ECS Fargate provider: %w", err)


### PR DESCRIPTION
#### Description
Skip source provider when hostname is set in config to avoid unnecessary probes to Cloud providers

#### Authorship

- [x] I, a human, wrote this pull request description myself.