### PR TITLE
fix splunk hec version telemetry tag

### DIFF
--- a/.chloggen/49511-splunkhec-version-telemetry.yaml
+++ b/.chloggen/49511-splunkhec-version-telemetry.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: exporter/splunkhec
+component: exporter/splunk_hec
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Use `buildInfo.Version` as fallback for `__splunk_app_version` header when `splunk_app_version` is not configured.

--- a/.chloggen/49511-splunkhec-version-telemetry.yaml
+++ b/.chloggen/49511-splunkhec-version-telemetry.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/splunkhec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use `buildInfo.Version` as fallback for `__splunk_app_version` header when `splunk_app_version` is not configured.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49511]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -673,7 +673,7 @@ func buildHTTPHeaders(config *Config, buildInfo component.BuildInfo) map[string]
 		"User-Agent":           config.SplunkAppName + "/" + appVersion,
 		"Authorization":        splunk.HECTokenHeader + " " + string(config.Token),
 		"__splunk_app_name":    config.SplunkAppName,
-		"__splunk_app_version": config.SplunkAppVersion,
+		"__splunk_app_version": appVersion,
 	}
 }
 

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -2175,3 +2175,28 @@ func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 		assert.Contains(t, string(p), e)
 	}
 }
+
+func TestBuildHTTPHeaders(t *testing.T) {
+	buildInfo := component.BuildInfo{Version: "1.2.3"}
+
+	t.Run("splunk_app_version set explicitly", func(t *testing.T) {
+		cfg := &Config{
+			Token:            "test-token",
+			SplunkAppName:    "myapp",
+			SplunkAppVersion: "9.9.9",
+		}
+		headers := buildHTTPHeaders(cfg, buildInfo)
+		assert.Equal(t, "9.9.9", headers["__splunk_app_version"])
+		assert.Equal(t, "myapp/9.9.9", headers["User-Agent"])
+	})
+
+	t.Run("splunk_app_version unset falls back to build version", func(t *testing.T) {
+		cfg := &Config{
+			Token:         "test-token",
+			SplunkAppName: "myapp",
+		}
+		headers := buildHTTPHeaders(cfg, buildInfo)
+		assert.Equal(t, "1.2.3", headers["__splunk_app_version"])
+		assert.Equal(t, "myapp/1.2.3", headers["User-Agent"])
+	})
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Use `buildInfo.Version` as fallback for `__splunk_app_version` header when `splunk_app_version` is not configured, consistent with the User-Agent header behaviour.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49510

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Add unit tests covering this case.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
