### PR TITLE
[Receiver][aws_lambda] Support using static credentials for S3 access

### DIFF
--- a/.chloggen/feat_aws-lambda-receiver-static-creds.yaml
+++ b/.chloggen/feat_aws-lambda-receiver-static-creds.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/aws_lambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for AWS configuration overrides for static credentials
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49163]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -239,11 +239,16 @@ See [Filter pattern syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/
 
 The following receiver configuration parameters are supported.
 
-| Name                   | Description                                             |
-|:-----------------------|:--------------------------------------------------------|
-| `s3::encoding`         | Optional encoder to use for S3 event processing         | 
-| `cloudwatch::encoding` | Optional encoder to use for CloudWatch event processing | 
-| `custom::encoding`     | Optional encoder to use for custom event processing     | 
+| Name                    | Description                                                                                                                                      |
+|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `s3::encoding`          | Optional encoder to use for S3 event processing                                                                                                  |
+| `s3::encodings`         | Optional list of path-based encoders for multi-format S3 routing (see [Multi-Format S3 Configuration](#multi-format-s3-configuration-encodings)) |
+| `s3::access_key_id`     | Optional static AWS access key ID for S3 access                                                                                                  |
+| `s3::secret_access_key` | Optional static AWS secret access key for S3 access                                                                                              |
+| `s3::session_token`     | Optional static AWS session token for S3 access                                                                                                  |
+| `cloudwatch::encoding`  | Optional encoder to use for CloudWatch event processing                                                                                          |
+| `custom::encoding`      | Optional encoder to use for custom event processing                                                                                              |
+| `failure_bucket_arn`    | Optional S3 bucket ARN holding failed Lambda records for replay                                                                                  | 
 
 Consider following notes on default behaviors:
 

--- a/receiver/awslambdareceiver/config.go
+++ b/receiver/awslambdareceiver/config.go
@@ -78,7 +78,7 @@ type sharedConfig struct {
 type S3Config struct {
 	sharedConfig `mapstructure:",squash"`
 
-	internal.AWSOptions `mapstructure:",squash"`
+	AWSOptions internal.AWSOptions `mapstructure:",squash"`
 
 	// Encodings defines multiple encoding entries for S3 path-based routing (multi-format mode).
 	// Each entry maps a path_pattern prefix to an encoding extension.
@@ -95,7 +95,7 @@ func (c *S3Config) Validate() error {
 	}
 
 	// Make sure static credential overrides are provided correctly
-	if (c.AccessKeyID == "") != (c.SecretAccessKey == "") {
+	if (c.AWSOptions.AccessKeyID == "") != (c.AWSOptions.SecretAccessKey == "") {
 		return errors.New("both 'access_key_id' and 'secret_access_key' must be provided together")
 	}
 

--- a/receiver/awslambdareceiver/config.go
+++ b/receiver/awslambdareceiver/config.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver/internal"
 )
 
 const s3ARNPrefix = "arn:aws:s3:::"
@@ -76,6 +78,8 @@ type sharedConfig struct {
 type S3Config struct {
 	sharedConfig `mapstructure:",squash"`
 
+	internal.AWSOptions `mapstructure:",squash"`
+
 	// Encodings defines multiple encoding entries for S3 path-based routing (multi-format mode).
 	// Each entry maps a path_pattern prefix to an encoding extension.
 	// Mutually exclusive with sharedConfig.Encoding.
@@ -89,6 +93,12 @@ func (c *S3Config) Validate() error {
 	if c.Encoding != "" && len(c.Encodings) > 0 {
 		return errors.New("'encoding' and 'encodings' are mutually exclusive; use 'encodings' for multi-format support")
 	}
+
+	// Make sure static credential overrides are provided correctly
+	if (c.AccessKeyID == "") != (c.SecretAccessKey == "") {
+		return errors.New("both 'access_key_id' and 'secret_access_key' must be provided together")
+	}
+
 	seen := make(map[string]bool, len(c.Encodings))
 	for i, e := range c.Encodings {
 		if err := e.Validate(); err != nil {

--- a/receiver/awslambdareceiver/config.schema.yaml
+++ b/receiver/awslambdareceiver/config.schema.yaml
@@ -11,6 +11,8 @@ $defs:
         type: array
         items:
           $ref: s_3_encoding
+    allOf:
+      - $ref: ./internal.aws_options
   s_3_encoding:
     description: S3Encoding defines one entry in the S3 multi-encoding routing table.
     type: object

--- a/receiver/awslambdareceiver/config_test.go
+++ b/receiver/awslambdareceiver/config_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver/internal/metadata"
 )
 
@@ -69,6 +70,23 @@ func TestLoadConfig(t *testing.T) {
 						{Name: "vpcflow", Encoding: "awslogs_encoding/vpcflow"},
 						{Name: "cloudtrail", Encoding: "awslogs_encoding/cloudtrail"},
 						{Name: "catchall", PathPattern: "*"},
+					},
+				},
+				CloudWatch: sharedConfig{},
+			},
+		},
+		{
+			name:              "Config with S3 and AWS options",
+			componentIDToLoad: component.NewIDWithName(metadata.Type, "s3_with_aws_options"),
+			expected: &Config{
+				S3: S3Config{
+					sharedConfig: sharedConfig{
+						Encoding: "aws_logs_encoding",
+					},
+					AWSOptions: internal.AWSOptions{
+						AccessKeyID:     "key",
+						SecretAccessKey: "accessKey",
+						SessionToken:    "session",
 					},
 				},
 				CloudWatch: sharedConfig{},

--- a/receiver/awslambdareceiver/go.mod
+++ b/receiver/awslambdareceiver/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-lambda-go v1.54.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.155.0
@@ -33,7 +34,6 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect

--- a/receiver/awslambdareceiver/go.mod
+++ b/receiver/awslambdareceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/client v1.61.0
 	go.opentelemetry.io/collector/component v1.61.0
 	go.opentelemetry.io/collector/component/componenttest v0.155.0
+	go.opentelemetry.io/collector/config/configopaque v1.61.0
 	go.opentelemetry.io/collector/confmap v1.61.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.155.0
 	go.opentelemetry.io/collector/consumer v1.61.0

--- a/receiver/awslambdareceiver/go.sum
+++ b/receiver/awslambdareceiver/go.sum
@@ -101,6 +101,8 @@ go.opentelemetry.io/collector/component v1.61.0 h1:f2dUAPK1xu3FSY3QG2whG9PEEs+Qg
 go.opentelemetry.io/collector/component v1.61.0/go.mod h1:TFmz1NXfMDG4aKTAYcdi5gFntdAW/+Vq/iHYDoou/0E=
 go.opentelemetry.io/collector/component/componenttest v0.155.0 h1:FfQQpYJnkNhNW5EPSD+vBiUL7Mwgkudrkr0LRYpi7HA=
 go.opentelemetry.io/collector/component/componenttest v0.155.0/go.mod h1:MkXnGN4QH6El1GGTTOrDUqY8/p8Vkbfi0Non2Pmi0m4=
+go.opentelemetry.io/collector/config/configopaque v1.61.0 h1:bqH+EYJ5vXNgYqzTQrPscz19qPX7AzDHeSX0UoGX5mI=
+go.opentelemetry.io/collector/config/configopaque v1.61.0/go.mod h1:au3YBsaIaX1BezbqAEN9ddbMakth0DZYHEtz89N4jpA=
 go.opentelemetry.io/collector/confmap v1.61.0 h1:LkSQF8tt3eyYTK+sW4d4ub2T0SjUwwzxAt7dJnfKFHs=
 go.opentelemetry.io/collector/confmap v1.61.0/go.mod h1:OmuazWMkNuAwJr5BMuloacsNrW9ES458VHjVfLB0B78=
 go.opentelemetry.io/collector/confmap/xconfmap v0.155.0 h1:tJ8UbfRsG7Owqfixr3n3Jq6os1Qk50ZCUUPtBXpXT7w=

--- a/receiver/awslambdareceiver/internal/mock_s3_service.go
+++ b/receiver/awslambdareceiver/internal/mock_s3_service.go
@@ -210,16 +210,16 @@ func (m *MockS3Provider) EXPECT() *MockS3ProviderMockRecorder {
 }
 
 // GetService mocks base method.
-func (m *MockS3Provider) GetService(ctx context.Context) (S3Service, error) {
+func (m *MockS3Provider) GetService(ctx context.Context, staticCreds AWSOptions) (S3Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetService", ctx)
+	ret := m.ctrl.Call(m, "GetService", ctx, staticCreds)
 	ret0, _ := ret[0].(S3Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetService indicates an expected call of GetService.
-func (mr *MockS3ProviderMockRecorder) GetService(ctx any) *gomock.Call {
+func (mr *MockS3ProviderMockRecorder) GetService(ctx, staticCreds any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockS3Provider)(nil).GetService), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockS3Provider)(nil).GetService), ctx, staticCreds)
 }

--- a/receiver/awslambdareceiver/internal/s3.go
+++ b/receiver/awslambdareceiver/internal/s3.go
@@ -12,14 +12,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
 // AWSOptions holds configuration overrides for AWS SDK when accessing S3 data.
 type AWSOptions struct {
-	AccessKeyID     string `mapstructure:"access_key_id"`
-	SecretAccessKey string `mapstructure:"secret_access_key"`
-	SessionToken    string `mapstructure:"session_token"`
+	AccessKeyID     string              `mapstructure:"access_key_id"`
+	SecretAccessKey configopaque.String `mapstructure:"secret_access_key"`
+	SessionToken    configopaque.String `mapstructure:"session_token"`
 }
 
 // s3API abstracts out the S3 APIs allowing mocking for tests
@@ -62,8 +63,8 @@ func (s *S3ServiceProvider) GetService(ctx context.Context, awsOptions AWSOption
 		if awsOptions.AccessKeyID != "" && awsOptions.SecretAccessKey != "" {
 			cfg.Credentials = credentials.NewStaticCredentialsProvider(
 				awsOptions.AccessKeyID,
-				awsOptions.SecretAccessKey,
-				awsOptions.SessionToken,
+				string(awsOptions.SecretAccessKey),
+				string(awsOptions.SessionToken),
 			)
 		}
 

--- a/receiver/awslambdareceiver/internal/s3.go
+++ b/receiver/awslambdareceiver/internal/s3.go
@@ -7,11 +7,20 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 )
+
+// AWSOptions holds configuration overrides for AWS SDK when accessing S3 data.
+type AWSOptions struct {
+	AccessKeyID     string `mapstructure:"access_key_id"`
+	SecretAccessKey string `mapstructure:"secret_access_key"`
+	SessionToken    string `mapstructure:"session_token"`
+}
 
 // s3API abstracts out the S3 APIs allowing mocking for tests
 type s3API interface {
@@ -30,19 +39,38 @@ type S3Service interface {
 
 // S3Provider expose contract to get S3Service
 type S3Provider interface {
-	GetService(ctx context.Context) (S3Service, error)
+	GetService(ctx context.Context, options AWSOptions) (S3Service, error)
 }
 
 // S3ServiceProvider provides S3Service instances.
-type S3ServiceProvider struct{}
+type S3ServiceProvider struct {
+	service S3Service
+	err     error
 
-func (*S3ServiceProvider) GetService(ctx context.Context) (S3Service, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)
-	}
+	once sync.Once
+}
 
-	return &s3ServiceClient{api: s3.NewFromConfig(cfg)}, nil
+func (s *S3ServiceProvider) GetService(ctx context.Context, awsOptions AWSOptions) (S3Service, error) {
+	s.once.Do(func() {
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			s.err = fmt.Errorf("unable to load AWS SDK config: %w", err)
+			return
+		}
+
+		// Use static creds if provided
+		if awsOptions.AccessKeyID != "" && awsOptions.SecretAccessKey != "" {
+			cfg.Credentials = credentials.NewStaticCredentialsProvider(
+				awsOptions.AccessKeyID,
+				awsOptions.SecretAccessKey,
+				awsOptions.SessionToken,
+			)
+		}
+
+		s.service = &s3ServiceClient{api: s3.NewFromConfig(cfg)}
+	})
+
+	return s.service, s.err
 }
 
 // s3ServiceClient implements the S3Service

--- a/receiver/awslambdareceiver/internal/s3_test.go
+++ b/receiver/awslambdareceiver/internal/s3_test.go
@@ -19,7 +19,7 @@ import (
 func TestS3ServiceProvider(t *testing.T) {
 	provider := S3ServiceProvider{}
 
-	service, err := provider.GetService(t.Context())
+	service, err := provider.GetService(t.Context(), AWSOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, service)
 }

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -118,7 +118,7 @@ func (a *awsLambdaReceiver) processLambdaEvent(ctx context.Context, event json.R
 
 	if triggerType == replayEvent {
 		a.logger.Info("Running custom event", zap.String(logInvokedTrigger, string(triggerType)))
-		service, err := a.s3Provider.GetService(ctx)
+		service, err := a.s3Provider.GetService(ctx, a.cfg.S3.AWSOptions)
 		if err != nil {
 			return err
 		}
@@ -219,7 +219,7 @@ func newLogsHandler(
 ) (handlerProvider, error) {
 	logger := set.Logger
 
-	s3Service, err := s3Provider.GetService(ctx)
+	s3Service, err := s3Provider.GetService(ctx, cfg.S3.AWSOptions)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load the S3 service: %w", err)
 	}
@@ -341,7 +341,7 @@ func newMetricsHandler(
 		decoder = xstreamencoding.NewMetricsUnmarshalerDecoderFactory(metricsUnmarshaler)
 	}
 
-	s3Service, err := s3Provider.GetService(ctx)
+	s3Service, err := s3Provider.GetService(ctx, cfg.S3.AWSOptions)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load the S3 service: %w", err)
 	}

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -56,7 +56,7 @@ func TestCreateLogs(t *testing.T) {
 	goMock := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
-	s3Provider.EXPECT().GetService(gomock.Any()).AnyTimes().Return(s3Service, nil)
+	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
 
 	// Test data - mock S3 file content
 	testData := []byte("version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status\n2 627286350134 eni-0377aa710071c557e 172.31.31.124 140.82.121.6 52718 443 6 13 3777 1751375679 ENDTIME ACCEPT OK\n")
@@ -133,7 +133,7 @@ func TestCreateMetrics(t *testing.T) {
 	goMock := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
-	s3Provider.EXPECT().GetService(gomock.Any()).AnyTimes().Return(s3Service, nil)
+	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
 	s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(io.NopCloser(bytes.NewReader([]byte("dummy data"))), nil)
@@ -188,7 +188,7 @@ func TestCustomHandlerRegistration(t *testing.T) {
 	goMock := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
-	s3Provider.EXPECT().GetService(gomock.Any()).AnyTimes().Return(s3Service, nil)
+	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
 
 	// A custom event payload that detectTriggerType classifies as customEvent.
 	customEventPayload := []byte(`{"custom":"payload"}`)
@@ -646,7 +646,7 @@ func TestNewLogsHandler_MultiEncodingS3_Branch(t *testing.T) {
 	ctr := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(ctr)
 	s3Provider := internal.NewMockS3Provider(ctr)
-	s3Provider.EXPECT().GetService(gomock.Any()).Return(s3Service, nil)
+	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).Return(s3Service, nil)
 
 	settings := receivertest.NewNopSettings(metadata.Type)
 	host := componenttest.NewNopHost() // no extensions needed — all raw passthrough

--- a/receiver/awslambdareceiver/testdata/config.yaml
+++ b/receiver/awslambdareceiver/testdata/config.yaml
@@ -26,3 +26,10 @@ aws_lambda/s3_multi_encoding:
 aws_lambda/custom_event:
   custom:
     encoding: custom_encoding
+
+aws_lambda/s3_with_aws_options:
+  s3:
+    encoding: aws_logs_encoding
+    access_key_id: "key"
+    secret_access_key: "accessKey"
+    session_token: "session"


### PR DESCRIPTION
#### Description

This PR adds support to use static credentials when accessing S3. Prior to this change, S3 access was done using default credentials.

With the change, config can be set as below (extracted from config test),

```yaml
aws_lambda:
  s3:
    encoding: aws_logs_encoding
    access_key_id: "key"
    secret_access_key: "accessKey"
```

If defined, static credentials are used to derive S3 service.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49163

#### Testing

Added config tests to validate the functionality

#### Documentation

Updated the public documentation on the available options

#### Authorship

- [x] I, a human, wrote this pull request description myself.