### PR TITLE
[pkg/translator/jaeger] preserve the sampled flag across Jaeger/OTLP translation

### DIFF
--- a/.chloggen/jaeger-sampled-flag.yaml
+++ b/.chloggen/jaeger-sampled-flag.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/jaeger
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve the sampled flag when translating spans between Jaeger and OTLP.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48247]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Jaeger to OTLP translators (proto and thrift) now map the Jaeger SampledFlag to bit 0 of the OTLP Span.flags field (the W3C Trace Context sampled bit), and the OTLP to Jaeger translator maps it back. Previously the sampled bit was always dropped in both directions, so downstream sampling-aware components lost that information whenever a Jaeger receiver or exporter was in the pipeline.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/jaeger/constants.go
+++ b/pkg/translator/jaeger/constants.go
@@ -18,5 +18,9 @@ const (
 // https://github.com/open-telemetry/opentelemetry-specification/blob/34b907207f3dfe1635a35c4cdac6b6ab3a495e18/specification/trace/sdk_exporters/jaeger.md#events
 const eventNameAttr = "event"
 
+// spanFlagsSampled is bit 0 of the OTLP Span.flags field, the W3C Trace Context
+// "sampled" trace flag (SPAN_FLAGS_TRACE_FLAGS_MASK covers bits 0-7).
+const spanFlagsSampled = uint32(1)
+
 // errType indicates that a value is not convertible to the target type.
 var errType = errors.New("invalid type")

--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -203,6 +203,10 @@ func jSpanToInternal(span *model.Span, dest ptrace.Span) {
 	dest.SetStartTimestamp(pcommon.NewTimestampFromTime(span.StartTime))
 	dest.SetEndTimestamp(pcommon.NewTimestampFromTime(span.StartTime.Add(span.Duration)))
 
+	if span.Flags.IsSampled() {
+		dest.SetFlags(dest.Flags() | spanFlagsSampled)
+	}
+
 	parentSpanID := span.ParentSpanID()
 	if parentSpanID != model.SpanID(0) {
 		dest.SetParentSpanID(idutils.UInt64ToSpanID(uint64(parentSpanID)))

--- a/pkg/translator/jaeger/jaegerthrift_to_traces.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/thrift-gen/jaeger"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -112,6 +113,10 @@ func jThriftSpanToInternal(span *jaeger.Span, dest ptrace.Span) {
 	dest.SetName(span.OperationName)
 	dest.SetStartTimestamp(microsecondsToUnixNano(span.StartTime))
 	dest.SetEndTimestamp(microsecondsToUnixNano(span.StartTime + span.Duration))
+
+	if model.Flags(span.Flags).IsSampled() {
+		dest.SetFlags(dest.Flags() | spanFlagsSampled)
+	}
 
 	parentSpanID := jThriftSpanParentID(span)
 	if parentSpanID != 0 {

--- a/pkg/translator/jaeger/sampled_flag_test.go
+++ b/pkg/translator/jaeger/sampled_flag_test.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jaeger // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+
+import (
+	"testing"
+	"time"
+
+	model "github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/jaeger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func newProtoBatch(flags model.Flags) []*model.Batch {
+	span := &model.Span{
+		TraceID:       model.NewTraceID(0, 1),
+		SpanID:        model.NewSpanID(2),
+		OperationName: "op",
+		StartTime:     time.Unix(0, 0),
+		Duration:      time.Millisecond,
+		Flags:         flags,
+	}
+	return []*model.Batch{{
+		Process: &model.Process{ServiceName: "svc"},
+		Spans:   []*model.Span{span},
+	}}
+}
+
+func firstSpan(t *testing.T, td ptrace.Traces) ptrace.Span {
+	t.Helper()
+	require.Equal(t, 1, td.ResourceSpans().Len())
+	ss := td.ResourceSpans().At(0).ScopeSpans()
+	require.Equal(t, 1, ss.Len())
+	require.Equal(t, 1, ss.At(0).Spans().Len())
+	return ss.At(0).Spans().At(0)
+}
+
+func TestProtoSampledFlagToOTLP(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       model.Flags
+		wantSampled bool
+	}{
+		{"sampled", model.SampledFlag, true},
+		{"not sampled", model.Flags(0), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td, err := ProtoToTraces(newProtoBatch(tt.flags))
+			require.NoError(t, err)
+			got := firstSpan(t, td).Flags()&spanFlagsSampled != 0
+			assert.Equal(t, tt.wantSampled, got)
+		})
+	}
+}
+
+func TestThriftSampledFlagToOTLP(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       int32
+		wantSampled bool
+	}{
+		{"sampled", int32(model.SampledFlag), true},
+		{"not sampled", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch := &jaeger.Batch{
+				Process: &jaeger.Process{ServiceName: "svc"},
+				Spans: []*jaeger.Span{{
+					TraceIdLow:    1,
+					SpanId:        2,
+					OperationName: "op",
+					StartTime:     0,
+					Duration:      1000,
+					Flags:         tt.flags,
+				}},
+			}
+			td, err := ThriftToTraces(batch)
+			require.NoError(t, err)
+			got := firstSpan(t, td).Flags()&spanFlagsSampled != 0
+			assert.Equal(t, tt.wantSampled, got)
+		})
+	}
+}
+
+func TestOTLPSampledFlagToProto(t *testing.T) {
+	tests := []struct {
+		name        string
+		otlpFlags   uint32
+		wantSampled bool
+	}{
+		{"sampled", spanFlagsSampled, true},
+		{"not sampled", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := ptrace.NewTraces()
+			span := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetTraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+			span.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2})
+			span.SetName("op")
+			span.SetFlags(tt.otlpFlags)
+
+			batches := ProtoFromTraces(td)
+			require.Len(t, batches, 1)
+			require.Len(t, batches[0].Spans, 1)
+			assert.Equal(t, tt.wantSampled, batches[0].Spans[0].Flags.IsSampled())
+		})
+	}
+}
+
+func TestSampledFlagRoundTrip(t *testing.T) {
+	// Jaeger (sampled) -> OTLP -> Jaeger must keep the sampled bit.
+	td, err := ProtoToTraces(newProtoBatch(model.SampledFlag))
+	require.NoError(t, err)
+	require.True(t, firstSpan(t, td).Flags()&spanFlagsSampled != 0)
+
+	batches := ProtoFromTraces(td)
+	require.Len(t, batches, 1)
+	require.Len(t, batches[0].Spans, 1)
+	assert.True(t, batches[0].Spans[0].Flags.IsSampled())
+}

--- a/pkg/translator/jaeger/sampled_flag_test.go
+++ b/pkg/translator/jaeger/sampled_flag_test.go
@@ -117,7 +117,7 @@ func TestSampledFlagRoundTrip(t *testing.T) {
 	// Jaeger (sampled) -> OTLP -> Jaeger must keep the sampled bit.
 	td, err := ProtoToTraces(newProtoBatch(model.SampledFlag))
 	require.NoError(t, err)
-	require.True(t, firstSpan(t, td).Flags()&spanFlagsSampled != 0)
+	require.NotZero(t, firstSpan(t, td).Flags()&spanFlagsSampled)
 
 	batches := ProtoFromTraces(td)
 	require.Len(t, batches, 1)

--- a/pkg/translator/jaeger/traces_to_jaegerproto.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto.go
@@ -146,6 +146,12 @@ func spanToJaegerProto(span ptrace.Span, libraryTags pcommon.InstrumentationScop
 	jReferences := makeJaegerProtoReferences(span.Links(), spanIDToJaegerProto(span.ParentSpanID()), traceID)
 
 	startTime := span.StartTimestamp().AsTime()
+
+	var flags model.Flags
+	if span.Flags()&spanFlagsSampled != 0 {
+		flags.SetSampled()
+	}
+
 	return &model.Span{
 		TraceID:       traceID,
 		SpanID:        spanIDToJaegerProto(span.SpanID()),
@@ -155,6 +161,7 @@ func spanToJaegerProto(span ptrace.Span, libraryTags pcommon.InstrumentationScop
 		Duration:      span.EndTimestamp().AsTime().Sub(startTime),
 		Tags:          getJaegerProtoSpanTags(span, libraryTags),
 		Logs:          spanEventsToJaegerProtoLogs(span.Events()),
+		Flags:         flags,
 	}
 }
 


### PR DESCRIPTION
#### Description

The Jaeger↔OTLP translators in `pkg/translator/jaeger` ignored the Jaeger span `Flags` field (proto + thrift) and the `flags` field on `ptrace.Span`, so the W3C `sampled` bit was dropped in both directions. Any downstream sampling-aware component (`probabilisticsampler`, `tailsamplingprocessor`, exporters that respect sampled state) lost that information whenever a Jaeger receiver/exporter was in the pipeline.

This maps the Jaeger `SampledFlag` (`= 1`) to bit 0 of the OTLP `Span.flags` field — the W3C Trace Context sampled bit, `SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF` — in the inbound proto and thrift translators, and maps it back in the outbound proto translator. Only the sampled bit is handled; the `is_remote` bits (8, 9) are out of scope and left untouched.

#### Link to tracking issue
Fixes #48247

#### Testing
Added `sampled_flag_test.go` covering:
- Jaeger proto → OTLP (sampled / not sampled)
- Jaeger thrift → OTLP (sampled / not sampled)
- OTLP → Jaeger proto (sampled / not sampled)
- a Jaeger → OTLP → Jaeger round trip that keeps the sampled bit

Each direction fails before this change and passes after; the full `pkg/translator/jaeger` suite still passes.

#### Documentation
No user-facing docs change; this fixes a translation-fidelity bug.