### PR TITLE
[internal/coreinternal] Exclude AIX from CGO strptime validation tests

### DIFF
--- a/internal/coreinternal/timeutils/strptime_cgo_test.go
+++ b/internal/coreinternal/timeutils/strptime_cgo_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build cgo && unix
+//go:build cgo && unix && !aix
 
 package timeutils
 

--- a/internal/coreinternal/timeutils/strptime_cgo_testlib.go
+++ b/internal/coreinternal/timeutils/strptime_cgo_testlib.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build cgo && unix
+//go:build cgo && unix && !aix
 
 // This file is ONLY used as part of TestTimeParserStrptimeCgo to verify that TestParseStrptime is correct.
 


### PR DESCRIPTION
#### Description
AIX's `struct tm` does not have `tm_gmtoff` (a glibc/BSD extension), so `strptime_cgo_testlib.go` fails to compile on AIX/ppc64.

```
timeutils/strptime_cgo_testlib.go:34:36: tm.tm_gmtoff undefined (type _Ctype_struct_tm has no field or method tm_gmtoff)
timeutils/strptime_cgo_testlib.go:48:3: unknown field tm_gmtoff in struct literal of type _Ctype_struct_tm (typecheck)
 ```

https://www.ibm.com/docs/en/psfa/7.1.0?topic=representations-support-struct-tm-temporal-structures
> The API uses the strict implementation of struct tm which does not contain the additional fields tm_zone and tm_gmtoff

This PR excludes `internal/coreinternal/timeutils/strptime_cgo_test.go` and `internal/coreinternal/timeutils/strptime_cgo_testlib.go` on AIX to fix the compilation errors.

Introduced by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48112.

#### Testing
Validated that it fixed the compilation error on AIX.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
