### PR TITLE
[chore] [cmd/mdatagen] Remove reaggregation metadata setting

### DIFF
--- a/receiver/activedirectorydsreceiver/metadata.yaml
+++ b/receiver/activedirectorydsreceiver/metadata.yaml
@@ -15,8 +15,6 @@ status:
     seeking_new: true
   unsupported_platforms: [darwin, linux]
 
-reaggregation_enabled: true
-
 attributes:
   bind_type:
     name_override: type

--- a/receiver/aerospikereceiver/metadata.yaml
+++ b/receiver/aerospikereceiver/metadata.yaml
@@ -4,8 +4,6 @@ type: aerospike
 description: |
   The Aerospike receiver is designed to collect performance metrics from one or more Aerospike nodes.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -13,8 +13,6 @@ status:
     active: [colelaven, ishleenk17]
     emeritus: [djaglowski]
 
-reaggregation_enabled: true
-
 resource_attributes:
   apache.server.name:
     description: The name of the Apache HTTP server.

--- a/receiver/apachesparkreceiver/metadata.yaml
+++ b/receiver/apachesparkreceiver/metadata.yaml
@@ -7,8 +7,6 @@ description: |
   the `/metrics/json`, `/api/v1/applications/[app-id]/stages`, `/api/v1/applications/[app-id]/executors`, and
   `/api/v1/applications/[app-id]/jobs` endpoints.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/chronyreceiver/metadata.yaml
+++ b/receiver/chronyreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: Chrony Receiver
 type: chrony
-reaggregation_enabled: true
 
 status:
   class: receiver

--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: CouchDB Receiver
 type: couchdb
-reaggregation_enabled: true
 
 description: |
   This receiver fetches stats from a CouchDB server using the `/_node/{node-name}/_stats/couchdb`

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -17,8 +17,6 @@ status:
     emeritus: [rmfitzpatrick]
   unsupported_platforms: [darwin, windows]
 
-reaggregation_enabled: true
-
 sem_conv_version: 1.40.0
 
 tests:

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -7,8 +7,6 @@ description: |
   [index stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html) endpoints in order
   to scrape metrics from a running Elasticsearch cluster.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/expvarreceiver/metadata.yaml
+++ b/receiver/expvarreceiver/metadata.yaml
@@ -15,8 +15,6 @@ status:
   codeowners:
     active: [jamesmoessis, MovieStoreGuy]
 
-reaggregation_enabled: true
-
 metrics:
   process.runtime.memstats.buck_hash_sys:
     enabled: true

--- a/receiver/filestatsreceiver/metadata.yaml
+++ b/receiver/filestatsreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: File Stats Receiver
 type: file_stats
 deprecated_type: filestats
-reaggregation_enabled: true
 
 description: The File Stats receiver collects metrics from files specified with a glob pattern.
 

--- a/receiver/flinkmetricsreceiver/metadata.yaml
+++ b/receiver/flinkmetricsreceiver/metadata.yaml
@@ -15,8 +15,6 @@ status:
     active: [JonathanWamsley]
     seeking_new: true
 
-reaggregation_enabled: true
-
 resource_attributes:
   # These resource attributes are Flinks system scope variables, which contains context information about metrics. These are required to uniquely identify incoming metrics as the same job can run multiple times concurrently. See https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/ops/metrics/#system-scope for more information.
   flink.job.name:

--- a/receiver/githubreceiver/metadata.yaml
+++ b/receiver/githubreceiver/metadata.yaml
@@ -11,8 +11,6 @@ status:
   codeowners:
     active: [adrielp, crobert-1, TylerHelmuth]
 
-reaggregation_enabled: true
-
 feature_gates:
   - id: receiver.githubreceiver.UseCheckRunID
     description: >-

--- a/receiver/haproxyreceiver/metadata.yaml
+++ b/receiver/haproxyreceiver/metadata.yaml
@@ -4,8 +4,6 @@ type: haproxy
 description: |
   The HAProxy receiver generates metrics by polling periodically the HAProxy process through a dedicated socket or HTTP URL.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -8,8 +8,6 @@ status:
   codeowners:
     active: [dmitryax, braydonk, rogercoll]
 
-reaggregation_enabled: true
-
 sem_conv_version: 1.9.0
 
 attributes:

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -8,8 +8,6 @@ status:
   codeowners:
     active: [dmitryax, braydonk, rogercoll]
 
-reaggregation_enabled: true
-
 sem_conv_version: 1.9.0
 
 attributes:

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -8,8 +8,6 @@ status:
   codeowners:
     active: [dmitryax, braydonk, rogercoll]
 
-reaggregation_enabled: true
-
 sem_conv_version: 1.9.0
 
 attributes:

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -8,8 +8,6 @@ status:
   codeowners:
     active: [dmitryax, braydonk, rogercoll]
 
-reaggregation_enabled: true
-
 sem_conv_version: 1.9.0
 
 metrics:

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -10,8 +10,6 @@ status:
 
 sem_conv_version: 1.9.0
 
-reaggregation_enabled: true
-
 attributes:
   state:
     description: Breakdown of memory usage by type.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -8,8 +8,6 @@ status:
   codeowners:
     active: [dmitryax, braydonk, rogercoll]
 
-reaggregation_enabled: true
-
 sem_conv_version: 1.9.0
 
 attributes:

--- a/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/metadata.yaml
@@ -11,8 +11,6 @@ status:
 
 sem_conv_version: 1.9.0
 
-reaggregation_enabled: true
-
 attributes:
   error.type:
     description: Describes a class of error the operation ended with.

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -10,8 +10,6 @@ status:
 
 sem_conv_version: 1.9.0
 
-reaggregation_enabled: true
-
 attributes:
   device:
     description: Name of the page file.

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -10,8 +10,6 @@ status:
 
 sem_conv_version: 1.9.0
 
-reaggregation_enabled: true
-
 attributes:
   status:
     description: Breakdown status of the processes.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -10,8 +10,6 @@ status:
 
 sem_conv_version: 1.9.0
 
-reaggregation_enabled: true
-
 resource_attributes:
   process.cgroup:
     description: cgroup associated with the process (Linux only).

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/metadata.yaml
@@ -10,8 +10,6 @@ status:
 
 sem_conv_version: 1.9.0
 
-reaggregation_enabled: true
-
 metrics:
   system.uptime:
     enabled: true

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -5,8 +5,6 @@ deprecated_type: httpcheck
 description: |
   The HTTP Check Receiver can be used for synthetic checks against HTTP endpoints.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/icmpcheckreceiver/metadata.yaml
+++ b/receiver/icmpcheckreceiver/metadata.yaml
@@ -14,8 +14,6 @@ status:
   codeowners:
     active: [atoulme, jkoronaAtCisco]
 
-reaggregation_enabled: true
-
 resource_attributes:
   net.peer.ip:
     enabled: true

--- a/receiver/iisreceiver/metadata.yaml
+++ b/receiver/iisreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: Microsoft IIS Receiver
 type: iis
-reaggregation_enabled: true
 
 description: |
   The Microsoft IIS Receiver grabs metrics about an IIS instance using the Windows Performance Counters. Because of

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -17,8 +17,6 @@ status:
 
 sem_conv_version: 1.18.0
 
-reaggregation_enabled: true
-
 entities:
   - type: k8s.namespace
     brief: A Kubernetes namespace

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -24,7 +24,6 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41480
     skip_strict_validation: true
 
-reaggregation_enabled: true
 resource_attributes:
   kafka.cluster.alias:
     description: The alias name (string) of the cluster

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: Kubelet Stats Receiver
 type: kubelet_stats
 deprecated_type: kubeletstats
-reaggregation_enabled: true
 
 description: |
   The Kubelet Stats Receiver pulls node, pod, container, and volume metrics from the API server on a kubelet

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: Memcached Receiver
 type: memcached
-reaggregation_enabled: true
 
 description: |
   This receiver can fetch stats from a Memcached instance using the [stats

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: MongoDB Atlas Receiver
 type: mongodb_atlas
 deprecated_type: mongodbatlas
-reaggregation_enabled: true
 
 description: |
   The MongoDB Atlas Receiver receives metrics from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) 

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: MongoDB Receiver
 type: mongodb
-reaggregation_enabled: true
 
 description: |
   This receiver fetches stats from a MongoDB instance using the 

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -12,8 +12,6 @@ status:
     seeking_new: true
     emeritus: [djaglowski]
 
-reaggregation_enabled: true
-
 resource_attributes:
   mysql.instance.endpoint:
     description: Endpoint of the MySQL instance.

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -5,8 +5,6 @@ description: |
   This receiver can fetch stats from a NGINX instance using the `ngx_http_stub_status_module` module's `status`
   endpoint.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: NSX-T Receiver
 type: nsxt
-reaggregation_enabled: true
 
 description: |
   This receiver fetches metrics important to run virtual networking using NSX-T. The receiver ingests metrics via the

--- a/receiver/ntpreceiver/metadata.yaml
+++ b/receiver/ntpreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: NTP Receiver
 type: ntp
-reaggregation_enabled: true
 
 description: |
   This receiver periodically retrieves the clock offset from a NTP server.

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -4,8 +4,6 @@ type: oracledb
 description: |
   This receiver periodically queries an Oracle Database host to collect metrics.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/podmanreceiver/metadata.yaml
+++ b/receiver/podmanreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: Podman Stats Receiver
 type: podman_stats
 
-reaggregation_enabled: true
 description: |
   The Podman Stats Receiver queries the Podman service API to fetch stats for all running containers
   on a configured interval.  These stats are for container resource usage of cpu, memory, network, and

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -15,8 +15,6 @@ status:
     seeking_new: true
     emeritus: [djaglowski]
 
-reaggregation_enabled: true
-
 feature_gates:
   - id: postgresqlreceiver.preciselagmetrics
     description: Metric `postgresql.wal.lag` is replaced by more precise `postgresql.wal.delay`.

--- a/receiver/rabbitmqreceiver/metadata.yaml
+++ b/receiver/rabbitmqreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: RabbitMQ Receiver
 type: rabbitmq
 
-reaggregation_enabled: true
 description: |
   This receiver fetches stats from a RabbitMQ node using the [RabbitMQ Management Plugin](https://www.rabbitmq.com/management.html).
 

--- a/receiver/redfishreceiver/metadata.yaml
+++ b/receiver/redfishreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: Redfish Receiver
 type: redfish
-reaggregation_enabled: true
 
 description: |
   This receiver fetches metrics for a server running a [Redfish](https://en.wikipedia.org/wiki/Redfish_(specification))

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -6,8 +6,6 @@ description: |
   instance, build metrics from that data, and send them to the next consumer at a
   configurable interval.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/riakreceiver/metadata.yaml
+++ b/receiver/riakreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: Riak Receiver
 type: riak
-reaggregation_enabled: true
 
 status:
   class: receiver

--- a/receiver/saphanareceiver/metadata.yaml
+++ b/receiver/saphanareceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: SAP HANA Receiver
 type: saphana
-reaggregation_enabled: true
 
 description: |
   This receiver can fetch stats from a SAP HANA instance. It leverages the [driver](https://github.com/SAP/go-hdb)

--- a/receiver/snowflakereceiver/metadata.yaml
+++ b/receiver/snowflakereceiver/metadata.yaml
@@ -12,8 +12,6 @@ status:
   codeowners:
     active: [dmitryax, shalper2]
 
-reaggregation_enabled: true
-
 # every meter will have these attributes
 resource_attributes:
   snowflake.account.name:

--- a/receiver/splunkenterprisereceiver/metadata.yaml
+++ b/receiver/splunkenterprisereceiver/metadata.yaml
@@ -17,7 +17,6 @@ status:
   codeowners:
     active: [shalper2, MovieStoreGuy, greatestusername]
 
-reaggregation_enabled: true
 attributes:
   splunk.bucket.dir:
     description: The bucket super-directory (home, cold, thawed) for each index

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -6,7 +6,6 @@ description: |
   Windows Performance Counters, or by directly connecting to the instance and querying it. Windows Performance Counters
   are only available when running on Windows.
 
-reaggregation_enabled: true
 override_value_enabled: true
 
 status:

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: SSH Check Receiver
 type: ssh_check
 deprecated_type: sshcheck
-reaggregation_enabled: true
 
 description: This receiver creates stats by connecting to an SSH server which may be an SFTP server.
 

--- a/receiver/systemdreceiver/metadata.yaml
+++ b/receiver/systemdreceiver/metadata.yaml
@@ -3,8 +3,6 @@ type: systemd
 
 description: The Systemd Receiver gathers metrics for locally running systemd units.
 
-reaggregation_enabled: true
-
 status:
   class: receiver
   stability:

--- a/receiver/tcpcheckreceiver/metadata.yaml
+++ b/receiver/tcpcheckreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: TCP Check Receiver
 type: tcp_check
 deprecated_type: tcpcheck
-reaggregation_enabled: true
 
 description: This receiver creates stats by connecting to a TCP server.
 

--- a/receiver/tlscheckreceiver/metadata.yaml
+++ b/receiver/tlscheckreceiver/metadata.yaml
@@ -1,7 +1,6 @@
 display_name: TLS Check Receiver
 type: tls_check
 deprecated_type: tlscheck
-reaggregation_enabled: true
 
 description: This receiver emits metrics about x.509 certificates.
 

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -1,6 +1,5 @@
 display_name: vCenter Receiver
 type: vcenter
-reaggregation_enabled: true
 
 description: This receiver fetches metrics from a vCenter or ESXi host running VMware vSphere APIs.
 

--- a/receiver/windowsservicereceiver/metadata.yaml
+++ b/receiver/windowsservicereceiver/metadata.yaml
@@ -15,8 +15,6 @@ status:
     active: [pjanotti, shalper2]
   unsupported_platforms: [darwin, linux]
 
-reaggregation_enabled: true
-
 attributes:
   name:
     description: The name of the windows Service being reported.


### PR DESCRIPTION
Closes #49240.

Follow-up to open-telemetry/opentelemetry-collector#15385. Removes the now-unused `reaggregation_enabled` setting from contrib receiver `metadata.yaml` files.

Unblocks core dependency update