### PR TITLE
[receiver/hostmetrics] Enable system.cpu.logical.count metric by default

### DIFF
--- a/.chloggen/hostmetrics-cpu-logical-count-default.yaml
+++ b/.chloggen/hostmetrics-cpu-logical-count-default.yaml
@@ -1,0 +1,10 @@
+change_type: breaking
+
+component: receiver/hostmetrics
+
+note: Enable the `system.cpu.logical.count` metric by default in the CPU scraper.
+
+issues: [49162]
+
+subtext: |
+  The logical CPU count is recommended by the System CPU semantic conventions and preserves host CPU cardinality information when per-CPU attributes are disabled.

--- a/.chloggen/hostmetrics-cpu-logical-count-default.yaml
+++ b/.chloggen/hostmetrics-cpu-logical-count-default.yaml
@@ -1,6 +1,6 @@
 change_type: breaking
 
-component: receiver/hostmetrics
+component: receiver/host_metrics
 
 note: Enable the `system.cpu.logical.count` metric by default in the CPU scraper.
 

--- a/.chloggen/hostmetrics-cpu-logical-count-default.yaml
+++ b/.chloggen/hostmetrics-cpu-logical-count-default.yaml
@@ -4,7 +4,7 @@ component: receiver/hostmetrics
 
 note: Enable the `system.cpu.logical.count` metric by default in the CPU scraper.
 
-issues: [49162]
+issues: [49325]
 
 subtext: |
   The logical CPU count is recommended by the System CPU semantic conventions and preserves host CPU cardinality information when per-CPU attributes are disabled.

--- a/.chloggen/hostmetrics-cpu-logical-count-default.yaml
+++ b/.chloggen/hostmetrics-cpu-logical-count-default.yaml
@@ -7,4 +7,13 @@ note: Enable the `system.cpu.logical.count` metric by default in the CPU scraper
 issues: [49325]
 
 subtext: |
-  The logical CPU count is recommended by the System CPU semantic conventions and preserves host CPU cardinality information when per-CPU attributes are disabled.
+  To restore the previous behavior, disable the new metric by applying the following config:
+  ```yaml
+  receivers:
+    host_metrics:
+      scrapers:
+        cpu:
+          metrics:
+            system.cpu.logical.count:
+              enabled: false
+  ```

--- a/processor/resourcedetectionprocessor/testdata/e2e/akamai/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/akamai/expected.yaml
@@ -31,6 +31,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/aks/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/aks/expected.yaml
@@ -13,6 +13,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/alibaba_ecs/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/alibaba_ecs/expected.yaml
@@ -31,6 +31,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/azure/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/azure/expected.yaml
@@ -43,6 +43,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/consul/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/consul/expected.yaml
@@ -22,6 +22,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/digitalocean/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/digitalocean/expected.yaml
@@ -16,6 +16,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/docker/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/docker/expected.yaml
@@ -16,6 +16,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/dynatrace/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/dynatrace/expected.yaml
@@ -13,6 +13,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/ec2/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ec2/expected.yaml
@@ -37,6 +37,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/ecs/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ecs/expected.yaml
@@ -57,6 +57,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/eks/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/eks/expected.yaml
@@ -31,6 +31,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/elasticbeanstalk/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/elasticbeanstalk/expected.yaml
@@ -19,6 +19,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/env/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/env/expected.yaml
@@ -16,6 +16,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/gcp/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/gcp/expected.yaml
@@ -40,6 +40,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/heroku/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/heroku/expected.yaml
@@ -25,6 +25,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/hetzner/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/hetzner/expected.yaml
@@ -22,6 +22,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_classic/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_classic/expected.yaml
@@ -25,6 +25,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_vpc/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/ibmcloud_vpc/expected.yaml
@@ -37,6 +37,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/k8s_api/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/k8s_api/expected.yaml
@@ -13,6 +13,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/k8snode/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/k8snode/expected.yaml
@@ -13,6 +13,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/kubeadm/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/kubeadm/expected.yaml
@@ -10,6 +10,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/lambda/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/lambda/expected.yaml
@@ -35,6 +35,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/nova/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/nova/expected.yaml
@@ -31,6 +31,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/openshift/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/openshift/expected.yaml
@@ -16,6 +16,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/oraclecloud/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/oraclecloud/expected.yaml
@@ -31,6 +31,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/scaleway/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/scaleway/expected.yaml
@@ -34,6 +34,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/system/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/system/expected.yaml
@@ -19,6 +19,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/tencent_cvm/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/tencent_cvm/expected.yaml
@@ -31,6 +31,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/upcloud/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/upcloud/expected.yaml
@@ -16,6 +16,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/processor/resourcedetectionprocessor/testdata/e2e/vultr/expected.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/vultr/expected.yaml
@@ -19,6 +19,16 @@ resourceMetrics:
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
     scopeMetrics:
       - metrics:
+          - description: Number of available logical CPUs.
+            name: system.cpu.logical.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: false
+            unit: "{cpu}"
           - description: Total seconds each logical CPU spent on each mode.
             name: system.cpu.time
             sum:

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -38,6 +38,7 @@ import (
 
 var allMetrics = []string{
 	"system.cpu.time",
+	"system.cpu.logical.count",
 	"system.cpu.load_average.1m",
 	"system.cpu.load_average.5m",
 	"system.cpu.load_average.15m",

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux_test.go
@@ -41,6 +41,7 @@ func TestScrape_CpuFrequency(t *testing.T) {
 
 			cfg := metadata.NewDefaultMetricsBuilderConfig()
 			cfg.Metrics.SystemCPUTime.Enabled = false
+			cfg.Metrics.SystemCPULogicalCount.Enabled = false
 			cfg.Metrics.SystemCPUFrequency.Enabled = test.enabledFrequency
 
 			scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type),

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -43,13 +43,13 @@ func TestScrape(t *testing.T) {
 		{
 			name:                "Standard",
 			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 1,
+			expectedMetricCount: 2,
 		},
 		{
 			name:                "Validate Start Time",
 			bootTimeFunc:        func(context.Context) (uint64, error) { return 100, nil },
 			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 1,
+			expectedMetricCount: 2,
 			expectedStartTime:   100 * 1e9,
 		},
 		{
@@ -63,13 +63,13 @@ func TestScrape(t *testing.T) {
 			name:                "Times Error",
 			timesFunc:           func(context.Context, bool) ([]cpu.TimesStat, error) { return nil, errors.New("err2") },
 			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 1,
+			expectedMetricCount: 2,
 			expectedErr:         "err2",
 		},
 		{
 			name:                "SystemCPUTime metric is disabled ",
 			metricsConfig:       disabledMetric,
-			expectedMetricCount: 0,
+			expectedMetricCount: 1,
 		},
 	}
 
@@ -110,10 +110,16 @@ func TestScrape(t *testing.T) {
 
 			if test.expectedMetricCount > 0 {
 				metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
-				assertCPUMetricValid(t, metrics.At(0), test.expectedStartTime)
 
-				if runtime.GOOS == "linux" {
-					assertCPUMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
+				if test.metricsConfig.Metrics.SystemCPUTime.Enabled {
+					cpuTimeMetric := findMetricByName(t, metrics, "system.cpu.time")
+					assertCPUMetricValid(t, cpuTimeMetric, test.expectedStartTime)
+					if runtime.GOOS == "linux" {
+						assertCPUMetricHasLinuxSpecificStateLabels(t, cpuTimeMetric)
+					}
+				}
+				if test.metricsConfig.Metrics.SystemCPULogicalCount.Enabled {
+					assertCPULogicalCountMetricValid(t, findMetricByName(t, metrics, "system.cpu.logical.count"))
 				}
 
 				internal.AssertSameTimeStampForAllMetrics(t, metrics)
@@ -227,29 +233,31 @@ func TestScrape_CpuUtilization(t *testing.T) {
 		expectedMetricCount int
 		times               bool
 		utilization         bool
-		utilizationIndex    int
+		logicalCount        bool
 	}
 
 	testCases := []testCase{
 		{
 			name:                "Standard",
 			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 1,
+			expectedMetricCount: 2,
 			times:               true,
 			utilization:         false,
+			logicalCount:        true,
 		},
 		{
 			name:                "SystemCPUTime metric is disabled",
 			times:               false,
 			utilization:         true,
-			expectedMetricCount: 1,
+			logicalCount:        true,
+			expectedMetricCount: 2,
 		},
 		{
 			name:                "all metrics are enabled",
 			times:               true,
 			utilization:         true,
-			expectedMetricCount: 2,
-			utilizationIndex:    1,
+			logicalCount:        true,
+			expectedMetricCount: 3,
 		},
 		{
 			name:                "all metrics are disabled",
@@ -267,6 +275,7 @@ func TestScrape_CpuUtilization(t *testing.T) {
 				settings = metadata.NewDefaultMetricsBuilderConfig()
 				settings.Metrics.SystemCPUTime.Enabled = test.times
 				settings.Metrics.SystemCPUUtilization.Enabled = test.utilization
+				settings.Metrics.SystemCPULogicalCount.Enabled = test.logicalCount
 			}
 
 			scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: settings})
@@ -287,18 +296,21 @@ func TestScrape_CpuUtilization(t *testing.T) {
 			metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 			if test.times {
-				timesMetrics := metrics.At(0)
+				timesMetrics := findMetricByName(t, metrics, "system.cpu.time")
 				assertCPUMetricValid(t, timesMetrics, 0)
 				if runtime.GOOS == "linux" {
 					assertCPUMetricHasLinuxSpecificStateLabels(t, timesMetrics)
 				}
 			}
 			if test.utilization {
-				utilizationMetrics := metrics.At(test.utilizationIndex)
+				utilizationMetrics := findMetricByName(t, metrics, "system.cpu.utilization")
 				assertCPUUtilizationMetricValid(t, utilizationMetrics, 0)
 				if runtime.GOOS == "linux" {
 					assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, utilizationMetrics)
 				}
+			}
+			if settings.Metrics.SystemCPULogicalCount.Enabled {
+				assertCPULogicalCountMetricValid(t, findMetricByName(t, metrics, "system.cpu.logical.count"))
 			}
 		})
 	}
@@ -331,6 +343,7 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 	overriddenMetricsSettings := metadata.NewDefaultMetricsBuilderConfig()
 	overriddenMetricsSettings.Metrics.SystemCPUUtilization.Enabled = true
 	overriddenMetricsSettings.Metrics.SystemCPUTime.Enabled = false
+	overriddenMetricsSettings.Metrics.SystemCPULogicalCount.Enabled = false
 
 	// datapoint data
 	type dpData struct {
@@ -417,6 +430,17 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 			assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
 		}
 	}
+}
+
+func findMetricByName(t *testing.T, metrics pmetric.MetricSlice, name string) pmetric.Metric {
+	for i := 0; i < metrics.Len(); i++ {
+		metric := metrics.At(i)
+		if metric.Name() == name {
+			return metric
+		}
+	}
+	require.Fail(t, "missing metric", "Expected metric %q not found", name)
+	return pmetric.Metric{}
 }
 
 func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberDataPoint, value float64, attrs map[string]string) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -36,24 +36,20 @@ func TestScrape(t *testing.T) {
 		expectedErr         string
 	}
 
-	defaultMetrics := metadata.NewDefaultMetricsBuilderConfig()
-	defaultMetrics.Metrics.SystemCPULogicalCount.Enabled = false
-
 	disabledMetric := metadata.NewDefaultMetricsBuilderConfig()
 	disabledMetric.Metrics.SystemCPUTime.Enabled = false
-	disabledMetric.Metrics.SystemCPULogicalCount.Enabled = false
 
 	testCases := []testCase{
 		{
 			name:                "Standard",
-			metricsConfig:       defaultMetrics,
-			expectedMetricCount: 1,
+			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
+			expectedMetricCount: 2,
 		},
 		{
 			name:                "Validate Start Time",
 			bootTimeFunc:        func(context.Context) (uint64, error) { return 100, nil },
-			metricsConfig:       defaultMetrics,
-			expectedMetricCount: 1,
+			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
+			expectedMetricCount: 2,
 			expectedStartTime:   100 * 1e9,
 		},
 		{
@@ -66,14 +62,14 @@ func TestScrape(t *testing.T) {
 		{
 			name:                "Times Error",
 			timesFunc:           func(context.Context, bool) ([]cpu.TimesStat, error) { return nil, errors.New("err2") },
-			metricsConfig:       defaultMetrics,
-			expectedMetricCount: 1,
+			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
+			expectedMetricCount: 2,
 			expectedErr:         "err2",
 		},
 		{
 			name:                "SystemCPUTime metric is disabled ",
 			metricsConfig:       disabledMetric,
-			expectedMetricCount: 0,
+			expectedMetricCount: 1,
 		},
 	}
 
@@ -114,10 +110,14 @@ func TestScrape(t *testing.T) {
 
 			if test.expectedMetricCount > 0 {
 				metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
-				assertCPUMetricValid(t, metrics.At(0), test.expectedStartTime)
+				assertCPULogicalCountMetricValid(t, metrics.At(0))
 
-				if runtime.GOOS == "linux" {
-					assertCPUMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
+				if test.metricsConfig.Metrics.SystemCPUTime.Enabled {
+					cpuTimeMetric := metrics.At(1)
+					assertCPUMetricValid(t, cpuTimeMetric, test.expectedStartTime)
+					if runtime.GOOS == "linux" {
+						assertCPUMetricHasLinuxSpecificStateLabels(t, cpuTimeMetric)
+					}
 				}
 
 				internal.AssertSameTimeStampForAllMetrics(t, metrics)

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -36,20 +36,24 @@ func TestScrape(t *testing.T) {
 		expectedErr         string
 	}
 
+	defaultMetrics := metadata.NewDefaultMetricsBuilderConfig()
+	defaultMetrics.Metrics.SystemCPULogicalCount.Enabled = false
+
 	disabledMetric := metadata.NewDefaultMetricsBuilderConfig()
 	disabledMetric.Metrics.SystemCPUTime.Enabled = false
+	disabledMetric.Metrics.SystemCPULogicalCount.Enabled = false
 
 	testCases := []testCase{
 		{
 			name:                "Standard",
-			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 2,
+			metricsConfig:       defaultMetrics,
+			expectedMetricCount: 1,
 		},
 		{
 			name:                "Validate Start Time",
 			bootTimeFunc:        func(context.Context) (uint64, error) { return 100, nil },
-			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 2,
+			metricsConfig:       defaultMetrics,
+			expectedMetricCount: 1,
 			expectedStartTime:   100 * 1e9,
 		},
 		{
@@ -62,14 +66,14 @@ func TestScrape(t *testing.T) {
 		{
 			name:                "Times Error",
 			timesFunc:           func(context.Context, bool) ([]cpu.TimesStat, error) { return nil, errors.New("err2") },
-			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 2,
+			metricsConfig:       defaultMetrics,
+			expectedMetricCount: 1,
 			expectedErr:         "err2",
 		},
 		{
 			name:                "SystemCPUTime metric is disabled ",
 			metricsConfig:       disabledMetric,
-			expectedMetricCount: 1,
+			expectedMetricCount: 0,
 		},
 	}
 
@@ -110,16 +114,10 @@ func TestScrape(t *testing.T) {
 
 			if test.expectedMetricCount > 0 {
 				metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+				assertCPUMetricValid(t, metrics.At(0), test.expectedStartTime)
 
-				if test.metricsConfig.Metrics.SystemCPUTime.Enabled {
-					cpuTimeMetric := findMetricByName(t, metrics, "system.cpu.time")
-					assertCPUMetricValid(t, cpuTimeMetric, test.expectedStartTime)
-					if runtime.GOOS == "linux" {
-						assertCPUMetricHasLinuxSpecificStateLabels(t, cpuTimeMetric)
-					}
-				}
-				if test.metricsConfig.Metrics.SystemCPULogicalCount.Enabled {
-					assertCPULogicalCountMetricValid(t, findMetricByName(t, metrics, "system.cpu.logical.count"))
+				if runtime.GOOS == "linux" {
+					assertCPUMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
 				}
 
 				internal.AssertSameTimeStampForAllMetrics(t, metrics)
@@ -233,31 +231,32 @@ func TestScrape_CpuUtilization(t *testing.T) {
 		expectedMetricCount int
 		times               bool
 		utilization         bool
-		logicalCount        bool
+		utilizationIndex    int
 	}
+
+	defaultMetrics := metadata.NewDefaultMetricsBuilderConfig()
+	defaultMetrics.Metrics.SystemCPULogicalCount.Enabled = false
 
 	testCases := []testCase{
 		{
 			name:                "Standard",
-			metricsConfig:       metadata.NewDefaultMetricsBuilderConfig(),
-			expectedMetricCount: 2,
+			metricsConfig:       defaultMetrics,
+			expectedMetricCount: 1,
 			times:               true,
 			utilization:         false,
-			logicalCount:        true,
 		},
 		{
 			name:                "SystemCPUTime metric is disabled",
 			times:               false,
 			utilization:         true,
-			logicalCount:        true,
-			expectedMetricCount: 2,
+			expectedMetricCount: 1,
 		},
 		{
 			name:                "all metrics are enabled",
 			times:               true,
 			utilization:         true,
-			logicalCount:        true,
-			expectedMetricCount: 3,
+			expectedMetricCount: 2,
+			utilizationIndex:    1,
 		},
 		{
 			name:                "all metrics are disabled",
@@ -275,7 +274,7 @@ func TestScrape_CpuUtilization(t *testing.T) {
 				settings = metadata.NewDefaultMetricsBuilderConfig()
 				settings.Metrics.SystemCPUTime.Enabled = test.times
 				settings.Metrics.SystemCPUUtilization.Enabled = test.utilization
-				settings.Metrics.SystemCPULogicalCount.Enabled = test.logicalCount
+				settings.Metrics.SystemCPULogicalCount.Enabled = false
 			}
 
 			scraper := newCPUScraper(t.Context(), scrapertest.NewNopSettings(metadata.Type), &Config{MetricsBuilderConfig: settings})
@@ -296,21 +295,18 @@ func TestScrape_CpuUtilization(t *testing.T) {
 			metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 			if test.times {
-				timesMetrics := findMetricByName(t, metrics, "system.cpu.time")
+				timesMetrics := metrics.At(0)
 				assertCPUMetricValid(t, timesMetrics, 0)
 				if runtime.GOOS == "linux" {
 					assertCPUMetricHasLinuxSpecificStateLabels(t, timesMetrics)
 				}
 			}
 			if test.utilization {
-				utilizationMetrics := findMetricByName(t, metrics, "system.cpu.utilization")
+				utilizationMetrics := metrics.At(test.utilizationIndex)
 				assertCPUUtilizationMetricValid(t, utilizationMetrics, 0)
 				if runtime.GOOS == "linux" {
 					assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t, utilizationMetrics)
 				}
-			}
-			if settings.Metrics.SystemCPULogicalCount.Enabled {
-				assertCPULogicalCountMetricValid(t, findMetricByName(t, metrics, "system.cpu.logical.count"))
 			}
 		})
 	}
@@ -430,17 +426,6 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 			assertDatapointValueAndStringAttributes(t, dp.At(idx), expectedDp.val, expectedDp.attrs)
 		}
 	}
-}
-
-func findMetricByName(t *testing.T, metrics pmetric.MetricSlice, name string) pmetric.Metric {
-	for i := 0; i < metrics.Len(); i++ {
-		metric := metrics.At(i)
-		if metric.Name() == name {
-			return metric
-		}
-	}
-	require.Fail(t, "missing metric", "Expected metric %q not found", name)
-	return pmetric.Metric{}
 }
 
 func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberDataPoint, value float64, attrs map[string]string) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -12,6 +12,14 @@ metrics:
     enabled: false
 ```
 
+### system.cpu.logical.count
+
+Number of available logical CPUs.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {cpu} | Sum | Int | Cumulative | false | Development |
+
 ### system.cpu.time
 
 Total seconds each logical CPU spent on each mode.
@@ -50,14 +58,6 @@ Current frequency of the CPU core in Hz.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | cpu | Logical CPU number starting at 0. | Any Str | Recommended | - |
-
-### system.cpu.logical.count
-
-Number of available logical CPUs.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {cpu} | Sum | Int | Cumulative | false | Development |
 
 ### system.cpu.physical.count
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
@@ -211,7 +211,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			EnabledAttributes:   []SystemCPUFrequencyMetricAttributeKey{SystemCPUFrequencyMetricAttributeKeyCPU},
 		},
 		SystemCPULogicalCount: SystemCPULogicalCountMetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		SystemCPUPhysicalCount: SystemCPUPhysicalCountMetricConfig{
 			Enabled: false,

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -75,7 +75,7 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordSystemCPUFrequencyDataPoint(ts, 3, "cpu-val-2")
 			}
-
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemCPULogicalCountDataPoint(ts, 1)
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -33,7 +33,7 @@ metrics:
     attributes: [cpu]
 
   system.cpu.logical.count:
-    enabled: false
+    enabled: true
     description: Number of available logical CPUs.
     unit: "{cpu}"
     stability: development


### PR DESCRIPTION
Enables `system.cpu.logical.count` by default in the hostmetrics CPU scraper. With #49162 making the per-CPU `cpu` attribute opt-in for CPU time and utilization, default CPU metrics should still preserve logical CPU cardinality. This metric is important host information and is recommended by the System CPU semantic conventions.

To restore the previous behavior, disable the new metric by applying the following config:

```yaml
receivers:
  hostmetrics:
    scrapers:
      cpu:
        metrics:
          system.cpu.logical.count:
            enabled: false
```

Marked as breaking because it changes the default emitted telemetry.