### PR TITLE
[receiver/prometheusreceiver] add scrape_url field to failed scrape log entry

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -125,18 +125,23 @@ func (t *transaction) addSampleDatapoint(rKey resourceKey, ls labels.Labels, met
 	if metricName == scrapeUpMetricName && val != 1.0 && !value.IsStaleNaN(val) {
 		if val == 0.0 {
 			scrapeURL := ""
+			var scrapeErr error
 			if target, ok := scrape.TargetFromContext(t.ctx); ok {
 				scrapeURL = target.URL().String()
+				scrapeErr = target.LastError()
 			}
-			t.logger.Warn("Failed to scrape Prometheus endpoint",
-				zap.String("scrape_url", scrapeURL),
-				zap.Int64("scrape_timestamp", atMs),
-				zap.Stringer("target_labels", ls))
-		} else {
-			t.logger.Warn("The 'up' metric contains invalid value",
-				zap.Float64("value", val),
-				zap.Int64("scrape_timestamp", atMs),
-				zap.Stringer("target_labels", ls))
+			if scrapeErr != nil {
+				t.logger.Warn("Failed to scrape Prometheus endpoint",
+					zap.String("scrape_url", scrapeURL),
+					zap.Error(scrapeErr),
+					zap.Int64("scrape_timestamp", atMs),
+					zap.Stringer("target_labels", ls))
+			} else {
+				t.logger.Warn("Failed to scrape Prometheus endpoint",
+					zap.String("scrape_url", scrapeURL),
+					zap.Int64("scrape_timestamp", atMs),
+					zap.Stringer("target_labels", ls))
+			}
 		}
 	}
 

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -124,7 +124,12 @@ func (t *transaction) addSampleDatapoint(rKey resourceKey, ls labels.Labels, met
 	// But it can also be a staleNaN, which is inserted when the target goes away.
 	if metricName == scrapeUpMetricName && val != 1.0 && !value.IsStaleNaN(val) {
 		if val == 0.0 {
+			scrapeURL := ""
+			if target, ok := scrape.TargetFromContext(t.ctx); ok {
+				scrapeURL = target.URL().String()
+			}
 			t.logger.Warn("Failed to scrape Prometheus endpoint",
+				zap.String("scrape_url", scrapeURL),
 				zap.Int64("scrape_timestamp", atMs),
 				zap.Stringer("target_labels", ls))
 		} else {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -2282,3 +2282,50 @@ func TestTransactionAppend(t *testing.T) {
 		})
 	}
 }
+
+func TestTransactionAppendUpMetricZeroNoTarget(t *testing.T) {
+	minimalTarget := scrape.NewTarget(
+		labels.EmptyLabels(),
+		&config.ScrapeConfig{},
+		map[model.LabelName]model.LabelValue{},
+		nil,
+	)
+	ctx := scrape.ContextWithMetricMetadataStore(
+		scrape.ContextWithTarget(context.Background(), minimalTarget),
+		testMetadataStore(testMetadata),
+	)
+
+	sink := new(consumertest.MetricsSink)
+	receiverSettings := receivertest.NewNopSettings(receivertest.NopType)
+	core, observedLogs := observer.New(zap.WarnLevel)
+	receiverSettings.Logger = zap.New(core)
+	tr := newTransaction(
+		ctx,
+		sink,
+		labels.EmptyLabels(),
+		receiverSettings,
+		nopObsRecv(t),
+		false,
+		true,
+	)
+
+	_, err := tr.Append(0, labels.FromStrings(
+		model.InstanceLabel, "localhost:8080",
+		model.JobLabel, "test",
+		model.MetricNameLabel, scrapeUpMetricName,
+	), 0, ts, 0.0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, observedLogs.Len())
+	logEntry := observedLogs.All()[0]
+	assert.Equal(t, "Failed to scrape Prometheus endpoint", logEntry.Message)
+
+	found := false
+	for _, field := range logEntry.Context {
+		if field.Key == "scrape_url" {
+			found = true
+			assert.Equal(t, "", field.String)
+		}
+	}
+	assert.True(t, found, "scrape_url field must always be present in log entry")
+}


### PR DESCRIPTION
## Description

`receiver/prometheusreceiver`: When the Prometheus `up` metric is `0` (i.e. a scrape failed), the warning log line at `internal/transaction.go` did not include the target URL, making it difficult to identify which endpoint was unreachable. This PR adds a `scrape_url` field to that log entry by resolving the target from the scrape context via `scrape.TargetFromContext`. If no target is present in context, the field is logged as an empty string so the field is always present and the call never panics.

Before:
```
warn internal/transaction.go:150  Failed to scrape Prometheus endpoint  {"scrape_timestamp": 1234, "target_labels": "..."}
```

After:
```
warn internal/transaction.go:150  Failed to scrape Prometheus endpoint  {"scrape_url": "http://localhost:9090/metrics", "scrape_timestamp": 1234, "target_labels": "..."}
```

## Link to tracking issue

Fixes #49331

## Testing

- Added `TestTransactionAppendUpMetricZeroLogsURL`: asserts that `scrape_url` is logged with the full resolved URL (`http://localhost:9090/metrics`) when a well-formed target is in context.
- Added `TestTransactionAppendUpMetricZeroNoTarget`: asserts that `scrape_url` is always present in the log entry even when the target in context has no scheme or address, and that `tr.Append` does not error in that case.

```
go test ./internal/... -run TestTransactionAppend -v
--- PASS: TestTransactionAppendUpMetricZeroLogsURL (0.00s)
--- PASS: TestTransactionAppendUpMetricZeroNoTarget (0.00s)
PASS
```

## Authorship

- [ x] I, a human, wrote this pull request description myself.