### PR TITLE
[exporter/azuremonitor] include url path in dependency name when no h…

### DIFF
--- a/.chloggen/azuremonitor-dependency-name-url.yaml
+++ b/.chloggen/azuremonitor-dependency-name-url.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Include the URL path in the HTTP dependency name when `http.route` is not present, instead of falling back to just the request method.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -127,7 +127,7 @@ The exporter follows the semantic conventions to fill the Application Insights s
 | Request.Source                | `http.client_ip` or `net.peer.name`                   |           |
 | Request.ResponseCode          | `http.status_code` or `status_code`                   | `"0"`     |
 | Request.Success               | `http.status_code` or `status_code`                   | `true`    |
-| Dependency.Name               | `http.method`, `http.route`                           | span name |
+| Dependency.Name               | `http.method`, `http.route`, or path of `http.url`    | span name |
 | Dependency.Data               | `http.url` or span name or `db.statement`             |           |
 | Dependency.Type               | `"HTTP"` or `rpc.system` or `db.system` or `"InProc"` |           |
 | Dependency.Target             | host of `http.url` or `net.peer.name`                 |           |

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -406,6 +406,11 @@ func fillRemoteDependencyDataHTTP(span ptrace.Span, data *contracts.RemoteDepend
 	if attrs.HTTPRoute != "" {
 		sb.WriteString(" ")
 		sb.WriteString(attrs.HTTPRoute)
+	} else if attrs.URLAttributes.URLFull != "" {
+		if u, err := url.Parse(attrs.URLAttributes.URLFull); err == nil {
+			sb.WriteString(" ")
+			sb.WriteString(u.Path)
+		}
 	}
 
 	data.Name = sb.String()

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -407,7 +407,7 @@ func fillRemoteDependencyDataHTTP(span ptrace.Span, data *contracts.RemoteDepend
 		sb.WriteString(" ")
 		sb.WriteString(attrs.HTTPRoute)
 	} else if attrs.URLAttributes.URLFull != "" {
-		if u, err := url.Parse(attrs.URLAttributes.URLFull); err == nil {
+		if u, err := url.Parse(attrs.URLAttributes.URLFull); err == nil && u.Path != "" {
 			sb.WriteString(" ")
 			sb.WriteString(u.Path)
 		}

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -259,7 +259,7 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet1(t *testing.T) {
 
 	assert.Equal(t, "400", data.ResultCode)
 	assert.False(t, data.Success)
-	assert.Equal(t, defaultHTTPMethod, data.Name)
+	assert.Equal(t, defaultHTTPMethod+" /bar", data.Name)
 	assert.Equal(t, "https://foo:81/bar?biz=baz", data.Data)
 	assert.Equal(t, "HTTP", data.Type)
 }
@@ -346,6 +346,26 @@ func TestHTTPClientSpanToRemoteDependencyAttributeSet4(t *testing.T) {
 	defaultHTTPRemoteDependencyDataValidations(t, span, data)
 	assert.Equal(t, "https://127.0.0.1:81/bar?biz=baz", data.Data)
 	assert.Equal(t, "12345", envelope.Tags[contracts.UserId])
+}
+
+// Tests that the dependency name falls back to just the request method when
+// neither http.route nor url.full is present.
+func TestHTTPClientSpanToRemoteDependencyNameFallbackToMethod(t *testing.T) {
+	span := getDefaultHTTPClientSpan()
+	spanAttributes := span.Attributes()
+
+	spanAttributes.PutInt("http.response.status_code", defaultHTTPStatusCode)
+
+	// No http.route and no url.full => name defaults to just the request method.
+	spanAttributes.PutStr("url.full", "")
+
+	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, nil, zap.NewNop())
+	envelope := envelopes[0]
+	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
+	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	commonRemoteDependencyDataValidations(t, span, data)
+
+	assert.Equal(t, defaultHTTPMethod, data.Name)
 }
 
 // Tests proper assignment for an RPC server span


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This is a minor quality of life improvement. The Azure Monitor exporter builds the depenency Name field using `http.request.method` + `http.route`. However, `http.route` only exists on server spans. Client spans don't have it. So the dependency name ends up as just the request method. Adding the `else if` that falls back to parsing the URL path from `url.full` when `http.route` isn't available (Client spans always have `url.full`. )

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`TestHTTPClientSpanToRemoteDependencyNameFallbackToMethod` in `trace_to_envelope_test.go`. This test covers the case where `http.route` and `url.full` are not present, that it will set the dependency name to just the request method.

`Method + route` is covered by AttributeSet2

`Method + no route, url.full fallback` is covered by AttributeSet1

`Method + no route, no url.full` is covered by the test I added

<!--Describe the documentation added.-->
#### Documentation
Updated the attribute mapping table in the README for `azuremonitorexporter`

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.