### PR TITLE
[chore]: enforce collector-contrib-contributors membership for codeowners

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -61,7 +61,7 @@ jobs:
       # team, which grants the repository access required to be requested as a reviewer.
       - name: Gen CODEOWNERS
         run: |
-          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=pr -github-team=collector-contrib-contributors" make codeowners
-          if ! git -C pr diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git -C pr diff && exit 1; fi
+          if ! GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=pr -github-team=collector-contrib-contributors" make codeowners; then echo 'Failed to generate CODEOWNERS. If you added a new code owner, ensure they are a member of the open-telemetry organization and the open-telemetry/collector-contrib-contributors team (https://github.com/orgs/open-telemetry/teams/collector-contrib-contributors).' && exit 1; fi
+          if ! git -C pr diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR. If you added a new code owner, also ensure they are a member of the open-telemetry/collector-contrib-contributors team.' && git -C pr diff && exit 1; fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -56,9 +56,12 @@ jobs:
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           permission-members: read
 
+      # githubgen enforces that every code owner is an organization member and,
+      # via -github-team, that they are a member of the collector-contrib-contributors
+      # team, which grants the repository access required to be requested as a reviewer.
       - name: Gen CODEOWNERS
         run: |
-          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=pr" make codeowners
+          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} GITHUBGEN_ARGS="-folder=pr -github-team=collector-contrib-contributors" make codeowners
           if ! git -C pr diff -s --exit-code; then echo 'Generated code is out of date, please run "make update-codeowners" and commit the changes in this PR.' && git -C pr diff && exit 1; fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -141,8 +141,6 @@ main () {
     #
     # Reviewers are requested one at a time so a single invalid reviewer
     # doesn't drop the rest of the requests.
-    # Use key expansion rather than ${#REVIEWER_SET[@]} to test for entries: the
-    # latter trips "unbound variable" under 'set -u' when the array is empty.
     if [[ -n "${!REVIEWER_SET[*]}" ]]; then
         for REVIEWER in "${!REVIEWER_SET[@]}"; do
             request_review "${REVIEWER}"

--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -141,7 +141,9 @@ main () {
     #
     # Reviewers are requested one at a time so a single invalid reviewer
     # doesn't drop the rest of the requests.
-    if [[ ${#REVIEWER_SET[@]} -gt 0 ]]; then
+    # Use key expansion rather than ${#REVIEWER_SET[@]} to test for entries: the
+    # latter trips "unbound variable" under 'set -u' when the array is empty.
+    if [[ -n "${!REVIEWER_SET[*]}" ]]; then
         for REVIEWER in "${!REVIEWER_SET[@]}"; do
             request_review "${REVIEWER}"
         done

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -277,7 +277,7 @@ require (
 	go.opentelemetry.io/build-tools/checkfile v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/chloggen v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/crosslink v0.30.0 // indirect
-	go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260629131108-f40f26bd9a4e // indirect
+	go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260702202003-335e29c1ae8a // indirect
 	go.opentelemetry.io/build-tools/issuegenerator v0.30.0 // indirect
 	go.opentelemetry.io/build-tools/multimod v0.30.0 // indirect
 	go.opentelemetry.io/collector/cmd/builder v0.155.1-0.20260702132714-193fe1b7ac5d // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -610,8 +610,8 @@ go.opentelemetry.io/build-tools/chloggen v0.30.0 h1:vAHRnY59kRHqIUrsnmBYAcJ0+p8u
 go.opentelemetry.io/build-tools/chloggen v0.30.0/go.mod h1:7ZVQIvfBkhncKSyk6WY1F0Kkg/9ibxRZkUrHP7EJ9XY=
 go.opentelemetry.io/build-tools/crosslink v0.30.0 h1:aNk0ENhJEoeVYBPUD3nIGlkVphsIoN8LTC/MASc6xb8=
 go.opentelemetry.io/build-tools/crosslink v0.30.0/go.mod h1:4bR5pDaAwGYR0wBeVh+HdtnMyJHT4L9xsxOL4E3idzg=
-go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260629131108-f40f26bd9a4e h1:oVoybVEgh10We8k1X3CelNnB1sqSGujwq6WDAcIRNSc=
-go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260629131108-f40f26bd9a4e/go.mod h1:Z0A1NV2fLlP+uLThBDR49ue7fuvzkPgA3QylTlKByw0=
+go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260702202003-335e29c1ae8a h1:7/gop/xsJ2Q3BfBKahjRF/dd3D+ooO+V3Q5vNilrghM=
+go.opentelemetry.io/build-tools/githubgen v0.30.1-0.20260702202003-335e29c1ae8a/go.mod h1:Z0A1NV2fLlP+uLThBDR49ue7fuvzkPgA3QylTlKByw0=
 go.opentelemetry.io/build-tools/issuegenerator v0.30.0 h1:hUTh2h9j49cXn0Yg6cri/moWK4wu5AevcEHUj+slDm4=
 go.opentelemetry.io/build-tools/issuegenerator v0.30.0/go.mod h1:4KIkVTICFreixQUIzbE8JMbt9QhWllTC1gsn6iR684w=
 go.opentelemetry.io/build-tools/multimod v0.30.0 h1:f3L37C35ds33QIx2pwacH4F+EZp9BxGjbw3IIplu+uc=


### PR DESCRIPTION
#### Description

Being a member of open-telemetry is no longer sufficient for being added as a reviewing on a PR. You must also be in the https://github.com/orgs/open-telemetry/teams/collector-contrib-contributors team. This PR updates githubgen to use the new team-member enforcement feature.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Ran locally and found 30 code owners who were not members of the team. I've since added them.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
