### PR TITLE
[extension/pebble_tail_storage] Add max_storage_size_mib to limit the size in disk

### DIFF
--- a/.chloggen/49592.yaml
+++ b/.chloggen/49592.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/pebble_tail_storage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added `max_storage_size_mib` support to the Pebble tail storage extension to bound local disk usage for pending tail-sampling trace data.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49592]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Configuration example:
+    extensions:
+      pebble_tail_storage:
+        directory: /var/lib/otelcol/pebble-tail-storage
+        max_storage_size_mib: 10240
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/tailstorage/pebbletailstorageextension/README.md
+++ b/extension/tailstorage/pebbletailstorageextension/README.md
@@ -34,6 +34,11 @@ treat the directory as ephemeral.
 ## Configuration
 
 - `directory` (required): directory used to store Pebble DB files.
+- `max_storage_size_mib` (optional): maximum on-disk size observed for the Pebble tail
+  store. `0` keeps the existing unlimited behavior.
+
+The size limit protects normal runtime disk usage for this extension. It does not make
+the storage durable across restarts. Startup still clears any existing Pebble database.
 
 ## Example
 
@@ -52,6 +57,7 @@ policies.
 extensions:
   pebble_tail_storage:
     directory: /var/lib/otelcol/pebble-tail-storage
+    max_storage_size_mib: 10240
 
 receivers:
   otlp:

--- a/extension/tailstorage/pebbletailstorageextension/README.md
+++ b/extension/tailstorage/pebbletailstorageextension/README.md
@@ -35,7 +35,9 @@ treat the directory as ephemeral.
 
 - `directory` (required): directory used to store Pebble DB files.
 - `max_storage_size_mib` (optional): maximum on-disk size observed for the Pebble tail
-  store. `0` keeps the existing unlimited behavior.
+  store. The limit is best-effort because Pebble may perform filesystem operations
+  asynchronously. After the last periodic size observation exceeds the limit, new
+  appends fail. `0` keeps the existing unlimited behavior.
 
 The size limit protects normal runtime disk usage for this extension. It does not make
 the storage durable across restarts. Startup still clears any existing Pebble database.

--- a/extension/tailstorage/pebbletailstorageextension/config.go
+++ b/extension/tailstorage/pebbletailstorageextension/config.go
@@ -10,6 +10,9 @@ import "errors"
 type Config struct {
 	// Directory is where the extension stores Pebble DB files.
 	Directory string `mapstructure:"directory"`
+	// MaxStorageSizeMiB limits the amount of Pebble storage that may be used.
+	// Zero means unlimited.
+	MaxStorageSizeMiB int `mapstructure:"max_storage_size_mib"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -17,6 +20,9 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.Directory == "" {
 		return errors.New("directory must be set")
+	}
+	if c.MaxStorageSizeMiB < 0 {
+		return errors.New("max_storage_size_mib must be greater than or equal to zero")
 	}
 	return nil
 }

--- a/extension/tailstorage/pebbletailstorageextension/config_test.go
+++ b/extension/tailstorage/pebbletailstorageextension/config_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pebbletailstorageextension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "valid unlimited",
+			cfg: Config{
+				Directory: "test-storage",
+			},
+		},
+		{
+			name: "valid bounded config",
+			cfg: Config{
+				Directory:         "test-storage",
+				MaxStorageSizeMiB: 1,
+			},
+		},
+		{
+			name:    "missing directory",
+			cfg:     Config{},
+			wantErr: "directory must be set",
+		},
+		{
+			name: "negative size",
+			cfg: Config{
+				Directory:         "test-storage",
+				MaxStorageSizeMiB: -1,
+			},
+			wantErr: "max_storage_size_mib",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/extension/tailstorage/pebbletailstorageextension/extension.go
+++ b/extension/tailstorage/pebbletailstorageextension/extension.go
@@ -31,7 +31,7 @@ func newExtension(settings extension.Settings, cfg *Config) *pebbleTailStorageEx
 }
 
 func (e *pebbleTailStorageExtension) Start(ctx context.Context, _ component.Host) error {
-	storage, err := newStorage(ctx, e.cfg.Directory, e.settings.Logger)
+	storage, err := newStorage(ctx, e.cfg, e.settings.Logger)
 	if err != nil {
 		return err
 	}

--- a/extension/tailstorage/pebbletailstorageextension/generated_package_test.go
+++ b/extension/tailstorage/pebbletailstorageextension/generated_package_test.go
@@ -3,8 +3,9 @@
 package pebbletailstorageextension
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/extension/tailstorage/pebbletailstorageextension/generated_package_test.go
+++ b/extension/tailstorage/pebbletailstorageextension/generated_package_test.go
@@ -3,11 +3,11 @@
 package pebbletailstorageextension
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {
+	setupTestMain(m)
 	goleak.VerifyTestMain(m)
 }

--- a/extension/tailstorage/pebbletailstorageextension/metadata.yaml
+++ b/extension/tailstorage/pebbletailstorageextension/metadata.yaml
@@ -3,6 +3,13 @@ type: pebble_tail_storage
 
 description: Stores pending trace data for tail sampling in a local Pebble database.
 
+tests:
+  config:
+    directory: test-storage
+    max_storage_size_mib: 1
+  goleak:
+    setup: "setupTestMain(m)"
+
 status:
   class: extension
   stability:

--- a/extension/tailstorage/pebbletailstorageextension/package_test.go
+++ b/extension/tailstorage/pebbletailstorageextension/package_test.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pebbletailstorageextension
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func setupTestMain(m *testing.M) {
+	_ = os.RemoveAll("test-storage")
+	goleak.VerifyTestMain(m, goleak.Cleanup(func(code int) {
+		_ = os.RemoveAll("test-storage")
+		os.Exit(code)
+	}))
+}

--- a/extension/tailstorage/pebbletailstorageextension/storage.go
+++ b/extension/tailstorage/pebbletailstorageextension/storage.go
@@ -8,9 +8,12 @@ package pebbletailstorageextension // import "github.com/open-telemetry/opentele
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -24,22 +27,33 @@ const (
 
 	// storageVersion is a version to support evolution.
 	storageVersion = "v0"
+
+	sizeCheckInterval = time.Second
 )
+
+var errStorageLimitReached = errors.New("pebble tail storage size limit reached")
 
 type storage struct {
 	db          *pebble.DB
 	logger      *zap.Logger
+	maxSize     uint64
 	nextSeq     atomic.Uint64
 	unmarshaler ptrace.Unmarshaler
 	marshaler   ptrace.Marshaler
+
+	mu               sync.Mutex
+	lastSizeCheck    time.Time
+	lastObservedSize uint64
+	now              func() time.Time
+	diskUsage        func() uint64
 }
 
-func newStorage(ctx context.Context, storageDir string, logger *zap.Logger) (*storage, error) {
+func newStorage(ctx context.Context, cfg *Config, logger *zap.Logger) (*storage, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	db, created, err := newPebbleDB(filepath.Join(storageDir, storageVersion), logger)
+	db, created, err := newPebbleDB(filepath.Join(cfg.Directory, storageVersion), logger)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +61,13 @@ func newStorage(ctx context.Context, storageDir string, logger *zap.Logger) (*st
 	s := &storage{
 		db:          db,
 		logger:      logger,
+		maxSize:     uint64(cfg.MaxStorageSizeMiB) << 20,
 		marshaler:   &ptrace.ProtoMarshaler{},
 		unmarshaler: &ptrace.ProtoUnmarshaler{},
+		now:         time.Now,
+	}
+	s.diskUsage = func() uint64 {
+		return s.db.Metrics().DiskSpaceUsage()
 	}
 
 	if !created {
@@ -92,7 +111,16 @@ func (s *storage) Append(traceID pcommon.TraceID, td ptrace.Traces) error {
 		return fmt.Errorf("failed to marshal trace payload: %w", err)
 	}
 
-	key := traceEntryKey(traceID, s.nextSeq.Add(1))
+	seq := s.nextSeq.Add(1)
+	key := traceEntryKey(traceID, seq)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ensureCapacityLocked(); err != nil {
+		return err
+	}
+
 	if err := s.db.Set(key[:], data, pebble.NoSync); err != nil {
 		return fmt.Errorf("pebble Set error: %w", err)
 	}
@@ -100,6 +128,9 @@ func (s *storage) Append(traceID pcommon.TraceID, td ptrace.Traces) error {
 }
 
 func (s *storage) Take(traceID pcommon.TraceID) (ptrace.Traces, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	prefix := tracePrefix(traceID)
 	out := s.readByTracePrefix(prefix[:])
 	if out.ResourceSpans().Len() == 0 {
@@ -113,6 +144,9 @@ func (s *storage) Take(traceID pcommon.TraceID) (ptrace.Traces, error) {
 }
 
 func (s *storage) Delete(traceID pcommon.TraceID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	prefix := tracePrefix(traceID)
 	// Delete all entries for the trace in one range operation instead of
 	// iterating keys and deleting one-by-one.
@@ -181,4 +215,19 @@ func traceEntryKey(traceID pcommon.TraceID, seq uint64) (key [traceIDBytes + 1 +
 	key[traceIDBytes] = traceIDSeparator
 	binary.BigEndian.PutUint64(key[traceIDBytes+1:], seq)
 	return key
+}
+
+func (s *storage) ensureCapacityLocked() error {
+	if s.maxSize == 0 {
+		return nil
+	}
+	now := s.now()
+	if s.lastSizeCheck.IsZero() || now.Sub(s.lastSizeCheck) >= sizeCheckInterval {
+		s.lastObservedSize = s.diskUsage()
+		s.lastSizeCheck = now
+	}
+	if s.lastObservedSize > s.maxSize {
+		return fmt.Errorf("%w: last observed database size %d exceeds configured limit %d", errStorageLimitReached, s.lastObservedSize, s.maxSize)
+	}
+	return nil
 }

--- a/extension/tailstorage/pebbletailstorageextension/storage.go
+++ b/extension/tailstorage/pebbletailstorageextension/storage.go
@@ -34,18 +34,18 @@ const (
 var errStorageLimitReached = errors.New("pebble tail storage size limit reached")
 
 type storage struct {
-	db          *pebble.DB
-	logger      *zap.Logger
-	maxSize     uint64
-	nextSeq     atomic.Uint64
-	unmarshaler ptrace.Unmarshaler
-	marshaler   ptrace.Marshaler
+	db               *pebble.DB
+	logger           *zap.Logger
+	maxSize          uint64
+	nextSeq          atomic.Uint64
+	lastObservedSize atomic.Uint64
+	unmarshaler      ptrace.Unmarshaler
+	marshaler        ptrace.Marshaler
 
-	mu               sync.Mutex
-	lastSizeCheck    time.Time
-	lastObservedSize uint64
-	now              func() time.Time
-	diskUsage        func() uint64
+	mu                   sync.Mutex
+	diskUsage            func() uint64
+	stopSizeMonitor      context.CancelFunc
+	sizeMonitorWaitGroup sync.WaitGroup
 }
 
 func newStorage(ctx context.Context, cfg *Config, logger *zap.Logger) (*storage, error) {
@@ -64,7 +64,6 @@ func newStorage(ctx context.Context, cfg *Config, logger *zap.Logger) (*storage,
 		maxSize:     uint64(cfg.MaxStorageSizeMiB) << 20,
 		marshaler:   &ptrace.ProtoMarshaler{},
 		unmarshaler: &ptrace.ProtoUnmarshaler{},
-		now:         time.Now,
 	}
 	s.diskUsage = func() uint64 {
 		return s.db.Metrics().DiskSpaceUsage()
@@ -77,6 +76,14 @@ func newStorage(ctx context.Context, cfg *Config, logger *zap.Logger) (*storage,
 		if err := s.drop(ctx); err != nil {
 			return nil, err
 		}
+	}
+
+	if s.maxSize > 0 {
+		s.updateDiskUsage()
+		monitorCtx, cancel := context.WithCancel(context.Background())
+		s.stopSizeMonitor = cancel
+		s.sizeMonitorWaitGroup.Add(1)
+		go s.monitorDiskUsage(monitorCtx)
 	}
 
 	return s, nil
@@ -102,6 +109,10 @@ func (s *storage) drop(ctx context.Context) error {
 }
 
 func (s *storage) Close() error {
+	if s.stopSizeMonitor != nil {
+		s.stopSizeMonitor()
+		s.sizeMonitorWaitGroup.Wait()
+	}
 	return s.db.Close()
 }
 
@@ -114,12 +125,12 @@ func (s *storage) Append(traceID pcommon.TraceID, td ptrace.Traces) error {
 	seq := s.nextSeq.Add(1)
 	key := traceEntryKey(traceID, seq)
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err := s.ensureCapacityLocked(); err != nil {
+	if err := s.ensureCapacity(); err != nil {
 		return err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.db.Set(key[:], data, pebble.NoSync); err != nil {
 		return fmt.Errorf("pebble Set error: %w", err)
@@ -217,17 +228,33 @@ func traceEntryKey(traceID pcommon.TraceID, seq uint64) (key [traceIDBytes + 1 +
 	return key
 }
 
-func (s *storage) ensureCapacityLocked() error {
+func (s *storage) monitorDiskUsage(ctx context.Context) {
+	defer s.sizeMonitorWaitGroup.Done()
+
+	ticker := time.NewTicker(sizeCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.updateDiskUsage()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *storage) updateDiskUsage() {
+	s.lastObservedSize.Store(s.diskUsage())
+}
+
+func (s *storage) ensureCapacity() error {
 	if s.maxSize == 0 {
 		return nil
 	}
-	now := s.now()
-	if s.lastSizeCheck.IsZero() || now.Sub(s.lastSizeCheck) >= sizeCheckInterval {
-		s.lastObservedSize = s.diskUsage()
-		s.lastSizeCheck = now
-	}
-	if s.lastObservedSize > s.maxSize {
-		return fmt.Errorf("%w: last observed database size %d exceeds configured limit %d", errStorageLimitReached, s.lastObservedSize, s.maxSize)
+	lastObservedSize := s.lastObservedSize.Load()
+	if lastObservedSize > s.maxSize {
+		return fmt.Errorf("%w: last observed database size %d exceeds configured limit %d", errStorageLimitReached, lastObservedSize, s.maxSize)
 	}
 	return nil
 }

--- a/extension/tailstorage/pebbletailstorageextension/storage.go
+++ b/extension/tailstorage/pebbletailstorageextension/storage.go
@@ -42,7 +42,6 @@ type storage struct {
 	unmarshaler      ptrace.Unmarshaler
 	marshaler        ptrace.Marshaler
 
-	mu                   sync.Mutex
 	diskUsage            func() uint64
 	stopSizeMonitor      context.CancelFunc
 	sizeMonitorWaitGroup sync.WaitGroup
@@ -82,8 +81,9 @@ func newStorage(ctx context.Context, cfg *Config, logger *zap.Logger) (*storage,
 		s.updateDiskUsage()
 		monitorCtx, cancel := context.WithCancel(context.Background())
 		s.stopSizeMonitor = cancel
-		s.sizeMonitorWaitGroup.Add(1)
-		go s.monitorDiskUsage(monitorCtx)
+		s.sizeMonitorWaitGroup.Go(func() {
+			s.monitorDiskUsage(monitorCtx)
+		})
 	}
 
 	return s, nil
@@ -129,9 +129,6 @@ func (s *storage) Append(traceID pcommon.TraceID, td ptrace.Traces) error {
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if err := s.db.Set(key[:], data, pebble.NoSync); err != nil {
 		return fmt.Errorf("pebble Set error: %w", err)
 	}
@@ -139,9 +136,6 @@ func (s *storage) Append(traceID pcommon.TraceID, td ptrace.Traces) error {
 }
 
 func (s *storage) Take(traceID pcommon.TraceID) (ptrace.Traces, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	prefix := tracePrefix(traceID)
 	out := s.readByTracePrefix(prefix[:])
 	if out.ResourceSpans().Len() == 0 {
@@ -155,9 +149,6 @@ func (s *storage) Take(traceID pcommon.TraceID) (ptrace.Traces, error) {
 }
 
 func (s *storage) Delete(traceID pcommon.TraceID) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	prefix := tracePrefix(traceID)
 	// Delete all entries for the trace in one range operation instead of
 	// iterating keys and deleting one-by-one.
@@ -229,8 +220,6 @@ func traceEntryKey(traceID pcommon.TraceID, seq uint64) (key [traceIDBytes + 1 +
 }
 
 func (s *storage) monitorDiskUsage(ctx context.Context) {
-	defer s.sizeMonitorWaitGroup.Done()
-
 	ticker := time.NewTicker(sizeCheckInterval)
 	defer ticker.Stop()
 

--- a/extension/tailstorage/pebbletailstorageextension/storage_size_limit_test.go
+++ b/extension/tailstorage/pebbletailstorageextension/storage_size_limit_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pebbletailstorageextension
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func newTestStorage(t *testing.T, cfg Config) *storage {
+	t.Helper()
+
+	cfg.Directory = t.TempDir()
+	require.NoError(t, cfg.Validate())
+
+	s, err := newStorage(t.Context(), &cfg, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, s.Close())
+	})
+
+	return s
+}
+
+func testTraces(traceID pcommon.TraceID, name string) ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetTraceID(traceID)
+	span.SetSpanID(pcommon.SpanID([8]byte{traceID[15], 1, 2, 3, 4, 5, 6, 7}))
+	span.SetName(name)
+	return td
+}
+
+func TestStorageSizeLimitRejectsWhenLastObservedSizeExceedsLimit(t *testing.T) {
+	s := newTestStorage(t, Config{MaxStorageSizeMiB: 1})
+	now := time.Unix(1, 0)
+	s.now = func() time.Time { return now }
+	s.diskUsage = func() uint64 { return s.maxSize + 1 }
+
+	err := s.Append(pcommon.TraceID([16]byte{1}), testTraces(pcommon.TraceID([16]byte{1}), "trace-1"))
+	require.ErrorContains(t, err, errStorageLimitReached.Error())
+	require.Contains(t, err.Error(), "last observed database size")
+}
+
+func TestStorageSizeLimitUsesCachedObservationInsideInterval(t *testing.T) {
+	s := newTestStorage(t, Config{MaxStorageSizeMiB: 1})
+	now := time.Unix(1, 0)
+	s.now = func() time.Time { return now }
+	s.diskUsage = func() uint64 { return 0 }
+
+	require.NoError(t, s.Append(pcommon.TraceID([16]byte{1}), testTraces(pcommon.TraceID([16]byte{1}), "trace-1")))
+	require.Equal(t, now, s.lastSizeCheck)
+
+	s.now = func() time.Time { return now.Add(100 * time.Millisecond) }
+	s.diskUsage = func() uint64 { return s.maxSize + 1 }
+	require.NoError(t, s.Append(pcommon.TraceID([16]byte{2}), testTraces(pcommon.TraceID([16]byte{2}), "trace-2")))
+}
+
+func TestStorageSizeLimitRefreshesObservationAfterInterval(t *testing.T) {
+	s := newTestStorage(t, Config{MaxStorageSizeMiB: 1})
+	now := time.Unix(1, 0)
+	s.now = func() time.Time { return now }
+	s.diskUsage = func() uint64 { return 0 }
+	require.NoError(t, s.Append(pcommon.TraceID([16]byte{1}), testTraces(pcommon.TraceID([16]byte{1}), "trace-1")))
+
+	s.now = func() time.Time { return now.Add(sizeCheckInterval + time.Millisecond) }
+	s.diskUsage = func() uint64 { return s.maxSize + 1 }
+	err := s.Append(pcommon.TraceID([16]byte{2}), testTraces(pcommon.TraceID([16]byte{2}), "trace-2"))
+	require.ErrorContains(t, err, errStorageLimitReached.Error())
+}

--- a/extension/tailstorage/pebbletailstorageextension/storage_size_limit_test.go
+++ b/extension/tailstorage/pebbletailstorageextension/storage_size_limit_test.go
@@ -5,7 +5,6 @@ package pebbletailstorageextension
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -40,38 +39,19 @@ func testTraces(traceID pcommon.TraceID, name string) ptrace.Traces {
 
 func TestStorageSizeLimitRejectsWhenLastObservedSizeExceedsLimit(t *testing.T) {
 	s := newTestStorage(t, Config{MaxStorageSizeMiB: 1})
-	now := time.Unix(1, 0)
-	s.now = func() time.Time { return now }
-	s.diskUsage = func() uint64 { return s.maxSize + 1 }
+	s.lastObservedSize.Store(s.maxSize + 1)
 
 	err := s.Append(pcommon.TraceID([16]byte{1}), testTraces(pcommon.TraceID([16]byte{1}), "trace-1"))
 	require.ErrorContains(t, err, errStorageLimitReached.Error())
 	require.Contains(t, err.Error(), "last observed database size")
 }
 
-func TestStorageSizeLimitUsesCachedObservationInsideInterval(t *testing.T) {
+func TestStorageSizeLimitUsesCachedObservation(t *testing.T) {
 	s := newTestStorage(t, Config{MaxStorageSizeMiB: 1})
-	now := time.Unix(1, 0)
-	s.now = func() time.Time { return now }
-	s.diskUsage = func() uint64 { return 0 }
-
-	require.NoError(t, s.Append(pcommon.TraceID([16]byte{1}), testTraces(pcommon.TraceID([16]byte{1}), "trace-1")))
-	require.Equal(t, now, s.lastSizeCheck)
-
-	s.now = func() time.Time { return now.Add(100 * time.Millisecond) }
-	s.diskUsage = func() uint64 { return s.maxSize + 1 }
-	require.NoError(t, s.Append(pcommon.TraceID([16]byte{2}), testTraces(pcommon.TraceID([16]byte{2}), "trace-2")))
-}
-
-func TestStorageSizeLimitRefreshesObservationAfterInterval(t *testing.T) {
-	s := newTestStorage(t, Config{MaxStorageSizeMiB: 1})
-	now := time.Unix(1, 0)
-	s.now = func() time.Time { return now }
-	s.diskUsage = func() uint64 { return 0 }
+	s.lastObservedSize.Store(0)
 	require.NoError(t, s.Append(pcommon.TraceID([16]byte{1}), testTraces(pcommon.TraceID([16]byte{1}), "trace-1")))
 
-	s.now = func() time.Time { return now.Add(sizeCheckInterval + time.Millisecond) }
-	s.diskUsage = func() uint64 { return s.maxSize + 1 }
+	s.lastObservedSize.Store(s.maxSize + 1)
 	err := s.Append(pcommon.TraceID([16]byte{2}), testTraces(pcommon.TraceID([16]byte{2}), "trace-2"))
 	require.ErrorContains(t, err, errStorageLimitReached.Error())
 }


### PR DESCRIPTION
#### Description
Add a mechanism to limit the size on disk of the generated pebble database.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49592

#### Authorship

- [x] I, a human, wrote this pull request description myself.
