### PR TITLE
[chore] [exporter/signalfx] move defaults to embedded YAML

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -64,12 +64,12 @@ The following configuration options can also be configured:
   excluded from sending to Signalfx backend. The filtering is applied after the default 
   translations controlled by `disable_default_translation_rules` option.
   See in [testdata/config.yaml](./testdata/config.yaml) for examples. Apart from the values explicitly
-  provided via this option, by default, [default metrics](./internal/translation/default_metrics.go) are
+  provided via this option, by default, [default metrics](./internal/translation/default_metrics.yaml) are
   also appended to this list. Setting this option to `[]` will override all the default
   excludes.
 - `include_metrics`: List of filters to override exclusion of any metrics.
   This option can be used to included metrics that are otherwise dropped by
-  default. See [default metrics](./internal/translation/default_metrics.go) for a list of metrics
+  default. See [default metrics](./internal/translation/default_metrics.yaml) for a list of metrics
   that are dropped by default. For example, the following configuration can be
   used to send through some of that are dropped by default.
   ```yaml
@@ -87,7 +87,7 @@ The following configuration options can also be configured:
   updates.
 - `disable_default_translation_rules` (default = `false`): Disable default translation
   of the OTel metrics to a SignalFx compatible format. The default translation rules are
-  defined in [`internal/translation/constants.go`](./internal/translation/constants.go).
+  defined in [`internal/translation/default_translation_rules.yaml`](./internal/translation/default_translation_rules.yaml).
 - `timeout` (default = 10s): Amount of time to wait for a send operation to
   complete.
 - `http2_read_idle_timeout` (default = 10s): Send a ping frame for a health check if the connection has been idle for the configured value.
@@ -190,9 +190,9 @@ One of `realm` and `api_url` are required.
   - `sync_attributes` (default = `{"k8s.pod.uid": "k8s.pod.uid", "container.id": "container.id"}`) Map containing key of the attribute to read from spans to sync to dimensions specified as the value.
 
 ## Default Metric Filters
-[List of metrics excluded by default](./internal/translation/default_metrics.go)
+[List of metrics excluded by default](./internal/translation/default_metrics.yaml)
 
-Some OpenTelemetry receivers may send metrics that SignalFx considers to be categorized as custom metrics. In order to prevent unwanted overage usage due to custom metrics from these receivers, the SignalFx exporter has a [set of metrics excluded by default](./internal/translation/default_metrics.go). Some exclusion rules use regex to exclude multiple metric names. Some metrics are only excluded if specific resource labels (dimensions) are present. If the default translation rules are enabled and match an exclusion rule, the exclusion takes precedence. Users may configure the SignalFx exporter's `include_metrics` config option to override the any of the default exclusions, as `include_metrics` will always take precedence over any exclusions. An example of `include_metrics` is shown below.
+Some OpenTelemetry receivers may send metrics that SignalFx considers to be categorized as custom metrics. In order to prevent unwanted overage usage due to custom metrics from these receivers, the SignalFx exporter has a [set of metrics excluded by default](./internal/translation/default_metrics.yaml). Some exclusion rules use regex to exclude multiple metric names. Some metrics are only excluded if specific resource labels (dimensions) are present. If the default translation rules are enabled and match an exclusion rule, the exclusion takes precedence. Users may configure the SignalFx exporter's `include_metrics` config option to override the any of the default exclusions, as `include_metrics` will always take precedence over any exclusions. An example of `include_metrics` is shown below.
 
 ```
 exporters:
@@ -206,7 +206,7 @@ exporters:
 
 ## Translation Rules and Metric Transformations
 
-The default translation rules defined in [`translation/constants.go`](./internal/translation/constants.go) are used by the SignalFx exporter
+The default translation rules defined in [`translation/default_translation_rules.yaml`](./internal/translation/default_translation_rules.yaml) are used by the SignalFx exporter
 to help ensure compatibility with custom charts and dashboards when using the OpenTelemetry Collector.
 The default rules will create the following aggregated metrics from the [`hostmetrics` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md):
 

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -126,7 +126,7 @@ type Config struct {
 
 	// IncludeMetrics defines dpfilter.MetricFilters to override exclusion any of metric.
 	// This option can be used to included metrics that are otherwise dropped by default.
-	// See ./translation/default_metrics.go for a list of metrics that are dropped by default.
+	// See ./internal/translation/default_metrics.yaml for a list of metrics that are dropped by default.
 	IncludeMetrics []dpfilters.MetricFilter `mapstructure:"include_metrics"`
 
 	// ExcludeProperties defines dpfilter.PropertyFilters to prevent inclusion of

--- a/exporter/signalfxexporter/config.schema.yaml
+++ b/exporter/signalfxexporter/config.schema.yaml
@@ -67,7 +67,7 @@ properties:
     items:
       $ref: ./internal/translation/dpfilters.property_filter
   include_metrics:
-    description: IncludeMetrics defines dpfilter.MetricFilters to override exclusion any of metric. This option can be used to included metrics that are otherwise dropped by default. See ./translation/default_metrics.go for a list of metrics that are dropped by default.
+    description: IncludeMetrics defines dpfilter.MetricFilters to override exclusion any of metric. This option can be used to included metrics that are otherwise dropped by default. See ./internal/translation/default_metrics.yaml for a list of metrics that are dropped by default.
     type: array
     items:
       $ref: ./internal/translation/dpfilters.metric_filter

--- a/exporter/signalfxexporter/internal/translation/default_metrics.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.yaml
@@ -1,14 +1,3 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package translation // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/translation"
-
-// DefaultExcludeMetricsYaml holds list of hard coded metrics that will added to the
-// exclude list from the config. It includes non-default metrics collected by
-// receivers. This list is determined by categorization of metrics in the SignalFx
-// Agent. Metrics in the OpenTelemetry convention, that have equivalents in the
-// SignalFx Agent that are categorized as non-default are also included in this list.
-const DefaultExcludeMetricsYaml = `
 exclude_metrics:
 
 # Metrics in SignalFx Agent Format.
@@ -117,4 +106,3 @@ exclude_metrics:
 
   # matches k8s.volume.inodes, k8s.volume.inodes and k8s.volume.inodes.used
   - /^k8s\.volume\.inodes(\.free|\.used)*$/
-`

--- a/exporter/signalfxexporter/internal/translation/default_metrics.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.yaml
@@ -1,3 +1,8 @@
+# DefaultExcludeMetricsYaml holds the list of hard-coded metrics that will be added to the
+# exclude list from the config. It includes non-default metrics collected by
+# receivers. This list is determined by categorization of metrics in the SignalFx
+# Agent. Metrics in the OpenTelemetry convention, that have equivalents in the
+# SignalFx Agent that are categorized as non-default are also included in this list.
 exclude_metrics:
 
 # Metrics in SignalFx Agent Format.

--- a/exporter/signalfxexporter/internal/translation/default_metrics.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.yaml
@@ -1,8 +1,6 @@
-# DefaultExcludeMetricsYaml holds the list of hard-coded metrics that will be added to the
-# exclude list from the config. It includes non-default metrics collected by
-# receivers. This list is determined by categorization of metrics in the SignalFx
-# Agent. Metrics in the OpenTelemetry convention, that have equivalents in the
-# SignalFx Agent that are categorized as non-default are also included in this list.
+# exclude_metrics holds the list of hard-coded metrics that will be added to the
+# exclude list by default. It includes non-default metrics collected by receivers.
+# This list is determined by categorization of metrics in the Splunk Obserability.
 exclude_metrics:
 
 # Metrics in SignalFx Agent Format.

--- a/exporter/signalfxexporter/internal/translation/default_translation_rules.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_translation_rules.yaml
@@ -1,3 +1,5 @@
+# DefaultTranslationRulesYaml defines default translation rules that will be applied to metrics if
+# config.TranslationRules is not specified explicitly.
 translation_rules:
 - action: copy_metrics
   mapping:

--- a/exporter/signalfxexporter/internal/translation/default_translation_rules.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_translation_rules.yaml
@@ -1,12 +1,3 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package translation // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/translation"
-
-// DefaultTranslationRulesYaml defines default translation rules that will be applied to metrics if
-// config.TranslationRules not specified explicitly.
-// Keep it in YAML format to be able to easily copy and paste it in config if modifications needed.
-const DefaultTranslationRulesYaml = `
 translation_rules:
 - action: copy_metrics
   mapping:
@@ -434,4 +425,3 @@ translation_rules:
     sf_temp.system.paging.operations: true
     sf_temp.system.paging.operations.page_in: true
     sf_temp.system.paging.operations.page_out: true
-`

--- a/exporter/signalfxexporter/internal/translation/default_translation_rules.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_translation_rules.yaml
@@ -1,5 +1,5 @@
-# DefaultTranslationRulesYaml defines default translation rules that will be applied to metrics if
-# config.TranslationRules is not specified explicitly.
+# translation_rules defines default translation rules that will be applied to metrics if
+# disable_default_translation_rules is not explicitly set to true.
 translation_rules:
 - action: copy_metrics
   mapping:

--- a/exporter/signalfxexporter/internal/translation/defaults.go
+++ b/exporter/signalfxexporter/internal/translation/defaults.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package translation // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/translation"
+
+import _ "embed"
+
+// DefaultExcludeMetricsYaml holds list of hard coded metrics that will added to the
+// exclude list from the config. It includes non-default metrics collected by
+// receivers. This list is determined by categorization of metrics in the SignalFx
+// Agent. Metrics in the OpenTelemetry convention, that have equivalents in the
+// SignalFx Agent that are categorized as non-default are also included in this list.
+//
+//go:embed default_metrics.yaml
+var DefaultExcludeMetricsYaml string
+
+// DefaultTranslationRulesYaml defines default translation rules that will be applied to metrics if
+// config.TranslationRules not specified explicitly.
+//
+//go:embed default_translation_rules.yaml
+var DefaultTranslationRulesYaml string

--- a/exporter/signalfxexporter/internal/translation/defaults.go
+++ b/exporter/signalfxexporter/internal/translation/defaults.go
@@ -5,17 +5,8 @@ package translation // import "github.com/open-telemetry/opentelemetry-collector
 
 import _ "embed"
 
-// DefaultExcludeMetricsYaml holds list of hard coded metrics that will added to the
-// exclude list from the config. It includes non-default metrics collected by
-// receivers. This list is determined by categorization of metrics in the SignalFx
-// Agent. Metrics in the OpenTelemetry convention, that have equivalents in the
-// SignalFx Agent that are categorized as non-default are also included in this list.
-//
 //go:embed default_metrics.yaml
 var DefaultExcludeMetricsYaml string
 
-// DefaultTranslationRulesYaml defines default translation rules that will be applied to metrics if
-// config.TranslationRules not specified explicitly.
-//
 //go:embed default_translation_rules.yaml
 var DefaultTranslationRulesYaml string


### PR DESCRIPTION
Moves the Signalfx exporter default metric exclusions and translation rules from Go raw-string constants to embedded YAML files, preserving the exported string values used by existing config loading.