### PR TITLE
[chore] Add cooldown period to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "schedule": [
     "on tuesday"
   ],
+  "minimumReleaseAge": "2 days",
   "extends": [
     "config:recommended",
     "customManagers:githubActionsVersions",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds [`minimumReleaseAge`](https://docs.renovatebot.com/key-concepts/minimum-release-age/) to Renovate configuration and sets it to two days.

This is useful for following Datadog internal policies, but in general it seems like good industry practice so I wanted to see what people think :)

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
