### PR TITLE
fix(metricstransformprocessor): preserve absent histogram sum on merge

### DIFF
--- a/.chloggen/49379-metricstransform-preserve-absent-sum.yaml
+++ b/.chloggen/49379-metricstransform-preserve-absent-sum.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/metricstransform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve an absent histogram sum when aggregating datapoints instead of reporting a sum of 0
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49379]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When merging (exponential) histogram datapoints, the sum is now only kept when every merged
+  datapoint carries one, matching the existing handling of min and max. Previously a merge that
+  involved a datapoint without a sum produced HasSum=true with Sum=0, which is indistinguishable
+  from a genuine zero sum.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/49379-metricstransform-preserve-absent-sum.yaml
+++ b/.chloggen/49379-metricstransform-preserve-absent-sum.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: processor/metricstransform
+component: processor/metrics_transform
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Preserve an absent histogram sum when aggregating datapoints instead of reporting a sum of 0

--- a/internal/coreinternal/aggregateutil/aggregate.go
+++ b/internal/coreinternal/aggregateutil/aggregate.go
@@ -254,7 +254,14 @@ func mergeHistogramDataPoints(dpsMap map[string]pmetric.HistogramDataPointSlice,
 				continue
 			}
 			dp.SetCount(dp.Count() + dps.At(i).Count())
-			dp.SetSum(dp.Sum() + dps.At(i).Sum())
+			// Sum is optional: only keep an aggregate sum while every merged
+			// datapoint carries one. Once any contributor lacks a sum the total
+			// is unknowable, so drop it rather than treating absent as zero.
+			if dp.HasSum() && dps.At(i).HasSum() {
+				dp.SetSum(dp.Sum() + dps.At(i).Sum())
+			} else {
+				dp.RemoveSum()
+			}
 			if dp.HasMin() && dp.Min() > dps.At(i).Min() {
 				dp.SetMin(dps.At(i).Min())
 			}
@@ -285,7 +292,13 @@ func mergeExponentialHistogramDataPoints(dpsMap map[string]pmetric.ExponentialHi
 				continue
 			}
 			dp.SetCount(dp.Count() + dps.At(i).Count())
-			dp.SetSum(dp.Sum() + dps.At(i).Sum())
+			// Sum is optional: only keep an aggregate sum while every merged
+			// datapoint carries one (see mergeHistogramDataPoints).
+			if dp.HasSum() && dps.At(i).HasSum() {
+				dp.SetSum(dp.Sum() + dps.At(i).Sum())
+			} else {
+				dp.RemoveSum()
+			}
 			dp.SetZeroCount(dp.ZeroCount() + dps.At(i).ZeroCount())
 			if dp.HasMin() && dp.Min() > dps.At(i).Min() {
 				dp.SetMin(dps.At(i).Min())

--- a/internal/coreinternal/aggregateutil/aggregate.go
+++ b/internal/coreinternal/aggregateutil/aggregate.go
@@ -292,8 +292,9 @@ func mergeExponentialHistogramDataPoints(dpsMap map[string]pmetric.ExponentialHi
 				continue
 			}
 			dp.SetCount(dp.Count() + dps.At(i).Count())
-			// Sum is optional: only keep an aggregate sum while every merged
-			// datapoint carries one (see mergeHistogramDataPoints).
+			// Sum is optional on histogram datapoints. Keep the aggregated sum only
+			// while every merged datapoint carries one; if any is missing a sum, the
+			// total would be incomplete, so drop it entirely.
 			if dp.HasSum() && dps.At(i).HasSum() {
 				dp.SetSum(dp.Sum() + dps.At(i).Sum())
 			} else {

--- a/internal/coreinternal/aggregateutil/aggregate_test.go
+++ b/internal/coreinternal/aggregateutil/aggregate_test.go
@@ -465,7 +465,6 @@ func Test_MergeDataPoints(t *testing.T) {
 				d := s.DataPoints().AppendEmpty()
 				d.Attributes().PutStr("attr1", "val1")
 				d.SetCount(3)
-				d.SetSum(0)
 				return m
 			},
 			in: func() pmetric.Metric {
@@ -488,7 +487,6 @@ func Test_MergeDataPoints(t *testing.T) {
 				d := s.DataPoints().AppendEmpty()
 				d.Attributes().PutStr("attr1", "val1")
 				d.SetCount(16)
-				d.SetSum(0)
 				d.SetZeroCount(3)
 				d.Positive().BucketCounts().Append(0, 2, 4, 3)
 				d.Negative().BucketCounts().Append(0, 2, 2)
@@ -514,7 +512,6 @@ func Test_MergeDataPoints(t *testing.T) {
 				d := s.DataPoints().AppendEmpty()
 				d.Attributes().PutStr("attr1", "val1")
 				d.SetCount(12)
-				d.SetSum(0)
 				d.SetZeroCount(3)
 				// First datapoint: positive offset 0, buckets [1, 2]
 				// Second datapoint: positive offset 1, buckets [3, 4] (represents [0, 3, 4])
@@ -546,6 +543,83 @@ func Test_MergeDataPoints(t *testing.T) {
 			require.Equal(t, tt.want(), m)
 		})
 	}
+}
+
+// Test_MergeDataPoints_SumPresence is a regression test for #49379: merging
+// histogram datapoints must add their sums when all of them carry one, and must
+// leave the merged datapoint without a sum as soon as any contributor lacks one
+// (rather than reporting a fabricated sum of 0).
+func Test_MergeDataPoints_SumPresence(t *testing.T) {
+	mapAttr := pcommon.NewMap()
+	mapAttr.PutStr("attr1", "val1")
+	hashHistogram := dataPointHashKey(mapAttr, pcommon.NewTimestampFromTime(time.Time{}), false, false, 0)
+	hashExpHistogram := dataPointHashKey(mapAttr, pcommon.NewTimestampFromTime(time.Time{}), 0, false, false, 0)
+
+	histogramPair := func(setSum0, setSum1 bool) pmetric.HistogramDataPointSlice {
+		s := pmetric.NewHistogramDataPointSlice()
+		d0 := s.AppendEmpty()
+		d0.Attributes().PutStr("attr1", "val1")
+		d0.SetCount(2)
+		if setSum0 {
+			d0.SetSum(1.5)
+		}
+		d1 := s.AppendEmpty()
+		d1.SetTimestamp(pcommon.NewTimestampFromTime(time.Time{}))
+		d1.Attributes().PutStr("attr1", "val1")
+		d1.SetCount(1)
+		if setSum1 {
+			d1.SetSum(2.5)
+		}
+		return s
+	}
+	expHistogramPair := func(setSum0, setSum1 bool) pmetric.ExponentialHistogramDataPointSlice {
+		s := pmetric.NewExponentialHistogramDataPointSlice()
+		d0 := s.AppendEmpty()
+		d0.Attributes().PutStr("attr1", "val1")
+		d0.SetCount(2)
+		if setSum0 {
+			d0.SetSum(1.5)
+		}
+		d1 := s.AppendEmpty()
+		d1.SetTimestamp(pcommon.NewTimestampFromTime(time.Time{}))
+		d1.Attributes().PutStr("attr1", "val1")
+		d1.SetCount(1)
+		if setSum1 {
+			d1.SetSum(2.5)
+		}
+		return s
+	}
+
+	t.Run("histogram both have sum -> sum added", func(t *testing.T) {
+		m := pmetric.NewMetric()
+		m.SetEmptyHistogram()
+		MergeDataPoints(m, Sum, AggGroups{histogram: map[string]pmetric.HistogramDataPointSlice{hashHistogram: histogramPair(true, true)}})
+		d := m.Histogram().DataPoints().At(0)
+		require.True(t, d.HasSum())
+		require.Equal(t, 4.0, d.Sum())
+	})
+	t.Run("histogram one missing sum -> sum absent", func(t *testing.T) {
+		m := pmetric.NewMetric()
+		m.SetEmptyHistogram()
+		MergeDataPoints(m, Sum, AggGroups{histogram: map[string]pmetric.HistogramDataPointSlice{hashHistogram: histogramPair(true, false)}})
+		d := m.Histogram().DataPoints().At(0)
+		require.False(t, d.HasSum())
+	})
+	t.Run("exp histogram both have sum -> sum added", func(t *testing.T) {
+		m := pmetric.NewMetric()
+		m.SetEmptyExponentialHistogram()
+		MergeDataPoints(m, Sum, AggGroups{expHistogram: map[string]pmetric.ExponentialHistogramDataPointSlice{hashExpHistogram: expHistogramPair(true, true)}})
+		d := m.ExponentialHistogram().DataPoints().At(0)
+		require.True(t, d.HasSum())
+		require.Equal(t, 4.0, d.Sum())
+	})
+	t.Run("exp histogram one missing sum -> sum absent", func(t *testing.T) {
+		m := pmetric.NewMetric()
+		m.SetEmptyExponentialHistogram()
+		MergeDataPoints(m, Sum, AggGroups{expHistogram: map[string]pmetric.ExponentialHistogramDataPointSlice{hashExpHistogram: expHistogramPair(false, true)}})
+		d := m.ExponentialHistogram().DataPoints().At(0)
+		require.False(t, d.HasSum())
+	})
 }
 
 func testDataNumber() pmetric.NumberDataPointSlice {


### PR DESCRIPTION
#### Description

When merging (exponential) histogram datapoints in `aggregateutil`, the sum was set unconditionally (`dp.SetSum(dp.Sum() + dps.At(i).Sum())`). Because `SetSum` always marks the value present, merging datapoints that had no sum (`HasSum() == false`) produced `HasSum() == true` with `Sum() == 0`, which is indistinguishable from a genuine zero sum. Min and max in the same loop are already guarded with `HasMin()`/`HasMax()`; the sum is now handled the same way: it is only accumulated while every merged datapoint carries one, and is otherwise removed.

#### Link to tracking issue
Fixes #49379

#### Testing

Added a regression test (`Test_MergeDataPoints_SumPresence`) covering histogram and exponential-histogram merges for both the all-present case (sums add, `HasSum` stays true) and the any-absent case (`HasSum` becomes false). Existing `Test_MergeDataPoints` expectations that encoded the old behavior (a fabricated `Sum=0` on sumless inputs) were corrected. The new and corrected tests fail before the change and pass after; `go test`, `gofmt`, and `go vet` pass for the package.

#### Documentation

No user-facing documentation changes; a `.chloggen` changelog entry is included.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<sub>Authored with AI assistance (Claude Code) and reviewed before submission.</sub>