### PR TITLE
exporter/signalfx: remove per-core cpu.* default translations

### DIFF
--- a/.chloggen/signalfx-cpu-per-core.yaml
+++ b/.chloggen/signalfx-cpu-per-core.yaml
@@ -10,7 +10,6 @@ subtext: |
     hostmetrics:
       scrapers:
         cpu:
-
   processors:
     transform/cpu_idle_per_core:
       error_mode: ignore
@@ -28,7 +27,6 @@ subtext: |
         - context: datapoint
           statements:
             - set(datapoint.value_int, Int(datapoint.value_double)) where metric.name == "cpu.idle"
-
   service:
     pipelines:
       metrics:

--- a/.chloggen/signalfx-cpu-per-core.yaml
+++ b/.chloggen/signalfx-cpu-per-core.yaml
@@ -1,0 +1,39 @@
+change_type: breaking
+component: exporter/signalfx
+note: "Stop calculating per-core `cpu.*` metrics disabled by default."
+issues: [49247]
+subtext: |
+  The default transformations still create aggregate CPU metrics. However, per-core `cpu.*` metrics which are disabled by default aren't produced by the default transformations anymore.
+  To emit equivalent per-core CPU metrics, copy and aggregate `system.cpu.time` with the transform processor. For example, to emit per-core `cpu.idle` metrics:
+  ```yaml
+  receivers:
+    hostmetrics:
+      scrapers:
+        cpu:
+
+  processors:
+    transform/cpu_idle_per_core:
+      error_mode: ignore
+      metric_statements:
+        - context: metric
+          statements:
+            - copy_metric(name="cpu.idle") where metric.name == "system.cpu.time"
+        - context: datapoint
+          statements:
+            - set(datapoint.value_double, 0.0) where metric.name == "cpu.idle" and datapoint.attributes["state"] != "idle"
+        - context: metric
+          statements:
+            - aggregate_on_attributes("sum", ["cpu"]) where metric.name == "cpu.idle"
+            - scale_metric(100.0) where metric.name == "cpu.idle"
+        - context: datapoint
+          statements:
+            - set(datapoint.value_int, Int(datapoint.value_double)) where metric.name == "cpu.idle"
+
+  service:
+    pipelines:
+      metrics:
+        receivers: [hostmetrics]
+        processors: [transform/cpu_idle_per_core]
+        exporters: [signalfx]
+  ```
+change_logs: [user]

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -204,18 +204,6 @@ exporters:
           state: [interrupt, user, system]
 ```
 
-The following `include_metrics` example would instruct the exporter to send only `cpu.interrupt` metrics with a `cpu` dimension value ("per core" datapoints), and both "per core" and aggregate `cpu.idle` metrics:
-
-```
-exporters:
-  signalfx:
-    include_metrics:
-      - metric_name: "cpu.idle"
-      - metric_name: "cpu.interrupt"
-        dimensions:
-          cpu: ["*"]
-```
-
 ## Translation Rules and Metric Transformations
 
 The default translation rules defined in [`translation/constants.go`](./internal/translation/constants.go) are used by the SignalFx exporter
@@ -248,19 +236,6 @@ The default rules will create the following aggregated metrics from the [`hostme
 * vmpage_io.memory.out
 * vmpage_io.swap.in
 * vmpage_io.swap.out
-
-In addition to the aggregated metrics, the default translation rules make available the following "per core" custom hostmetrics.
-The CPU number is assigned to the dimension `cpu` 
-
-* cpu.interrupt
-* cpu.nice
-* cpu.softirq
-* cpu.steal
-* cpu.system
-* cpu.user
-* cpu.wait
-
-These metrics are intended to be reported directly to Splunk IM by the SignalFx exporter.  Any desired changes to their attributes or values should be made via their constituent host metrics.
 
 ## Example Config
 

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -501,7 +501,7 @@ func TestUnmarshalExcludeMetrics(t *testing.T) {
 		{
 			name:              "empty config",
 			cfg:               &Config{},
-			excludeMetricsLen: 12,
+			excludeMetricsLen: 11,
 		},
 		{
 			name: "existing exclude config",
@@ -512,7 +512,7 @@ func TestUnmarshalExcludeMetrics(t *testing.T) {
 					},
 				},
 			},
-			excludeMetricsLen: 13,
+			excludeMetricsLen: 12,
 		},
 		{
 			name: "existing empty exclude config",

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -257,6 +257,12 @@ func requireDimension(t *testing.T, dims []*sfxpb.Dimension, key, val string) {
 	require.True(t, found, `missing dimension: %s`, key)
 }
 
+func requireNoDimension(t *testing.T, dims []*sfxpb.Dimension, key string) {
+	for _, dim := range dims {
+		require.NotEqual(t, key, dim.Key)
+	}
+}
+
 func testMetricsData(addHistogram bool) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 
@@ -561,11 +567,25 @@ func TestDefaultCPUTranslations(t *testing.T) {
 	cpuNumProcessors := m["cpu.num_processors"]
 	require.Len(t, cpuNumProcessors, 1)
 
+	cpuIdle := m["cpu.idle"]
+	require.Len(t, cpuIdle, 1)
+
 	cpuStateMetrics := []string{"cpu.idle", "cpu.interrupt", "cpu.system", "cpu.user"}
 	for _, metric := range cpuStateMetrics {
 		dps, ok := m[metric]
 		require.Truef(t, ok, "%s metrics not found", metric)
-		require.Len(t, dps, 9)
+		require.Len(t, dps, 1)
+	}
+
+	for metric, dps := range m {
+		switch metric {
+		case "cpu.num_processors", "cpu.utilization", "cpu.idle", "cpu.interrupt", "cpu.nice",
+			"cpu.softirq", "cpu.steal", "cpu.system", "cpu.user", "cpu.wait":
+			require.Len(t, dps, 1)
+			for _, dp := range dps {
+				requireNoDimension(t, dp.Dimensions, "cpu")
+			}
+		}
 	}
 }
 

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -105,17 +105,6 @@ translation_rules:
   without_dimensions:
   - cpu
 
-- action: copy_metrics
-  mapping:
-    sf_temp.cpu.idle: sf_temp.cpu.idle_per_core
-    sf_temp.cpu.interrupt: sf_temp.cpu.interrupt_per_core
-    sf_temp.cpu.system: sf_temp.cpu.system_per_core
-    sf_temp.cpu.user: sf_temp.cpu.user_per_core
-    sf_temp.cpu.wait: sf_temp.cpu.wait_per_core
-    sf_temp.cpu.steal: sf_temp.cpu.steal_per_core
-    sf_temp.cpu.softirq: sf_temp.cpu.softirq_per_core
-    sf_temp.cpu.nice: sf_temp.cpu.nice_per_core
-
 - action: aggregate_metric
   metric_name: sf_temp.cpu.idle
   aggregation_method: sum
@@ -407,23 +396,15 @@ translation_rules:
   mapping:
     sf_temp.container_cpu_utilization: container_cpu_utilization
     sf_temp.cpu.idle: cpu.idle
-    sf_temp.cpu.idle_per_core: cpu.idle
     sf_temp.cpu.interrupt: cpu.interrupt
-    sf_temp.cpu.interrupt_per_core: cpu.interrupt
     sf_temp.cpu.nice: cpu.nice
-    sf_temp.cpu.nice_per_core: cpu.nice
     sf_temp.cpu.num_processors: cpu.num_processors
     sf_temp.cpu.softirq: cpu.softirq
-    sf_temp.cpu.softirq_per_core: cpu.softirq
     sf_temp.cpu.steal: cpu.steal
-    sf_temp.cpu.steal_per_core: cpu.steal
     sf_temp.cpu.system: cpu.system
-    sf_temp.cpu.system_per_core: cpu.system
     sf_temp.cpu.user: cpu.user
-    sf_temp.cpu.user_per_core: cpu.user
     sf_temp.cpu.utilization: cpu.utilization
     sf_temp.cpu.wait: cpu.wait
-    sf_temp.cpu.wait_per_core: cpu.wait
     sf_temp.disk.summary_utilization: disk.summary_utilization
     sf_temp.disk.utilization: disk.utilization
     sf_temp.memory.total: memory.total

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -37,10 +37,6 @@ exclude_metrics:
   dimensions:
     state: [idle, interrupt, nice, softirq, steal, system, user, wait]
 
-- metric_name: cpu.idle
-  dimensions:
-    cpu: ["*"]
-
 # Memory metrics.
 - metric_name: system.memory.usage
   dimensions:


### PR DESCRIPTION
Removes the SignalFx exporter default translations for per-core `cpu.*` datapoints. Aggregate CPU default translations remain, and the changelog shows how to recreate per-core CPU metrics with the transform processor.