### PR TITLE
[processor/gen_ai_normalizer] Add an opt-in `overwrite_schema_url` setting to replace an existing scope schema URL after normalization writes an attribute.

### DIFF
--- a/.chloggen/48280-genainormalizer-overwrite-schema-url.yaml
+++ b/.chloggen/48280-genainormalizer-overwrite-schema-url.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: processor/gen_ai_normalizer
+note: Add an opt-in `overwrite_schema_url` setting to replace an existing scope schema URL after normalization writes an attribute.
+issues: [48280]
+change_logs: [user]

--- a/processor/genainormalizerprocessor/README.md
+++ b/processor/genainormalizerprocessor/README.md
@@ -27,6 +27,7 @@ Any other `name` is a [user-defined source](#user-defined-sources): the entry's 
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `overwrite_schema_url` | bool | `false` | When `true`, replace an existing scope schema URL after normalization writes an attribute. |
 | `sources` | list of [source](#source) | _required_ | Ordered list of sources to normalize. At least one must be specified. Each span is processed by every source in the order given. |
 
 ### Source
@@ -56,7 +57,7 @@ The following are not modified:
 
 ### Schema URL
 
-When a mapping fires on a span, the enclosing `ScopeSpans.schema_url` is set to the OTel semantic-conventions version this processor targets (`https://opentelemetry.io/schemas/1.40.0`). An existing `schema_url` is overwritten. `ResourceSpans.schema_url` is never modified.
+When a normalization writes an attribute on a span, the enclosing `ScopeSpans.schema_url` is set to the OTel semantic-conventions version this processor targets (`https://opentelemetry.io/schemas/1.40.0`) if the scope does not already have a schema URL. By default, an existing `schema_url` is preserved because the scope may contain other attributes that still follow the original semantic conventions. Set `overwrite_schema_url: true` when the whole scope has already been normalized and the existing value should be replaced. A scope with no normalization writes is unchanged. `ResourceSpans.schema_url` is never modified.
 
 ### Type handling
 
@@ -79,6 +80,16 @@ Default configuration:
 ```yaml
 processors:
   gen_ai_normalizer:
+    sources:
+      - name: openinference
+```
+
+Overwrite an existing scope schema URL after normalization writes an attribute:
+
+```yaml
+processors:
+  gen_ai_normalizer:
+    overwrite_schema_url: true
     sources:
       - name: openinference
 ```
@@ -216,7 +227,7 @@ Roles are constrained to the GenAI semconv enum: `system`, `user`, `assistant`, 
 
 ##### GenAI semconv part types not produced
 
-The following part types are defined in the [GenAI input messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-input-messages.json) and [output messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-output-messages.json) but are not emitted by this processor:
+The following part types are defined in the [GenAI input messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json) and [output messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-output-messages.json) but are not emitted by this processor:
 
 | Part type | Applies to | Reason not produced |
 |-----------|------------|---------------------|
@@ -232,7 +243,7 @@ The following part types are defined in the [GenAI input messages schema](https:
 
 ##### Output format
 
-Messages are serialized as a JSON array of objects. Input messages (`gen_ai.input.messages`) follow the [GenAI input messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-input-messages.json); output messages (`gen_ai.output.messages`) follow the [GenAI output messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-output-messages.json).
+Messages are serialized as a JSON array of objects. Input messages (`gen_ai.input.messages`) follow the [GenAI input messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json); output messages (`gen_ai.output.messages`) follow the [GenAI output messages schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-output-messages.json).
 
 Example `gen_ai.input.messages`:
 

--- a/processor/genainormalizerprocessor/config.go
+++ b/processor/genainormalizerprocessor/config.go
@@ -61,6 +61,12 @@ type Source struct {
 type Config struct {
 	_ struct{}
 
+	// OverwriteSchemaURL replaces an existing ScopeSpans schema URL with the
+	// semantic-conventions schema URL targeted by this processor when at least
+	// one normalization writes an attribute. When false (default), an existing
+	// scope schema URL is preserved.
+	OverwriteSchemaURL bool `mapstructure:"overwrite_schema_url"`
+
 	// Sources is an ordered list of sources to normalize. Each span is
 	// processed by every source in the order specified. At least one source
 	// must be specified.

--- a/processor/genainormalizerprocessor/config_test.go
+++ b/processor/genainormalizerprocessor/config_test.go
@@ -172,6 +172,7 @@ func TestValidate(t *testing.T) {
 func TestDefaultConfigIsInvalid(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.Empty(t, cfg.Sources)
+	assert.False(t, cfg.OverwriteSchemaURL)
 	require.ErrorContains(t, cfg.Validate(), "at least one source must be specified")
 }
 
@@ -187,6 +188,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
 			expected: &Config{
+				OverwriteSchemaURL: true,
 				Sources: []Source{
 					{
 						Name:            SourceOpenInference,

--- a/processor/genainormalizerprocessor/processor.go
+++ b/processor/genainormalizerprocessor/processor.go
@@ -62,13 +62,17 @@ func newSourceNormalizer(src Source) sourceNormalizer {
 
 // genaiNormalizerProcessor normalizes span attributes for each configured source.
 type genaiNormalizerProcessor struct {
-	sources []sourceNormalizer
+	sources            []sourceNormalizer
+	overwriteSchemaURL bool
 }
 
 // newGenaiNormalizerProcessor builds a processor from a validated Config.
 // Sources are applied in the order specified in the configuration.
 func newGenaiNormalizerProcessor(cfg *Config) *genaiNormalizerProcessor {
-	p := &genaiNormalizerProcessor{sources: make([]sourceNormalizer, 0, len(cfg.Sources))}
+	p := &genaiNormalizerProcessor{
+		sources:            make([]sourceNormalizer, 0, len(cfg.Sources)),
+		overwriteSchemaURL: cfg.OverwriteSchemaURL,
+	}
 	for _, src := range cfg.Sources {
 		p.sources = append(p.sources, newSourceNormalizer(src))
 	}
@@ -89,7 +93,7 @@ func (p *genaiNormalizerProcessor) processTraces(_ context.Context, td ptrace.Tr
 					scopeWrote = p.sources[s].normalizeAttributes(attrs) || scopeWrote
 				}
 			}
-			if scopeWrote && ss.SchemaUrl() == "" {
+			if scopeWrote && (ss.SchemaUrl() == "" || p.overwriteSchemaURL) {
 				ss.SetSchemaUrl(otelsemconv.SchemaURL)
 			}
 		}

--- a/processor/genainormalizerprocessor/processor_test.go
+++ b/processor/genainormalizerprocessor/processor_test.go
@@ -433,6 +433,25 @@ func TestProcessTraces_LeavesSchemaURLWhenNoMappingFires(t *testing.T) {
 	assert.Empty(t, ss.SchemaUrl(), "schema_url must not be set when no mapping fires")
 }
 
+func TestProcessTraces_LeavesExistingSchemaURLWhenOverwriteEnabledButNoMappingFires(t *testing.T) {
+	p := &genaiNormalizerProcessor{
+		overwriteSchemaURL: true,
+		sources: []sourceNormalizer{
+			newNormalizer(map[string]string{"src.model": "dst.model"}, true, false),
+		},
+	}
+
+	td, span := newSpan()
+	td.ResourceSpans().At(0).ScopeSpans().At(0).SetSchemaUrl("https://opentelemetry.io/schemas/1.38.0")
+	span.Attributes().PutStr("http.method", "GET")
+
+	_, err := p.processTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	ss := td.ResourceSpans().At(0).ScopeSpans().At(0)
+	assert.Equal(t, "https://opentelemetry.io/schemas/1.38.0", ss.SchemaUrl())
+}
+
 func TestProcessTraces_PreservesExistingSchemaURL(t *testing.T) {
 	// Existing schema_url must not be overridden. Other attributes on the
 	// scope may still follow the original semantic conventions, and
@@ -455,8 +474,30 @@ func TestProcessTraces_PreservesExistingSchemaURL(t *testing.T) {
 	assert.Equal(t, "https://opentelemetry.io/schemas/1.38.0", ss.SchemaUrl())
 }
 
+func TestProcessTraces_OverwritesExistingSchemaURLWhenEnabled(t *testing.T) {
+	p := newGenaiNormalizerProcessor(&Config{
+		OverwriteSchemaURL: true,
+		Sources: []Source{{
+			Name:            "test",
+			RemoveOriginals: true,
+			Mappings:        map[string]string{"src.model": "dst.model"},
+		}},
+	})
+
+	td, span := newSpan()
+	td.ResourceSpans().At(0).ScopeSpans().At(0).SetSchemaUrl("https://opentelemetry.io/schemas/1.38.0")
+	span.Attributes().PutStr("src.model", "m")
+
+	_, err := p.processTraces(t.Context(), td)
+	require.NoError(t, err)
+
+	ss := td.ResourceSpans().At(0).ScopeSpans().At(0)
+	assert.Equal(t, "https://opentelemetry.io/schemas/1.40.0", ss.SchemaUrl())
+}
+
 func TestProcessTraces_DoesNotModifyResourceSchemaURL(t *testing.T) {
 	p := &genaiNormalizerProcessor{
+		overwriteSchemaURL: true,
 		sources: []sourceNormalizer{
 			newNormalizer(map[string]string{"src.model": "dst.model"}, true, false),
 		},

--- a/processor/genainormalizerprocessor/testdata/config.yaml
+++ b/processor/genainormalizerprocessor/testdata/config.yaml
@@ -1,5 +1,6 @@
 # Full config exercising the supported source and its per-source fields.
 gen_ai_normalizer:
+  overwrite_schema_url: true
   sources:
     - name: openinference
       remove_originals: true


### PR DESCRIPTION
#### Description

This PR introduces a new optional boolean setting called overwrite_schema_url (default: false). By default, the existing ScopeSpans.schema_url is kept as-is. With this opt-in enabled, the schema URL can be overwritten after normalization has actually written an attribute. If no normalization change occurs, the URL remains unchanged. Note that ResourceSpans.schema_url is not touched by this logic. The README has been updated with this setting, a behavior explanation, and a YAML example, while the changelog references issue #48280.

#### Link to tracking issue

Fixes #48280

#### Testing

The test suite includes six directly involved SchemaURL tests that verify the correct behavior of the schema URL update logic. The opt-in flag correctly toggles the update behavior for ScopeSpans.schema_url without affecting ResourceSpans.schema_url.

The following checks were executed and passed successfully:

go test ./...
go test -race ./...
make test lint
make chlog-validate
git diff --check
All relevant upstream unit, integration, and lint controls also passed.

#### Documentation

The README section for this component was updated to document the new overwrite_schema_url setting. It explains that when enabled, the schema URL will be replaced after normalization writes an attribute, whereas the default behavior preserves the original URL. A YAML configuration example is included to illustrate how to use the opt-in.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
