### PR TITLE
[connector/routing] promote defaultErrorModeIgnore feature gate to beta

### DIFF
--- a/.chloggen/routing-default-error-mode-ignore-beta.yaml
+++ b/.chloggen/routing-default-error-mode-ignore-beta.yaml
@@ -1,0 +1,11 @@
+change_type: breaking
+
+component: connector/routing
+
+note: Promote the `connector.routing.defaultErrorModeIgnore` feature gate to beta. The default `error_mode` is now `ignore` instead of `propagate`.
+
+issues: [48418]
+
+subtext: To restore the previous default of `propagate`, run the collector with the feature gate disabled by passing `--feature-gates=-connector.routing.defaultErrorModeIgnore`.
+
+change_logs: [user]

--- a/connector/routingconnector/README.md
+++ b/connector/routingconnector/README.md
@@ -42,7 +42,7 @@ The following settings are available:
   - `copy`: Matched data is copied to the target pipeline(s) but remains available for evaluation by subsequent routes. This allows the same data to be routed to multiple pipelines.
 - `table.pipelines (required)`: the list of pipelines to use when the routing condition is met.
 - `default_pipelines (optional)`: contains the list of pipelines to use when a record does not meet any of specified conditions.
-- `error_mode (optional)`: determines how errors returned from OTTL statements are handled. Valid values are `propagate`, `ignore` and `silent`. If `ignore` or `silent` is used and a statement's condition has an error then the payload will be routed to the default pipelines. When `silent` is used the error is not logged. If not supplied, `propagate` is used.
+- `error_mode (optional)`: determines how errors returned from OTTL statements are handled. Valid values are `propagate`, `ignore` and `silent`. If `ignore` or `silent` is used and a statement's condition has an error then the payload will be routed to the default pipelines. When `silent` is used the error is not logged. If not supplied, `ignore` is used.
 
 ### Context Inference
 

--- a/connector/routingconnector/config.go
+++ b/connector/routingconnector/config.go
@@ -38,8 +38,7 @@ type Config struct {
 	// condition has an error then the payload will be routed to the default exporter. `propagate`
 	// means the processor returns the error up the pipeline.  This will result in the payload being
 	// dropped from the collector.
-	// The default value is `propagate`, but when the `connector.routing.defaultErrorModeIgnore`
-	// feature gate is enabled, the default changes to `ignore`.
+	// The default value is `ignore` when the `connector.routing.defaultErrorModeIgnore` feature gate is enabled (default), and `propagate` when disabled.
 	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
 	// DefaultPipelines contains the list of pipelines to use when a more specific record can't be
 	// found in the routing table.

--- a/connector/routingconnector/config.schema.yaml
+++ b/connector/routingconnector/config.schema.yaml
@@ -31,7 +31,7 @@ properties:
     items:
       $ref: go.opentelemetry.io/collector/pipeline.id
   error_mode:
-    description: ErrorMode determines how the processor reacts to errors that occur while processing an OTTL condition. Valid values are `ignore` and `propagate`. `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode. If `ignore` is used and a statement's condition has an error then the payload will be routed to the default exporter. `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector. The default value is `propagate`, but when the `connector.routing.defaultErrorModeIgnore` feature gate is enabled, the default changes to `ignore`.
+    description: ErrorMode determines how the processor reacts to errors that occur while processing an OTTL condition. Valid values are `ignore` and `propagate`. `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode. If `ignore` is used and a statement's condition has an error then the payload will be routed to the default exporter. `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector. The default value is `ignore` when the `connector.routing.defaultErrorModeIgnore` feature gate is enabled (default), and `propagate` when disabled.
     $ref: /pkg/ottl.error_mode
   table:
     description: Table contains the routing table for this processor. Required.

--- a/connector/routingconnector/config_test.go
+++ b/connector/routingconnector/config_test.go
@@ -31,7 +31,7 @@ func TestLoadConfig(t *testing.T) {
 				DefaultPipelines: []pipeline.ID{
 					pipeline.NewIDWithName(pipeline.SignalTraces, "otlp-all"),
 				},
-				ErrorMode: ottl.PropagateError,
+				ErrorMode: ottl.IgnoreError,
 				Table: []RoutingTableItem{
 					{
 						Statement: `route() where attributes["X-Tenant"] == "acme"`,
@@ -56,7 +56,7 @@ func TestLoadConfig(t *testing.T) {
 				DefaultPipelines: []pipeline.ID{
 					pipeline.NewIDWithName(pipeline.SignalMetrics, "otlp-all"),
 				},
-				ErrorMode: ottl.PropagateError,
+				ErrorMode: ottl.IgnoreError,
 				Table: []RoutingTableItem{
 					{
 						Statement: `route() where attributes["X-Tenant"] == "acme"`,
@@ -81,7 +81,7 @@ func TestLoadConfig(t *testing.T) {
 				DefaultPipelines: []pipeline.ID{
 					pipeline.NewIDWithName(pipeline.SignalLogs, "otlp-all"),
 				},
-				ErrorMode: ottl.PropagateError,
+				ErrorMode: ottl.IgnoreError,
 				Table: []RoutingTableItem{
 					{
 						Statement: `route() where attributes["X-Tenant"] == "acme"`,

--- a/connector/routingconnector/documentation.md
+++ b/connector/routingconnector/documentation.md
@@ -8,6 +8,6 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `connector.routing.defaultErrorModeIgnore` | alpha | When enabled, the default error_mode is `ignore` instead of `propagate`. | v0.155.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48418) |
+| `connector.routing.defaultErrorModeIgnore` | beta | When enabled, the default error_mode is `ignore` instead of `propagate`. | v0.155.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48418) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/connector/routingconnector/factory_test.go
+++ b/connector/routingconnector/factory_test.go
@@ -65,34 +65,18 @@ func TestCreationFailsWithIncorrectConsumer(t *testing.T) {
 }
 
 func TestDefaultErrorModeWithFeatureGate(t *testing.T) {
-	tests := []struct {
-		name               string
-		featureGateEnabled bool
-		expectedErrorMode  ottl.ErrorMode
-	}{
-		{
-			name:               "feature gate disabled",
-			featureGateEnabled: false,
-			expectedErrorMode:  ottl.PropagateError,
-		},
-		{
-			name:               "feature gate enabled",
-			featureGateEnabled: true,
-			expectedErrorMode:  ottl.IgnoreError,
-		},
-	}
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			previousValue := metadata.ConnectorRoutingDefaultErrorModeIgnoreFeatureGate.IsEnabled()
-			require.NoError(t, featuregate.GlobalRegistry().Set(metadata.ConnectorRoutingDefaultErrorModeIgnoreFeatureGate.ID(), tt.featureGateEnabled))
-			defer func() {
-				require.NoError(t, featuregate.GlobalRegistry().Set(metadata.ConnectorRoutingDefaultErrorModeIgnoreFeatureGate.ID(), previousValue))
-			}()
+	assert.Equal(t, ottl.IgnoreError, cfg.(*Config).ErrorMode)
 
-			factory := NewFactory()
-			cfg := factory.CreateDefaultConfig().(*Config)
-			assert.Equal(t, tt.expectedErrorMode, cfg.ErrorMode)
-		})
-	}
+	t.Cleanup(func() {
+		_ = featuregate.GlobalRegistry().Set(metadata.ConnectorRoutingDefaultErrorModeIgnoreFeatureGate.ID(), true)
+	})
+
+	err := featuregate.GlobalRegistry().Set(metadata.ConnectorRoutingDefaultErrorModeIgnoreFeatureGate.ID(), false)
+	require.NoError(t, err)
+
+	cfg = factory.CreateDefaultConfig()
+	assert.Equal(t, ottl.PropagateError, cfg.(*Config).ErrorMode)
 }

--- a/connector/routingconnector/internal/metadata/generated_feature_gates.go
+++ b/connector/routingconnector/internal/metadata/generated_feature_gates.go
@@ -8,7 +8,7 @@ import (
 
 var ConnectorRoutingDefaultErrorModeIgnoreFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"connector.routing.defaultErrorModeIgnore",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, the default error_mode is `ignore` instead of `propagate`."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48418"),
 	featuregate.WithRegisterFromVersion("v0.155.0"),

--- a/connector/routingconnector/metadata.yaml
+++ b/connector/routingconnector/metadata.yaml
@@ -14,7 +14,7 @@ status:
 feature_gates:
   - id: connector.routing.defaultErrorModeIgnore
     description: When enabled, the default error_mode is `ignore` instead of `propagate`.
-    stage: alpha
+    stage: beta
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48418
 


### PR DESCRIPTION
#### Description

Promotes the `connector.routing.defaultErrorModeIgnore` feature gate from alpha to beta, making `ignore` the default `error_mode` for the routing connector. Users who need to restore the previous default can disable the gate with `--feature-gates=-connector.routing.defaultErrorModeIgnore`.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48418

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
