### PR TITLE
[pkg/ottl]: add IsEmpty Converter

### DIFF
--- a/.chloggen/ottl-is-empty.yaml
+++ b/.chloggen/ottl-is-empty.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `IsEmpty` converter that returns `true` when the given value is nil, an empty `pcommon.Value`/`Map`/`Slice`, or a zero value.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/ottl-is-empty.yaml
+++ b/.chloggen/ottl-is-empty.yaml
@@ -7,10 +7,10 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `IsEmpty` converter that returns `true` when the given value is nil, an empty `pcommon.Value`/`Map`/`Slice`, or a zero value.
+note: Add `IsEmpty` converter that returns `true` when the given value is nil or an empty value.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [49635]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -933,6 +933,30 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], "pass") where IsEmpty("")`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where not IsEmpty(attributes["foo"])`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], IsEmpty(attributes["things"]))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutBool("test", false)
+			},
+		},
+		{
+			statement: `set(attributes["test"], IsEmpty(["a", "b"]))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutBool("test", false)
+			},
+		},
+		{
 			statement: `set(attributes["test"], Len(attributes["foo"]))`,
 			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 4)

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -532,6 +532,7 @@ Available Converters:
 - [Int](#int)
 - [IsBool](#isbool)
 - [IsDouble](#isdouble)
+- [IsEmpty](#isempty)
 - [IsInCIDR](#isincidr)
 - [IsInt](#isint)
 - [IsRootSpan](#isrootspan)
@@ -1491,6 +1492,32 @@ Examples:
 - `IsDouble(log.body)`
 
 - `IsDouble(log.attributes["maybe a double"])`
+
+### IsEmpty
+
+`IsEmpty(value)`
+
+The `IsEmpty` Converter returns `true` if the given `value` is considered empty.
+
+The `value` is either a path expression to a telemetry field to retrieve, or a literal.
+
+Specifically, it will return `true` if the provided `value` is one of the following:
+
+1. `nil`.
+2. An empty `pcommon.Value` (`pcommon.ValueTypeEmpty`).
+3. A `pcommon.Map` or native map with no entries.
+4. A `pcommon.Slice` or native slice (including `[]byte`) with no elements.
+5. Any other value equal to its type's zero value (for example, `""`, `0`, `false`, or an unset all-zero `pcommon.TraceID`/`pcommon.SpanID`).
+
+Otherwise, it will return `false`.
+
+Examples:
+
+- `IsEmpty(log.body)`
+
+- `IsEmpty(resource.attributes["maybe empty"])`
+
+- `IsEmpty("")`
 
 ### IsInCIDR
 

--- a/pkg/ottl/ottlfuncs/func_is_empty.go
+++ b/pkg/ottl/ottlfuncs/func_is_empty.go
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type IsEmptyArguments[K any] struct {
+	Target ottl.Getter[K]
+}
+
+func NewIsEmptyFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("IsEmpty", &IsEmptyArguments[K]{}, createIsEmptyFunction[K])
+}
+
+func createIsEmptyFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*IsEmptyArguments[K])
+
+	if !ok {
+		return nil, errors.New("IsEmptyFactory args must be of type *IsEmptyArguments[K]")
+	}
+
+	return isEmpty(args.Target), nil
+}
+
+func isEmpty[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return false, err
+		}
+		if val == nil {
+			return true, nil
+		}
+		switch v := val.(type) {
+		case pcommon.Value:
+			return v.Type() == pcommon.ValueTypeEmpty, nil
+		case pcommon.Map:
+			return v.Len() == 0, nil
+		case pcommon.Slice:
+			return v.Len() == 0, nil
+		default:
+			// Handle native collection types (slices such as []any, []byte or
+			// []string, and maps such as map[string]any) by length. Fixed-size
+			// arrays have a constant length, so for them - and any other type -
+			// emptiness means the zero value. This treats an unset (all-zero)
+			// pcommon.TraceID/SpanID as empty, matching pdata's own IsEmpty.
+			rv := reflect.ValueOf(v)
+			switch rv.Kind() {
+			case reflect.Slice, reflect.Map:
+				return rv.Len() == 0, nil
+			default:
+				return rv.IsZero(), nil
+			}
+		}
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_is_empty.go
+++ b/pkg/ottl/ottlfuncs/func_is_empty.go
@@ -48,12 +48,13 @@ func isEmpty[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
 		case pcommon.Slice:
 			return v.Len() == 0, nil
 		default:
-			// Handle native collection types (slices such as []any, []byte or
-			// []string, and maps such as map[string]any) by length. Fixed-size
-			// arrays have a constant length, so for them - and any other type -
-			// emptiness means the zero value. This treats an unset (all-zero)
-			// pcommon.TraceID/SpanID as empty, matching pdata's own IsEmpty.
 			rv := reflect.ValueOf(v)
+			if rv.Kind() == reflect.Ptr {
+				if rv.IsNil() {
+					return true, nil
+				}
+				rv = rv.Elem()
+			}
 			switch rv.Kind() {
 			case reflect.Slice, reflect.Map:
 				return rv.Len() == 0, nil

--- a/pkg/ottl/ottlfuncs/func_is_empty.go
+++ b/pkg/ottl/ottlfuncs/func_is_empty.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 type IsEmptyArguments[K any] struct {

--- a/pkg/ottl/ottlfuncs/func_is_empty_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_empty_test.go
@@ -1,0 +1,258 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_IsEmpty(t *testing.T) {
+	nonEmptyMap := pcommon.NewMap()
+	nonEmptyMap.PutStr("k", "v")
+
+	nonEmptySlice := pcommon.NewSlice()
+	nonEmptySlice.AppendEmpty().SetStr("v")
+
+	tests := []struct {
+		name     string
+		value    any
+		expected bool
+	}{
+		{
+			name:     "nil",
+			value:    nil,
+			expected: true,
+		},
+		{
+			name:     "empty string",
+			value:    "",
+			expected: true,
+		},
+		{
+			name:     "non-empty string",
+			value:    "hello",
+			expected: false,
+		},
+		{
+			name:     "zero int",
+			value:    0,
+			expected: true,
+		},
+		{
+			name:     "non-zero int",
+			value:    1,
+			expected: false,
+		},
+		{
+			name:     "zero int64",
+			value:    int64(0),
+			expected: true,
+		},
+		{
+			name:     "zero float64",
+			value:    float64(0),
+			expected: true,
+		},
+		{
+			name:     "non-zero float64",
+			value:    1.5,
+			expected: false,
+		},
+		{
+			name:     "false bool",
+			value:    false,
+			expected: true,
+		},
+		{
+			name:     "true bool",
+			value:    true,
+			expected: false,
+		},
+		{
+			name:     "empty pcommon.Value",
+			value:    pcommon.NewValueEmpty(),
+			expected: true,
+		},
+		{
+			name:     "non-empty pcommon.Value",
+			value:    pcommon.NewValueStr("v"),
+			expected: false,
+		},
+		{
+			name:     "empty pcommon.Map",
+			value:    pcommon.NewMap(),
+			expected: true,
+		},
+		{
+			name:     "non-empty pcommon.Map",
+			value:    nonEmptyMap,
+			expected: false,
+		},
+		{
+			name:     "empty pcommon.Slice",
+			value:    pcommon.NewSlice(),
+			expected: true,
+		},
+		{
+			name:     "non-empty pcommon.Slice",
+			value:    nonEmptySlice,
+			expected: false,
+		},
+		{
+			name:     "empty []any",
+			value:    []any{},
+			expected: true,
+		},
+		{
+			name:     "non-empty []any",
+			value:    []any{"v"},
+			expected: false,
+		},
+		{
+			name:     "empty map[string]any",
+			value:    map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "non-empty map[string]any",
+			value:    map[string]any{"k": "v"},
+			expected: false,
+		},
+		{
+			name:     "empty []byte",
+			value:    []byte{},
+			expected: true,
+		},
+		{
+			name:     "non-empty []byte",
+			value:    []byte("v"),
+			expected: false,
+		},
+		{
+			name:     "empty []string",
+			value:    []string{},
+			expected: true,
+		},
+		{
+			name:     "non-empty []string",
+			value:    []string{"v"},
+			expected: false,
+		},
+		{
+			name:     "empty []int64",
+			value:    []int64{},
+			expected: true,
+		},
+		{
+			name:     "non-empty []int64",
+			value:    []int64{1},
+			expected: false,
+		},
+		{
+			name:     "unset pcommon.TraceID",
+			value:    pcommon.NewTraceIDEmpty(),
+			expected: true,
+		},
+		{
+			name:     "set pcommon.TraceID",
+			value:    pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
+			expected: false,
+		},
+		{
+			name:     "unset pcommon.SpanID",
+			value:    pcommon.NewSpanIDEmpty(),
+			expected: true,
+		},
+		{
+			name:     "set pcommon.SpanID",
+			value:    pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := isEmpty[any](&ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return tt.value, nil
+				},
+			})
+			result, err := exprFunc(t.Context(), nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_IsEmpty_Error(t *testing.T) {
+	exprFunc := isEmpty[any](&ottl.StandardGetSetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return nil, errors.New("error getting value")
+		},
+	})
+	result, err := exprFunc(t.Context(), nil)
+	assert.Equal(t, false, result)
+	assert.Error(t, err)
+}
+
+func BenchmarkIsEmpty(b *testing.B) {
+	nonEmptyMap := pcommon.NewMap()
+	nonEmptyMap.PutStr("k", "v")
+
+	nonEmptySlice := pcommon.NewSlice()
+	nonEmptySlice.AppendEmpty().SetStr("v")
+
+	benchmarks := []struct {
+		name  string
+		value any
+	}{
+		{name: "nil", value: nil},
+		{name: "empty_string", value: ""},
+		{name: "non_empty_string", value: "hello"},
+		{name: "empty_int64", value: int64(0)},
+		{name: "non_empty_int64", value: int64(1)},
+		{name: "empty_float64", value: float64(0)},
+		{name: "non_empty_float64", value: 1.5},
+		{name: "empty_bool", value: false},
+		{name: "non_empty_bool", value: true},
+		{name: "empty_pcommon.Value", value: pcommon.NewValueEmpty()},
+		{name: "non_empty_pcommon.Value", value: pcommon.NewValueStr("v")},
+		{name: "empty_pcommon.Map", value: pcommon.NewMap()},
+		{name: "non_empty_pcommon.Map", value: nonEmptyMap},
+		{name: "empty_pcommon.Slice", value: pcommon.NewSlice()},
+		{name: "non_empty_pcommon.Slice", value: nonEmptySlice},
+		{name: "empty_[]any", value: []any{}},
+		{name: "non_empty_[]any", value: []any{"v"}},
+		{name: "empty_map[string]any", value: map[string]any{}},
+		{name: "non_empty_map[string]any", value: map[string]any{"k": "v"}},
+		{name: "empty_[]byte", value: []byte{}},
+		{name: "non_empty_[]byte", value: []byte("v")},
+		{name: "empty_pcommon.TraceID", value: pcommon.NewTraceIDEmpty()},
+		{name: "non_empty_pcommon.TraceID", value: pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})},
+		{name: "empty_pcommon.SpanID", value: pcommon.NewSpanIDEmpty()},
+		{name: "non_empty_pcommon.SpanID", value: pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})},
+	}
+	ctx := b.Context()
+	for _, bm := range benchmarks {
+		exprFunc := isEmpty[any](&ottl.StandardGetSetter[any]{
+			Getter: func(context.Context, any) (any, error) {
+				return bm.value, nil
+			},
+		})
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, err := exprFunc(ctx, nil)
+				require.NoError(b, err)
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_is_empty_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_empty_test.go
@@ -177,6 +177,21 @@ func Test_IsEmpty(t *testing.T) {
 			value:    pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 			expected: false,
 		},
+		{
+			name:     "nil pointer",
+			value:    (*string)(nil),
+			expected: true,
+		},
+		{
+			name:     "pointer to empty value",
+			value:    func() *string { s := ""; return &s }(),
+			expected: true,
+		},
+		{
+			name:     "pointer to non-empty value",
+			value:    func() *string { s := "v"; return &s }(),
+			expected: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -70,6 +70,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewIntFactory[K](),
 		NewIsBoolFactory[K](),
 		NewIsDoubleFactory[K](),
+		NewIsEmptyFactory[K](),
 		NewIsListFactory[K](),
 		NewIsIntFactory[K](),
 		NewIsMapFactory[K](),


### PR DESCRIPTION
#### Description

Currently the best way to check if an attribute has a value is to do

```
attributes["service.name"] != nil and attributes["service.name"] != ""
```

This check can get annoying when done enough times. For example in statements like [these](https://github.com/grafana/k8s-monitoring-helm/blob/95faa3aca50f282f7584f97849c26f34719f18a8/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy#L213-L229).

```
set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""
```

This PR adds a new Converter, `IsEmpty`, that returns `true` if the value is `nil` or the empty value for its type. This function simplifies the above statement to

```
set(attributes["service.namespace"], attributes["service_namespace"]) where IsEmpty(attributes["service.namespace"]) and not IsEmpty(attributes["service_namespace"])
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added new unit tests and e2e test. Also added benchmarks to show the use of reflection in this case is not a performance hit.

<!--Describe the documentation added.-->
#### Documentation

Added a readme entry for the function

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
