### PR TITLE
[pkg/stanza] Add otelcol parser operator preset for collector self-logs

### DIFF
--- a/.chloggen/49525-add-otelcol-parser.yaml
+++ b/.chloggen/49525-add-otelcol-parser.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: pkg/stanza
+note: Add `otelcol` parser operator preset for parsing collector self-logs.
+issues: [49525]

--- a/pkg/stanza/adapter/register.go
+++ b/pkg/stanza/adapter/register.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/jsonarray"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/jsonparser"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/keyvalue"
+	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/otelcol"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/scope"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/severity"

--- a/pkg/stanza/operator/parser/otelcol/config.go
+++ b/pkg/stanza/operator/parser/otelcol/config.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcol // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/otelcol"
+
+import (
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+const operatorType = "otelcol"
+
+func init() {
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
+}
+
+// NewConfig creates a new otelcol parser config with default values
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new otelcol parser config with default values
+func NewConfigWithID(operatorID string) *Config {
+	return &Config{
+		ParserConfig: helper.NewParserConfig(operatorID, operatorType),
+	}
+}
+
+// Config is the configuration of an otelcol parser operator.
+type Config struct {
+	helper.ParserConfig `mapstructure:",squash"`
+}
+
+// Build will build an otelcol parser operator.
+func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(set)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Parser{
+		ParserOperator: parserOperator,
+	}, nil
+}

--- a/pkg/stanza/operator/parser/otelcol/parser.go
+++ b/pkg/stanza/operator/parser/otelcol/parser.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcol // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/otelcol"
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+// Parser is an operator that parses Collector self-logs.
+type Parser struct {
+	helper.ParserOperator
+}
+
+// ProcessBatch will process a batch of log entries.
+func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
+	return p.ProcessBatchWithCallback(ctx, entries, p.parse, p.postProcess)
+}
+
+// Process will process a single log entry.
+func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
+	return p.ProcessWithCallback(ctx, entry, p.parse, p.postProcess)
+}
+
+// parse will parse a value as JSON.
+func (*Parser) parse(value any) (any, error) {
+	var parsedValue map[string]any
+	switch m := value.(type) {
+	case string:
+		err := json.Unmarshal([]byte(m), &parsedValue)
+		if err != nil {
+			return nil, err
+		}
+	case []byte:
+		err := json.Unmarshal(m, &parsedValue)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("type %T cannot be parsed as JSON", value)
+	}
+
+	return parsedValue, nil
+}
+
+// postProcess performs the specific mappings for otelcol self-logs
+func (p *Parser) postProcess(e *entry.Entry) error {
+	val, ok := e.Get(p.ParseTo)
+	if !ok {
+		return nil
+	}
+
+	parsedMap, ok := val.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	// 1. Parse Timestamp (ts)
+	if tsVal, ok := parsedMap["ts"]; ok {
+		switch v := tsVal.(type) {
+		case string:
+			for _, layout := range []string{
+				time.RFC3339Nano,
+				time.RFC3339,
+				"2006-01-02 15:04:05.999999999",
+			} {
+				if t, err := time.Parse(layout, v); err == nil {
+					e.Timestamp = t
+					break
+				}
+			}
+		case float64:
+			sec, dec := math.Modf(v)
+			nanos := int64(math.Round(dec*1e6)) * 1e3
+			e.Timestamp = time.Unix(int64(sec), nanos)
+		case int64:
+			e.Timestamp = time.Unix(v, 0)
+		}
+		delete(parsedMap, "ts")
+	}
+
+	// 2. Parse Severity (level)
+	if lvlVal, ok := parsedMap["level"]; ok {
+		if lvlStr, ok := lvlVal.(string); ok {
+			switch strings.ToLower(lvlStr) {
+			case "trace":
+				e.Severity = entry.Trace
+			case "debug":
+				e.Severity = entry.Debug
+			case "info":
+				e.Severity = entry.Info
+			case "warn", "warning":
+				e.Severity = entry.Warn
+			case "error":
+				e.Severity = entry.Error
+			case "dpanic", "panic":
+				e.Severity = entry.Fatal
+			case "fatal":
+				e.Severity = entry.Fatal
+			}
+			e.SeverityText = lvlStr
+		}
+		delete(parsedMap, "level")
+	}
+
+	// 3. Parse Body (msg)
+	if msgVal, ok := parsedMap["msg"]; ok {
+		e.Body = msgVal
+		delete(parsedMap, "msg")
+	}
+
+	// 4. Parse Resource (resource)
+	if resVal, ok := parsedMap["resource"]; ok {
+		if resMap, ok := resVal.(map[string]any); ok {
+			if e.Resource == nil {
+				e.Resource = make(map[string]any)
+			}
+			maps.Copy(e.Resource, resMap)
+		}
+		delete(parsedMap, "resource")
+	}
+
+	return nil
+}

--- a/pkg/stanza/operator/parser/otelcol/parser_test.go
+++ b/pkg/stanza/operator/parser/otelcol/parser_test.go
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+)
+
+func newTestParser(t *testing.T) *Parser {
+	config := NewConfigWithID("test")
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := config.Build(set)
+	require.NoError(t, err)
+	return op.(*Parser)
+}
+
+func TestConfigBuild(t *testing.T) {
+	config := NewConfigWithID("test")
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := config.Build(set)
+	require.NoError(t, err)
+	require.IsType(t, &Parser{}, op)
+}
+
+func TestJSONImplementations(t *testing.T) {
+	require.Implements(t, (*operator.Operator)(nil), new(Parser))
+}
+
+func TestParser(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  *entry.Entry
+		expect func(t *testing.T, actual *entry.Entry)
+	}{
+		{
+			"simple_string_ts_and_warn",
+			&entry.Entry{
+				Body: `{"ts":"2026-07-06T22:56:21.989Z","level":"warn","msg":"Failed to scrape","resource":{"service.name":"otel-agent"},"caller":"main.go:12","otelcol.component.id":"receiver"}`,
+			},
+			func(t *testing.T, actual *entry.Entry) {
+				expectedTime, err := time.Parse(time.RFC3339Nano, "2026-07-06T22:56:21.989Z")
+				require.NoError(t, err)
+				require.Equal(t, expectedTime, actual.Timestamp)
+				require.Equal(t, entry.Warn, actual.Severity)
+				require.Equal(t, "warn", actual.SeverityText)
+				require.Equal(t, "Failed to scrape", actual.Body)
+				require.Equal(t, map[string]any{"service.name": "otel-agent"}, actual.Resource)
+				require.Equal(t, map[string]any{
+					"caller":               "main.go:12",
+					"otelcol.component.id": "receiver",
+				}, actual.Attributes)
+			},
+		},
+		{
+			"float_ts_and_info",
+			&entry.Entry{
+				Body: `{"ts":1690000000.123,"level":"info","msg":"Success","resource":{"service.name":"otel-collector"}}`,
+			},
+			func(t *testing.T, actual *entry.Entry) {
+				expectedTime := time.Unix(1690000000, 123000000)
+				require.Equal(t, expectedTime, actual.Timestamp)
+				require.Equal(t, entry.Info, actual.Severity)
+				require.Equal(t, "info", actual.SeverityText)
+				require.Equal(t, "Success", actual.Body)
+				require.Equal(t, map[string]any{"service.name": "otel-collector"}, actual.Resource)
+				require.Empty(t, actual.Attributes)
+			},
+		},
+		{
+			"missing_fields",
+			&entry.Entry{
+				Body: `{"caller":"main.go:12"}`,
+			},
+			func(t *testing.T, actual *entry.Entry) {
+				require.True(t, actual.Timestamp.IsZero())
+				require.Equal(t, entry.Default, actual.Severity)
+				require.Empty(t, actual.SeverityText)
+				require.Equal(t, `{"caller":"main.go:12"}`, actual.Body) // ParseWith does not delete msg/ts since they aren't there, body is not changed if msg not found
+				require.Nil(t, actual.Resource)
+				require.Equal(t, map[string]any{
+					"caller": "main.go:12",
+				}, actual.Attributes)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestParser(t)
+			err := p.Process(t.Context(), tc.input)
+			require.NoError(t, err)
+			tc.expect(t, tc.input)
+		})
+	}
+}

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -251,6 +251,27 @@ When this option is set, all files ending with that suffix are scanned using a g
 before scanning through it. Please note that if the compressed file is expected to be updated, the additional compressed logs must be appended to the
 compressed file, rather than recompressing the whole content and overwriting the previous file.
 
+## Example - Tailing Collector Self-Logs
+
+The OpenTelemetry Collector emits its own logs in Zap JSON format when configured with JSON logging under `service.telemetry.logs`. To parse these logs and promote the `resource` field directly to OTLP Resource attributes in one step, use the `otelcol` parser operator.
+
+Receiver Configuration:
+```yaml
+receivers:
+  filelog:
+    include: [ /var/log/otelcol.log ]
+    operators:
+      - type: otelcol
+```
+
+This operator automatically:
+- Parses the log line as JSON.
+- Extracts `ts` and sets it as the log record timestamp (handling both ISO8601 string and epoch seconds).
+- Extracts `level` and sets it as severity.
+- Extracts `msg` and sets it as the log body.
+- Extracts the `resource` map and merges its fields directly into OTLP Resource attributes.
+- Leaves all other dynamic fields (e.g., `caller`, `otelcol.component.id`, etc.) in the log record attributes.
+
 ## Offset tracking
 
 The `storage` setting allows you to define the proper storage extension for storing file offsets.


### PR DESCRIPTION
### Context
When the OpenTelemetry Collector is deployed with self-monitoring enabled and its self-logs are ingested using the `filelogreceiver`, the log's top-level `resource` block (emitted in zap JSON format) gets parsed into a nested log attribute or body field. This makes correlation of collector logs and telemetry metrics difficult.

This PR implements a dedicated `otelcol` parser operator inside `pkg/stanza` that recognizes the zap schema (`ts`, `level`, `msg`, `resource`) and automatically maps the fields onto the record's Timestamp, Severity, Body, and Resource attributes in one line of config.

Fixes: #49525

### Changes
- Created a new `otelcol` parser operator under `pkg/stanza/operator/parser/otelcol`.
- Registered `otelcol` in `pkg/stanza/adapter/register.go`.
- Added unit tests in `pkg/stanza/operator/parser/otelcol/parser_test.go`.
- Updated `receiver/filelogreceiver/README.md` with an example showing how to use the operator.

### Verification
- Run new unit tests: `go test -v ./operator/parser/otelcol/...`
- Run adapter tests: `go test -v ./adapter/...`
