### PR TITLE
[Receiver][aws_lambda] fix error replaying S3 service usage

### DIFF
--- a/.chloggen/fix_aws-lambda-fix-s3-service-usage.yaml
+++ b/.chloggen/fix_aws-lambda-fix-s3-service-usage.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/aws_lambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix S3 service usage of the error replaying
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49671]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -243,12 +243,12 @@ The following receiver configuration parameters are supported.
 |:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
 | `s3::encoding`          | Optional encoder to use for S3 event processing                                                                                                  |
 | `s3::encodings`         | Optional list of path-based encoders for multi-format S3 routing (see [Multi-Format S3 Configuration](#multi-format-s3-configuration-encodings)) |
-| `s3::access_key_id`     | Optional static AWS access key ID for S3 access                                                                                                  |
-| `s3::secret_access_key` | Optional static AWS secret access key for S3 access                                                                                              |
-| `s3::session_token`     | Optional static AWS session token for S3 access                                                                                                  |
+| `s3::access_key_id`     | Optional static AWS access key ID for S3 access. Applies only to S3 event handling.                                                              |
+| `s3::secret_access_key` | Optional static AWS secret access key for S3 access. Applies only to S3 event handling.                                                          |
+| `s3::session_token`     | Optional static AWS session token for S3 access. Applies only to S3 event handling.                                                              |
 | `cloudwatch::encoding`  | Optional encoder to use for CloudWatch event processing                                                                                          |
 | `custom::encoding`      | Optional encoder to use for custom event processing                                                                                              |
-| `failure_bucket_arn`    | Optional S3 bucket ARN holding failed Lambda records for replay                                                                                  | 
+| `failure_bucket_arn`    | Optional S3 bucket ARN holding failed Lambda records for replay. Bucket access utilize default credentials of the Lambda runtime environment     | 
 
 Consider following notes on default behaviors:
 

--- a/receiver/awslambdareceiver/internal/mock_s3_service.go
+++ b/receiver/awslambdareceiver/internal/mock_s3_service.go
@@ -210,16 +210,31 @@ func (m *MockS3Provider) EXPECT() *MockS3ProviderMockRecorder {
 }
 
 // GetService mocks base method.
-func (m *MockS3Provider) GetService(ctx context.Context, staticCreds AWSOptions) (S3Service, error) {
+func (m *MockS3Provider) GetService(ctx context.Context) (S3Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetService", ctx, staticCreds)
+	ret := m.ctrl.Call(m, "GetService", ctx)
 	ret0, _ := ret[0].(S3Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetService indicates an expected call of GetService.
-func (mr *MockS3ProviderMockRecorder) GetService(ctx, staticCreds any) *gomock.Call {
+func (mr *MockS3ProviderMockRecorder) GetService(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockS3Provider)(nil).GetService), ctx, staticCreds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockS3Provider)(nil).GetService), ctx)
+}
+
+// GetServiceForConfig mocks base method.
+func (m *MockS3Provider) GetServiceForConfig(ctx context.Context, options AWSOptions) (S3Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceForConfig", ctx, options)
+	ret0, _ := ret[0].(S3Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServiceForConfig indicates an expected call of GetServiceForConfig.
+func (mr *MockS3ProviderMockRecorder) GetServiceForConfig(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceForConfig", reflect.TypeOf((*MockS3Provider)(nil).GetServiceForConfig), ctx, options)
 }

--- a/receiver/awslambdareceiver/internal/s3.go
+++ b/receiver/awslambdareceiver/internal/s3.go
@@ -40,38 +40,74 @@ type S3Service interface {
 
 // S3Provider expose contract to get S3Service
 type S3Provider interface {
-	GetService(ctx context.Context, options AWSOptions) (S3Service, error)
+	GetService(ctx context.Context) (S3Service, error)
+	GetServiceForConfig(ctx context.Context, options AWSOptions) (S3Service, error)
 }
 
 // S3ServiceProvider provides S3Service instances.
 type S3ServiceProvider struct {
-	service S3Service
-	err     error
+	mu sync.Mutex
 
-	once sync.Once
+	// defaultService is built with the default AWS credential chain.
+	defaultService S3Service
+
+	// configService is built with the optional static credential overrides.
+	configService S3Service
 }
 
-func (s *S3ServiceProvider) GetService(ctx context.Context, awsOptions AWSOptions) (S3Service, error) {
-	s.once.Do(func() {
-		cfg, err := config.LoadDefaultConfig(ctx)
-		if err != nil {
-			s.err = fmt.Errorf("unable to load AWS SDK config: %w", err)
-			return
-		}
+// GetService returns a service built from the default AWS credential chain.
+func (s *S3ServiceProvider) GetService(ctx context.Context) (S3Service, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-		// Use static creds if provided
-		if awsOptions.AccessKeyID != "" && awsOptions.SecretAccessKey != "" {
-			cfg.Credentials = credentials.NewStaticCredentialsProvider(
-				awsOptions.AccessKeyID,
-				string(awsOptions.SecretAccessKey),
-				string(awsOptions.SessionToken),
-			)
-		}
+	if s.defaultService != nil {
+		return s.defaultService, nil
+	}
 
-		s.service = &s3ServiceClient{api: s3.NewFromConfig(cfg)}
-	})
+	service, err := newS3Service(ctx, AWSOptions{})
+	if err != nil {
+		return nil, err
+	}
 
-	return s.service, s.err
+	s.defaultService = service
+	return s.defaultService, nil
+}
+
+// GetServiceForConfig returns a service honoring the optional static credential overrides in awsOptions.
+func (s *S3ServiceProvider) GetServiceForConfig(ctx context.Context, awsOptions AWSOptions) (S3Service, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.configService != nil {
+		return s.configService, nil
+	}
+
+	service, err := newS3Service(ctx, awsOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	s.configService = service
+	return s.configService, nil
+}
+
+// newS3Service is a helper to derive S3Service.
+func newS3Service(ctx context.Context, awsOptions AWSOptions) (S3Service, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)
+	}
+
+	// Use static creds if provided
+	if awsOptions.AccessKeyID != "" && awsOptions.SecretAccessKey != "" {
+		cfg.Credentials = credentials.NewStaticCredentialsProvider(
+			awsOptions.AccessKeyID,
+			string(awsOptions.SecretAccessKey),
+			string(awsOptions.SessionToken),
+		)
+	}
+
+	return &s3ServiceClient{api: s3.NewFromConfig(cfg)}, nil
 }
 
 // s3ServiceClient implements the S3Service

--- a/receiver/awslambdareceiver/internal/s3_test.go
+++ b/receiver/awslambdareceiver/internal/s3_test.go
@@ -19,9 +19,16 @@ import (
 func TestS3ServiceProvider(t *testing.T) {
 	provider := S3ServiceProvider{}
 
-	service, err := provider.GetService(t.Context(), AWSOptions{})
+	service, err := provider.GetService(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, service)
+
+	serviceWithCfg, err := provider.GetServiceForConfig(t.Context(), AWSOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, service)
+
+	// Services are different instances
+	require.NotEqual(t, service, serviceWithCfg)
 }
 
 func TestS3ServiceReadObject(t *testing.T) {

--- a/receiver/awslambdareceiver/receiver.go
+++ b/receiver/awslambdareceiver/receiver.go
@@ -118,7 +118,10 @@ func (a *awsLambdaReceiver) processLambdaEvent(ctx context.Context, event json.R
 
 	if triggerType == replayEvent {
 		a.logger.Info("Running custom event", zap.String(logInvokedTrigger, string(triggerType)))
-		service, err := a.s3Provider.GetService(ctx, a.cfg.S3.AWSOptions)
+
+		// Note - derive S3 service with default credentials.
+		// This may extend for event replay specific credential overrides
+		service, err := a.s3Provider.GetService(ctx)
 		if err != nil {
 			return err
 		}
@@ -219,7 +222,7 @@ func newLogsHandler(
 ) (handlerProvider, error) {
 	logger := set.Logger
 
-	s3Service, err := s3Provider.GetService(ctx, cfg.S3.AWSOptions)
+	s3Service, err := s3Provider.GetServiceForConfig(ctx, cfg.S3.AWSOptions)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load the S3 service: %w", err)
 	}
@@ -341,7 +344,7 @@ func newMetricsHandler(
 		decoder = xstreamencoding.NewMetricsUnmarshalerDecoderFactory(metricsUnmarshaler)
 	}
 
-	s3Service, err := s3Provider.GetService(ctx, cfg.S3.AWSOptions)
+	s3Service, err := s3Provider.GetServiceForConfig(ctx, cfg.S3.AWSOptions)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load the S3 service: %w", err)
 	}

--- a/receiver/awslambdareceiver/receiver_test.go
+++ b/receiver/awslambdareceiver/receiver_test.go
@@ -56,7 +56,7 @@ func TestCreateLogs(t *testing.T) {
 	goMock := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
-	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
+	s3Provider.EXPECT().GetServiceForConfig(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
 
 	// Test data - mock S3 file content
 	testData := []byte("version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status\n2 627286350134 eni-0377aa710071c557e 172.31.31.124 140.82.121.6 52718 443 6 13 3777 1751375679 ENDTIME ACCEPT OK\n")
@@ -133,7 +133,7 @@ func TestCreateMetrics(t *testing.T) {
 	goMock := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
-	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
+	s3Provider.EXPECT().GetServiceForConfig(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
 	s3Service.EXPECT().GetReader(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(io.NopCloser(bytes.NewReader([]byte("dummy data"))), nil)
@@ -188,7 +188,7 @@ func TestCustomHandlerRegistration(t *testing.T) {
 	goMock := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(goMock)
 	s3Provider := internal.NewMockS3Provider(goMock)
-	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
+	s3Provider.EXPECT().GetServiceForConfig(gomock.Any(), gomock.Any()).AnyTimes().Return(s3Service, nil)
 
 	// A custom event payload that detectTriggerType classifies as customEvent.
 	customEventPayload := []byte(`{"custom":"payload"}`)
@@ -646,7 +646,7 @@ func TestNewLogsHandler_MultiEncodingS3_Branch(t *testing.T) {
 	ctr := gomock.NewController(t)
 	s3Service := internal.NewMockS3Service(ctr)
 	s3Provider := internal.NewMockS3Provider(ctr)
-	s3Provider.EXPECT().GetService(gomock.Any(), gomock.Any()).Return(s3Service, nil)
+	s3Provider.EXPECT().GetServiceForConfig(gomock.Any(), gomock.Any()).Return(s3Service, nil)
 
 	settings := receivertest.NewNopSettings(metadata.Type)
 	host := componenttest.NewNopHost() // no extensions needed — all raw passthrough


### PR DESCRIPTION
#### Description

The error replaying of `aws_lambda` was incorrectly using S3 service with credential overrides provided for S3 handler path. This PR fixes S3 service usage of the error replaying.

Note that, currently there's no credential overriding capability for error replaying. This means, error destination is expected to use default AWS credentials of the Lambda runtime. This could be enhanced in future if a need arise. 

#### Testing

Updated testing to validate service deriving

#### Documentation

Not applicable 
#### Authorship

- [x] I, a human, wrote this pull request description myself.