### PR TITLE
implement informer based observer

### DIFF
--- a/.chloggen/k8sobject_informer-based-observer.yaml
+++ b/.chloggen/k8sobject_informer-based-observer.yaml
@@ -10,7 +10,7 @@ component: internal/k8sinventory
 note: Add informer-based observer implementation
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [49695]
+issues: [43602]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/k8sobject_informer-based-observer.yaml
+++ b/.chloggen/k8sobject_informer-based-observer.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: internal/k8sinventory
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add informer-based observer implementation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49695]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/k8sinventory/go.mod
+++ b/internal/k8sinventory/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -109,7 +109,7 @@ func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, hand
 		exclude:          config.Exclude,
 		logger:           logger,
 	}
-	if config.StorageClient != nil && config.IncludeInitialState {
+	if config.StorageClient != nil {
 		o.cp = checkpoint.New(config.StorageClient, logger)
 	}
 	for _, nf := range factories {

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -48,6 +48,7 @@ type namespacedFactory struct {
 // Observer uses SharedInformerFactories to watch or pull Kubernetes objects.
 type Observer struct {
 	infs             map[namespacedFactory]cache.SharedIndexInformer
+	handlerRegs      map[namespacedFactory]cache.ResourceEventHandlerRegistration
 	base             k8sinventory.Config
 	cacheSyncTimeout time.Duration
 	// Shared stop channel from the registry; closing it stops every observer at once.
@@ -100,6 +101,7 @@ func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, hand
 	}
 	o := &Observer{
 		infs:             make(map[namespacedFactory]cache.SharedIndexInformer, len(factories)),
+		handlerRegs:      make(map[namespacedFactory]cache.ResourceEventHandlerRegistration, len(factories)),
 		base:             config.Config,
 		cacheSyncTimeout: config.CacheSyncTimeout,
 		stopCh:           reg.StopCh(),
@@ -113,9 +115,11 @@ func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, hand
 	for _, nf := range factories {
 		inf := nf.factory.ForResource(config.Gvr).Informer()
 		o.infs[nf] = inf
-		if _, err := inf.AddEventHandler(o.buildEventHandler(!config.IncludeInitialState, nf.namespace)); err != nil {
+		handle, err := inf.AddEventHandler(o.buildEventHandler(!config.IncludeInitialState, nf.namespace))
+		if err != nil {
 			return nil, fmt.Errorf("failed to add event handler for %s: %w", config.Gvr.String(), err)
 		}
+		o.handlerRegs[nf] = handle
 	}
 	return o, nil
 }
@@ -187,6 +191,12 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 
 	stopCh := make(chan struct{})
 
+	// Informers keep running under the registry stopCh; unsubscribe our handlers when the observer stops.
+	if len(o.handlerRegs) > 0 {
+		wg.Add(1)
+		go o.runHandlerRemover(ctx, stopCh, wg)
+	}
+
 	if o.cp != nil {
 		wg.Add(1)
 		go o.runCheckpointFlusher(ctx, stopCh, wg)
@@ -229,6 +239,25 @@ func (o *Observer) waitForCacheSync(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// runHandlerRemover unsubscribes this observer's ResourceEventHandlers on any
+// stop signal. An in-flight callback may complete after removal.
+func (o *Observer) runHandlerRemover(ctx context.Context, stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	select {
+	case <-stopCh:
+	case <-ctx.Done():
+	case <-o.stopCh:
+	}
+	for nf, handle := range o.handlerRegs {
+		if err := o.infs[nf].RemoveEventHandler(handle); err != nil {
+			o.logger.Warn("failed to remove event handler",
+				zap.String("namespace", nf.namespace),
+				zap.String("gvr", o.base.Gvr.String()),
+				zap.Error(err))
+		}
+	}
 }
 
 func (o *Observer) buildEventHandler(skipInitialList bool, namespace string) cache.ResourceEventHandler {

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -1,0 +1,340 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package informer // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory/informer"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiWatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory/checkpoint"
+)
+
+const checkpointFlushInterval = 5 * time.Second
+
+// PullConfig configures an informer-based pull observer.
+type PullConfig struct {
+	k8sinventory.Config
+	Interval         time.Duration
+	CacheSyncTimeout time.Duration
+}
+
+// WatchConfig configures an informer-based watch observer.
+type WatchConfig struct {
+	k8sinventory.Config
+	IncludeInitialState bool
+	Exclude             map[apiWatch.EventType]bool
+	CacheSyncTimeout    time.Duration
+	StorageClient       storage.Client
+}
+
+// namespacedFactory pairs a factory with its namespace (empty = cluster-wide).
+type namespacedFactory struct {
+	namespace string
+	factory   dynamicinformer.DynamicSharedInformerFactory
+}
+
+// Observer uses SharedInformerFactories to watch or pull Kubernetes objects.
+type Observer struct {
+	infs             map[namespacedFactory]cache.SharedIndexInformer
+	base             k8sinventory.Config
+	cacheSyncTimeout time.Duration
+	// Shared stop channel from the registry; closing it stops every observer at once.
+	stopCh <-chan struct{}
+	// pull-only
+	pullHandler func(*unstructured.UnstructuredList)
+	interval    time.Duration
+	// watch-only
+	watchHandler func(*apiWatch.Event)
+	exclude      map[apiWatch.EventType]bool
+	cp           *checkpoint.Checkpointer
+	logger       *zap.Logger
+}
+
+// NewPull creates a pull-mode observer.
+func NewPull(reg *FactoryRegistry, config PullConfig, logger *zap.Logger, handler func(*unstructured.UnstructuredList)) (*Observer, error) {
+	return pull(reg, factoriesForConfig(reg, config.Config), config, logger, handler)
+}
+
+// NewWatch creates a watch-mode observer.
+func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, handler func(*apiWatch.Event)) (*Observer, error) {
+	return watch(reg, factoriesForConfig(reg, config.Config), config, logger, handler)
+}
+
+func pull(reg *FactoryRegistry, factories []namespacedFactory, config PullConfig, logger *zap.Logger, handler func(*unstructured.UnstructuredList)) (*Observer, error) {
+	if len(factories) == 0 {
+		return nil, errors.New("at least one factory is required")
+	}
+	o := &Observer{
+		infs:             make(map[namespacedFactory]cache.SharedIndexInformer, len(factories)),
+		base:             config.Config,
+		cacheSyncTimeout: config.CacheSyncTimeout,
+		stopCh:           reg.StopCh(),
+		pullHandler:      handler,
+		interval:         config.Interval,
+		logger:           logger,
+	}
+	for _, nf := range factories {
+		o.infs[nf] = nf.factory.ForResource(config.Gvr).Informer()
+	}
+	return o, nil
+}
+
+func watch(reg *FactoryRegistry, factories []namespacedFactory, config WatchConfig, logger *zap.Logger, handler func(*apiWatch.Event)) (*Observer, error) {
+	if len(factories) == 0 {
+		return nil, errors.New("at least one factory is required")
+	}
+	if config.Exclude[apiWatch.Bookmark] {
+		logger.Warn("exclude_watch_type: BOOKMARK has no effect with informer-based watching; informers never surface BOOKMARK events")
+	}
+	o := &Observer{
+		infs:             make(map[namespacedFactory]cache.SharedIndexInformer, len(factories)),
+		base:             config.Config,
+		cacheSyncTimeout: config.CacheSyncTimeout,
+		stopCh:           reg.StopCh(),
+		watchHandler:     handler,
+		exclude:          config.Exclude,
+		logger:           logger,
+	}
+	if config.StorageClient != nil && config.IncludeInitialState {
+		o.cp = checkpoint.New(config.StorageClient, logger)
+	}
+	for _, nf := range factories {
+		inf := nf.factory.ForResource(config.Gvr).Informer()
+		o.infs[nf] = inf
+		if _, err := inf.AddEventHandler(o.buildEventHandler(!config.IncludeInitialState, nf.namespace)); err != nil {
+			return nil, fmt.Errorf("failed to add event handler for %s: %w", config.Gvr.String(), err)
+		}
+	}
+	return o, nil
+}
+
+// factoriesForConfig resolves one factory per configured namespace from the registry.
+func factoriesForConfig(reg *FactoryRegistry, config k8sinventory.Config) []namespacedFactory {
+	namespaces := config.Namespaces
+	if len(namespaces) == 0 {
+		namespaces = []string{""}
+	}
+	factories := make([]namespacedFactory, 0, len(namespaces))
+	for _, ns := range namespaces {
+		factories = append(factories, namespacedFactory{
+			namespace: ns,
+			factory:   reg.Get(ns, config.LabelSelector, config.FieldSelector),
+		})
+	}
+	return factories
+}
+
+// Start starts the observer's factories, waits for cache sync, then launches workers.
+// Safe to call across observers that share a factory: factory.Start is idempotent.
+func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}, error) {
+	o.logger.Info("starting informer and waiting for cache sync",
+		zap.String("gvr", o.base.Gvr.String()))
+
+	if o.cp != nil {
+		namespaces := make([]string, 0, len(o.infs))
+		for nf := range o.infs {
+			namespaces = append(namespaces, nf.namespace)
+		}
+		if err := o.cp.Load(ctx, namespaces, o.base.Gvr.Resource); err != nil {
+			o.logger.Warn("failed to load checkpoints from storage", zap.Error(err))
+		}
+	}
+
+	for nf := range o.infs {
+		nf.factory.Start(o.stopCh)
+	}
+
+	if err := o.waitForCacheSync(ctx); err != nil {
+		return nil, err
+	}
+
+	o.logger.Info("informer cache synced, observer ready",
+		zap.String("gvr", o.base.Gvr.String()))
+
+	if o.cp != nil {
+		for nf, inf := range o.infs {
+			if listRV := inf.LastSyncResourceVersion(); listRV != "" {
+				if err := o.cp.SetCheckpoint(ctx, nf.namespace, o.base.Gvr.Resource, listRV); err != nil {
+					o.logger.Warn("failed to persist post-sync checkpoint",
+						zap.String("namespace", nf.namespace), zap.Error(err))
+					continue
+				}
+				if err := o.cp.Flush(ctx); err != nil {
+					o.logger.Warn("failed to flush post-sync checkpoint",
+						zap.String("namespace", nf.namespace), zap.Error(err))
+				}
+			}
+		}
+	}
+
+	stopCh := make(chan struct{})
+
+	if o.cp != nil {
+		wg.Add(1)
+		go o.runCheckpointFlusher(ctx, stopCh, wg)
+	}
+
+	if o.pullHandler != nil {
+		for _, inf := range o.infs {
+			wg.Add(1)
+			go o.runPullTicker(ctx, inf.GetStore(), stopCh, wg)
+		}
+	}
+
+	return stopCh, nil
+}
+
+// waitForCacheSync waits for every informer to sync, collecting all errors.
+func (o *Observer) waitForCacheSync(ctx context.Context) error {
+	syncCtx, syncCancel := context.WithTimeout(ctx, o.cacheSyncTimeout)
+	defer syncCancel()
+
+	errCh := make(chan error, len(o.infs))
+	for nf := range o.infs {
+		go func() {
+			for gvr, synced := range nf.factory.WaitForCacheSync(syncCtx.Done()) {
+				if !synced {
+					if ctx.Err() != nil {
+						errCh <- fmt.Errorf("informer cache sync aborted for %s: %w", gvr, ctx.Err())
+					} else {
+						errCh <- fmt.Errorf("timed out waiting for informer cache to sync for %s", gvr)
+					}
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+	for range o.infs {
+		if err := <-errCh; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *Observer) buildEventHandler(skipInitialList bool, namespace string) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj any, isInInitialList bool) {
+			if isInInitialList && o.suppressInitialListEvent(obj, skipInitialList, namespace) {
+				return
+			}
+			o.handleWatchEvent(apiWatch.Added, obj, namespace)
+		},
+		UpdateFunc: func(_, newObj any) {
+			o.handleWatchEvent(apiWatch.Modified, newObj, namespace)
+		},
+		DeleteFunc: func(obj any) {
+			o.handleWatchEvent(apiWatch.Deleted, obj, namespace)
+		},
+	}
+}
+
+func (o *Observer) suppressInitialListEvent(obj any, skipInitialList bool, namespace string) bool {
+	if skipInitialList {
+		return true
+	}
+	if o.cp == nil {
+		return false
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return false
+	}
+	seen, err := o.cp.AlreadySeen(u.GetResourceVersion(), namespace)
+	if err != nil {
+		o.logger.Warn("failed to check if object was already seen", zap.Error(err))
+		return false
+	}
+	return seen
+}
+
+func (o *Observer) handleWatchEvent(eventType apiWatch.EventType, obj any, namespace string) {
+	if o.exclude[eventType] {
+		return
+	}
+	// Unwrap tombstone objects produced when a delete is missed and detected on re-list.
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		o.logger.Error("unexpected object type in watch event", zap.String("type", string(eventType)))
+		return
+	}
+	if o.cp != nil {
+		if rv := u.GetResourceVersion(); rv != "" {
+			if err := o.cp.SetCheckpoint(context.Background(), namespace, o.base.Gvr.Resource, rv); err != nil {
+				o.logger.Warn("failed to buffer resourceVersion checkpoint", zap.Error(err))
+			}
+		}
+	}
+	o.watchHandler(&apiWatch.Event{Type: eventType, Object: u})
+}
+
+func (o *Observer) runCheckpointFlusher(ctx context.Context, stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ticker := time.NewTicker(checkpointFlushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := o.cp.Flush(ctx); err != nil {
+				o.logger.Error("failed to flush checkpoints", zap.Error(err))
+			}
+		case <-stopCh:
+			if err := o.cp.Flush(context.Background()); err != nil {
+				o.logger.Error("failed to flush final checkpoints", zap.Error(err))
+			}
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (o *Observer) runPullTicker(ctx context.Context, store cache.Store, stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	o.emitSnapshot(store)
+	ticker := time.NewTicker(o.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			o.emitSnapshot(store)
+		case <-stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (o *Observer) emitSnapshot(store cache.Store) {
+	items := store.List()
+	if len(items) == 0 {
+		return
+	}
+	list := &unstructured.UnstructuredList{}
+	for _, item := range items {
+		u, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			o.logger.Error("unexpected item type in informer cache")
+			continue
+		}
+		list.Items = append(list.Items, *u)
+	}
+	o.pullHandler(list)
+}

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -352,6 +352,9 @@ func (o *Observer) runCheckpointFlusher(ctx context.Context, stopCh <-chan struc
 			}
 			return
 		case <-ctx.Done():
+			if err := o.cp.Flush(context.Background()); err != nil {
+				o.logger.Error("failed to flush final checkpoints", zap.Error(err))
+			}
 			return
 		}
 	}

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -64,15 +64,7 @@ type Observer struct {
 
 // NewPull creates a pull-mode observer.
 func NewPull(reg *FactoryRegistry, config PullConfig, logger *zap.Logger, handler func(*unstructured.UnstructuredList)) (*Observer, error) {
-	return pull(reg, factoriesForConfig(reg, config.Config), config, logger, handler)
-}
-
-// NewWatch creates a watch-mode observer.
-func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, handler func(*apiWatch.Event)) (*Observer, error) {
-	return watch(reg, factoriesForConfig(reg, config.Config), config, logger, handler)
-}
-
-func pull(reg *FactoryRegistry, factories []namespacedFactory, config PullConfig, logger *zap.Logger, handler func(*unstructured.UnstructuredList)) (*Observer, error) {
+	factories := factoriesForConfig(reg, config.Config)
 	if len(factories) == 0 {
 		return nil, errors.New("at least one factory is required")
 	}
@@ -91,7 +83,9 @@ func pull(reg *FactoryRegistry, factories []namespacedFactory, config PullConfig
 	return o, nil
 }
 
-func watch(reg *FactoryRegistry, factories []namespacedFactory, config WatchConfig, logger *zap.Logger, handler func(*apiWatch.Event)) (*Observer, error) {
+// NewWatch creates a watch-mode observer.
+func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, handler func(*apiWatch.Event)) (*Observer, error) {
+	factories := factoriesForConfig(reg, config.Config)
 	if len(factories) == 0 {
 		return nil, errors.New("at least one factory is required")
 	}

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -57,10 +57,11 @@ type Observer struct {
 	pullHandler func(*unstructured.UnstructuredList)
 	interval    time.Duration
 	// watch-only
-	watchHandler func(*apiWatch.Event)
-	exclude      map[apiWatch.EventType]bool
-	cp           *checkpoint.Checkpointer
-	logger       *zap.Logger
+	watchHandler    func(*apiWatch.Event)
+	exclude         map[apiWatch.EventType]bool
+	skipInitialList bool
+	cp              *checkpoint.Checkpointer
+	logger          *zap.Logger
 }
 
 // NewPull creates a pull-mode observer.
@@ -107,19 +108,14 @@ func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, hand
 		stopCh:           reg.StopCh(),
 		watchHandler:     handler,
 		exclude:          config.Exclude,
+		skipInitialList:  !config.IncludeInitialState,
 		logger:           logger,
 	}
 	if config.StorageClient != nil {
 		o.cp = checkpoint.New(config.StorageClient, logger)
 	}
 	for _, nf := range factories {
-		inf := nf.factory.ForResource(config.Gvr).Informer()
-		o.infs[nf] = inf
-		handle, err := inf.AddEventHandler(o.buildEventHandler(!config.IncludeInitialState, nf.namespace))
-		if err != nil {
-			return nil, fmt.Errorf("failed to add event handler for %s: %w", config.Gvr.String(), err)
-		}
-		o.handlerRegs[nf] = handle
+		o.infs[nf] = nf.factory.ForResource(config.Gvr).Informer()
 	}
 	return o, nil
 }
@@ -163,6 +159,17 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 		}
 	}
 
+	if o.watchHandler != nil {
+		for nf, inf := range o.infs {
+			handle, err := inf.AddEventHandler(o.buildEventHandler(o.skipInitialList, nf.namespace))
+			if err != nil {
+				o.removeHandlers()
+				return nil, fmt.Errorf("failed to add event handler for %s: %w", o.base.Gvr.String(), err)
+			}
+			o.handlerRegs[nf] = handle
+		}
+	}
+
 	for nf := range o.infs {
 		nf.factory.Start(o.stopCh)
 	}
@@ -198,7 +205,7 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 	stopCh := make(chan struct{})
 
 	// Informers keep running under the registry stopCh; unsubscribe our handlers when the observer stops.
-	if len(o.handlerRegs) > 0 {
+	if o.watchHandler != nil {
 		wg.Add(1)
 		go o.runHandlerRemover(ctx, stopCh, wg)
 	}

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -131,7 +131,12 @@ func factoriesForConfig(reg *FactoryRegistry, config k8sinventory.Config) ([]nam
 		namespaces = []string{""}
 	}
 	factories := make([]namespacedFactory, 0, len(namespaces))
+	seen := make(map[string]struct{}, len(namespaces))
 	for _, ns := range namespaces {
+		if _, ok := seen[ns]; ok {
+			continue
+		}
+		seen[ns] = struct{}{}
 		f, err := reg.Get(ns, config.LabelSelector, config.FieldSelector)
 		if err != nil {
 			return nil, err
@@ -163,6 +168,7 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 	}
 
 	if err := o.waitForCacheSync(ctx); err != nil {
+		o.removeHandlers()
 		return nil, err
 	}
 
@@ -251,6 +257,10 @@ func (o *Observer) runHandlerRemover(ctx context.Context, stopCh <-chan struct{}
 	case <-ctx.Done():
 	case <-o.stopCh:
 	}
+	o.removeHandlers()
+}
+
+func (o *Observer) removeHandlers() {
 	for nf, handle := range o.handlerRegs {
 		if err := o.infs[nf].RemoveEventHandler(handle); err != nil {
 			o.logger.Warn("failed to remove event handler",

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -64,7 +64,10 @@ type Observer struct {
 
 // NewPull creates a pull-mode observer.
 func NewPull(reg *FactoryRegistry, config PullConfig, logger *zap.Logger, handler func(*unstructured.UnstructuredList)) (*Observer, error) {
-	factories := factoriesForConfig(reg, config.Config)
+	factories, err := factoriesForConfig(reg, config.Config)
+	if err != nil {
+		return nil, err
+	}
 	if len(factories) == 0 {
 		return nil, errors.New("at least one factory is required")
 	}
@@ -85,7 +88,10 @@ func NewPull(reg *FactoryRegistry, config PullConfig, logger *zap.Logger, handle
 
 // NewWatch creates a watch-mode observer.
 func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, handler func(*apiWatch.Event)) (*Observer, error) {
-	factories := factoriesForConfig(reg, config.Config)
+	factories, err := factoriesForConfig(reg, config.Config)
+	if err != nil {
+		return nil, err
+	}
 	if len(factories) == 0 {
 		return nil, errors.New("at least one factory is required")
 	}
@@ -115,19 +121,20 @@ func NewWatch(reg *FactoryRegistry, config WatchConfig, logger *zap.Logger, hand
 }
 
 // factoriesForConfig resolves one factory per configured namespace from the registry.
-func factoriesForConfig(reg *FactoryRegistry, config k8sinventory.Config) []namespacedFactory {
+func factoriesForConfig(reg *FactoryRegistry, config k8sinventory.Config) ([]namespacedFactory, error) {
 	namespaces := config.Namespaces
 	if len(namespaces) == 0 {
 		namespaces = []string{""}
 	}
 	factories := make([]namespacedFactory, 0, len(namespaces))
 	for _, ns := range namespaces {
-		factories = append(factories, namespacedFactory{
-			namespace: ns,
-			factory:   reg.Get(ns, config.LabelSelector, config.FieldSelector),
-		})
+		f, err := reg.Get(ns, config.LabelSelector, config.FieldSelector)
+		if err != nil {
+			return nil, err
+		}
+		factories = append(factories, namespacedFactory{namespace: ns, factory: f})
 	}
-	return factories
+	return factories, nil
 }
 
 // Start starts the observer's factories, waits for cache sync, then launches workers.

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -225,31 +225,34 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 	return stopCh, nil
 }
 
-// waitForCacheSync waits for every informer to sync, collecting all errors.
+// waitForCacheSync waits for every informer (or handler, for watch observers) to sync.
 func (o *Observer) waitForCacheSync(ctx context.Context) error {
 	syncCtx, syncCancel := context.WithTimeout(ctx, o.cacheSyncTimeout)
 	defer syncCancel()
 
-	errCh := make(chan error, len(o.infs))
-	for nf := range o.infs {
-		go func() {
-			var errs []error
-			for gvr, synced := range nf.factory.WaitForCacheSync(syncCtx.Done()) {
-				if !synced {
-					if ctx.Err() != nil {
-						errs = append(errs, fmt.Errorf("informer cache sync aborted for %s: %w", gvr, ctx.Err()))
-					} else {
-						errs = append(errs, fmt.Errorf("timed out waiting for informer cache to sync for %s", gvr))
-					}
-				}
-			}
-			errCh <- errors.Join(errs...)
-		}()
+	type namedSync struct {
+		namespace string
+		hasSynced func() bool
 	}
+	syncs := make([]namedSync, 0, len(o.infs))
+	if o.watchHandler != nil {
+		for nf, handle := range o.handlerRegs {
+			syncs = append(syncs, namedSync{namespace: nf.namespace, hasSynced: handle.HasSynced})
+		}
+	} else {
+		for nf, inf := range o.infs {
+			syncs = append(syncs, namedSync{namespace: nf.namespace, hasSynced: inf.HasSynced})
+		}
+	}
+
 	var errs []error
-	for range o.infs {
-		if err := <-errCh; err != nil {
-			errs = append(errs, err)
+	for _, s := range syncs {
+		if !cache.WaitForCacheSync(syncCtx.Done(), s.hasSynced) {
+			if ctx.Err() != nil {
+				errs = append(errs, fmt.Errorf("informer cache sync aborted for %s (namespace=%q): %w", o.base.Gvr, s.namespace, ctx.Err()))
+			} else {
+				errs = append(errs, fmt.Errorf("timed out waiting for informer cache to sync for %s (namespace=%q)", o.base.Gvr, s.namespace))
+			}
 		}
 	}
 	return errors.Join(errs...)
@@ -330,6 +333,8 @@ func (o *Observer) handleWatchEvent(eventType apiWatch.EventType, obj any, names
 			zap.String("gvr", o.base.Gvr.String()))
 		return
 	}
+	// Deliver first, then checkpoint: a crash between the two replays rather than skips.
+	o.watchHandler(&apiWatch.Event{Type: eventType, Object: u})
 	if o.cp != nil {
 		if rv := u.GetResourceVersion(); rv != "" {
 			if err := o.cp.SetCheckpoint(context.Background(), namespace, o.base.Gvr.Resource, rv); err != nil {
@@ -340,7 +345,6 @@ func (o *Observer) handleWatchEvent(eventType apiWatch.EventType, obj any, names
 			}
 		}
 	}
-	o.watchHandler(&apiWatch.Event{Type: eventType, Object: u})
 }
 
 func (o *Observer) runCheckpointFlusher(ctx context.Context, stopCh <-chan struct{}, wg *sync.WaitGroup) {

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -148,7 +148,8 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 			namespaces = append(namespaces, nf.namespace)
 		}
 		if err := o.cp.Load(ctx, namespaces, o.base.Gvr.Resource); err != nil {
-			o.logger.Warn("failed to load checkpoints from storage", zap.Error(err))
+			o.logger.Warn("failed to load checkpoints from storage",
+				zap.String("gvr", o.base.Gvr.String()), zap.Error(err))
 		}
 	}
 
@@ -168,12 +169,16 @@ func (o *Observer) Start(ctx context.Context, wg *sync.WaitGroup) (chan struct{}
 			if listRV := inf.LastSyncResourceVersion(); listRV != "" {
 				if err := o.cp.SetCheckpoint(ctx, nf.namespace, o.base.Gvr.Resource, listRV); err != nil {
 					o.logger.Warn("failed to persist post-sync checkpoint",
-						zap.String("namespace", nf.namespace), zap.Error(err))
+						zap.String("namespace", nf.namespace),
+						zap.String("gvr", o.base.Gvr.String()),
+						zap.Error(err))
 					continue
 				}
 				if err := o.cp.Flush(ctx); err != nil {
 					o.logger.Warn("failed to flush post-sync checkpoint",
-						zap.String("namespace", nf.namespace), zap.Error(err))
+						zap.String("namespace", nf.namespace),
+						zap.String("gvr", o.base.Gvr.String()),
+						zap.Error(err))
 				}
 			}
 		}
@@ -271,13 +276,19 @@ func (o *Observer) handleWatchEvent(eventType apiWatch.EventType, obj any, names
 	}
 	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
-		o.logger.Error("unexpected object type in watch event", zap.String("type", string(eventType)))
+		o.logger.Error("unexpected object type in watch event",
+			zap.String("event_type", string(eventType)),
+			zap.String("go_type", fmt.Sprintf("%T", obj)),
+			zap.String("gvr", o.base.Gvr.String()))
 		return
 	}
 	if o.cp != nil {
 		if rv := u.GetResourceVersion(); rv != "" {
 			if err := o.cp.SetCheckpoint(context.Background(), namespace, o.base.Gvr.Resource, rv); err != nil {
-				o.logger.Warn("failed to buffer resourceVersion checkpoint", zap.Error(err))
+				o.logger.Warn("failed to buffer resourceVersion checkpoint",
+					zap.String("namespace", namespace),
+					zap.String("gvr", o.base.Gvr.String()),
+					zap.Error(err))
 			}
 		}
 	}

--- a/internal/k8sinventory/informer/observer.go
+++ b/internal/k8sinventory/informer/observer.go
@@ -220,25 +220,26 @@ func (o *Observer) waitForCacheSync(ctx context.Context) error {
 	errCh := make(chan error, len(o.infs))
 	for nf := range o.infs {
 		go func() {
+			var errs []error
 			for gvr, synced := range nf.factory.WaitForCacheSync(syncCtx.Done()) {
 				if !synced {
 					if ctx.Err() != nil {
-						errCh <- fmt.Errorf("informer cache sync aborted for %s: %w", gvr, ctx.Err())
+						errs = append(errs, fmt.Errorf("informer cache sync aborted for %s: %w", gvr, ctx.Err()))
 					} else {
-						errCh <- fmt.Errorf("timed out waiting for informer cache to sync for %s", gvr)
+						errs = append(errs, fmt.Errorf("timed out waiting for informer cache to sync for %s", gvr))
 					}
-					return
 				}
 			}
-			errCh <- nil
+			errCh <- errors.Join(errs...)
 		}()
 	}
+	var errs []error
 	for range o.infs {
 		if err := <-errCh; err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // runHandlerRemover unsubscribes this observer's ResourceEventHandlers on any

--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -646,6 +647,76 @@ func TestCheckpointRestartSkipsSeenObjects(t *testing.T) {
 	require.Len(t, events, 1)
 	assert.Equal(t, apiWatch.Added, events[0].Type)
 	assert.Equal(t, "pod2", events[0].Object.(*unstructured.Unstructured).GetName())
+}
+
+// Duplicate namespaces in Config.Namespaces must not cause duplicate event delivery.
+func TestWatchModeDeduplicatesNamespaces(t *testing.T) {
+	t.Parallel()
+	client, addObj := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config: k8sinventory.Config{
+			Gvr:        podsGVR,
+			Namespaces: []string{"default", "default"},
+		},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: false,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	addObj(makePod("pod1"))
+
+	assert.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) > 1
+	}, 300*time.Millisecond, 20*time.Millisecond, "duplicate namespaces must not produce duplicate events")
+
+	mu.Lock()
+	assert.Len(t, events, 1)
+	mu.Unlock()
+}
+
+// If Start fails during cache sync, registered handlers must be removed so
+// the shared informer doesn't keep firing into a stopped observer.
+func TestWatchModeStartFailureUnregistersHandlers(t *testing.T) {
+	t.Parallel()
+	client, addObj := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var calls atomic.Int32
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 1 * time.Nanosecond, // force sync failure
+	}, zap.NewNop(), func(*apiWatch.Event) {
+		calls.Add(1)
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	_, err = obs.Start(t.Context(), &wg)
+	require.Error(t, err, "Start must fail with an unrealistic cache sync timeout")
+
+	addObj(makePod("late-pod"))
+
+	assert.Never(t, func() bool {
+		return calls.Load() > 0
+	}, 300*time.Millisecond, 20*time.Millisecond, "handlers must be removed after Start failure")
 }
 
 func makePodWithRV(name, rv string) *unstructured.Unstructured {

--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -724,3 +724,39 @@ func makePodWithRV(name, rv string) *unstructured.Unstructured {
 	u.SetResourceVersion(rv)
 	return u
 }
+
+// TestCheckpointFlushOnCtxCancel verifies that buffered checkpoints are flushed
+// when ctx is cancelled, not only when stopCh is closed.
+func TestCheckpointFlushOnCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newFakeClient(t, makePodWithRV("pod1", "42"))
+	storageClient := newTestStorageClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: true,
+		StorageClient:       storageClient,
+	}, zap.NewNop(), func(*apiWatch.Event) {})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(ctx, &wg)
+	require.NoError(t, err)
+
+	// Buffer a RV in memory without flushing, then cancel ctx to trigger
+	// shutdown down the ctx.Done() path in runCheckpointFlusher.
+	require.NoError(t, obs.cp.SetCheckpoint(t.Context(), "", podsGVR.Resource, "100"))
+	cancel()
+	close(stopCh)
+	wg.Wait()
+
+	verifier := checkpoint.New(storageClient, zap.NewNop())
+	rv, err := verifier.GetCheckpoint(t.Context(), "", podsGVR.Resource)
+	require.NoError(t, err)
+	assert.Equal(t, "100", rv, "buffered checkpoint must be flushed on ctx cancel")
+}

--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -725,6 +725,74 @@ func makePodWithRV(name, rv string) *unstructured.Unstructured {
 	return u
 }
 
+func TestSharedFactoryPullStartsBeforeWatch(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newFakeClient(t,
+		makePodWithRV("pod-seen", "10"), // already covered by pre-seeded checkpoint
+		makePodWithRV("pod-new", "30"),  // must still be emitted
+	)
+
+	storageClient := newTestStorageClient(t)
+	// Pre-seed checkpoint at RV 20 so pod-seen is deduped but pod-new is not.
+	chk := checkpoint.New(storageClient, zap.NewNop())
+	require.NoError(t, chk.SetCheckpoint(t.Context(), "", podsGVR.Resource, "20"))
+	require.NoError(t, chk.Flush(t.Context()))
+
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	pullObs, err := NewPull(reg, PullConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+		Interval:         time.Hour,
+	}, zap.NewNop(), func(*unstructured.UnstructuredList) {})
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+	watchObs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: true,
+		StorageClient:       storageClient,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	// Start pull first: this starts the shared factory before the watch
+	// observer loads its checkpoint. Handler registration in watchObs.Start
+	// must happen after Load so AlreadySeen() dedups correctly.
+	var wg sync.WaitGroup
+	pullStop, err := pullObs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(pullStop) })
+
+	watchStop, err := watchObs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(watchStop); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) >= 1
+	}, 5*time.Second, 10*time.Millisecond, "expected pod-new ADDED event")
+
+	assert.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) > 1
+	}, 300*time.Millisecond, 20*time.Millisecond, "pod-seen must be deduped by checkpoint")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, events, 1)
+	assert.Equal(t, "pod-new", events[0].Object.(*unstructured.Unstructured).GetName())
+}
+
 // TestCheckpointFlushOnCtxCancel verifies that buffered checkpoints are flushed
 // when ctx is cancelled, not only when stopCh is closed.
 func TestCheckpointFlushOnCtxCancel(t *testing.T) {

--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -465,6 +465,50 @@ func TestWatchModeDeletedEvent(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "expected Deleted event")
 }
 
+// Closing Start's stopCh must stop watch event delivery, not just the pull ticker.
+func TestWatchModeStopChStopsEventDelivery(t *testing.T) {
+	t.Parallel()
+	client, addObj := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: false,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+
+	addObj(makePod("pod-before-stop"))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) == 1
+	}, 5*time.Second, 10*time.Millisecond, "expected event for pod-before-stop")
+
+	close(stopCh)
+	wg.Wait()
+
+	// Handlers are removed after stopCh close; new objects must not produce events.
+	addObj(makePod("pod-after-stop"))
+	assert.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) > 1
+	}, 300*time.Millisecond, 20*time.Millisecond, "events delivered after stopCh close")
+}
+
 func TestHandleWatchEventTombstone(t *testing.T) {
 	t.Parallel()
 	client, _ := newFakeClient(t)

--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -1,0 +1,611 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package informer
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiWatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory/checkpoint"
+)
+
+var (
+	podsGVR       = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	configmapsGVR = schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+)
+
+// newFakeClient creates a fake dynamic client pre-seeded with pods.
+// Returns the client and an addObj helper.
+func newFakeClient(t *testing.T, objects ...*unstructured.Unstructured) (*fake.FakeDynamicClient, func(*unstructured.Unstructured)) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{podsGVR: "PodList"}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+	for _, obj := range objects {
+		_, err := client.Resource(podsGVR).Namespace(obj.GetNamespace()).Create(
+			t.Context(), obj, metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+	addObj := func(obj *unstructured.Unstructured) {
+		_, err := client.Resource(podsGVR).Namespace(obj.GetNamespace()).Create(
+			t.Context(), obj, metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+	return client, addObj
+}
+
+// newFakeClientWithMutations is like newFakeClient but also returns update and delete helpers.
+func newFakeClientWithMutations(t *testing.T, objects ...*unstructured.Unstructured) (
+	*fake.FakeDynamicClient,
+	func(*unstructured.Unstructured),
+	func(name, namespace string),
+) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{podsGVR: "PodList"}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+	for _, obj := range objects {
+		_, err := client.Resource(podsGVR).Namespace(obj.GetNamespace()).Create(
+			t.Context(), obj, metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+	updateObj := func(obj *unstructured.Unstructured) {
+		_, err := client.Resource(podsGVR).Namespace(obj.GetNamespace()).Update(
+			t.Context(), obj, metav1.UpdateOptions{},
+		)
+		require.NoError(t, err)
+	}
+	deleteObj := func(name, namespace string) {
+		err := client.Resource(podsGVR).Namespace(namespace).Delete(
+			t.Context(), name, metav1.DeleteOptions{},
+		)
+		require.NoError(t, err)
+	}
+	return client, updateObj, deleteObj
+}
+
+func makePod(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+		},
+	}
+	u.SetResourceVersion("1")
+	return u
+}
+
+func TestPullModeEmitsSnapshotOnStart(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t, makePod("pod1"))
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var received []*unstructured.UnstructuredList
+
+	obs, err := NewPull(reg, PullConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+		Interval:         100 * time.Millisecond,
+	}, zap.NewNop(), func(list *unstructured.UnstructuredList) {
+		mu.Lock()
+		received = append(received, list)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, received[0].Items, 1)
+	assert.Equal(t, "pod1", received[0].Items[0].GetName())
+}
+
+func TestPullModeEmitsOnInterval(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t, makePod("pod1"))
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	snapshots := 0
+
+	obs, err := NewPull(reg, PullConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+		Interval:         50 * time.Millisecond,
+	}, zap.NewNop(), func(_ *unstructured.UnstructuredList) {
+		mu.Lock()
+		snapshots++
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return snapshots >= 3
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestWatchModeIncludeInitialStateTrue(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t, makePod("pod1"))
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: true,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, apiWatch.Added, events[0].Type)
+}
+
+func TestWatchModeIncludeInitialStateFalse(t *testing.T) {
+	t.Parallel()
+	client, addObj := newFakeClient(t, makePod("existing-pod"))
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: false,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	addObj(makePod("new-pod"))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range events {
+		u := ev.Object.(*unstructured.Unstructured)
+		assert.Equal(t, "new-pod", u.GetName(), "existing-pod must not appear when include_initial_state=false")
+	}
+}
+
+// TestTwoObserversIndependent verifies that two observers watching different GVRs
+// on the same client do not cross-contaminate event delivery.
+func TestTwoObserversIndependent(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		podsGVR:       "PodList",
+		configmapsGVR: "ConfigMapList",
+	}
+	client := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+
+	pod := makePod("pod1")
+	_, err := client.Resource(podsGVR).Namespace("default").Create(t.Context(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	cm := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "cm1", "namespace": "default"},
+	}}
+	cm.SetResourceVersion("1")
+	_, err = client.Resource(configmapsGVR).Namespace("default").Create(t.Context(), cm, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var (
+		mu              sync.Mutex
+		podsReceived    []*unstructured.UnstructuredList
+		configsReceived []*unstructured.UnstructuredList
+	)
+
+	obs1, err := NewPull(reg, PullConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+		Interval:         50 * time.Millisecond,
+	}, zap.NewNop(), func(list *unstructured.UnstructuredList) {
+		mu.Lock()
+		podsReceived = append(podsReceived, list)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	obs2, err := NewPull(reg, PullConfig{
+		Config:           k8sinventory.Config{Gvr: configmapsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+		Interval:         50 * time.Millisecond,
+	}, zap.NewNop(), func(list *unstructured.UnstructuredList) {
+		mu.Lock()
+		configsReceived = append(configsReceived, list)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh1, err := obs1.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	stopCh2, err := obs2.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh1); close(stopCh2); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(podsReceived) > 0 && len(configsReceived) > 0
+	}, 5*time.Second, 10*time.Millisecond, "both observers must receive their respective objects")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "pod1", podsReceived[0].Items[0].GetName())
+	assert.Equal(t, "cm1", configsReceived[0].Items[0].GetName())
+}
+
+func TestWatchModeExcludeWatchType(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t, makePod("pod1"))
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var eventTypes []apiWatch.EventType
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: true,
+		Exclude:             map[apiWatch.EventType]bool{apiWatch.Deleted: true},
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		eventTypes = append(eventTypes, ev.Type)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Contains(eventTypes, apiWatch.Added)
+	}, 5*time.Second, 10*time.Millisecond, "expected Added event for pre-existing pod")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, et := range eventTypes {
+		assert.NotEqual(t, apiWatch.Deleted, et, "Deleted events must be filtered by Exclude map")
+	}
+}
+
+func TestStartCacheSyncContextCancelled(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t, makePod("pod1"))
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	obs, err := NewPull(reg, PullConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+		Interval:         time.Hour,
+	}, zap.NewNop(), func(_ *unstructured.UnstructuredList) {})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before Start so cache sync is immediately aborted
+
+	var wg sync.WaitGroup
+	_, err = obs.Start(ctx, &wg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aborted")
+}
+
+func TestWatchModeModifiedEvent(t *testing.T) {
+	t.Parallel()
+	pod := makePod("pod1")
+	client, updateObj, _ := newFakeClientWithMutations(t, pod)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: false,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	updated := pod.DeepCopy()
+	updated.SetResourceVersion("2")
+	updated.SetLabels(map[string]string{"updated": "true"})
+	updateObj(updated)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, ev := range events {
+			if ev.Type == apiWatch.Modified {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "expected Modified event")
+}
+
+func TestWatchModeDeletedEvent(t *testing.T) {
+	t.Parallel()
+	pod := makePod("pod1")
+	client, _, deleteObj := newFakeClientWithMutations(t, pod)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: false,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	deleteObj("pod1", "default")
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, ev := range events {
+			if ev.Type == apiWatch.Deleted {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "expected Deleted event")
+}
+
+func TestHandleWatchEventTombstone(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:           k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout: 5 * time.Second,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	pod := makePod("tombstone-pod")
+	tombstone := cache.DeletedFinalStateUnknown{Key: "default/tombstone-pod", Obj: pod}
+	obs.handleWatchEvent(apiWatch.Deleted, tombstone, "")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, events, 1)
+	assert.Equal(t, apiWatch.Deleted, events[0].Type)
+	assert.Equal(t, "tombstone-pod", events[0].Object.(*unstructured.Unstructured).GetName())
+}
+
+func newTestStorageClient(t *testing.T) *storagetest.TestClient {
+	t.Helper()
+	return storagetest.NewInMemoryClient(component.KindReceiver, component.MustNewID("test"), "test")
+}
+
+// TestCheckpointFirstRunEmitsAll verifies that on first startup (no persisted checkpoint),
+// all objects in the initial list are emitted as ADDED events.
+func TestCheckpointFirstRunEmitsAll(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newFakeClient(t, makePodWithRV("pod1", "10"), makePodWithRV("pod2", "20"))
+	storageClient := newTestStorageClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: true,
+		StorageClient:       storageClient,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) >= 2
+	}, 5*time.Second, 10*time.Millisecond, "expected 2 ADDED events on first run")
+
+	mu.Lock()
+	defer mu.Unlock()
+	names := make([]string, 0, len(events))
+	for _, ev := range events {
+		assert.Equal(t, apiWatch.Added, ev.Type)
+		names = append(names, ev.Object.(*unstructured.Unstructured).GetName())
+	}
+	assert.ElementsMatch(t, []string{"pod1", "pod2"}, names)
+}
+
+// TestCheckpointRestartSkipsSeenObjects verifies that on restart with a persisted checkpoint,
+// objects whose resourceVersion is ≤ the checkpoint are skipped, while newer ones are emitted.
+func TestCheckpointRestartSkipsSeenObjects(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newFakeClient(t,
+		makePodWithRV("pod1", "10"), // RV 10 — already seen
+		makePodWithRV("pod2", "30"), // RV 30 — new since checkpoint
+	)
+
+	// Pre-seed checkpoint at RV 20 (pod1 seen, pod2 not yet seen).
+	storageClient := newTestStorageClient(t)
+	chk := checkpoint.New(storageClient, zap.NewNop())
+	require.NoError(t, chk.SetCheckpoint(t.Context(), "", podsGVR.Resource, "20"))
+	require.NoError(t, chk.Flush(t.Context()))
+
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	var mu sync.Mutex
+	var events []apiWatch.Event
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: true,
+		StorageClient:       storageClient,
+	}, zap.NewNop(), func(ev *apiWatch.Event) {
+		mu.Lock()
+		events = append(events, *ev)
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { close(stopCh); wg.Wait() })
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) >= 1
+	}, 5*time.Second, 10*time.Millisecond, "expected at least 1 ADDED event")
+
+	assert.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) > 1
+	}, 200*time.Millisecond, 10*time.Millisecond, "only pod2 (RV 30) should be emitted")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, events, 1)
+	assert.Equal(t, apiWatch.Added, events[0].Type)
+	assert.Equal(t, "pod2", events[0].Object.(*unstructured.Unstructured).GetName())
+}
+
+func makePodWithRV(name, rv string) *unstructured.Unstructured {
+	u := makePod(name)
+	u.SetResourceVersion(rv)
+	return u
+}

--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -725,6 +725,69 @@ func makePodWithRV(name, rv string) *unstructured.Unstructured {
 	return u
 }
 
+// Checkpoint must be buffered only after watchHandler returns so a crash
+// mid-processing replays the event instead of skipping it.
+func TestCheckpointAdvancesAfterHandler(t *testing.T) {
+	t.Parallel()
+
+	client, addObj := newFakeClient(t)
+	storageClient := newTestStorageClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	// Handler blocks on `release` and signals `entered` when it is invoked.
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+
+	obs, err := NewWatch(reg, WatchConfig{
+		Config:              k8sinventory.Config{Gvr: podsGVR},
+		CacheSyncTimeout:    5 * time.Second,
+		IncludeInitialState: false,
+		StorageClient:       storageClient,
+	}, zap.NewNop(), func(*apiWatch.Event) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stopCh, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() { releaseHandler(); close(stopCh); wg.Wait() })
+
+	addObj(makePodWithRV("pod1", "77"))
+
+	// Wait until the handler is blocked mid-callback.
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchHandler was not called")
+	}
+
+	// While the handler is blocked, storage must not have RV 77 yet.
+	require.NoError(t, obs.cp.Flush(t.Context()))
+	verifier := checkpoint.New(storageClient, zap.NewNop())
+	rv, err := verifier.GetCheckpoint(t.Context(), "", podsGVR.Resource)
+	require.NoError(t, err)
+	assert.Empty(t, rv, "checkpoint must not advance before handler returns")
+
+	// Unblock the handler; RV 77 should now flow into storage.
+	releaseHandler()
+
+	require.Eventually(t, func() bool {
+		if err := obs.cp.Flush(t.Context()); err != nil {
+			return false
+		}
+		rv, err := verifier.GetCheckpoint(t.Context(), "", podsGVR.Resource)
+		return err == nil && rv == "77"
+	}, 5*time.Second, 10*time.Millisecond, "checkpoint must advance after handler returns")
+}
+
 func TestSharedFactoryPullStartsBeforeWatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/k8sinventory/informer/registry.go
+++ b/internal/k8sinventory/informer/registry.go
@@ -26,6 +26,7 @@ type FactoryRegistry struct {
 	client       dynamic.Interface
 	resyncPeriod time.Duration
 	stopCh       chan struct{}
+	stopOnce     sync.Once
 
 	mu    sync.Mutex
 	cache map[factoryKey]dynamicinformer.DynamicSharedInformerFactory
@@ -81,11 +82,7 @@ func (r *FactoryRegistry) Shutdown() {
 	r.cache = nil
 	r.mu.Unlock()
 
-	select {
-	case <-r.stopCh:
-	default:
-		close(r.stopCh)
-	}
+	r.stopOnce.Do(func() { close(r.stopCh) })
 
 	for _, f := range factories {
 		f.Shutdown()

--- a/internal/k8sinventory/informer/registry.go
+++ b/internal/k8sinventory/informer/registry.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package informer // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory/informer"
+
+import (
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+)
+
+type factoryKey struct {
+	namespace     string
+	labelSelector string
+	fieldSelector string
+}
+
+// FactoryRegistry shares a SharedInformerFactory across observers with the same
+// (namespace, labelSelector, fieldSelector) scope. The receiver builds one
+// registry per leader term and calls Shutdown() to stop everything at once.
+type FactoryRegistry struct {
+	client       dynamic.Interface
+	resyncPeriod time.Duration
+	stopCh       chan struct{}
+
+	mu    sync.Mutex
+	cache map[factoryKey]dynamicinformer.DynamicSharedInformerFactory
+}
+
+// NewFactoryRegistry creates a registry backed by client.
+func NewFactoryRegistry(client dynamic.Interface, resyncPeriod time.Duration) *FactoryRegistry {
+	return &FactoryRegistry{
+		client:       client,
+		resyncPeriod: resyncPeriod,
+		stopCh:       make(chan struct{}),
+		cache:        make(map[factoryKey]dynamicinformer.DynamicSharedInformerFactory),
+	}
+}
+
+// Get returns the factory for the given scope, creating it on first use.
+func (r *FactoryRegistry) Get(namespace, labelSelector, fieldSelector string) dynamicinformer.DynamicSharedInformerFactory {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := factoryKey{namespace: namespace, labelSelector: labelSelector, fieldSelector: fieldSelector}
+	if f, ok := r.cache[key]; ok {
+		return f
+	}
+	tweak := func(opts *metav1.ListOptions) {
+		if key.labelSelector != "" {
+			opts.LabelSelector = key.labelSelector
+		}
+		if key.fieldSelector != "" {
+			opts.FieldSelector = key.fieldSelector
+		}
+	}
+	f := dynamicinformer.NewFilteredDynamicSharedInformerFactory(r.client, r.resyncPeriod, key.namespace, tweak)
+	r.cache[key] = f
+	return f
+}
+
+// StopCh returns the channel that signals factory shutdown. Observers pass it to factory.Start.
+func (r *FactoryRegistry) StopCh() <-chan struct{} {
+	return r.stopCh
+}
+
+// Shutdown stops every factory. The registry is single-use; build a new one for the next leader term.
+func (r *FactoryRegistry) Shutdown() {
+	r.mu.Lock()
+	factories := make([]dynamicinformer.DynamicSharedInformerFactory, 0, len(r.cache))
+	for _, f := range r.cache {
+		factories = append(factories, f)
+	}
+	r.cache = nil
+	r.mu.Unlock()
+
+	select {
+	case <-r.stopCh:
+	default:
+		close(r.stopCh)
+	}
+
+	for _, f := range factories {
+		f.Shutdown()
+	}
+}

--- a/internal/k8sinventory/informer/registry.go
+++ b/internal/k8sinventory/informer/registry.go
@@ -4,6 +4,7 @@
 package informer // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory/informer"
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -41,12 +42,16 @@ func NewFactoryRegistry(client dynamic.Interface, resyncPeriod time.Duration) *F
 }
 
 // Get returns the factory for the given scope, creating it on first use.
-func (r *FactoryRegistry) Get(namespace, labelSelector, fieldSelector string) dynamicinformer.DynamicSharedInformerFactory {
+// Returns an error if called after Shutdown.
+func (r *FactoryRegistry) Get(namespace, labelSelector, fieldSelector string) (dynamicinformer.DynamicSharedInformerFactory, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.cache == nil {
+		return nil, errors.New("registry has been shut down")
+	}
 	key := factoryKey{namespace: namespace, labelSelector: labelSelector, fieldSelector: fieldSelector}
 	if f, ok := r.cache[key]; ok {
-		return f
+		return f, nil
 	}
 	tweak := func(opts *metav1.ListOptions) {
 		if key.labelSelector != "" {
@@ -58,7 +63,7 @@ func (r *FactoryRegistry) Get(namespace, labelSelector, fieldSelector string) dy
 	}
 	f := dynamicinformer.NewFilteredDynamicSharedInformerFactory(r.client, r.resyncPeriod, key.namespace, tweak)
 	r.cache[key] = f
-	return f
+	return f, nil
 }
 
 // StopCh returns the channel that signals factory shutdown. Observers pass it to factory.Start.

--- a/internal/k8sinventory/informer/registry_test.go
+++ b/internal/k8sinventory/informer/registry_test.go
@@ -23,6 +23,21 @@ func TestRegistryShutdownIdempotent(t *testing.T) {
 	require.NotPanics(t, reg.Shutdown)
 }
 
+func TestRegistryShutdownConcurrent(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+
+	const n = 16
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			assert.NotPanics(t, reg.Shutdown)
+		})
+	}
+	wg.Wait()
+}
+
 func TestRegistryStopChClosesOnShutdown(t *testing.T) {
 	t.Parallel()
 	client, _ := newFakeClient(t)

--- a/internal/k8sinventory/informer/registry_test.go
+++ b/internal/k8sinventory/informer/registry_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package informer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryShutdownIdempotent(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	reg.Get("default", "", "")
+
+	require.NotPanics(t, reg.Shutdown)
+	require.NotPanics(t, reg.Shutdown)
+}
+
+func TestRegistryStopChClosesOnShutdown(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+
+	stopCh := reg.StopCh()
+	select {
+	case <-stopCh:
+		t.Fatal("StopCh must not be closed before Shutdown")
+	default:
+	}
+
+	reg.Shutdown()
+
+	select {
+	case <-stopCh:
+	case <-time.After(time.Second):
+		t.Fatal("StopCh must be closed after Shutdown")
+	}
+}
+
+func TestRegistryConcurrentGetSameKeyReturnsSameFactory(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	const n = 32
+	var wg sync.WaitGroup
+	results := make([]any, n)
+	for i := range n {
+		wg.Go(func() {
+			results[i] = reg.Get("default", "app=foo", "")
+		})
+	}
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		assert.Same(t, results[0], results[i], "concurrent Get with same scope must return the same factory")
+	}
+}
+
+func TestRegistryConcurrentGetDifferentKeysProducesDistinctFactories(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	const n = 16
+	var wg sync.WaitGroup
+	results := make([]any, n)
+	for i := range n {
+		wg.Go(func() {
+			// Distinct label selector per goroutine forces a distinct factoryKey.
+			results[i] = reg.Get("default", "app="+string(rune('a'+i)), "")
+		})
+	}
+	wg.Wait()
+
+	seen := make(map[any]struct{}, n)
+	for _, f := range results {
+		seen[f] = struct{}{}
+	}
+	assert.Len(t, seen, n, "distinct scopes must each produce a distinct factory")
+}
+
+func TestRegistryGetAfterShutdownPanics(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	reg.Shutdown()
+
+	assert.Panics(t, func() {
+		reg.Get("default", "", "")
+	})
+}
+
+// Pins the registry's sharing contract: same scope => same factory, different scope => different factory.
+func TestRegistrySharesFactoryAcrossObservers(t *testing.T) {
+	t.Parallel()
+	client, _ := newFakeClient(t)
+	reg := NewFactoryRegistry(client, 0)
+	t.Cleanup(reg.Shutdown)
+
+	f1 := reg.Get("default", "app=foo", "")
+	f2 := reg.Get("default", "app=foo", "")
+	assert.Same(t, f1, f2, "same scope must return the same factory instance")
+
+	f3 := reg.Get("default", "app=bar", "")
+	assert.NotSame(t, f1, f3, "different label selector must produce a different factory")
+
+	f4 := reg.Get("other", "app=foo", "")
+	assert.NotSame(t, f1, f4, "different namespace must produce a different factory")
+}

--- a/internal/k8sinventory/informer/registry_test.go
+++ b/internal/k8sinventory/informer/registry_test.go
@@ -16,7 +16,8 @@ func TestRegistryShutdownIdempotent(t *testing.T) {
 	t.Parallel()
 	client, _ := newFakeClient(t)
 	reg := NewFactoryRegistry(client, 0)
-	reg.Get("default", "", "")
+	_, err := reg.Get("default", "", "")
+	require.NoError(t, err)
 
 	require.NotPanics(t, reg.Shutdown)
 	require.NotPanics(t, reg.Shutdown)
@@ -54,7 +55,9 @@ func TestRegistryConcurrentGetSameKeyReturnsSameFactory(t *testing.T) {
 	results := make([]any, n)
 	for i := range n {
 		wg.Go(func() {
-			results[i] = reg.Get("default", "app=foo", "")
+			f, err := reg.Get("default", "app=foo", "")
+			assert.NoError(t, err)
+			results[i] = f
 		})
 	}
 	wg.Wait()
@@ -76,7 +79,9 @@ func TestRegistryConcurrentGetDifferentKeysProducesDistinctFactories(t *testing.
 	for i := range n {
 		wg.Go(func() {
 			// Distinct label selector per goroutine forces a distinct factoryKey.
-			results[i] = reg.Get("default", "app="+string(rune('a'+i)), "")
+			f, err := reg.Get("default", "app="+string(rune('a'+i)), "")
+			assert.NoError(t, err)
+			results[i] = f
 		})
 	}
 	wg.Wait()
@@ -88,31 +93,34 @@ func TestRegistryConcurrentGetDifferentKeysProducesDistinctFactories(t *testing.
 	assert.Len(t, seen, n, "distinct scopes must each produce a distinct factory")
 }
 
-func TestRegistryGetAfterShutdownPanics(t *testing.T) {
+func TestRegistryGetAfterShutdownReturnsError(t *testing.T) {
 	t.Parallel()
 	client, _ := newFakeClient(t)
 	reg := NewFactoryRegistry(client, 0)
 	reg.Shutdown()
 
-	assert.Panics(t, func() {
-		reg.Get("default", "", "")
-	})
+	f, err := reg.Get("default", "", "")
+	assert.Nil(t, f)
+	assert.Error(t, err)
 }
 
-// Pins the registry's sharing contract: same scope => same factory, different scope => different factory.
 func TestRegistrySharesFactoryAcrossObservers(t *testing.T) {
 	t.Parallel()
 	client, _ := newFakeClient(t)
 	reg := NewFactoryRegistry(client, 0)
 	t.Cleanup(reg.Shutdown)
 
-	f1 := reg.Get("default", "app=foo", "")
-	f2 := reg.Get("default", "app=foo", "")
+	f1, err := reg.Get("default", "app=foo", "")
+	require.NoError(t, err)
+	f2, err := reg.Get("default", "app=foo", "")
+	require.NoError(t, err)
 	assert.Same(t, f1, f2, "same scope must return the same factory instance")
 
-	f3 := reg.Get("default", "app=bar", "")
+	f3, err := reg.Get("default", "app=bar", "")
+	require.NoError(t, err)
 	assert.NotSame(t, f1, f3, "different label selector must produce a different factory")
 
-	f4 := reg.Get("other", "app=foo", "")
+	f4, err := reg.Get("other", "app=foo", "")
+	require.NoError(t, err)
 	assert.NotSame(t, f1, f4, "different namespace must produce a different factory")
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is the second of three PRs splitting the informer-based k8sobjects observer work originally proposed in #48663. The split plan is documented here (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48663#issuecomment-4600125637):                                                                                                                 
                                                                                                                                                                                                                          
1. #48765 (merged) — extract the checkpoint package out of watch/ so it can be reused.                                                                                                                                  
2.   **_This PR: implement the informer-based Observer in a new `internal/k8sinventory/informer `package. The k8sobjects receiver is not wired to it yet, so there is no user-visible behavior change_.**                        
3. Follow-up — migrate the k8sobjects receiver to use the new observer.
                                                                                                                                                                                                                          

##### What this PR adds:                                                                                                                                                                 
                                                                                                                                                                                                                          
* `FactoryRegistry`: reuses informers for the same `(namespace, labelSelector, fieldSelector)` scope and GVR, so multiple observers can share one informer and one `List+Watch` connection.

* `Observer`: implements the existing `k8sinventory.Observer` interface using a factory from the registry. It supports both modes:

  * Pull mode: waits for the initial cache sync, then emits `store.List()` snapshots on the configured interval. It does not call the API on every tick.
  * Watch mode: registers a `ResourceEventHandler`, converts informer callbacks to `apiWatch.Event`, applies the `Exclude` filter, and saves `resourceVersion` checkpoints through the shared checkpoint package, with periodic flushes and a final flush on stop.
                                                                                                                                                                
  ---

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43602


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
