### PR TITLE
[chore][govuln] revert to oldstable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,7 +208,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: ./.github/actions/setup-go-tools
         with:
-          go-version: 1.25.11 # TODO: revert to oldstable when actions/setup-go reliably resolves oldstable to 1.25.11
+          go-version: oldstable
       - name: Run `govulncheck`
         run: make gogovulncheck GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
#### Description
revert to oldstable Go version in go vuln check, fixes a known vuln: http://pkg.go.dev/vuln/GO-2026-5856

#### Authorship

- [x] I, a human, wrote this pull request description myself.

