### PR TITLE
Fix incorrect %w format verb usage in structured zap logging calls

### DIFF
--- a/.chloggen/49627-zap-logging-format-fix.yaml
+++ b/.chloggen/49627-zap-logging-format-fix.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: all
+note: Fix incorrect usage of the %w format verb in structured zap logging calls across multiple components.
+issues: [49627]
+change_logs: [user]

--- a/processor/remotetapprocessor/processor.go
+++ b/processor/remotetapprocessor/processor.go
@@ -77,7 +77,7 @@ func (w *wsprocessor) handleConn(conn *websocket.Conn) {
 	for bytes := range ch {
 		_, err := conn.Write(bytes)
 		if err != nil {
-			w.telemetrySettings.Logger.Debug("websocket write error: %w", zap.Error(err))
+			w.telemetrySettings.Logger.Debug("websocket write error", zap.Error(err))
 			w.cs.closeAndRemove(idx)
 			break
 		}

--- a/receiver/aerospikereceiver/scraper.go
+++ b/receiver/aerospikereceiver/scraper.go
@@ -92,7 +92,7 @@ func (r *aerospikeReceiver) start(_ context.Context, _ component.Host) error {
 	client, err := r.clientFactory()
 	if err != nil {
 		client = nil
-		r.logger.Warn("initial client creation failed: %w", err) //  .Sugar().Warnf("initial client creation failed: %w", err)
+		r.logger.Warn("initial client creation failed", zap.Error(err))
 	}
 
 	r.client = client

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -82,7 +82,7 @@ func (s *filesystemsScraper) scrape(ctx context.Context) (pmetric.Metrics, error
 			// locked and unavailable. For this particular case, we do not want
 			// to log an error message on every poll.
 			// See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18236
-			s.settings.Logger.Debug("failed collecting locked partitions information: %w", zap.Error(err))
+			s.settings.Logger.Debug("failed collecting locked partitions information", zap.Error(err))
 		} else {
 			errors.AddPartial(0, fmt.Errorf("failed collecting partitions information: %w", err))
 		}

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -215,7 +215,7 @@ func (receiver *logsReceiver) collect() {
 		err := receiver.nextConsumer.ConsumeLogs(context.Background(), allLogs)
 		receiver.obsrecv.EndLogsOp(ctx, metadata.Type.String(), logRecordCount, err)
 		if err != nil {
-			receiver.settings.Logger.Error("failed to send logs: %w", zap.Error(err))
+			receiver.settings.Logger.Error("failed to send logs", zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes the incorrect usage of Go's `%w` format verb inside static message strings passed to structured `zap` logger methods across four components (`sqlqueryreceiver`, `hostmetricsreceiver`, `aerospikereceiver`, and `remotetapprocessor`). Additionally, wraps the raw error in `zap.Error(err)` for `aerospikereceiver` logging to ensure it is properly structured.


Fixes #49627

## Testing
Unit tests were executed and passed successfully for all modified components:
- `go test -v ./...` in `receiver/sqlqueryreceiver`
- `go test -v ./internal/scraper/filesystemscraper/...` in `receiver/hostmetricsreceiver`
- `go test -v ./...` in `receiver/aerospikereceiver`
- `go test -v ./...` in `processor/remotetapprocessor`

## Documentation
No documentation changes are required.
