### PR TITLE
[processor/filter] promote processor.filter.defaultErrorModeIgnore to stable

### DIFF
--- a/.chloggen/filter-default-error-mode-ignore-stable.yaml
+++ b/.chloggen/filter-default-error-mode-ignore-stable.yaml
@@ -6,9 +6,6 @@ note: Promote the `processor.filter.defaultErrorModeIgnore` feature gate to stab
 
 issues: [47232]
 
-subtext: |
-  The `processor.filter.defaultErrorModeIgnore` feature gate is now stable and always enabled.
-  The `error_mode` default is permanently `ignore`. The gate will be removed in v0.159.0.
-  If you were relying on `propagate` as the default, explicitly set `error_mode: propagate` in your filter processor configuration.
+subtext: The gate will be removed in v0.159.0.
 
 change_logs: [user]

--- a/.chloggen/filter-default-error-mode-ignore-stable.yaml
+++ b/.chloggen/filter-default-error-mode-ignore-stable.yaml
@@ -1,0 +1,14 @@
+change_type: breaking
+
+component: processor/filter
+
+note: Promote the `processor.filter.defaultErrorModeIgnore` feature gate to stable. The default top-level `error_mode` is now permanently `ignore` instead of `propagate`.
+
+issues: [47232]
+
+subtext: |
+  The `processor.filter.defaultErrorModeIgnore` feature gate is now stable and always enabled.
+  The `error_mode` default is permanently `ignore`. The gate will be removed in v0.159.0.
+  If you were relying on `propagate` as the default, explicitly set `error_mode: propagate` in your filter processor configuration.
+
+change_logs: [user]

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -34,7 +34,7 @@ If **any** condition is met, the telemetry is dropped (each condition is ORed to
 
 ```yaml
 filter:
-  error_mode: propagate
+  error_mode: ignore
   <trace|metric|log|profile>_conditions: []
 ```
 
@@ -107,13 +107,9 @@ The filter processor also allows configuring an optional field, `error_mode`, wh
 
 ##### `processor.filter.defaultErrorModeIgnore`
 
-The `processor.filter.defaultErrorModeIgnore` feature gate changes the default `error_mode` of the filter processor from `propagate` to `ignore`.
-`ignore` is the recommended mode to improve resiliency, as errors are logged for visibility but valid data is preserved, and processing continues with the next condition.
-This feature gate is currently in Beta (enabled by default).
-
-**Example Usage**
-
-To restore the previous default of `propagate`, run the collector with the feature gate disabled: `./otelcol --config config.yaml --feature-gates=-processor.filter.defaultErrorModeIgnore`.
+The `processor.filter.defaultErrorModeIgnore` [feature gate](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md#collector-feature-gates) changes the default `error_mode` of the filter processor from `propagate` to `ignore`.
+This gate is currently in `stable` (always enabled). The default `error_mode` is `ignore` and can no longer be reverted via this gate.
+The gate will be removed in v0.159.0.
 
 ### Basic Config
 

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// Valid values are `ignore` and `propagate`.
 	// `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode.
 	// `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector.
-	// The default value is `ignore` when the `processor.filter.defaultErrorModeIgnore` feature gate is enabled (default), and `propagate` when disabled.
+	// The default value is `ignore`.
 	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
 
 	// Deprecated: use TraceConditions instead.

--- a/processor/filterprocessor/config.schema.yaml
+++ b/processor/filterprocessor/config.schema.yaml
@@ -132,7 +132,7 @@ description: Config defines configuration for Resource processor.
 type: object
 properties:
   error_mode:
-    description: ErrorMode determines how the processor reacts to errors that occur while processing an OTTL condition. Valid values are `ignore` and `propagate`. `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode. `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector. The default value is `ignore` when the `processor.filter.defaultErrorModeIgnore` feature gate is enabled (default), and `propagate` when disabled.
+    description: ErrorMode determines how the processor reacts to errors that occur while processing an OTTL condition. Valid values are `ignore` and `propagate`. `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode. `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector. The default value is `ignore`.
     $ref: /pkg/ottl.error_mode
   log_conditions:
     type: array

--- a/processor/filterprocessor/documentation.md
+++ b/processor/filterprocessor/documentation.md
@@ -44,6 +44,6 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `processor.filter.defaultErrorModeIgnore` | beta | Changes the default error_mode of the filter processor from propagate to ignore | v0.150.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232) |
+| `processor.filter.defaultErrorModeIgnore` | stable | Changes the default error_mode of the filter processor from propagate to ignore | v0.150.0 | v0.159.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -198,12 +198,8 @@ func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 }
 
 func (f *filterProcessorFactory) createDefaultConfig() component.Config {
-	defaultErrorMode := ottl.PropagateError
-	if metadata.ProcessorFilterDefaultErrorModeIgnoreFeatureGate.IsEnabled() {
-		defaultErrorMode = ottl.IgnoreError
-	}
 	return &Config{
-		ErrorMode:          defaultErrorMode,
+		ErrorMode:          ottl.IgnoreError,
 		resourceFunctions:  f.resourceFunctions,
 		dataPointFunctions: f.dataPointFunctions,
 		logFunctions:       f.logFunctions,

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/processor/processortest"
 	"go.opentelemetry.io/collector/processor/xprocessor"
 
@@ -45,16 +44,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 	}, cfg)
 	assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
-
-	t.Cleanup(func() {
-		_ = featuregate.GlobalRegistry().Set(metadata.ProcessorFilterDefaultErrorModeIgnoreFeatureGate.ID(), true)
-	})
-
-	err := featuregate.GlobalRegistry().Set(metadata.ProcessorFilterDefaultErrorModeIgnoreFeatureGate.ID(), false)
-	require.NoError(t, err)
-
-	cfg = factory.CreateDefaultConfig()
-	assert.Equal(t, ottl.PropagateError, cfg.(*Config).ErrorMode)
 }
 
 func TestCreateProcessors(t *testing.T) {

--- a/processor/filterprocessor/internal/metadata/generated_feature_gates.go
+++ b/processor/filterprocessor/internal/metadata/generated_feature_gates.go
@@ -8,8 +8,9 @@ import (
 
 var ProcessorFilterDefaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"processor.filter.defaultErrorModeIgnore",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("Changes the default error_mode of the filter processor from propagate to ignore"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232"),
 	featuregate.WithRegisterFromVersion("v0.150.0"),
+	featuregate.WithRegisterToVersion("v0.159.0"),
 )

--- a/processor/filterprocessor/metadata.yaml
+++ b/processor/filterprocessor/metadata.yaml
@@ -17,8 +17,9 @@ feature_gates:
   - id: processor.filter.defaultErrorModeIgnore
     description: >-
       Changes the default error_mode of the filter processor from propagate to ignore
-    stage: beta
+    stage: stable
     from_version: "v0.150.0"
+    to_version: "v0.159.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232
 
 tests:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Promotes the feature gate to stable, making `ignore` the permanent default `error_mode` for the filter processor.

The gate registration is kept for backward compatibility and will be removed in v0.159.0.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47232

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
Fixed references of the feature gate.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
