### PR TITLE
[chore] avoid multiple datadog make targets at the same time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,9 @@ $(ALL_MODS):
 # is used so it works on the runner's GNU Make 4.3 (`.WAIT`/`.NOTPARALLEL`
 # prereqs need 4.4+).
 exporter/datadogexporter/integrationtest: exporter/datadogexporter
+pkg/datadog: exporter/datadogexporter/integrationtest
+extension/datadogextension: pkg/datadog
+connector/datadogconnector: extension/datadogextension
 
 # Trigger each module's delegation target
 .PHONY: for-all-target


### PR DESCRIPTION
#### Description
Avoid multiple datadog make targets at the same time, otherwise it may lead to OOM kill in CIs
Example: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/28476135050/job/84405883206?pr=49408

#### Link to tracking issue
Follow-up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49396

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
