### PR TITLE
[processor/spanpruning] preserve outlier subtrees with multi-level detection

### DIFF
--- a/.chloggen/49324-spanpruning-outlier-subtrees.yaml
+++ b/.chloggen/49324-spanpruning-outlier-subtrees.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/spanpruning
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve whole outlier subtrees instead of individual spans and detect outliers at every aggregation level, so a slow interior span (e.g. one slow handler among many) keeps its entire subtree.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49324]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/49324-spanpruning-outlier-subtrees.yaml
+++ b/.chloggen/49324-spanpruning-outlier-subtrees.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: processor/spanpruning
+component: processor/span_pruning
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Preserve whole outlier subtrees instead of individual spans and detect outliers at every aggregation level, so a slow interior span (e.g. one slow handler among many) keeps its entire subtree.

--- a/processor/spanpruningprocessor/README.md
+++ b/processor/spanpruningprocessor/README.md
@@ -28,7 +28,7 @@ Spans are grouped by:
 
 Parent spans are eligible for aggregation when all of their children are aggregated, they share the same name, kind, and status code, and they are not root spans.
 
-Optionally, the processor can detect **duration outliers** using statistical methods (IQR or MAD) and either annotate summary spans with outlier correlations or **preserve outlier spans** as individual spans for debugging while still aggregating normal spans.
+Optionally, the processor can detect **duration outliers** using statistical methods (IQR or MAD) and either annotate summary spans with outlier correlations or **preserve outlier subtrees** for debugging while still aggregating normal spans. Detection runs at every aggregation level, so a slow interior span (for example one slow `handler` among many) is caught and its whole subtree is kept intact.
 
 This processor is useful for reducing trace data volume while preserving meaningful information about repeated operations.
 
@@ -141,13 +141,15 @@ processors:
       # Default: 5
       max_correlated_attributes: 5
 
-      # Preserve outlier spans as individual spans instead of aggregating
-      # When true, only normal spans are aggregated; outliers remain in the trace
+      # Preserve outlier subtrees instead of aggregating them
+      # When true, each detected outlier and its whole subtree are kept; only
+      # normal spans are aggregated. Detection runs at every level, so slow
+      # interior spans (not just leaves) are preserved with their subtree.
       # Default: false
       preserve_outliers: false
 
-      # Maximum number of outlier spans to preserve per aggregation group
-      # Spans are selected by most extreme duration first
+      # Maximum number of outlier subtrees to preserve per aggregation group
+      # Outliers are selected by most extreme duration first
       # 0 = preserve all detected outliers
       # Default: 2
       max_preserved_outliers: 2
@@ -184,8 +186,8 @@ processors:
 | `outlier_analysis.correlation_min_occurrence` | float64 | 0.75 | Minimum outlier occurrence fraction for correlation |
 | `outlier_analysis.correlation_max_normal_occurrence` | float64 | 0.25 | Maximum normal occurrence fraction for correlation |
 | `outlier_analysis.max_correlated_attributes` | int | 5 | Maximum correlated attributes to report |
-| `outlier_analysis.preserve_outliers` | bool | false | Keep outliers as individual spans instead of aggregating |
-| `outlier_analysis.max_preserved_outliers` | int | 2 | Max outliers to preserve per group (0=preserve all) |
+| `outlier_analysis.preserve_outliers` | bool | false | Keep outlier subtrees instead of aggregating |
+| `outlier_analysis.max_preserved_outliers` | int | 2 | Max outlier subtrees to preserve per group (0=preserve all) |
 | `outlier_analysis.preserve_only_with_correlation` | bool | false | Only preserve outliers if a strong correlation is found |
 | `outlier_analysis.min_outlier_threshold_percent` | float64 | 0.1 | Minimum percentage above median required before a span is considered an outlier |
 
@@ -296,10 +298,10 @@ Preserved outlier spans are annotated with:
 | `<prefix>is_preserved_outlier` | bool | Identifies span as a preserved outlier |
 | `<prefix>summary_span_id` | string | SpanID of the associated summary span |
 
-A preserved outlier becomes a sibling of its summary span. Grouping is
-depth-aware — leaves and parents are never grouped with same-named ancestors at
-a different depth — so an outlier stays at its original depth and the summary it
-links to (via `summary_span_id`) sits where its group was.
+A preserved outlier (the root of its subtree) becomes a sibling of its summary
+span, and its whole subtree moves with it. The outlier keeps everything beneath it,
+but its aggregated ancestors are replaced by the summary it now hangs from
+(linked via `summary_span_id`).
 
 ### Histogram Buckets
 
@@ -401,13 +403,15 @@ This helps identify root causes of latency issues:
 - **Minimal when disabled**: Zero overhead (no sorting or calculations)
 - **Recommended**: Use `min_group_size: 7` or higher to skip analysis on small groups
 
-### Preserving Outlier Spans (Optional)
+### Preserving Outlier Subtrees (Optional)
 
-When `outlier_analysis.preserve_outliers: true`, detected outlier spans are **kept as individual spans** instead of being aggregated. This provides:
+When `outlier_analysis.preserve_outliers: true`, each detected outlier is **kept along with its whole subtree** instead of being aggregated. A leaf outlier (e.g. a slow query) is the degenerate single-span case; an interior outlier (e.g. a slow `handler`) keeps every span beneath it. This provides:
 
-- **Full visibility** into slow operations for debugging
-- **Preserved context**: Original attributes, events, and links remain intact
-- **Selective aggregation**: Only prune repetitive normal spans
+- **Full visibility** into slow operations for debugging, including everything the slow span did
+- **Preserved context**: original attributes, events, links, and tree structure remain intact
+- **Selective aggregation**: only prune repetitive normal spans
+
+Preservation keeps everything **beneath** an outlier, not above it: the outlier's subtree is kept, but its ancestors still aggregate normally. The preserved subtree is reparented as a sibling of its summary span (the whole subtree moves with its root), so a slow leaf ends up under the same summary its normal siblings collapsed into, and a slow interior span hangs off the summary that replaced its peers.
 
 #### Configuration
 
@@ -425,8 +429,8 @@ processors:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `preserve_outliers` | bool | false | Keep outliers as individual spans instead of aggregating |
-| `max_preserved_outliers` | int | 2 | Max outliers to preserve per group (0=preserve all detected) |
+| `preserve_outliers` | bool | false | Keep outlier subtrees instead of aggregating |
+| `max_preserved_outliers` | int | 2 | Max outlier subtrees to preserve per group (0=preserve all detected) |
 | `preserve_only_with_correlation` | bool | false | Only preserve outliers if a strong attribute correlation is found |
 
 #### Example Output
@@ -464,9 +468,11 @@ handler
 
 #### Behavior Notes
 
-- **Parent aggregation**: Parents can still be aggregated if all their children are either aggregated or preserved as outliers
-- **Skip aggregation**: If preserving outliers leaves too few normal spans (below `min_spans_to_aggregate`), the entire group is left unchanged
-- **Selection order**: Outliers are preserved starting with the most extreme (longest duration) first
+- **Multi-level detection**: outliers are detected within each sibling group at every level (leaf groups and eligible parent groups) that meets `min_group_size`.
+- **Subtree, not ancestors**: a preserved outlier keeps everything beneath it (its whole subtree), but its ancestors still aggregate; the subtree is reparented as a sibling of its summary.
+- **Nested outliers**: an outlier already inside a preserved subtree is not preserved (or counted) again, since the enclosing subtree already keeps it.
+- **Skip aggregation**: if protection leaves a group below `min_spans_to_aggregate`, that group is left unchanged.
+- **Selection order**: outliers are preserved starting with the most extreme (longest duration) first, capped by `max_preserved_outliers` subtrees per group.
 
 ## Pipeline Placement
 
@@ -617,7 +623,7 @@ The processor emits the following metrics to help monitor its operation:
 | `otelcol_processor_spanpruning_aggregations_created` | Total number of aggregation summary spans created |
 | `otelcol_processor_spanpruning_traces_processed` | Total number of traces processed |
 | `otelcol_processor_spanpruning_outliers_detected` | Total spans identified as outliers by analysis (when `enable_outlier_analysis: true`) |
-| `otelcol_processor_spanpruning_outliers_preserved` | Total outlier spans kept as individual spans (when `preserve_outliers: true`) |
+| `otelcol_processor_spanpruning_outliers_preserved` | Total outlier spans kept (when `preserve_outliers: true`) |
 | `otelcol_processor_spanpruning_outliers_correlations_detected` | Total aggregation groups where outliers had correlated attributes |
 | `otelcol_processor_spanpruning_bytes_received` | Total bytes of serialized traces received before pruning (when `enable_bytes_metrics: true`) |
 | `otelcol_processor_spanpruning_bytes_processed_input` | Total bytes of serialized traces in the matched subset, measured before pruning (when `enable_bytes_metrics: true`) |

--- a/processor/spanpruningprocessor/processor.go
+++ b/processor/spanpruningprocessor/processor.go
@@ -401,12 +401,23 @@ func (p *spanPruningProcessor) detectAndProtectOutliers(ctx context.Context, gro
 		if !preserve {
 			continue
 		}
-		// filterOutlierNodes applies MaxPreservedOutliers and correlation gating.
-		_, outliers := filterOutlierNodes(group.nodes, res, p.config.OutlierAnalysis)
+		// filterOutlierNodes applies correlation gating and orders outliers most
+		// extreme first. Ask it for all of them (cap 0) and apply
+		// MaxPreservedOutliers here, after dropping outliers already kept by an
+		// enclosing protected subtree. Letting filterOutlierNodes cap first would
+		// spend a budget slot on an already-covered outlier and starve a
+		// not-yet-preserved one further down the order.
+		unlimited := p.config.OutlierAnalysis
+		unlimited.MaxPreservedOutliers = 0
+		_, outliers := filterOutlierNodes(group.nodes, res, unlimited)
+		limit := p.config.OutlierAnalysis.MaxPreservedOutliers
 		for _, o := range outliers {
 			// Skip outliers already kept by an enclosing protected subtree.
 			if o.protected {
 				continue
+			}
+			if limit > 0 && len(protectedRootsByKey[group.key]) >= limit {
+				break
 			}
 			markOutlierSubtree(o)
 			protectedRootsByKey[group.key] = append(protectedRootsByKey[group.key], o)

--- a/processor/spanpruningprocessor/processor.go
+++ b/processor/spanpruningprocessor/processor.go
@@ -258,204 +258,286 @@ func (p *spanPruningProcessor) processTrace(ctx context.Context, spans []spanInf
 	}
 }
 
-// analyzeAggregationsWithTree performs Phase 1 using tree structure
-// Uses markedForRemoval field on nodes instead of separate map for better performance
-// Optimized to walk up from marked nodes instead of scanning all nodes
+// analyzeAggregationsWithTree plans the candidate aggregation groups, then
+// detects and protects outliers within them, then aggregates the non-protected
+// spans. Planning runs once and feeds both detection and execution.
 func (p *spanPruningProcessor) analyzeAggregationsWithTree(ctx context.Context, tree *traceTree) map[string]aggregationGroup {
-	// Step 1: Get pre-computed leaf nodes
+	// Step 1: plan the groups that would aggregate.
+	groups := p.planCandidateGroups(tree)
+	if len(groups) == 0 {
+		return nil
+	}
+
+	// Step 2: detect outliers over those groups and protect their subtrees
+	// before any aggregation runs.
+	outlierResultByKey, protectedRootsByKey := p.detectAndProtectOutliers(ctx, groups)
+
+	// Step 3: aggregate. planCandidateGroups returns groups bottom-up (leaves
+	// first, then parents by increasing depth), so processing them in order
+	// marks a group's children before the parent group is evaluated.
+	aggregationGroups := make(map[string]aggregationGroup, len(groups))
+	preserving := p.config.EnableOutlierAnalysis && p.config.OutlierAnalysis.PreserveOutliers
+
+	for _, g := range groups {
+		nodes := g.nodes
+		if g.depth == 0 {
+			// Leaf group: drop preserved-outlier subtrees, then re-check the floor.
+			if preserving {
+				nodes = excludeProtectedNodes(nodes)
+			}
+			if len(nodes) < p.config.MinSpansToAggregate {
+				continue
+			}
+		} else {
+			// Parent group: protection, or a child group that fell below the
+			// floor, can leave a planned parent with an un-aggregated child, so
+			// re-check eligibility against the marks set by the deeper groups.
+			nodes = p.eligibleParents(nodes)
+			if len(nodes) < 2 {
+				continue
+			}
+		}
+
+		templateNode := findLongestDurationNode(nodes)
+		lossInfo := p.recordAttributeLoss(ctx, g.depth == 0, nodes, templateNode)
+
+		preserved := protectedRootsByKey[g.key]
+		aggregationGroups[g.key] = aggregationGroup{
+			nodes:             nodes,
+			depth:             g.depth,
+			lossInfo:          lossInfo,
+			templateNode:      templateNode,
+			outlierAnalysis:   outlierResultByKey[g.key],
+			preservedOutliers: preserved,
+		}
+		for _, n := range nodes {
+			n.markedForRemoval = true
+		}
+		p.recordPreserved(ctx, preserved)
+	}
+
+	return aggregationGroups
+}
+
+// eligibleParents returns the parents of a planned parent group that are still
+// eligible to aggregate, in a stable order so the summary's parent is chosen
+// deterministically. Protection, or a child group that fell below
+// MinSpansToAggregate, can make a planned parent ineligible by the time it is
+// executed.
+func (p *spanPruningProcessor) eligibleParents(nodes []*spanNode) []*spanNode {
+	out := make([]*spanNode, 0, len(nodes))
+	for _, n := range nodes {
+		if p.isEligibleForParentAggregation(n) {
+			out = append(out, n)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return nodeOrderLess(out[i], out[j])
+	})
+	return out
+}
+
+// recordAttributeLoss computes attribute loss for a group and records the
+// matching leaf or parent telemetry, returning the loss summary.
+func (p *spanPruningProcessor) recordAttributeLoss(ctx context.Context, isLeaf bool, nodes []*spanNode, templateNode *spanNode) attributeLossSummary {
+	if !p.enableAttributeLossAnalysis {
+		return attributeLossSummary{}
+	}
+	lossInfo := analyzeAttributeLoss(nodes, templateNode)
+	if lossInfo.isEmpty() {
+		return lossInfo
+	}
+	recordCtx := ctx
+	if p.shouldSampleAttributeLossExemplar() {
+		recordCtx = createExemplarContext(ctx, templateNode.span.TraceID(), templateNode.span.SpanID())
+	}
+	if isLeaf {
+		p.telemetryBuilder.ProcessorSpanpruningLeafAttributeDiversityLoss.Record(recordCtx, int64(len(lossInfo.diverse)))
+		p.telemetryBuilder.ProcessorSpanpruningLeafAttributeLoss.Record(recordCtx, int64(len(lossInfo.missing)))
+	} else {
+		p.telemetryBuilder.ProcessorSpanpruningParentAttributeDiversityLoss.Record(recordCtx, int64(len(lossInfo.diverse)))
+		p.telemetryBuilder.ProcessorSpanpruningParentAttributeLoss.Record(recordCtx, int64(len(lossInfo.missing)))
+	}
+	return lossInfo
+}
+
+// detectAndProtectOutliers runs outlier detection over the planned groups and,
+// when preservation is enabled, protects each preserved outlier's whole subtree
+// so it is kept instead of aggregated. It returns per-group detection results (to
+// annotate the matching summary) and the preserved-outlier roots grouped by group
+// key (to link them to their summary during execution).
+func (p *spanPruningProcessor) detectAndProtectOutliers(ctx context.Context, groups []candidateGroup) (map[string]*outlierAnalysisResult, map[string][]*spanNode) {
+	if !p.config.EnableOutlierAnalysis {
+		return nil, nil
+	}
+
+	outlierResultByKey := make(map[string]*outlierAnalysisResult)
+	protectedRootsByKey := make(map[string][]*spanNode)
+	preserve := p.config.OutlierAnalysis.PreserveOutliers
+
+	// Process groups shallowest-first (by tree depth) so an interior outlier's
+	// subtree protection lands before any group nested beneath it; a leaf outlier
+	// inside an already-protected subtree is then skipped rather than preserved
+	// (and counted) twice. Sort a copy so the caller keeps its bottom-up order.
+	ordered := append([]candidateGroup(nil), groups...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].nodes[0].depth() < ordered[j].nodes[0].depth()
+	})
+
+	for _, group := range ordered {
+		res := analyzeOutliers(group.nodes, p.config.OutlierAnalysis)
+		if res == nil {
+			continue
+		}
+		outlierResultByKey[group.key] = res
+
+		if res.hasOutliers {
+			p.telemetryBuilder.ProcessorSpanpruningOutliersDetected.Add(ctx, int64(len(res.outlierIndices)))
+			if len(res.correlations) > 0 {
+				p.telemetryBuilder.ProcessorSpanpruningOutliersCorrelationsDetected.Add(ctx, 1)
+			}
+		}
+
+		if !preserve {
+			continue
+		}
+		// filterOutlierNodes applies MaxPreservedOutliers and correlation gating.
+		_, outliers := filterOutlierNodes(group.nodes, res, p.config.OutlierAnalysis)
+		for _, o := range outliers {
+			// Skip outliers already kept by an enclosing protected subtree.
+			if o.protected {
+				continue
+			}
+			markOutlierSubtree(o)
+			protectedRootsByKey[group.key] = append(protectedRootsByKey[group.key], o)
+		}
+	}
+	return outlierResultByKey, protectedRootsByKey
+}
+
+// candidateGroup is a group of sibling spans that would aggregate, paired with
+// the key and aggregation depth the executor will use for it (depth 0 for a leaf
+// group, >=1 for a parent group). Carrying these from planning means detection
+// and execution agree without recomputing them.
+type candidateGroup struct {
+	key   string
+	depth int
+	nodes []*spanNode
+}
+
+// planCandidateGroups computes the groups that would aggregate (leaf groups at
+// or above MinSpansToAggregate and eligible parent groups), ignoring outlier
+// protection. It mutates no node state, tracking would-aggregate membership in a
+// local set, so detection runs over the same groups the executor later forms.
+func (p *spanPruningProcessor) planCandidateGroups(tree *traceTree) []candidateGroup {
 	leafNodes := tree.getLeaves()
 	if len(leafNodes) == 0 {
 		return nil
 	}
 
-	// Step 2: Group similar leaf nodes
-	leafGroups := p.groupLeafNodesByKey(leafNodes)
+	var groups []candidateGroup
+	would := make(map[*spanNode]bool)
+	var marked []*spanNode
 
-	// Step 3: Filter groups meeting minimum threshold and mark nodes
-	// Pre-size based on expected number of groups
-	aggregationGroups := make(map[string]aggregationGroup, len(leafGroups)/2)
-
-	// Track nodes marked in this round for candidate collection
-	var markedNodes []*spanNode
-
-	for groupKey, nodes := range leafGroups {
+	for key, nodes := range p.groupLeafNodesByKey(leafNodes) {
 		if len(nodes) < p.config.MinSpansToAggregate {
 			continue
 		}
-
-		// Outlier analysis and filtering FIRST (before attribute loss).
-		var outlierResult *outlierAnalysisResult
-		var preservedOutliers []*spanNode
-		aggregateNodes := nodes
-
-		if p.config.EnableOutlierAnalysis {
-			outlierResult = analyzeOutliers(nodes, p.config.OutlierAnalysis)
-
-			// Record outlier metrics.
-			if outlierResult != nil && outlierResult.hasOutliers {
-				p.telemetryBuilder.ProcessorSpanpruningOutliersDetected.Add(ctx, int64(len(outlierResult.outlierIndices)))
-				if len(outlierResult.correlations) > 0 {
-					p.telemetryBuilder.ProcessorSpanpruningOutliersCorrelationsDetected.Add(ctx, 1)
-				}
-			}
-
-			// Filter outliers when preservation is enabled.
-			if p.config.OutlierAnalysis.PreserveOutliers && outlierResult != nil {
-				aggregateNodes, preservedOutliers = filterOutlierNodes(
-					nodes,
-					outlierResult,
-					p.config.OutlierAnalysis,
-				)
-
-				if len(preservedOutliers) > 0 {
-					p.telemetryBuilder.ProcessorSpanpruningOutliersPreserved.Add(ctx, int64(len(preservedOutliers)))
-				}
-
-				// Skip aggregation if too few normal spans remain.
-				if len(aggregateNodes) < p.config.MinSpansToAggregate {
-					continue
-				}
-			}
-		}
-
-		// Find template from filtered nodes (excludes preserved outliers).
-		templateNode := findLongestDurationNode(aggregateNodes)
-		var lossInfo attributeLossSummary
-		if p.enableAttributeLossAnalysis {
-			lossInfo = analyzeAttributeLoss(aggregateNodes, templateNode)
-			if !lossInfo.isEmpty() {
-				recordCtx := ctx
-				if p.shouldSampleAttributeLossExemplar() {
-					recordCtx = createExemplarContext(ctx, templateNode.span.TraceID(), templateNode.span.SpanID())
-				}
-				p.telemetryBuilder.ProcessorSpanpruningLeafAttributeDiversityLoss.Record(recordCtx, int64(len(lossInfo.diverse)))
-				p.telemetryBuilder.ProcessorSpanpruningLeafAttributeLoss.Record(recordCtx, int64(len(lossInfo.missing)))
-			}
-		}
-
-		aggregationGroups[groupKey] = aggregationGroup{
-			nodes:             aggregateNodes,
-			depth:             0,
-			lossInfo:          lossInfo,
-			templateNode:      templateNode,
-			outlierAnalysis:   outlierResult,
-			preservedOutliers: preservedOutliers,
-		}
-
-		// Mark only aggregated spans for removal.
-		for _, node := range aggregateNodes {
-			node.markedForRemoval = true
-		}
-		markedNodes = append(markedNodes, aggregateNodes...)
-
-		// Mark outliers as preserved (not removed).
-		for _, outlier := range preservedOutliers {
-			outlier.isPreservedOutlier = true
+		groups = append(groups, candidateGroup{key: key, depth: 0, nodes: nodes})
+		for _, n := range nodes {
+			would[n] = true
+			marked = append(marked, n)
 		}
 	}
 
-	if len(aggregationGroups) == 0 {
-		return nil
-	}
-
-	// Step 4: Walk up the tree to find eligible parent spans recursively
-	// Respect MaxParentDepth: 0 = no parent aggregation, -1 = unlimited, >0 = limit
 	if p.config.MaxParentDepth == 0 {
-		return aggregationGroups
+		return groups
 	}
 
-	// Collect initial parent candidates from marked leaf nodes
-	candidates := collectParentCandidates(markedNodes)
-
+	candidates := collectParentCandidates(marked)
 	depth := 1
 	for len(candidates) > 0 {
-		// Check if we've reached the maximum parent depth limit
 		if p.config.MaxParentDepth > 0 && depth > p.config.MaxParentDepth {
 			break
 		}
 
-		// Find eligible parents from candidates (walks up from marked nodes)
-		eligibleParents := p.findEligibleParentNodesFromCandidates(candidates)
-		if len(eligibleParents) == 0 {
+		var eligible []*spanNode
+		for _, n := range candidates {
+			if planEligibleForParentAggregation(n, would) {
+				eligible = append(eligible, n)
+			}
+		}
+		if len(eligible) == 0 {
 			break
 		}
 
-		// Candidates derive from leaf groups visited in map order, so sort them
-		// into a stable order before grouping. This keeps the summary anchor
-		// (group.nodes[0]) deterministic when same-named parents under different
-		// parents merge into one group.
-		sort.Slice(eligibleParents, func(i, j int) bool {
-			return nodeOrderLess(eligibleParents[i], eligibleParents[j])
-		})
-
-		// Group parent candidates by name + status, keyed on the node's tree
-		// depth (not the loop iteration). Branches of unequal height can make
-		// same-named ancestors at different tree depths eligible in the same
-		// round; keying on iteration depth would merge them and anchor the
-		// summary at a non-deterministic depth.
 		parentGroups := make(map[string][]*spanNode)
-		for _, node := range eligibleParents {
-			parentKey := p.buildParentGroupKey(node.span, node.depth())
-			parentGroups[parentKey] = append(parentGroups[parentKey], node)
+		for _, n := range eligible {
+			key := p.buildParentGroupKey(n.span, n.depth())
+			parentGroups[key] = append(parentGroups[key], n)
 		}
 
-		// Add parent groups (at least 2 parents to aggregate)
-		markedNodes = markedNodes[:0] // reset for this round
-		for parentKey, nodes := range parentGroups {
+		marked = marked[:0]
+		for key, nodes := range parentGroups {
 			if len(nodes) < 2 {
 				continue
 			}
-
-			// Outlier analysis FIRST (before attribute loss).
-			var outlierResult *outlierAnalysisResult
-			if p.config.EnableOutlierAnalysis {
-				outlierResult = analyzeOutliers(nodes, p.config.OutlierAnalysis)
-
-				if outlierResult != nil && outlierResult.hasOutliers {
-					p.telemetryBuilder.ProcessorSpanpruningOutliersDetected.Add(ctx, int64(len(outlierResult.outlierIndices)))
-					if len(outlierResult.correlations) > 0 {
-						p.telemetryBuilder.ProcessorSpanpruningOutliersCorrelationsDetected.Add(ctx, 1)
-					}
-				}
+			groups = append(groups, candidateGroup{key: key, depth: depth, nodes: nodes})
+			for _, n := range nodes {
+				would[n] = true
+				marked = append(marked, n)
 			}
-
-			// Find the template node (longest duration) for this group.
-			templateNode := findLongestDurationNode(nodes)
-			var lossInfo attributeLossSummary
-			if p.enableAttributeLossAnalysis {
-				lossInfo = analyzeAttributeLoss(nodes, templateNode)
-				if !lossInfo.isEmpty() {
-					recordCtx := ctx
-					if p.shouldSampleAttributeLossExemplar() {
-						recordCtx = createExemplarContext(ctx, templateNode.span.TraceID(), templateNode.span.SpanID())
-					}
-					p.telemetryBuilder.ProcessorSpanpruningParentAttributeDiversityLoss.Record(recordCtx, int64(len(lossInfo.diverse)))
-					p.telemetryBuilder.ProcessorSpanpruningParentAttributeLoss.Record(recordCtx, int64(len(lossInfo.missing)))
-				}
-			}
-
-			aggregationGroups[parentKey] = aggregationGroup{
-				nodes:           nodes,
-				depth:           depth,
-				lossInfo:        lossInfo,
-				templateNode:    templateNode,
-				outlierAnalysis: outlierResult,
-			}
-			// Mark parent nodes for removal
-			for _, node := range nodes {
-				node.markedForRemoval = true
-			}
-			markedNodes = append(markedNodes, nodes...)
 		}
-
-		if len(markedNodes) == 0 {
+		if len(marked) == 0 {
 			break
 		}
-
-		// Collect next round of candidates from newly marked nodes
-		candidates = collectParentCandidates(markedNodes)
+		candidates = collectParentCandidates(marked)
 		depth++
 	}
+	return groups
+}
 
-	return aggregationGroups
+// recordPreserved emits preserved-outlier telemetry: every span kept across the
+// preserved subtrees rooted at the given outlier roots, not just the roots.
+func (p *spanPruningProcessor) recordPreserved(ctx context.Context, roots []*spanNode) {
+	if len(roots) == 0 {
+		return
+	}
+	p.telemetryBuilder.ProcessorSpanpruningOutliersPreserved.Add(ctx, int64(preservedSpanCount(roots)))
+}
+
+// planEligibleForParentAggregation mirrors isEligibleForParentAggregation for
+// the planning phase, using the local would-aggregate set rather than node
+// flags and ignoring protection (not yet decided during planning).
+func planEligibleForParentAggregation(node *spanNode, would map[*spanNode]bool) bool {
+	if node.isLeaf || node.parent == nil || would[node] {
+		return false
+	}
+	for _, child := range node.children {
+		if !would[child] {
+			return false
+		}
+	}
+	return true
+}
+
+// excludeProtectedNodes returns the subset of nodes that are not protected,
+// allocating only when at least one node is protected.
+func excludeProtectedNodes(nodes []*spanNode) []*spanNode {
+	protectedCount := 0
+	for _, n := range nodes {
+		if n.protected {
+			protectedCount++
+		}
+	}
+	if protectedCount == 0 {
+		return nodes
+	}
+	out := make([]*spanNode, 0, len(nodes)-protectedCount)
+	for _, n := range nodes {
+		if !n.protected {
+			out = append(out, n)
+		}
+	}
+	return out
 }

--- a/processor/spanpruningprocessor/processor_benchmark_test.go
+++ b/processor/spanpruningprocessor/processor_benchmark_test.go
@@ -75,7 +75,7 @@ func BenchmarkGroupLeafNodes(b *testing.B) {
 }
 
 // BenchmarkFindEligibleParents benchmarks parent candidate discovery.
-func BenchmarkFindEligibleParents(b *testing.B) {
+func BenchmarkEligibleParents(b *testing.B) {
 	proc := newBenchmarkProcessor(b, 5)
 	spans := generateTestSpans(1000, 50)
 	tree := proc.buildTraceTree(spans)
@@ -91,7 +91,7 @@ func BenchmarkFindEligibleParents(b *testing.B) {
 		for _, c := range candidates {
 			c.markedForRemoval = false
 		}
-		_ = proc.findEligibleParentNodesFromCandidates(candidates)
+		_ = proc.eligibleParents(candidates)
 	}
 }
 

--- a/processor/spanpruningprocessor/processor_test.go
+++ b/processor/spanpruningprocessor/processor_test.go
@@ -2965,3 +2965,129 @@ func createTraceWithSameNamedParentsUnderDifferentGrandparents(t *testing.T) ptr
 
 	return td
 }
+
+// TestOutlierInteriorSubtreePreserved verifies that a duration outlier at an
+// interior level (a slow "handler" among many) has its entire subtree preserved
+// while the normal handlers aggregate.
+func TestOutlierInteriorSubtreePreserved(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.MaxParentDepth = -1
+	cfg.EnableOutlierAnalysis = true
+	cfg.OutlierAnalysis = OutlierAnalysisConfig{
+		Method:                         OutlierMethodIQR,
+		IQRMultiplier:                  1.5,
+		MinGroupSize:                   7,
+		PreserveOutliers:               true,
+		MaxPreservedOutliers:           0,
+		CorrelationMinOccurrence:       0.5,
+		CorrelationMaxNormalOccurrence: 0.5,
+		MaxCorrelatedAttributes:        5,
+		MinOutlierThresholdPercent:     0.1,
+	}
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	td, slowHandlerID := createTraceWithSlowHandler(t)
+	require.NoError(t, tp.ConsumeTraces(t.Context(), td))
+
+	// The slow handler is preserved as an outlier subtree root and stays put.
+	slow, found := findSpanByID(td, slowHandlerID)
+	require.True(t, found, "slow handler should be preserved, not aggregated")
+	v, ok := slow.Attributes().Get("aggregation.is_preserved_outlier")
+	require.True(t, ok, "slow handler should be tagged as a preserved outlier")
+	assert.True(t, v.Bool())
+
+	// Its whole subtree is intact: all 5 SELECT children remain under it.
+	assert.Equal(t, 5, countChildren(td, slowHandlerID), "slow handler subtree should be preserved intact")
+
+	// The 7 normal handlers aggregate into a single handler summary.
+	summary, found := findSummarySpanByName(td, "handler")
+	require.True(t, found, "normal handlers should aggregate into a summary")
+	sc, ok := summary.Attributes().Get("aggregation.span_count")
+	require.True(t, ok)
+	assert.Equal(t, int64(7), sc.Int(), "summary should aggregate the 7 normal handlers")
+}
+
+func findSpanByID(td ptrace.Traces, id pcommon.SpanID) (ptrace.Span, bool) {
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		for j := 0; j < rss.At(i).ScopeSpans().Len(); j++ {
+			spans := rss.At(i).ScopeSpans().At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				if spans.At(k).SpanID() == id {
+					return spans.At(k), true
+				}
+			}
+		}
+	}
+	return ptrace.Span{}, false
+}
+
+func countChildren(td ptrace.Traces, parentID pcommon.SpanID) int {
+	count := 0
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		for j := 0; j < rss.At(i).ScopeSpans().Len(); j++ {
+			spans := rss.At(i).ScopeSpans().At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				if spans.At(k).ParentSpanID() == parentID {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+// createTraceWithSlowHandler builds a trace with 7 normal "handler" spans and
+// one slow "handler" (a duration outlier among the handlers), each with 5
+// normal-duration SELECT children.
+func createTraceWithSlowHandler(t *testing.T) (ptrace.Traces, pcommon.SpanID) {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	rootID := pcommon.SpanID([8]byte{1, 0, 0, 0, 0, 0, 0, 0})
+	baseNs := int64(1_000_000_000)
+	ms := int64(1_000_000)
+
+	idCounter := byte(2)
+	nextID := func() pcommon.SpanID {
+		var id [8]byte
+		id[0] = idCounter
+		idCounter++
+		return pcommon.SpanID(id)
+	}
+
+	add := func(id, parentID pcommon.SpanID, name string, durMs int64) {
+		s := ss.Spans().AppendEmpty()
+		s.SetTraceID(traceID)
+		s.SetSpanID(id)
+		s.SetParentSpanID(parentID)
+		s.SetName(name)
+		s.SetStartTimestamp(pcommon.Timestamp(baseNs))
+		s.SetEndTimestamp(pcommon.Timestamp(baseNs + durMs*ms))
+	}
+
+	add(rootID, pcommon.SpanID{}, "root", 1000)
+
+	addHandler := func(durMs int64) pcommon.SpanID {
+		hid := nextID()
+		add(hid, rootID, "handler", durMs)
+		for range 5 {
+			add(nextID(), hid, "SELECT", 5)
+		}
+		return hid
+	}
+
+	for range 7 {
+		addHandler(10)
+	}
+	slowID := addHandler(500)
+	return td, slowID
+}

--- a/processor/spanpruningprocessor/processor_test.go
+++ b/processor/spanpruningprocessor/processor_test.go
@@ -837,6 +837,65 @@ func TestProcessorPreservesOutlierSpans(t *testing.T) {
 	}
 }
 
+// TestProcessorOutlierBudgetSkipsCoveredOutliers verifies that MaxPreservedOutliers
+// is not spent on an outlier already kept by an ancestor's preserved subtree. With
+// a budget of one, the most extreme leaf outlier is a child of the preserved outlier
+// handler, so the budget must go to the next leaf outlier under a normal handler
+// rather than being silently consumed by the already-covered one.
+func TestProcessorOutlierBudgetSkipsCoveredOutliers(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.MinSpansToAggregate = 5
+	cfg.MaxParentDepth = -1
+	cfg.GroupByAttributes = []string{"db.operation"}
+	cfg.EnableOutlierAnalysis = true
+	cfg.OutlierAnalysis.Method = OutlierMethodIQR
+	cfg.OutlierAnalysis.PreserveOutliers = true
+	cfg.OutlierAnalysis.MaxPreservedOutliers = 1
+	cfg.OutlierAnalysis.IQRMultiplier = 1.5
+	cfg.OutlierAnalysis.MinGroupSize = 5
+	cfg.OutlierAnalysis.CorrelationMinOccurrence = 0.75
+	cfg.OutlierAnalysis.CorrelationMaxNormalOccurrence = 0.25
+	cfg.OutlierAnalysis.MaxCorrelatedAttributes = 5
+
+	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+
+	td := createTestTraceWithNestedOutliers(t)
+	err = tp.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	ms := int64(1000000)
+	var preservedHandler, preservedLeaf, coveredLeaf bool
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				dur := int64(span.EndTimestamp() - span.StartTimestamp())
+				_, isPreserved := span.Attributes().Get("aggregation.is_preserved_outlier")
+				switch {
+				case span.Name() == "handler" && dur == 2000*ms:
+					assert.True(t, isPreserved, "outlier handler should be a preserved outlier root")
+					preservedHandler = true
+				case span.Name() == "SELECT" && dur == 500*ms:
+					assert.True(t, isPreserved, "leaf outlier under a normal handler should be preserved, not starved by the already-covered outlier")
+					preservedLeaf = true
+				case span.Name() == "SELECT" && dur == 900*ms:
+					// Covered by the handler's preserved subtree: kept, but not a root.
+					assert.False(t, isPreserved, "leaf outlier already covered by an ancestor subtree should not be a preserved root")
+					coveredLeaf = true
+				}
+			}
+		}
+	}
+
+	assert.True(t, preservedHandler, "outlier handler not found in output")
+	assert.True(t, preservedLeaf, "leaf outlier under a normal handler not found in output")
+	assert.True(t, coveredLeaf, "covered leaf outlier (900ms) not found in output")
+}
+
 // TestProcessorSkipsAggregationWhenTooFewNormalSpans tests that aggregation is skipped
 // when preserving outliers would leave too few normal spans to aggregate.
 func TestProcessorSkipsAggregationWhenTooFewNormalSpans(t *testing.T) {
@@ -1032,6 +1091,75 @@ func createTestTraceWithManyOutliers(t *testing.T) ptrace.Traces {
 		span.SetStartTimestamp(pcommon.Timestamp(baseTime))
 		span.SetEndTimestamp(pcommon.Timestamp(baseTime + dur*ms))
 		span.Attributes().PutStr("db.operation", "SELECT")
+	}
+
+	return td
+}
+
+// createTestTraceWithNestedOutliers builds a trace with outliers at two levels:
+// one handler is a duration outlier among its siblings (so its whole subtree is
+// preserved), and the SELECT leaf group nested beneath all handlers contains two
+// duration outliers. The most extreme leaf outlier (900ms) is a child of the
+// outlier handler and is therefore already covered by its preserved subtree; the
+// other (500ms) sits under a normal handler.
+func createTestTraceWithNestedOutliers(t *testing.T) ptrace.Traces {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	traceID := pcommon.TraceID([16]byte{9, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14})
+	rootID := pcommon.SpanID([8]byte{1, 0, 0, 0, 0, 0, 0, 0})
+
+	baseTime := int64(1000000000)
+	ms := int64(1000000)
+
+	root := ss.Spans().AppendEmpty()
+	root.SetTraceID(traceID)
+	root.SetSpanID(rootID)
+	root.SetName("root")
+	root.SetStartTimestamp(pcommon.Timestamp(baseTime))
+	root.SetEndTimestamp(pcommon.Timestamp(baseTime + 3000*ms))
+
+	// Six handlers under the root. Handler 5 is a clear duration outlier, so its
+	// whole subtree (including its leaf children) is preserved first.
+	handlerDurations := []int64{20, 21, 22, 23, 24, 2000}
+	handlerIDs := make([]pcommon.SpanID, len(handlerDurations))
+	for i, dur := range handlerDurations {
+		id := pcommon.SpanID([8]byte{2, byte(i), 0, 0, 0, 0, 0, 0})
+		handlerIDs[i] = id
+		h := ss.Spans().AppendEmpty()
+		h.SetTraceID(traceID)
+		h.SetSpanID(id)
+		h.SetParentSpanID(rootID)
+		h.SetName("handler")
+		h.SetStartTimestamp(pcommon.Timestamp(baseTime))
+		h.SetEndTimestamp(pcommon.Timestamp(baseTime + dur*ms))
+	}
+
+	// Two SELECT leaves under each handler. They share one leaf group (keyed by
+	// parent name, depth, and db.operation). The 900ms leaf under the outlier
+	// handler is the most extreme outlier, and the 500ms leaf sits under a normal
+	// handler.
+	leafDurations := [][]int64{
+		{5, 6},
+		{7, 8},
+		{9, 10},
+		{11, 500}, // 500ms outlier under a normal handler
+		{12, 13},
+		{900, 14}, // 900ms outlier under the outlier handler
+	}
+	for hi, durs := range leafDurations {
+		for li, dur := range durs {
+			leaf := ss.Spans().AppendEmpty()
+			leaf.SetTraceID(traceID)
+			leaf.SetSpanID(pcommon.SpanID([8]byte{3, byte(hi), byte(li), 0, 0, 0, 0, 0}))
+			leaf.SetParentSpanID(handlerIDs[hi])
+			leaf.SetName("SELECT")
+			leaf.SetStartTimestamp(pcommon.Timestamp(baseTime))
+			leaf.SetEndTimestamp(pcommon.Timestamp(baseTime + dur*ms))
+			leaf.Attributes().PutStr("db.operation", "SELECT")
+		}
 	}
 
 	return td

--- a/processor/spanpruningprocessor/tree.go
+++ b/processor/spanpruningprocessor/tree.go
@@ -23,7 +23,8 @@ type spanNode struct {
 	replacementSpanID  pcommon.SpanID // summary span ID that replaced this node's group
 	isLeaf             bool           // true if node has no children
 	markedForRemoval   bool           // true if node will be aggregated
-	isPreservedOutlier bool           // true if preserved as outlier (not aggregated)
+	isPreservedOutlier bool           // true if this node is the root of a preserved outlier subtree
+	protected          bool           // true if this node is within a preserved outlier subtree (never aggregated)
 }
 
 // traceTree holds span nodes indexed by ID plus quick leaf/orphan lists for
@@ -138,21 +139,34 @@ func (n *spanNode) depth() int {
 	return d
 }
 
-// findEligibleParentNodesFromCandidates filters candidate parents to those
-// whose children are all marked for aggregation and that are themselves
-// aggregate-able.
-func (p *spanPruningProcessor) findEligibleParentNodesFromCandidates(candidates []*spanNode) []*spanNode {
-	if len(candidates) == 0 {
-		return nil
+// markOutlierSubtree records root as a preserved-outlier root and marks every
+// node in its subtree (root included) as protected, so the whole subtree is kept
+// (never aggregated). It is outlier-specific (it sets isPreservedOutlier); other
+// preservation features should not reuse it.
+func markOutlierSubtree(root *spanNode) {
+	root.isPreservedOutlier = true
+	for _, n := range subtreeNodes(root) {
+		n.protected = true
 	}
+}
 
-	eligibleParents := make([]*spanNode, 0, len(candidates)/4)
-	for _, node := range candidates {
-		if p.isEligibleForParentAggregation(node) {
-			eligibleParents = append(eligibleParents, node)
-		}
+// subtreeNodes returns root and all of its descendants.
+func subtreeNodes(root *spanNode) []*spanNode {
+	nodes := []*spanNode{root}
+	for i := 0; i < len(nodes); i++ {
+		nodes = append(nodes, nodes[i].children...)
 	}
-	return eligibleParents
+	return nodes
+}
+
+// preservedSpanCount returns the total number of spans across the subtrees
+// rooted at the given preserved-outlier roots.
+func preservedSpanCount(roots []*spanNode) int {
+	total := 0
+	for _, r := range roots {
+		total += len(subtreeNodes(r))
+	}
+	return total
 }
 
 // collectParentCandidates returns unique parents of marked nodes for the
@@ -178,7 +192,11 @@ func collectParentCandidates(markedNodes []*spanNode) []*spanNode {
 }
 
 // isEligibleForParentAggregation verifies that a node meets the criteria for
-// parent aggregation (not root, all children marked or preserved, not already marked).
+// parent aggregation: not a leaf, not a root, not already aggregated, not itself
+// a preserved outlier, and every child either aggregated or part of a preserved
+// outlier subtree. A preserved subtree is reparented onto this node's summary,
+// so it does not block aggregation. The outlier keeps everything beneath it but
+// not its ancestors.
 func (*spanPruningProcessor) isEligibleForParentAggregation(node *spanNode) bool {
 	// Must have children (not a leaf)
 	if node.isLeaf {
@@ -190,14 +208,15 @@ func (*spanPruningProcessor) isEligibleForParentAggregation(node *spanNode) bool
 		return false
 	}
 
-	// Must not already be marked for removal
-	if node.markedForRemoval {
+	// Must not already be marked for removal, and must not itself be a protected
+	// outlier subtree (those are preserved, not aggregated).
+	if node.markedForRemoval || node.protected {
 		return false
 	}
 
-	// All children must be either marked for removal OR preserved as outliers
+	// All children must be aggregated or part of a preserved outlier subtree.
 	for _, child := range node.children {
-		if !child.markedForRemoval && !child.isPreservedOutlier {
+		if !child.markedForRemoval && !child.protected {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This updates how outliers are calculated to detect non-leaf outliers, such as an entire slow request that also has subspans, and preserve it. For example, given a trace that looks something like this:
```
root (1000ms)
  handler (50ms)
    query (5ms)
    query (5ms)
    query (5ms)
    query (5ms)
  handler (50ms)
    query (5ms)
    query (5ms)
    query (5ms)
    query (5ms)
  handler (50ms)
    query (5ms)
    query (5ms)
    query (5ms)
    query (5ms)
  handler (50ms)
    query (5ms)
    query (5ms)
    query (5ms)
    query (5ms)
  handler (50ms)
    query (5ms)
    query (5ms)
    query (5ms)
    query (5ms)
  handler (50ms)
    query (5ms)
    query (5ms)
    query (5ms)
    query (5ms)
  handler (50ms) label=handler-with-slow-query
    query (5ms)
    query (5ms)
    query (5ms)
    query (45ms) label=slow-query
  handler (600ms) label=slow-handler
    query (5ms)
    query (5ms)
    query (5ms)
    query (550ms) label=slow-query
```

The current algorithm would produce a result that looks like this:
```
root (1000ms)
  handler (600ms) [SUMMARY n=8] label=slow-handler
    query (5ms) [SUMMARY n=30] preserved_outlier_count=2
    query (45ms) [PRESERVED_OUTLIER] label=slow-query
    query (550ms) [PRESERVED_OUTLIER] label=slow-query
```

This entirely misses the context around the slow handler vs just two slow queries. You can imagine this being especially bad if it wasn't the query that was slow, but just something else that was not traced, then no outlier would be found at all.

Now the result will look like:
```
root (1000ms)
  handler (600ms) [PRESERVED_OUTLIER] label=slow-handler
    query (5ms)
    query (5ms)
    query (5ms)
    query (550ms) label=slow-query
  handler (50ms) [SUMMARY n=7] preserved_outlier_count=1
    query (5ms) [SUMMARY n=27] preserved_outlier_count=1
    query (45ms) [PRESERVED_OUTLIER] label=slow-query
```

So we can see that there is both a very slow handler caused by an excessively slow query, and another outlier for just a slow query, but which didn't cause the entire handler to be abnormally slow.

This is done by changing how the processor works a bit, but I think it is a clearer workflow as well. First the aggregation groups are planned without outlier influence, then outlier detection runs and protects various subtrees, then finally the aggregation work is done and spans are marked for removal.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

All existing unit tests continue to pass, and a new test was added for the intermediate-span outlier case. In addition, I ran through an example trace as described above.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
