### PR TITLE
Support resource detectors for service telemetry

### DIFF
--- a/.chloggen/45116.yaml
+++ b/.chloggen/45116.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for `telemetry.resource.detection/development` in OpAMP Supervisor telemetry.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45116]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Example:
+    telemetry:
+      resource:
+        detection/development:
+          detectors:
+            - host: {}
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -155,7 +155,11 @@ require (
 	go.opentelemetry.io/collector/service/hostcapabilities v0.155.1-0.20260625204839-9782f9e8a3d6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
+	go.opentelemetry.io/contrib/propagators/autoprop v0.69.0 // indirect
+	go.opentelemetry.io/contrib/propagators/aws v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0 // indirect
+	go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 // indirect
+	go.opentelemetry.io/contrib/propagators/ot v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect

--- a/cmd/opampsupervisor/go.sum
+++ b/cmd/opampsupervisor/go.sum
@@ -385,8 +385,16 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/contrib/otelconf v0.24.0 h1:Vtj36YS7OrMiXR7sT95NCv4/Ua0d6a3Q1uIC/+0gD64=
 go.opentelemetry.io/contrib/otelconf v0.24.0/go.mod h1:GJjg913kO9Q7MZ7Tw+cTZxPU0VxepUIRE1XMLjoVvyI=
+go.opentelemetry.io/contrib/propagators/autoprop v0.69.0 h1:3gzAeb5dgGzwB7hXutgJ07Xsv3v4Wc0llV8AaMc0wiQ=
+go.opentelemetry.io/contrib/propagators/autoprop v0.69.0/go.mod h1:SpChkgQWjh6egTT0chEc7VfusZgQMPzLsxRWWrqJdaQ=
+go.opentelemetry.io/contrib/propagators/aws v1.44.0 h1:Rtvfd6nTbAF2csjiw41m1DfuqC5TneXs+gB84ZA3gq4=
+go.opentelemetry.io/contrib/propagators/aws v1.44.0/go.mod h1:auu0tIyZErQGLLUvOp9DgmhKALIoebR4Fpkt9CT0c0k=
 go.opentelemetry.io/contrib/propagators/b3 v1.44.0 h1:1IFH4oFKK8KupzIelCl3u+bkxpGRps1oWRjQI2+TTWs=
 go.opentelemetry.io/contrib/propagators/b3 v1.44.0/go.mod h1:JqWFXsc7VDaqIyubFhEd2cPHqsrzqP0Lvn783SUwyro=
+go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 h1:OyzvsAMc/zHt0DRPcfstn0wgfq8ApDkeY0ABMcueweM=
+go.opentelemetry.io/contrib/propagators/jaeger v1.44.0/go.mod h1:44kghcGX+BNxy9UTiWtd6VDt8Nd4EypGBkH2+v2Dqrc=
+go.opentelemetry.io/contrib/propagators/ot v1.44.0 h1:JLTPenzmPtLp5ODPntAA5JhxVu1i3pAFUvXcAORMZAk=
+go.opentelemetry.io/contrib/propagators/ot v1.44.0/go.mod h1:8zr0bHgwkoQXucBK39/H4QphmLf1lSen1Z7FPDZD5Uc=
 go.opentelemetry.io/contrib/zpages v0.69.0 h1:YQC1PumJq6lUGQNrLW14ID9a0dXSBcbC/aC6VRSIARU=
 go.opentelemetry.io/contrib/zpages v0.69.0/go.mod h1:FGvUcMGN5atRzUIgUsqOi+MiMvlQsfbuYATBHPP4cGs=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	xotelconf "go.opentelemetry.io/contrib/otelconf/x"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/extensions"
@@ -373,9 +374,14 @@ type Telemetry struct {
 	Metrics Metrics                        `mapstructure:"metrics"`
 	Traces  otelconftelemetry.TracesConfig `mapstructure:"traces"`
 
-	Resource otelconftelemetry.ResourceConfig `mapstructure:"resource"`
+	Resource ResourceConfig `mapstructure:"resource"`
 	// prevent unkeyed literal initialization
 	_ struct{}
+}
+
+type ResourceConfig struct {
+	otelconftelemetry.ResourceConfig `mapstructure:",squash"`
+	DetectionDevelopment             *xotelconf.ExperimentalResourceDetection `mapstructure:"detection/development,omitempty"`
 }
 
 type HealthCheck struct {

--- a/cmd/opampsupervisor/supervisor/config/resource_config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/resource_config_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	otelconftelemetry "go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	otelconf "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	xotelconf "go.opentelemetry.io/contrib/otelconf/x"
 )
 
 func TestTelemetryResourceConfigUnmarshal(t *testing.T) {
@@ -71,6 +72,45 @@ func TestTelemetryResourceConfigUnmarshal(t *testing.T) {
 		require.NoError(t, conf.Unmarshal(&cfg))
 		require.ErrorContains(t, confmap.Validate(&cfg), "resource::attributes cannot be used together with legacy inline resource attributes")
 	})
+
+	t.Run("experimental detection", func(t *testing.T) {
+		conf := confmap.NewFromStringMap(map[string]any{
+			"detection/development": map[string]any{
+				"detectors": []any{
+					map[string]any{"host": map[string]any{}},
+				},
+			},
+		})
+
+		var cfg ResourceConfig
+		require.NoError(t, conf.Unmarshal(&cfg))
+		require.NotNil(t, cfg.DetectionDevelopment)
+		require.Len(t, cfg.DetectionDevelopment.Detectors, 1)
+		assert.NotNil(t, cfg.DetectionDevelopment.Detectors[0].Host)
+	})
+}
+
+func TestTelemetryResourceConfigLoadDetectionDevelopment(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"telemetry": map[string]any{
+			"resource": map[string]any{
+				"attributes": []any{
+					map[string]any{"name": "service.name", "value": "custom-supervisor"},
+				},
+				"detection/development": map[string]any{
+					"detectors": []any{
+						map[string]any{"host": map[string]any{}},
+					},
+				},
+			},
+		},
+	})
+
+	cfg := DefaultSupervisor()
+	require.NoError(t, conf.Unmarshal(&cfg))
+	require.NotNil(t, cfg.Telemetry.Resource.DetectionDevelopment)
+	assert.Equal(t, "custom-supervisor", cfg.Telemetry.Resource.Attributes[0].Value)
+	assert.Equal(t, xotelconf.ExperimentalHostResourceDetector{}, cfg.Telemetry.Resource.DetectionDevelopment.Detectors[0].Host)
 }
 
 func TestTelemetryResourceConfigMarshal(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/resource_config.go
+++ b/cmd/opampsupervisor/supervisor/resource_config.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	telemetryconfig "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	xotelconf "go.opentelemetry.io/contrib/otelconf/x"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 )
 
-func buildSupervisorResourceConfig(cfg *otelconftelemetry.ResourceConfig) (*telemetryconfig.Resource, error) {
+var newExperimentalSDK = xotelconf.NewSDK
+
+func buildSupervisorResourceConfig(ctx context.Context, cfg *config.ResourceConfig) (*telemetryconfig.Resource, error) {
 	instanceUUID, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err
@@ -63,7 +67,32 @@ func buildSupervisorResourceConfig(cfg *otelconftelemetry.ResourceConfig) (*tele
 		resourceCfg.SchemaUrl = &schemaURL
 	}
 
+	if cfg.DetectionDevelopment != nil {
+		detectionSDK, err := newDetectionResourceSDK(ctx, cfg.DetectionDevelopment)
+		if err != nil {
+			return nil, err
+		}
+		attrs := detectionSDK.Resource().Attributes()
+		detectedAttrs := make([]telemetryconfig.AttributeNameValue, 0, len(attrs))
+		for _, attr := range attrs {
+			detectedAttrs = append(detectedAttrs, telemetryconfig.AttributeNameValue{
+				Name:  string(attr.Key),
+				Value: attr.Value.AsInterface(),
+			})
+		}
+		resourceCfg.Attributes = append(detectedAttrs, resourceCfg.Attributes...)
+	}
+
 	return &resourceCfg, nil
+}
+
+func newDetectionResourceSDK(ctx context.Context, detection *xotelconf.ExperimentalResourceDetection) (xotelconf.SDK, error) {
+	return newExperimentalSDK(
+		xotelconf.WithContext(ctx),
+		xotelconf.WithOpenTelemetryConfiguration(xotelconf.OpenTelemetryConfiguration{
+			Resource: &xotelconf.Resource{DetectionDevelopment: detection},
+		}),
+	)
 }
 
 func resourceConfigToPcommon(ctx context.Context, resourceCfg *telemetryconfig.Resource) (pcommon.Resource, error) {

--- a/cmd/opampsupervisor/supervisor/resource_config_test.go
+++ b/cmd/opampsupervisor/supervisor/resource_config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	otelconf "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+	xotelconf "go.opentelemetry.io/contrib/otelconf/x"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
@@ -23,14 +24,16 @@ func TestInitTelemetrySettingsWithDeclarativeResourceConfig(t *testing.T) {
 			OutputPaths:      []string{"stdout"},
 			ErrorOutputPaths: []string{"stderr"},
 		},
-		Resource: otelconftelemetry.ResourceConfig{
-			Resource: otelconf.Resource{
-				SchemaUrl: &schemaURL,
-				Attributes: []otelconf.AttributeNameValue{
-					{Name: "custom.bool", Value: true},
-					{Name: "service.name", Value: "custom-supervisor"},
+		Resource: config.ResourceConfig{
+			ResourceConfig: otelconftelemetry.ResourceConfig{
+				Resource: otelconf.Resource{
+					SchemaUrl: &schemaURL,
+					Attributes: []otelconf.AttributeNameValue{
+						{Name: "custom.bool", Value: true},
+						{Name: "service.name", Value: "custom-supervisor"},
+					},
+					Detectors: &otelconf.Detectors{},
 				},
-				Detectors: &otelconf.Detectors{},
 			},
 		},
 	})
@@ -55,9 +58,11 @@ func TestInitTelemetrySettingsWithLegacyNilResourceOverride(t *testing.T) {
 			OutputPaths:      []string{"stdout"},
 			ErrorOutputPaths: []string{"stderr"},
 		},
-		Resource: otelconftelemetry.ResourceConfig{
-			LegacyAttributes: map[string]any{
-				"service.name": nil,
+		Resource: config.ResourceConfig{
+			ResourceConfig: otelconftelemetry.ResourceConfig{
+				LegacyAttributes: map[string]any{
+					"service.name": nil,
+				},
 			},
 		},
 	})
@@ -67,4 +72,88 @@ func TestInitTelemetrySettingsWithLegacyNilResourceOverride(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = settings.Resource.Attributes().Get("service.instance.id")
 	assert.True(t, ok)
+}
+
+func TestInitTelemetrySettingsWithHostResourceDetection(t *testing.T) {
+	settings, err := initTelemetrySettings(t.Context(), zap.NewNop(), config.Telemetry{
+		Logs: config.Logs{
+			Level:            zap.InfoLevel,
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+		},
+		Resource: config.ResourceConfig{
+			DetectionDevelopment: &xotelconf.ExperimentalResourceDetection{
+				Detectors: []xotelconf.ExperimentalResourceDetector{
+					{Host: xotelconf.ExperimentalHostResourceDetector{}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	attrs := settings.Resource.Attributes()
+	_, hasHostName := attrs.Get("host.name")
+	_, hasOSType := attrs.Get("os.type")
+	_, hasOSDescription := attrs.Get("os.description")
+	assert.True(t, hasHostName || hasOSType || hasOSDescription)
+}
+
+func TestInitTelemetrySettingsResourceDetectionKeepsSupervisorServiceAttributes(t *testing.T) {
+	settings, err := initTelemetrySettings(t.Context(), zap.NewNop(), config.Telemetry{
+		Logs: config.Logs{
+			Level:            zap.InfoLevel,
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+		},
+		Resource: config.ResourceConfig{
+			ResourceConfig: otelconftelemetry.ResourceConfig{
+				Resource: otelconf.Resource{
+					Attributes: []otelconf.AttributeNameValue{
+						{Name: "service.name", Value: "custom-supervisor"},
+						{Name: "service.instance.id", Value: "configured-instance"},
+					},
+				},
+			},
+			DetectionDevelopment: &xotelconf.ExperimentalResourceDetection{
+				Detectors: []xotelconf.ExperimentalResourceDetector{
+					{Service: xotelconf.ExperimentalServiceResourceDetector{}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	serviceName, ok := settings.Resource.Attributes().Get("service.name")
+	require.True(t, ok)
+	assert.Equal(t, "custom-supervisor", serviceName.AsString())
+
+	instanceID, ok := settings.Resource.Attributes().Get("service.instance.id")
+	require.True(t, ok)
+	assert.Equal(t, "configured-instance", instanceID.AsString())
+}
+
+func TestInitTelemetrySettingsReturnsResourceDetectionErrors(t *testing.T) {
+	originalNewExperimentalSDK := newExperimentalSDK
+	t.Cleanup(func() {
+		newExperimentalSDK = originalNewExperimentalSDK
+	})
+	newExperimentalSDK = func(...xotelconf.ConfigurationOption) (xotelconf.SDK, error) {
+		return xotelconf.SDK{}, assert.AnError
+	}
+
+	_, err := initTelemetrySettings(t.Context(), zap.NewNop(), config.Telemetry{
+		Logs: config.Logs{
+			Level:            zap.InfoLevel,
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+		},
+		Resource: config.ResourceConfig{
+			DetectionDevelopment: &xotelconf.ExperimentalResourceDetection{
+				Detectors: []xotelconf.ExperimentalResourceDetector{
+					{Host: xotelconf.ExperimentalHostResourceDetector{}},
+				},
+			},
+		},
+	})
+	assert.ErrorIs(t, err, assert.AnError)
 }

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -281,7 +281,7 @@ func initTelemetrySettings(ctx context.Context, logger *zap.Logger, cfg config.T
 		readers = []telemetryconfig.MetricReader{}
 	}
 
-	resourceCfg, err := buildSupervisorResourceConfig(&cfg.Resource)
+	resourceCfg, err := buildSupervisorResourceConfig(ctx, &cfg.Resource)
 	if err != nil {
 		return telemetrySettings{}, err
 	}


### PR DESCRIPTION
#### Description
Add support for resource detectors for internal telemetry.

Before, I created https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48849 but polluted because a git mistake.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45116

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
