### PR TITLE
[exporter/elasticsearch]Support routing from data_stream attrs as scope attributes

### DIFF
--- a/.chloggen/scope-attrs-routing.yaml
+++ b/.chloggen/scope-attrs-routing.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support routing from data_stream attributes defined as scope attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/scope-attrs-routing.yaml
+++ b/.chloggen/scope-attrs-routing.yaml
@@ -10,7 +10,7 @@ component: exporter/elasticsearch
 note: Support routing from data_stream attributes defined as scope attributes
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [49306]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -610,7 +610,7 @@ func ecsSpanEventDataset(ec encodingContext, event ptrace.SpanEvent) string {
 
 func ecsSpanEventNamespace(ec encodingContext, event ptrace.SpanEvent) string {
 	ns, _ := getFromAttributes(elasticsearch.DataStreamNamespace, defaultDataStreamNamespace,
-		event.Attributes(), ec.resource.Attributes())
+		event.Attributes(), ec.scope.Attributes(), ec.resource.Attributes())
 	return sanitizeDataStreamField(ns, disallowedNamespaceRunes, "")
 }
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1603,6 +1603,7 @@ func TestECSSpanEventEncoder(t *testing.T) {
 	tests := []struct {
 		name          string
 		resourceAttrs func(pcommon.Map)
+		scopeAttrs    func(pcommon.Map) // nil = no scope attrs
 		spanSpanID    [8]byte
 		spanAttrs     func(pcommon.Map) // nil = no extra span attrs
 		eventName     string
@@ -1768,6 +1769,53 @@ func TestECSSpanEventEncoder(t *testing.T) {
 				assert.False(t, gjson.Get(body, "error").Exists())
 			},
 		},
+		{
+			name: "exception_namespace_from_scope_attrs",
+			resourceAttrs: func(m pcommon.Map) {
+				m.PutStr("service.name", "my-service")
+			},
+			scopeAttrs: func(m pcommon.Map) {
+				m.PutStr("data_stream.namespace", "production")
+			},
+			spanSpanID: [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			spanAttrs: func(m pcommon.Map) {
+				m.PutStr("transaction.id", txnID)
+			},
+			eventName: "exception",
+			eventAttrs: func(m pcommon.Map) {
+				m.PutStr("exception.type", "java.lang.NullPointerException")
+				m.PutStr("exception.message", "null pointer")
+			},
+			wantDataset:   "apm.error",
+			wantNamespace: "production",
+			checkBody: func(t *testing.T, body string) {
+				assert.Equal(t, "production", gjson.Get(body, "data_stream.namespace").String())
+				assert.Equal(t, "java.lang.NullPointerException", gjson.Get(body, "error.exception.type").String())
+			},
+		},
+		{
+			name: "non_exception_namespace_from_scope_attrs",
+			resourceAttrs: func(m pcommon.Map) {
+				m.PutStr("service.name", "my-service")
+			},
+			scopeAttrs: func(m pcommon.Map) {
+				m.PutStr("data_stream.namespace", "production")
+			},
+			spanSpanID: [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			spanAttrs: func(m pcommon.Map) {
+				m.PutStr("transaction.id", txnID)
+			},
+			eventName: "http.server.request",
+			eventAttrs: func(m pcommon.Map) {
+				m.PutInt("timestamp.us", 1000000)
+			},
+			wantDataset:   "apm.app.my_service",
+			wantNamespace: "production",
+			checkBody: func(t *testing.T, body string) {
+				assert.Equal(t, "production", gjson.Get(body, "data_stream.namespace").String())
+				assert.Equal(t, "http.server.request", gjson.Get(body, "message").String())
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1778,6 +1826,9 @@ func TestECSSpanEventEncoder(t *testing.T) {
 			tc.resourceAttrs(resource.Attributes())
 
 			scope := pcommon.NewInstrumentationScope()
+			if tc.scopeAttrs != nil {
+				tc.scopeAttrs(scope.Attributes())
+			}
 
 			span := ptrace.NewSpan()
 			span.SetTraceID(commonTraceID)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Datastream attribute defined as scope attributes were ignored for span events in ECS mode, this PR adds support for this. The priority order is event attributes > scope attributes > resource attributes > `default`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added test cases

<!--Describe the documentation added.-->
#### Documentation

Driven by specs around handling span events.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
