### PR TITLE
[processor/transform] promote defaultErrorModeIgnore feature gate to stable

### DIFF
--- a/.chloggen/transform-default-error-mode-ignore-stable.yaml
+++ b/.chloggen/transform-default-error-mode-ignore-stable.yaml
@@ -1,0 +1,11 @@
+change_type: breaking
+
+component: processor/transform
+
+note: Promote the `processor.transform.defaultErrorModeIgnore` feature gate to stable. The default top-level `error_mode` is now permanently `ignore` instead of `propagate`.
+
+issues: [47231]
+
+subtext: The gate will be removed in v0.159.0.
+
+change_logs: [user]

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	// Valid values are `ignore` and `propagate`.
 	// `ignore` means the processor ignores errors returned by statements and continues on to the next statement. This is the recommended mode.
 	// `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector.
-	// The default value is `ignore`, which can be changed back to `propagate` by disabling the `processor.transform.defaultErrorModeIgnore` feature gate.
+	// The default value is `ignore`.
 	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
 
 	TraceStatements   []common.ContextStatements `mapstructure:"trace_statements"`

--- a/processor/transformprocessor/documentation.md
+++ b/processor/transformprocessor/documentation.md
@@ -8,7 +8,7 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `processor.transform.defaultErrorModeIgnore` | beta | Changes the default error_mode of the transform processor from propagate to ignore | v0.150.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231) |
+| `processor.transform.defaultErrorModeIgnore` | stable | Changes the default error_mode of the transform processor from propagate to ignore | v0.150.0 | v0.159.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231) |
 | `transform.flatten.logs` | alpha | Flatten log data prior to transformation so every record has a unique copy of the resource and scope. Regroups logs based on resource and scope after transformations. | v0.103.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32080#issuecomment-2120764953) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -198,12 +198,8 @@ func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 }
 
 func (f *transformProcessorFactory) createDefaultConfig() component.Config {
-	defaultErrorMode := ottl.PropagateError
-	if metadata.ProcessorTransformDefaultErrorModeIgnoreFeatureGate.IsEnabled() {
-		defaultErrorMode = ottl.IgnoreError
-	}
 	return &Config{
-		ErrorMode:          defaultErrorMode,
+		ErrorMode:          ottl.IgnoreError,
 		TraceStatements:    []common.ContextStatements{},
 		MetricStatements:   []common.ContextStatements{},
 		LogStatements:      []common.ContextStatements{},

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -65,10 +64,6 @@ func TestFactory_Type(t *testing.T) {
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
-	t.Cleanup(func() {
-		_ = featuregate.GlobalRegistry().Set(metadata.ProcessorTransformDefaultErrorModeIgnoreFeatureGate.ID(), true)
-	})
-
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.EqualExportedValues(t, &Config{
@@ -80,12 +75,6 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	}, cfg)
 	assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
 	require.NoError(t, componenttest.CheckConfigStruct(cfg))
-
-	err := featuregate.GlobalRegistry().Set(metadata.ProcessorTransformDefaultErrorModeIgnoreFeatureGate.ID(), false)
-	require.NoError(t, err)
-
-	cfg = factory.CreateDefaultConfig()
-	assert.Equal(t, ottl.PropagateError, cfg.(*Config).ErrorMode)
 }
 
 func TestFactoryCreateProcessor_Empty(t *testing.T) {

--- a/processor/transformprocessor/internal/metadata/generated_feature_gates.go
+++ b/processor/transformprocessor/internal/metadata/generated_feature_gates.go
@@ -8,10 +8,11 @@ import (
 
 var ProcessorTransformDefaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"processor.transform.defaultErrorModeIgnore",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("Changes the default error_mode of the transform processor from propagate to ignore"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231"),
 	featuregate.WithRegisterFromVersion("v0.150.0"),
+	featuregate.WithRegisterToVersion("v0.159.0"),
 )
 
 var TransformFlattenLogsFeatureGate = featuregate.GlobalRegistry().MustRegister(

--- a/processor/transformprocessor/metadata.yaml
+++ b/processor/transformprocessor/metadata.yaml
@@ -16,8 +16,9 @@ status:
 feature_gates:
   - id: "processor.transform.defaultErrorModeIgnore"
     description: Changes the default error_mode of the transform processor from propagate to ignore
-    stage: beta
+    stage: stable
     from_version: v0.150.0
+    to_version: v0.159.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47231
 
   - id: "transform.flatten.logs"


### PR DESCRIPTION
#### Description
The `processor.transform.defaultErrorModeIgnore` feature gate is now stable (to be removed in v0.159.0). The default `error_mode` is permanently `ignore`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #47231

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
