### PR TITLE
[chore][exporter/clickhouse] Document read-path considerations for querying a shared table by a high-cardinality resource attribute

### DIFF
--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -322,6 +322,22 @@ add more clickhouse node to cluster can increase linearly.
 The otel-collector with `otlp receiver/clickhouse tcp exporter` (with `sending_queue` batching enabled) can process
 around 40k/s logs entry per CPU cores, add more collector node can increase linearly.
 
+### Reading a shared table by a resource attribute
+
+The default schemas order primarily by time and `ServiceName`, and store resource-level
+labels (for example a `tenant` or `namespace` attribute) in the `ResourceAttributes` map
+rather than in the sort key. A skip index on the map values lets a query that filters on a
+single attribute value prune granules, but because every value shares the same
+time-partitioned parts, a wide time-range read filtered to one value still scans granules
+that also contain other values' rows — the filter is applied after the granule is read.
+
+For a low-cardinality attribute this is negligible. If you query a shared table by a
+*high-cardinality* attribute (for example one tenant out of hundreds or thousands, each
+reading concurrently), that shared-parts scan can become the read bottleneck. In that case,
+set [`create_schema: false`](#schema-management) and manage the DDL yourself so the
+attribute participates in the primary key — for example by adding it early in `ORDER BY` or
+via a projection — accepting that this diverges from the default schema.
+
 ## Configuration options
 
 The following settings are required:


### PR DESCRIPTION
#### Description

Adds a short subsection to the ClickHouse exporter's Performance Guide about reading a shared table filtered by a resource attribute.

The default schemas order primarily by time and `ServiceName` and keep resource-level labels (e.g. a `tenant`/`namespace` attribute) in the `ResourceAttributes` map, reachable via a skip index but not the sort key. So a query that filters a shared table to a single attribute value can prune granules via the skip index, but a wide time-range read still scans granules that hold other values' rows, since they share the same time-partitioned parts. For a low-cardinality attribute this is negligible; for a high-cardinality one (e.g. one tenant out of many, read concurrently) the shared-parts scan can become the read bottleneck, in which case `create_schema: false` + a tenant-aware DDL is the lever.

This documents an existing property of the default schema — no code or schema change. It came out of a discussion with a user running the stock `clickhouseexporter` in a multi-tenant setup (perses/otelhouse); documenting the trade-off so others with that access pattern find it.

#### Link to tracking issue

None — documentation only.

#### Testing

Docs only.

#### Documentation

This PR is the documentation.
