### PR TITLE
Unbounded Entry Count in FluentForward Receiver Enables OOM Kill via Tiny Malicious Frames  

### DIFF
--- a/.chloggen/49295.yaml
+++ b/.chloggen/49295.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/fluent_forward
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a denial-of-service (memory exhaustion) vulnerability in the `fluentforward` receiver by validating msgpack array and map length fields before allocation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49295]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/49295.yaml
+++ b/.chloggen/49295.yaml
@@ -10,7 +10,7 @@ component: receiver/fluent_forward
 note: Fix a denial-of-service (memory exhaustion) vulnerability in the `fluentforward` receiver by validating msgpack array and map length fields before allocation.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [49295]
+issues: [49223]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -18,7 +18,11 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-const tagAttributeKey = "fluent.tag"
+const (
+	tagAttributeKey = "fluent.tag"
+	maxEntryCount   = 1_000_000
+	maxOptionCount  = 1_000
+)
 
 // Most of this logic is derived directly from
 // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1,
@@ -234,6 +238,9 @@ func parseOptions(dc *msgp.Reader) (optionsMap, error) {
 	if err != nil {
 		return nil, msgp.WrapError(err, "Option")
 	}
+	if optionLen > maxOptionCount {
+		return nil, fmt.Errorf("option count %d exceeds maximum %d", optionLen, maxOptionCount)
+	}
 	out := make(optionsMap, optionLen)
 
 	for optionLen > 0 {
@@ -279,6 +286,9 @@ func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 	entryLen, err := dc.ReadArrayHeader()
 	if err != nil {
 		return msgp.WrapError(err, "Record")
+	}
+	if entryLen > maxEntryCount {
+		return fmt.Errorf("entry count %d exceeds maximum %d", entryLen, maxEntryCount)
 	}
 
 	fe.EnsureCapacity(int(entryLen))

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -280,4 +280,3 @@ func TestDecodeMsgLimits(t *testing.T) {
 		require.ErrorContains(t, err, "exceeds maximum")
 	})
 }
-

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -246,3 +246,38 @@ func TestBodyConversion(t *testing.T) {
 		},
 	).ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0), le))
 }
+
+func TestDecodeMsgLimits(t *testing.T) {
+	t.Run("Entry count exceeds limit", func(t *testing.T) {
+		var b []byte
+		// Forward mode is an array of size 3 (tag, entries array, options) or 2 (tag, entries array)
+		b = msgp.AppendArrayHeader(b, 2)
+		b = msgp.AppendString(b, "my-tag")
+		// Specify too large an entries array
+		b = msgp.AppendArrayHeader(b, maxEntryCount+1)
+
+		reader := msgp.NewReader(bytes.NewReader(b))
+		var event forwardEventLogRecords
+		err := event.DecodeMsg(reader)
+		require.ErrorContains(t, err, "exceeds maximum")
+	})
+
+	t.Run("Option count exceeds limit", func(t *testing.T) {
+		var b []byte
+		// Message mode: arrLen 4, tag, time, record map, options map
+		b = msgp.AppendArrayHeader(b, 4)
+		b = msgp.AppendString(b, "my-tag")
+		b = msgp.AppendInt(b, 5000)
+		b = msgp.AppendMapHeader(b, 1)
+		b = msgp.AppendString(b, "a")
+		b = msgp.AppendFloat64(b, 5.0)
+		// Options map with excessive size
+		b = msgp.AppendMapHeader(b, maxOptionCount+1)
+
+		reader := msgp.NewReader(bytes.NewReader(b))
+		var event messageEventLogRecord
+		err := event.DecodeMsg(reader)
+		require.ErrorContains(t, err, "exceeds maximum")
+	})
+}
+


### PR DESCRIPTION
#### Description
This PR addresses a denial-of-service (memory exhaustion) vulnerability in the `fluentforward` receiver. 

The receiver reads array and map length fields from untrusted msgpack wire data and passes them directly to pre-allocation functions (e.g., `EnsureCapacity` or `make()`). A malicious frame could request extreme capacities (such as 4,294,967,295 entries), causing the collector to attempt huge memory reservations and trigger an Out-of-Memory (OOM) shutdown.

We introduce two validation limits:
- `maxEntryCount` = `1,000,000` (limits array entries before calling `EnsureCapacity`)
- `maxOptionCount` = `1,000` (limits map header options before pre-allocating the options map)


#### Testing
- Added `TestDecodeMsgLimits` inside `conversion_test.go` to test validation limits for both `forwardEventLogRecords.DecodeMsg` and `parseOptions`.
- Verified all package tests pass via `go test ./...` in the `receiver/fluentforwardreceiver` directory.

#### Documentation
None

#### Authorship

- [x] I, a human, wrote this pull request description myself.


Closes #49223 