### PR TITLE
[chore] Bump go.opentelemetry.io/build-tools/githubgen to eb92bc360a35

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -134,6 +134,7 @@ require (
 	github.com/google/addlicense v1.2.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v84 v84.0.0 // indirect
+	github.com/google/go-github/v85 v85.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gordonklaus/ineffassign v0.2.0 // indirect
@@ -226,7 +227,7 @@ require (
 	github.com/rhysd/actionlint v1.7.12 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
@@ -276,7 +277,7 @@ require (
 	go.opentelemetry.io/build-tools/checkfile v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/chloggen v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/crosslink v0.30.0 // indirect
-	go.opentelemetry.io/build-tools/githubgen v0.30.0 // indirect
+	go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260609000124-eb92bc360a35 // indirect
 	go.opentelemetry.io/build-tools/issuegenerator v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/multimod v0.30.0 // indirect
 	go.opentelemetry.io/collector/cmd/builder v0.155.0 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -250,6 +250,8 @@ github.com/google/go-github/v73 v73.0.0 h1:aR+Utnh+Y4mMkS+2qLQwcQ/cF9mOTpdwnzlaw
 github.com/google/go-github/v73 v73.0.0/go.mod h1:fa6w8+/V+edSU0muqdhCVY7Beh1M8F1IlQPZIANKIYw=
 github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
 github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
+github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
+github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -485,6 +487,8 @@ github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.4.1 h1:eWC8eUMNZ/wM/PWuZBv7JxxqT5fiIKSIyTvjb7Elr+g=
 github.com/ryancurrah/gomodguard v1.4.1/go.mod h1:qnMJwV1hX9m+YJseXEBhd2s90+1Xn6x9dLz11ualI1I=
@@ -610,6 +614,8 @@ go.opentelemetry.io/build-tools/crosslink v0.30.0 h1:aNk0ENhJEoeVYBPUD3nIGlkVphs
 go.opentelemetry.io/build-tools/crosslink v0.30.0/go.mod h1:4bR5pDaAwGYR0wBeVh+HdtnMyJHT4L9xsxOL4E3idzg=
 go.opentelemetry.io/build-tools/githubgen v0.30.0 h1:+BWBYGP6BbP1Lv3sK4Ey5Wtcw0+9dFJgegzENw24ne0=
 go.opentelemetry.io/build-tools/githubgen v0.30.0/go.mod h1:+sAD+GhmK2W3GdsQBHla+rvs76DC26Ct0aMySRl1i2E=
+go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260609000124-eb92bc360a35 h1:9UYE0Z1j/B1nIpUF0pEmQEDMJtt06aqrQY/HVppjOPQ=
+go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260609000124-eb92bc360a35/go.mod h1:Z0A1NV2fLlP+uLThBDR49ue7fuvzkPgA3QylTlKByw0=
 go.opentelemetry.io/build-tools/issuegenerator v0.30.0 h1:hUTh2h9j49cXn0Yg6cri/moWK4wu5AevcEHUj+slDm4=
 go.opentelemetry.io/build-tools/issuegenerator v0.30.0/go.mod h1:4KIkVTICFreixQUIzbE8JMbt9QhWllTC1gsn6iR684w=
 go.opentelemetry.io/build-tools/multimod v0.30.0 h1:f3L37C35ds33QIx2pwacH4F+EZp9BxGjbw3IIplu+uc=

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -485,8 +485,6 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
-github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -612,8 +610,6 @@ go.opentelemetry.io/build-tools/chloggen v0.30.0 h1:vAHRnY59kRHqIUrsnmBYAcJ0+p8u
 go.opentelemetry.io/build-tools/chloggen v0.30.0/go.mod h1:7ZVQIvfBkhncKSyk6WY1F0Kkg/9ibxRZkUrHP7EJ9XY=
 go.opentelemetry.io/build-tools/crosslink v0.30.0 h1:aNk0ENhJEoeVYBPUD3nIGlkVphsIoN8LTC/MASc6xb8=
 go.opentelemetry.io/build-tools/crosslink v0.30.0/go.mod h1:4bR5pDaAwGYR0wBeVh+HdtnMyJHT4L9xsxOL4E3idzg=
-go.opentelemetry.io/build-tools/githubgen v0.30.0 h1:+BWBYGP6BbP1Lv3sK4Ey5Wtcw0+9dFJgegzENw24ne0=
-go.opentelemetry.io/build-tools/githubgen v0.30.0/go.mod h1:+sAD+GhmK2W3GdsQBHla+rvs76DC26Ct0aMySRl1i2E=
 go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260609000124-eb92bc360a35 h1:9UYE0Z1j/B1nIpUF0pEmQEDMJtt06aqrQY/HVppjOPQ=
 go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260609000124-eb92bc360a35/go.mod h1:Z0A1NV2fLlP+uLThBDR49ue7fuvzkPgA3QylTlKByw0=
 go.opentelemetry.io/build-tools/issuegenerator v0.30.0 h1:hUTh2h9j49cXn0Yg6cri/moWK4wu5AevcEHUj+slDm4=


### PR DESCRIPTION
#### Description
Bump go.opentelemetry.io/build-tools/githubgen to include https://github.com/open-telemetry/opentelemetry-go-build-tools/commit/eb92bc360a35e59165e04f37e2a125757e976e72.

Fixes failues in check-codeowners CI, e.g. http://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/28122193465/job/83276725636

#### Authorship

- [x] I, a human, wrote this pull request description myself.
