### PR TITLE
[exporter/datadog] Compress metric sketches payload with gzip

### DIFF
--- a/.chloggen/datadogexporter-compress-sketches.yaml
+++ b/.chloggen/datadogexporter-compress-sketches.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: exporter/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Compress the metric sketches payload with gzip, matching the metric series payload. Previously sketches were sent uncompressed, increasing egress for distribution/histogram metrics.
+note: Compress the metric sketches payload with gzip in the legacy metric API client, matching the metric series payload. Previously sketches were sent uncompressed, increasing egress for distribution/histogram metrics.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # TODO: replace 00000 with the tracking issue or PR number before opening the PR.

--- a/.chloggen/datadogexporter-compress-sketches.yaml
+++ b/.chloggen/datadogexporter-compress-sketches.yaml
@@ -11,7 +11,7 @@ note: Compress the metric sketches payload with gzip in the legacy metric API cl
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # TODO: replace 00000 with the tracking issue or PR number before opening the PR.
-issues: [00000]
+issues: [49313]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/datadogexporter-compress-sketches.yaml
+++ b/.chloggen/datadogexporter-compress-sketches.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Compress the metric sketches payload with gzip, matching the metric series payload. Previously sketches were sent uncompressed, increasing egress for distribution/histogram metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# TODO: replace 00000 with the tracking issue or PR number before opening the PR.
+issues: [00000]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/datadogexporter/compression_test.go
+++ b/exporter/datadogexporter/compression_test.go
@@ -1,0 +1,222 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !aix
+
+package datadogexporter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
+	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
+	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
+)
+
+// The Datadog exporter MUST send every signal gzip-compressed. This is a single
+// source of truth that guards against one signal silently diverging from the
+// others (which is exactly how metric sketches once shipped uncompressed).
+//
+// Compression contract enforced here:
+//
+//	Signal              Path                          Compression  Set by
+//	------------------  ----------------------------  -----------  -----------------------------------------------
+//	Metrics — series    native datadog-api client     gzip         clientutil.GZipSubmitMetricsOptionalParameters
+//	Metrics — sketches  manual POST in pushSketches    gzip         clientutil.ProtobufHeaders + gzip writer
+//	Traces              embedded trace agent          gzip         gzip.NewComponent() in newTraceAgent
+//	Logs                embedded logs pipeline        gzip         compression_kind=gzip in agentcomponents
+//
+// APM stats use the same trace-agent gzip component as traces but only flow when
+// the traces and metrics exporters are wired together through the internal stats
+// channel (only the full collector does this), so they are guarded in
+// integrationtest/integration_test.go rather than here.
+
+// assertGzip fails unless the request advertised gzip and its body really is a
+// non-empty gzip stream.
+func assertGzip(t *testing.T, signal string, hdr http.Header, body []byte) {
+	t.Helper()
+	assert.Equalf(t, "gzip", hdr.Get("Content-Encoding"), "%s: Content-Encoding must be gzip", signal)
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	require.NoErrorf(t, err, "%s: body is not a valid gzip stream", signal)
+	decoded, err := io.ReadAll(zr)
+	require.NoErrorf(t, err, "%s: failed to gunzip body", signal)
+	assert.NotEmptyf(t, decoded, "%s: decompressed body should not be empty", signal)
+}
+
+type capturedRequest struct {
+	header http.Header
+	body   []byte
+}
+
+// headerBodyRecorder records the headers and raw body of requests to a path.
+// Unlike testutil.HTTPRequestRecorderWithChan (body only) it also captures
+// headers, which the compression contract needs, and it synchronizes through a
+// channel so it is safe for the asynchronous trace/log send paths.
+type headerBodyRecorder struct {
+	pattern string
+	reqs    chan capturedRequest
+}
+
+func (rec *headerBodyRecorder) HandlerFunc() (string, http.HandlerFunc) {
+	return rec.pattern, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		select {
+		case rec.reqs <- capturedRequest{header: r.Header.Clone(), body: body}:
+		default:
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// TestSignalCompressionMetrics asserts that both metric payloads — series and
+// sketches — are gzip-compressed by the native metrics client.
+func TestSignalCompressionMetrics(t *testing.T) {
+	seriesRec := &testutil.HTTPRequestRecorder{Pattern: testutil.MetricV2Endpoint}
+	sketchRec := &testutil.HTTPRequestRecorder{Pattern: testutil.SketchesMetricEndpoint}
+	server := testutil.DatadogServerMock(seriesRec.HandlerFunc, sketchRec.HandlerFunc)
+	defer server.Close()
+
+	var once sync.Once
+	reporter, err := inframetadata.NewReporter(zap.NewNop(), newTestPusher(t), time.Second)
+	require.NoError(t, err)
+	attrsTranslator, err := attributes.NewTranslator(componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+
+	exp, err := newMetricsExporter(
+		t.Context(),
+		exportertest.NewNopSettings(metadata.Type),
+		// Distributions mode turns the histogram in createTestMetrics into a
+		// sketch, so this single push exercises both the series and the
+		// sketches paths.
+		newTestConfig(t, server.URL, nil, datadogconfig.HistogramModeDistributions),
+		traceconfig.New(),
+		&once,
+		attrsTranslator,
+		&testutil.MockSourceProvider{Src: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}},
+		reporter,
+		nil,
+		attributes.NewGatewayUsage(),
+	)
+	require.NoError(t, err)
+	exp.getPushTime = func() uint64 { return 0 }
+
+	require.NoError(t, exp.PushMetricsData(t.Context(), createTestMetrics(nil)))
+
+	require.NotNil(t, seriesRec.ByteBody, "expected a series payload to be sent")
+	assertGzip(t, "metrics series", seriesRec.Header, seriesRec.ByteBody)
+
+	require.NotNil(t, sketchRec.ByteBody, "expected a sketches payload to be sent")
+	assertGzip(t, "metrics sketches", sketchRec.Header, sketchRec.ByteBody)
+}
+
+// TestSignalCompressionTraces asserts that the trace payload is gzip-compressed
+// by the embedded trace agent.
+func TestSignalCompressionTraces(t *testing.T) {
+	tracesRec := &headerBodyRecorder{pattern: testutil.TraceEndpoint, reqs: make(chan capturedRequest, 4)}
+	server := testutil.DatadogServerMock(tracesRec.HandlerFunc)
+	defer server.Close()
+
+	cfg := &datadogconfig.Config{
+		API:        datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		TagsConfig: datadogconfig.TagsConfig{Hostname: "test-host"},
+		Metrics:    datadogconfig.MetricsConfig{TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL}},
+		Traces:     datadogconfig.TracesExporterConfig{TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL}},
+	}
+	cfg.Traces.SetFlushInterval(0.1)
+
+	f := NewFactory()
+	exp, err := f.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exp.ConsumeTraces(t.Context(), simpleTraces(nil, nil, ptrace.SpanKindInternal)))
+
+	select {
+	case req := <-tracesRec.reqs:
+		assertGzip(t, "traces", req.header, req.body)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a trace request")
+	}
+}
+
+// TestSignalCompressionLogs asserts that the logs payload is gzip-compressed by
+// the embedded logs pipeline.
+func TestSignalCompressionLogs(t *testing.T) {
+	// Capture every request to the logs intake. The logs agent may send a
+	// startup connectivity probe (empty/uncompressed) before the real batch, so
+	// we record all requests and pick out the actual log payload below rather
+	// than guessing which request is which.
+	logsReqs := make(chan capturedRequest, 8)
+	server := testutil.DatadogLogServerMock(func() (string, http.HandlerFunc) {
+		return "/api/v2/logs", func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			select {
+			case logsReqs <- capturedRequest{header: r.Header.Clone(), body: body}:
+			default:
+			}
+			w.WriteHeader(http.StatusAccepted)
+		}
+	})
+	defer server.Close()
+
+	cfg := &datadogconfig.Config{
+		API: datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		Logs: datadogconfig.LogsConfig{
+			TCPAddrConfig:    confignet.TCPAddrConfig{Endpoint: server.URL},
+			UseCompression:   true,
+			CompressionLevel: 6,
+			BatchWait:        1,
+		},
+	}
+
+	f := NewFactory()
+	exp, err := f.CreateLogs(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	// The logs pipeline only sends once the exporter is started.
+	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() { assert.NoError(t, exp.Shutdown(t.Context())) }()
+
+	require.NoError(t, exp.ConsumeLogs(t.Context(), testutil.GenerateLogsOneLogRecord()))
+
+	// Drain requests until we see the real log batch: a non-empty, gzip-decodable
+	// body. Empty or non-gzip startup probes are skipped.
+	deadline := time.After(60 * time.Second)
+	sawRequest := false
+	for {
+		select {
+		case req := <-logsReqs:
+			sawRequest = true
+			zr, zerr := gzip.NewReader(bytes.NewReader(req.body))
+			if zerr != nil {
+				continue
+			}
+			decoded, rerr := io.ReadAll(zr)
+			if rerr != nil || len(decoded) == 0 {
+				continue
+			}
+			assert.Equal(t, "gzip", req.header.Get("Content-Encoding"), "logs payload must advertise gzip")
+			return
+		case <-deadline:
+			if sawRequest {
+				t.Fatal("received logs request(s) but none were a non-empty gzip payload — logs may not be compressed")
+			}
+			t.Fatal("timed out waiting for a logs request")
+		}
+	}
+}

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -266,7 +266,17 @@ func sendTraces(t *testing.T, endpoint string) {
 	time.Sleep(1 * time.Second)
 }
 
+// getGzipReader returns a reader over the gzip-decompressed reqBytes. It doubles
+// as the compression guard for the trace, APM stats, and native-client series
+// payloads: the Datadog exporter MUST gzip every signal it sends (see the
+// compression contract in the exporter's compression_test.go), so a payload that
+// arrives uncompressed fails here. gzip streams begin with the magic bytes
+// 0x1f 0x8b; asserting them explicitly makes a regression read as "payload not
+// gzip-compressed" rather than an opaque decode error.
 func getGzipReader(t *testing.T, reqBytes []byte) io.Reader {
+	t.Helper()
+	require.GreaterOrEqual(t, len(reqBytes), 2, "payload too short to be gzip-compressed")
+	assert.Equal(t, []byte{0x1f, 0x8b}, reqBytes[:2], "payload must be gzip-compressed")
 	buf := bytes.NewBuffer(reqBytes)
 	reader, err := gzip.NewReader(buf)
 	require.NoError(t, err)

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -7,6 +7,7 @@ package datadogexporter // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -127,10 +128,24 @@ func (exp *metricsExporter) pushSketches(ctx context.Context, sl sketches.Sketch
 		return fmt.Errorf("failed to marshal sketches: %w", err)
 	}
 
+	// Compress the payload with gzip to stay consistent with the metric series
+	// path (SubmitMetrics + GZipSubmitMetricsOptionalParameters). The sketches
+	// intake accepts gzip-encoded payloads just like the series intake, so this
+	// reduces egress without any behavior change. ProtobufHeaders advertises the
+	// gzip Content-Encoding.
+	var buf bytes.Buffer
+	g := gzip.NewWriter(&buf)
+	if _, err = g.Write(payload); err != nil {
+		return fmt.Errorf("failed to compress sketches payload: %w", err)
+	}
+	if err = g.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer for sketches payload: %w", err)
+	}
+
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodPost,
 		exp.cfg.Metrics.Endpoint+sketches.SketchSeriesEndpoint,
-		bytes.NewBuffer(payload),
+		&buf,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build sketches HTTP request: %w", err)

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -530,10 +531,15 @@ func Test_metricsExporter_PushMetricsData(t *testing.T) {
 			} else {
 				assert.Equal(t, "gzip", sketchRecorder.Header.Get("Accept-Encoding"))
 				assert.Equal(t, "application/x-protobuf", sketchRecorder.Header.Get("Content-Type"))
+				assert.Equal(t, "gzip", sketchRecorder.Header.Get("Content-Encoding"))
 				assert.Equal(t, "otelcol/latest", sketchRecorder.Header.Get("User-Agent"))
 				expected, err := tt.expectedSketchPayload.Marshal()
 				assert.NoError(t, err)
-				assert.Equal(t, expected, sketchRecorder.ByteBody)
+				reader, err := gzip.NewReader(bytes.NewReader(sketchRecorder.ByteBody))
+				require.NoError(t, err)
+				decompressed, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				assert.Equal(t, expected, decompressed)
 			}
 		})
 	}
@@ -600,8 +606,14 @@ func Test_metricsExporter_HistogramZeroLowerBoundDoesNotLeakToZeroBin(t *testing
 	require.NoError(t, exp.PushMetricsData(t.Context(), md))
 	require.NotNil(t, sketchRecorder.ByteBody, "expected a sketch payload to be sent")
 
+	// The sketches payload is gzip-compressed (consistent with the series path).
+	gzReader, err := gzip.NewReader(bytes.NewReader(sketchRecorder.ByteBody))
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(gzReader)
+	require.NoError(t, err)
+
 	var payload gogen.SketchPayload
-	require.NoError(t, payload.Unmarshal(sketchRecorder.ByteBody))
+	require.NoError(t, payload.Unmarshal(decompressed))
 	require.Len(t, payload.Sketches, 1)
 	sketch := payload.Sketches[0]
 	require.Len(t, sketch.Dogsketches, 1)

--- a/internal/datadog/clientutil/http.go
+++ b/internal/datadog/clientutil/http.go
@@ -22,9 +22,11 @@ var (
 		"Content-Encoding": "gzip",
 	}
 	// ProtobufHeaders headers for protobuf requests.
+	// Content-Encoding is gzip to stay consistent with the metric series path,
+	// which is always gzip-compressed (see clientutil.GZipSubmitMetricsOptionalParameters).
 	ProtobufHeaders = map[string]string{
 		"Content-Type":     "application/x-protobuf",
-		"Content-Encoding": "identity",
+		"Content-Encoding": "gzip",
 	}
 )
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In the legacy native metrics client exporter gzip-compresses the series payload but sent the sketches payload uncompressed (Content-Encoding: identity), inflating egress for distribution/histogram metrics. 

This PR adds compression the sketches payload with gzip in pushSketches, matching the series path, and sets the shared ProtobufHeaders to Content-Encoding: gzip.

We also add a guard and test to ensure we have consistent compression across different metric types moving forward.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
No tracking issue.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
New tests have been added to ensure gzip compression is applied as expected to the various signal types:
- `TestSignalCompressionMetrics`
- `TestSignalCompressionTraces`
- `TestSignalCompressionLogs`

The integration tests have also been updated to catch gzip compression absence.

<!--Describe the documentation added.-->
#### Documentation
No documentation changes are necessary given the fact this addresses an unexpected current behavior. The release note should suffice.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
