### PR TITLE
[receiver/k8sobjectsreceiver] Fix panic and data race during leader re-acquisition

### DIFF
--- a/.chloggen/fix-issue-49601.yaml
+++ b/.chloggen/fix-issue-49601.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: receiver/k8s_objects
+note: Fix panic and data race in stopperChanList during leader election re-acquisition
+issues: [49601]
+change_logs: [user]

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -263,6 +263,7 @@ func (kr *k8sobjectsreceiver) stopWatches() {
 	for _, stopperChan := range kr.stopperChanList {
 		close(stopperChan)
 	}
+	kr.stopperChanList = nil
 	kr.mu.Unlock()
 	kr.wg.Wait()
 }
@@ -307,7 +308,9 @@ func (kr *k8sobjectsreceiver) start(ctx context.Context, object *K8sObjectsConfi
 	}
 
 	stopChan := kr.startObserver(ctx, obs, object)
+	kr.mu.Lock()
 	kr.stopperChanList = append(kr.stopperChanList, stopChan)
+	kr.mu.Unlock()
 
 	return nil
 }

--- a/receiver/k8sobjectsreceiver/receiver_test.go
+++ b/receiver/k8sobjectsreceiver/receiver_test.go
@@ -621,6 +621,8 @@ func TestReceiverWithLeaderElection(t *testing.T) {
 		return sink.LogRecordCount() == 2
 	}, 20*time.Second, 100*time.Millisecond,
 		"logs not collected")
+
+	assert.NoError(t, r.Shutdown(t.Context()))
 }
 
 func TestNamespaceDenyListWatchObject(t *testing.T) {


### PR DESCRIPTION
### Context
When the receiver loses leadership, `stopWatches()` closes the channels in `stopperChanList` but leaves them in the slice. When the receiver re-acquires leadership, `start()` appends new stop channels to the same slice. When stopping again, the receiver attempts to close already-closed channels, resulting in a panic. Furthermore, `start()` mutated `stopperChanList` without holding the mutex `kr.mu`, causing a data race with `stopWatches()`.

### Changes
- Reset `stopperChanList` to `nil` in `stopWatches()` under lock.
- Acquire `kr.mu` lock in `start()` before appending to `stopperChanList`.
- Call `Shutdown` at the end of `TestReceiverWithLeaderElection` to ensure leader changes and shutdowns are fully verified.

### Verification
- Ran `go test -v ./...` in the `receiver/k8sobjectsreceiver` directory. All tests passed.

