### PR TITLE
[processor/tailsampling] align latency lower bound behavior

### DIFF
--- a/.chloggen/49593-tailsampling-exclusive-lower-bound.yaml
+++ b/.chloggen/49593-tailsampling-exclusive-lower-bound.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Treat `threshold_ms` as an exclusive lower bound when `upper_threshold_ms` is not set.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49593]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -50,9 +50,9 @@ func (l *latency) Evaluate(_ context.Context, _ pcommon.TraceID, traceData *samp
 
 		duration := maxTime.AsTime().Sub(minTime.AsTime())
 		if l.upperThresholdMs == 0 {
-			return duration.Milliseconds() >= l.thresholdMs
+			return duration.Milliseconds() > l.thresholdMs
 		}
-		return (l.thresholdMs < duration.Milliseconds() && duration.Milliseconds() <= l.upperThresholdMs)
+		return l.thresholdMs < duration.Milliseconds() && duration.Milliseconds() <= l.upperThresholdMs
 	}), nil
 }
 

--- a/processor/tailsamplingprocessor/internal/sampling/latency_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency_test.go
@@ -44,7 +44,7 @@ func TestEvaluate_Latency(t *testing.T) {
 					Duration:  5000 * time.Millisecond,
 				},
 			},
-			samplingpolicy.Sampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"total trace duration is longer than threshold but every single span is shorter",


### PR DESCRIPTION
#### Description

Previously, the latency policy handled the lower threshold differently depending on whether `upper_threshold_ms` was configured:

- Without `upper_threshold_ms`, traces with `duration >= threshold_ms` were sampled.
- With `upper_threshold_ms`, traces with `duration > threshold_ms` were sampled.

This change makes the behavior consistent by always treating `threshold_ms` as an exclusive lower bound. Traces whose duration is exactly equal to `threshold_ms` are no longer sampled.

#### Link to tracking issue

Fixes #49593

#### Testing

Added regression tests covering both lower-bound scenarios:

- without `upper_threshold_ms`, where `duration == threshold_ms`
- with `upper_threshold_ms`, where `duration == threshold_ms`

Both cases are expected to be `NotSampled`.

- `go test ./... -count=1`
- `make lint`
- `make chlog-validate`
- `git diff --check`

#### Documentation

Added a changelog entry for this change. No README updates were required.

#### Authorship

- [x] I, a human, wrote this pull request description myself.