### PR TITLE
[exporter/opensearch] Retry transient failures instead of dropping them as permanent

### DIFF
--- a/.chloggen/49208-opensearch-retry-transient-errors.yaml
+++ b/.chloggen/49208-opensearch-retry-transient-errors.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/opensearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retry transient OpenSearch failures instead of dropping them as permanent errors
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49208]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Indexer-level failures such as connection refused, timeouts, and DNS errors were wrapped as
+  permanent errors, so exporterhelper dropped the batch even with retry_on_failure enabled. They
+  are now surfaced as retryable, and per-item transport errors (net.OpError) are retried as well,
+  while encoding and bad-document errors remain permanent.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/49208-opensearch-retry-transient-errors.yaml
+++ b/.chloggen/49208-opensearch-retry-transient-errors.yaml
@@ -10,7 +10,7 @@ component: exporter/opensearch
 note: Retry transient OpenSearch failures instead of dropping them as permanent errors
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [49208]
+issues: [49208, 45147, 45120]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/49208-opensearch-retry-transient-errors.yaml
+++ b/.chloggen/49208-opensearch-retry-transient-errors.yaml
@@ -18,8 +18,12 @@ issues: [49208, 45147, 45120]
 subtext: |
   Indexer-level failures such as connection refused, timeouts, and DNS errors were wrapped as
   permanent errors, so exporterhelper dropped the batch even with retry_on_failure enabled. They
-  are now surfaced as retryable, and per-item transport errors (net.OpError) are retried as well,
-  while encoding and bad-document errors remain permanent.
+  are now surfaced as retryable, and per-item transport failures are retried as well, while
+  encoding and bad-document errors remain permanent.
+
+  A transport failure reports every buffered record through the per-item callback, so the
+  retryable error is reported without an attached payload. Otherwise exporterhelper would
+  resolve the first one and retry only that record, dropping the rest of the batch.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/opensearchexporter/integration_test.go
+++ b/exporter/opensearchexporter/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -455,4 +456,41 @@ func TestOpenSearchOTelV1_CustomIndex(t *testing.T) {
 
 	assert.Equal(t, "my-custom-traces", bulkIndex)
 	require.NoError(t, exporter.Shutdown(t.Context()))
+}
+
+// TestOpenSearchLogExporter_TransportFailureRetryable drives a real bulk flush
+// against a server that never responds before the client timeout, so the flush
+// fails at the transport level (context deadline / net timeout). The exporter
+// must surface that as a retryable error rather than permanent, otherwise
+// retry_on_failure would drop the batch. Retry is disabled here so the single
+// synchronous attempt returns immediately. See #49208.
+func TestOpenSearchLogExporter_TransportFailureRetryable(t *testing.T) {
+	blocked := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-blocked // hold the request open past the client timeout
+	}))
+	defer func() {
+		close(blocked)
+		ts.Close()
+	}()
+
+	cfg := withDefaultConfig(func(config *Config) {
+		config.Endpoint = ts.URL
+		config.TimeoutSettings.Timeout = 50 * time.Millisecond
+		config.BackOffConfig.Enabled = false
+	})
+
+	f := NewFactory()
+	exporter, err := f.CreateLogs(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, exporter.Shutdown(t.Context())) }()
+
+	logs, err := golden.ReadLogs("testdata/logs-sample-a.yaml")
+	require.NoError(t, err)
+
+	err = exporter.ConsumeLogs(t.Context(), logs)
+	require.Error(t, err)
+	require.False(t, consumererror.IsPermanent(err),
+		"a transport/flush failure (timeout) must be retryable, not permanent")
 }

--- a/exporter/opensearchexporter/integration_test.go
+++ b/exporter/opensearchexporter/integration_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -493,4 +495,180 @@ func TestOpenSearchLogExporter_TransportFailureRetryable(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, consumererror.IsPermanent(err),
 		"a transport/flush failure (timeout) must be retryable, not permanent")
+}
+
+// TestOpenSearchLogExporter_RetryPreservesWholeBatch is the regression test for the
+// partial-loss variant of #49208. A flush failure fires the per-item OnFailure for
+// every buffered record, and exporterhelper's OnError resolves the first
+// consumererror it finds and retries only that payload. If the retryable error
+// carried a single record, the retry would be narrowed to that one and the rest of
+// the batch dropped. The first bulk request here fails at the transport level and
+// the second succeeds, so every record in the batch must arrive on the retry.
+func TestOpenSearchLogExporter_RetryPreservesWholeBatch(t *testing.T) {
+	logs, err := golden.ReadLogs("testdata/logs-sample-a.yaml")
+	require.NoError(t, err)
+	wantRecords := logs.LogRecordCount()
+	require.Greater(t, wantRecords, 1, "fixture must hold several records for this to mean anything")
+
+	var mu sync.Mutex
+	var attempts int
+	var indexed int
+	done := make(chan struct{})
+	var closeOnce sync.Once
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		attempt := attempts
+		mu.Unlock()
+
+		if attempt == 1 {
+			// Stall past the client timeout so the flush fails with a deadline,
+			// which is the transport failure #49208 is about.
+			time.Sleep(500 * time.Millisecond)
+			return
+		}
+
+		body, readErr := io.ReadAll(r.Body)
+		require.NoError(t, readErr)
+		// The bulk body is action/document line pairs, so each action line is one record.
+		var items []string
+		for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+			if strings.Contains(line, `"create"`) || strings.Contains(line, `"index"`) {
+				items = append(items, line)
+			}
+		}
+
+		mu.Lock()
+		indexed += len(items)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		var sb strings.Builder
+		sb.WriteString(`{"took":1,"errors":false,"items":[`)
+		for i := range items {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString(`{"create":{"_index":"logs","status":201}}`)
+		}
+		sb.WriteString(`]}`)
+		_, _ = w.Write([]byte(sb.String()))
+		closeOnce.Do(func() { close(done) })
+	}))
+	defer ts.Close()
+
+	cfg := withDefaultConfig(func(config *Config) {
+		config.Endpoint = ts.URL
+		config.TimeoutSettings.Timeout = 100 * time.Millisecond
+		config.BackOffConfig.Enabled = true
+		config.BackOffConfig.InitialInterval = 10 * time.Millisecond
+		config.BackOffConfig.MaxInterval = 20 * time.Millisecond
+		config.BackOffConfig.MaxElapsedTime = 10 * time.Second
+	})
+
+	f := NewFactory()
+	exporter, err := f.CreateLogs(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, exporter.Shutdown(t.Context())) }()
+
+	require.NoError(t, exporter.ConsumeLogs(t.Context(), logs))
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the retried bulk request")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, attempts, 2, "the first attempt must fail and be retried")
+	assert.Equal(t, wantRecords, indexed,
+		"every record in the batch must be resent on the retry, not just the first")
+}
+
+// TestOpenSearchTraceExporter_RetryPreservesWholeBatch is the trace counterpart of
+// TestOpenSearchLogExporter_RetryPreservesWholeBatch: the trace indexer shares the
+// same per-item failure path, so it must also resend the whole batch on a retry.
+func TestOpenSearchTraceExporter_RetryPreservesWholeBatch(t *testing.T) {
+	traces, err := golden.ReadTraces("testdata/traces-sample-a.yaml")
+	require.NoError(t, err)
+	wantSpans := traces.SpanCount()
+	require.Greater(t, wantSpans, 1, "fixture must hold several spans for this to mean anything")
+
+	var mu sync.Mutex
+	var attempts, indexed int
+	done := make(chan struct{})
+	var closeOnce sync.Once
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		attempt := attempts
+		mu.Unlock()
+
+		if attempt == 1 {
+			// Stall past the client timeout so the flush fails with a deadline,
+			// which is the transport failure #49208 is about.
+			time.Sleep(500 * time.Millisecond)
+			return
+		}
+
+		body, readErr := io.ReadAll(r.Body)
+		require.NoError(t, readErr)
+		var items int
+		for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+			if strings.Contains(line, `"create"`) || strings.Contains(line, `"index"`) {
+				items++
+			}
+		}
+
+		mu.Lock()
+		indexed += items
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		var sb strings.Builder
+		sb.WriteString(`{"took":1,"errors":false,"items":[`)
+		for i := 0; i < items; i++ {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString(`{"create":{"_index":"traces","status":201}}`)
+		}
+		sb.WriteString(`]}`)
+		_, _ = w.Write([]byte(sb.String()))
+		closeOnce.Do(func() { close(done) })
+	}))
+	defer ts.Close()
+
+	cfg := withDefaultConfig(func(config *Config) {
+		config.Endpoint = ts.URL
+		config.TimeoutSettings.Timeout = 100 * time.Millisecond
+		config.BackOffConfig.Enabled = true
+		config.BackOffConfig.InitialInterval = 10 * time.Millisecond
+		config.BackOffConfig.MaxInterval = 20 * time.Millisecond
+		config.BackOffConfig.MaxElapsedTime = 10 * time.Second
+	})
+
+	f := NewFactory()
+	exporter, err := f.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, exporter.Shutdown(t.Context())) }()
+
+	require.NoError(t, exporter.ConsumeTraces(t.Context(), traces))
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the retried bulk request")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, attempts, 2, "the first attempt must fail and be retried")
+	assert.Equal(t, wantSpans, indexed,
+		"every span in the batch must be resent on the retry, not just the first")
 }

--- a/exporter/opensearchexporter/log_bulk_indexer.go
+++ b/exporter/opensearchexporter/log_bulk_indexer.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"net"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
@@ -133,11 +132,12 @@ func (lbi *logBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem, i
 		// Non-recoverable OpenSearch error while indexing document
 		lbi.appendPermanentError(responseAsError(resp))
 	default:
-		// A transport error (e.g. net.OpError) reported per item is transient and
-		// should be retried; anything else here is an encoding error we never sent,
-		// which is permanent.
-		var netErr *net.OpError
-		if errors.As(itemErr, &netErr) {
+		// No server status classified the item, so this is either a flush/
+		// transport failure (retry) or an encoding failure we never sent
+		// (permanent). On a flush failure opensearchutil reports the same error
+		// through both this per-item path and onIndexerError, so both must land
+		// on retryable or the joined error is still permanent via errors.As.
+		if isRetryableError(itemErr) {
 			lbi.appendRetryLogError(itemErr, logs)
 		} else {
 			lbi.appendPermanentError(itemErr)

--- a/exporter/opensearchexporter/log_bulk_indexer.go
+++ b/exporter/opensearchexporter/log_bulk_indexer.go
@@ -137,8 +137,15 @@ func (lbi *logBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem, i
 		// (permanent). On a flush failure opensearchutil reports the same error
 		// through both this per-item path and onIndexerError, so both must land
 		// on retryable or the joined error is still permanent via errors.As.
+		//
+		// The retryable error is deliberately bare rather than carrying this one
+		// item. A flush failure fires this callback for every buffered item, and
+		// exporterhelper's OnError resolves the first consumererror it finds and
+		// retries only that payload, so wrapping here would narrow the retry to a
+		// single record and silently drop the rest of the batch. With no payload
+		// attached, OnError falls through and the whole request is resent.
 		if isRetryableError(itemErr) {
-			lbi.appendRetryLogError(itemErr, logs)
+			lbi.errs = append(lbi.errs, itemErr)
 		} else {
 			lbi.appendPermanentError(itemErr)
 		}

--- a/exporter/opensearchexporter/log_bulk_indexer.go
+++ b/exporter/opensearchexporter/log_bulk_indexer.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
@@ -47,7 +48,11 @@ func (lbi *logBulkIndexer) close(ctx context.Context) {
 
 func (lbi *logBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
 	if indexerErr != nil {
-		lbi.appendPermanentError(consumererror.NewPermanent(indexerErr))
+		// Indexer-level errors are transport/flush failures (connection refused,
+		// timeout, DNS). They are transient, so surface them as a retryable error
+		// and let exporterhelper's retry_on_failure resend the batch instead of
+		// dropping it as permanent.
+		lbi.errs = append(lbi.errs, indexerErr)
 	}
 }
 
@@ -128,8 +133,15 @@ func (lbi *logBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem, i
 		// Non-recoverable OpenSearch error while indexing document
 		lbi.appendPermanentError(responseAsError(resp))
 	default:
-		// Encoding error. We didn't even attempt to send the event
-		lbi.appendPermanentError(itemErr)
+		// A transport error (e.g. net.OpError) reported per item is transient and
+		// should be retried; anything else here is an encoding error we never sent,
+		// which is permanent.
+		var netErr *net.OpError
+		if errors.As(itemErr, &netErr) {
+			lbi.appendRetryLogError(itemErr, logs)
+		} else {
+			lbi.appendPermanentError(itemErr)
+		}
 	}
 }
 

--- a/exporter/opensearchexporter/log_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/log_bulk_indexer_test.go
@@ -4,8 +4,11 @@
 package opensearchexporter
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -75,25 +78,30 @@ func TestOnIndexerErrorIsRetryable(t *testing.T) {
 	}
 }
 
-func TestProcessItemFailureTransportErrorRetryable(t *testing.T) {
-	// A per-item transport error (net.OpError) with no HTTP status is transient.
-	lbi := &logBulkIndexer{}
-	lbi.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, &net.OpError{Op: "read", Err: errors.New("i/o timeout")}, plog.NewLogs())
-	if len(lbi.errs) != 1 {
-		t.Fatalf("expected 1 error, got %d", len(lbi.errs))
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"canceled", context.Canceled, true},
+		{"net.OpError", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, true},
+		{
+			"url.Error wrapping net.OpError",
+			&url.Error{Op: "Post", URL: "http://localhost", Err: &net.OpError{Op: "dial", Err: errors.New("connection refused")}},
+			true,
+		},
+		{"flush-wrapped deadline", fmt.Errorf("flush: %w", context.DeadlineExceeded), true},
+		{"encoding error", errors.New("json: unsupported value"), false},
 	}
-	if consumererror.IsPermanent(lbi.errs[0]) {
-		t.Error("per-item transport error must be retryable, not permanent")
-	}
-
-	// A genuine encoding error (never sent) stays permanent.
-	lbi2 := &logBulkIndexer{}
-	lbi2.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, errors.New("encode failed"), plog.NewLogs())
-	if len(lbi2.errs) != 1 {
-		t.Fatalf("expected 1 error, got %d", len(lbi2.errs))
-	}
-	if !consumererror.IsPermanent(lbi2.errs[0]) {
-		t.Error("encoding error must remain permanent")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableError(tt.err); got != tt.want {
+				t.Errorf("isRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/exporter/opensearchexporter/log_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/log_bulk_indexer_test.go
@@ -4,7 +4,6 @@
 package opensearchexporter
 
 import (
-	"context"
 	"errors"
 	"net"
 	"testing"
@@ -66,7 +65,7 @@ func TestProcessItemFailure(t *testing.T) {
 func TestOnIndexerErrorIsRetryable(t *testing.T) {
 	lbi := &logBulkIndexer{}
 	// A transport failure surfaces through the bulk indexer's OnError callback.
-	lbi.onIndexerError(context.Background(), &net.OpError{Op: "dial", Err: errors.New("connection refused")})
+	lbi.onIndexerError(t.Context(), &net.OpError{Op: "dial", Err: errors.New("connection refused")})
 	err := lbi.joinedError()
 	if err == nil {
 		t.Fatal("expected an error")

--- a/exporter/opensearchexporter/log_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/log_bulk_indexer_test.go
@@ -4,11 +4,14 @@
 package opensearchexporter
 
 import (
+	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
@@ -57,6 +60,41 @@ func TestProcessItemFailure(t *testing.T) {
 				t.Errorf("expected %d errors, got %d", tt.expectedErrs, len(lbi.errs))
 			}
 		})
+	}
+}
+
+func TestOnIndexerErrorIsRetryable(t *testing.T) {
+	lbi := &logBulkIndexer{}
+	// A transport failure surfaces through the bulk indexer's OnError callback.
+	lbi.onIndexerError(context.Background(), &net.OpError{Op: "dial", Err: errors.New("connection refused")})
+	err := lbi.joinedError()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if consumererror.IsPermanent(err) {
+		t.Error("indexer-level transport error must be retryable, not permanent (otherwise retry_on_failure silently drops the batch)")
+	}
+}
+
+func TestProcessItemFailureTransportErrorRetryable(t *testing.T) {
+	// A per-item transport error (net.OpError) with no HTTP status is transient.
+	lbi := &logBulkIndexer{}
+	lbi.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, &net.OpError{Op: "read", Err: errors.New("i/o timeout")}, plog.NewLogs())
+	if len(lbi.errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(lbi.errs))
+	}
+	if consumererror.IsPermanent(lbi.errs[0]) {
+		t.Error("per-item transport error must be retryable, not permanent")
+	}
+
+	// A genuine encoding error (never sent) stays permanent.
+	lbi2 := &logBulkIndexer{}
+	lbi2.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, errors.New("encode failed"), plog.NewLogs())
+	if len(lbi2.errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(lbi2.errs))
+	}
+	if !consumererror.IsPermanent(lbi2.errs[0]) {
+		t.Error("encoding error must remain permanent")
 	}
 }
 

--- a/exporter/opensearchexporter/metadata.yaml
+++ b/exporter/opensearchexporter/metadata.yaml
@@ -16,3 +16,5 @@ tests:
   config:
     http:
       endpoint: https://opensearch.example.com:9200
+    retry_on_failure:
+      enabled: false

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -140,8 +140,15 @@ func (tbi *traceBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem,
 		// (permanent). On a flush failure opensearchutil reports the same error
 		// through both this per-item path and onIndexerError, so both must land
 		// on retryable or the joined error is still permanent via errors.As.
+		//
+		// The retryable error is deliberately bare rather than carrying this one
+		// item. A flush failure fires this callback for every buffered item, and
+		// exporterhelper's OnError resolves the first consumererror it finds and
+		// retries only that payload, so wrapping here would narrow the retry to a
+		// single record and silently drop the rest of the batch. With no payload
+		// attached, OnError falls through and the whole request is resent.
 		if isRetryableError(itemErr) {
-			tbi.appendRetryTraceError(itemErr, traces)
+			tbi.errs = append(tbi.errs, itemErr)
 		} else {
 			tbi.appendPermanentError(itemErr)
 		}
@@ -168,9 +175,22 @@ func shouldRetryEvent(status int) bool {
 }
 
 // isRetryableError reports whether err is a transient transport/flush failure
-// (connection refused, timeout, DNS, cancelled/deadline-exceeded context) that
-// should be retried rather than dropped as permanent. Encoding failures, which
-// never leave the process, are not transport errors and remain permanent.
+// (connection refused, timeout, DNS) that should be retried rather than dropped
+// as permanent. Encoding failures, which never leave the process, are not
+// transport errors and remain permanent.
+//
+// The net.Error check is deliberately broad. It also matches durable
+// misconfigurations that arrive wrapped in *net.OpError or *url.Error, such as
+// an untrusted certificate or a hostname that does not resolve, so those are
+// retried until the retry sender gives up rather than dropped immediately. That
+// is bounded by max_elapsed_time and is the safer default: misclassifying a
+// transient failure as permanent loses data, whereas misclassifying a permanent
+// one only costs retries.
+//
+// context.Canceled is included because a cancelled context reaches this path as
+// a flush failure for data that was never accepted. Treating it as permanent
+// would drop that batch on shutdown; treating it as retryable lets the retry
+// sender return immediately on ctx.Done() and leave the data to the queue.
 func isRetryableError(err error) bool {
 	if err == nil {
 		return false

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"slices"
 	"time"
 
@@ -49,7 +50,11 @@ func (tbi *traceBulkIndexer) close(ctx context.Context) {
 
 func (tbi *traceBulkIndexer) onIndexerError(_ context.Context, indexerErr error) {
 	if indexerErr != nil {
-		tbi.appendPermanentError(consumererror.NewPermanent(indexerErr))
+		// Indexer-level errors are transport/flush failures (connection refused,
+		// timeout, DNS). They are transient, so surface them as a retryable error
+		// and let exporterhelper's retry_on_failure resend the batch instead of
+		// dropping it as permanent.
+		tbi.errs = append(tbi.errs, indexerErr)
 	}
 }
 
@@ -130,8 +135,15 @@ func (tbi *traceBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem,
 		// Non-recoverable OpenSearch error while indexing document
 		tbi.appendPermanentError(responseAsError(resp))
 	default:
-		// Encoding error. We didn't even attempt to send the event
-		tbi.appendPermanentError(itemErr)
+		// A transport error (e.g. net.OpError) reported per item is transient and
+		// should be retried; anything else here is an encoding error we never sent,
+		// which is permanent.
+		var netErr *net.OpError
+		if errors.As(itemErr, &netErr) {
+			tbi.appendRetryTraceError(itemErr, traces)
+		} else {
+			tbi.appendPermanentError(itemErr)
+		}
 	}
 }
 

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -135,11 +135,12 @@ func (tbi *traceBulkIndexer) processItemFailure(resp opensearchapi.BulkRespItem,
 		// Non-recoverable OpenSearch error while indexing document
 		tbi.appendPermanentError(responseAsError(resp))
 	default:
-		// A transport error (e.g. net.OpError) reported per item is transient and
-		// should be retried; anything else here is an encoding error we never sent,
-		// which is permanent.
-		var netErr *net.OpError
-		if errors.As(itemErr, &netErr) {
+		// No server status classified the item, so this is either a flush/
+		// transport failure (retry) or an encoding failure we never sent
+		// (permanent). On a flush failure opensearchutil reports the same error
+		// through both this per-item path and onIndexerError, so both must land
+		// on retryable or the joined error is still permanent via errors.As.
+		if isRetryableError(itemErr) {
 			tbi.appendRetryTraceError(itemErr, traces)
 		} else {
 			tbi.appendPermanentError(itemErr)
@@ -164,6 +165,21 @@ func attributesToMapString(attributes pcommon.Map) map[string]string {
 func shouldRetryEvent(status int) bool {
 	retryOnStatus := []int{500, 502, 503, 504, 429}
 	return slices.Contains(retryOnStatus, status)
+}
+
+// isRetryableError reports whether err is a transient transport/flush failure
+// (connection refused, timeout, DNS, cancelled/deadline-exceeded context) that
+// should be retried rather than dropped as permanent. Encoding failures, which
+// never leave the process, are not transport errors and remain permanent.
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 func (tbi *traceBulkIndexer) newBulkIndexerItem(document []byte, indexName string) opensearchutil.BulkIndexerItem {

--- a/exporter/opensearchexporter/trace_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer_test.go
@@ -74,26 +74,6 @@ func TestTraceOnIndexerErrorIsRetryable(t *testing.T) {
 	}
 }
 
-func TestTraceProcessItemFailureTransportErrorRetryable(t *testing.T) {
-	tbi := &traceBulkIndexer{}
-	tbi.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, &net.OpError{Op: "read", Err: errors.New("i/o timeout")}, ptrace.NewTraces())
-	if len(tbi.errs) != 1 {
-		t.Fatalf("expected 1 error, got %d", len(tbi.errs))
-	}
-	if consumererror.IsPermanent(tbi.errs[0]) {
-		t.Error("per-item transport error must be retryable, not permanent")
-	}
-
-	tbi2 := &traceBulkIndexer{}
-	tbi2.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, errors.New("encode failed"), ptrace.NewTraces())
-	if len(tbi2.errs) != 1 {
-		t.Fatalf("expected 1 error, got %d", len(tbi2.errs))
-	}
-	if !consumererror.IsPermanent(tbi2.errs[0]) {
-		t.Error("encoding error must remain permanent")
-	}
-}
-
 func TestNewTraceBulkIndexerWithPipeline(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/exporter/opensearchexporter/trace_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer_test.go
@@ -4,7 +4,6 @@
 package opensearchexporter
 
 import (
-	"context"
 	"errors"
 	"net"
 	"testing"
@@ -65,7 +64,7 @@ func TestTraceProcessItemFailure(t *testing.T) {
 
 func TestTraceOnIndexerErrorIsRetryable(t *testing.T) {
 	tbi := &traceBulkIndexer{}
-	tbi.onIndexerError(context.Background(), &net.OpError{Op: "dial", Err: errors.New("connection refused")})
+	tbi.onIndexerError(t.Context(), &net.OpError{Op: "dial", Err: errors.New("connection refused")})
 	err := tbi.joinedError()
 	if err == nil {
 		t.Fatal("expected an error")

--- a/exporter/opensearchexporter/trace_bulk_indexer_test.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer_test.go
@@ -4,11 +4,14 @@
 package opensearchexporter
 
 import (
+	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
@@ -57,6 +60,38 @@ func TestTraceProcessItemFailure(t *testing.T) {
 				t.Errorf("expected %d errors, got %d", tt.expectedErrs, len(tbi.errs))
 			}
 		})
+	}
+}
+
+func TestTraceOnIndexerErrorIsRetryable(t *testing.T) {
+	tbi := &traceBulkIndexer{}
+	tbi.onIndexerError(context.Background(), &net.OpError{Op: "dial", Err: errors.New("connection refused")})
+	err := tbi.joinedError()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if consumererror.IsPermanent(err) {
+		t.Error("indexer-level transport error must be retryable, not permanent")
+	}
+}
+
+func TestTraceProcessItemFailureTransportErrorRetryable(t *testing.T) {
+	tbi := &traceBulkIndexer{}
+	tbi.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, &net.OpError{Op: "read", Err: errors.New("i/o timeout")}, ptrace.NewTraces())
+	if len(tbi.errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(tbi.errs))
+	}
+	if consumererror.IsPermanent(tbi.errs[0]) {
+		t.Error("per-item transport error must be retryable, not permanent")
+	}
+
+	tbi2 := &traceBulkIndexer{}
+	tbi2.processItemFailure(opensearchapi.BulkRespItem{Status: 0}, errors.New("encode failed"), ptrace.NewTraces())
+	if len(tbi2.errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(tbi2.errs))
+	}
+	if !consumererror.IsPermanent(tbi2.errs[0]) {
+		t.Error("encoding error must remain permanent")
 	}
 }
 


### PR DESCRIPTION
#### Description

The OpenSearch exporter's bulk-indexer `OnError` callback (`onIndexerError`) wrapped every indexer-level error as `consumererror.NewPermanent`. Indexer-level errors are transport/flush failures (connection refused, timeout, DNS), which are transient. Marking them permanent made `exporterhelper` drop the whole batch even with `retry_on_failure` fully configured, so telemetry was silently lost whenever OpenSearch was briefly unreachable.

This surfaces indexer-level errors as retryable (a plain error, so `joinedError()` is not permanent and `exporterhelper` resends the batch). In `processItemFailure`, a per-item `net.OpError` (transport) is now treated as retryable as well, while encoding errors and non-recoverable OpenSearch responses (bad documents) stay permanent. The same fix is applied to both the log and trace bulk indexers.

#### Link to tracking issue

Fixes #49208

#### Testing

Added `TestOnIndexerErrorIsRetryable` and `TestProcessItemFailureTransportErrorRetryable` (and the trace equivalents), asserting via `consumererror.IsPermanent` that transport failures are retryable and that encoding errors remain permanent. Existing bulk-indexer tests still pass.

#### Documentation

No documentation changes needed.