### PR TITLE
fix: correct max_batch_byte_size typo in validation error message

### DIFF
--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -139,7 +139,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.MaxBatchSizeBytes < 0 {
-		return errors.New("max_batch_byte_size must be greater than 0")
+		return errors.New("max_batch_size_bytes must be greater than 0")
 	}
 	if cfg.MaxBatchSizeBytes == 0 {
 		// Defaults to ~2.81MB


### PR DESCRIPTION
## Summary

Correct a typo in the  validation error message in .

## Problem

The error message referenced the config key as  (missing the 's' in 'bytes'), but the actual field name is . Users would be confused when seeing the error and trying to find the corresponding config key.

## Fix

**File:** 



## Verification

- 1 file changed, 1 line modified
- 1 commit (GH007 compliant)