### PR TITLE
[processor/schema] Add cache_ttl configuration option for in-memory schema cache

### DIFF
--- a/.chloggen/feat-schema-processor-cache-ttl.yaml
+++ b/.chloggen/feat-schema-processor-cache-ttl.yaml
@@ -1,0 +1,20 @@
+change_type: enhancement
+
+component: processor/schema
+
+note: Add `cache_ttl` configuration option to control how long successfully fetched schemas are kept in the in-memory cache before being re-fetched from the upstream provider.
+
+issues: [48342]
+
+subtext: |
+  Previously the in-memory cache used `cache.NoExpiration`, meaning a schema
+  fetched once would live for the entire process lifetime. If a schema URL
+  initially returned incorrect content, or if the file was updated on the
+  server, the collector had to be restarted to pick up the change.
+
+  Setting `cache_ttl` (e.g. `cache_ttl: 24h`) causes entries to expire after
+  the given duration, after which the next access triggers a fresh fetch from
+  the upstream provider. A value of 0 (the default) preserves the previous
+  no-expiration behaviour.
+
+change_logs: [user]

--- a/processor/schemaprocessor/README.md
+++ b/processor/schemaprocessor/README.md
@@ -104,8 +104,16 @@ processor retries up to `cache_retry_limit` times before entering a cooldown
 period of `cache_cooldown` during which further attempts for the same key
 return an error immediately.
 
+By default, successfully fetched schemas are cached indefinitely for the
+process lifetime. Set `cache_ttl` to a positive duration to evict entries after
+that period; the next access triggers a fresh fetch from the upstream provider.
+This is useful when a schema URL may return incorrect content initially, or when
+schema files are updated on the server. A value of `0` (the default) keeps the
+previous no-expiration behaviour.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `cache_ttl` | duration | `0` (no expiration) | How long a successfully fetched schema is cached before being re-fetched |
 | `cache_cooldown` | duration | `5m` | Wait time after retry limit is reached |
 | `cache_retry_limit` | int | `5` | Consecutive failures before cooldown |
 

--- a/processor/schemaprocessor/config.go
+++ b/processor/schemaprocessor/config.go
@@ -27,6 +27,12 @@ var (
 type Config struct {
 	confighttp.ClientConfig `mapstructure:",squash"`
 
+	// CacheTTL controls how long a successfully fetched schema is kept in
+	// the in-memory cache before it is evicted and re-fetched from the
+	// upstream provider on next access. A value of 0 (the default) means
+	// entries never expire, which matches the previous behaviour.
+	CacheTTL time.Duration `mapstructure:"cache_ttl"`
+
 	// CacheCooldown is the duration to wait before retrying schema fetches
 	// after the retry limit has been reached. Defaults to 5 minutes.
 	CacheCooldown time.Duration `mapstructure:"cache_cooldown"`
@@ -73,6 +79,9 @@ type MigrationEntry struct {
 }
 
 func (c *Config) Validate() error {
+	if c.CacheTTL < 0 {
+		return errors.New("cache_ttl must not be negative")
+	}
 	if c.CacheCooldown < 0 {
 		return errors.New("cache_cooldown must not be negative")
 	}

--- a/processor/schemaprocessor/config_test.go
+++ b/processor/schemaprocessor/config_test.go
@@ -34,6 +34,7 @@ func TestLoadConfig(t *testing.T) {
 
 	assert.Equal(t, &Config{
 		ClientConfig:    confighttp.NewDefaultClientConfig(),
+		CacheTTL:        24 * time.Hour,
 		CacheCooldown:   10 * time.Minute,
 		CacheRetryLimit: 3,
 		Prefetch: []string{
@@ -152,10 +153,18 @@ func TestConfigurationValidation_CacheFields(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
+		Targets:  []string{"https://opentelemetry.io/schemas/1.9.0"},
+		CacheTTL: -1 * time.Second,
+	}
+	err := xconfmap.Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache_ttl must not be negative")
+
+	cfg = &Config{
 		Targets:       []string{"https://opentelemetry.io/schemas/1.9.0"},
 		CacheCooldown: -1 * time.Minute,
 	}
-	err := xconfmap.Validate(cfg)
+	err = xconfmap.Validate(cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cache_cooldown must not be negative")
 

--- a/processor/schemaprocessor/internal/translation/cacheable_provider.go
+++ b/processor/schemaprocessor/internal/translation/cacheable_provider.go
@@ -38,10 +38,20 @@ type CacheableProvider struct {
 // NewCacheableProvider creates a new CacheableProvider.
 // The cooldown parameter is the time to wait before retrying a failed call.
 // The limit parameter is the number of failed calls to allow before setting the cooldown period.
-func NewCacheableProvider(provider Provider, cooldown time.Duration, limit int, telemetryBuilder *metadata.TelemetryBuilder) Provider {
+// The ttl parameter controls how long successfully fetched entries remain in the cache before
+// being evicted and re-fetched. A ttl of 0 means entries never expire (previous behaviour).
+func NewCacheableProvider(provider Provider, cooldown time.Duration, limit int, ttl time.Duration, telemetryBuilder *metadata.TelemetryBuilder) Provider {
+	// go-cache uses cache.NoExpiration (-1) to mean "never expire".
+	// A ttl of 0 from the user also means "never expire", so map 0 → NoExpiration.
+	cacheExpiration := cache.NoExpiration
+	cleanupInterval := cache.NoExpiration
+	if ttl > 0 {
+		cacheExpiration = ttl
+		cleanupInterval = 2 * ttl
+	}
 	return &CacheableProvider{
 		provider:         provider,
-		cache:            cache.New(cache.NoExpiration, cache.NoExpiration),
+		cache:            cache.New(cacheExpiration, cleanupInterval),
 		cooldown:         cooldown,
 		limit:            limit,
 		telemetryBuilder: telemetryBuilder,
@@ -96,6 +106,6 @@ func (p *CacheableProvider) Retrieve(ctx context.Context, key string) (string, e
 		return "", err
 	}
 	p.callcount = 0
-	p.cache.Set(key, v, cache.NoExpiration)
+	p.cache.Set(key, v, cache.DefaultExpiration)
 	return v, nil
 }

--- a/processor/schemaprocessor/internal/translation/cacheable_provider_test.go
+++ b/processor/schemaprocessor/internal/translation/cacheable_provider_test.go
@@ -79,7 +79,7 @@ func TestCacheableProviderCounters(t *testing.T) {
 			tb, err := metadata.NewTelemetryBuilder(metadatatest.NewSettings(testTel).TelemetrySettings)
 			require.NoError(t, err)
 
-			cp := NewCacheableProvider(&staticProvider{value: "result"}, 0, 5, tb)
+			cp := NewCacheableProvider(&staticProvider{value: "result"}, 0, 5, 0, tb)
 
 			for _, key := range tt.retrievals {
 				_, err := cp.Retrieve(t.Context(), key)
@@ -118,7 +118,7 @@ func BenchmarkCacheableProviderConcurrentFetch(b *testing.B) {
 	)
 
 	for range b.N {
-		cp := NewCacheableProvider(&slowProvider{delay: providerDelay}, time.Minute, 10, tb)
+		cp := NewCacheableProvider(&slowProvider{delay: providerDelay}, time.Minute, 10, 0, tb)
 		var wg sync.WaitGroup
 		for g := range goroutines {
 			wg.Add(1)
@@ -153,7 +153,7 @@ func (p *alwaysErrorProvider) Retrieve(_ context.Context, _ string) (string, err
 func TestCacheableProviderRateLimit(t *testing.T) {
 	provider := &alwaysErrorProvider{}
 	tb, _ := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
-	cp := NewCacheableProvider(provider, time.Hour, 3, tb).(*CacheableProvider)
+	cp := NewCacheableProvider(provider, time.Hour, 3, 0, tb).(*CacheableProvider)
 
 	// Exhaust the limit: 3 calls should reach the provider.
 	for range 3 {
@@ -203,7 +203,7 @@ func TestCacheableProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a new cacheable provider
 			tb, _ := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
-			provider := NewCacheableProvider(&firstErrorProvider{}, 0*time.Nanosecond, tt.limit, tb)
+			provider := NewCacheableProvider(&firstErrorProvider{}, 0*time.Nanosecond, tt.limit, 0, tb)
 
 			var p string
 			var err error
@@ -218,4 +218,72 @@ func TestCacheableProvider(t *testing.T) {
 			require.Equal(t, "key", p, "value is key")
 		})
 	}
+}
+
+// countingProvider counts how many times Retrieve is called.
+type countingProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *countingProvider) Retrieve(_ context.Context, key string) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	return key, nil
+}
+
+func (p *countingProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// TestCacheableProviderTTL verifies that entries expire after the configured TTL
+// and cause the underlying provider to be called again on the next access.
+func TestCacheableProviderTTL(t *testing.T) {
+	tb, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+
+	ttl := 50 * time.Millisecond
+	underlying := &countingProvider{}
+	cp := NewCacheableProvider(underlying, 0, 5, ttl, tb)
+
+	// First call — cache miss, hits the underlying provider.
+	v, err := cp.Retrieve(t.Context(), "key")
+	require.NoError(t, err)
+	require.Equal(t, "key", v)
+	require.Equal(t, 1, underlying.Calls(), "first call should reach the provider")
+
+	// Immediate second call — cache hit, should not reach the underlying provider.
+	v, err = cp.Retrieve(t.Context(), "key")
+	require.NoError(t, err)
+	require.Equal(t, "key", v)
+	require.Equal(t, 1, underlying.Calls(), "second call should be served from cache")
+
+	// Wait for the TTL to expire.
+	time.Sleep(2 * ttl)
+
+	// Call after TTL — cache miss, hits the underlying provider again.
+	v, err = cp.Retrieve(t.Context(), "key")
+	require.NoError(t, err)
+	require.Equal(t, "key", v)
+	require.Equal(t, 2, underlying.Calls(), "call after TTL expiry should reach the provider again")
+}
+
+// TestCacheableProviderNoTTL verifies that a zero TTL (the default) means
+// entries never expire — the underlying provider is only called once.
+func TestCacheableProviderNoTTL(t *testing.T) {
+	tb, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+
+	underlying := &countingProvider{}
+	cp := NewCacheableProvider(underlying, 0, 5, 0, tb)
+
+	for range 5 {
+		v, retrieveErr := cp.Retrieve(t.Context(), "key")
+		require.NoError(t, retrieveErr)
+		require.Equal(t, "key", v)
+	}
+	require.Equal(t, 1, underlying.Calls(), "zero TTL: provider should only be called once")
 }

--- a/processor/schemaprocessor/internal/translation/manager.go
+++ b/processor/schemaprocessor/internal/translation/manager.go
@@ -35,6 +35,7 @@ type manager struct {
 	migrationMap     map[string]*Version // target schema URL → copyFromVersion
 	cooldown         time.Duration
 	limit            int
+	cacheTTL         time.Duration
 
 	rw            sync.RWMutex
 	providers     []Provider
@@ -46,7 +47,7 @@ var _ Manager = (*manager)(nil)
 
 // NewManager creates a manager that will allow for management
 // of schema
-func NewManager(targetSchemaURLS []string, log *zap.Logger, cooldown time.Duration, limit int, telemetryBuilder *metadata.TelemetryBuilder, migrationMap map[string]*Version, providers ...Provider) (Manager, error) {
+func NewManager(targetSchemaURLS []string, log *zap.Logger, cooldown time.Duration, limit int, cacheTTL time.Duration, telemetryBuilder *metadata.TelemetryBuilder, migrationMap map[string]*Version, providers ...Provider) (Manager, error) {
 	if log == nil {
 		return nil, fmt.Errorf("logger: %w", errNilValueProvided)
 	}
@@ -66,6 +67,7 @@ func NewManager(targetSchemaURLS []string, log *zap.Logger, cooldown time.Durati
 		migrationMap:     migrationMap,
 		cooldown:         cooldown,
 		limit:            limit,
+		cacheTTL:         cacheTTL,
 		match:            match,
 		translatorMap:    make(map[string]*translator),
 	}
@@ -80,7 +82,7 @@ func NewManager(targetSchemaURLS []string, log *zap.Logger, cooldown time.Durati
 
 // newCacheableProvider wraps p with a CacheableProvider wired to the manager's telemetry.
 func (m *manager) newCacheableProvider(p Provider) Provider {
-	return NewCacheableProvider(p, m.cooldown, m.limit, m.telemetryBuilder)
+	return NewCacheableProvider(p, m.cooldown, m.limit, m.cacheTTL, m.telemetryBuilder)
 }
 
 func (m *manager) RequestTranslation(ctx context.Context, schemaURL string) (Translation, error) {

--- a/processor/schemaprocessor/internal/translation/manager_test.go
+++ b/processor/schemaprocessor/internal/translation/manager_test.go
@@ -48,7 +48,7 @@ func TestRequestTranslation(t *testing.T) {
 	m, err := NewManager(
 		[]string{schemaURL},
 		zaptest.NewLogger(t),
-		5*time.Minute, 5,
+		5*time.Minute, 5, 0,
 		telemetryBuilder,
 		nil,
 		NewHTTPProvider(s.Client()),
@@ -118,7 +118,7 @@ versions:
 	m, err := NewManager(
 		[]string{targetURL},
 		zaptest.NewLogger(t),
-		5*time.Minute, 5,
+		5*time.Minute, 5, 0,
 		telemetryBuilder,
 		nil,
 		NewHTTPProvider(s.Client()),
@@ -183,7 +183,7 @@ resolved_registry_uri: %s/resolved/2.0.0.yaml
 	m, err := NewManager(
 		[]string{targetURL},
 		zaptest.NewLogger(t),
-		5*time.Minute, 5,
+		5*time.Minute, 5, 0,
 		telemetryBuilder,
 		nil,
 		NewHTTPProvider(s.Client()),
@@ -223,7 +223,7 @@ func TestManagerError(t *testing.T) {
 	m, err := NewManager(
 		[]string{"http://localhost/1.1.0"},
 		zaptest.NewLogger(t),
-		5*time.Minute, 5,
+		5*time.Minute, 5, 0,
 		telemetryBuilder,
 		nil,
 		&errorProvider{},

--- a/processor/schemaprocessor/processor.go
+++ b/processor/schemaprocessor/processor.go
@@ -64,6 +64,7 @@ func newSchemaProcessor(_ context.Context, conf component.Config, set processor.
 		set.Logger.Named("schema-manager"),
 		cfg.CacheCooldown,
 		cfg.CacheRetryLimit,
+		cfg.CacheTTL,
 		telemetryBuilder,
 		migrationMap,
 	)

--- a/processor/schemaprocessor/testdata/config.yml
+++ b/processor/schemaprocessor/testdata/config.yml
@@ -1,4 +1,5 @@
 schema/with-all-options:
+  cache_ttl: 24h
   cache_cooldown: 10m
   cache_retry_limit: 3
   # Prefetch is an optional field that allows


### PR DESCRIPTION
## What's the problem?

The schema processor's in-memory cache used `cache.NoExpiration` — schemas fetched once were pinned for the entire collector lifetime. Two real problems follow:

1. **Stale bad data** — if a schema URL initially returns incorrect or empty content, the bad result is cached forever until a restart.
2. **Missed updates** — if the schema file changes on the server, the collector never picks up the new version.

Raised in #48342 during review of the storage extension work (#48267).

## What does this add?

A new `cache_ttl` field in the processor config:

```yaml
processors:
  schema:
    cache_ttl: 24h   # default: 0 = no expiration (previous behaviour)
    targets:
      - https://opentelemetry.io/schemas/1.26.0
```

When `cache_ttl > 0`, in-memory entries expire after the configured duration. On the next access the provider chain is traversed from the top, reaching the HTTP provider and fetching a fresh copy. A value of `0` (the default) keeps the existing no-expiration behaviour — no breaking change.

## Implementation

- `config.go` — adds `CacheTTL time.Duration` field and validates it's ≥ 0
- `cacheable_provider.go` — `NewCacheableProvider` now takes a `ttl` param; maps `0 → cache.NoExpiration` in `cache.New`, uses `cache.DefaultExpiration` in `cache.Set` so the per-instance TTL is respected
- `manager.go` — threads `cacheTTL` through the manager struct to `newCacheableProvider`
- `processor.go` — passes `cfg.CacheTTL` to `NewManager`

## Tests

- `TestCacheableProviderTTL` — verifies entries expire after TTL and the underlying provider is called again post-expiry
- `TestCacheableProviderNoTTL` — verifies TTL=0 preserves the no-expiration behaviour
- `TestConfigurationValidation_CacheFields` — validates `cache_ttl` rejects negative values
- `TestLoadConfig` — `testdata/config.yml` updated with `cache_ttl: 24h` and golden test updated

Closes #48342
