### PR TITLE
[processor/cumulativetodelta] Align reset behavior for all histogram types and check bucket count resets

### DIFF
--- a/.chloggen/mx-psi_detect-bucket-count-reset.yaml
+++ b/.chloggen/mx-psi_detect-bucket-count-reset.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/cumulativetodelta
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Align reset detection and dropping on histograms and exponential histograms
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48278]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Histograms and exponential histograms where there is a drop in total count or on any bucket counts are now treated as a reset and dropped.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -195,15 +195,26 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool, rea
 
 		delta := value.Clone()
 
-		// Calculate deltas unless histogram count was reset
-		if valid && delta.Count >= prevValue.Count {
+		// Calculate deltas unless there was a reset.
+		if valid {
+			// Detect a reset when there is a drop in the total count OR a bucket count.
+			isReset := delta.Count < prevValue.Count
+			if !isReset {
+				for index, prevBucket := range prevValue.BucketCounts {
+					if delta.BucketCounts[index] < prevBucket {
+						isReset = true
+						break
+					}
+				}
+			}
+			if isReset {
+				return out, false, ReasonReset
+			}
 			delta.Count -= prevValue.Count
 			delta.Sum -= prevValue.Sum
 			for index, prevBucket := range prevValue.BucketCounts {
 				delta.BucketCounts[index] -= prevBucket
 			}
-		} else if valid {
-			reason = ReasonReset
 		}
 
 		out.HistogramValue = &delta
@@ -242,8 +253,15 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool, rea
 			prevValue.Positive = prevValue.Positive.Coarsen(bitsLost)
 			prevValue.Negative = prevValue.Negative.Coarsen(bitsLost)
 		}
-		delta.Positive = value.Positive.Diff(&prevValue.Positive)
-		delta.Negative = value.Negative.Diff(&prevValue.Negative)
+		var reset bool
+		delta.Positive, reset = value.Positive.Diff(&prevValue.Positive)
+		if reset {
+			return out, false, ReasonReset
+		}
+		delta.Negative, reset = value.Negative.Diff(&prevValue.Negative)
+		if reset {
+			return out, false, ReasonReset
+		}
 
 		out.ExponentialHistogramPoint = &delta
 

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -114,6 +114,22 @@ func (t *MetricTracker) Streams() int64 {
 	return t.streams.Load()
 }
 
+// isMonotonicHistogram reports if a histogram is monotonic.
+// A histogram is not monotonic when there is a drop in the total count or a bucket count.
+func isMonotonicHistogram(value, prevValue *HistogramPoint) bool {
+	if value.Count < prevValue.Count {
+		return false
+	}
+
+	for index, prevBucket := range prevValue.BucketCounts {
+		if value.BucketCounts[index] < prevBucket {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool, reason string) {
 	metricID := in.Identity
 	metricPoint := in.Value
@@ -197,17 +213,7 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool, rea
 
 		// Calculate deltas unless there was a reset.
 		if valid {
-			// Detect a reset when there is a drop in the total count OR a bucket count.
-			isReset := delta.Count < prevValue.Count
-			if !isReset {
-				for index, prevBucket := range prevValue.BucketCounts {
-					if delta.BucketCounts[index] < prevBucket {
-						isReset = true
-						break
-					}
-				}
-			}
-			if isReset {
+			if !isMonotonicHistogram(&delta, prevValue) {
 				return out, false, ReasonReset
 			}
 			delta.Count -= prevValue.Count

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -268,6 +268,55 @@ func TestMetricTracker_Convert(t *testing.T) {
 	})
 }
 
+func TestMetricTracker_ConvertHistogramReset(t *testing.T) {
+	miHist := MetricIdentity{
+		Resource:               pcommon.NewResource(),
+		InstrumentationLibrary: pcommon.NewInstrumentationScope(),
+		MetricType:             pmetric.MetricTypeHistogram,
+		MetricName:             "hist",
+		Attributes:             pcommon.NewMap(),
+	}
+
+	now := pcommon.NewTimestampFromTime(time.Now())
+	point := func(count uint64, sum float64, buckets []uint64) MetricPoint {
+		return MetricPoint{
+			Identity: miHist,
+			Value: ValuePoint{
+				ObservedTimestamp: now,
+				HistogramValue: &HistogramPoint{
+					Count:        count,
+					Sum:          sum,
+					BucketBounds: []float64{1, 2},
+					BucketCounts: buckets,
+				},
+			},
+		}
+	}
+
+	// Setup tracker and initial point.
+	m := NewMetricTracker(t.Context(), zap.NewNop(), 0, InitialValueKeep)
+	out, valid, _ := m.Convert(point(10, 5, []uint64{4, 6}))
+	require.True(t, valid)
+	assert.Equal(t, []uint64{4, 6}, out.HistogramValue.BucketCounts)
+
+	// Bucket count drops.
+	_, valid, reason := m.Convert(point(11, 6, []uint64{2, 9}))
+	require.False(t, valid)
+	assert.Equal(t, ReasonReset, reason)
+
+	// Setup tracker and initial point.
+	m = NewMetricTracker(t.Context(), zap.NewNop(), 0, InitialValueKeep)
+	out, valid, _ = m.Convert(point(10, 5, []uint64{4, 6}))
+	require.True(t, valid)
+	assert.Equal(t, []uint64{4, 6}, out.HistogramValue.BucketCounts)
+
+	// Monotonic increase.
+	out, valid, _ = m.Convert(point(15, 10, []uint64{4, 11}))
+	require.True(t, valid)
+	assert.Equal(t, uint64(5), out.HistogramValue.Count)
+	assert.Equal(t, []uint64{0, 5}, out.HistogramValue.BucketCounts)
+}
+
 func Test_metricTracker_removeStale(t *testing.T) {
 	currentTime := pcommon.Timestamp(100)
 	freshPoint := ValuePoint{

--- a/processor/cumulativetodeltaprocessor/internal/tracking/value.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/value.go
@@ -71,7 +71,7 @@ func (buckets *ExponentialBuckets) TrimZeros(thresholdBucket int32) uint64 {
 }
 
 // Diff computes the delta between two sets of buckets with the same scale.
-func (buckets *ExponentialBuckets) Diff(old *ExponentialBuckets) (out ExponentialBuckets) {
+func (buckets *ExponentialBuckets) Diff(old *ExponentialBuckets) (out ExponentialBuckets, reset bool) {
 	for index, bucketCount := range buckets.BucketCounts {
 		if bucketCount == 0 {
 			continue
@@ -82,9 +82,11 @@ func (buckets *ExponentialBuckets) Diff(old *ExponentialBuckets) (out Exponentia
 		if oldIndex >= 0 && oldIndex < len(old.BucketCounts) {
 			oldCount = old.BucketCounts[oldIndex]
 		}
-		if bucketCount <= oldCount {
-			// bucketCount < oldCount is a monotonicity error, we'll consider the diff to be zero as fallback
+		if bucketCount == oldCount {
 			continue
+		} else if bucketCount < oldCount {
+			// reset happened
+			return out, true
 		}
 		diff := bucketCount - oldCount
 		if out.BucketCounts == nil {
@@ -96,7 +98,7 @@ func (buckets *ExponentialBuckets) Diff(old *ExponentialBuckets) (out Exponentia
 		}
 		out.BucketCounts = append(out.BucketCounts, diff)
 	}
-	return out
+	return out, false
 }
 
 type ExponentialHistogramPoint struct {

--- a/processor/cumulativetodeltaprocessor/internal/tracking/value_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/value_test.go
@@ -15,6 +15,7 @@ func TestExponentialBuckets_Diff(t *testing.T) {
 		current ExponentialBuckets
 		old     ExponentialBuckets
 		want    ExponentialBuckets
+		reset   bool
 	}{
 		{
 			name: "sparse buckets without previous",
@@ -62,7 +63,7 @@ func TestExponentialBuckets_Diff(t *testing.T) {
 			},
 		},
 		{
-			name: "monotonicity fallback keeps later valid bucket",
+			name: "monotonicity failure means a reset",
 			current: ExponentialBuckets{
 				Offset:       0,
 				BucketCounts: []uint64{1, 2, 1, 5},
@@ -71,13 +72,10 @@ func TestExponentialBuckets_Diff(t *testing.T) {
 				Offset:       0,
 				BucketCounts: []uint64{1, 3, 2, 3},
 			},
-			want: ExponentialBuckets{
-				Offset:       3,
-				BucketCounts: []uint64{2},
-			},
+			reset: true,
 		},
 		{
-			name: "empty when all buckets are non-increasing",
+			name: "reset when all buckets are non-increasing",
 			current: ExponentialBuckets{
 				Offset:       10,
 				BucketCounts: []uint64{0, 1},
@@ -86,7 +84,7 @@ func TestExponentialBuckets_Diff(t *testing.T) {
 				Offset:       10,
 				BucketCounts: []uint64{0, 2},
 			},
-			want: ExponentialBuckets{},
+			reset: true,
 		},
 		{
 			name: "negative offsets",
@@ -122,8 +120,11 @@ func TestExponentialBuckets_Diff(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.current.Diff(&tc.old)
-			assert.Equal(t, tc.want, got)
+			got, reset := tc.current.Diff(&tc.old)
+			assert.Equal(t, tc.reset, reset)
+			if !reset {
+				assert.Equal(t, tc.want, got)
+			}
 		})
 	}
 }

--- a/processor/cumulativetodeltaprocessor/processor_telemetry_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_telemetry_test.go
@@ -60,22 +60,20 @@ func TestProcessorTelemetry(t *testing.T) {
 		{
 			// Three histogram points: first is the baseline (initial drop),
 			// second is a valid conversion, third's count drops below the
-			// previous one which counts as a reset. Note that for histograms
-			// the reset point is forwarded with the full cumulative value as
-			// if it were a delta (the conversion counter is incremented and
-			// no drop is recorded). This is incorrect behavior — see #48278
-			name: "histogram: reset does not drop",
+			// previous one which counts as a reset.
+			name: "histogram: reset drops",
 			inputs: []pmetric.Metrics{
 				newHistogramMetrics("metric_1", now, 0, 10, 100, []uint64{10}),
 				newHistogramMetrics("metric_1", now, 1, 20, 200, []uint64{20}),
 				newHistogramMetrics("metric_1", now, 2, 5, 50, []uint64{5}),
 			},
 			wantConv: []metricdata.DataPoint[int64]{
-				{Attributes: histAttrs, Value: 2},
+				{Attributes: histAttrs, Value: 1},
 			},
 			wantStrm: []metricdata.DataPoint[int64]{{Value: 1}},
 			wantDrop: []metricdata.DataPoint[int64]{
 				{Attributes: dropAttrs("histogram", "initial"), Value: 1},
+				{Attributes: dropAttrs("histogram", "reset"), Value: 1},
 			},
 		},
 		{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Checks on both exponential histograms and histograms if there is a bucket count reset
- Drops Histogram points when a reset is detected by either total or bucket count

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48278

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit test, updated existing test suite

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

(PR itself is assisted by Claude Opus 4.8)

<!--Please delete paragraphs that you did not use before submitting.-->
