### PR TITLE
[pkg/pdatatest] selective histogram bounds writer

### DIFF
--- a/.chloggen/pmetricassert-histogram-explicit-bounds.yaml
+++ b/.chloggen/pmetricassert-histogram-explicit-bounds.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `IncludeHistogramExplicitBounds` option to pmetricassert snapshot generation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49732]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The option includes histogram explicit bounds without including other histogram datapoint values.
+  Snapshot compaction preserves selected histogram datapoint assertion fields, including empty explicit bounds.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/pdatatest/pmetricassert/README.md
+++ b/pkg/pdatatest/pmetricassert/README.md
@@ -35,6 +35,10 @@ The following are ignored:
 - batch boundaries — multiple `ResourceMetrics` / `ScopeMetrics` / `Metric`
   entries with the same identity are normalized before comparison.
 
+Use `IncludeValues()` to write supported datapoint values, or
+`IncludeHistogramExplicitBounds()` to write histogram bounds without other
+histogram values.
+
 `WriteAssertionFile` expects semantically valid metrics. It normalizes valid
 metrics into an assertion snapshot; it is not a validator for producer output.
 

--- a/pkg/pdatatest/pmetricassert/assert.go
+++ b/pkg/pdatatest/pmetricassert/assert.go
@@ -216,8 +216,8 @@ func compareDatapointValues(expected, actual datapointAssertion) error {
 	if expected.ExplicitBounds != nil {
 		if actual.ExplicitBounds == nil {
 			errs = append(errs, errors.New("missing expected explicit_bounds"))
-		} else if !slices.Equal(expected.ExplicitBounds, actual.ExplicitBounds) {
-			errs = append(errs, fmt.Errorf("explicit_bounds mismatch: expected %v, got %v", expected.ExplicitBounds, actual.ExplicitBounds))
+		} else if !slices.Equal(*expected.ExplicitBounds, *actual.ExplicitBounds) {
+			errs = append(errs, fmt.Errorf("explicit_bounds mismatch: expected %v, got %v", *expected.ExplicitBounds, *actual.ExplicitBounds))
 		}
 	}
 	if expected.BucketCounts != nil {

--- a/pkg/pdatatest/pmetricassert/assert_test.go
+++ b/pkg/pdatatest/pmetricassert/assert_test.go
@@ -55,6 +55,49 @@ func TestAssertMetrics_IncludeValues(t *testing.T) {
 	require.Contains(t, err.Error(), "value mismatch")
 }
 
+func TestWriteAssertionFile_IncludeHistogramExplicitBounds(t *testing.T) {
+	m := buildHistogramMetrics()
+	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
+	require.NoError(t, WriteAssertionFile(t, path, m, IncludeHistogramExplicitBounds()))
+
+	doc, err := readDocument(path)
+	require.NoError(t, err)
+	datapoints := doc.Resources[0].Scopes[0].Metrics[0].Datapoints
+	require.Equal(t, []datapointAssertion{{
+		ExplicitBounds: &[]float64{0.005, 0.01, 0.025},
+	}}, datapoints)
+
+	dp := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Histogram().DataPoints().At(0)
+	dp.SetCount(999)
+	dp.SetSum(123.45)
+	dp.SetMin(0.001)
+	dp.SetMax(100)
+	dp.BucketCounts().FromRaw([]uint64{9, 8, 7, 6})
+	require.NoError(t, AssertMetrics(path, m))
+
+	dp.ExplicitBounds().FromRaw([]float64{0.005, 0.02, 0.025})
+	err = AssertMetrics(path, m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "explicit_bounds mismatch")
+}
+
+func TestWriteAssertionFile_IncludeEmptyHistogramExplicitBounds(t *testing.T) {
+	m := buildHistogramMetrics()
+	dp := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Histogram().DataPoints().At(0)
+	dp.ExplicitBounds().FromRaw([]float64{})
+	dp.BucketCounts().FromRaw([]uint64{10})
+
+	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
+	require.NoError(t, WriteAssertionFile(t, path, m, IncludeHistogramExplicitBounds()))
+	require.NoError(t, AssertMetrics(path, m))
+
+	dp.ExplicitBounds().FromRaw([]float64{1})
+	dp.BucketCounts().FromRaw([]uint64{0, 10})
+	err := AssertMetrics(path, m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "explicit_bounds mismatch")
+}
+
 func TestAssertMetrics_DetectsMissingMetric(t *testing.T) {
 	m := buildSampleMetrics()
 	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
@@ -334,6 +377,26 @@ func buildSampleMetrics() pmetric.Metrics {
 		dp.SetTimestamp(pcommon.Timestamp(1))
 	}
 
+	return m
+}
+
+func buildHistogramMetrics() pmetric.Metrics {
+	m := pmetric.NewMetrics()
+	rm := m.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("scope")
+
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("request.duration")
+	histogram := metric.SetEmptyHistogram()
+	histogram.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	dp := histogram.DataPoints().AppendEmpty()
+	dp.SetCount(10)
+	dp.SetSum(0.5)
+	dp.SetMin(0.001)
+	dp.SetMax(0.2)
+	dp.ExplicitBounds().FromRaw([]float64{0.005, 0.01, 0.025})
+	dp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 	return m
 }
 

--- a/pkg/pdatatest/pmetricassert/document.go
+++ b/pkg/pdatatest/pmetricassert/document.go
@@ -52,7 +52,7 @@ type datapointAssertion struct {
 	Value          any            `yaml:"value,omitempty"`
 	Count          *uint64        `yaml:"count,omitempty"`
 	Sum            *float64       `yaml:"sum,omitempty"`
-	ExplicitBounds []float64      `yaml:"explicit_bounds,omitempty"`
+	ExplicitBounds *[]float64     `yaml:"explicit_bounds,omitempty"`
 	BucketCounts   []uint64       `yaml:"bucket_counts,omitempty"`
 	Min            *float64       `yaml:"min,omitempty"`
 	Max            *float64       `yaml:"max,omitempty"`
@@ -117,10 +117,21 @@ func compactShorthand(doc *document) {
 		for j := range doc.Resources[i].Scopes {
 			for k := range doc.Resources[i].Scopes[j].Metrics {
 				m := &doc.Resources[i].Scopes[j].Metrics[k]
-				if len(m.Datapoints) == 1 && len(m.Datapoints[0].Attributes) == 0 && m.Datapoints[0].Value == nil {
+				if len(m.Datapoints) == 1 && isEmptyDatapointAssertion(m.Datapoints[0]) {
 					m.Datapoints = nil
 				}
 			}
 		}
 	}
+}
+
+func isEmptyDatapointAssertion(dp datapointAssertion) bool {
+	return len(dp.Attributes) == 0 &&
+		dp.Value == nil &&
+		dp.Count == nil &&
+		dp.Sum == nil &&
+		dp.ExplicitBounds == nil &&
+		len(dp.BucketCounts) == 0 &&
+		dp.Min == nil &&
+		dp.Max == nil
 }

--- a/pkg/pdatatest/pmetricassert/normalize.go
+++ b/pkg/pdatatest/pmetricassert/normalize.go
@@ -100,6 +100,9 @@ func normalize(m pmetric.Metrics, opts writeOptions) *document {
 							dp.BucketCounts = extDP.bucketCounts
 						}
 					}
+					if opts.includeHistogramExplicitBounds && extDP.explicitBounds != nil {
+						dp.ExplicitBounds = extDP.explicitBounds
+					}
 					mAgg.datapoints[key] = dp
 				}
 			}
@@ -206,7 +209,7 @@ type extractedDatapoint struct {
 	sum            *float64
 	minVal         *float64
 	maxVal         *float64
-	explicitBounds []float64
+	explicitBounds *[]float64
 	bucketCounts   []uint64
 }
 
@@ -246,9 +249,8 @@ func extractDatapoints(metric pmetric.Metric) []extractedDatapoint {
 				maxVal := dp.Max()
 				edp.maxVal = &maxVal
 			}
-			if dp.ExplicitBounds().Len() > 0 {
-				edp.explicitBounds = dp.ExplicitBounds().AsRaw()
-			}
+			bounds := dp.ExplicitBounds().AsRaw()
+			edp.explicitBounds = &bounds
 			if dp.BucketCounts().Len() > 0 {
 				edp.bucketCounts = dp.BucketCounts().AsRaw()
 			}

--- a/pkg/pdatatest/pmetricassert/write.go
+++ b/pkg/pdatatest/pmetricassert/write.go
@@ -10,7 +10,8 @@ import (
 )
 
 type writeOptions struct {
-	includeValues bool
+	includeValues                  bool
+	includeHistogramExplicitBounds bool
 }
 
 // WriteOption configures the snapshot generation.
@@ -29,14 +30,26 @@ func IncludeValues() WriteOption {
 	return includeValuesOption{}
 }
 
+type includeHistogramExplicitBoundsOption struct{}
+
+func (includeHistogramExplicitBoundsOption) apply(o *writeOptions) {
+	o.includeHistogramExplicitBounds = true
+}
+
+// IncludeHistogramExplicitBounds opts into asserting each histogram datapoint's
+// exact explicit bounds without other histogram values.
+func IncludeHistogramExplicitBounds() WriteOption {
+	return includeHistogramExplicitBoundsOption{}
+}
+
 // WriteAssertionFile regenerates the default-strict assertion snapshot at path
 // from actual. It is intended to be called manually during test authoring,
 // analogous to golden.WriteMetrics, and removed before committing.
 //
-// Emitted snapshots capture identity fields only: resource attributes, scope
-// name/version, metric name/type/unit/temporality/monotonic, and the set of
-// datapoint attribute permutations. Values, timestamps, and exemplars are
-// omitted.
+// By default, emitted snapshots capture identity fields only: resource
+// attributes, scope name/version, metric name/type/unit/temporality/monotonic,
+// and the set of datapoint attribute permutations. Values, timestamps, and
+// exemplars are omitted.
 //
 // The input metrics must be semantically valid. WriteAssertionFile normalizes
 // valid metrics for assertion readability; it does not validate producer


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add an `IncludeHistogramExplicitBounds` option to assert histogram bucket layouts without including other histogram values. Empty explicit bounds are also preserved and asserted.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49732

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added tests for matching, changed, and empty explicit bounds.

<!--Describe the documentation added.-->
#### Documentation
Updated the `pmetricassert` README.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
