### PR TITLE
exporter/signalfx: remove cpu.utilization_per_core default translation

### DIFF
--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -3,7 +3,7 @@ component: exporter/signalfx
 note: "Remove `cpu.utilization_per_core` from the SignalFx exporter's default translations and default exclude list."
 issues: [49243]
 subtext: |
-  The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` with the required attributes in the `hostmetrics` receiver, then copy and aggregate it with the transform processor:
+  The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` with the required attributes in the `hostmetrics` receiver, then rename and aggregate it with the transform processor:
   ```yaml
   receivers:
     hostmetrics:
@@ -20,7 +20,7 @@ subtext: |
       metric_statements:
         - context: metric
           statements:
-            - copy_metric(name="cpu.utilization_per_core") where metric.name == "system.cpu.utilization"
+            - set(metric.name, "cpu.utilization_per_core") where metric.name == "system.cpu.utilization"
         - context: datapoint
           statements:
             - set(datapoint.value_double, 0.0) where metric.name == "cpu.utilization_per_core" and datapoint.attributes["state"] == "idle"

--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -1,0 +1,37 @@
+change_type: breaking
+component: exporter/signalfx
+note: "Remove `cpu.utilization_per_core` from the SignalFx exporter's default translations and default exclude list."
+issues: []
+subtext: |
+  The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` in the `hostmetrics` receiver, then copy and aggregate it with the transform processor:
+  ```yaml
+  receivers:
+    hostmetrics:
+      scrapers:
+        cpu:
+          metrics:
+            system.cpu.utilization:
+              enabled: true
+
+  processors:
+    transform/cpu_utilization_per_core:
+      error_mode: ignore
+      metric_statements:
+        - context: metric
+          statements:
+            - copy_metric(name="cpu.utilization_per_core") where metric.name == "system.cpu.utilization"
+        - context: datapoint
+          statements:
+            - set(datapoint.value_double, 0.0) where metric.name == "cpu.utilization_per_core" and datapoint.attributes["state"] == "idle"
+        - context: metric
+          statements:
+            - aggregate_on_attributes("sum", ["cpu"]) where metric.name == "cpu.utilization_per_core"
+
+  service:
+    pipelines:
+      metrics:
+        receivers: [hostmetrics]
+        processors: [transform/cpu_utilization_per_core]
+        exporters: [signalfx]
+  ```
+change_logs: [user]

--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -26,6 +26,7 @@ subtext: |
         - context: metric
           statements:
             - aggregate_on_attributes("sum", ["cpu"]) where metric.name == "cpu.utilization_per_core"
+            - scale_metric(100.0) where metric.name == "cpu.utilization_per_core"
 
   service:
     pipelines:

--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -1,9 +1,10 @@
 change_type: breaking
 component: exporter/signalfx
-note: "Remove `cpu.utilization_per_core` from the SignalFx exporter's default translations and default exclude list."
+note: "Stop calculating `cpu.utilization_per_core` disabled by default."
 issues: [49243]
 subtext: |
-  The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` with the required attributes in the `hostmetrics` receiver, then rename and aggregate it with the transform processor:
+  The exporter still creates the aggregate `cpu.utilization` metric by default. However, `cpu.utilization_per_core` which is disabled by default isn't produced by the default transformations anymore.
+  To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` in the `host_metrics` receiver, then rename and aggregate it with the transform processor:
   ```yaml
   receivers:
     hostmetrics:
@@ -13,7 +14,6 @@ subtext: |
             system.cpu.utilization:
               enabled: true
               attributes: [cpu, state]
-
   processors:
     transform/cpu_utilization_per_core:
       error_mode: ignore
@@ -27,7 +27,6 @@ subtext: |
         - context: metric
           statements:
             - aggregate_on_attributes("sum", ["cpu"]) where metric.name == "cpu.utilization_per_core"
-
   service:
     pipelines:
       metrics:

--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -27,7 +27,6 @@ subtext: |
         - context: metric
           statements:
             - aggregate_on_attributes("sum", ["cpu"]) where metric.name == "cpu.utilization_per_core"
-            - scale_metric(100.0) where metric.name == "cpu.utilization_per_core"
 
   service:
     pipelines:

--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -3,7 +3,7 @@ component: exporter/signalfx
 note: "Remove `cpu.utilization_per_core` from the SignalFx exporter's default translations and default exclude list."
 issues: [49243]
 subtext: |
-  The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` in the `hostmetrics` receiver, then copy and aggregate it with the transform processor:
+  The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` with the required attributes in the `hostmetrics` receiver, then copy and aggregate it with the transform processor:
   ```yaml
   receivers:
     hostmetrics:
@@ -12,6 +12,7 @@ subtext: |
           metrics:
             system.cpu.utilization:
               enabled: true
+              attributes: [cpu, state]
 
   processors:
     transform/cpu_utilization_per_core:

--- a/.chloggen/signalfx-cpu-utilization-per-core.yaml
+++ b/.chloggen/signalfx-cpu-utilization-per-core.yaml
@@ -1,7 +1,7 @@
 change_type: breaking
 component: exporter/signalfx
 note: "Remove `cpu.utilization_per_core` from the SignalFx exporter's default translations and default exclude list."
-issues: []
+issues: [49243]
 subtext: |
   The exporter still creates the aggregate `cpu.utilization` metric by default. To emit an equivalent `cpu.utilization_per_core` metric, enable `system.cpu.utilization` in the `hostmetrics` receiver, then copy and aggregate it with the transform processor:
   ```yaml

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -231,7 +231,6 @@ The default rules will create the following aggregated metrics from the [`hostme
 * cpu.system
 * cpu.user
 * cpu.utilization
-* cpu.utilization_per_core
 * cpu.wait
 * disk.summary_utilization
 * disk.utilization

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -558,8 +558,7 @@ func TestDefaultCPUTranslations(t *testing.T) {
 		require.Equal(t, 66, int(*pt.Value.DoubleValue))
 	}
 
-	cpuUtilPerCore := m["cpu.utilization_per_core"]
-	require.Len(t, cpuUtilPerCore, 8)
+	require.NotContains(t, m, "cpu.utilization_per_core")
 
 	cpuNumProcessors := m["cpu.num_processors"]
 	require.Len(t, cpuNumProcessors, 1)
@@ -625,13 +624,25 @@ func TestDefaultExcludesTranslated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 9, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 8, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 
-	// the default cpu.utilization metric is added after applying the default translations
-	// (because cpu.utilization_per_core is supplied) and should not be excluded
+	require.Empty(t, dps)
+}
+
+func TestDefaultExcludesDoNotDropCPUUtilizationPerCore(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	require.NoError(t, setDefaultExcludes(cfg))
+
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics, "", false, true)
+	require.NoError(t, err)
+
+	md := getMetrics([]map[string]string{{"cpu.utilization_per_core": ""}})
+	dps := converter.MetricsToSignalFxV2(md)
+
 	require.Len(t, dps, 1)
-	require.Equal(t, "cpu.utilization", dps[0].Metric)
+	require.Equal(t, "cpu.utilization_per_core", dps[0].Metric)
 }
 
 func TestDefaultExcludes_not_translated(t *testing.T) {

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -558,8 +558,6 @@ func TestDefaultCPUTranslations(t *testing.T) {
 		require.Equal(t, 66, int(*pt.Value.DoubleValue))
 	}
 
-	require.NotContains(t, m, "cpu.utilization_per_core")
-
 	cpuNumProcessors := m["cpu.num_processors"]
 	require.Len(t, cpuNumProcessors, 1)
 
@@ -628,21 +626,6 @@ func TestDefaultExcludesTranslated(t *testing.T) {
 	dps := converter.MetricsToSignalFxV2(md)
 
 	require.Empty(t, dps)
-}
-
-func TestDefaultExcludesDoNotDropCPUUtilizationPerCore(t *testing.T) {
-	f := NewFactory()
-	cfg := f.CreateDefaultConfig().(*Config)
-	require.NoError(t, setDefaultExcludes(cfg))
-
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics, "", false, true)
-	require.NoError(t, err)
-
-	md := getMetrics([]map[string]string{{"cpu.utilization_per_core": ""}})
-	dps := converter.MetricsToSignalFxV2(md)
-
-	require.Len(t, dps, 1)
-	require.Equal(t, "cpu.utilization_per_core", dps[0].Metric)
 }
 
 func TestDefaultExcludes_not_translated(t *testing.T) {

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -13,7 +13,7 @@ translation_rules:
     # kubeletstats container cpu needed for calculation below
     container.cpu.time: sf_temp.container_cpu_utilization
 
-# compute cpu utilization metrics: cpu.utilization_per_core (excluded by default) and cpu.utilization
+# compute cpu.utilization metric
 - action: delta_metric
   mapping:
     system.cpu.time: sf_temp.system.cpu.delta
@@ -43,13 +43,10 @@ translation_rules:
   without_dimensions:
   - state
 - action: calculate_new_metric
-  metric_name: cpu.utilization_per_core
+  metric_name: sf_temp.cpu.utilization
   operand1_metric: sf_temp.system.cpu.usage
   operand2_metric: sf_temp.system.cpu.total
   operator: /
-- action: copy_metrics
-  mapping:
-    cpu.utilization_per_core: sf_temp.cpu.utilization
 - action: aggregate_metric
   metric_name: sf_temp.cpu.utilization
   aggregation_method: avg

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -20,7 +20,6 @@ exclude_metrics:
   - cpu.steal
   - cpu.system
   - cpu.user
-  - cpu.utilization_per_core
   - cpu.wait
 
   # Disk-IO metrics.

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics.json
@@ -18,9 +18,6 @@
     "cpu.user": null
   },
   {
-    "cpu.utilization_per_core": null
-  },
-  {
     "cpu.wait": null
   },
   {


### PR DESCRIPTION
Removes the SignalFx exporter default translation and default exclude entry for `cpu.utilization_per_core`. The aggregate `cpu.utilization` default translation remains, and the changelog shows how to recreate the per-core metric with the hostmetrics receiver and transform processor.