### PR TITLE
[pkg/translator/pprof] Fix wrong conversion of labels from pprof to OTLP profiles

### DIFF
--- a/.chloggen/fix-pprof-label-conversion.yaml
+++ b/.chloggen/fix-pprof-label-conversion.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: buf_fix
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: pkg/translator/pprof

--- a/.chloggen/fix-pprof-label-conversion.yaml
+++ b/.chloggen/fix-pprof-label-conversion.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: buf_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/pprof
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Wrong conversion of labels from pprof to OTLP profiles
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49449]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/pprof/pprof_to_profiles.go
+++ b/pkg/translator/pprof/pprof_to_profiles.go
@@ -163,8 +163,7 @@ func ConvertPprofToProfiles(src *profile.Profile) (*pprofile.Profiles, error) {
 			// pprof.Sample.label - this field is split into string and numeric labels.
 			for lk, lv := range sample.Label {
 				if len(lv) != 1 {
-					return nil, fmt.Errorf("labels with multiple values (%d) are not supported: %w",
-						len(lv), errPprofInvalid)
+					return nil, fmt.Errorf("labels with multiple values (%d) are not supported", len(lv))
 				}
 				idx := lts.getIdxForAttribute(lk, lv[0])
 				s.AttributeIndices().Append(idx)
@@ -172,8 +171,7 @@ func ConvertPprofToProfiles(src *profile.Profile) (*pprofile.Profiles, error) {
 
 			for lk, lv := range sample.NumLabel {
 				if len(lv) != 1 {
-					return nil, fmt.Errorf("invalid length of numeric label value %d: %w",
-						len(lv), errPprofInvalid)
+					return nil, fmt.Errorf("numeric labels with multiple values (%d) are not supported", len(lv))
 				}
 				var idx int32
 				lu, exist := sample.NumUnit[lk]
@@ -181,8 +179,7 @@ func ConvertPprofToProfiles(src *profile.Profile) (*pprofile.Profiles, error) {
 					idx = lts.getIdxForAttribute(lk, lv[0])
 				} else {
 					if len(lu) != 1 {
-						return nil, fmt.Errorf("invalid length of numeric unit value %d: %w",
-							len(lu), errPprofInvalid)
+						return nil, fmt.Errorf("numeric units with multiple values (%d) are not supported", len(lu))
 					}
 					idx = lts.getIdxForAttributeWithUnit(lk, lu[0], lv[0])
 				}

--- a/pkg/translator/pprof/pprof_to_profiles.go
+++ b/pkg/translator/pprof/pprof_to_profiles.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-"reflect"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -166,8 +166,7 @@ func ConvertPprofToProfiles(src *profile.Profile) (*pprofile.Profiles, error) {
 					return nil, fmt.Errorf("labels with multiple values (%d) are not supported: %w",
 						len(lv), errPprofInvalid)
 				}
-				var idx int32
-				idx = lts.getIdxForAttribute(lk, lv[0])
+				idx := lts.getIdxForAttribute(lk, lv[0])
 				s.AttributeIndices().Append(idx)
 			}
 

--- a/pkg/translator/pprof/pprof_to_profiles.go
+++ b/pkg/translator/pprof/pprof_to_profiles.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"reflect"
+"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -167,12 +167,7 @@ func ConvertPprofToProfiles(src *profile.Profile) (*pprofile.Profiles, error) {
 						len(lv), errPprofInvalid)
 				}
 				var idx int32
-				lu, exist := sample.NumUnit[lk]
-				if !exist {
-					idx = lts.getIdxForAttribute(lk, lv)
-				} else {
-					idx = lts.getIdxForAttributeWithUnit(lk, lu[0], lv)
-				}
+				idx = lts.getIdxForAttribute(lk, lv[0])
 				s.AttributeIndices().Append(idx)
 			}
 
@@ -184,9 +179,13 @@ func ConvertPprofToProfiles(src *profile.Profile) (*pprofile.Profiles, error) {
 				var idx int32
 				lu, exist := sample.NumUnit[lk]
 				if !exist {
-					idx = lts.getIdxForAttribute(lk, lv)
+					idx = lts.getIdxForAttribute(lk, lv[0])
 				} else {
-					idx = lts.getIdxForAttributeWithUnit(lk, lu[0], lv)
+					if len(lu) != 1 {
+						return nil, fmt.Errorf("invalid length of numeric unit value %d: %w",
+							len(lu), errPprofInvalid)
+					}
+					idx = lts.getIdxForAttributeWithUnit(lk, lu[0], lv[0])
 				}
 				s.AttributeIndices().Append(idx)
 			}

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -455,9 +456,13 @@ func TestConvertPprofToProfiles_LabelValidationErrors(t *testing.T) {
 			},
 		}
 
-		_, err := ConvertPprofToProfiles(makeProfile(sample))
+		pprof := makeProfile(sample)
+
+		require.NoError(t, pprof.CheckValid())
+
+		_, err := ConvertPprofToProfiles(pprof)
 		require.Error(t, err)
-		require.ErrorIs(t, err, errPprofInvalid)
+		require.EqualError(t, err, fmt.Sprintf("labels with multiple values (%d) are not supported", 2))
 	})
 
 	t.Run("numeric label with multiple values", func(t *testing.T) {
@@ -471,7 +476,24 @@ func TestConvertPprofToProfiles_LabelValidationErrors(t *testing.T) {
 
 		_, err := ConvertPprofToProfiles(makeProfile(sample))
 		require.Error(t, err)
-		require.ErrorIs(t, err, errPprofInvalid)
+		require.EqualError(t, err, fmt.Sprintf("numeric labels with multiple values (%d) are not supported", 2))
+	})
+
+	t.Run("numeric unit with multiple values", func(t *testing.T) {
+		sample := &profile.Sample{
+			Location: []*profile.Location{baseLocation},
+			Value:    []int64{10},
+			NumLabel: map[string][]int64{
+				"n": {1},
+			},
+			NumUnit: map[string][]string{
+				"n": {"a", "b"},
+			},
+		}
+
+		_, err := ConvertPprofToProfiles(makeProfile(sample))
+		require.Error(t, err)
+		require.EqualError(t, err, fmt.Sprintf("numeric units with multiple values (%d) are not supported", 2))
 	})
 }
 

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -532,7 +532,7 @@ func TestConvertPprofToProfiles_LabelAndNumUnitPaths(t *testing.T) {
 
 	p := out.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0)
 	require.Equal(t, 1, p.Samples().Len())
-	require.Equal(t, p.Samples().At(0).AttributeIndices().Len(), 4)
+	require.Equal(t, 4, p.Samples().At(0).AttributeIndices().Len())
 	for _, attrIdx := range p.Samples().At(0).AttributeIndices().All() {
 		require.NotZero(t, attrIdx)
 		attr := out.Dictionary().AttributeTable().At(int(attrIdx))

--- a/pkg/translator/pprof/pprof_to_profiles_test.go
+++ b/pkg/translator/pprof/pprof_to_profiles_test.go
@@ -532,7 +532,33 @@ func TestConvertPprofToProfiles_LabelAndNumUnitPaths(t *testing.T) {
 
 	p := out.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0)
 	require.Equal(t, 1, p.Samples().Len())
-	require.GreaterOrEqual(t, p.Samples().At(0).AttributeIndices().Len(), 4)
+	require.Equal(t, p.Samples().At(0).AttributeIndices().Len(), 4)
+	for _, attrIdx := range p.Samples().At(0).AttributeIndices().All() {
+		require.NotZero(t, attrIdx)
+		attr := out.Dictionary().AttributeTable().At(int(attrIdx))
+		keyIdx := attr.KeyStrindex()
+		require.NotZero(t, keyIdx)
+		key := out.Dictionary().StringTable().At(int(keyIdx))
+		switch key {
+		case "label.with.unit":
+			require.Equal(t, "v", attr.Value().AsString())
+			require.Zero(t, attr.UnitStrindex())
+		case "label.no.unit":
+			require.Equal(t, "x", attr.Value().AsString())
+			require.Zero(t, attr.UnitStrindex())
+		case "num.with.unit":
+			require.Equal(t, int64(7), attr.Value().Int())
+			unitIdx := attr.UnitStrindex()
+			require.NotZero(t, unitIdx)
+			unit := out.Dictionary().StringTable().At(int(unitIdx))
+			require.Equal(t, "ms", unit)
+		case "num.no.unit":
+			require.Equal(t, int64(8), attr.Value().Int())
+			require.Zero(t, attr.UnitStrindex())
+		default:
+			t.Errorf("unexpected key: %s", key)
+		}
+	}
 	require.GreaterOrEqual(t, p.AttributeIndices().Len(), 3)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fix wrong conversion of labels from pprof to OTLP profiles.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49449

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
