### PR TITLE
[chore] : [receiver/prometheusreceiver] Log scrape failure error reason when scraping fails

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -124,9 +124,20 @@ func (t *transaction) addSampleDatapoint(rKey resourceKey, ls labels.Labels, met
 	// But it can also be a staleNaN, which is inserted when the target goes away.
 	if metricName == scrapeUpMetricName && val != 1.0 && !value.IsStaleNaN(val) {
 		if val == 0.0 {
-			t.logger.Warn("Failed to scrape Prometheus endpoint",
-				zap.Int64("scrape_timestamp", atMs),
-				zap.Stringer("target_labels", ls))
+			var scrapeErr error
+			if target, ok := scrape.TargetFromContext(t.ctx); ok {
+				scrapeErr = target.LastError()
+			}
+			if scrapeErr != nil {
+				t.logger.Warn("Failed to scrape Prometheus endpoint",
+					zap.Error(scrapeErr),
+					zap.Int64("scrape_timestamp", atMs),
+					zap.Stringer("target_labels", ls))
+			} else {
+				t.logger.Warn("Failed to scrape Prometheus endpoint",
+					zap.Int64("scrape_timestamp", atMs),
+					zap.Stringer("target_labels", ls))
+			}
 		} else {
 			t.logger.Warn("The 'up' metric contains invalid value",
 				zap.Float64("value", val),

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -2281,4 +2282,57 @@ func TestTransactionAppend(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTransactionAppendFailedScrapeWithReason(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+	receiverSettings := receivertest.NewNopSettings(receivertest.NopType)
+	core, observedLogs := observer.New(zap.WarnLevel)
+	receiverSettings.Logger = zap.New(core)
+
+	scrapeErr := errors.New("connection refused")
+	targetWithErr := scrape.NewTarget(
+		labels.FromMap(map[string]string{
+			model.InstanceLabel: "localhost:8080",
+			model.JobLabel:      "test",
+		}),
+		&config.ScrapeConfig{},
+		map[model.LabelName]model.LabelValue{
+			model.AddressLabel: "address:8080",
+			model.SchemeLabel:  "http",
+		},
+		nil,
+	)
+	targetWithErr.Report(time.Now(), 0, scrapeErr)
+
+	scrapeCtxWithTarget := scrape.ContextWithMetricMetadataStore(
+		scrape.ContextWithTarget(context.Background(), targetWithErr),
+		testMetadataStore(testMetadata))
+
+	tr := newTransaction(
+		scrapeCtxWithTarget,
+		sink,
+		labels.EmptyLabels(),
+		receiverSettings,
+		nopObsRecv(t),
+		false,
+		true,
+	)
+
+	badLabels := labels.FromMap(map[string]string{
+		model.InstanceLabel:   "localhost:8080",
+		model.JobLabel:        "test",
+		model.MetricNameLabel: scrapeUpMetricName,
+	})
+
+	_, err := tr.Append(0, badLabels, 0, time.Now().Unix()*1000, 0.0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, observedLogs.Len())
+	logs := observedLogs.All()
+	assert.Equal(t, "Failed to scrape Prometheus endpoint", logs[0].Message)
+
+	errField, ok := logs[0].ContextMap()["error"]
+	assert.True(t, ok)
+	assert.Equal(t, "connection refused", errField)
 }

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -2306,7 +2306,7 @@ func TestTransactionAppendFailedScrapeWithReason(t *testing.T) {
 	targetWithErr.Report(time.Now(), 0, scrapeErr)
 
 	scrapeCtxWithTarget := scrape.ContextWithMetricMetadataStore(
-		scrape.ContextWithTarget(context.Background(), targetWithErr),
+		scrape.ContextWithTarget(t.Context(), targetWithErr),
 		testMetadataStore(testMetadata))
 
 	tr := newTransaction(


### PR DESCRIPTION
## Description
## Prometheus Scrape Failure Reason Logging

When the Prometheus receiver fails to scrape a target, it currently logs a generic warning statement without detailing the reason for the failure. This PR retrieves the scrape target from context when the `up` metric value is `0.0`, fetches the `LastError()`, and prints it as a structured log error.

## Changes Made

#### [transaction.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/transaction.go)
- Updated `addSampleDatapoint` to fetch target information using `scrape.TargetFromContext(t.ctx)` when the `up` metric is reported as `0.0`.
- Inspected the target's last error via `target.LastError()`.
- Logged the warning with `zap.Error` when a scrape failure reason is available.

#### [transaction_test.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/transaction_test.go)
- Added the unit test `TestTransactionAppendFailedScrapeWithReason` to verify that the logged warning contains the correct scrape failure error message.
- Imported the standard `"errors"` package to construct errors in tests.

## Testing

Added a new unit test `TestTransactionAppendFailedScrapeWithReason` inside `receiver/prometheusreceiver/internal/transaction_test.go` verifying that the error reason is correctly logged.
## Verification Results

### Automated Tests
Ran the unit tests in `receiver/prometheusreceiver/internal` package:
```powershell
go test -v ./internal/... -run TestTransactionAppendFailedScrapeWithReason
```
All tests compiled and passed successfully.
