### PR TITLE
[receiver/postgresql] Update `explainQuery` client method to also include context

### DIFF
--- a/.chloggen/fix-postgresql-explain-context.yaml
+++ b/.chloggen/fix-postgresql-explain-context.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: 'receiver/postgresqlreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Fixes a bug in `explainQuery` so that it honors context cancellation'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -68,7 +68,7 @@ type client interface {
 	getVersion(ctx context.Context) (string, error)
 	getQuerySamples(ctx context.Context, limit int64, newestQueryTimestamp float64, logger *zap.Logger) ([]map[string]any, float64, error)
 	getTopQuery(ctx context.Context, limit int64, logger *zap.Logger) ([]map[string]any, error)
-	explainQuery(query, queryID string, logger *zap.Logger) (string, error)
+	explainQuery(ctx context.Context, query, queryID string, logger *zap.Logger) (string, error)
 }
 
 type postgreSQLClient struct {
@@ -129,7 +129,7 @@ func isExplainableQuery(query string) bool {
 }
 
 // explainQuery implements client.
-func (c *postgreSQLClient) explainQuery(query, queryID string, logger *zap.Logger) (string, error) {
+func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID string, logger *zap.Logger) (string, error) {
 	// Check if the query is explainable before attempting EXPLAIN
 	if !isExplainableQuery(query) {
 		logger.Debug("skipping EXPLAIN for non-explainable query", zap.String("queryID", queryID))
@@ -149,7 +149,7 @@ func (c *postgreSQLClient) explainQuery(query, queryID string, logger *zap.Logge
 	}
 
 	defer func() {
-		_, _ = c.client.Exec(fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
+		_, _ = c.client.ExecContext(ctx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
 	}()
 
 	// if there is no parameter needed, we can not put an empty bracket
@@ -164,7 +164,7 @@ func (c *postgreSQLClient) explainQuery(query, queryID string, logger *zap.Logge
 
 	wrappedDb := sqlquery.NewDbClient(sqlquery.DbWrapper{Db: c.client}, setPlanCacheMode+prepareStatement+explainStatement, logger, sqlquery.TelemetryConfig{})
 
-	result, err := wrappedDb.QueryRows(context.Background())
+	result, err := wrappedDb.QueryRows(ctx)
 	if err != nil {
 		logger.Error("failed to explain statement", zap.Error(err))
 		return "", err

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -32,6 +32,10 @@ import (
 
 const querySampleTraceContextKey = "_otel_trace_context"
 
+// detachedCleanupTimeout bounds best-effort cleanup statements (see execDetached)
+// so a truly unresponsive backend can't hang cleanup forever.
+const detachedCleanupTimeout = 5 * time.Second
+
 // databaseName is a name that refers to a database so that it can be uniquely referred to later
 // i.e. database1
 type databaseName string
@@ -128,6 +132,17 @@ func isExplainableQuery(query string) bool {
 	return ok
 }
 
+// execDetached runs a best-effort cleanup statement using a context that
+// survives cancellation of ctx, so cleanup still runs even if ctx was already
+// canceled or timed out (e.g. because the operation it was cleaning up after
+// got canceled) — otherwise long-lived pooled connections can be left with
+// leaked server-side state such as a prepared statement.
+func (c *postgreSQLClient) execDetached(ctx context.Context, query string) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), detachedCleanupTimeout)
+	defer cancel()
+	_, _ = c.client.ExecContext(cleanupCtx, query)
+}
+
 // explainQuery implements client.
 func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID string, logger *zap.Logger) (string, error) {
 	// Check if the query is explainable before attempting EXPLAIN
@@ -148,16 +163,7 @@ func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID stri
 		nulls[i] = "null"
 	}
 
-	defer func() {
-		// Use a context detached from ctx's cancellation so that cleanup still runs
-		// even if the caller's context was canceled or timed out (e.g. due to the
-		// EXPLAIN itself being blocked), avoiding leaked prepared statements on
-		// long-lived pooled connections. Bound it with its own timeout so a truly
-		// unresponsive backend can't hang cleanup forever.
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-		defer cancel()
-		_, _ = c.client.ExecContext(cleanupCtx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
-	}()
+	defer c.execDetached(ctx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
 
 	// if there is no parameter needed, we can not put an empty bracket
 

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -149,7 +149,14 @@ func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID stri
 	}
 
 	defer func() {
-		_, _ = c.client.ExecContext(ctx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
+		// Use a context detached from ctx's cancellation so that cleanup still runs
+		// even if the caller's context was canceled or timed out (e.g. due to the
+		// EXPLAIN itself being blocked), avoiding leaked prepared statements on
+		// long-lived pooled connections. Bound it with its own timeout so a truly
+		// unresponsive backend can't hang cleanup forever.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		_, _ = c.client.ExecContext(cleanupCtx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
 	}()
 
 	// if there is no parameter needed, we can not put an empty bracket

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -32,8 +32,8 @@ import (
 
 const querySampleTraceContextKey = "_otel_trace_context"
 
-// detachedCleanupTimeout bounds best-effort cleanup statements (see execDetached)
-// so a truly unresponsive backend can't hang cleanup forever.
+// detachedCleanupTimeout bounds the best-effort DEALLOCATE PREPARE cleanup in
+// explainQuery so a truly unresponsive backend can't hang cleanup forever.
 const detachedCleanupTimeout = 5 * time.Second
 
 // databaseName is a name that refers to a database so that it can be uniquely referred to later
@@ -132,17 +132,6 @@ func isExplainableQuery(query string) bool {
 	return ok
 }
 
-// execDetached runs a best-effort cleanup statement using a context that
-// survives cancellation of ctx, so cleanup still runs even if ctx was already
-// canceled or timed out (e.g. because the operation it was cleaning up after
-// got canceled) — otherwise long-lived pooled connections can be left with
-// leaked server-side state such as a prepared statement.
-func (c *postgreSQLClient) execDetached(ctx context.Context, query string) {
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), detachedCleanupTimeout)
-	defer cancel()
-	_, _ = c.client.ExecContext(cleanupCtx, query)
-}
-
 // explainQuery implements client.
 func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID string, logger *zap.Logger) (string, error) {
 	// Check if the query is explainable before attempting EXPLAIN
@@ -163,7 +152,15 @@ func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID stri
 		nulls[i] = "null"
 	}
 
-	defer c.execDetached(ctx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
+	// run cleanup on a context that survives cancellation of ctx, so it still
+	// runs even if ctx was already canceled or timed out.
+	// otherwise, long-lived pooled connections can be left with leaked
+	// server-side state since prepared statements need to be deallocated
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), detachedCleanupTimeout)
+		defer cancel()
+		_, _ = c.client.ExecContext(cleanupCtx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
+	}()
 
 	// if there is no parameter needed, we can not put an empty bracket
 

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -360,7 +360,7 @@ func (p *postgreSQLScraper) collectTopQuery(ctx context.Context, clientFactory p
 			database := item.Value[string(semconv.DBNamespaceKey)].(string)
 			dbClient, err := clientFactory.getClient(database)
 			if err == nil {
-				plan, err = dbClient.explainQuery(rawQuery, queryID, logger)
+				plan, err = dbClient.explainQuery(ctx, rawQuery, queryID, logger)
 				if err != nil {
 					logger.Error("failed to explain query", zap.String("query", rawQuery), zap.Error(err))
 				}

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -968,11 +968,34 @@ func TestExplainQuery(t *testing.T) {
 				sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(tc.mockPlanResult),
 			)
 
-			plan, err := client.explainQuery(tc.query, tc.queryID, logger)
+			plan, err := client.explainQuery(t.Context(), tc.query, tc.queryID, logger)
 			require.NoError(t, err)
 			assert.Equal(t, tc.mockPlanResult, plan)
 		})
 	}
+}
+
+func TestExplainQueryUsesContext(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	logger := zap.NewNop()
+	client := &postgreSQLClient{
+		client:  db,
+		closeFn: func() error { return nil },
+	}
+
+	expectedSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;EXPLAIN(FORMAT JSON) EXECUTE otel_12345;"
+	mock.ExpectQuery(expectedSQL).
+		WillDelayFor(50 * time.Millisecond).
+		WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(`[{"Plan":{"Node Type":"Seq Scan","Relation Name":"users"}}]`))
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer cancel()
+
+	_, err = client.explainQuery(ctx, "SELECT * FROM users", "12345", logger)
+	require.Error(t, err)
 }
 
 type (
@@ -984,7 +1007,7 @@ type (
 )
 
 // explainQuery implements client.
-func (*mockClient) explainQuery(string, string, *zap.Logger) (string, error) {
+func (*mockClient) explainQuery(context.Context, string, string, *zap.Logger) (string, error) {
 	panic("unimplemented")
 }
 

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -991,11 +991,22 @@ func TestExplainQueryUsesContext(t *testing.T) {
 		WillDelayFor(50 * time.Millisecond).
 		WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(`[{"Plan":{"Node Type":"Seq Scan","Relation Name":"users"}}]`))
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	// Cleanup must still run even though the caller's context is already
+	// expired by the time the deferred DEALLOCATE PREPARE fires, otherwise
+	// the prepared statement leaks on long-lived pooled connections.
+	mock.ExpectExec("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_12345").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// The timeout must be short enough to expire before the mocked query's
+	// delay elapses (so explainQuery observes a context error), but long
+	// enough that the query actually reaches the driver first (otherwise the
+	// ExpectQuery above is never triggered).
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 
 	_, err = client.explainQuery(ctx, "SELECT * FROM users", "12345", logger)
 	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 type (

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -988,20 +988,15 @@ func TestExplainQueryUsesContext(t *testing.T) {
 
 	expectedSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;EXPLAIN(FORMAT JSON) EXECUTE otel_12345;"
 	mock.ExpectQuery(expectedSQL).
-		WillDelayFor(50 * time.Millisecond).
+		WillDelayFor(200 * time.Millisecond).
 		WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(`[{"Plan":{"Node Type":"Seq Scan","Relation Name":"users"}}]`))
 
-	// Cleanup must still run even though the caller's context is already
-	// expired by the time the deferred DEALLOCATE PREPARE fires, otherwise
-	// the prepared statement leaks on long-lived pooled connections.
+	// Cleanup (DEALLOCATE PREPARE) must still run even though ctx expires
+	// mid-query, otherwise the prepared statement leaks on pooled connections.
 	mock.ExpectExec("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_12345").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
-	// The timeout must be short enough to expire before the mocked query's
-	// delay elapses (so explainQuery observes a context error), but long
-	// enough that the query actually reaches the driver first (otherwise the
-	// ExpectQuery above is never triggered).
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 
 	_, err = client.explainQuery(ctx, "SELECT * FROM users", "12345", logger)

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -968,11 +968,42 @@ func TestExplainQuery(t *testing.T) {
 				sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(tc.mockPlanResult),
 			)
 
+			// The prepared statement must always be deallocated afterwards,
+			// otherwise it leaks server-side state on pooled connections.
+			normalizedQueryID := strings.ReplaceAll(tc.queryID, "-", "_")
+			mock.ExpectExec(fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID)).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+
 			plan, err := client.explainQuery(t.Context(), tc.query, tc.queryID, logger)
 			require.NoError(t, err)
 			assert.Equal(t, tc.mockPlanResult, plan)
+			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestExplainQueryErrorStillCleansUp(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer db.Close()
+
+	logger := zap.NewNop()
+	client := &postgreSQLClient{
+		client:  db,
+		closeFn: func() error { return nil },
+	}
+
+	expectedSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;EXPLAIN(FORMAT JSON) EXECUTE otel_12345;"
+	mock.ExpectQuery(expectedSQL).WillReturnError(errors.New("syntax error"))
+
+	// Even though the EXPLAIN itself failed, PREPARE may have already
+	// registered the statement server-side, so cleanup must still run.
+	mock.ExpectExec("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_12345").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	_, err = client.explainQuery(t.Context(), "SELECT * FROM users", "12345", logger)
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestExplainQueryUsesContext(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Noticed this issue (while working on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49352) where `explainQuery` API in client.go doesn't take in context unlike the rest of the interface functions, and uses background context instead.
This can be problematic since if the context is cancelled, the `explainQuery` API will not honor it and could keep on going. Some problems that can arise -
1. EXPLAIN query would ignore the scrape timeouts and cancellations
2. Collector shutdown won't be honored by the receiver
3. Breaks client interface established conventions
As part of the fix, I added the `context` back in the API and updated the function.

There's a small caveat with `DEALLOCATE PREPARE` though; In the original code it was using global context and was unbounded, I have now added it with a timed out context since `DEALLOCATE PREPARE` must be called even if the parent context is cancelled to stop polluting the shared connection pool.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
