### PR TITLE
[processor/tailsampling] Make latency threshold_ms inclusive in bound…

### DIFF
--- a/.chloggen/49593-tailsampling-latency-inclusive.yaml
+++ b/.chloggen/49593-tailsampling-latency-inclusive.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: processor/tail_sampling
+note: "Fix inconsistency where `threshold_ms` is exclusive when `upper_threshold_ms` is set but inclusive when it is unset"
+issues: [49593]

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -52,7 +52,7 @@ func (l *latency) Evaluate(_ context.Context, _ pcommon.TraceID, traceData *samp
 		if l.upperThresholdMs == 0 {
 			return duration.Milliseconds() >= l.thresholdMs
 		}
-		return (l.thresholdMs < duration.Milliseconds() && duration.Milliseconds() <= l.upperThresholdMs)
+		return (l.thresholdMs <= duration.Milliseconds() && duration.Milliseconds() <= l.upperThresholdMs)
 	}), nil
 }
 

--- a/processor/tailsamplingprocessor/internal/sampling/latency_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency_test.go
@@ -101,7 +101,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  5000 * time.Millisecond,
 				},
 			},
-			samplingpolicy.NotSampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"trace duration is within lower and upper bounds",


### PR DESCRIPTION
## Description
This PR resolves an inconsistency in the tail sampling processor's `latency` policy where the lower-bound check is exclusive (`<`) if `upper_threshold_ms` is set, but inclusive (`>=`) if `upper_threshold_ms` is unset or zero.

This inconsistency makes boundary behaviors confusing and unpredictable. The lower-bound check has been modified to be inclusive (`<=`) under both paths.

#### Fixes 49593

## Changes
- Updated `processor/tailsamplingprocessor/internal/sampling/latency.go` to use `<=` instead of `<` in bounded evaluation.
- Updated `processor/tailsamplingprocessor/internal/sampling/latency_test.go` to assert `Sampled` for the lower-bound equality test case.

## Verification
### Automated Tests
Ran unit tests in `processor/tailsamplingprocessor`:
```bash
go test -v ./...
