### PR TITLE
[pkg/translator/pprof] reduce redundant work in sample conversion

### DIFF
--- a/.chloggen/pprof-redundant-sample-conversion.yaml
+++ b/.chloggen/pprof-redundant-sample-conversion.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/pprof
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: reduce redundant work in sample conversion
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/pprof/profiles_to_pprof.go
+++ b/pkg/translator/pprof/profiles_to_pprof.go
@@ -51,15 +51,16 @@ func ConvertPprofileToPprof(src *pprofile.Profiles) (*profile.Profile, error) {
 	// "All Samples for a Profile SHOULD have the same shape."
 	for profileIdx := range numProfiles {
 		prof := pprofiles.At(profileIdx)
-		if prof.Samples().Len() == 0 {
+		samples := prof.Samples()
+		if samples.Len() == 0 {
 			continue
 		}
-		firstShape, err := sampleShapeOf(prof.Samples().At(0))
+		firstShape, err := sampleShapeOf(samples.At(0))
 		if err != nil {
 			return nil, fmt.Errorf("profile %d, sample 0: %w", profileIdx, err)
 		}
-		for sampleIdx := 1; sampleIdx < prof.Samples().Len(); sampleIdx++ {
-			shape, err := sampleShapeOf(prof.Samples().At(sampleIdx))
+		for sampleIdx := 1; sampleIdx < samples.Len(); sampleIdx++ {
+			shape, err := sampleShapeOf(samples.At(sampleIdx))
 			if err != nil {
 				return nil, fmt.Errorf("profile %d, sample %d: %w", profileIdx, sampleIdx, err)
 			}
@@ -120,7 +121,11 @@ func ConvertPprofileToPprof(src *pprofile.Profiles) (*profile.Profile, error) {
 				mappedIdx = i
 			}
 			otlpSample := pprofiles.At(mappedIdx).Samples().At(sampleIdx)
-			vals, err := sampleToPprofValues(otlpSample)
+			shape, err := sampleShapeOf(otlpSample)
+			if err != nil {
+				return nil, err
+			}
+			vals, err := sampleToPprofValues(otlpSample, shape)
 			if err != nil {
 				return nil, err
 			}
@@ -289,21 +294,18 @@ func sampleShapeOf(s pprofile.Sample) (sampleShape, error) {
 // The caller emits one pprof Sample per returned element, all sharing the same
 // location list. This matches the pprof proto convention where aggregation is
 // done by summing samples that share the same stack, not by pre-collapsing.
-func sampleToPprofValues(s pprofile.Sample) ([]int64, error) {
-	shape, err := sampleShapeOf(s)
-	if err != nil {
-		return nil, err
-	}
+func sampleToPprofValues(s pprofile.Sample, shape sampleShape) ([]int64, error) {
 	switch shape {
 	case timestampsOnly:
 		return []int64{int64(s.TimestampsUnixNano().Len())}, nil
 	case singleAggregate:
 		return []int64{s.Values().At(0)}, nil
 	case perObservation:
-		nValues := s.Values().Len()
+		sv := s.Values()
+		nValues := sv.Len()
 		vals := make([]int64, nValues)
 		for i := range nValues {
-			vals[i] = s.Values().At(i)
+			vals[i] = sv.At(i)
 		}
 		return vals, nil
 	default:


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`sampleShapeOf` was called twice per sample during conversion: once explicitly in the cross-profile loop and again inside `sampleToPprofValues`. Similarly, `prof.Samples()` was reconstructed on every iteration of the shape-validation loop guard, and `s.Values()` was reconstructed on every element access in the perObservation branch. Fix this by passing the pre-computed shape into `sampleToPprofValues`, hoisting `prof.Samples()` into a local variable, and caching `s.Values()` before the inner loop.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
