### PR TITLE
[chore][receiver/kafka,exporter/kafka] document SASL/OAUTHBEARER auth

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -72,10 +72,11 @@ The following settings can be optionally configured:
   - `sasl`
     - `username`: The username to use.
     - `password`: The password to use
-    - `mechanism`: The SASL mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM_OAUTHBEARER, or PLAIN)
+    - `mechanism`: The SASL mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM_OAUTHBEARER, OAUTHBEARER, or PLAIN)
     - `version` (default = 0): The SASL protocol version to use (0 or 1)
     - `aws_msk`
       - `region`: AWS Region in case of AWS_MSK_IAM_OAUTHBEARER mechanism
+    - `oauthbearer_token_source`: The component ID of an authenticator extension that provides OAuth2 tokens (e.g. `oauth2client` or `azure_auth`). Required when `mechanism` is `OAUTHBEARER`; the extension must be listed under `service.extensions`.
   - `tls` (Deprecated in v0.124.0: configure tls at the top level): this is an alias for tls at the top level.
   - `kerberos`
     - `service_name`: Kerberos service name
@@ -161,6 +162,42 @@ exporters:
       my-custom-header: "my-custom-value"
       another-header: "another-value"
 ```
+
+### SASL/OAUTHBEARER (OAuth2 token source)
+
+The `OAUTHBEARER` mechanism delegates token acquisition and refresh to an authenticator
+extension referenced by `oauthbearer_token_source`. Any extension that implements the
+`Token(context.Context) (*oauth2.Token, error)` interface works, such as
+[`oauth2clientauth`](../../extension/oauth2clientauthextension/README.md):
+
+```yaml
+extensions:
+  oauth2client:
+    client_id: someclientid
+    client_secret: someclientsecret
+    token_url: https://example.com/oauth2/default/v1/token
+
+exporters:
+  kafka:
+    brokers: ["localhost:9092"]
+    tls:
+      insecure: false
+    auth:
+      sasl:
+        mechanism: OAUTHBEARER
+        oauthbearer_token_source: oauth2client
+
+service:
+  extensions: [oauth2client]
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [kafka]
+```
+
+The [`azureauth`](../../extension/azureauthextension/README.md) extension can also be used
+as a token source, which supports managed identity, workload identity, and service principal
+for authenticating against Azure Event Hubs.
 
 ## Destination Topic
 

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -166,8 +166,7 @@ exporters:
 ### SASL/OAUTHBEARER (OAuth2 token source)
 
 The `OAUTHBEARER` mechanism delegates token acquisition and refresh to an authenticator
-extension referenced by `oauthbearer_token_source`. Any extension that implements the
-`Token(context.Context) (*oauth2.Token, error)` interface works, such as
+extension referenced by `oauthbearer_token_source`, such as
 [`oauth2clientauth`](../../extension/oauth2clientauthextension/README.md):
 
 ```yaml

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -103,9 +103,10 @@ The following settings can be optionally configured:
   - `sasl`
     - `username`: The username to use.
     - `password`: The password to use.
-    - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM_OAUTHBEARER, or PLAIN)
+    - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM_OAUTHBEARER, OAUTHBEARER, or PLAIN)
     - `aws_msk`
       - `region`: AWS Region in case of AWS_MSK_IAM_OAUTHBEARER mechanism
+    - `oauthbearer_token_source`: The component ID of an authenticator extension that provides OAuth2 tokens (e.g. `oauth2client` or `azure_auth`). Required when `mechanism` is `OAUTHBEARER`; the extension must be listed under `service.extensions`.
   - `tls` (Deprecated in v0.124.0: configure tls at the top level): this is an alias for tls at the top level.
   - `kerberos`
     - `service_name`: Kerberos service name
@@ -214,6 +215,41 @@ receivers:
         password: "secret"
         mechanism: "SCRAM-SHA-512"
 ```
+
+#### SASL/OAUTHBEARER (OAuth2 token source)
+
+The `OAUTHBEARER` mechanism delegates token acquisition and refresh to an authenticator
+extension referenced by `oauthbearer_token_source`. Any extension that implements the
+`Token(context.Context) (*oauth2.Token, error)` interface works, such as
+[`oauth2clientauth`](../../extension/oauth2clientauthextension/README.md):
+
+```yaml
+extensions:
+  oauth2client:
+    client_id: someclientid
+    client_secret: someclientsecret
+    token_url: https://example.com/oauth2/default/v1/token
+
+receivers:
+  kafka:
+    tls:
+      insecure: false
+    auth:
+      sasl:
+        mechanism: OAUTHBEARER
+        oauthbearer_token_source: oauth2client
+
+service:
+  extensions: [oauth2client]
+  pipelines:
+    logs:
+      receivers: [kafka]
+      exporters: [debug]
+```
+
+The [`azureauth`](../../extension/azureauthextension/README.md) extension can also be used
+as a token source, which supports managed identity, workload identity, and service principal
+for authenticating against Azure Event Hubs.
 
 #### Header extraction
 

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -219,8 +219,7 @@ receivers:
 #### SASL/OAUTHBEARER (OAuth2 token source)
 
 The `OAUTHBEARER` mechanism delegates token acquisition and refresh to an authenticator
-extension referenced by `oauthbearer_token_source`. Any extension that implements the
-`Token(context.Context) (*oauth2.Token, error)` interface works, such as
+extension referenced by `oauthbearer_token_source`, such as
 [`oauth2clientauth`](../../extension/oauth2clientauthextension/README.md):
 
 ```yaml


### PR DESCRIPTION
#### Description

Update READMEs to mention SASL/OAUTHBEARER support, along with examples using the oauth2client extension, and mentions of/links to the azure_auth extension.

#### Link to tracking issue

Closes #45052

#### Testing

N/A, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45052#issuecomment-4236483611 for testing of the azure_auth extension

#### Documentation

Yes

#### Authorship

- [x] I, a human, wrote this pull request description myself.