### PR TITLE
[processor/metricstransform] Fix silent data loss for Summary metrics in aggregate_labels and aggregate_label_values operations

### DIFF
--- a/.chloggen/49456-metricstransform-summary-aggregation.yaml
+++ b/.chloggen/49456-metricstransform-summary-aggregation.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: processor/metrics_transform
+
+note: aggregate_labels and aggregate_label_values operations no longer silently drop all data points when applied to Summary metrics. The operation is now skipped with a warning log instead.
+
+issues: [49456]
+
+change_logs: [user]

--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -185,6 +185,19 @@ func buildExpHistogramBucket(m map[int]uint64) []uint64 {
 	return result
 }
 
+func (b builder) addSummaryDatapoint(start, ts pcommon.Timestamp, count uint64, sum float64, attrValues ...string) builder {
+	if b.metric.Type() != pmetric.MetricTypeSummary {
+		panic(b.metric.Type().String())
+	}
+	dp := b.metric.Summary().DataPoints().AppendEmpty()
+	b.setAttrs(dp.Attributes(), attrValues)
+	dp.SetCount(count)
+	dp.SetSum(sum)
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	return b
+}
+
 // setUnit sets the unit of this metric
 func (b builder) setUnit(unit string) builder {
 	b.metric.SetUnit(unit)

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -256,7 +256,11 @@ func (mtp *metricsTransformProcessor) processMetrics(_ context.Context, md pmetr
 					extractedMetrics := pmetric.NewMetricSlice()
 					extractAndRemoveMatchedMetrics(extractedMetrics, transform.MetricIncludeFilter, metrics)
 					combinedMetric := combine(transform, extractedMetrics)
-					if transformMetric(combinedMetric, transform) {
+					valid, err := transformMetric(combinedMetric, transform)
+					if err != nil {
+						mtp.logger.Warn(err.Error())
+					}
+					if valid {
 						combinedMetric.MoveTo(metrics.AppendEmpty())
 					}
 				case Insert:
@@ -272,7 +276,11 @@ func (mtp *metricsTransformProcessor) processMetrics(_ context.Context, md pmetr
 							newMetric = pmetric.NewMetric()
 							metric.CopyTo(newMetric)
 						}
-						if transformMetric(newMetric, transform) {
+						valid, err := transformMetric(newMetric, transform)
+						if err != nil {
+							mtp.logger.Warn(err.Error())
+						}
+						if valid {
 							newMetric.MoveTo(metrics.AppendEmpty())
 						}
 					}
@@ -283,7 +291,11 @@ func (mtp *metricsTransformProcessor) processMetrics(_ context.Context, md pmetr
 						}
 
 						// Drop the metric if all the data points were dropped after transformations.
-						return !transformMetric(metric, transform)
+						valid, err := transformMetric(metric, transform)
+						if err != nil {
+							mtp.logger.Warn(err.Error())
+						}
+						return !valid
 					})
 				}
 			}
@@ -533,7 +545,8 @@ func countDataPoints(metric pmetric.Metric) int {
 // transformMetric updates the metric content based on operations indicated in transform and returns a flag
 // specifying whether the metric is valid after applying the translations,
 // e.g. false is returned if all the data points were removed after applying the translations.
-func transformMetric(metric pmetric.Metric, transform internalTransform) bool {
+// A non-nil error is returned when an operation is not supported for the metric type; the metric is left unchanged.
+func transformMetric(metric pmetric.Metric, transform internalTransform) (bool, error) {
 	isMetricEmpty := countDataPoints(metric) == 0
 	canChangeMetric := transform.Action != Update || matchAllDps(metric, transform.MetricIncludeFilter)
 
@@ -558,11 +571,15 @@ func transformMetric(metric pmetric.Metric, transform internalTransform) bool {
 						attrs = append(attrs, k)
 					}
 				}
-				aggregateLabelsOp(metric, attrs, op.configOperation.AggregationType)
+				if err := aggregateLabelsOp(metric, attrs, op.configOperation.AggregationType); err != nil {
+					return true, err
+				}
 			}
 		case aggregateLabelValues:
 			if canChangeMetric {
-				aggregateLabelValuesOp(metric, op)
+				if err := aggregateLabelValuesOp(metric, op); err != nil {
+					return true, err
+				}
 			}
 		case toggleScalarDataType:
 			toggleScalarDataTypeOp(metric, transform.MetricIncludeFilter)
@@ -580,5 +597,5 @@ func transformMetric(metric pmetric.Metric, transform internalTransform) bool {
 	}
 
 	// Consider metric invalid if all its data points were removed after applying the operations.
-	return isMetricEmpty || countDataPoints(metric) > 0
+	return isMetricEmpty || countDataPoints(metric) > 0, nil
 }

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -2063,4 +2063,63 @@ var standardTests = []metricsTransformTest{
 		},
 		out: []pmetric.Metric{},
 	},
+	{
+		name: "metric_aggregate_labels_summary_passthrough",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: &operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSummary, "metric1", "label1", "label2").
+				addSummaryDatapoint(1, 2, 10, 100.0, "label1-value1", "label2-value1").
+				addSummaryDatapoint(3, 4, 20, 200.0, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSummary, "metric1", "label1", "label2").
+				addSummaryDatapoint(1, 2, 10, 100.0, "label1-value1", "label2-value1").
+				addSummaryDatapoint(3, 4, 20, 200.0, "label1-value1", "label2-value2").build(),
+		},
+	},
+	{
+		name: "metric_aggregate_label_values_summary_passthrough",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: &operation{
+							Action:          aggregateLabelValues,
+							Label:           "label2",
+							NewValue:        "new-label2",
+							AggregationType: aggregateutil.Sum,
+						},
+						aggregatedValuesSet: map[string]bool{"label2-value1": true, "label2-value2": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSummary, "metric1", "label1", "label2").
+				addSummaryDatapoint(1, 2, 10, 100.0, "label1-value1", "label2-value1").
+				addSummaryDatapoint(3, 4, 20, 200.0, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSummary, "metric1", "label1", "label2").
+				addSummaryDatapoint(1, 2, 10, 100.0, "label1-value1", "label2-value1").
+				addSummaryDatapoint(3, 4, 20, 200.0, "label1-value1", "label2-value2").build(),
+		},
+	},
 }

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -4,6 +4,8 @@
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -11,7 +13,10 @@ import (
 )
 
 // aggregateLabelValuesOp aggregates points that have the label values specified in aggregated_values
-func aggregateLabelValuesOp(metric pmetric.Metric, mtpOp *internalOperation) {
+func aggregateLabelValuesOp(metric pmetric.Metric, mtpOp *internalOperation) error {
+	if metric.Type() == pmetric.MetricTypeSummary {
+		return fmt.Errorf("aggregate_label_values is not supported for Summary metrics: %v", metric.Name())
+	}
 	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
 		val, ok := attrs.Get(mtpOp.configOperation.Label)
 		if !ok {
@@ -30,4 +35,5 @@ func aggregateLabelValuesOp(metric pmetric.Metric, mtpOp *internalOperation) {
 	aggregateutil.GroupDataPoints(metric, &ag)
 	aggregateutil.MergeDataPoints(newMetric, mtpOp.configOperation.AggregationType, ag)
 	newMetric.MoveTo(metric)
+	return nil
 }

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -4,13 +4,18 @@
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/aggregateutil"
 )
 
 // aggregateLabelsOp aggregates points that have the labels excluded in label_set
-func aggregateLabelsOp(metric pmetric.Metric, attributes []string, aggrType aggregateutil.AggregationType) {
+func aggregateLabelsOp(metric pmetric.Metric, attributes []string, aggrType aggregateutil.AggregationType) error {
+	if metric.Type() == pmetric.MetricTypeSummary {
+		return fmt.Errorf("aggregate_labels is not supported for Summary metrics: %v", metric.Name())
+	}
 	ag := aggregateutil.AggGroups{}
 	aggregateutil.FilterAttrs(metric, attributes)
 	newMetric := pmetric.NewMetric()
@@ -18,4 +23,5 @@ func aggregateLabelsOp(metric pmetric.Metric, attributes []string, aggrType aggr
 	aggregateutil.GroupDataPoints(metric, &ag)
 	aggregateutil.MergeDataPoints(newMetric, aggrType, ag)
 	newMetric.MoveTo(metric)
+	return nil
 }


### PR DESCRIPTION
fixes #49456 
- aggregateLabelsOp and aggregateLabelValuesOp previously had no guard for Summary metrics. When called on a Summary, GroupDataPoints and MergeDataPoints had no Summary case, so they produced an empty metric, and MoveTo then replaced the original with that empty metric — silently dropping all data points.
- The fix adds a Summary type check at the top of both functions that returns an fmt.Errorf immediately, leaving the metric completely unchanged.
- transformMetric signature was changed from bool to (bool, error) to propagate that error up to where the logger lives. All three call sites now log the error as mtp.logger.Warn.
- Two test cases were added to verify Summary metrics pass through with all data points intact.
- Same pattern as canBeCombined already uses for the combine action

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
