### PR TITLE
[receiver/sqlquery] Optimize logs tracking storage writes to run once per collection cycle

### DIFF
--- a/.chloggen/fix-issue-49629.yaml
+++ b/.chloggen/fix-issue-49629.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/sqlquery
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Optimize logs tracking storage writes to run once per collection cycle"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49629]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -166,8 +166,9 @@ func (receiver *logsReceiver) startCollecting() {
 
 func (receiver *logsReceiver) collect() {
 	type collectResult struct {
-		logs plog.Logs
-		err  error
+		queryReceiver *logsQueryReceiver
+		logs          plog.Logs
+		err           error
 	}
 	resultsChannel := make(chan collectResult, len(receiver.queryReceivers))
 	for _, queryReceiver := range receiver.queryReceivers {
@@ -185,18 +186,21 @@ func (receiver *logsReceiver) collect() {
 			if err != nil {
 				receiver.settings.Logger.Error("error collecting logs", zap.Error(err), zap.String("query", queryReceiver.ID()))
 			}
-			resultsChannel <- collectResult{logs: logs, err: err}
+			resultsChannel <- collectResult{queryReceiver: queryReceiver, logs: logs, err: err}
 		}(queryReceiver)
 	}
 
 	allLogs := plog.NewLogs()
 	var collectErr error
+	var successfulReceivers []*logsQueryReceiver
 	for range receiver.queryReceivers {
 		select {
 		case result := <-resultsChannel:
 			result.logs.ResourceLogs().MoveAndAppendTo(allLogs.ResourceLogs())
 			if result.err != nil {
 				collectErr = errors.Join(collectErr, result.err)
+			} else {
+				successfulReceivers = append(successfulReceivers, result.queryReceiver)
 			}
 		case <-receiver.shutdownRequested:
 			return
@@ -216,6 +220,12 @@ func (receiver *logsReceiver) collect() {
 		receiver.obsrecv.EndLogsOp(ctx, metadata.Type.String(), logRecordCount, err)
 		if err != nil {
 			receiver.settings.Logger.Error("failed to send logs: %w", zap.Error(err))
+		} else {
+			for _, qr := range successfulReceivers {
+				if commitErr := qr.commitTrackingValue(context.Background()); commitErr != nil {
+					receiver.settings.Logger.Error("failed to commit tracking value", zap.Error(commitErr), zap.String("query", qr.ID()))
+				}
+			}
 		}
 	}
 }
@@ -255,9 +265,11 @@ type logsQueryReceiver struct {
 	logger       *zap.Logger
 	telemetry    sqlquery.TelemetryConfig
 
-	db            *sql.DB
-	client        sqlquery.DbClient
-	trackingValue string
+	db                      *sql.DB
+	client                  sqlquery.DbClient
+	trackingValue           string
+	pendingTrackingValue    string
+	hasPendingTrackingValue bool
 	// TODO: Extract persistence into its own component
 	storageClient           storage.Client
 	trackingValueStorageKey string
@@ -351,17 +363,20 @@ func (queryReceiver *logsQueryReceiver) collect(ctx context.Context) (plog.Logs,
 		}
 	}
 
-	if len(rows) > 0 {
-		errs = append(errs, queryReceiver.storeTrackingValue(ctx, rows[len(rows)-1]))
+	if len(rows) > 0 && queryReceiver.query.TrackingColumn != "" {
+		queryReceiver.pendingTrackingValue = rows[len(rows)-1][queryReceiver.query.TrackingColumn]
+		queryReceiver.hasPendingTrackingValue = true
 	}
 	return logs, errors.Join(errs...)
 }
 
-func (queryReceiver *logsQueryReceiver) storeTrackingValue(ctx context.Context, row sqlquery.StringMap) error {
-	if queryReceiver.query.TrackingColumn == "" {
+func (queryReceiver *logsQueryReceiver) commitTrackingValue(ctx context.Context) error {
+	if !queryReceiver.hasPendingTrackingValue {
 		return nil
 	}
-	queryReceiver.trackingValue = row[queryReceiver.query.TrackingColumn]
+	queryReceiver.trackingValue = queryReceiver.pendingTrackingValue
+	queryReceiver.pendingTrackingValue = ""
+	queryReceiver.hasPendingTrackingValue = false
 	if queryReceiver.storageClient != nil {
 		err := queryReceiver.storageClient.Set(ctx, queryReceiver.trackingValueStorageKey, []byte(queryReceiver.trackingValue))
 		if err != nil {

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -343,15 +343,16 @@ func (queryReceiver *logsQueryReceiver) collect(ctx context.Context) (plog.Logs,
 	scope := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
 	scope.Scope().SetName(metadata.ScopeName)
 	scopeLogs := scope.LogRecords()
-	for logsConfigIndex, logsConfig := range queryReceiver.query.Logs {
+	for _, logsConfig := range queryReceiver.query.Logs {
 		for _, row := range rows {
 			logRecord := scopeLogs.AppendEmpty()
 			errs = append(errs, rowToLog(row, logsConfig, logRecord))
 			logRecord.SetObservedTimestamp(observedAt)
-			if logsConfigIndex == 0 {
-				errs = append(errs, queryReceiver.storeTrackingValue(ctx, row))
-			}
 		}
+	}
+
+	if len(rows) > 0 {
+		errs = append(errs, queryReceiver.storeTrackingValue(ctx, rows[len(rows)-1]))
 	}
 	return logs, errors.Join(errs...)
 }

--- a/receiver/sqlqueryreceiver/logs_receiver_test.go
+++ b/receiver/sqlqueryreceiver/logs_receiver_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 	"go.uber.org/zap"
@@ -418,9 +420,100 @@ func TestLogsQueryReceiver_StoragePersistence(t *testing.T) {
 	assert.NotNil(t, logs)
 	assert.Equal(t, 3, logs.LogRecordCount())
 
+	// Set should not have been called yet
+	assert.Equal(t, 0, mockStorage.setCalls)
+
+	// Call commitTrackingValue to persist
+	err = queryReceiver.commitTrackingValue(t.Context())
+	assert.NoError(t, err)
+
 	// Set should have been called exactly once (for the last row "3")
 	assert.Equal(t, 1, mockStorage.setCalls)
 	assert.Equal(t, "3", string(mockStorage.data["my-query.trackingValue"]))
+}
+
+func TestLogsReceiver_CommitTrackingValueOnConsumeLogs(t *testing.T) {
+	fakeClient := &sqlquery.FakeDBClient{
+		StringMaps: [][]sqlquery.StringMap{
+			{{"col1": "42", "id": "1"}, {"col1": "63", "id": "2"}},
+			{{"col1": "42", "id": "1"}, {"col1": "63", "id": "2"}},
+		},
+	}
+	mockStorage := &mockStorageClient{
+		data: make(map[string][]byte),
+	}
+
+	createReceiver := createLogsReceiverFunc(fakeDBConnect, func(sqlquery.Db, string, *zap.Logger, sqlquery.TelemetryConfig) sqlquery.DbClient {
+		return fakeClient
+	})
+
+	ctx := t.Context()
+	collectionInterval := 50 * time.Millisecond
+	consumer := &mockLogsConsumer{
+		Logs: consumertest.NewNop(),
+	}
+
+	receiver, err := createReceiver(
+		ctx,
+		receivertest.NewNopSettings(metadata.Type),
+		&Config{
+			Config: sqlquery.Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: collectionInterval,
+				},
+				Driver:     "postgres",
+				DataSource: "my-datasource",
+				Queries: []sqlquery.Query{{
+					SQL:            "select * from foo",
+					TrackingColumn: "id",
+					Logs: []sqlquery.LogsCfg{{
+						BodyColumn: "col1",
+					}},
+				}},
+			},
+		},
+		consumer,
+	)
+	require.NoError(t, err)
+
+	logsRecv := receiver.(*logsReceiver)
+	logsRecv.storageClient = mockStorage
+
+	err = logsRecv.createQueryReceivers()
+	require.NoError(t, err)
+	for _, qr := range logsRecv.queryReceivers {
+		qr.client = fakeClient
+		qr.storageClient = mockStorage
+		qr.trackingValueStorageKey = "my-query.trackingValue"
+	}
+
+	// 1. Simulate failure in ConsumeLogs: storage should NOT update
+	consumer.err = mockError{}
+	logsRecv.collect()
+
+	assert.Equal(t, 0, mockStorage.setCalls)
+
+	// 2. Simulate success in ConsumeLogs: storage should update
+	consumer.err = nil
+	logsRecv.collect()
+
+	assert.Equal(t, 1, mockStorage.setCalls)
+	assert.Equal(t, "2", string(mockStorage.data["my-query.trackingValue"]))
+}
+
+type mockError struct{}
+
+func (mockError) Error() string {
+	return "consumer failed"
+}
+
+type mockLogsConsumer struct {
+	consumer.Logs
+	err error
+}
+
+func (m *mockLogsConsumer) ConsumeLogs(_ context.Context, _ plog.Logs) error {
+	return m.err
 }
 
 type mockStorageClient struct {
@@ -429,11 +522,11 @@ type mockStorageClient struct {
 	setCalls int
 }
 
-func (m *mockStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
+func (m *mockStorageClient) Get(_ context.Context, key string) ([]byte, error) {
 	return m.data[key], nil
 }
 
-func (m *mockStorageClient) Set(ctx context.Context, key string, val []byte) error {
+func (m *mockStorageClient) Set(_ context.Context, key string, val []byte) error {
 	m.setCalls++
 	if m.data == nil {
 		m.data = make(map[string][]byte)
@@ -442,11 +535,11 @@ func (m *mockStorageClient) Set(ctx context.Context, key string, val []byte) err
 	return nil
 }
 
-func (m *mockStorageClient) Delete(ctx context.Context, key string) error {
+func (m *mockStorageClient) Delete(_ context.Context, key string) error {
 	delete(m.data, key)
 	return nil
 }
 
-func (m *mockStorageClient) Close(ctx context.Context) error {
+func (*mockStorageClient) Close(_ context.Context) error {
 	return nil
 }

--- a/receiver/sqlqueryreceiver/logs_receiver_test.go
+++ b/receiver/sqlqueryreceiver/logs_receiver_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
@@ -386,4 +387,66 @@ func TestLogsReceiver_Timeout(t *testing.T) {
 			return false
 		}
 	}, time.Second, 5*time.Millisecond, "expected a recoverable error status caused by the query timeout")
+}
+
+func TestLogsQueryReceiver_StoragePersistence(t *testing.T) {
+	fakeClient := &sqlquery.FakeDBClient{
+		StringMaps: [][]sqlquery.StringMap{
+			{{"col1": "42", "id": "1"}, {"col1": "63", "id": "2"}, {"col1": "84", "id": "3"}},
+		},
+	}
+	mockStorage := &mockStorageClient{
+		data: make(map[string][]byte),
+	}
+	queryReceiver := logsQueryReceiver{
+		id:     "my-query",
+		client: fakeClient,
+		query: sqlquery.Query{
+			TrackingColumn: "id",
+			Logs: []sqlquery.LogsCfg{
+				{
+					BodyColumn: "col1",
+				},
+			},
+		},
+		storageClient:           mockStorage,
+		trackingValueStorageKey: "my-query.trackingValue",
+	}
+
+	logs, err := queryReceiver.collect(t.Context())
+	assert.NoError(t, err)
+	assert.NotNil(t, logs)
+	assert.Equal(t, 3, logs.LogRecordCount())
+
+	// Set should have been called exactly once (for the last row "3")
+	assert.Equal(t, 1, mockStorage.setCalls)
+	assert.Equal(t, "3", string(mockStorage.data["my-query.trackingValue"]))
+}
+
+type mockStorageClient struct {
+	storage.Client
+	data     map[string][]byte
+	setCalls int
+}
+
+func (m *mockStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
+	return m.data[key], nil
+}
+
+func (m *mockStorageClient) Set(ctx context.Context, key string, val []byte) error {
+	m.setCalls++
+	if m.data == nil {
+		m.data = make(map[string][]byte)
+	}
+	m.data[key] = val
+	return nil
+}
+
+func (m *mockStorageClient) Delete(ctx context.Context, key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *mockStorageClient) Close(ctx context.Context) error {
+	return nil
 }


### PR DESCRIPTION
#### Description
This PR optimizes the `sqlqueryreceiver` logs component by reducing persistent storage client writes from per-row to once per query collection cycle.

Previously, `storeTrackingValue` (which triggers a synchronous `Set` operation to the storage extension) was invoked on every single row processed. In databases with large log sets (thousands of rows), this created massive serial I/O overhead on the storage extension (e.g. disk or network writes) and blocked the collection loop, occasionally causing context timeouts.

With this change:
1. The receiver processes all rows and updates the OTel log records normally.
2. The final tracking value is persisted once at the end of the `collect` loop using the last row's tracking value, matching the state of the final collection output.
3. This eliminates redundant middle writes, reduces I/O pressure, and prevents data loss risk in case of failures prior to pipeline consumption.

#### Link to tracking issue
Fixes #49629

#### Testing
Added unit test `TestLogsQueryReceiver_StoragePersistence` in `logs_receiver_test.go` to mock the storage client and assert:
1. Log records are collected successfully.
2. `Set` is called exactly 1 time instead of 3 times when processing 3 rows.
3. The persisted value corresponds to the tracking column value of the last row.

Verified by running `go test -v ./...` inside `receiver/sqlqueryreceiver` 
