### PR TITLE
[pkg/ottl] Add `String()` method to `Statement`, `Condition`, and `ValueExpression`

### DIFF
--- a/.chloggen/add-stmt-cond-expr-string.yaml
+++ b/.chloggen/add-stmt-cond-expr-string.yaml
@@ -10,7 +10,7 @@ component: pkg/ottl
 note: Add `String()` method to `ottl.Statement`, `ottl.Condition`, and `ottl.ValueExpression` that return the original OTTL text used during parsing.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [TBD]
+issues: [49415]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/add-stmt-cond-expr-string.yaml
+++ b/.chloggen/add-stmt-cond-expr-string.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `String()` method to `ottl.Statement`, `ottl.Condition`, and `ottl.ValueExpression` that return the original OTTL text used during parsing.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [TBD]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -50,10 +50,20 @@ func (s *Statement[K]) Execute(ctx context.Context, tCtx K) (any, bool, error) {
 	return result, condition, nil
 }
 
+// String returns the original statement text used to create the Statement.
+func (s *Statement[K]) String() string {
+	return s.origText
+}
+
 // Condition holds a top level Condition. A Condition is a boolean expression to match telemetry.
 type Condition[K any] struct {
 	condition boolExpr[K]
 	origText  string
+}
+
+// String returns the original condition text used to create the Condition.
+func (c *Condition[K]) String() string {
+	return c.origText
 }
 
 // Eval returns true if the condition was met for the given TransformContext and false otherwise.
@@ -517,6 +527,11 @@ type ValueExpression[K any] struct {
 // Eval evaluates the given expression and returns the value the expression resolves to.
 func (e *ValueExpression[K]) Eval(ctx context.Context, tCtx K) (any, error) {
 	return e.getter.Get(ctx, tCtx)
+}
+
+// String returns the original OTTL expression used to create the ValueExpression.
+func (e *ValueExpression[K]) String() string {
+	return e.origText
 }
 
 // ParseValueExpressions parses string expressions into a ValueExpression slice ready for execution.

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -2438,6 +2438,54 @@ func Test_ParseConditions_Error(t *testing.T) {
 	}
 }
 
+func Test_String(t *testing.T) {
+	type mockSetArguments[K any] struct {
+		Target Setter[K]
+		Value  Getter[K]
+	}
+
+	mockSetFactory := NewFactory("set", &mockSetArguments[any]{}, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+		return func(context.Context, any) (any, error) {
+			return nil, nil
+		}, nil
+	})
+
+	mockFooFactory := NewFactory("Foo", &struct{}{}, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+		return func(context.Context, any) (any, error) {
+			return nil, nil
+		}, nil
+	})
+
+	p, err := NewParser(
+		CreateFactoryMap[any](mockSetFactory, mockFooFactory),
+		testParsePath[any],
+		componenttest.NewNopTelemetrySettings(),
+		WithEnumParser[any](testParseEnum),
+	)
+	require.NoError(t, err)
+
+	t.Run("Statement", func(t *testing.T) {
+		statement := `set(name, "bar") where name == "foo"`
+		s, err := p.ParseStatement(statement)
+		require.NoError(t, err)
+		assert.Equal(t, statement, s.String())
+	})
+
+	t.Run("Condition", func(t *testing.T) {
+		condition := `name == "foo"`
+		c, err := p.ParseCondition(condition)
+		require.NoError(t, err)
+		assert.Equal(t, condition, c.String())
+	})
+
+	t.Run("ValueExpression", func(t *testing.T) {
+		expression := `Foo()`
+		e, err := p.ParseValueExpression(expression)
+		require.NoError(t, err)
+		assert.Equal(t, expression, e.String())
+	})
+}
+
 // This test doesn't validate parser results, simply checks whether the parse succeeds or not.
 // It's a fast way to check a large range of possible syntaxes.
 func Test_parseStatement(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR add the `String()` method to `ottl.Statement`, `ottl.Condition`, and `ottl.ValueExpression`, returning the original text used to create each of them.

The main goal of adding those new functions are logging purposes, and allowing APIs to have access to the actual OTTL text used to parse them. For example, the `ottl.ParserCollection` rewrite paths under the hood, meaning that the provided OTTL text callers pass to it might be different from the ones used to actually parse it. 

One example of usage for this is the route table deduplication on the routing connector. We're currently adding support to context inference, but deduplicating it properly is currently not possible given the statement we pass to the parser collection might be modified under the hood, and generate false-positive/negative. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44762#discussion_r3247618313.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Unit

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
