### PR TITLE
[receiver/jaegerreceiver] Fix memory amplification DoS in Thrift deserialization

### DIFF
--- a/.chloggen/49218-jaegerreceiver-thrift-memory-amplification.yaml
+++ b/.chloggen/49218-jaegerreceiver-thrift-memory-amplification.yaml
@@ -1,5 +1,5 @@
 change_type: bug_fix
-component: receiver/jaegerreceiver
+component: receiver/jaeger
 note: "Fix memory amplification DoS in Thrift deserialization"
 issues: [49218]
 change_logs: [user]

--- a/.chloggen/49218-jaegerreceiver-thrift-memory-amplification.yaml
+++ b/.chloggen/49218-jaegerreceiver-thrift-memory-amplification.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: receiver/jaegerreceiver
+note: "Fix memory amplification DoS in Thrift deserialization"
+issues: [49218]
+change_logs: [user]

--- a/receiver/jaegerreceiver/internal/udpserver/size_checking_protocol.go
+++ b/receiver/jaegerreceiver/internal/udpserver/size_checking_protocol.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package udpserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type sizeCheckingProtocol struct {
+	thrift.TProtocol
+}
+
+// WrapProtocol wraps a thrift.TProtocol with container size checks.
+func WrapProtocol(proto thrift.TProtocol) thrift.TProtocol {
+	return &sizeCheckingProtocol{TProtocol: proto}
+}
+
+func (p *sizeCheckingProtocol) ReadListBegin(ctx context.Context) (elemType thrift.TType, size int, err error) {
+	elemType, size, err = p.TProtocol.ReadListBegin(ctx)
+	if err != nil {
+		return elemType, size, err
+	}
+	if err := checkContainerSize(size, p.TProtocol.Transport()); err != nil {
+		return elemType, 0, err
+	}
+	return elemType, size, nil
+}
+
+func (p *sizeCheckingProtocol) ReadSetBegin(ctx context.Context) (elemType thrift.TType, size int, err error) {
+	elemType, size, err = p.TProtocol.ReadSetBegin(ctx)
+	if err != nil {
+		return elemType, size, err
+	}
+	if err := checkContainerSize(size, p.TProtocol.Transport()); err != nil {
+		return elemType, 0, err
+	}
+	return elemType, size, nil
+}
+
+func (p *sizeCheckingProtocol) ReadMapBegin(ctx context.Context) (keyType thrift.TType, valType thrift.TType, size int, err error) {
+	keyType, valType, size, err = p.TProtocol.ReadMapBegin(ctx)
+	if err != nil {
+		return keyType, valType, size, err
+	}
+	if err := checkContainerSize(size, p.TProtocol.Transport()); err != nil {
+		return keyType, valType, 0, err
+	}
+	return keyType, valType, size, nil
+}
+
+func checkContainerSize(size int, trans thrift.TTransport) error {
+	if size < 0 {
+		return thrift.NewTProtocolExceptionWithType(thrift.NEGATIVE_SIZE, fmt.Errorf("negative container size: %d", size))
+	}
+	if size == 0 {
+		return nil
+	}
+
+	// Check remaining bytes if the transport supports it
+	if sizeProvider, ok := trans.(interface{ RemainingBytes() uint64 }); ok {
+		remaining := sizeProvider.RemainingBytes()
+		// Each element in a container must take at least 1 byte.
+		// If the size is greater than the remaining bytes in the transport, it's invalid.
+		if uint64(size) > remaining {
+			return thrift.NewTProtocolExceptionWithType(thrift.SIZE_LIMIT, fmt.Errorf("container size %d exceeds remaining bytes %d", size, remaining))
+		}
+	} else {
+		// Fallback safety limit for transports that don't provide remaining bytes
+		const maxContainerSize = 10_000_000
+		if size > maxContainerSize {
+			return thrift.NewTProtocolExceptionWithType(thrift.SIZE_LIMIT, fmt.Errorf("container size %d exceeds fallback max limit %d", size, maxContainerSize))
+		}
+	}
+	return nil
+}

--- a/receiver/jaegerreceiver/internal/udpserver/size_checking_protocol_test.go
+++ b/receiver/jaegerreceiver/internal/udpserver/size_checking_protocol_test.go
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package udpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSizeCheckingProtocol_ReadListBegin_Ok(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	protocol := thrift.NewTBinaryProtocolTransport(trans)
+	wrapped := WrapProtocol(protocol)
+
+	// Write a valid list header: type=STRUCT(12), size=5
+	ctx := context.Background()
+	err := protocol.WriteListBegin(ctx, thrift.STRUCT, 5)
+	require.NoError(t, err)
+	// Write 5 bytes of data so the remaining bytes checks pass (each struct is at least 1 byte stop field)
+	_, err = trans.Write([]byte{0, 0, 0, 0, 0})
+	require.NoError(t, err)
+
+	elemType, size, err := wrapped.ReadListBegin(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, thrift.TType(thrift.STRUCT), elemType)
+	assert.Equal(t, 5, size)
+}
+
+func TestSizeCheckingProtocol_ReadListBegin_NegativeSize(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	protocol := thrift.NewTBinaryProtocolTransport(trans)
+	wrapped := WrapProtocol(protocol)
+
+	// Write negative size.
+	// In TBinaryProtocol, list is serialized as 1 byte type + 4 bytes size.
+	// Type STRUCT (12)
+	trans.Write([]byte{12})
+	// Size -5 (0xFFFFFFFB)
+	trans.Write([]byte{0xFF, 0xFF, 0xFF, 0xFB})
+
+	ctx := context.Background()
+	_, _, err := wrapped.ReadListBegin(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negative")
+}
+
+func TestSizeCheckingProtocol_ReadListBegin_ExcessiveSize(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	protocol := thrift.NewTBinaryProtocolTransport(trans)
+	wrapped := WrapProtocol(protocol)
+
+	// Write a list with type=STRUCT(12), size=100
+	// But there are 0 remaining bytes in the buffer after reading the header.
+	trans.Write([]byte{12})
+	trans.Write([]byte{0x00, 0x00, 0x00, 0x64}) // 100
+
+	ctx := context.Background()
+	_, _, err := wrapped.ReadListBegin(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds remaining bytes")
+}
+
+func TestSizeCheckingProtocol_ReadMapBegin_ExcessiveSize(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	protocol := thrift.NewTBinaryProtocolTransport(trans)
+	wrapped := WrapProtocol(protocol)
+
+	// In TBinaryProtocol, map is keyType (1 byte) + valType (1 byte) + size (4 bytes).
+	trans.Write([]byte{12, 12})                 // key=STRUCT, val=STRUCT
+	trans.Write([]byte{0x00, 0x00, 0x00, 0x64}) // 100
+
+	ctx := context.Background()
+	_, _, _, err := wrapped.ReadMapBegin(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds remaining bytes")
+}
+
+func TestSizeCheckingProtocol_ReadSetBegin_ExcessiveSize(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	protocol := thrift.NewTBinaryProtocolTransport(trans)
+	wrapped := WrapProtocol(protocol)
+
+	// Set is like List in binary protocol: type (1 byte) + size (4 bytes).
+	trans.Write([]byte{12})
+	trans.Write([]byte{0x00, 0x00, 0x00, 0x64}) // 100
+
+	ctx := context.Background()
+	_, _, err := wrapped.ReadSetBegin(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds remaining bytes")
+}

--- a/receiver/jaegerreceiver/internal/udpserver/thrift_processor.go
+++ b/receiver/jaegerreceiver/internal/udpserver/thrift_processor.go
@@ -47,7 +47,7 @@ func NewThriftProcessor(
 	protocolPool := &sync.Pool{
 		New: func() any {
 			trans := &TBufferedReadTransport{}
-			return factory.GetProtocol(trans)
+			return WrapProtocol(factory.GetProtocol(trans))
 		},
 	}
 

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -290,7 +290,13 @@ func (*jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *httpErr
 		}
 	}
 
-	tdes := apacheThrift.NewTDeserializer()
+	trans := apacheThrift.NewTMemoryBufferLen(len(bodyBytes))
+	protocol := apacheThrift.NewTBinaryProtocolTransport(trans)
+	customProto := udpserver.WrapProtocol(protocol)
+	tdes := &apacheThrift.TDeserializer{
+		Transport: trans,
+		Protocol:  customProto,
+	}
 	batch := &jaeger.Batch{}
 	if err = tdes.Read(r.Context(), batch, bodyBytes); err != nil {
 		return nil, &httpError{

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -75,6 +75,29 @@ func TestThriftHTTPBodyDecode(t *testing.T) {
 	assert.Equal(t, batch, gotBatch)
 }
 
+func TestThriftHTTPBodyDecode_ExcessiveSize(t *testing.T) {
+	jr := jReceiver{}
+	// Malicious payload declaring 33,554,432 spans in a 20-byte payload.
+	// hex: 0c0001 0b0001 00000001 78 00 0f0002 0c 02000000
+	payload := []byte{
+		0x0c, 0x00, 0x01, // Process struct start
+		0x0b, 0x00, 0x01, // serviceName string start
+		0x00, 0x00, 0x00, 0x01, // string length 1
+		0x78,             // 'x'
+		0x00,             // Process struct end
+		0x0f, 0x00, 0x02, // Spans list start
+		0x0c,             // element type struct
+		0x02, 0x00, 0x00, 0x00, // list size 33,554,432
+	}
+	r := httptest.NewRequest(http.MethodPost, "/api/traces", bytes.NewReader(payload))
+	r.Header.Add("content-type", "application/x-thrift")
+
+	gotBatch, hErr := jr.decodeThriftHTTPBody(r)
+	require.NotNil(t, hErr, "expected error due to excessive list size")
+	assert.Nil(t, gotBatch)
+	assert.Contains(t, hErr.msg, "exceeds remaining bytes")
+}
+
 func TestReception(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	// 1. Create the Jaeger receiver aka "server"


### PR DESCRIPTION
## Description
Fixes a memory amplification vulnerability (CWE-789) where malformed Thrift payloads containing large declared container sizes caused immediate memory allocations and OOM crashes. This wraps the underlying thrift.TProtocol inside a custom validator checking sizes against remaining buffer bytes.

Fixes #49218

## Testing
- Added unit tests in `size_checking_protocol_test.go` verifying that lists, maps, and sets with negative or excessive sizes are rejected.
- Added an HTTP endpoint test in `trace_receiver_test.go` with a 20-byte payload declaring a 33M element list to verify it rejects the payload instead of OOMing.
- Verified that all unit tests pass: `go test -v ./...` in `receiver/jaegerreceiver`.
