### PR TITLE
[chore][receiver/aws_cloudwatch] Fix race condition causing flaky test

### DIFF
--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -595,7 +595,7 @@ func TestShutdownWithoutCheckpointer(t *testing.T) {
 func TestDeletedLogGroupContinuesPolling(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Region = "us-west-1"
-	cfg.Logs.PollInterval = 1 * time.Second
+	cfg.Logs.PollInterval = 100 * time.Millisecond
 	cfg.Logs.Groups = GroupConfig{
 		NamedConfigs: map[string]StreamConfig{
 			"existing-group": {
@@ -641,10 +641,10 @@ func TestDeletedLogGroupContinuesPolling(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return sink.LogRecordCount() > 0
+		return sink.LogRecordCount() > 1
 	}, 2*time.Second, 10*time.Millisecond)
 	logs := sink.AllLogs()
-	require.Len(t, logs, 1)
+	require.GreaterOrEqual(t, len(logs), 2)
 	require.Equal(t, 1, logs[0].LogRecordCount())
 
 	logRecord := logs[0].ResourceLogs().At(0)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes the small chance of the `TestDeletedLogGroupContinuesPolling` test failing due to a race condition

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49531

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
