### PR TITLE
[pkg/ottl] Slice standardization step2

### DIFF
--- a/.chloggen/enhancement_ottlfuncs-standarlization.yaml
+++ b/.chloggen/enhancement_ottlfuncs-standarlization.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Standardizing OTTL functions to expect, use, and return standard pdata slice type `pcommon.Slice`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47230]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Please note that *only* the following functions got affected by this change:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/enhancement_ottlfuncs-standarlization.yaml
+++ b/.chloggen/enhancement_ottlfuncs-standarlization.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: pkg/ottl
@@ -15,7 +15,7 @@ issues: [47230]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Please note that *only* the following functions got affected by this change:
+subtext: "Please note that *only* the following functions got affected by this change: Sort Converter, Split Converter."
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
@@ -24,4 +24,4 @@ subtext: Please note that *only* the following functions got affected by this ch
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user]
+change_logs: [api]

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
@@ -485,7 +485,7 @@ func accessExplicitBounds[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
-				return histogramDataPoint.ExplicitBounds().AsRaw(), nil
+				return histogramDataPoint.ExplicitBounds(), nil
 			}
 			return nil, nil
 		},
@@ -503,7 +503,7 @@ func accessBucketCounts[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
-				return histogramDataPoint.BucketCounts().AsRaw(), nil
+				return histogramDataPoint.BucketCounts(), nil
 			}
 			return nil, nil
 		},
@@ -613,7 +613,7 @@ func accessPositiveBucketCounts[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return expoHistogramDataPoint.Positive().BucketCounts().AsRaw(), nil
+				return expoHistogramDataPoint.Positive().BucketCounts(), nil
 			}
 			return nil, nil
 		},
@@ -677,7 +677,7 @@ func accessNegativeBucketCounts[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
-				return expoHistogramDataPoint.Negative().BucketCounts().AsRaw(), nil
+				return expoHistogramDataPoint.Negative().BucketCounts(), nil
 			}
 			return nil, nil
 		},

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -584,7 +584,12 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: &pathtest.Path[*testContext]{
 				N: "bucket_counts",
 			},
-			orig:   []uint64{1, 1},
+			orig: func() pcommon.UInt64Slice {
+				ps := pcommon.NewUInt64Slice()
+				ps.Append(1)
+				ps.Append(1)
+				return ps
+			}(),
 			newVal: []uint64{1, 2},
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				datapoint.BucketCounts().FromRaw([]uint64{1, 2})
@@ -595,7 +600,12 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: &pathtest.Path[*testContext]{
 				N: "explicit_bounds",
 			},
-			orig:   []float64{1, 2},
+			orig: func() pcommon.Float64Slice {
+				ps := pcommon.NewFloat64Slice()
+				ps.Append(1)
+				ps.Append(2)
+				return ps
+			}(),
 			newVal: []float64{1, 2, 3},
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				datapoint.ExplicitBounds().FromRaw([]float64{1, 2, 3})
@@ -1121,7 +1131,12 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 					N: "bucket_counts",
 				},
 			},
-			orig:   []uint64{1, 1},
+			orig: func() pcommon.UInt64Slice {
+				ps := pcommon.NewUInt64Slice()
+				ps.Append(1)
+				ps.Append(1)
+				return ps
+			}(),
 			newVal: []uint64{0, 1, 2},
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
 				datapoint.Positive().BucketCounts().FromRaw([]uint64{0, 1, 2})
@@ -1160,7 +1175,12 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 					N: "bucket_counts",
 				},
 			},
-			orig:   []uint64{1, 1},
+			orig: func() pcommon.UInt64Slice {
+				ps := pcommon.NewUInt64Slice()
+				ps.Append(1)
+				ps.Append(1)
+				return ps
+			}(),
 			newVal: []uint64{0, 1, 2},
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
 				datapoint.Negative().BucketCounts().FromRaw([]uint64{0, 1, 2})

--- a/pkg/ottl/contexts/internal/ctxutil/slice.go
+++ b/pkg/ottl/contexts/internal/ctxutil/slice.go
@@ -161,6 +161,7 @@ func SetCommonTypedSliceValues[V any](s CommonTypedSlice[V], val any) error {
 	return nil
 }
 
+// GetCommonIntSliceValues is Depricated. The standard OTTL type for integer slices has changed to pcommon.Int64Slice.
 // GetCommonIntSliceValues converts a pdata typed slice of [constraints.Integer] into
 // []int64, which is the standard OTTL type for integer slices.
 func GetCommonIntSliceValues[V constraints.Integer](val CommonTypedSlice[V]) []int64 {

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -647,7 +647,12 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: &pathtest.Path[*TransformContext]{
 				N: "bucket_counts",
 			},
-			orig:   []uint64{1, 1},
+			orig: func() pcommon.UInt64Slice {
+				ps := pcommon.NewUInt64Slice()
+				ps.Append(1)
+				ps.Append(1)
+				return ps
+			}(),
 			newVal: []uint64{1, 2},
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				datapoint.BucketCounts().FromRaw([]uint64{1, 2})
@@ -658,7 +663,12 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: &pathtest.Path[*TransformContext]{
 				N: "explicit_bounds",
 			},
-			orig:   []float64{1, 2},
+			orig: func() pcommon.Float64Slice {
+				ps := pcommon.NewFloat64Slice()
+				ps.Append(1)
+				ps.Append(2)
+				return ps
+			}(),
 			newVal: []float64{1, 2, 3},
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				datapoint.ExplicitBounds().FromRaw([]float64{1, 2, 3})
@@ -1151,7 +1161,12 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 					N: "bucket_counts",
 				},
 			},
-			orig:   []uint64{1, 1},
+			orig: func() pcommon.UInt64Slice {
+				ps := pcommon.NewUInt64Slice()
+				ps.Append(1)
+				ps.Append(1)
+				return ps
+			}(),
 			newVal: []uint64{0, 1, 2},
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
 				datapoint.Positive().BucketCounts().FromRaw([]uint64{0, 1, 2})
@@ -1190,7 +1205,12 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 					N: "bucket_counts",
 				},
 			},
-			orig:   []uint64{1, 1},
+			orig: func() pcommon.UInt64Slice {
+				ps := pcommon.NewUInt64Slice()
+				ps.Append(1)
+				ps.Append(1)
+				return ps
+			}(),
 			newVal: []uint64{0, 1, 2},
 			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
 				datapoint.Negative().BucketCounts().FromRaw([]uint64{0, 1, 2})

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2546,7 +2546,7 @@ Examples:
 
 ```Split(target, delimiter)```
 
-The `Split` Converter separates a string by the delimiter, and returns an array of substrings.
+The `Split` Converter separates a string by the delimiter, and returns an `pcommon.Slice` of substrings.
 
 `target` is a string. `delimiter` is a string.
 

--- a/pkg/ottl/ottlfuncs/func_sort.go
+++ b/pkg/ottl/ottlfuncs/func_sort.go
@@ -75,13 +75,13 @@ func sort[K any](target ottl.Getter[K], order string) ottl.ExprFunc[K] {
 			return sortSlice(slice, order)
 		case []string:
 			dup := makeCopy(v)
-			return sortTypedSlice(dup, order), nil
+			return sortTypedSlice(dup, order)
 		case []int64:
 			dup := makeCopy(v)
-			return sortTypedSlice(dup, order), nil
+			return sortTypedSlice(dup, order)
 		case []float64:
 			dup := makeCopy(v)
-			return sortTypedSlice(dup, order), nil
+			return sortTypedSlice(dup, order)
 		case []bool:
 			var strings []string
 			for _, b := range v {
@@ -90,12 +90,14 @@ func sort[K any](target ottl.Getter[K], order string) ottl.ExprFunc[K] {
 
 			sortTypedSlice(strings, order)
 
-			bools := make([]bool, len(strings))
-			for i, s := range strings {
+			pSBools := pcommon.NewSlice()
+			pSBools.EnsureCapacity(len(strings))
+
+			for _, s := range strings {
 				boolValue, _ := strconv.ParseBool(s)
-				bools[i] = boolValue
+				pSBools.AppendEmpty().SetBool(boolValue)
 			}
-			return bools, nil
+			return pSBools, nil
 		default:
 			return nil, fmt.Errorf("sort with unsupported type: '%T'. Target is not a list", v)
 		}
@@ -109,7 +111,7 @@ func sort[K any](target ottl.Getter[K], order string) ottl.ExprFunc[K] {
 //   - order: The sort order. "asc" for ascending, "desc" for descending
 //
 // Returns:
-//   - A sorted slice as []any or the original pcommon.Slice
+//   - A sorted slice the original pcommon.Slice
 //   - An error if an unsupported type is encountered
 func sortSlice(slice pcommon.Slice, order string) (any, error) {
 	length := slice.Len()
@@ -127,7 +129,7 @@ func sortSlice(slice pcommon.Slice, order string) (any, error) {
 		arr := makeConvertedCopy(slice, func(idx int) int64 {
 			return slice.At(idx).Int()
 		})
-		return sortConvertedSlice(arr, order), nil
+		return sortConvertedSlice(arr, order)
 	case pcommon.ValueTypeDouble:
 		arr := makeConvertedCopy(slice, func(idx int) float64 {
 			s := slice.At(idx)
@@ -137,12 +139,12 @@ func sortSlice(slice pcommon.Slice, order string) (any, error) {
 
 			return s.Double()
 		})
-		return sortConvertedSlice(arr, order), nil
+		return sortConvertedSlice(arr, order)
 	case pcommon.ValueTypeStr:
 		arr := makeConvertedCopy(slice, func(idx int) string {
 			return slice.At(idx).AsString()
 		})
-		return sortConvertedSlice(arr, order), nil
+		return sortConvertedSlice(arr, order)
 	default:
 		return nil, fmt.Errorf("sort with unsupported type: '%T'", commonType)
 	}
@@ -204,9 +206,9 @@ func makeCopy[T targetType](src []T) []T {
 	return dup
 }
 
-func sortTypedSlice[T targetType](arr []T, order string) []T {
+func sortTypedSlice[T targetType](arr []T, order string) (pcommon.Slice, error) {
 	if len(arr) == 0 {
-		return arr
+		return pcommon.Slice{}, nil
 	}
 
 	slices.SortFunc(arr, func(a, b T) int {
@@ -216,7 +218,15 @@ func sortTypedSlice[T targetType](arr []T, order string) []T {
 		return cmp.Compare(a, b)
 	})
 
-	return arr
+	pSlice := pcommon.NewSlice()
+	pSlice.EnsureCapacity(len(arr))
+	for _, val := range arr {
+		err := pSlice.AppendEmpty().FromRaw(val)
+		if err != nil {
+			return pcommon.Slice{}, fmt.Errorf("failed to sort slice: %w", err)
+		}
+	}
+	return pSlice, nil
 }
 
 type convertedValue[T targetType] struct {
@@ -241,7 +251,7 @@ func makeConvertedCopy[T targetType](slice pcommon.Slice, converter func(idx int
 	return out
 }
 
-func sortConvertedSlice[T targetType](cvs []convertedValue[T], order string) []any {
+func sortConvertedSlice[T targetType](cvs []convertedValue[T], order string) (pcommon.Slice, error) {
 	slices.SortFunc(cvs, func(a, b convertedValue[T]) int {
 		if order == sortDesc {
 			return cmp.Compare(b.value, a.value)
@@ -249,10 +259,15 @@ func sortConvertedSlice[T targetType](cvs []convertedValue[T], order string) []a
 		return cmp.Compare(a.value, b.value)
 	})
 
-	out := make([]any, 0, len(cvs))
+	out := pcommon.NewSlice()
+	out.EnsureCapacity(len(cvs))
+
 	for _, cv := range cvs {
-		out = append(out, cv.originalValue)
+		err := out.AppendEmpty().FromRaw(cv.originalValue)
+		if err != nil {
+			return pcommon.Slice{}, fmt.Errorf("failed to convert value: '%w'", err)
+		}
 	}
 
-	return out
+	return out, nil
 }

--- a/pkg/ottl/ottlfuncs/func_sort.go
+++ b/pkg/ottl/ottlfuncs/func_sort.go
@@ -88,7 +88,10 @@ func sort[K any](target ottl.Getter[K], order string) ottl.ExprFunc[K] {
 				strings = append(strings, strconv.FormatBool(b))
 			}
 
-			sortTypedSlice(strings, order)
+			_, err := sortTypedSlice(strings, order)
+			if err != nil {
+				return nil, err
+			}
 
 			pSBools := pcommon.NewSlice()
 			pSBools.EnsureCapacity(len(strings))

--- a/pkg/ottl/ottlfuncs/func_sort_test.go
+++ b/pkg/ottl/ottlfuncs/func_sort_test.go
@@ -35,8 +35,14 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{int64(3), int64(6), int64(9)},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(3)
+				s.AppendEmpty().SetInt(6)
+				s.AppendEmpty().SetInt(9)
+				return s
+			}(),
 		},
 		{
 			name: "int slice desc",
@@ -47,8 +53,14 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortDesc,
-			expected: []any{int64(9), int64(6), int64(3)},
+			order: sortDesc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(9)
+				s.AppendEmpty().SetInt(6)
+				s.AppendEmpty().SetInt(3)
+				return s
+			}(),
 		},
 		{
 			name: "string slice",
@@ -59,8 +71,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{"am", "awesome", "i", "slice"},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("am")
+				s.AppendEmpty().SetStr("awesome")
+				s.AppendEmpty().SetStr("i")
+				s.AppendEmpty().SetStr("slice")
+				return s
+			}(),
 		},
 		{
 			name: "double slice",
@@ -71,8 +90,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{0.5, 1.5, 2.3, 10.2},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetDouble(0.5)
+				s.AppendEmpty().SetDouble(1.5)
+				s.AppendEmpty().SetDouble(2.3)
+				s.AppendEmpty().SetDouble(10.2)
+				return s
+			}(),
 		},
 		{
 			name: "empty slice",
@@ -94,8 +120,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{false, false, true, true},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetBool(false)
+				s.AppendEmpty().SetBool(false)
+				s.AppendEmpty().SetBool(true)
+				s.AppendEmpty().SetBool(true)
+				return s
+			}(),
 		},
 		{
 			name: "mixed types slice compares as string",
@@ -106,8 +139,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{int64(1), 3.33, false, "two"},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(1)
+				s.AppendEmpty().SetDouble(3.33)
+				s.AppendEmpty().SetBool(false)
+				s.AppendEmpty().SetStr("two")
+				return s
+			}(),
 		},
 		{
 			name: "double and string slice compares as string",
@@ -118,8 +158,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{0.5, 1.5, "10.2", 2.3},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetDouble(0.5)
+				s.AppendEmpty().SetDouble(1.5)
+				s.AppendEmpty().SetStr("10.2")
+				s.AppendEmpty().SetDouble(2.3)
+				return s
+			}(),
 		},
 		{
 			name: "mixed numeric types slice compares as double",
@@ -130,8 +177,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{int64(0), int64(0), int64(2), 3.33},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(0)
+				s.AppendEmpty().SetInt(0)
+				s.AppendEmpty().SetInt(2)
+				s.AppendEmpty().SetDouble(3.33)
+				return s
+			}(),
 		},
 		{
 			name: "mixed numeric types slice compares as double desc",
@@ -142,8 +196,15 @@ func Test_Sort(t *testing.T) {
 					return s, nil
 				},
 			},
-			order:    sortDesc,
-			expected: []any{3.33, 3.14, int64(2), int64(0)},
+			order: sortDesc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetDouble(3.33)
+				s.AppendEmpty().SetDouble(3.14)
+				s.AppendEmpty().SetInt(2)
+				s.AppendEmpty().SetInt(0)
+				return s
+			}(),
 		},
 		{
 			name: "[]any compares as string",
@@ -152,8 +213,15 @@ func Test_Sort(t *testing.T) {
 					return []any{1, "two", 3.33, false}, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{int64(1), 3.33, false, "two"},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(1)
+				s.AppendEmpty().SetDouble(3.33)
+				s.AppendEmpty().SetBool(false)
+				s.AppendEmpty().SetStr("two")
+				return s
+			}(),
 		},
 		{
 			name: "[]string",
@@ -162,8 +230,14 @@ func Test_Sort(t *testing.T) {
 					return []string{"A", "a", "aa"}, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []string{"A", "a", "aa"},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("A")
+				s.AppendEmpty().SetStr("a")
+				s.AppendEmpty().SetStr("aa")
+				return s
+			}(),
 		},
 		{
 			name: "[]bool compares as string",
@@ -172,8 +246,13 @@ func Test_Sort(t *testing.T) {
 					return []bool{true, false}, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []bool{false, true},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetBool(false)
+				s.AppendEmpty().SetBool(true)
+				return s
+			}(),
 		},
 		{
 			name: "[]int64",
@@ -182,8 +261,14 @@ func Test_Sort(t *testing.T) {
 					return []int64{6, 3, 9}, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []int64{3, 6, 9},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetInt(3)
+				s.AppendEmpty().SetInt(6)
+				s.AppendEmpty().SetInt(9)
+				return s
+			}(),
 		},
 		{
 			name: "[]float64",
@@ -192,8 +277,15 @@ func Test_Sort(t *testing.T) {
 					return []float64{1.5, 10.2, 2.3, 0.5}, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []float64{0.5, 1.5, 2.3, 10.2},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetDouble(0.5)
+				s.AppendEmpty().SetDouble(1.5)
+				s.AppendEmpty().SetDouble(2.3)
+				s.AppendEmpty().SetDouble(10.2)
+				return s
+			}(),
 		},
 		{
 			name: "pcommon.Value is a slice",
@@ -205,8 +297,14 @@ func Test_Sort(t *testing.T) {
 					return pv, nil
 				},
 			},
-			order:    sortAsc,
-			expected: []any{"a", "a", "slice"},
+			order: sortAsc,
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("a")
+				s.AppendEmpty().SetStr("a")
+				s.AppendEmpty().SetStr("slice")
+				return s
+			}(),
 		},
 		{
 			name: "pcommon.Value is empty",

--- a/pkg/ottl/ottlfuncs/func_split.go
+++ b/pkg/ottl/ottlfuncs/func_split.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 type SplitArguments[K any] struct {

--- a/pkg/ottl/ottlfuncs/func_split.go
+++ b/pkg/ottl/ottlfuncs/func_split.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 type SplitArguments[K any] struct {
@@ -40,6 +41,14 @@ func split[K any](target, delimiter ottl.StringGetter[K]) ottl.ExprFunc[K] {
 		if err != nil {
 			return nil, err
 		}
-		return strings.Split(val, delimiterVal), nil
+		res := strings.Split(val, delimiterVal)
+
+		resPSlice := pcommon.NewSlice()
+		resPSlice.EnsureCapacity(len(res))
+
+		for _, s := range res {
+			resPSlice.AppendEmpty().SetStr(s)
+		}
+		return resPSlice, nil
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -18,7 +19,7 @@ func Test_split(t *testing.T) {
 		name      string
 		target    ottl.StringGetter[any]
 		delimiter ottl.StringGetter[any]
-		expected  any
+		expected  pcommon.Slice
 	}{
 		{
 			name: "split string",
@@ -32,7 +33,13 @@ func Test_split(t *testing.T) {
 					return "|", nil
 				},
 			},
-			expected: []string{"A", "B", "C"},
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("A")
+				s.AppendEmpty().SetStr("B")
+				s.AppendEmpty().SetStr("C")
+				return s
+			}(),
 		},
 		{
 			name: "split empty string",
@@ -46,7 +53,11 @@ func Test_split(t *testing.T) {
 					return "|", nil
 				},
 			},
-			expected: []string{""},
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("")
+				return s
+			}(),
 		},
 		{
 			name: "split empty delimiter",
@@ -60,7 +71,15 @@ func Test_split(t *testing.T) {
 					return "", nil
 				},
 			},
-			expected: []string{"A", "|", "B", "|", "C"},
+			expected: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.AppendEmpty().SetStr("A")
+				s.AppendEmpty().SetStr("|")
+				s.AppendEmpty().SetStr("B")
+				s.AppendEmpty().SetStr("|")
+				s.AppendEmpty().SetStr("C")
+				return s
+			}(),
 		},
 		{
 			name: "split empty string and empty delimiter",
@@ -74,7 +93,7 @@ func Test_split(t *testing.T) {
 					return "", nil
 				},
 			},
-			expected: []string{},
+			expected: pcommon.NewSlice(),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### Description
Continuing the effort of standardizing raw go slices to `pcommon.Slice` started at #47985 this part standardizing contexts and ottl functions that still returning raw go slices

**Note:** Please note this is independent PR. It's not blocked by the status of Step1.

#### Link to tracking issue
Fixes #47230

#### Testing
refactored existing unittests to match the new refactored logic. no new tests was introduced.

#### Documentation
modified some APIs documentation as well as README.md to reflect the new return slice format.

#### Authorship
- [x] I, a human, wrote this pull request description myself.