### PR TITLE
[receiver/azuremonitor] Fix metric data loss and incorrect timestamps

### DIFF
--- a/.chloggen/fix-azuremonitor-data-loss.yaml
+++ b/.chloggen/fix-azuremonitor-data-loss.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azure_monitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix metric data loss and incorrect timestamps
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49532]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azuremonitorreceiver/mocks_test.go
+++ b/receiver/azuremonitorreceiver/mocks_test.go
@@ -430,6 +430,14 @@ func newMetricsClientListResponseMockData(inputMap map[string]map[string][]metri
 					Unit:       &input.Unit,
 					Timeseries: input.TimeSeries,
 				}
+				for _, ts := range result3.Value[i].Timeseries {
+					for _, d := range ts.Data {
+						if d.TimeStamp == nil {
+							t := time.Unix(1, 0).UTC()
+							d.TimeStamp = &t
+						}
+					}
+				}
 			}
 			result2[metricNames] = result3
 		}

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -85,8 +86,9 @@ type metricsCompositeKey struct {
 }
 
 type azureResourceMetrics struct {
-	metrics              []string
-	metricsValuesUpdated time.Time
+	metrics               []string
+	metricsValuesUpdated  time.Time
+	lastEmittedTimestamps map[string]time.Time
 }
 
 type void struct{}
@@ -581,7 +583,10 @@ func (s *azureScraper) loadMetricsDefinition(subscriptionID, resourceID, metricN
 			s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey].metrics, metricName,
 		)
 	} else {
-		s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey] = &azureResourceMetrics{metrics: []string{metricName}}
+		s.resources[subscriptionID][resourceID].metricsByCompositeKey[compositeKey] = &azureResourceMetrics{
+			metrics:               []string{metricName},
+			lastEmittedTimestamps: make(map[string]time.Time),
+		}
 	}
 }
 
@@ -647,6 +652,10 @@ func (s *azureScraper) loadMetricsValues(ctx context.Context, subscriptionID, re
 			logFields = append(logFields, zap.Int("metrics_count", len(result.Value)))
 			s.settings.Logger.Debug("Collected Azure Metrics values from Azure", logFields...)
 
+			if metricsByGrain.lastEmittedTimestamps == nil {
+				metricsByGrain.lastEmittedTimestamps = make(map[string]time.Time)
+			}
+
 			for _, metric := range result.Value {
 				for _, timeseriesElement := range metric.Timeseries {
 					if timeseriesElement.Data == nil {
@@ -662,8 +671,25 @@ func (s *azureScraper) loadMetricsValues(ctx context.Context, subscriptionID, re
 						name := tagPrefix + tagName
 						attributes[name] = value
 					}
+
+					var metricName string
+					if metric.Name != nil && metric.Name.Value != nil {
+						metricName = *metric.Name.Value
+					}
+					tsKeyPrefix := resourceID + "#" + metricName + "#" + serializeArmMetadataValues(timeseriesElement.Metadatavalues)
+
 					for _, metricValue := range timeseriesElement.Data {
-						s.processTimeseriesData(resourceID, metric, metricValue, attributes)
+						if metricValue == nil || metricValue.TimeStamp == nil {
+							continue
+						}
+						t := *metricValue.TimeStamp
+
+						lastTime, exists := metricsByGrain.lastEmittedTimestamps[tsKeyPrefix]
+						if !exists || t.After(lastTime) {
+							pts := pcommon.NewTimestampFromTime(t)
+							s.processTimeseriesData(resourceID, metric, metricValue, attributes, pts)
+							metricsByGrain.lastEmittedTimestamps[tsKeyPrefix] = t
+						}
 					}
 				}
 			}
@@ -703,11 +729,10 @@ func (s *azureScraper) processTimeseriesData(
 	metric *armmonitor.Metric,
 	metricValue *armmonitor.MetricValue,
 	attributes map[string]*string,
+	ts pcommon.Timestamp,
 ) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
-	ts := pcommon.NewTimestampFromTime(time.Now())
 
 	aggregationsData := []struct {
 		name  string
@@ -822,4 +847,18 @@ func filterResourceTags(tagFilterList map[string]struct{}, resourceTags map[stri
 	}
 
 	return includedTags
+}
+
+func serializeArmMetadataValues(metadataValues []*armmonitor.MetadataValue) string {
+	if len(metadataValues) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(metadataValues))
+	for _, val := range metadataValues {
+		if val.Name != nil && val.Name.Value != nil && val.Value != nil {
+			parts = append(parts, *val.Name.Value+"="+*val.Value)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
 }

--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -537,7 +537,10 @@ func (s *azureBatchScraper) loadMetricsDefinitionByType(subscriptionID, resource
 			s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey].metrics, metricName,
 		)
 	} else {
-		s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey] = &azureResourceMetrics{metrics: []string{metricName}}
+		s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey] = &azureResourceMetrics{
+			metrics:               []string{metricName},
+			lastEmittedTimestamps: make(map[string]time.Time),
+		}
 	}
 }
 
@@ -556,7 +559,7 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 	}
 
 	for compositeKey, metricsByGrain := range resType.metricsByCompositeKey {
-		now := time.Now().UTC()
+		now := s.time.Now().UTC()
 
 		// Anti-duplicate guard: do not re-scrape a (resourceType, compositeKey) pair more often
 		// than its Azure timeGrain. The batch scraper emits points using the original Azure
@@ -637,6 +640,10 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 					logFields = append(logFields, zap.Int("metrics_count", len(response.Values)))
 					s.settings.Logger.Debug("Collected Azure Metrics values from Azure", logFields...)
 
+					if metricsByGrain.lastEmittedTimestamps == nil {
+						metricsByGrain.lastEmittedTimestamps = make(map[string]time.Time)
+					}
+
 					for _, metricValues := range response.Values {
 						if metricValues.ResourceID == nil {
 							continue
@@ -659,10 +666,22 @@ func (s *azureBatchScraper) loadBatchMetricsValues(ctx context.Context, subscrip
 									attributes[name] = value
 								}
 								attributes["timegrain"] = &compositeKey.timeGrain
-								for _, metricValue := range slices.Backward(timeseriesElement.Data) { // reverse for loop because newest timestamp is at the end of the slice
-									if metricValueIsNotEmpty(metricValue) {
+
+								var metricName string
+								if metric.Name != nil && metric.Name.Value != nil {
+									metricName = *metric.Name.Value
+								}
+								tsKeyPrefix := resID + "#" + metricName + "#" + serializeMetadataValues(timeseriesElement.MetadataValues)
+
+								for _, metricValue := range timeseriesElement.Data {
+									if !metricValueIsNotEmpty(metricValue) || metricValue.TimeStamp == nil {
+										continue
+									}
+									t := *metricValue.TimeStamp
+									lastTime, exists := metricsByGrain.lastEmittedTimestamps[tsKeyPrefix]
+									if !exists || t.After(lastTime) {
 										s.processQueryTimeseriesData(mb, resID, metric, metricValue, attributes)
-										break
+										metricsByGrain.lastEmittedTimestamps[tsKeyPrefix] = t
 									}
 								}
 							}
@@ -740,4 +759,18 @@ func (s *azureBatchScraper) processQueryTimeseriesData(
 			)
 		}
 	}
+}
+
+func serializeMetadataValues(metadataValues []azmetrics.MetadataValue) string {
+	if len(metadataValues) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(metadataValues))
+	for _, val := range metadataValues {
+		if val.Name != nil && val.Name.Value != nil && val.Value != nil {
+			parts = append(parts, *val.Name.Value+"="+*val.Value)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
 }

--- a/receiver/azuremonitorreceiver/scraper_batch_test.go
+++ b/receiver/azuremonitorreceiver/scraper_batch_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
@@ -318,6 +320,152 @@ func TestAzureScraperBatchScrape_NoDuplicateOnRescrape(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, second.DataPointCount(),
 		"second scrape must not re-emit Azure data points (would cause 409 duplicate sample for timestamp on Prometheus remote write backends)")
+}
+
+func TestAzureScraperBatchScrape_ChronologicalAndNoDuplicate(t *testing.T) {
+	cfg := createDefaultTestConfig()
+	cfg.SubscriptionIDs = []string{"subscriptionId1"}
+	cfg.Metrics = NestedListAlias{
+		"namespace1": {
+			"metric1": {"Average"},
+		},
+	}
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+
+	resourceID := "/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1"
+	t1 := time.Now().Add(-2 * time.Minute).Truncate(time.Minute)
+	t2 := time.Now().Add(-1 * time.Minute).Truncate(time.Minute)
+	value1 := 10.0
+	value2 := 12.0
+
+	mockQueryResponse1 := []queryResourcesResponseMock{
+		{
+			params: queryResourcesResponseMockParams{
+				subscriptionID:  "subscriptionId1",
+				metricNamespace: "namespace1",
+				metricNames:     []string{"metric1"},
+				resourceIDs: []string{
+					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1",
+					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId2",
+					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId3",
+				},
+			},
+			response: newQueryResourcesResponseMockData([]queryResourceMockInput{
+				{
+					ResourceID: resourceID,
+					Metrics: []metricMockInput{
+						{
+							Name: "metric1",
+							Unit: azmetrics.MetricUnitPercent,
+							TimeSeries: []azmetrics.TimeSeriesElement{{
+								Data: []azmetrics.MetricValue{
+									{TimeStamp: &t1, Average: &value1},
+									{TimeStamp: &t2, Average: &value2},
+								},
+							}},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	optionsResolver1 := newMockClientOptionsResolver(
+		getSubscriptionByIDMockData(),
+		getSubscriptionsMockData(),
+		getResourcesMockData(),
+		getMetricsDefinitionsMockData(),
+		nil,
+		mockQueryResponse1,
+	)
+
+	s := &azureBatchScraper{
+		cfg:                          cfg,
+		mbs:                          newConcurrentMapImpl[*metadata.MetricsBuilder](),
+		mutex:                        &sync.Mutex{},
+		time:                         getTimeMock(),
+		clientOptionsResolver:        optionsResolver1,
+		receiverSettings:             settings,
+		settings:                     settings.TelemetrySettings,
+		storageAccountSpecificConfig: newStorageAccountSpecificConfig(cfg.Services),
+
+		subscriptions: map[string]*azureSubscription{},
+		resources:     map[string]map[string]*azureResource{},
+		regions:       map[string]map[string]struct{}{},
+		resourceTypes: map[string]map[string]*azureType{},
+	}
+
+	metrics, err := s.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 2, metrics.DataPointCount())
+
+	rm := metrics.ResourceMetrics().At(0)
+	sm := rm.ScopeMetrics().At(0)
+	m := sm.Metrics().At(0)
+	dps := m.Gauge().DataPoints()
+
+	dp1 := dps.At(0)
+	dp2 := dps.At(1)
+	assert.Equal(t, value1, dp1.DoubleValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(t1), dp1.Timestamp())
+	assert.Equal(t, value2, dp2.DoubleValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(t2), dp2.Timestamp())
+
+	t3 := time.Now().Truncate(time.Minute)
+	value3 := 15.0
+	mockQueryResponse2 := []queryResourcesResponseMock{
+		{
+			params: queryResourcesResponseMockParams{
+				subscriptionID:  "subscriptionId1",
+				metricNamespace: "namespace1",
+				metricNames:     []string{"metric1"},
+				resourceIDs: []string{
+					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1",
+					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId2",
+					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId3",
+				},
+			},
+			response: newQueryResourcesResponseMockData([]queryResourceMockInput{
+				{
+					ResourceID: resourceID,
+					Metrics: []metricMockInput{
+						{
+							Name: "metric1",
+							Unit: azmetrics.MetricUnitPercent,
+							TimeSeries: []azmetrics.TimeSeriesElement{{
+								Data: []azmetrics.MetricValue{
+									{TimeStamp: &t1, Average: &value1},
+									{TimeStamp: &t2, Average: &value2},
+									{TimeStamp: &t3, Average: &value3},
+								},
+							}},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	s.clientOptionsResolver = newMockClientOptionsResolver(
+		getSubscriptionByIDMockData(),
+		getSubscriptionsMockData(),
+		getResourcesMockData(),
+		getMetricsDefinitionsMockData(),
+		nil,
+		mockQueryResponse2,
+	)
+
+	mockTime := s.time.(*timeMock)
+	mockTime.time = mockTime.time.Add(time.Minute)
+
+	metrics2, err := s.scrape(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, metrics2.DataPointCount())
+	dp3 := metrics2.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0)
+	assert.Equal(t, value3, dp3.DoubleValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(t3), dp3.Timestamp())
 }
 
 // TestAzureScraperBatchScrapeCustomNamespaceMetrics verifies that the batch scraper discovers and

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
@@ -170,6 +171,135 @@ func TestAzureScraperScrape(t *testing.T) {
 			))
 		})
 	}
+}
+
+func TestAzureScraperScrape_ChronologicalAndNoDuplicate(t *testing.T) {
+	fakeSubID := "subscriptionId1"
+	resourceID := "/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1"
+	metricName := "metric1"
+	var unit armmonitor.MetricUnit = "unit1"
+	value1 := 10.0
+	value2 := 12.0
+
+	t1 := time.Now().Add(-2 * time.Minute).Truncate(time.Minute)
+	t2 := time.Now().Add(-1 * time.Minute).Truncate(time.Minute)
+
+	mockMetricsValues1 := map[string]map[string]armmonitor.MetricsClientListResponse{
+		resourceID: {
+			metricName: armmonitor.MetricsClientListResponse{
+				Response: armmonitor.Response{
+					Value: []*armmonitor.Metric{
+						{
+							Name: &armmonitor.LocalizableString{Value: to.Ptr(metricName)},
+							Unit: &unit,
+							Timeseries: []*armmonitor.TimeSeriesElement{
+								{
+									Data: []*armmonitor.MetricValue{
+										{TimeStamp: &t1, Average: &value1},
+										{TimeStamp: &t2, Average: &value2},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	optionsResolver1 := newMockClientOptionsResolver(
+		getSubscriptionByIDMockData(),
+		getSubscriptionsMockData(),
+		getResourcesMockData(),
+		getMetricsDefinitionsMockData(),
+		mockMetricsValues1,
+		nil,
+	)
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	cfg := createDefaultTestConfig()
+	cfg.SubscriptionIDs = []string{fakeSubID}
+	cfg.Metrics = NestedListAlias{
+		"namespace1": {
+			"metric1": {"Average"},
+		},
+	}
+
+	s := &azureScraper{
+		cfg:                          cfg,
+		settings:                     settings.TelemetrySettings,
+		mb:                           metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings),
+		mutex:                        &sync.Mutex{},
+		time:                         getTimeMock(),
+		clientOptionsResolver:        optionsResolver1,
+		storageAccountSpecificConfig: newStorageAccountSpecificConfig(cfg.Services),
+		subscriptions:                map[string]*azureSubscription{},
+		resources:                    map[string]map[string]*azureResource{},
+	}
+
+	metrics, err := s.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 2, metrics.DataPointCount())
+
+	rm := metrics.ResourceMetrics().At(0)
+	sm := rm.ScopeMetrics().At(0)
+	m := sm.Metrics().At(0)
+	dps := m.Gauge().DataPoints()
+
+	dp1 := dps.At(0)
+	dp2 := dps.At(1)
+	assert.Equal(t, value1, dp1.DoubleValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(t1), dp1.Timestamp())
+	assert.Equal(t, value2, dp2.DoubleValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(t2), dp2.Timestamp())
+
+	t3 := time.Now().Truncate(time.Minute)
+	value3 := 15.0
+	mockMetricsValues2 := map[string]map[string]armmonitor.MetricsClientListResponse{
+		resourceID: {
+			metricName: armmonitor.MetricsClientListResponse{
+				Response: armmonitor.Response{
+					Value: []*armmonitor.Metric{
+						{
+							Name: &armmonitor.LocalizableString{Value: to.Ptr(metricName)},
+							Unit: &unit,
+							Timeseries: []*armmonitor.TimeSeriesElement{
+								{
+									Data: []*armmonitor.MetricValue{
+										{TimeStamp: &t1, Average: &value1},
+										{TimeStamp: &t2, Average: &value2},
+										{TimeStamp: &t3, Average: &value3},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.clientOptionsResolver = newMockClientOptionsResolver(
+		getSubscriptionByIDMockData(),
+		getSubscriptionsMockData(),
+		getResourcesMockData(),
+		getMetricsDefinitionsMockData(),
+		mockMetricsValues2,
+		nil,
+	)
+
+	mockTime := s.time.(*timeMock)
+	mockTime.time = mockTime.time.Add(time.Minute)
+
+	s.mb = metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings)
+
+	metrics2, err := s.scrape(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, metrics2.DataPointCount())
+	dp3 := metrics2.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0)
+	assert.Equal(t, value3, dp3.DoubleValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(t3), dp3.Timestamp())
 }
 
 func TestAzureScraperScrapeFilterMetrics(t *testing.T) {
@@ -634,6 +764,14 @@ func TestAzureScraperScrapeHonorTimeGrain(t *testing.T) {
 			// we can travel in time by adjusting result of timeWrapper.Now
 			prevTime := mockedTime.time
 			mockedTime.time = timeNowNew
+			// Clear point-level deduplication so it doesn't interfere with the block-level guard test
+			for _, subMap := range s.resources {
+				for _, res := range subMap {
+					for _, met := range res.metricsByCompositeKey {
+						met.lastEmittedTimestamps = make(map[string]time.Time)
+					}
+				}
+			}
 
 			metrics, err := s.scrape(ctx)
 


### PR DESCRIPTION
## Description
Fixes metric data loss and incorrect timestamping in the `azuremonitor` receiver:
- Tracks the last emitted timestamp per unique timeseries (`resourceID + metricName + dimensions`) to filter out already-emitted historical data.
- Processes all newly populated data points in chronological order instead of breaking after the first one.
- Uses actual Azure timestamps in the non-batch scraper (`scraper.go`) instead of replacing them with `time.Now()`.

Relates #49508

## Testing
Unit tests updated to verify correct chronological ordering of multiple data points, use of correct Azure timestamps, and no duplicate emissions on subsequent scrapes.
