### PR TITLE
[ci]: disable importcomment on modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -255,8 +255,6 @@ linters:
           files:
             - "!**/*_test.go"
 
-
-
     forbidigo:
       analyze-types: true
       forbid:
@@ -325,6 +323,10 @@ linters:
       # Default is to use a neutral variety of English.
       # Setting locale to US will correct the British spelling of 'colour' to 'color'.
       locale: US
+
+    modernize:
+      disable:
+        - importcomment
 
     nolintlint:
       require-specific: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`golang.org/x/tools` v0.48.0 adds a new `importcomment` modernize analyzer that flags the legacy canonical import path comments (ignored in module mode). Explicitly disable it in the `modernize` make target's analyzer allowlist so the tool bump doesn't introduce repo-wide churn.

Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49646

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tested locally against https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49646 without errors.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
