### PR TITLE
[receiver/mongodb] Ignore noisy `$indexStats` errors for views

### DIFF
--- a/.chloggen/dylan_ignore-view-index-scrape-errors.yaml
+++ b/.chloggen/dylan_ignore-view-index-scrape-errors.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ignore the `$indexStats` scrape error that occurs when scraping views
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49494]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -610,7 +610,7 @@ func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Time
 	indexStats, err := s.client.IndexStats(ctx, databaseName, collectionName)
 	if err != nil {
 		var srvErr mongo.ServerError
-		// ignore error $indexStats is not supported on views
+		// ignore the error, $indexStats is not supported on views
 		if errors.As(err, &srvErr) && srvErr.HasErrorCode(40602) {
 			s.logger.Debug("skipping unsupported index stats for view",
 				zap.String("database", databaseName), zap.String("view", collectionName))

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -608,6 +609,13 @@ func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Time
 	}
 	indexStats, err := s.client.IndexStats(ctx, databaseName, collectionName)
 	if err != nil {
+		var srvErr mongo.ServerError
+		// ignore error $indexStats is not supported on views
+		if errors.As(err, &srvErr) && srvErr.HasErrorCode(40602) {
+			s.logger.Debug("skipping unsupported index stats for view",
+				zap.String("database", databaseName), zap.String("view", collectionName))
+			return
+		}
 		errs.AddPartial(1, fmt.Errorf("failed to fetch index stats metrics: %w", err))
 		return
 	}

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -1675,3 +1675,14 @@ func TestDependentMetricsWhenDisabled(t *testing.T) {
 		})
 	}
 }
+
+func TestCollectIndexStatsSkipsViews(t *testing.T) {
+	fc := &fakeClient{}
+	viewErr := mongo.CommandError{Code: 40602, Message: "$indexStats is only valid as the first stage in a pipeline"}
+	fc.On("IndexStats", mock.Anything, "fakedatabase", "someview").Return([]bson.M{}, viewErr)
+	scraper := &mongodbScraper{logger: zap.NewNop(), client: fc}
+
+	errs := &scrapererror.ScrapeErrors{}
+	scraper.collectIndexStats(t.Context(), pcommon.NewTimestampFromTime(time.Now()), "fakedatabase", "someview", errs)
+	require.NoError(t, errs.Combine())
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When views have aggregation pipeline steps, `$indexStats` does not work because its added to the end of the aggregation pipeline and `$indexStats` must be first.

This means the collector keeps throwing the following error
```
failed to fetch index stats metrics: (Location40602) $indexStats is only valid as the first stage in a pipeline
```

this PR catches and ignores that specific error.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49494

<!--Describe what testing was performed and which tests were added.-->
#### Testing
A simple test was added and this was tested on a MongoDB instance with, collections, views, and time series.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
