### PR TITLE
Unbounded XML recursion in ParseXML OTTL function causes unrecoverable stack overflow

### DIFF
--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -61,9 +61,8 @@ func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
 	}
 }
 
-// maxXMLElementDepth mirrors encoding/xml maxUnmarshalDepth to bound the
-// recursion depth of XML parsing input.
-const maxXMLElementDepth = 10_000
+// maxXMLElementDepth limits the recursion depth of XML parsing input to prevent stack overflow.
+const maxXMLElementDepth = 1000
 
 type xmlElement struct {
 	depth      int


### PR DESCRIPTION
Closes #49222 
Fixed the issue:
### issue
The ParseXML OTTL function recursively decodes XML elements via xmlElement.UnmarshalXML with no depth limit. Deeply nested XML input causes an unrecoverable Go stack overflow (runtime.throw), terminating the entire collector process. Any pipeline applying ParseXML(...) to attacker-influenced string data (attributes, log bodies, resource values from OTLP ingestion) is vulnerable.
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
