### PR TITLE
chore: add permission

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -9,6 +9,8 @@ permissions: read-all
 
 jobs:
   welcome_first_contributor:
+    permissions:
+      pull-requests: write # required by the workflow to post the welcome comment
     uses: open-telemetry/shared-workflows/.github/workflows/first-time-pr.yml@2192ef0cade1b727dafcc3ebba58713281059653 # v0.1.0
     with:
       label: 'first-time contributor'


### PR DESCRIPTION
The first time contributor workflow needs the pull request write permission to be able to add the comment.