### PR TITLE
[cmd/opampsupervisor] Use agent args to validate startup fallback config

### DIFF
--- a/.chloggen/fix-startup-fallback-config-validation.yaml
+++ b/.chloggen/fix-startup-fallback-config-validation.yaml
@@ -1,0 +1,27 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pass agent CLI args to startup fallback config validation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49609]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This should ensure the startup fallback configuration validation works
+  taking into account potential feature gates that may be enabled or disabled.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -420,6 +420,22 @@ func TestValidateFallbackConfigsWithColBin_E2E(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Valid profiles fallback config using agent feature gates", func(t *testing.T) {
+		profilesConfigPath := filepath.Join("testdata", "collector", "profiles_pipeline.yaml")
+		cfgFile := getSupervisorConfig(t, "fallback", map[string]string{
+			"url":                     "localhost:12345",
+			"storage_dir":             t.TempDir(),
+			"agent_argument":          "--feature-gates=+service.profilesSupport",
+			"startup_fallback_config": escapePathStringForWin(profilesConfigPath),
+		})
+
+		cfg, err := config.Load(cfgFile.Name())
+		require.NoError(t, err)
+		require.Equal(t, []string{"--feature-gates=+service.profilesSupport"}, cfg.Agent.Arguments)
+		_, err = supervisor.NewSupervisor(t.Context(), zap.NewNop(), cfg)
+		require.NoError(t, err)
+	})
+
 	t.Run("Invalid fallback config", func(t *testing.T) {
 		badColConfigPath := filepath.Join("testdata", "collector", "bad_config.yaml")
 		badCfgFile := getSupervisorConfig(t, "fallback", map[string]string{

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -337,6 +337,8 @@ func (a Agent) validateFallbackConfigsWithColBin() error {
 	for _, cfgPath := range a.StartupFallbackConfigs {
 		cfgValidateCommand = append(cfgValidateCommand, "--config", cfgPath)
 	}
+	cfgValidateCommand = append(cfgValidateCommand, a.Arguments...)
+
 	cmd := exec.Command(cfgValidateCommand[0], cfgValidateCommand[1:]...) // #nosec G204
 
 	cmd.Stdout = os.Stdout

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -856,6 +857,57 @@ func TestOpAMPServer_OpaqueHeaders(t *testing.T) {
 			require.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestAgent_validateFallbackConfigsWithColBinUsesAgentArguments(t *testing.T) {
+	validateStub := writeFeatureGateValidateStub(t)
+	profilesConfigPath := filepath.Join("..", "..", "testdata", "collector", "profiles_pipeline.yaml")
+	agent := Agent{
+		Executable:             validateStub,
+		Arguments:              []string{"--feature-gates=+service.profilesSupport"},
+		StartupFallbackConfigs: []string{profilesConfigPath},
+	}
+
+	require.NoError(t, agent.validateFallbackConfigsWithColBin())
+}
+
+func writeFeatureGateValidateStub(t *testing.T) string {
+	t.Helper()
+
+	const featureGateArg = "--feature-gates=+service.profilesSupport"
+
+	tempDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(tempDir, "validate-stub.bat")
+		script := []string{
+			"@echo off",
+			"if not \"%1\"==\"validate\" exit /b 1",
+			"if not \"%2\"==\"--config\" exit /b 1",
+			"if not \"%4\"==\"" + featureGateArg + "\" exit /b 1",
+			"findstr /C:\"profiles:\" \"%3\" >nul",
+			"if errorlevel 1 exit /b 1",
+			"findstr /C:\"processors:\" \"%3\" >nul",
+			"if not errorlevel 1 exit /b 1",
+			"exit /b 0",
+		}
+		require.NoError(t, os.WriteFile(path, []byte(strings.Join(script, "\r\n")+"\r\n"), 0o600))
+		return path
+	}
+
+	path := filepath.Join(tempDir, "validate-stub.sh")
+	script := []string{
+		"#!/bin/sh",
+		"[ \"$1\" = 'validate' ] || exit 1",
+		"[ \"$2\" = '--config' ] || exit 1",
+		"[ \"$4\" = '" + featureGateArg + "' ] || exit 1",
+		"grep -q 'profiles:' \"$3\" || exit 1",
+		"grep -q 'processors:' \"$3\" && exit 1",
+		"exit 0",
+	}
+	require.NoError(t, os.WriteFile(path, []byte(strings.Join(script, "\n")+"\n"), 0o600))
+	require.NoError(t, os.Chmod(path, 0o700))
+
+	return path
 }
 
 func TestCapabilities_SupportedCapabilities(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -874,26 +874,22 @@ func TestAgent_validateFallbackConfigsWithColBinUsesAgentArguments(t *testing.T)
 func writeFeatureGateValidateStub(t *testing.T) string {
 	t.Helper()
 
-	const featureGateArg = "--feature-gates=+service.profilesSupport"
+	const (
+		featureGateName  = "--feature-gates"
+		featureGateValue = "+service.profilesSupport"
+		featureGateArg   = featureGateName + "=" + featureGateValue
+	)
 
 	tempDir := t.TempDir()
 	if runtime.GOOS == "windows" {
 		path := filepath.Join(tempDir, "validate-stub.bat")
 		script := []string{
 			"@echo off",
-			"echo validate-stub cwd=[%CD%] 1>&2",
-			"echo validate-stub temp=[%TEMP%] 1>&2",
-			"echo validate-stub script=[%~f0] 1>&2",
-			"echo validate-stub args=[%*] 1>&2",
-			"echo validate-stub arg4=[%4] 1>&2",
-			"echo validate-stub arg4-unquoted=[%~4] 1>&2",
-			"echo validate-stub config=[%~f3] 1>&2",
-			"if exist \"%3\" echo validate-stub config-exists=yes 1>&2",
-			"if not exist \"%3\" echo validate-stub config-exists=no 1>&2",
 			"if not \"%1\"==\"validate\" exit /b 11",
 			"if not \"%2\"==\"--config\" exit /b 12",
-			"if not \"%4\"==\"" + featureGateArg + "\" exit /b 13",
-			"if not exist \"%3\" exit /b 14",
+			// cmd.exe uses "=" as a delimiter when assigning batch parameters.
+			"if not \"%4\"==\"" + featureGateName + "\" exit /b 13",
+			"if not \"%5\"==\"" + featureGateValue + "\" exit /b 14",
 			"findstr /C:\"profiles:\" \"%3\" >nul",
 			"if errorlevel 1 exit /b 15",
 			"findstr /C:\"processors:\" \"%3\" >nul",

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -881,13 +881,21 @@ func writeFeatureGateValidateStub(t *testing.T) string {
 		path := filepath.Join(tempDir, "validate-stub.bat")
 		script := []string{
 			"@echo off",
-			"if not \"%1\"==\"validate\" exit /b 1",
-			"if not \"%2\"==\"--config\" exit /b 1",
-			"if not \"%4\"==\"" + featureGateArg + "\" exit /b 1",
+			"echo validate-stub cwd=[%CD%] 1>&2",
+			"echo validate-stub temp=[%TEMP%] 1>&2",
+			"echo validate-stub script=[%~f0] 1>&2",
+			"echo validate-stub args=[%*] 1>&2",
+			"echo validate-stub config=[%~f3] 1>&2",
+			"if exist \"%3\" echo validate-stub config-exists=yes 1>&2",
+			"if not exist \"%3\" echo validate-stub config-exists=no 1>&2",
+			"if not \"%1\"==\"validate\" exit /b 11",
+			"if not \"%2\"==\"--config\" exit /b 12",
+			"if not \"%4\"==\"" + featureGateArg + "\" exit /b 13",
+			"if not exist \"%3\" exit /b 14",
 			"findstr /C:\"profiles:\" \"%3\" >nul",
-			"if errorlevel 1 exit /b 1",
+			"if errorlevel 1 exit /b 15",
 			"findstr /C:\"processors:\" \"%3\" >nul",
-			"if not errorlevel 1 exit /b 1",
+			"if not errorlevel 1 exit /b 16",
 			"exit /b 0",
 		}
 		require.NoError(t, os.WriteFile(path, []byte(strings.Join(script, "\r\n")+"\r\n"), 0o600))

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -885,6 +885,8 @@ func writeFeatureGateValidateStub(t *testing.T) string {
 			"echo validate-stub temp=[%TEMP%] 1>&2",
 			"echo validate-stub script=[%~f0] 1>&2",
 			"echo validate-stub args=[%*] 1>&2",
+			"echo validate-stub arg4=[%4] 1>&2",
+			"echo validate-stub arg4-unquoted=[%~4] 1>&2",
 			"echo validate-stub config=[%~f3] 1>&2",
 			"if exist \"%3\" echo validate-stub config-exists=yes 1>&2",
 			"if not exist \"%3\" echo validate-stub config-exists=no 1>&2",

--- a/cmd/opampsupervisor/testdata/collector/profiles_pipeline.yaml
+++ b/cmd/opampsupervisor/testdata/collector/profiles_pipeline.yaml
@@ -1,0 +1,14 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:0
+
+exporters:
+  debug:
+
+service:
+  pipelines:
+    profiles:
+      receivers: [otlp]
+      exporters: [debug]

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_fallback.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_fallback.yaml
@@ -16,6 +16,10 @@ storage:
 
 agent:
   executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
+  {{- if .agent_argument }}
+  args:
+    - '{{.agent_argument}}'
+  {{- end }}
   {{- if .local_config }}
   config_files:
     - '{{.local_config}}'


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR makes the startup fallback configuration validation include all the CLI args of the agent, fetched from `agent.args`. This matches the behavior of the configuration validation done by the Supervisor when `agent.config_validation` is turned on.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49609

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a unit and an e2e test to cover this scenario.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
