### PR TITLE
[receiver/prometheus] Use confighttp defaulting constructor

### DIFF
--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -9,12 +9,15 @@ import (
 	promconfig "github.com/prometheus/prometheus/config"
 	_ "github.com/prometheus/prometheus/plugins" // init() of this package registers service discovery impl.
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/apiserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/targetallocator"
 )
 
 // NewFactory creates a new Prometheus receiver factory.
@@ -26,10 +29,18 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	taClientConfig := confighttp.NewDefaultClientConfig()
+	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
+	taClientConfig.MaxIdleConns = 0
+	taClientConfig.IdleConnTimeout = 0
+	taClientConfig.ForceAttemptHTTP2 = false
 	return &Config{
 		PrometheusConfig: &PromConfig{
 			GlobalConfig: promconfig.DefaultGlobalConfig,
 		},
+		TargetAllocator: configoptional.Default(targetallocator.Config{
+			ClientConfig: taClientConfig,
+		}),
 		APIServer: apiserver.DefaultConfig(),
 	}
 }


### PR DESCRIPTION
#### Description

The target allocator's embedded confighttp.ClientConfig defaulted to a zero value. Use the confighttp.ClientConfig defaulting constructor instead, resetting the other constructor-set fields to preserve existing behavior.

#### Link to tracking issue

Part of #49308. Missed it in #49307.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
