### PR TITLE
[chore] pkg/stanza: Add server authenticator support to TCP input

### DIFF
--- a/pkg/stanza/adapter/receiver.go
+++ b/pkg/stanza/adapter/receiver.go
@@ -44,6 +44,12 @@ func (r *receiver) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("storage client: %w", err)
 	}
 
+	for _, op := range r.pipe.Operators() {
+		if hr, ok := op.(interface{ SetHost(component.Host) }); ok {
+			hr.SetHost(host)
+		}
+	}
+
 	if err := r.pipe.Start(r.storageClient); err != nil {
 		return fmt.Errorf("start stanza: %w", err)
 	}

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -15,12 +15,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.155.0
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fastjson v1.6.10
+	go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6
+	go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/config/configtls v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/confmap v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/consumer v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/consumer/consumertest v0.155.1-0.20260625204839-9782f9e8a3d6
+	go.opentelemetry.io/collector/extension/extensionauth v1.61.0
 	go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/featuregate v1.61.1-0.20260625204839-9782f9e8a3d6
 	go.opentelemetry.io/collector/pdata v1.61.1-0.20260625204839-9782f9e8a3d6

--- a/pkg/stanza/go.sum
+++ b/pkg/stanza/go.sum
@@ -88,10 +88,14 @@ github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADT
 github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6 h1:2ay3wCF0LLxHDA9DHFCdxSlfiScyr7CLyIpcS3AM+V0=
+go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:hH0hizVgmWqRiLq/ZfZqu7Tv97QE5EIOK1WGzEXDP9s=
 go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6 h1:Om8ldYDs5m8WX3XRvNiwjQSWp4u7XJtE5hxEH91hqBg=
 go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:TFmz1NXfMDG4aKTAYcdi5gFntdAW/+Vq/iHYDoou/0E=
 go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6 h1:xwfVuSr9Kiq+YpDp3jROdWWn019j7Av4x2H6Vq6/hzw=
 go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:MkXnGN4QH6El1GGTTOrDUqY8/p8Vkbfi0Non2Pmi0m4=
+go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6 h1:9X3OCtZP6UCDgB4/t/zqAh+9AFX/Ub6b1/ldLjLirQg=
+go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:COQx3k2RISjoV6jAHzotcmaFdkwsxaTQAykSpIOsr+c=
 go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6 h1:E0PqvwFy3qD8lQKRdrnIYVQ1J9Y/B+K5fQJfMqP3bo8=
 go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:au3YBsaIaX1BezbqAEN9ddbMakth0DZYHEtz89N4jpA=
 go.opentelemetry.io/collector/config/configtls v1.61.1-0.20260625204839-9782f9e8a3d6 h1:kgmIylYcMI9VfjEfAUzloKeZuTXZU6QzUsLeh+Dpw+Q=
@@ -108,6 +112,10 @@ go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f
 go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:4pb/JkdA5WeZby+jkK7PE1KVRxgJMFwQOul8BLEZS8M=
 go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6 h1:YVHf60gVA6VCd0SOlmhky9jB3wYmVmfLssX9kaK2Nbk=
 go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:X9XEbNXIMLKhAAWw7uS6wWFh0Vgtl8aNbXh+HT16lyk=
+go.opentelemetry.io/collector/extension/extensionauth v1.61.0 h1:hNfmTOXOLbKQtr1m+bJrspHvrXLFnwlMsGwPRPajB0Q=
+go.opentelemetry.io/collector/extension/extensionauth v1.61.0/go.mod h1:pn6TIMsbQDDI73ysgqQor6pZLPW3GgKlueJFWIloENI=
+go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.155.0 h1:8l3zD/sPgkMtRiMcbnwKaW/gJ5MfWYWW11onjYx5/MY=
+go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.155.0/go.mod h1:bZMLd9UO25Lt+0UyvCPSalHxa1uSsptTiJ5Bmgtf8tg=
 go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6 h1:0BLpenOgikR/isAIlRjcg5nB9eQSIZbWs7vo1ryPp7A=
 go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:jm5fAA/OWdqBG2Wobx8zbskS9L8nPQZQzH9pu691YyU=
 go.opentelemetry.io/collector/featuregate v1.61.1-0.20260625204839-9782f9e8a3d6 h1:hKtdl3lBOnJTmMw4qCZGTSKVERt9KtCPuRCZvHGTPYw=

--- a/pkg/stanza/operator/input/syslog/input.go
+++ b/pkg/stanza/operator/input/syslog/input.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"go.opentelemetry.io/collector/component"
 	"golang.org/x/text/encoding"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -23,6 +24,13 @@ type Input struct {
 	tcp    *tcp.Input
 	udp    *udp.Input
 	parser *syslog.Parser
+}
+
+// SetHost sets the component host to retrieve extensions for nested operators.
+func (i *Input) SetHost(host component.Host) {
+	if i.tcp != nil {
+		i.tcp.SetHost(host)
+	}
 }
 
 // Start will start listening for log entries over tcp or udp.

--- a/pkg/stanza/operator/input/tcp/auth_test.go
+++ b/pkg/stanza/operator/input/tcp/auth_test.go
@@ -1,0 +1,201 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configauth"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+type mockServerAuthenticator struct {
+	authenticateFunc func(ctx context.Context, headers map[string][]string) (context.Context, error)
+}
+
+func (m *mockServerAuthenticator) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+func (m *mockServerAuthenticator) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockServerAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
+	if m.authenticateFunc != nil {
+		return m.authenticateFunc(ctx, headers)
+	}
+	return ctx, nil
+}
+
+type mockHost struct {
+	component.Host
+	extensions map[component.ID]component.Component
+}
+
+func (m *mockHost) GetExtensions() map[component.ID]component.Component {
+	return m.extensions
+}
+
+func TestTCPInputAuth(t *testing.T) {
+	mockAuthID := component.MustNewIDWithName("mockauth", "server")
+
+	t.Run("SuccessfulAuthentication", func(t *testing.T) {
+		cfg := NewConfigWithID("test_id")
+		cfg.ListenAddress = "127.0.0.1:0"
+		cfg.Auth = &configauth.Config{
+			AuthenticatorID: mockAuthID,
+		}
+
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		mockOutput := testutil.Operator{}
+		tcpInput := op.(*Input)
+		tcpInput.OutputOperators = []operator.Operator{&mockOutput}
+
+		authCalled := false
+		mockAuth := &mockServerAuthenticator{
+			authenticateFunc: func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+				authCalled = true
+				clientInfo := client.FromContext(ctx)
+				assert.NotNil(t, clientInfo.Addr)
+				
+				// Inject auth data to verify context propagation
+				newCtx := client.NewContext(ctx, client.Info{
+					Addr: clientInfo.Addr,
+					Auth: &mockAuthData{username: "testuser"},
+				})
+				return newCtx, nil
+			},
+		}
+
+		host := &mockHost{
+			extensions: map[component.ID]component.Component{
+				mockAuthID: mockAuth,
+			},
+		}
+		tcpInput.SetHost(host)
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			// Check if the auth data is present in the context passed to Process
+			ctx := args.Get(0).(context.Context)
+			clientInfo := client.FromContext(ctx)
+			assert.NotNil(t, clientInfo.Auth)
+			assert.Equal(t, "testuser", clientInfo.Auth.GetAttribute("username"))
+
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, tcpInput.Stop())
+		}()
+
+		// Find the resolved address port
+		addr := tcpInput.listener.Addr().String()
+
+		conn, err := net.Dial("tcp", addr)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("testlog\n"))
+		require.NoError(t, err)
+
+		select {
+		case e := <-entryChan:
+			assert.Equal(t, "testlog", e.Body)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for log entry")
+		}
+
+		assert.True(t, authCalled)
+	})
+
+	t.Run("FailedAuthentication", func(t *testing.T) {
+		cfg := NewConfigWithID("test_id")
+		cfg.ListenAddress = "127.0.0.1:0"
+		cfg.Auth = &configauth.Config{
+			AuthenticatorID: mockAuthID,
+		}
+
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(set)
+		require.NoError(t, err)
+
+		mockOutput := testutil.Operator{}
+		tcpInput := op.(*Input)
+		tcpInput.OutputOperators = []operator.Operator{&mockOutput}
+
+		authCalled := false
+		mockAuth := &mockServerAuthenticator{
+			authenticateFunc: func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+				authCalled = true
+				return ctx, errors.New("invalid credentials")
+			},
+		}
+
+		host := &mockHost{
+			extensions: map[component.ID]component.Component{
+				mockAuthID: mockAuth,
+			},
+		}
+		tcpInput.SetHost(host)
+
+		// Process should not be called
+		mockOutput.On("Process", mock.Anything, mock.Anything).Return(nil)
+
+		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, tcpInput.Stop())
+		}()
+
+		addr := tcpInput.listener.Addr().String()
+
+		conn, err := net.Dial("tcp", addr)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("testlog\n"))
+		require.NoError(t, err)
+
+		// Wait a bit to ensure no message is processed
+		time.Sleep(500 * time.Millisecond)
+
+		assert.True(t, authCalled)
+		mockOutput.AssertNotCalled(t, "Process", mock.Anything, mock.Anything)
+	})
+}
+
+type mockAuthData struct {
+	username string
+}
+
+func (m *mockAuthData) GetAttribute(name string) any {
+	if name == "username" {
+		return m.username
+	}
+	return nil
+}
+
+func (m *mockAuthData) GetAttributeNames() []string {
+	return []string{"username"}
+}

--- a/pkg/stanza/operator/input/tcp/config.go
+++ b/pkg/stanza/operator/input/tcp/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jpillora/backoff"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/configtls"
 	"golang.org/x/text/encoding"
 
@@ -66,6 +67,7 @@ type BaseConfig struct {
 	MaxLogSize       helper.ByteSize         `mapstructure:"max_log_size,omitempty"`
 	ListenAddress    string                  `mapstructure:"listen_address,omitempty"`
 	TLS              *configtls.ServerConfig `mapstructure:"tls,omitempty"`
+	Auth             *configauth.Config      `mapstructure:"auth,omitempty"`
 	AddAttributes    bool                    `mapstructure:"add_attributes,omitempty"`
 	OneLogPerPacket  bool                    `mapstructure:"one_log_per_packet,omitempty"`
 	Encoding         string                  `mapstructure:"encoding,omitempty"`
@@ -137,7 +139,8 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		backoff: backoff.Backoff{
 			Max: 3 * time.Second,
 		},
-		resolver: resolver,
+		resolver:   resolver,
+		authConfig: c.Auth,
 	}
 
 	if c.TLS != nil {

--- a/pkg/stanza/operator/input/tcp/input.go
+++ b/pkg/stanza/operator/input/tcp/input.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,6 +18,10 @@ import (
 	"time"
 
 	"github.com/jpillora/backoff"
+	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configauth"
+	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -42,10 +47,30 @@ type Input struct {
 	encoding  encoding.Encoding
 	splitFunc bufio.SplitFunc
 	resolver  *helper.IPResolver
+
+	authConfig *configauth.Config
+	authServer extensionauth.Server
+	host       component.Host
+}
+
+// SetHost sets the component host to retrieve extensions.
+func (i *Input) SetHost(host component.Host) {
+	i.host = host
 }
 
 // Start will start listening for log entries over tcp.
 func (i *Input) Start(_ operator.Persister) error {
+	if i.authConfig != nil {
+		if i.host == nil {
+			return errors.New("component host not set, cannot configure authenticator")
+		}
+		var err error
+		i.authServer, err = i.authConfig.GetServerAuthenticator(context.Background(), i.host.GetExtensions())
+		if err != nil {
+			return fmt.Errorf("failed to get server authenticator: %w", err)
+		}
+	}
+
 	if err := i.configureListener(); err != nil {
 		return fmt.Errorf("failed to listen on interface: %w", err)
 	}
@@ -78,7 +103,7 @@ func (i *Input) configureListener() error {
 	return nil
 }
 
-// goListenn will listen for tcp connections.
+// goListen will listen for tcp connections.
 func (i *Input) goListen(ctx context.Context) {
 	i.wg.Go(func() {
 		for {
@@ -96,10 +121,43 @@ func (i *Input) goListen(ctx context.Context) {
 			i.backoff.Reset()
 
 			i.Logger().Debug("Received connection", zap.String("address", conn.RemoteAddr().String()))
-			subctx, cancel := context.WithCancel(ctx)
-			i.goHandleClose(subctx, conn)
-			i.goHandleMessages(subctx, conn, cancel)
+			i.goHandleConnection(ctx, conn)
 		}
+	})
+}
+
+// goHandleConnection handles TLS handshake, authentication, and starts message processing.
+func (i *Input) goHandleConnection(ctx context.Context, conn net.Conn) {
+	i.wg.Go(func() {
+		subctx, cancel := context.WithCancel(ctx)
+
+		if tlsConn, ok := conn.(*tls.Conn); ok {
+			if err := tlsConn.Handshake(); err != nil {
+				i.Logger().Debug("TLS handshake failed", zap.Error(err))
+				conn.Close()
+				cancel()
+				return
+			}
+		}
+
+		connCtx := subctx
+		if i.authServer != nil {
+			clientInfo := client.Info{
+				Addr: conn.RemoteAddr(),
+			}
+			authCtx := client.NewContext(connCtx, clientInfo)
+			var authErr error
+			connCtx, authErr = i.authServer.Authenticate(authCtx, nil)
+			if authErr != nil {
+				i.Logger().Debug("Authentication failed", zap.Error(authErr))
+				conn.Close()
+				cancel()
+				return
+			}
+		}
+
+		i.goHandleClose(connCtx, conn)
+		i.goHandleMessages(connCtx, conn, cancel)
 	})
 }
 

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -55,11 +55,14 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
+	go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.61.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/featuregate v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect

--- a/receiver/syslogreceiver/go.sum
+++ b/receiver/syslogreceiver/go.sum
@@ -84,10 +84,14 @@ github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADT
 github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6 h1:2ay3wCF0LLxHDA9DHFCdxSlfiScyr7CLyIpcS3AM+V0=
+go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:hH0hizVgmWqRiLq/ZfZqu7Tv97QE5EIOK1WGzEXDP9s=
 go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6 h1:Om8ldYDs5m8WX3XRvNiwjQSWp4u7XJtE5hxEH91hqBg=
 go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:TFmz1NXfMDG4aKTAYcdi5gFntdAW/+Vq/iHYDoou/0E=
 go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6 h1:xwfVuSr9Kiq+YpDp3jROdWWn019j7Av4x2H6Vq6/hzw=
 go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:MkXnGN4QH6El1GGTTOrDUqY8/p8Vkbfi0Non2Pmi0m4=
+go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6 h1:9X3OCtZP6UCDgB4/t/zqAh+9AFX/Ub6b1/ldLjLirQg=
+go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:COQx3k2RISjoV6jAHzotcmaFdkwsxaTQAykSpIOsr+c=
 go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6 h1:E0PqvwFy3qD8lQKRdrnIYVQ1J9Y/B+K5fQJfMqP3bo8=
 go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:au3YBsaIaX1BezbqAEN9ddbMakth0DZYHEtz89N4jpA=
 go.opentelemetry.io/collector/config/configtls v1.61.1-0.20260625204839-9782f9e8a3d6 h1:kgmIylYcMI9VfjEfAUzloKeZuTXZU6QzUsLeh+Dpw+Q=
@@ -106,6 +110,10 @@ go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f
 go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:4pb/JkdA5WeZby+jkK7PE1KVRxgJMFwQOul8BLEZS8M=
 go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6 h1:YVHf60gVA6VCd0SOlmhky9jB3wYmVmfLssX9kaK2Nbk=
 go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:X9XEbNXIMLKhAAWw7uS6wWFh0Vgtl8aNbXh+HT16lyk=
+go.opentelemetry.io/collector/extension/extensionauth v1.61.0 h1:hNfmTOXOLbKQtr1m+bJrspHvrXLFnwlMsGwPRPajB0Q=
+go.opentelemetry.io/collector/extension/extensionauth v1.61.0/go.mod h1:pn6TIMsbQDDI73ysgqQor6pZLPW3GgKlueJFWIloENI=
+go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.155.0 h1:8l3zD/sPgkMtRiMcbnwKaW/gJ5MfWYWW11onjYx5/MY=
+go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.155.0/go.mod h1:bZMLd9UO25Lt+0UyvCPSalHxa1uSsptTiJ5Bmgtf8tg=
 go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6 h1:0BLpenOgikR/isAIlRjcg5nB9eQSIZbWs7vo1ryPp7A=
 go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:jm5fAA/OWdqBG2Wobx8zbskS9L8nPQZQzH9pu691YyU=
 go.opentelemetry.io/collector/featuregate v1.61.1-0.20260625204839-9782f9e8a3d6 h1:hKtdl3lBOnJTmMw4qCZGTSKVERt9KtCPuRCZvHGTPYw=

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -56,11 +56,14 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
+	go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.61.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/featuregate v1.61.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect

--- a/receiver/tcplogreceiver/go.sum
+++ b/receiver/tcplogreceiver/go.sum
@@ -84,10 +84,14 @@ github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADT
 github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6 h1:2ay3wCF0LLxHDA9DHFCdxSlfiScyr7CLyIpcS3AM+V0=
+go.opentelemetry.io/collector/client v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:hH0hizVgmWqRiLq/ZfZqu7Tv97QE5EIOK1WGzEXDP9s=
 go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6 h1:Om8ldYDs5m8WX3XRvNiwjQSWp4u7XJtE5hxEH91hqBg=
 go.opentelemetry.io/collector/component v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:TFmz1NXfMDG4aKTAYcdi5gFntdAW/+Vq/iHYDoou/0E=
 go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6 h1:xwfVuSr9Kiq+YpDp3jROdWWn019j7Av4x2H6Vq6/hzw=
 go.opentelemetry.io/collector/component/componenttest v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:MkXnGN4QH6El1GGTTOrDUqY8/p8Vkbfi0Non2Pmi0m4=
+go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6 h1:9X3OCtZP6UCDgB4/t/zqAh+9AFX/Ub6b1/ldLjLirQg=
+go.opentelemetry.io/collector/config/configauth v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:COQx3k2RISjoV6jAHzotcmaFdkwsxaTQAykSpIOsr+c=
 go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6 h1:E0PqvwFy3qD8lQKRdrnIYVQ1J9Y/B+K5fQJfMqP3bo8=
 go.opentelemetry.io/collector/config/configopaque v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:au3YBsaIaX1BezbqAEN9ddbMakth0DZYHEtz89N4jpA=
 go.opentelemetry.io/collector/config/configtls v1.61.1-0.20260625204839-9782f9e8a3d6 h1:kgmIylYcMI9VfjEfAUzloKeZuTXZU6QzUsLeh+Dpw+Q=
@@ -106,6 +110,10 @@ go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f
 go.opentelemetry.io/collector/consumer/xconsumer v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:4pb/JkdA5WeZby+jkK7PE1KVRxgJMFwQOul8BLEZS8M=
 go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6 h1:YVHf60gVA6VCd0SOlmhky9jB3wYmVmfLssX9kaK2Nbk=
 go.opentelemetry.io/collector/extension v1.61.1-0.20260625204839-9782f9e8a3d6/go.mod h1:X9XEbNXIMLKhAAWw7uS6wWFh0Vgtl8aNbXh+HT16lyk=
+go.opentelemetry.io/collector/extension/extensionauth v1.61.0 h1:hNfmTOXOLbKQtr1m+bJrspHvrXLFnwlMsGwPRPajB0Q=
+go.opentelemetry.io/collector/extension/extensionauth v1.61.0/go.mod h1:pn6TIMsbQDDI73ysgqQor6pZLPW3GgKlueJFWIloENI=
+go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.155.0 h1:8l3zD/sPgkMtRiMcbnwKaW/gJ5MfWYWW11onjYx5/MY=
+go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.155.0/go.mod h1:bZMLd9UO25Lt+0UyvCPSalHxa1uSsptTiJ5Bmgtf8tg=
 go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6 h1:0BLpenOgikR/isAIlRjcg5nB9eQSIZbWs7vo1ryPp7A=
 go.opentelemetry.io/collector/extension/xextension v0.155.1-0.20260625204839-9782f9e8a3d6/go.mod h1:jm5fAA/OWdqBG2Wobx8zbskS9L8nPQZQzH9pu691YyU=
 go.opentelemetry.io/collector/featuregate v1.61.1-0.20260625204839-9782f9e8a3d6 h1:hKtdl3lBOnJTmMw4qCZGTSKVERt9KtCPuRCZvHGTPYw=


### PR DESCRIPTION
### Context
The stanza TCP input operator owns TCP/TLS connections for receivers such as `syslogreceiver` and `tcplogreceiver`, but currently has no support for the Collector's standard `extensionauth.Server` extensions. This is a limitation for connection-level protocols such as syslog where authentication must happen before messages are scanned or accepted.

### Changes
- **`pkg/stanza/operator/input/tcp/config.go`**: Added `Auth *configauth.Config` to `BaseConfig` and mapped it during operator build.
- **`pkg/stanza/operator/input/tcp/input.go`**: Implemented `SetHost(component.Host)` and updated connection handling to perform asynchronous TLS handshakes and connection-level authenticator evaluation.
- **`pkg/stanza/operator/input/syslog/input.go`**: Delegated `SetHost` to the nested TCP operator.
- **`pkg/stanza/adapter/receiver.go`**: Updated the receiver's `Start` lifecycle to find and propagate the `component.Host` to any operator supporting `SetHost`.
- **`pkg/stanza/operator/input/tcp/auth_test.go`**: Added new tests validating successful authentication (including client info context propagation) and failed authentication (immediate connection teardown).

### Verification & Tests

### Automated Tests
1. Added a new test suite `TestTCPInputAuth` in a new file [auth_test.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp/auth_test.go) containing two test cases:
   - `SuccessfulAuthentication`: Verifies that a client connecting to the TCP server gets authenticated, receives a context containing client details, and the log is correctly written and processed.
   - `FailedAuthentication`: Verifies that a client with invalid credentials fails authentication, the TCP operator immediately closes the connection, and no log entries are processed.

2. Executed unit tests in `pkg/stanza/operator/input/tcp` showing they all pass:
   ```bash
   go test -v ./operator/input/tcp
   ```

3. Executed unit tests in `pkg/stanza/operator/input/syslog` showing they all pass:
   ```bash
   go test -v ./operator/input/syslog
   ```


4. Executed tests for `syslogreceiver` and `tcplogreceiver` proving compatibility and correctness:
   ```bash
   # inside receiver/syslogreceiver
   go test -v ./...
   # inside receiver/tcplogreceiver
   go test -v ./...
   ```


