### PR TITLE
[processor/filter] promote defaultErrorModeIgnore feature gate to stable

### DIFF
--- a/.chloggen/filter-default-error-mode-ignore-stable.yaml
+++ b/.chloggen/filter-default-error-mode-ignore-stable.yaml
@@ -1,0 +1,11 @@
+change_type: breaking
+
+component: processor/filter
+
+note: Promote the `processor.filter.defaultErrorModeIgnore` feature gate to stable. The default top-level `error_mode` is now permanently `ignore` instead of `propagate`.
+
+issues: [47232]
+
+subtext: The gate will be removed in v0.159.0.
+
+change_logs: [user]

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// Valid values are `ignore` and `propagate`.
 	// `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode.
 	// `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector.
-	// The default value is `ignore` when the `processor.filter.defaultErrorModeIgnore` feature gate is enabled (default), and `propagate` when disabled.
+	// The default value is `ignore`.
 	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
 
 	// Deprecated: use TraceConditions instead.

--- a/processor/filterprocessor/documentation.md
+++ b/processor/filterprocessor/documentation.md
@@ -44,6 +44,6 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `processor.filter.defaultErrorModeIgnore` | beta | Changes the default error_mode of the filter processor from propagate to ignore | v0.150.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232) |
+| `processor.filter.defaultErrorModeIgnore` | stable | Changes the default error_mode of the filter processor from propagate to ignore | v0.150.0 | v0.159.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -198,12 +198,8 @@ func NewFactoryWithOptions(options ...FactoryOption) processor.Factory {
 }
 
 func (f *filterProcessorFactory) createDefaultConfig() component.Config {
-	defaultErrorMode := ottl.PropagateError
-	if metadata.ProcessorFilterDefaultErrorModeIgnoreFeatureGate.IsEnabled() {
-		defaultErrorMode = ottl.IgnoreError
-	}
 	return &Config{
-		ErrorMode:          defaultErrorMode,
+		ErrorMode:          ottl.IgnoreError,
 		resourceFunctions:  f.resourceFunctions,
 		dataPointFunctions: f.dataPointFunctions,
 		logFunctions:       f.logFunctions,

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/processor/processortest"
 	"go.opentelemetry.io/collector/processor/xprocessor"
 
@@ -45,16 +44,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 	}, cfg)
 	assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
-
-	t.Cleanup(func() {
-		_ = featuregate.GlobalRegistry().Set(metadata.ProcessorFilterDefaultErrorModeIgnoreFeatureGate.ID(), true)
-	})
-
-	err := featuregate.GlobalRegistry().Set(metadata.ProcessorFilterDefaultErrorModeIgnoreFeatureGate.ID(), false)
-	require.NoError(t, err)
-
-	cfg = factory.CreateDefaultConfig()
-	assert.Equal(t, ottl.PropagateError, cfg.(*Config).ErrorMode)
 }
 
 func TestCreateProcessors(t *testing.T) {

--- a/processor/filterprocessor/generated_package_test.go
+++ b/processor/filterprocessor/generated_package_test.go
@@ -3,9 +3,8 @@
 package filterprocessor
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/filterprocessor/internal/metadata/generated_feature_gates.go
+++ b/processor/filterprocessor/internal/metadata/generated_feature_gates.go
@@ -8,8 +8,9 @@ import (
 
 var ProcessorFilterDefaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"processor.filter.defaultErrorModeIgnore",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("Changes the default error_mode of the filter processor from propagate to ignore"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232"),
 	featuregate.WithRegisterFromVersion("v0.150.0"),
+	featuregate.WithRegisterToVersion("v0.159.0"),
 )

--- a/processor/filterprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/filterprocessor/internal/metadata/generated_telemetry.go
@@ -6,9 +6,10 @@ import (
 	"errors"
 	"sync"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/collector/component"
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {

--- a/processor/filterprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/filterprocessor/internal/metadata/generated_telemetry_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/metric"
 	embeddedmetric "go.opentelemetry.io/otel/metric/embedded"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	embeddedtrace "go.opentelemetry.io/otel/trace/embedded"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 type mockMeter struct {

--- a/processor/filterprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/filterprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/metadata"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func TestSetupTelemetry(t *testing.T) {

--- a/processor/filterprocessor/metadata.yaml
+++ b/processor/filterprocessor/metadata.yaml
@@ -17,8 +17,9 @@ feature_gates:
   - id: processor.filter.defaultErrorModeIgnore
     description: >-
       Changes the default error_mode of the filter processor from propagate to ignore
-    stage: beta
+    stage: stable
     from_version: "v0.150.0"
+    to_version: "v0.159.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47232
 
 tests:


### PR DESCRIPTION
#### Description

The `processor.filter.defaultErrorModeIgnore` feature gate is now stable (to be removed in v0.159.0). The default `error_mode` is permanently `ignore`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #472132

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
