### PR TITLE
[pkg/ottl] Fix Decode function failing on byte-array log.body with base64 data

### DIFF
--- a/.chloggen/fix-ottl-decode-bytes-base64.yaml
+++ b/.chloggen/fix-ottl-decode-bytes-base64.yaml
@@ -1,0 +1,16 @@
+change_type: bug_fix
+
+component: pkg/ottl
+
+note: Fix `Decode` function failing with "illegal base64 data at input byte 0" when `log.body` is a byte-array (`pcommon.ValueTypeBytes`) whose content has leading or trailing whitespace such as a newline.
+
+issues: [48372]
+
+subtext: |
+  `base64.StdEncoding` has zero whitespace tolerance. Event-streaming systems
+  (e.g. Azure Event Hub with `format: raw`) commonly append a trailing newline
+  to message payloads, causing the first or last byte to be rejected as invalid
+  base64. The fix trims leading/trailing whitespace from the input before
+  decoding, matching common real-world usage without affecting any other decoder.
+
+change_logs: [user]

--- a/pkg/ottl/ottlfuncs/func_decode.go
+++ b/pkg/ottl/ottlfuncs/func_decode.go
@@ -4,10 +4,12 @@
 package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"golang.org/x/text/encoding"
@@ -46,6 +48,10 @@ type base64Decoder struct {
 }
 
 func (bd base64Decoder) Decode(src []byte) (any, error) {
+	// Trim whitespace so that message bodies with leading/trailing
+	// newlines or spaces (common in event-streaming systems) don't
+	// cause spurious "illegal base64 data at input byte 0" errors.
+	src = bytes.TrimSpace(src)
 	dbuf := make([]byte, bd.enc.DecodedLen(len(src)))
 	n, err := bd.enc.Decode(dbuf, src)
 	if err != nil {
@@ -55,7 +61,7 @@ func (bd base64Decoder) Decode(src []byte) (any, error) {
 }
 
 func (bd base64Decoder) DecodeString(src string) (any, error) {
-	buf, err := bd.enc.DecodeString(src)
+	buf, err := bd.enc.DecodeString(strings.TrimSpace(src))
 	if err != nil {
 		return nil, fmt.Errorf("could not decode: %w", err)
 	}

--- a/pkg/ottl/ottlfuncs/func_decode_test.go
+++ b/pkg/ottl/ottlfuncs/func_decode_test.go
@@ -25,6 +25,12 @@ func TestDecode(t *testing.T) {
 	testValueBytes := pcommon.NewValueBytes()
 	testValueBytes.Bytes().FromRaw([]byte{116, 0, 101, 0, 115, 0, 116, 0, 32, 0, 115, 0, 116, 0, 114, 0, 105, 0, 110, 0, 103, 0})
 
+	// pcommon.Value of type Bytes whose raw bytes ARE the base64-encoded text
+	// (mirrors what the azureeventhubreceiver stores in log.body with format:raw
+	// when the event payload is a base64-encoded string).
+	testValueBytesBase64 := pcommon.NewValueBytes()
+	testValueBytesBase64.Bytes().FromRaw([]byte("aGVsbG8gd29ybGQ="))
+
 	type testCase struct {
 		name          string
 		value         any
@@ -40,8 +46,44 @@ func TestDecode(t *testing.T) {
 			want:     "test\n",
 		},
 		{
+			name:     "convert base64 byte array with leading newline",
+			value:    []byte("\naGVsbG8gd29ybGQ="),
+			encoding: "base64",
+			want:     "hello world",
+		},
+		{
+			name:     "convert base64 byte array with trailing newline",
+			value:    []byte("aGVsbG8gd29ybGQ=\n"),
+			encoding: "base64",
+			want:     "hello world",
+		},
+		{
+			name:     "convert base64 ValueBytes (log.body bytes containing base64 text)",
+			value:    testValueBytesBase64,
+			encoding: "base64",
+			want:     "hello world",
+		},
+		{
+			name:     "convert base64 ValueBytes pointer",
+			value:    &testValueBytesBase64,
+			encoding: "base64",
+			want:     "hello world",
+		},
+		{
 			name:     "convert base64 string",
 			value:    "aGVsbG8gd29ybGQ=",
+			encoding: "base64",
+			want:     "hello world",
+		},
+		{
+			name:     "convert base64 string with leading whitespace",
+			value:    "  aGVsbG8gd29ybGQ=",
+			encoding: "base64",
+			want:     "hello world",
+		},
+		{
+			name:     "convert base64 string with trailing whitespace",
+			value:    "aGVsbG8gd29ybGQ=  ",
 			encoding: "base64",
 			want:     "hello world",
 		},


### PR DESCRIPTION
## What's the problem?

When the `azureeventhubreceiver` runs with `format: raw`, it stores the event payload as `log.body` of type **Bytes** (`pcommon.ValueTypeBytes`). The OTTL `Decode()` function then receives these as a raw `[]byte`.

If the message body has any leading or trailing whitespace — a trailing newline is common in event-streaming systems — `base64.StdEncoding.Decode` chokes immediately because it has zero whitespace tolerance:

```
could not decode: illegal base64 data at input byte 0
```

A leading `\n` is all it takes to get "at input byte 0", which is exactly what the reporter saw.

There was also a gap in test coverage: `pcommon.Value` of type `ValueTypeBytes` where the raw bytes _are_ base64-encoded text was never tested (only the UTF-16 bytes case existed).

## What does this fix?

Two small, targeted changes to `base64Decoder` in `func_decode.go`:

- **`Decode(src []byte)`** — calls `bytes.TrimSpace(src)` before decoding. Handles leading/trailing newlines and spaces that message-body pipelines often append.
- **`DecodeString(src string)`** — calls `strings.TrimSpace(src)` before decoding. Consistent behaviour for string inputs.

Text decoders (`textDecoder` — UTF-16, ISO-8859-1, etc.) are **not touched**; whitespace is semantically meaningful there.

## New test cases

| Case | Input | Expected |
|------|-------|----------|
| `[]byte` with leading `\n` | `"\naGVsbG8gd29ybGQ="` | `"hello world"` |
| `[]byte` with trailing `\n` | `"aGVsbG8gd29ybGQ=\n"` | `"hello world"` |
| `pcommon.Value{Bytes}` with base64 content | bytes of `"aGVsbG8gd29ybGQ="` | `"hello world"` |
| `*pcommon.Value{Bytes}` pointer | same | `"hello world"` |
| string with leading spaces | `"  aGVsbG8gd29ybGQ="` | `"hello world"` |
| string with trailing spaces | `"aGVsbG8gd29ybGQ=  "` | `"hello world"` |

All existing tests still pass — the trim is a no-op for inputs that have no surrounding whitespace.

Closes #48372
