### PR TITLE
[chore][pkg/stanza] docs: make list of input operators complete

### DIFF
--- a/pkg/stanza/docs/operators/README.md
+++ b/pkg/stanza/docs/operators/README.md
@@ -1,19 +1,27 @@
 ## What is an operator?
-An operator is the most basic unit of log processing. Each operator fulfills a single responsibility, such as reading lines from a file, or parsing JSON from a field. Operators are then chained together in a pipeline to achieve a desired result.
+
+An operator is the most basic unit of log processing in Stanza. Each operator fulfills a single responsibility, such as reading lines from a file, or parsing JSON from a field. Operators are then chained together in a pipeline to achieve a desired result.
 
 For instance, a user may read lines from a file using the `file_input` operator. From there, the results of this operation may be sent to a `regex_parser` operator that creates fields based on a regex pattern. And then finally, these results may be sent to a `file_output` operator that writes each line to a file on disk.
 
+In the context of the OpenTelemetry Collector:
+
+- input operators are exposed as receivers
+- transforming operators (parsers and general purpose) can be used in the Stanza-based receivers using the `operators` configuration option
+- output operators are not exposed at all - data from Stanza pipelines is sent into the Collector's pipeline.
 
 ## What operators are available?
 
-Inputs:
-- [file_input](./file_input.md)
-- [journald_input](./journald_input.md)
-- [stdin](./stdin.md)
-- [syslog_input](./syslog_input.md)
-- [tcp_input](./tcp_input.md)
-- [udp_input](./udp_input.md)
-- [windows_eventlog_input](./windows_eventlog_input.md)
+Inputs and their corresponding Collector receivers:
+- [file_input](./file_input.md) - [File Log receiver](../../../../receiver/filelogreceiver/README.md)
+- [generate_input](../../operator/input/generate/) - not exposed in OpenTelemetry Collector
+- [journald_input](./journald_input.md) - [Journald receiver](../../../../receiver/journaldreceiver/README.md)
+- [namedpipe](../../operator/input/namedpipe/) - [Named Pipe receiver](../../../../receiver/namedpipereceiver/README.md)
+- [stdin](./stdin.md) - not exposed in OpenTelemetry Collector
+- [syslog_input](./syslog_input.md) - [Syslog receiver](../../../../receiver/syslogreceiver/README.md)
+- [tcp_input](./tcp_input.md) - [TCP Log receiver](../../../../receiver/tcplogreceiver/README.md)
+- [udp_input](./udp_input.md) - [UDP Log receiver](../../../../receiver/udplogreceiver/README.md)
+- [windows_eventlog_input](./windows_eventlog_input.md) - [Windows Event Log receiver](../../../../receiver/windowseventlogreceiver/README.md)
 
 Parsers:
 - [csv_parser](./csv_parser.md)


### PR DESCRIPTION
The named pipe input operator was missing from the list, making it harder to see all OpenTelemetry Collector receivers based on Stanza.

I added the named pipe operator to the docs together with another missing operator - `generate_input`.

I've also added the corresponding Collector receivers and a description of how operators work in the context of the Collector.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
