### PR TITLE
[receiver/tlscheck] Support relative certificate file paths and fix malformed error formatting

### DIFF
--- a/.chloggen/fix-tlscheck-relative-paths.yaml
+++ b/.chloggen/fix-tlscheck-relative-paths.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: receiver/tls_check
+note: Support relative certificate file paths and fix malformed validation error output
+issues: [49684]
+change_logs: [user]

--- a/receiver/tlscheckreceiver/scraper.go
+++ b/receiver/tlscheckreceiver/scraper.go
@@ -87,7 +87,7 @@ func validateEndpoint(endpoint string) error {
 func validateFilepath(filePath string) error {
 	cleanPath := filepath.Clean(filePath)
 	fileInfo, err := os.Stat(cleanPath)
-	if err != nil || !filepath.IsAbs(cleanPath) {
+	if err != nil {
 		return fmt.Errorf("error accessing certificate file %s: %w", filePath, err)
 	}
 	if fileInfo.IsDir() {

--- a/receiver/tlscheckreceiver/scraper_test.go
+++ b/receiver/tlscheckreceiver/scraper_test.go
@@ -688,6 +688,14 @@ func TestValidateFilepath(t *testing.T) {
 	// Create a temporary directory for testing
 	tmpDir := t.TempDir()
 
+	// Create a relative file in the current working directory for testing relative paths
+	relFile, err := os.CreateTemp(".", "test-rel-cert-*.pem")
+	require.NoError(t, err)
+	relFile.Close()
+	t.Cleanup(func() {
+		_ = os.Remove(relFile.Name())
+	})
+
 	testCases := []struct {
 		desc        string
 		filePath    string
@@ -700,7 +708,12 @@ func TestValidateFilepath(t *testing.T) {
 		},
 		{
 			desc:        "relative file path",
-			filePath:    "cert.pem",
+			filePath:    relFile.Name(),
+			expectedErr: "",
+		},
+		{
+			desc:        "relative file path not found",
+			filePath:    "nonexistent-relative-file-name.pem",
 			expectedErr: "error accessing certificate file",
 		},
 		{


### PR DESCRIPTION
#### Description
Allows `tlscheckreceiver` (registered as `tls_check`) to monitor certificate files using relative paths (e.g. `cert.pem`), resolving them relative to the collector's current working directory. 

Previously, `validateFilepath` explicitly checked `!filepath.IsAbs(cleanPath)` and rejected any relative paths during scrape, logging a validation error and incrementing scraper error metrics. In addition, when it did so for an existing file, it formatted `err` (which was `nil` from `os.Stat`), resulting in a malformed error message containing `%!w(<nil>)`.

This change removes the absolute path restriction, allowing both absolute and relative certificate paths, and ensures that errors are only wrapped when they are non-nil.

#### Link to tracking issue
Fixes #49684

#### Testing
- Updated unit test `TestValidateFilepath` in `receiver/tlscheckreceiver/scraper_test.go` to test relative paths by creating a temporary relative file in the current working directory (`.`).
- Replaced the failing `"relative file path"` test expectation with an expectation of success (`expectedErr: ""`).
- Added a new test case `"relative file path not found"` to verify that nonexistent relative file paths still fail with the appropriate error.
- Ran all unit tests in the package: `go test -v ./...` (all passed).

#### Documentation
No user-facing documentation change is required, as the existing documentation already describes using paths without restricting them to absolute paths.
