### PR TITLE
fix(receiver/memcached): report hit ratio, not miss ratio

### DIFF
--- a/.chloggen/memcached-hit-ratio.yaml
+++ b/.chloggen/memcached-hit-ratio.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: receiver/memcached
+note: Fix `memcached.operation_hit_ratio` reporting the miss ratio instead of the hit ratio
+issues: [49470]
+subtext: |
+  The arguments passed to the hit-ratio helper were swapped relative to its
+  parameters, so the metric emitted misses / (hits + misses) rather than
+  hits / (hits + misses).

--- a/receiver/memcachedreceiver/scraper.go
+++ b/receiver/memcachedreceiver/scraper.go
@@ -178,7 +178,7 @@ func (r *memcachedScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 	return r.mb.Emit(), nil
 }
 
-func calculateHitRatio(misses, hits int64) float64 {
+func calculateHitRatio(hits, misses int64) float64 {
 	if misses+hits == 0 {
 		return 0
 	}

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -64,3 +64,22 @@ func TestScraperTLSConfigError(t *testing.T) {
 	_, err := scraper.scrape(t.Context())
 	require.Error(t, err)
 }
+
+func TestCalculateHitRatio(t *testing.T) {
+	tests := []struct {
+		name     string
+		hits     int64
+		misses   int64
+		expected float64
+	}{
+		{name: "all hits", hits: 100, misses: 0, expected: 100},
+		{name: "all misses", hits: 0, misses: 100, expected: 0},
+		{name: "mostly hits", hits: 90, misses: 10, expected: 90},
+		{name: "no operations", hits: 0, misses: 0, expected: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, calculateHitRatio(tt.hits, tt.misses))
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
 #### Description

  memcached.operation_hit_ratio was reporting the miss ratio instead of the hit ratio. calculateHitRatio
  was declared as (misses, hits) but every call site passes (hits, misses), so it computed misses / (hits + misses). This aligns the parameter order with the callers so the metric reports hits / (hits + 
  misses).

  #### Link to tracking issue

  None; found while reading the receiver code.

  #### Testing

  Added a unit test for calculateHitRatio covering all-hits, all-misses, a mixed case, and zero
  operations. The existing scraper test still passes.

  #### Documentation
  
  No documentation changes; the metric is already documented as a hit ratio.

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
