### PR TITLE
[receiver/elasticsearch] Fix pending state on cluster.state_queue metric

### DIFF
--- a/.chloggen/elasticsearch-cluster-state-queue-pending.yaml
+++ b/.chloggen/elasticsearch-cluster-state-queue-pending.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/elasticsearch
+
+note: "Report `elasticsearch.cluster.state_queue` with `state: pending` using the pending count instead of the committed count"
+
+issues: [49652]
+
+subtext: |
+  The data point for the `pending` state was recorded from the committed queue count, so it always
+  mirrored the `committed` data point. It now uses the pending count from the node discovery stats.

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -265,7 +265,7 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 		r.mb.RecordElasticsearchIndexingPressureMemoryTotalReplicaRejectionsDataPoint(now, info.IndexingPressure.Memory.Total.ReplicaRejections)
 
 		r.mb.RecordElasticsearchClusterStateQueueDataPoint(now, info.Discovery.ClusterStateQueue.Committed, metadata.AttributeClusterStateQueueStateCommitted)
-		r.mb.RecordElasticsearchClusterStateQueueDataPoint(now, info.Discovery.ClusterStateQueue.Committed, metadata.AttributeClusterStateQueueStatePending)
+		r.mb.RecordElasticsearchClusterStateQueueDataPoint(now, info.Discovery.ClusterStateQueue.Pending, metadata.AttributeClusterStateQueueStatePending)
 
 		r.mb.RecordElasticsearchClusterPublishedStatesFullDataPoint(now, info.Discovery.PublishedClusterStates.FullStates)
 		r.mb.RecordElasticsearchClusterPublishedStatesDifferencesDataPoint(now, info.Discovery.PublishedClusterStates.CompatibleDiffs, metadata.AttributeClusterPublishedDifferenceStateCompatible)

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
@@ -1924,14 +1924,14 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
+                - asInt: "5"
                   attributes:
                     - key: state
                       value:
                         stringValue: committed
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "0"
+                - asInt: "3"
                   attributes:
                     - key: state
                       value:

--- a/receiver/elasticsearchreceiver/testdata/sample_payloads/nodes_stats_other.json
+++ b/receiver/elasticsearchreceiver/testdata/sample_payloads/nodes_stats_other.json
@@ -412,9 +412,9 @@
       },
       "discovery": {
         "cluster_state_queue": {
-          "total": 0,
-          "pending": 0,
-          "committed": 0
+          "total": 8,
+          "pending": 3,
+          "committed": 5
         },
         "published_cluster_states": {
           "full_states": 2,


### PR DESCRIPTION
The `elasticsearch.cluster.state_queue` metric is emitted with two `state` values, `committed` and `pending`. Both data points were recorded from the committed queue count, so the `pending` series always mirrored `committed` instead of reporting the pending count from the node discovery stats.

This records the `pending` data point from the pending count instead. The `nodes_stats_other.json` sample payload happened to have equal pending and committed values, which hid the bug, so I gave them distinct values and regenerated the expected metrics.

#### Description
Fix the `pending` data point of `elasticsearch.cluster.state_queue`, which was sourced from the committed count.

#### Link to tracking issue
Found while reading the scraper, no existing issue.

#### Testing
Gave the `pending` and `committed` counts distinct values in `nodes_stats_other.json` and regenerated `full_other.yaml`. `go test ./receiver/elasticsearchreceiver/...` passes with the fix and fails without it.

#### Documentation
No documentation changes.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
