### PR TITLE
[receiver/splunk_hec] Fix `read_header_timeout` and `write_timeout` configuration options getting overridden

### DIFF
--- a/.chloggen/dylan_splunk-hec-http-config.yaml
+++ b/.chloggen/dylan_splunk-hec-http-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/splunk_hec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the receiver silently ignoring the `read_header_timeout` and `write_timeout` settings, which were overridden by a hard-coded 20s timeout
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dylan_splunk-hec-http-config.yaml
+++ b/.chloggen/dylan_splunk-hec-http-config.yaml
@@ -10,7 +10,7 @@ component: receiver/splunk_hec
 note: Fix the receiver silently ignoring the `read_header_timeout` and `write_timeout` settings, which were overridden by a hard-coded 20s timeout
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [49483]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -30,8 +30,8 @@ func TestLoadConfig(t *testing.T) {
 
 	allSettingsServerConfig := confighttp.NewDefaultServerConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	allSettingsServerConfig.WriteTimeout = 0
-	allSettingsServerConfig.ReadHeaderTimeout = 0
+	allSettingsServerConfig.WriteTimeout = defaultServerTimeout
+	allSettingsServerConfig.ReadHeaderTimeout = defaultServerTimeout
 	allSettingsServerConfig.IdleTimeout = 0
 	allSettingsServerConfig.KeepAlivesEnabled = false
 	allSettingsServerConfig.NetAddr = confignet.AddrConfig{
@@ -41,8 +41,8 @@ func TestLoadConfig(t *testing.T) {
 
 	tlsServerConfig := confighttp.NewDefaultServerConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	tlsServerConfig.WriteTimeout = 0
-	tlsServerConfig.ReadHeaderTimeout = 0
+	tlsServerConfig.WriteTimeout = defaultServerTimeout
+	tlsServerConfig.ReadHeaderTimeout = defaultServerTimeout
 	tlsServerConfig.IdleTimeout = 0
 	tlsServerConfig.KeepAlivesEnabled = false
 	tlsServerConfig.NetAddr = confignet.AddrConfig{

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -5,6 +5,7 @@ package splunkhecreceiver // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -24,6 +25,8 @@ import (
 const (
 	// Default endpoint to bind to.
 	defaultEndpoint = "localhost:8088"
+
+	defaultServerTimeout = 20 * time.Second
 )
 
 // NewFactory creates a factory for Splunk HEC receiver.
@@ -42,8 +45,8 @@ func createDefaultConfig() component.Config {
 	netAddr.Endpoint = defaultEndpoint
 	serverConfig := confighttp.NewDefaultServerConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
+	serverConfig.WriteTimeout = defaultServerTimeout
+	serverConfig.ReadHeaderTimeout = defaultServerTimeout
 	serverConfig.IdleTimeout = 0
 	serverConfig.KeepAlivesEnabled = false
 	serverConfig.NetAddr = netAddr

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -33,8 +33,6 @@ import (
 )
 
 const (
-	defaultServerTimeout = 20 * time.Second
-
 	ackResponse                       = `{"acks": %s}`
 	responseOK                        = `{"text": "Success", "code": 0}`
 	responseOKWithAckID               = `{"text": "Success", "code": 0, "ackId": %d}`
@@ -164,11 +162,6 @@ func (r *splunkReceiver) Start(ctx context.Context, host component.Host) error {
 	if err != nil {
 		return err
 	}
-
-	// TODO: Evaluate what properties should be configurable, for now
-	//		set some hard-coded values.
-	r.server.ReadHeaderTimeout = defaultServerTimeout
-	r.server.WriteTimeout = defaultServerTimeout
 
 	r.shutdownWG.Go(func() {
 		if errHTTP := r.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -65,8 +65,8 @@ func Test_splunkhecreceiver_NewReceiver(t *testing.T) {
 	}
 	happyPathServerConfig := confighttp.NewDefaultServerConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	happyPathServerConfig.WriteTimeout = 0
-	happyPathServerConfig.ReadHeaderTimeout = 0
+	happyPathServerConfig.WriteTimeout = defaultServerTimeout
+	happyPathServerConfig.ReadHeaderTimeout = defaultServerTimeout
 	happyPathServerConfig.IdleTimeout = 0
 	happyPathServerConfig.KeepAlivesEnabled = false
 	happyPathServerConfig.NetAddr = confignet.AddrConfig{
@@ -1371,6 +1371,23 @@ func Test_splunkhecReceiver_Start(t *testing.T) {
 			assert.NoError(t, rcv.Shutdown(t.Context()))
 		})
 	}
+}
+
+func Test_splunkhecReceiver_ServerTimeoutsFromConfig(t *testing.T) {
+	config := createDefaultConfig().(*Config)
+	config.NetAddr.Endpoint = "localhost:0"
+	config.WriteTimeout = 60 * time.Second
+	config.ReadHeaderTimeout = 5 * time.Second
+
+	rcv, err := newReceiver(receivertest.NewNopSettings(metadata.Type), *config)
+	require.NoError(t, err)
+	rcv.logsConsumer = new(consumertest.LogsSink)
+
+	require.NoError(t, rcv.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, rcv.Shutdown(t.Context())) })
+
+	assert.Equal(t, 60*time.Second, rcv.server.WriteTimeout)
+	assert.Equal(t, 5*time.Second, rcv.server.ReadHeaderTimeout)
 }
 
 func Test_splunkhecReceiver_handleAck(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
There were some hard coded timeout values for `read_header_timeout` and `write_timeout` set in the receiver startup. Even though the config options were exposed they would get overridden. 

This PR moves the defaults into `createDefaultConfig` so a users configuration options will overrride them.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Test written to test that the config options apply to the server

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
