### PR TITLE
[prometheusremotewrite/exporter] Fixing max_batch_size_bytes error typo, and added unit test

### DIFF
--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -139,7 +139,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.MaxBatchSizeBytes < 0 {
-		return errors.New("max_batch_byte_size must be greater than 0")
+		return errors.New("max_batch_size_bytes must be greater than 0")
 	}
 	if cfg.MaxBatchSizeBytes == 0 {
 		// Defaults to ~2.81MB

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -158,6 +158,10 @@ func TestLoadConfig(t *testing.T) {
 			id:           component.NewIDWithName(metadata.Type, "v1_no_translation"),
 			errorMessage: "translation strategy NoTranslation requires Prometheus Remote Write 2.0",
 		},
+		{
+			id:           component.NewIDWithName(metadata.Type, "negative_max_batch_size_bytes"),
+			errorMessage: "max_batch_size_bytes must be greater than 0",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -77,3 +77,7 @@ prometheus_remote_write/v1_no_translation:
   endpoint: "localhost:8888"
   protobuf_message: "prometheus.WriteRequest"
   translation_strategy: "NoTranslation"
+
+prometheus_remote_write/negative_max_batch_size_bytes:
+  endpoint: "localhost:8888"
+  max_batch_size_bytes: -1


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR fixes a typo in the error message returned with an invalid `max_batch_size_bytes` configuration field, and also adds a unit test to ensure that the correct error is returned when an invalid value is provided for the same field. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49442

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`exporter/prometheusremotewriteexporter/config_test.go` had a test added to ensure `max_batch_size_bytes` returns the correct error with an invalid value.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
