### PR TITLE
[chore][processor/transform/internal/logparsingfuncs] Add benchmark test for ParseCLF

### DIFF
--- a/processor/transformprocessor/internal/logparsingfuncs/func_parse_clf_test.go
+++ b/processor/transformprocessor/internal/logparsingfuncs/func_parse_clf_test.go
@@ -540,3 +540,34 @@ func assertCLFMap(t *testing.T, m pcommon.Map, expected map[string]any) {
 		}
 	}
 }
+
+// benchCLFMessage and benchCombinedMessage are representative Apache access
+// log entries in Common Log Format and NCSA Combined Log Format.
+const benchCLFMessage = `172.224.24.114 - frank [15/Jul/2026:00:00:01 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326`
+
+const benchCombinedMessage = benchCLFMessage +
+	` "https://example.com/start.html?q=otel+collector" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"`
+
+func benchmarkParseCLF(b *testing.B, message, format string) {
+	ctx := b.Context()
+	b.ReportAllocs()
+
+	exprFunc := parseCLF(ottl.StandardStringGetter[*ottllog.TransformContext]{
+		Getter: func(context.Context, *ottllog.TransformContext) (any, error) {
+			return message, nil
+		},
+	}, format)
+
+	for b.Loop() {
+		_, err := exprFunc(ctx, &ottllog.TransformContext{})
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkParseCLF(b *testing.B) {
+	benchmarkParseCLF(b, benchCLFMessage, clfFormatCLF)
+}
+
+func BenchmarkParseCLFCombined(b *testing.B) {
+	benchmarkParseCLF(b, benchCombinedMessage, clfFormatCombined)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
<!--Describe what testing was performed and which tests were added.-->
#### Testing
Adds a benchmark test to the `ParseCLF` function testing suite to compare any future changes against

Current baseline: 
BenchmarkParseCLF-18:
~1,335 ns/op   1,873 B/op   22 allocs/op
BenchmarkParseCLFCombined-18:
~2,860 ns/op   1,969 B/op   24 allocs/op

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
