### PR TITLE
[chore][connector/service_graph] remove linter exclusion for manual feature gate creation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,9 +124,6 @@ linters:
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46116
       - linters:
           - forbidigo
-        path: connector/servicegraphconnector/
-      - linters:
-          - forbidigo
         path: exporter/awsemfexporter/
       - linters:
           - forbidigo


### PR DESCRIPTION
#### Description
Following #49046 and #49215, feature gates for `servicegraphconnector` have been migrated to metadata.yaml. This PR removes the exclusion to the linter rule preventing manual feature gate creation (see: #47506).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
#46116 


#### Testing
`make lint` and `make test`


#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
