### PR TITLE
[chore][exporter/clickhouse] remove linter exclusion for manual feature gate creation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,9 +130,6 @@ linters:
         path: exporter/awsxrayexporter/
       - linters:
           - forbidigo
-        path: exporter/clickhouseexporter/
-      - linters:
-          - forbidigo
         path: internal/filter/
       - linters:
           - forbidigo


### PR DESCRIPTION
#### Description
In #47888, the `clickhouse.json` feature gate was removed from `clickhouseexporter`. It seems this was the only feature gate for this component, so it no longer needs a linter exclusion for manual feature gates  (see #47506 for additional context.) This PR removes this exclusion.

#### Link to tracking issue
#46116 

#### Testing
`make lint` and `make test`

#### Authorship

- [x] I, a human, wrote this pull request description myself.
