### PR TITLE
[receiver/host_metrics] Enable process scraper on Android

### DIFF
--- a/.chloggen/android_support_processscraper.yaml
+++ b/.chloggen/android_support_processscraper.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/hostmetrics
+component: receiver/host_metrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Enable the Android platform in the `process` scraper.

--- a/.chloggen/android_support_processscraper.yaml
+++ b/.chloggen/android_support_processscraper.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/hostmetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable the Android platform in the `process` scraper.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47296]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
@@ -6,12 +6,30 @@ package processscraper // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
+	"slices"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/scraper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
+)
+
+var (
+	// Hardcoded supported-OS list pending mdatagen `supported_os` annotation support.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
+	// migrate to a metadata.yaml declaration and drop the runtime.GOOS check once it lands.
+	supportedPlatforms = []string{
+		"linux",
+		"windows",
+		"darwin",
+		"freebsd",
+		"aix",
+		"android",
+	}
+
+	errUnsupportedPlatform = errors.New("the process scraper is unsupported on this platform")
 )
 
 // NewFactory for Process scraper.
@@ -32,11 +50,8 @@ func createMetricsScraper(
 	settings scraper.Settings,
 	cfg component.Config,
 ) (scraper.Metrics, error) {
-	// Hardcoded supported-OS list pending mdatagen `supported_os` annotation support.
-	// See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
-	// migrate to a metadata.yaml declaration and drop the runtime.GOOS check once it lands.
-	if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" && runtime.GOOS != "aix" {
-		return nil, errors.New("process scraper only available on Linux, Windows, macOS, FreeBSD, or AIX")
+	if !slices.Contains(supportedPlatforms, runtime.GOOS) {
+		return nil, fmt.Errorf("%w: %s", errUnsupportedPlatform, runtime.GOOS)
 	}
 
 	pCfg := cfg.(*Config)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory_test.go
@@ -5,6 +5,7 @@ package processscraper
 
 import (
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,11 +26,11 @@ func TestCreateResourceMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetrics(t.Context(), scrapertest.NewNopSettings(metadata.Type), cfg)
 
-	if runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "freebsd" || runtime.GOOS == "aix" {
+	if slices.Contains(supportedPlatforms, runtime.GOOS) {
 		assert.NoError(t, err)
 		assert.NotNil(t, scraper)
 	} else {
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, errUnsupportedPlatform)
 		assert.Nil(t, scraper)
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
User reports indicate that the process scraper can work on Android, and it does have its own `runtime.GOOS` value, so this PR adds support for the platform.

Incidentally, this does a minor refactor of the annoying way we detected unsupported platforms before. It aligns a bit more with how it will look when we use this from mdatagen in the future.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47296 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
The CI on this PR should run on the breadth of reported systems to make sure we are retaining our current list of support through the refactor.

<!--Describe the documentation added.-->
#### Documentation
The release note claims support for Android on `process` scraper. I am planning to improve `mdatagen`'s support for platform support that will hopefully be able to generate proper documentation for platform support a bit nicer.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

#### AI Usage Disclosure

No AI usage was necessary for this PR as it was pretty trivially small.

<!--Please delete paragraphs that you did not use before submitting.-->
