### PR TITLE
[receiver/hostmetrics] Add system.network.bandwidth.limit metric

### DIFF
--- a/.chloggen/49169-network-bandwidth-limit.yaml
+++ b/.chloggen/49169-network-bandwidth-limit.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: scraper/network
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add the optional `system.network.bandwidth.limit` metric to the network scraper, reporting the interface link speed in bytes/s. Linux only, disabled by default."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49169]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext: ""
+
+# Optional: The change log or logs in which this entry should be included.
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
@@ -97,6 +97,20 @@ metrics:
     enabled: true
 ```
 
+### system.network.bandwidth.limit
+
+Available link bandwidth for the network interface, derived from the reported link speed.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| device | Name of the network interface. | Any Str | Recommended | - |
+
 ### system.network.conntrack.count
 
 The count of entries in conntrack table.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
@@ -109,7 +109,8 @@ Available link bandwidth for the network interface, derived from the reported li
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| device | Name of the network interface. | Any Str | Recommended | - |
+| network.interface.name | The name of the network interface. | Any Str | Recommended | - |
+| network.io.direction | The network IO operation direction. | Str: ``transmit``, ``receive`` | Recommended | - |
 
 ### system.network.conntrack.count
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/generated_package_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/generated_package_test.go
@@ -3,9 +3,8 @@
 package networkscraper
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config.go
@@ -12,7 +12,8 @@ import (
 type SystemNetworkBandwidthLimitMetricAttributeKey string
 
 const (
-	SystemNetworkBandwidthLimitMetricAttributeKeyDevice SystemNetworkBandwidthLimitMetricAttributeKey = "device"
+	SystemNetworkBandwidthLimitMetricAttributeKeyNetworkInterfaceName SystemNetworkBandwidthLimitMetricAttributeKey = "network.interface.name"
+	SystemNetworkBandwidthLimitMetricAttributeKeyNetworkIoDirection   SystemNetworkBandwidthLimitMetricAttributeKey = "network.io.direction"
 )
 
 // SystemNetworkBandwidthLimitMetricConfig provides config for the system.network.bandwidth.limit metric.
@@ -41,9 +42,9 @@ func (ms *SystemNetworkBandwidthLimitMetricConfig) Unmarshal(parser *confmap.Con
 func (ms *SystemNetworkBandwidthLimitMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case SystemNetworkBandwidthLimitMetricAttributeKeyDevice:
+		case SystemNetworkBandwidthLimitMetricAttributeKeyNetworkInterfaceName, SystemNetworkBandwidthLimitMetricAttributeKeyNetworkIoDirection:
 		default:
-			return fmt.Errorf("metric system.network.bandwidth.limit doesn't have an attribute %v, valid attributes: [device]", val)
+			return fmt.Errorf("metric system.network.bandwidth.limit doesn't have an attribute %v, valid attributes: [network.interface.name, network.io.direction]", val)
 		}
 	}
 
@@ -358,7 +359,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		SystemNetworkBandwidthLimit: SystemNetworkBandwidthLimitMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyDevice},
+			EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyNetworkInterfaceName, SystemNetworkBandwidthLimitMetricAttributeKeyNetworkIoDirection},
 		},
 		SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 			Enabled:             true,

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config.go
@@ -8,6 +8,54 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 )
 
+// SystemNetworkBandwidthLimitMetricAttributeKey specifies the key of an attribute for the system.network.bandwidth.limit metric.
+type SystemNetworkBandwidthLimitMetricAttributeKey string
+
+const (
+	SystemNetworkBandwidthLimitMetricAttributeKeyDevice SystemNetworkBandwidthLimitMetricAttributeKey = "device"
+)
+
+// SystemNetworkBandwidthLimitMetricConfig provides config for the system.network.bandwidth.limit metric.
+type SystemNetworkBandwidthLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                          `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SystemNetworkBandwidthLimitMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SystemNetworkBandwidthLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SystemNetworkBandwidthLimitMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SystemNetworkBandwidthLimitMetricAttributeKeyDevice:
+		default:
+			return fmt.Errorf("metric system.network.bandwidth.limit doesn't have an attribute %v, valid attributes: [device]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SystemNetworkConnectionsMetricAttributeKey specifies the key of an attribute for the system.network.connections metric.
 type SystemNetworkConnectionsMetricAttributeKey string
 
@@ -295,6 +343,7 @@ func (ms *SystemNetworkPacketsMetricConfig) Validate() error {
 
 // MetricsConfig provides config for network metrics.
 type MetricsConfig struct {
+	SystemNetworkBandwidthLimit SystemNetworkBandwidthLimitMetricConfig `mapstructure:"system.network.bandwidth.limit"`
 	SystemNetworkConnections    SystemNetworkConnectionsMetricConfig    `mapstructure:"system.network.connections"`
 	SystemNetworkConntrackCount SystemNetworkConntrackCountMetricConfig `mapstructure:"system.network.conntrack.count"`
 	SystemNetworkConntrackMax   SystemNetworkConntrackMaxMetricConfig   `mapstructure:"system.network.conntrack.max"`
@@ -306,6 +355,11 @@ type MetricsConfig struct {
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		SystemNetworkBandwidthLimit: SystemNetworkBandwidthLimitMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyDevice},
+		},
 		SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config_test.go
@@ -29,7 +29,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemNetworkBandwidthLimit: SystemNetworkBandwidthLimitMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyDevice},
+						EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyNetworkInterfaceName, SystemNetworkBandwidthLimitMetricAttributeKeyNetworkIoDirection},
 					},
 					SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 						Enabled:             true,
@@ -72,7 +72,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SystemNetworkBandwidthLimit: SystemNetworkBandwidthLimitMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyDevice},
+						EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyNetworkInterfaceName, SystemNetworkBandwidthLimitMetricAttributeKeyNetworkIoDirection},
 					},
 					SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 						Enabled:             false,

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_config_test.go
@@ -26,6 +26,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					SystemNetworkBandwidthLimit: SystemNetworkBandwidthLimitMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyDevice},
+					},
 					SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -64,6 +69,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					SystemNetworkBandwidthLimit: SystemNetworkBandwidthLimitMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SystemNetworkBandwidthLimitMetricAttributeKey{SystemNetworkBandwidthLimitMetricAttributeKeyDevice},
+					},
 					SystemNetworkConnections: SystemNetworkConnectionsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -102,7 +112,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SystemNetworkConnectionsMetricConfig{}, SystemNetworkConntrackCountMetricConfig{}, SystemNetworkConntrackMaxMetricConfig{}, SystemNetworkDroppedMetricConfig{}, SystemNetworkErrorsMetricConfig{}, SystemNetworkIoMetricConfig{}, SystemNetworkPacketsMetricConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SystemNetworkBandwidthLimitMetricConfig{}, SystemNetworkConnectionsMetricConfig{}, SystemNetworkConntrackCountMetricConfig{}, SystemNetworkConntrackMaxMetricConfig{}, SystemNetworkDroppedMetricConfig{}, SystemNetworkErrorsMetricConfig{}, SystemNetworkIoMetricConfig{}, SystemNetworkPacketsMetricConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -69,6 +69,9 @@ var MapAttributeProtocol = map[string]AttributeProtocol{
 }
 
 var MetricsInfo = metricsInfo{
+	SystemNetworkBandwidthLimit: metricInfo{
+		Name: "system.network.bandwidth.limit",
+	},
 	SystemNetworkConnections: metricInfo{
 		Name: "system.network.connections",
 	},
@@ -93,6 +96,7 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
+	SystemNetworkBandwidthLimit metricInfo
 	SystemNetworkConnections    metricInfo
 	SystemNetworkConntrackCount metricInfo
 	SystemNetworkConntrackMax   metricInfo
@@ -104,6 +108,95 @@ type metricsInfo struct {
 
 type metricInfo struct {
 	Name string
+}
+
+type metricSystemNetworkBandwidthLimit struct {
+	data          pmetric.Metric                          // data buffer for generated metric.
+	config        SystemNetworkBandwidthLimitMetricConfig // metric config provided by user.
+	capacity      int                                     // max observed number of data points added to the metric.
+	aggDataPoints []int64                                 // slice containing number of aggregated datapoints at each index
+}
+
+// init fills system.network.bandwidth.limit metric with initial data.
+func (m *metricSystemNetworkBandwidthLimit) init() {
+	m.data.SetName("system.network.bandwidth.limit")
+	m.data.SetDescription("Available link bandwidth for the network interface, derived from the reported link speed.")
+	m.data.SetUnit("By/s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSystemNetworkBandwidthLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SystemNetworkBandwidthLimitMetricAttributeKeyDevice) {
+		dp.Attributes().PutStr("device", deviceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemNetworkBandwidthLimit) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemNetworkBandwidthLimit) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemNetworkBandwidthLimit(cfg SystemNetworkBandwidthLimitMetricConfig) metricSystemNetworkBandwidthLimit {
+	m := metricSystemNetworkBandwidthLimit{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
 }
 
 type metricSystemNetworkConnections struct {
@@ -688,6 +781,7 @@ type MetricsBuilder struct {
 	metricsCapacity                   int                  // maximum observed number of metrics per resource.
 	metricsBuffer                     pmetric.Metrics      // accumulates metrics data before emitting.
 	buildInfo                         component.BuildInfo  // contains version information.
+	metricSystemNetworkBandwidthLimit metricSystemNetworkBandwidthLimit
 	metricSystemNetworkConnections    metricSystemNetworkConnections
 	metricSystemNetworkConntrackCount metricSystemNetworkConntrackCount
 	metricSystemNetworkConntrackMax   metricSystemNetworkConntrackMax
@@ -720,6 +814,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings scraper.Settings, opti
 		startTime:                         pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                     pmetric.NewMetrics(),
 		buildInfo:                         settings.BuildInfo,
+		metricSystemNetworkBandwidthLimit: newMetricSystemNetworkBandwidthLimit(mbc.Metrics.SystemNetworkBandwidthLimit),
 		metricSystemNetworkConnections:    newMetricSystemNetworkConnections(mbc.Metrics.SystemNetworkConnections),
 		metricSystemNetworkConntrackCount: newMetricSystemNetworkConntrackCount(mbc.Metrics.SystemNetworkConntrackCount),
 		metricSystemNetworkConntrackMax:   newMetricSystemNetworkConntrackMax(mbc.Metrics.SystemNetworkConntrackMax),
@@ -793,6 +888,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetName(ScopeName)
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemNetworkBandwidthLimit.emit(ils.Metrics())
 	mb.metricSystemNetworkConnections.emit(ils.Metrics())
 	mb.metricSystemNetworkConntrackCount.emit(ils.Metrics())
 	mb.metricSystemNetworkConntrackMax.emit(ils.Metrics())
@@ -819,6 +915,11 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 	metrics := mb.metricsBuffer
 	mb.metricsBuffer = pmetric.NewMetrics()
 	return metrics
+}
+
+// RecordSystemNetworkBandwidthLimitDataPoint adds a data point to system.network.bandwidth.limit metric.
+func (mb *MetricsBuilder) RecordSystemNetworkBandwidthLimitDataPoint(ts pcommon.Timestamp, val int64, deviceAttributeValue string) {
+	mb.metricSystemNetworkBandwidthLimit.recordDataPoint(mb.startTime, ts, val, deviceAttributeValue)
 }
 
 // RecordSystemNetworkConnectionsDataPoint adds a data point to system.network.connections metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -46,6 +46,32 @@ var MapAttributeDirection = map[string]AttributeDirection{
 	"transmit": AttributeDirectionTransmit,
 }
 
+// AttributeNetworkIoDirection specifies the value network.io.direction attribute.
+type AttributeNetworkIoDirection int
+
+const (
+	_ AttributeNetworkIoDirection = iota
+	AttributeNetworkIoDirectionTransmit
+	AttributeNetworkIoDirectionReceive
+)
+
+// String returns the string representation of the AttributeNetworkIoDirection.
+func (av AttributeNetworkIoDirection) String() string {
+	switch av {
+	case AttributeNetworkIoDirectionTransmit:
+		return "transmit"
+	case AttributeNetworkIoDirectionReceive:
+		return "receive"
+	}
+	return ""
+}
+
+// MapAttributeNetworkIoDirection is a helper map of string to AttributeNetworkIoDirection attribute value.
+var MapAttributeNetworkIoDirection = map[string]AttributeNetworkIoDirection{
+	"transmit": AttributeNetworkIoDirectionTransmit,
+	"receive":  AttributeNetworkIoDirectionReceive,
+}
+
 // AttributeProtocol specifies the value protocol attribute.
 type AttributeProtocol int
 
@@ -127,7 +153,7 @@ func (m *metricSystemNetworkBandwidthLimit) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricSystemNetworkBandwidthLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string) {
+func (m *metricSystemNetworkBandwidthLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, networkInterfaceNameAttributeValue string, networkIoDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -135,8 +161,11 @@ func (m *metricSystemNetworkBandwidthLimit) recordDataPoint(start pcommon.Timest
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, SystemNetworkBandwidthLimitMetricAttributeKeyDevice) {
-		dp.Attributes().PutStr("device", deviceAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, SystemNetworkBandwidthLimitMetricAttributeKeyNetworkInterfaceName) {
+		dp.Attributes().PutStr("network.interface.name", networkInterfaceNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SystemNetworkBandwidthLimitMetricAttributeKeyNetworkIoDirection) {
+		dp.Attributes().PutStr("network.io.direction", networkIoDirectionAttributeValue)
 	}
 
 	var s string
@@ -918,8 +947,8 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordSystemNetworkBandwidthLimitDataPoint adds a data point to system.network.bandwidth.limit metric.
-func (mb *MetricsBuilder) RecordSystemNetworkBandwidthLimitDataPoint(ts pcommon.Timestamp, val int64, deviceAttributeValue string) {
-	mb.metricSystemNetworkBandwidthLimit.recordDataPoint(mb.startTime, ts, val, deviceAttributeValue)
+func (mb *MetricsBuilder) RecordSystemNetworkBandwidthLimitDataPoint(ts pcommon.Timestamp, val int64, networkInterfaceNameAttributeValue string, networkIoDirectionAttributeValue AttributeNetworkIoDirection) {
+	mb.metricSystemNetworkBandwidthLimit.recordDataPoint(mb.startTime, ts, val, networkInterfaceNameAttributeValue, networkIoDirectionAttributeValue.String())
 }
 
 // RecordSystemNetworkConnectionsDataPoint adds a data point to system.network.connections metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
@@ -74,9 +74,9 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount := 0
 
 			allMetricsCount++
-			mb.RecordSystemNetworkBandwidthLimitDataPoint(ts, 1, "device-val")
+			mb.RecordSystemNetworkBandwidthLimitDataPoint(ts, 1, "network.interface.name-val", AttributeNetworkIoDirectionTransmit)
 			if tt.name == "reaggregate_set" {
-				mb.RecordSystemNetworkBandwidthLimitDataPoint(ts, 3, "device-val-2")
+				mb.RecordSystemNetworkBandwidthLimitDataPoint(ts, 3, "network.interface.name-val-2", AttributeNetworkIoDirectionReceive)
 			}
 
 			defaultMetricsCount++
@@ -169,9 +169,12 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						deviceAttrVal, ok := dp.Attributes().Get("device")
+						networkInterfaceNameAttrVal, ok := dp.Attributes().Get("network.interface.name")
 						assert.True(t, ok)
-						assert.Equal(t, "device-val", deviceAttrVal.Str())
+						assert.Equal(t, "network.interface.name-val", networkInterfaceNameAttrVal.Str())
+						networkIoDirectionAttrVal, ok := dp.Attributes().Get("network.io.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "transmit", networkIoDirectionAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["system.network.bandwidth.limit"], "Found a duplicate in the metrics slice: system.network.bandwidth.limit")
 						validatedMetrics["system.network.bandwidth.limit"] = true
@@ -193,7 +196,9 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("device")
+						_, ok := dp.Attributes().Get("network.interface.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("network.io.direction")
 						assert.False(t, ok)
 					}
 				case "system.network.connections":

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_test.go
@@ -58,6 +58,7 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["system.network.bandwidth.limit"] = mb.metricSystemNetworkBandwidthLimit.config.AggregationStrategy
 			aggMap["system.network.connections"] = mb.metricSystemNetworkConnections.config.AggregationStrategy
 			aggMap["system.network.dropped"] = mb.metricSystemNetworkDropped.config.AggregationStrategy
 			aggMap["system.network.errors"] = mb.metricSystemNetworkErrors.config.AggregationStrategy
@@ -71,6 +72,12 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
+
+			allMetricsCount++
+			mb.RecordSystemNetworkBandwidthLimitDataPoint(ts, 1, "device-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemNetworkBandwidthLimitDataPoint(ts, 3, "device-val-2")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -116,6 +123,7 @@ func TestMetricsBuilder(t *testing.T) {
 			res := pcommon.NewResource()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricSystemNetworkBandwidthLimit.aggDataPoints)
 				assert.Empty(t, mb.metricSystemNetworkConnections.aggDataPoints)
 				assert.Empty(t, mb.metricSystemNetworkDropped.aggDataPoints)
 				assert.Empty(t, mb.metricSystemNetworkErrors.aggDataPoints)
@@ -148,6 +156,46 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
+				case "system.network.bandwidth.limit":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.network.bandwidth.limit"], "Found a duplicate in the metrics slice: system.network.bandwidth.limit")
+						validatedMetrics["system.network.bandwidth.limit"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Available link bandwidth for the network interface, derived from the reported link speed.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						deviceAttrVal, ok := dp.Attributes().Get("device")
+						assert.True(t, ok)
+						assert.Equal(t, "device-val", deviceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.network.bandwidth.limit"], "Found a duplicate in the metrics slice: system.network.bandwidth.limit")
+						validatedMetrics["system.network.bandwidth.limit"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Available link bandwidth for the network interface, derived from the reported link speed.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.network.bandwidth.limit"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("device")
+						assert.False(t, ok)
+					}
 				case "system.network.connections":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["system.network.connections"], "Found a duplicate in the metrics slice: system.network.connections")

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
@@ -3,7 +3,7 @@ all_set:
   metrics:
     system.network.bandwidth.limit:
       enabled: true
-      attributes: ["device"]
+      attributes: ["network.interface.name","network.io.direction"]
     system.network.connections:
       enabled: true
       attributes: ["protocol","state"]
@@ -51,7 +51,7 @@ none_set:
   metrics:
     system.network.bandwidth.limit:
       enabled: false
-      attributes: ["device"]
+      attributes: ["network.interface.name","network.io.direction"]
     system.network.connections:
       enabled: false
       attributes: ["protocol","state"]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/testdata/config.yaml
@@ -1,6 +1,9 @@
 default:
 all_set:
   metrics:
+    system.network.bandwidth.limit:
+      enabled: true
+      attributes: ["device"]
     system.network.connections:
       enabled: true
       attributes: ["protocol","state"]
@@ -22,6 +25,9 @@ all_set:
       attributes: ["device","direction"]
 reaggregate_set:
   metrics:
+    system.network.bandwidth.limit:
+      enabled: true
+      attributes: []
     system.network.connections:
       enabled: true
       attributes: []
@@ -43,6 +49,9 @@ reaggregate_set:
       attributes: []
 none_set:
   metrics:
+    system.network.bandwidth.limit:
+      enabled: false
+      attributes: ["device"]
     system.network.connections:
       enabled: false
       attributes: ["protocol","state"]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -22,6 +22,17 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [receive, transmit]
+  network.interface.name:
+    description: The name of the network interface.
+    type: string
+    requirement_level: recommended
+  network.io.direction:
+    description: The network IO operation direction.
+    type: string
+    enum:
+      - transmit
+      - receive
+    requirement_level: recommended
   protocol:
     description: Network protocol, e.g. TCP or UDP.
     type: string
@@ -40,7 +51,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
-    attributes: [device]
+    attributes: [network.interface.name, network.io.direction]
   system.network.connections:
     enabled: true
     description: The number of connections.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -33,6 +33,14 @@ attributes:
     requirement_level: recommended
 
 metrics:
+  system.network.bandwidth.limit:
+    enabled: false
+    description: Available link bandwidth for the network interface, derived from the reported link speed.
+    unit: By/s
+    stability: development
+    gauge:
+      value_type: int
+    attributes: [device]
   system.network.connections:
     enabled: true
     description: The number of connections.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata"
 )
 
 const (
@@ -66,8 +68,12 @@ func (s *networkScraper) recordNetworkBandwidthMetrics(ctx context.Context) erro
 		if !ok {
 			continue
 		}
-		// speed is reported in Mbit/s; convert to bytes/s.
-		s.mb.RecordSystemNetworkBandwidthLimitDataPoint(now, speedMbps*125000, ioc.Name)
+		// speed is reported in Mbit/s; convert to bytes/s. A full-duplex link
+		// carries this capacity in each direction, so it pairs with the
+		// directional system.network.io usage to give utilization.
+		limit := speedMbps * 125000
+		s.mb.RecordSystemNetworkBandwidthLimitDataPoint(now, limit, ioc.Name, metadata.AttributeNetworkIoDirectionTransmit)
+		s.mb.RecordSystemNetworkBandwidthLimitDataPoint(now, limit, ioc.Name, metadata.AttributeNetworkIoDirectionReceive)
 	}
 	return nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
@@ -8,6 +8,10 @@ package networkscraper // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -15,6 +19,7 @@ import (
 
 const (
 	conntrackMetricsLen = 2
+	bandwidthMetricsLen = 1
 )
 
 var allTCPStates = []string{
@@ -44,4 +49,44 @@ func (s *networkScraper) recordNetworkConntrackMetrics(ctx context.Context) erro
 	s.mb.RecordSystemNetworkConntrackCountDataPoint(now, conntrack[0].ConnTrackCount)
 	s.mb.RecordSystemNetworkConntrackMaxDataPoint(now, conntrack[0].ConnTrackMax)
 	return nil
+}
+
+func (s *networkScraper) recordNetworkBandwidthMetrics(ctx context.Context) error {
+	if !s.config.Metrics.SystemNetworkBandwidthLimit.Enabled {
+		return nil
+	}
+	ioCounters, err := s.ioCounters(ctx, true)
+	if err != nil {
+		return fmt.Errorf("failed to read network interfaces: %w", err)
+	}
+	ioCounters = s.filterByInterface(ioCounters)
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, ioc := range ioCounters {
+		speedMbps, ok := readInterfaceSpeedMbps(ioc.Name)
+		if !ok {
+			continue
+		}
+		// speed is reported in Mbit/s; convert to bytes/s.
+		s.mb.RecordSystemNetworkBandwidthLimitDataPoint(now, speedMbps*125000, ioc.Name)
+	}
+	return nil
+}
+
+// readInterfaceSpeedMbps returns the link speed in Mbit/s from sysfs, or false
+// for interfaces that report no usable speed (virtual or down links read -1).
+// HOST_SYS is honored to match gopsutil under a configured root_path.
+func readInterfaceSpeedMbps(device string) (int64, bool) {
+	hostSys := os.Getenv("HOST_SYS")
+	if hostSys == "" {
+		hostSys = "/sys"
+	}
+	data, err := os.ReadFile(filepath.Join(hostSys, "class", "net", device, "speed"))
+	if err != nil {
+		return 0, false
+	}
+	speed, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil || speed <= 0 {
+		return 0, false
+	}
+	return speed, true
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package networkscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper"
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInterfaceSpeedMbps(t *testing.T) {
+	sys := t.TempDir()
+	write := func(device, speed string) {
+		require.NoError(t, os.MkdirAll(filepath.Join(sys, "class", "net", device), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(sys, "class", "net", device, "speed"), []byte(speed), 0o644))
+	}
+	write("eth0", "1000\n")
+	write("lo", "-1\n")
+	write("bad", "notanumber\n")
+	t.Setenv("HOST_SYS", sys)
+
+	speed, ok := readInterfaceSpeedMbps("eth0")
+	assert.True(t, ok)
+	assert.Equal(t, int64(1000), speed)
+
+	_, ok = readInterfaceSpeedMbps("lo")
+	assert.False(t, ok, "down/virtual links report -1 and should be skipped")
+
+	_, ok = readInterfaceSpeedMbps("bad")
+	assert.False(t, ok, "unparseable speed should be skipped")
+
+	_, ok = readInterfaceSpeedMbps("missing")
+	assert.False(t, ok, "missing interface should be skipped")
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	conntrackMetricsLen = 0
+	bandwidthMetricsLen = 0
 )
 
 var allTCPStates = []string{
@@ -28,5 +29,9 @@ var allTCPStates = []string{
 }
 
 func (*networkScraper) recordNetworkConntrackMetrics(context.Context) error {
+	return nil
+}
+
+func (*networkScraper) recordNetworkBandwidthMetrics(context.Context) error {
 	return nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -100,6 +100,11 @@ func (s *networkScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		errors.AddPartial(conntrackMetricsLen, err)
 	}
 
+	err = s.recordNetworkBandwidthMetrics(ctx)
+	if err != nil {
+		errors.AddPartial(bandwidthMetricsLen, err)
+	}
+
 	return s.mb.Emit(), errors.Combine()
 }
 


### PR DESCRIPTION
**Description**

The network scraper exposes byte, packet, error, dropped, connection, and conntrack metrics, but nothing for link capacity. Consumers can derive byte rates from `system.network.io` but can't compute interface saturation without the NIC link speed.

This adds an optional, disabled-by-default `system.network.bandwidth.limit` gauge (unit `By/s`, attribute `device`). On Linux it reads the interface link speed from `/sys/class/net/<device>/speed` (honoring `HOST_SYS`) and converts Mbit/s to bytes/s. It's a no-op on other platforms, and interfaces that report `-1` (virtual or down links) are skipped.

I scoped this to the bandwidth limit only. The utilization metric from the issue can follow once the limit lands, since it needs prev-sample delta tracking.

**Link to tracking issue**

Part of #49169

**Testing**

Added a unit test for the sysfs speed read (valid speed, `-1`, unparseable, missing interface). Regenerated with mdatagen; `go test ./...` and `GOOS=linux go vet ./...` pass.

**Documentation**

Regenerated `documentation.md` via mdatagen and added a changelog entry.