### PR TITLE
[pkg/translator/prometheusremotewrite] preserve multiple underscores when permissive sanitization is enabled

### DIFF
--- a/.chloggen/prw-preserve-multiple-underscores.yaml
+++ b/.chloggen/prw-preserve-multiple-underscores.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve consecutive underscores in label names when the permissive label sanitization feature gate is enabled.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48991]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When the pkg.translator.prometheus.PermissiveLabelSanitization feature gate was enabled, label names with consecutive underscores (e.g. a__b) were still collapsed to a single underscore because the converter did not set PreserveMultipleUnderscores on the label namer. The gate now preserves them as intended.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/prometheusremotewrite/go.mod
+++ b/pkg/translator/prometheusremotewrite/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.158.0
 	github.com/prometheus/common v0.70.1

--- a/pkg/translator/prometheusremotewrite/labelnamer_underscore_test.go
+++ b/pkg/translator/prometheusremotewrite/labelnamer_underscore_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusremotewrite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+// When the permissive-label-sanitization feature gate is enabled, label names
+// with consecutive underscores must be preserved (a__b stays a__b) rather than
+// collapsed to a single underscore. When the gate is disabled, the default
+// sanitization still collapses them.
+func TestNewPrometheusConverterLabelNamerMultipleUnderscores(t *testing.T) {
+	t.Run("gate enabled preserves multiple underscores", func(t *testing.T) {
+		defer testutil.SetFeatureGateForTest(t, prometheustranslator.DropSanitizationGate, true)()
+
+		converter := newPrometheusConverter(Settings{})
+		got, err := converter.labelNamer.Build("a__b")
+		require.NoError(t, err)
+		require.Equal(t, "a__b", got)
+	})
+
+	t.Run("gate disabled collapses multiple underscores", func(t *testing.T) {
+		defer testutil.SetFeatureGateForTest(t, prometheustranslator.DropSanitizationGate, false)()
+
+		converter := newPrometheusConverter(Settings{})
+		got, err := converter.labelNamer.Build("a__b")
+		require.NoError(t, err)
+		require.Equal(t, "a_b", got)
+	})
+
+	t.Run("reserved double-underscore label is preserved regardless of gate", func(t *testing.T) {
+		defer testutil.SetFeatureGateForTest(t, prometheustranslator.DropSanitizationGate, false)()
+
+		converter := newPrometheusConverter(Settings{})
+		got, err := converter.labelNamer.Build("__name__")
+		require.NoError(t, err)
+		require.Equal(t, "__name__", got)
+	})
+}

--- a/pkg/translator/prometheusremotewrite/labelnamer_underscore_test.go
+++ b/pkg/translator/prometheusremotewrite/labelnamer_underscore_test.go
@@ -4,6 +4,7 @@
 package prometheusremotewrite
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,12 +36,36 @@ func TestNewPrometheusConverterLabelNamerMultipleUnderscores(t *testing.T) {
 		require.Equal(t, "a_b", got)
 	})
 
-	t.Run("reserved double-underscore label is preserved regardless of gate", func(t *testing.T) {
+	for _, gateEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reserved double-underscore label is preserved with gate=%t", gateEnabled), func(t *testing.T) {
+			defer testutil.SetFeatureGateForTest(t, prometheustranslator.DropSanitizationGate, gateEnabled)()
+
+			converter := newPrometheusConverter(Settings{})
+			got, err := converter.labelNamer.Build("__name__")
+			require.NoError(t, err)
+			require.Equal(t, "__name__", got)
+		})
+	}
+}
+
+// The remote-write v2 converter builds its own LabelNamer, so it needs the same
+// treatment — otherwise FromMetricsV2 keeps collapsing underscores with the gate on.
+func TestNewPrometheusConverterV2LabelNamerMultipleUnderscores(t *testing.T) {
+	t.Run("gate enabled preserves multiple underscores", func(t *testing.T) {
+		defer testutil.SetFeatureGateForTest(t, prometheustranslator.DropSanitizationGate, true)()
+
+		converter := newPrometheusConverterV2(Settings{})
+		got, err := converter.labelNamer.Build("a__b")
+		require.NoError(t, err)
+		require.Equal(t, "a__b", got)
+	})
+
+	t.Run("gate disabled collapses multiple underscores", func(t *testing.T) {
 		defer testutil.SetFeatureGateForTest(t, prometheustranslator.DropSanitizationGate, false)()
 
-		converter := newPrometheusConverter(Settings{})
-		got, err := converter.labelNamer.Build("__name__")
+		converter := newPrometheusConverterV2(Settings{})
+		got, err := converter.labelNamer.Build("a__b")
 		require.NoError(t, err)
-		require.Equal(t, "__name__", got)
+		require.Equal(t, "a_b", got)
 	})
 }

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -80,12 +80,13 @@ func getTranslationConfiguration(settings Settings) (withSuffixes, utf8Allowed b
 
 func newPrometheusConverter(settings Settings) *prometheusConverter {
 	withSuffixes, utf8Allowed := getTranslationConfiguration(settings)
+	permissiveSanitization := prometheus.DropSanitizationGate.IsEnabled()
 
 	return &prometheusConverter{
 		unique:      map[uint64]*prompb.TimeSeries{},
 		conflicts:   map[uint64][]*prompb.TimeSeries{},
 		metricNamer: otlptranslator.MetricNamer{WithMetricSuffixes: withSuffixes, Namespace: settings.Namespace, UTF8Allowed: utf8Allowed},
-		labelNamer:  otlptranslator.LabelNamer{UnderscoreLabelSanitization: !prometheus.DropSanitizationGate.IsEnabled(), PreserveMultipleUnderscores: prometheus.DropSanitizationGate.IsEnabled(), UTF8Allowed: utf8Allowed},
+		labelNamer:  otlptranslator.LabelNamer{UnderscoreLabelSanitization: !permissiveSanitization, PreserveMultipleUnderscores: permissiveSanitization, UTF8Allowed: utf8Allowed},
 		unitNamer:   otlptranslator.UnitNamer{UTF8Allowed: utf8Allowed},
 	}
 }

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -85,7 +85,7 @@ func newPrometheusConverter(settings Settings) *prometheusConverter {
 		unique:      map[uint64]*prompb.TimeSeries{},
 		conflicts:   map[uint64][]*prompb.TimeSeries{},
 		metricNamer: otlptranslator.MetricNamer{WithMetricSuffixes: withSuffixes, Namespace: settings.Namespace, UTF8Allowed: utf8Allowed},
-		labelNamer:  otlptranslator.LabelNamer{UnderscoreLabelSanitization: !prometheus.DropSanitizationGate.IsEnabled(), UTF8Allowed: utf8Allowed},
+		labelNamer:  otlptranslator.LabelNamer{UnderscoreLabelSanitization: !prometheus.DropSanitizationGate.IsEnabled(), PreserveMultipleUnderscores: prometheus.DropSanitizationGate.IsEnabled(), UTF8Allowed: utf8Allowed},
 		unitNamer:   otlptranslator.UnitNamer{UTF8Allowed: utf8Allowed},
 	}
 }

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_v2.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_v2.go
@@ -55,13 +55,14 @@ type metadata struct {
 
 func newPrometheusConverterV2(settings Settings) *prometheusConverterV2 {
 	withSuffixes, utf8Allowed := getTranslationConfiguration(settings)
+	permissiveSanitization := prometheus.DropSanitizationGate.IsEnabled()
 
 	return &prometheusConverterV2{
 		unique:      map[uint64]*writev2.TimeSeries{},
 		conflicts:   map[uint64][]*writev2.TimeSeries{},
 		symbolTable: writev2.NewSymbolTable(),
 		metricNamer: otlptranslator.MetricNamer{WithMetricSuffixes: withSuffixes, Namespace: settings.Namespace, UTF8Allowed: utf8Allowed},
-		labelNamer:  otlptranslator.LabelNamer{UnderscoreLabelSanitization: !prometheus.DropSanitizationGate.IsEnabled(), UTF8Allowed: utf8Allowed},
+		labelNamer:  otlptranslator.LabelNamer{UnderscoreLabelSanitization: !permissiveSanitization, PreserveMultipleUnderscores: permissiveSanitization, UTF8Allowed: utf8Allowed},
 		unitNamer:   otlptranslator.UnitNamer{UTF8Allowed: utf8Allowed},
 	}
 }


### PR DESCRIPTION
#### Description

`newPrometheusConverter` builds its `LabelNamer` with only `UnderscoreLabelSanitization` set:

```go
labelNamer: otlptranslator.LabelNamer{UnderscoreLabelSanitization: !prometheus.DropSanitizationGate.IsEnabled(), UTF8Allowed: utf8Allowed},
```

Because `PreserveMultipleUnderscores` is never set, label names with consecutive underscores (e.g. `a__b`) are collapsed to a single underscore (`a_b`) even when the `pkg.translator.prometheus.PermissiveLabelSanitization` feature gate is enabled — so enabling the gate does not fully drop sanitization as documented.

This sets `PreserveMultipleUnderscores` from the same feature gate, so when the gate is on, consecutive underscores are preserved. `otlptranslator.LabelNamer` already exposes this field (v1.0.0), and reserved `__`-prefixed labels remain untouched.

#### Link to tracking issue
Fixes #48991

#### Testing
Added `TestNewPrometheusConverterLabelNamerMultipleUnderscores` covering:
- gate enabled: `a__b` is preserved
- gate disabled: `a__b` is collapsed to `a_b` (unchanged behavior)
- reserved `__name__` is preserved regardless of the gate

The gate-enabled case fails before this change and passes after; the full package test suite still passes.

#### Documentation
No user-facing docs change; the feature gate behavior now matches its documented intent.