### PR TITLE
fix(transformprocessor): handle empty statement entries

### DIFF
--- a/.chloggen/49245-transformprocessor-empty-statement.yaml
+++ b/.chloggen/49245-transformprocessor-empty-statement.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: processor/transform
+note: Fix transform processor config unmarshaling to return an error for empty statement list items instead of panicking.
+issues: [49245]
+change_logs: [user]

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -99,6 +99,9 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 		statementsConfigs := make([]any, 0, len(values))
 		var basicStatements []any
 		for _, value := range values {
+			if value == nil {
+				return fmt.Errorf("invalid %s item: empty statement list items are not supported", fieldName)
+			}
 			// Array of strings means it's a basic configuration style
 			if reflect.TypeOf(value).Kind() == reflect.String {
 				basicStatements = append(basicStatements, value)

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
@@ -404,4 +405,26 @@ func Test_MixedConfigurationStyles(t *testing.T) {
 	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "mixed_configuration_styles").String())
 	require.NoError(t, err)
 	assert.ErrorContains(t, sub.Unmarshal(cfg), "configuring multiple configuration styles is not supported")
+}
+
+func Test_EmptyStatementListItem(t *testing.T) {
+	t.Parallel()
+
+	for _, fieldName := range []string{
+		"trace_statements",
+		"metric_statements",
+		"log_statements",
+		"profile_statements",
+	} {
+		t.Run(fieldName, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := NewFactory().CreateDefaultConfig()
+			conf := confmap.NewFromStringMap(map[string]any{
+				fieldName: []any{nil},
+			})
+
+			require.ErrorContains(t, conf.Unmarshal(cfg), "invalid "+fieldName+" item: empty statement list items are not supported")
+		})
+	}
 }


### PR DESCRIPTION
Fixes #49245.

Adds a nil entry check while normalizing transform statement lists so empty YAML list items return a config unmarshal error instead of panicking.