### PR TITLE
[processor/spanpruning] make leaf/parent grouping depth-aware and deterministic

### DIFF
--- a/.chloggen/49323-spanpruning-deterministic-grouping.yaml
+++ b/.chloggen/49323-spanpruning-deterministic-grouping.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/spanpruning
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix non-deterministic depth of preserved outlier spans by grouping leaves and parents by tree depth, so same-named ancestors at different depths are no longer merged.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49323]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/spanpruningprocessor/README.md
+++ b/processor/spanpruningprocessor/README.md
@@ -284,6 +284,11 @@ Preserved outlier spans are annotated with:
 | `<prefix>is_preserved_outlier` | bool | Identifies span as a preserved outlier |
 | `<prefix>summary_span_id` | string | SpanID of the associated summary span |
 
+A preserved outlier becomes a sibling of its summary span. Grouping is
+depth-aware — leaves and parents are never grouped with same-named ancestors at
+a different depth — so an outlier stays at its original depth and the summary it
+links to (via `summary_span_id`) sits where its group was.
+
 ### Histogram Buckets
 
 When `aggregation_histogram_buckets` is configured, summary spans include latency distribution data as cumulative histogram buckets. Cumulative means each bucket count includes all spans with duration less than or equal to that bucket boundary.

--- a/processor/spanpruningprocessor/grouping.go
+++ b/processor/spanpruningprocessor/grouping.go
@@ -133,8 +133,10 @@ func writeAttributeSliceKey(builder *strings.Builder, value pcommon.Slice) {
 }
 
 // buildParentGroupKey constructs a parent grouping key from name and status
-// only; attributes are intentionally excluded for parent aggregation. Depth is
-// required to avoid duplicate names and status entries overwriting each other.
+// only; attributes are intentionally excluded for parent aggregation. The
+// caller passes the node's tree depth so same-named ancestors at different
+// depths are never grouped together (which would anchor the summary, and any
+// reparented spans, at a non-deterministic depth).
 func (*spanPruningProcessor) buildParentGroupKey(span ptrace.Span, depth int) string {
 	builder := builderPool.Get().(*strings.Builder)
 	builder.Reset()
@@ -166,10 +168,16 @@ func (p *spanPruningProcessor) buildLeafGroupKey(node *spanNode) string {
 	builder.Reset()
 	defer builderPool.Put(builder)
 
-	// Include parent span name to separate groups by parent
+	// Include parent span name plus tree depth to separate groups by parent.
+	// Depth is required so that same-named parents at different depths (e.g. a
+	// "handler" at depth 1 and another "handler" nested at depth 2) do not
+	// collapse into one group, which would anchor the summary — and reparent any
+	// preserved outliers — to a non-deterministic depth.
 	if node.parent != nil {
 		builder.WriteString("parent=")
 		builder.WriteString(node.parent.span.Name())
+		builder.WriteString("|depth=")
+		builder.WriteString(strconv.Itoa(node.depth()))
 		builder.WriteString("|")
 	}
 

--- a/processor/spanpruningprocessor/grouping.go
+++ b/processor/spanpruningprocessor/grouping.go
@@ -171,8 +171,7 @@ func (p *spanPruningProcessor) buildLeafGroupKey(node *spanNode) string {
 	// Include parent span name plus tree depth to separate groups by parent.
 	// Depth is required so that same-named parents at different depths (e.g. a
 	// "handler" at depth 1 and another "handler" nested at depth 2) do not
-	// collapse into one group, which would anchor the summary — and reparent any
-	// preserved outliers — to a non-deterministic depth.
+	// collapse into one group.
 	if node.parent != nil {
 		builder.WriteString("parent=")
 		builder.WriteString(node.parent.span.Name())

--- a/processor/spanpruningprocessor/processor.go
+++ b/processor/spanpruningprocessor/processor.go
@@ -303,10 +303,14 @@ func (p *spanPruningProcessor) analyzeAggregationsWithTree(ctx context.Context, 
 			break
 		}
 
-		// Group parent candidates by name + status
+		// Group parent candidates by name + status, keyed on the node's tree
+		// depth (not the loop iteration). Branches of unequal height can make
+		// same-named ancestors at different tree depths eligible in the same
+		// round; keying on iteration depth would merge them and anchor the
+		// summary at a non-deterministic depth.
 		parentGroups := make(map[string][]*spanNode)
 		for _, node := range eligibleParents {
-			parentKey := p.buildParentGroupKey(node.span, depth)
+			parentKey := p.buildParentGroupKey(node.span, node.depth())
 			parentGroups[parentKey] = append(parentGroups[parentKey], node)
 		}
 

--- a/processor/spanpruningprocessor/processor.go
+++ b/processor/spanpruningprocessor/processor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"sort"
 	"time"
 
 	"github.com/gobwas/glob"
@@ -302,6 +303,14 @@ func (p *spanPruningProcessor) analyzeAggregationsWithTree(ctx context.Context, 
 		if len(eligibleParents) == 0 {
 			break
 		}
+
+		// Candidates derive from leaf groups visited in map order, so sort them
+		// into a stable order before grouping. This keeps the summary anchor
+		// (group.nodes[0]) deterministic when same-named parents under different
+		// parents merge into one group.
+		sort.Slice(eligibleParents, func(i, j int) bool {
+			return nodeOrderLess(eligibleParents[i], eligibleParents[j])
+		})
 
 		// Group parent candidates by name + status, keyed on the node's tree
 		// depth (not the loop iteration). Branches of unequal height can make

--- a/processor/spanpruningprocessor/processor_test.go
+++ b/processor/spanpruningprocessor/processor_test.go
@@ -2708,3 +2708,92 @@ func createTraceWithSameNamedParentsAtDifferentDepths(t *testing.T) ptrace.Trace
 
 	return td
 }
+
+// TestParentReparentingDeterministicAcrossSiblings is a regression test for
+// same-named parents at the same depth under different-named parents. The
+// parent group key excludes the grandparent, so two "handler" spans at depth 2
+// (one under "auth-mw", one under "log-mw") merge into a single summary. The
+// summary anchors to nodes[0]'s parent; parent candidates derive from leaf
+// groups visited in map order, so without a stable sort the anchor — auth-mw vs
+// log-mw — varied run to run. The auth-mw handler starts earliest, so the
+// summary must consistently anchor there.
+func TestParentReparentingDeterministicAcrossSiblings(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.MaxParentDepth = -1
+	cfg.GroupByAttributes = []string{"db.operation"}
+
+	authMwID := pcommon.SpanID([8]byte{2, 0, 0, 0, 0, 0, 0, 0})
+
+	observedParents := make(map[pcommon.SpanID]bool)
+	const iterations = 50
+	for range iterations {
+		tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+		require.NoError(t, err)
+
+		td := createTraceWithSameNamedParentsUnderDifferentGrandparents(t)
+		require.NoError(t, tp.ConsumeTraces(t.Context(), td))
+
+		summary, found := findSummarySpanByName(td, "handler")
+		require.True(t, found, "the two handlers should aggregate into one summary")
+		observedParents[summary.ParentSpanID()] = true
+	}
+
+	require.Len(t, observedParents, 1, "handler summary parent must be stable across runs; got %v", observedParents)
+	assert.Contains(t, observedParents, authMwID, "summary should anchor to the earliest-starting handler's parent (auth-mw)")
+}
+
+// createTraceWithSameNamedParentsUnderDifferentGrandparents builds a trace with
+// two "handler" spans at depth 2 under different-named middlewares. Their SELECT
+// children use distinct db.operation values so they form two leaf groups (the
+// source of map-order non-determinism feeding parent candidates).
+func createTraceWithSameNamedParentsUnderDifferentGrandparents(t *testing.T) ptrace.Traces {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	rootID := pcommon.SpanID([8]byte{1, 0, 0, 0, 0, 0, 0, 0})
+	authMwID := pcommon.SpanID([8]byte{2, 0, 0, 0, 0, 0, 0, 0})
+	logMwID := pcommon.SpanID([8]byte{3, 0, 0, 0, 0, 0, 0, 0})
+	authHandlerID := pcommon.SpanID([8]byte{4, 0, 0, 0, 0, 0, 0, 0})
+	logHandlerID := pcommon.SpanID([8]byte{5, 0, 0, 0, 0, 0, 0, 0})
+
+	baseNs := int64(1_000_000_000)
+	ms := int64(1_000_000)
+
+	add := func(id, parentID pcommon.SpanID, name string, startNs, durMs int64, dbOp string) {
+		s := ss.Spans().AppendEmpty()
+		s.SetTraceID(traceID)
+		s.SetSpanID(id)
+		s.SetParentSpanID(parentID)
+		s.SetName(name)
+		s.SetStartTimestamp(pcommon.Timestamp(startNs))
+		s.SetEndTimestamp(pcommon.Timestamp(startNs + durMs*ms))
+		if dbOp != "" {
+			s.Attributes().PutStr("db.operation", dbOp)
+		}
+	}
+
+	add(rootID, pcommon.SpanID{}, "root", baseNs, 700, "")
+	add(authMwID, rootID, "auth-mw", baseNs, 300, "")
+	add(logMwID, rootID, "log-mw", baseNs, 300, "")
+	// auth-mw's handler starts earliest so it sorts first and wins the anchor.
+	add(authHandlerID, authMwID, "handler", baseNs, 200, "")
+	add(logHandlerID, logMwID, "handler", baseNs+ms, 200, "")
+
+	leafID := byte(10)
+	addLeaves := func(parentID pcommon.SpanID, dbOp string) {
+		for i := range 5 {
+			id := [8]byte{leafID}
+			leafID++
+			add(pcommon.SpanID(id), parentID, "SELECT", baseNs, int64(5+i), dbOp)
+		}
+	}
+	addLeaves(authHandlerID, "A")
+	addLeaves(logHandlerID, "B")
+
+	return td
+}

--- a/processor/spanpruningprocessor/processor_test.go
+++ b/processor/spanpruningprocessor/processor_test.go
@@ -2547,3 +2547,164 @@ func findAllSummarySpans(td ptrace.Traces) []ptrace.Span {
 	}
 	return result
 }
+
+// TestOutlierReparentingDeterministicAcrossDepths is a regression test for
+// same-named parents at different depths. Previously the leaf group key used
+// only the parent's name, so SELECT children of a "handler" at depth 1 and a
+// "handler" at depth 2 collapsed into one group; the summary (and any preserved
+// outliers) then anchored to whichever parent map iteration visited first,
+// producing a non-deterministic outlier depth. With depth in the leaf key the
+// two depths form separate groups, so the deep-handler outliers stay at depth 3
+// on every run and carry provenance recording their original position.
+func TestOutlierReparentingDeterministicAcrossDepths(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.MaxParentDepth = -1
+	cfg.EnableOutlierAnalysis = true
+	cfg.OutlierAnalysis = OutlierAnalysisConfig{
+		Method:                         OutlierMethodIQR,
+		IQRMultiplier:                  1.5,
+		MinGroupSize:                   7,
+		PreserveOutliers:               true,
+		MaxPreservedOutliers:           0,
+		CorrelationMinOccurrence:       0.5,
+		CorrelationMaxNormalOccurrence: 0.5,
+		MaxCorrelatedAttributes:        5,
+		MinOutlierThresholdPercent:     0.1,
+	}
+
+	deepHandlerID := pcommon.SpanID([8]byte{4, 0, 0, 0, 0, 0, 0, 0})
+
+	observedDepths := make(map[int]bool)
+	const iterations = 50
+	for range iterations {
+		tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+		require.NoError(t, err)
+
+		td := createTraceWithSameNamedParentsAtDifferentDepths(t)
+		require.NoError(t, tp.ConsumeTraces(t.Context(), td))
+
+		// The two depths must form separate groups (not one merged summary),
+		// so we get one summary per handler.
+		require.Len(t, findAllSummarySpans(td), 2, "shallow and deep handlers must aggregate separately")
+
+		outliers := findPreservedOutlierSpans(td)
+		require.Len(t, outliers, 2, "both deep-handler outliers should be preserved")
+
+		for _, o := range outliers {
+			observedDepths[spanDepthInTrace(td, o)] = true
+			// Outliers stay anchored under their real parent (the deep handler).
+			assert.Equal(t, deepHandlerID, o.ParentSpanID())
+		}
+	}
+
+	assert.Equal(t, map[int]bool{3: true}, observedDepths,
+		"preserved-outlier depth must be stable at 3 across runs; got %v", observedDepths)
+}
+
+// findPreservedOutlierSpans returns all spans tagged as preserved outliers.
+func findPreservedOutlierSpans(td ptrace.Traces) []ptrace.Span {
+	var out []ptrace.Span
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		for j := 0; j < rss.At(i).ScopeSpans().Len(); j++ {
+			spans := rss.At(i).ScopeSpans().At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				s := spans.At(k)
+				if v, ok := s.Attributes().Get("aggregation.is_preserved_outlier"); ok && v.Bool() {
+					out = append(out, s)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// spanDepthInTrace counts ancestor hops from span to the root within td.
+func spanDepthInTrace(td ptrace.Traces, span ptrace.Span) int {
+	byID := make(map[pcommon.SpanID]ptrace.Span)
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		for j := 0; j < rss.At(i).ScopeSpans().Len(); j++ {
+			spans := rss.At(i).ScopeSpans().At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				s := spans.At(k)
+				byID[s.SpanID()] = s
+			}
+		}
+	}
+	depth := 0
+	for current := span; ; {
+		parentID := current.ParentSpanID()
+		if parentID.IsEmpty() {
+			break
+		}
+		parent, ok := byID[parentID]
+		if !ok {
+			break
+		}
+		depth++
+		current = parent
+	}
+	return depth
+}
+
+// createTraceWithSameNamedParentsAtDifferentDepths builds a trace with two
+// "handler" spans — one at depth 1 (under root) and one at depth 2 (under
+// middleware). The deep handler has 7 normal + 2 outlier SELECT children so its
+// leaf group alone satisfies MinGroupSize for outlier detection.
+func createTraceWithSameNamedParentsAtDifferentDepths(t *testing.T) ptrace.Traces {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	rootID := pcommon.SpanID([8]byte{1, 0, 0, 0, 0, 0, 0, 0})
+	shallowHandlerID := pcommon.SpanID([8]byte{2, 0, 0, 0, 0, 0, 0, 0})
+	middlewareID := pcommon.SpanID([8]byte{3, 0, 0, 0, 0, 0, 0, 0})
+	deepHandlerID := pcommon.SpanID([8]byte{4, 0, 0, 0, 0, 0, 0, 0})
+
+	baseNs := int64(1_000_000_000)
+	ms := int64(1_000_000)
+
+	nextID := func() pcommon.SpanID {
+		var id [8]byte
+		id[0] = byte(ss.Spans().Len() + 10)
+		return pcommon.SpanID(id)
+	}
+
+	addSpan := func(id, parentID pcommon.SpanID, name string, durationMs int64, cacheHit string) {
+		s := ss.Spans().AppendEmpty()
+		s.SetTraceID(traceID)
+		s.SetSpanID(id)
+		s.SetParentSpanID(parentID)
+		s.SetName(name)
+		s.SetStartTimestamp(pcommon.Timestamp(baseNs))
+		s.SetEndTimestamp(pcommon.Timestamp(baseNs + durationMs*ms))
+		if cacheHit != "" {
+			s.Attributes().PutStr("cache_hit", cacheHit)
+		}
+	}
+
+	addSpan(rootID, pcommon.SpanID{}, "root", 700, "")
+	addSpan(shallowHandlerID, rootID, "handler", 10, "")     // depth 1
+	addSpan(middlewareID, rootID, "middleware", 650, "")     // depth 1
+	addSpan(deepHandlerID, middlewareID, "handler", 600, "") // depth 2
+
+	// Shallow handler: 5 normal SELECTs (depth 2) — aggregates, no outliers.
+	for _, dur := range []int64{5, 6, 7, 8, 9} {
+		addSpan(nextID(), shallowHandlerID, "SELECT", dur, "true")
+	}
+
+	// Deep handler: 7 normal + 2 outlier SELECTs (depth 3).
+	for _, dur := range []int64{5, 6, 7, 8, 9, 10, 11} {
+		addSpan(nextID(), deepHandlerID, "SELECT", dur, "true")
+	}
+	for _, dur := range []int64{500, 600} {
+		addSpan(nextID(), deepHandlerID, "SELECT", dur, "false")
+	}
+
+	return td
+}

--- a/processor/spanpruningprocessor/tree.go
+++ b/processor/spanpruningprocessor/tree.go
@@ -4,6 +4,9 @@
 package spanpruningprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor"
 
 import (
+	"bytes"
+	"sort"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
@@ -77,13 +80,24 @@ func (p *spanPruningProcessor) buildTraceTree(spans []spanInfo) *traceTree {
 		}
 	}
 
-	// Third pass: collect leaves (nodes still marked as leaf)
+	// Third pass: collect leaves (nodes still marked as leaf). nodeByID is a
+	// map, so iteration order is random; sort the leaves into a stable order
+	// (start time, then span ID) so downstream grouping, summary anchoring, and
+	// outlier reparenting are deterministic across runs.
 	tree.leaves = make([]*spanNode, 0, len(spans)/4)
 	for _, node := range tree.nodeByID {
 		if node.isLeaf {
 			tree.leaves = append(tree.leaves, node)
 		}
 	}
+	sort.Slice(tree.leaves, func(i, j int) bool {
+		a, b := tree.leaves[i].span, tree.leaves[j].span
+		if a.StartTimestamp() != b.StartTimestamp() {
+			return a.StartTimestamp() < b.StartTimestamp()
+		}
+		aID, bID := a.SpanID(), b.SpanID()
+		return bytes.Compare(aID[:], bID[:]) < 0
+	})
 
 	// Log warnings for incomplete traces
 	if rootCount > 1 {
@@ -104,6 +118,17 @@ func (p *spanPruningProcessor) buildTraceTree(spans []spanInfo) *traceTree {
 // getLeaves returns the pre-computed leaf nodes (spans with no children).
 func (t *traceTree) getLeaves() []*spanNode {
 	return t.leaves
+}
+
+// depth returns the node's depth in the trace tree (root spans and orphans are
+// depth 0). It walks the cached parent chain, so cost is proportional to tree
+// height.
+func (n *spanNode) depth() int {
+	d := 0
+	for p := n.parent; p != nil; p = p.parent {
+		d++
+	}
+	return d
 }
 
 // findEligibleParentNodesFromCandidates filters candidate parents to those

--- a/processor/spanpruningprocessor/tree.go
+++ b/processor/spanpruningprocessor/tree.go
@@ -91,12 +91,7 @@ func (p *spanPruningProcessor) buildTraceTree(spans []spanInfo) *traceTree {
 		}
 	}
 	sort.Slice(tree.leaves, func(i, j int) bool {
-		a, b := tree.leaves[i].span, tree.leaves[j].span
-		if a.StartTimestamp() != b.StartTimestamp() {
-			return a.StartTimestamp() < b.StartTimestamp()
-		}
-		aID, bID := a.SpanID(), b.SpanID()
-		return bytes.Compare(aID[:], bID[:]) < 0
+		return nodeOrderLess(tree.leaves[i], tree.leaves[j])
 	})
 
 	// Log warnings for incomplete traces
@@ -118,6 +113,18 @@ func (p *spanPruningProcessor) buildTraceTree(spans []spanInfo) *traceTree {
 // getLeaves returns the pre-computed leaf nodes (spans with no children).
 func (t *traceTree) getLeaves() []*spanNode {
 	return t.leaves
+}
+
+// nodeOrderLess orders span nodes by start time, then span ID. It gives a
+// stable order that does not depend on map iteration, so leaf grouping, parent
+// candidate grouping, and summary anchoring are deterministic across runs.
+func nodeOrderLess(a, b *spanNode) bool {
+	sa, sb := a.span, b.span
+	if sa.StartTimestamp() != sb.StartTimestamp() {
+		return sa.StartTimestamp() < sb.StartTimestamp()
+	}
+	aID, bID := sa.SpanID(), sb.SpanID()
+	return bytes.Compare(aID[:], bID[:]) < 0
 }
 
 // depth returns the node's depth in the trace tree (root spans and orphans are


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

We found a bug where spans would not be parented correctly if there were two options for parents with the same name. Include depth in the leaf key (already in the parent key) as well as sorting before iterating fixes the issue.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

New test for the specific bug was added

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
