### PR TITLE
[receiver/httpcheck] Use confighttp defaulting constructor

### DIFF
--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -69,9 +69,9 @@ func (cfg *targetConfig) Unmarshal(conf *confmap.Conf) error {
 	}
 	cfg.ClientConfig = confighttp.NewDefaultClientConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	cfg.ClientConfig.MaxIdleConns = 0
-	cfg.ClientConfig.IdleConnTimeout = 0
-	cfg.ClientConfig.ForceAttemptHTTP2 = false
+	cfg.MaxIdleConns = 0
+	cfg.IdleConnTimeout = 0
+	cfg.ForceAttemptHTTP2 = false
 	return conf.Unmarshal(cfg)
 }
 

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -57,6 +58,21 @@ type targetConfig struct {
 	Body                    string             `mapstructure:"body"`              // Request body content
 	AutoContentType         bool               `mapstructure:"auto_content_type"` // Whether to automatically set Content-Type based on body
 	Validations             []validationConfig `mapstructure:"validations"`       // Response validation rules
+}
+
+// Unmarshal seeds the embedded ClientConfig with the confighttp defaults before
+// decoding the user-provided configuration. Each target is created by decoding a
+// list element, so without this the embedded ClientConfig would be a zero value.
+func (cfg *targetConfig) Unmarshal(conf *confmap.Conf) error {
+	if conf == nil {
+		return nil
+	}
+	cfg.ClientConfig = confighttp.NewDefaultClientConfig()
+	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
+	cfg.ClientConfig.MaxIdleConns = 0
+	cfg.ClientConfig.IdleConnTimeout = 0
+	cfg.ClientConfig.ForceAttemptHTTP2 = false
+	return conf.Unmarshal(cfg)
 }
 
 // Validate validates an individual targetConfig.


### PR DESCRIPTION
#### Description

The receiver creates a confighttp client for each target. The targets are an array, so during unmarshalling, they get zero values of confighttp.ClientConfig, which isn't correct. Use a custom unmarshaller to inject values from the ClientConfig defaulting constructor. The injected values are then reset, so this change is effectively a no-op.

#### Link to tracking issue

Part of #49308. Missed it in #49307.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Existing tests suffice.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
