### PR TITLE
[chore] [receiver/simpleprometheus] Remove temporary HTTP client overrides from tests

### DIFF
--- a/receiver/simpleprometheusreceiver/receiver_test.go
+++ b/receiver/simpleprometheusreceiver/receiver_test.go
@@ -86,10 +86,6 @@ func TestGetPrometheusConfig(t *testing.T) {
 	clientConfig.Endpoint = "localhost:1234"
 
 	clientConfigJobName := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	clientConfigJobName.MaxIdleConns = 0
-	clientConfigJobName.IdleConnTimeout = 0
-	clientConfigJobName.ForceAttemptHTTP2 = false
 	clientConfigJobName.Endpoint = "localhost:1234"
 
 	tests := []struct {


### PR DESCRIPTION
#### Description

Removes the temporary HTTP client default overrides from the
`simpleprometheusreceiver` test fixture.

These overrides were added during the migration to
`confighttp.NewDefaultClientConfig()` to preserve the previous zero-value
behavior. The component has now been reviewed and can use the defaults provided
by the constructor.

This change only affects test code. The resulting Prometheus configuration and
production behavior remain unchanged.

#### Link to tracking issue

Related to #49316

#### Testing

- Ran `TestGetPrometheusConfig/Test_with_job_name`
- Ran `make test`
- Ran `make lint`
- Ran `git diff --check`

No new test was added because this change updates an existing test fixture, and
the existing test verifies that the resulting Prometheus configuration remains
unchanged.

#### Documentation

No documentation changes are required because this change only updates a test
fixture.

#### Authorship

- [X] I, a human, wrote this pull request description myself.