### PR TITLE
[datadogextension] Send full_configuration as YAML to match opampextension

### DIFF
--- a/.chloggen/49701.yaml
+++ b/.chloggen/49701.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/datadogextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Report `full_configuration` as YAML instead of JSON, fixing incorrect rendering of `time.Duration` fields (e.g. a raw nanosecond count instead of `"200ms"`).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49701]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This aligns the extension with opampextension, which already reports its effective configuration as YAML.
+  `full_configuration` is still delivered as a JSON string value within the outer payload, but its own
+  content is now YAML text rather than JSON text. This is an observable format change for any consumer
+  that parses `full_configuration`'s content directly.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -121,8 +121,11 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		Version:     e.info.build.Version,
 	}
 
-	// Get the full collector configuration as a flattened JSON string
-	fullConfig := componentchecker.DataToFlattenedJSONString(e.configs.collector.ToStringMap())
+	// Get the full collector configuration as a YAML string. YAML (rather than JSON)
+	// is used here so that values such as time.Duration render using the collector's
+	// own human-readable format (e.g. "200ms") instead of a raw nanosecond count,
+	// matching the format used by the opampextension's effective configuration reporting.
+	fullConfig := componentchecker.DataToYAMLString(e.configs.collector.ToStringMap())
 
 	// Prepare the base payload
 	otelCollectorPayload := payload.PrepareOtelCollectorMetadata(

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -121,10 +121,6 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		Version:     e.info.build.Version,
 	}
 
-	// Get the full collector configuration as a YAML string. YAML (rather than JSON)
-	// is used here so that values such as time.Duration render using the collector's
-	// own human-readable format (e.g. "200ms") instead of a raw nanosecond count,
-	// matching the format used by the opampextension's effective configuration reporting.
 	fullConfig := componentchecker.DataToYAMLString(e.configs.collector.ToStringMap())
 
 	// Prepare the base payload

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -219,9 +219,7 @@ func TestNotifyConfig(t *testing.T) {
 		assert.NotEmpty(t, ext.otelCollectorMetadata.ActiveComponents)
 		assert.NotNil(t, ext.httpServer, "http server should be created and started")
 
-		// full_configuration must be valid YAML, and duration values must render
-		// using their own string format (e.g. "200ms") rather than a raw
-		// nanosecond count, matching the format used by opampextension.
+		// full_configuration must be valid YAML
 		var parsedConfig map[string]any
 		require.NoError(t, yaml.Unmarshal([]byte(ext.otelCollectorMetadata.FullConfiguration), &parsedConfig))
 		assert.Contains(t, ext.otelCollectorMetadata.FullConfiguration, "timeout: 200ms")

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/service"
+	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/agentcomponents"
@@ -200,7 +201,10 @@ func TestNotifyConfig(t *testing.T) {
 
 		conf := confmap.NewFromStringMap(map[string]any{
 			"receivers": map[string]any{"otlp": nil},
-			"service":   map[string]any{"pipelines": map[string]any{"traces": map[string]any{"receivers": []any{"otlp"}}}},
+			"processors": map[string]any{
+				"batch": map[string]any{"timeout": 200 * time.Millisecond},
+			},
+			"service": map[string]any{"pipelines": map[string]any{"traces": map[string]any{"receivers": []any{"otlp"}}}},
 		})
 		ext.info.modules = service.ModuleInfos{Receiver: map[component.Type]service.ModuleInfo{
 			component.MustNewType("otlp"): {BuilderRef: "gomod.example/otlp v1.0.0"},
@@ -214,6 +218,13 @@ func TestNotifyConfig(t *testing.T) {
 		assert.NotEmpty(t, ext.otelCollectorMetadata.FullComponents)
 		assert.NotEmpty(t, ext.otelCollectorMetadata.ActiveComponents)
 		assert.NotNil(t, ext.httpServer, "http server should be created and started")
+
+		// full_configuration must be valid YAML, and duration values must render
+		// using their own string format (e.g. "200ms") rather than a raw
+		// nanosecond count, matching the format used by opampextension.
+		var parsedConfig map[string]any
+		require.NoError(t, yaml.Unmarshal([]byte(ext.otelCollectorMetadata.FullConfiguration), &parsedConfig))
+		assert.Contains(t, ext.otelCollectorMetadata.FullConfiguration, "timeout: 200ms")
 
 		// Ensure shutdown works cleanly
 		assert.NoError(t, ext.Shutdown(t.Context()))

--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/collector/service/hostcapabilities v0.156.1-0.20260709230849-fe96e04e8916
 	go.opentelemetry.io/otel v1.44.0
 	go.uber.org/zap v1.28.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -291,7 +292,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.4 // indirect
 	k8s.io/apimachinery v0.35.6 // indirect
 	k8s.io/client-go v0.35.4 // indirect

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/componentchecker"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
@@ -143,7 +144,7 @@ func TestPopulateActiveComponentsIntegration(t *testing.T) {
 	assert.True(t, hasOtlphttp, "should have otlp_http exporter")
 }
 
-func TestDataToFlattenedJSONStringIntegration(t *testing.T) {
+func TestDataToYAMLStringIntegration(t *testing.T) {
 	// Load the sample configuration file
 	configPath := filepath.Join("internal", "componentchecker", "testdata", "sample-config.yaml")
 
@@ -162,18 +163,15 @@ func TestDataToFlattenedJSONStringIntegration(t *testing.T) {
 	confMap, err := resolver.Resolve(t.Context())
 	require.NoError(t, err, "should be able to load config file")
 
-	// Test DataToFlattenedJSONString with the loaded configuration
-	jsonString := componentchecker.DataToFlattenedJSONString(confMap.ToStringMap())
+	// Test DataToYAMLString with the loaded configuration
+	yamlString := componentchecker.DataToYAMLString(confMap.ToStringMap())
 
-	// Verify that the result is valid JSON and doesn't contain newlines or carriage returns
-	assert.NotEmpty(t, jsonString, "JSON string should not be empty")
-	assert.NotContains(t, jsonString, "\n", "JSON string should not contain newlines")
-	assert.NotContains(t, jsonString, "\r", "JSON string should not contain carriage returns")
+	// Verify that the result is non-empty valid YAML
+	assert.NotEmpty(t, yamlString, "YAML string should not be empty")
 
-	// Verify it's valid JSON by attempting to unmarshal
 	var result map[string]any
-	err = json.Unmarshal([]byte(jsonString), &result)
-	assert.NoError(t, err, "flattened JSON should be valid JSON")
+	err = yaml.Unmarshal([]byte(yamlString), &result)
+	assert.NoError(t, err, "result should be valid YAML")
 }
 
 // TestFullOtelCollectorPayloadIntegration tests the complete end-to-end flow of:
@@ -348,7 +346,7 @@ func createTestOtelCollectorPayload() *payload.OtelCollectorPayload {
 	}
 
 	// Get flattened configuration
-	fullConfig := componentchecker.DataToFlattenedJSONString(confMap.ToStringMap())
+	fullConfig := componentchecker.DataToYAMLString(confMap.ToStringMap())
 
 	// Prepare base metadata
 	hostname := "test-integration-host"
@@ -567,7 +565,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 		Description: "OpenTelemetry Collector Contrib",
 		Version:     "0.127.0",
 	}
-	fullConfig := componentchecker.DataToFlattenedJSONString(confMap.ToStringMap())
+	fullConfig := componentchecker.DataToYAMLString(confMap.ToStringMap())
 	otelMetadata := payload.PrepareOtelCollectorMetadata(
 		testHostname,
 		"config",

--- a/extension/datadogextension/internal/componentchecker/componentchecker.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/pipelines"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
 )
@@ -54,6 +55,26 @@ func DataToFlattenedJSONString(data any) string {
 	}
 	res := replacer.Replace(string(jsonData))
 	return res
+}
+
+// DataToYAMLString marshals data to a YAML string. Unlike DataToFlattenedJSONString,
+// this preserves the collector's own YAML type formatting for values such as
+// time.Duration (e.g. "200ms" instead of a raw nanosecond count), matching the
+// format used by the opampextension's effective configuration reporting.
+func DataToYAMLString(data any) (result string) {
+	// yaml.Marshal panics rather than returning an error for some unsupported
+	// types (e.g. channels), unlike encoding/json.Marshal.
+	defer func() {
+		if recover() != nil {
+			result = ""
+		}
+	}()
+
+	yamlData, err := yaml.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	return string(yamlData)
 }
 
 // PopulateFullComponentsJSON creates a ModuleInfoJSON struct with all components from ModuleInfos

--- a/extension/datadogextension/internal/componentchecker/componentchecker.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker.go
@@ -5,7 +5,6 @@
 package componentchecker // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/componentchecker"
 
 import (
-	"encoding/json"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
@@ -43,24 +42,7 @@ func isComponentConfigured(typ component.Type, c map[component.ID]component.Conf
 	return false
 }
 
-// DataToFlattenedJSONString is a helper function to ensure payload strings are
-// properly formatted for JSON parsing. This is necessary due to escaped newline
-// characters and whitespace causing failure on parsing when loading into
-// the underlying data platform.
-func DataToFlattenedJSONString(data any) string {
-	replacer := strings.NewReplacer("\r", "", "\n", "")
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return ""
-	}
-	res := replacer.Replace(string(jsonData))
-	return res
-}
-
-// DataToYAMLString marshals data to a YAML string. Unlike DataToFlattenedJSONString,
-// this preserves the collector's own YAML type formatting for values such as
-// time.Duration (e.g. "200ms" instead of a raw nanosecond count), matching the
-// format used by the opampextension's effective configuration reporting.
+// DataToYAMLString marshals data to a YAML string.
 func DataToYAMLString(data any) (result string) {
 	// yaml.Marshal panics rather than returning an error for some unsupported
 	// types (e.g. channels), unlike encoding/json.Marshal.

--- a/extension/datadogextension/internal/componentchecker/componentchecker_test.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker_test.go
@@ -6,6 +6,7 @@ package componentchecker // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
 )
@@ -730,4 +732,50 @@ func TestDataToFlattenedJSONStringAdditionalCases(t *testing.T) {
 		result := DataToFlattenedJSONString(nil)
 		assert.Equal(t, "null", result)
 	})
+}
+
+func TestDataToYAMLString(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     any
+		expected string
+	}{
+		{
+			name: "Simple map",
+			data: map[string]any{
+				"key": "value",
+			},
+			expected: "key: value\n",
+		},
+		{
+			// Regression test: time.Duration must render using its own string
+			// format (e.g. "200ms"), not as a raw nanosecond count. This is the
+			// exact bug this extension used to have when full_configuration was
+			// serialized as JSON instead of YAML, since encoding/json has no
+			// special handling for time.Duration.
+			name: "time.Duration renders as a duration string",
+			data: map[string]any{
+				"timeout": 200 * time.Millisecond,
+			},
+			expected: "timeout: 200ms\n",
+		},
+		{
+			name:     "Invalid YAML",
+			data:     make(chan int),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DataToYAMLString(tt.data)
+			assert.Equal(t, tt.expected, result)
+
+			if tt.expected != "" {
+				var parsed map[string]any
+				err := yaml.Unmarshal([]byte(result), &parsed)
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/extension/datadogextension/internal/componentchecker/componentchecker_test.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker_test.go
@@ -4,7 +4,6 @@
 package componentchecker // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/componentchecker"
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -18,34 +17,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
 )
-
-func TestDataToFlattenedJSONString(t *testing.T) {
-	tests := []struct {
-		name     string
-		data     any
-		expected string
-	}{
-		{
-			name: "Simple map without lines",
-			data: map[string]any{
-				"key": "value",
-			},
-			expected: `{"key":"value"}`,
-		},
-		{
-			name:     "Invalid JSON",
-			data:     make(chan int),
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := DataToFlattenedJSONString(tt.data)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
 
 func TestPopulateFullComponentsJSON(t *testing.T) {
 	tests := []struct {
@@ -704,36 +675,6 @@ func TestPopulateActiveComponentsAdditionalErrorPaths(t *testing.T) {
 	})
 }
 
-func TestDataToFlattenedJSONStringAdditionalCases(t *testing.T) {
-	t.Run("complex nested structure", func(t *testing.T) {
-		data := map[string]any{
-			"level1": map[string]any{
-				"level2": map[string]any{
-					"key":   "value",
-					"array": []string{"item1", "item2"},
-				},
-				"simple": "test",
-			},
-			"number": 123,
-		}
-
-		result := DataToFlattenedJSONString(data)
-		assert.NotEmpty(t, result)
-		assert.NotContains(t, result, "\n")
-		assert.NotContains(t, result, "\r")
-
-		// Verify it's valid JSON
-		var parsed map[string]any
-		err := json.Unmarshal([]byte(result), &parsed)
-		assert.NoError(t, err)
-	})
-
-	t.Run("nil input", func(t *testing.T) {
-		result := DataToFlattenedJSONString(nil)
-		assert.Equal(t, "null", result)
-	})
-}
-
 func TestDataToYAMLString(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -760,6 +701,65 @@ func TestDataToYAMLString(t *testing.T) {
 			expected: "timeout: 200ms\n",
 		},
 		{
+			name: "nested maps and slices",
+			data: map[string]any{
+				"receivers": map[string]any{
+					"otlp": map[string]any{
+						"protocols": map[string]any{
+							"grpc": map[string]any{},
+							"http": map[string]any{},
+						},
+					},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"metrics": map[string]any{
+							"receivers": []string{"otlp"},
+							"exporters": []string{"debug", "otlphttp"},
+						},
+					},
+				},
+			},
+			expected: "receivers:\n" +
+				"    otlp:\n" +
+				"        protocols:\n" +
+				"            grpc: {}\n" +
+				"            http: {}\n" +
+				"service:\n" +
+				"    pipelines:\n" +
+				"        metrics:\n" +
+				"            exporters:\n" +
+				"                - debug\n" +
+				"                - otlphttp\n" +
+				"            receivers:\n" +
+				"                - otlp\n",
+		},
+		{
+			name: "string requiring quoting is preserved",
+			data: map[string]any{
+				"password": "yes",
+				"endpoint": "0.0.0.0:4317",
+			},
+			expected: "endpoint: 0.0.0.0:4317\npassword: \"yes\"\n",
+		},
+		{
+			name: "multiline string renders as a literal block",
+			data: map[string]any{
+				"cert": "line1\nline2\n",
+			},
+			expected: "cert: |\n    line1\n    line2\n",
+		},
+		{
+			name:     "empty map",
+			data:     map[string]any{},
+			expected: "{}\n",
+		},
+		{
+			name:     "nil data",
+			data:     nil,
+			expected: "null\n",
+		},
+		{
 			name:     "Invalid YAML",
 			data:     make(chan int),
 			expected: "",
@@ -772,7 +772,7 @@ func TestDataToYAMLString(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 
 			if tt.expected != "" {
-				var parsed map[string]any
+				var parsed any
 				err := yaml.Unmarshal([]byte(result), &parsed)
 				assert.NoError(t, err)
 			}

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -33,7 +33,7 @@ type OtelCollector struct {
 	FullComponents              []CollectorModule  `json:"full_components"`
 	ActiveComponents            []ServiceComponent `json:"active_components"`
 	BuildInfo                   CustomBuildInfo    `json:"build_info"`
-	FullConfiguration           string             `json:"full_configuration"` // JSON passed as string
+	FullConfiguration           string             `json:"full_configuration"` // YAML passed as string
 	HealthStatus                string             `json:"health_status"`      // JSON passed as string
 	CollectorResourceAttributes map[string]string  `json:"collector_resource_attributes"`
 	CollectorDeploymentType     string             `json:"collector_deployment_type"`     // deployment type: gateway, daemonset, or unknown

--- a/extension/datadogextension/internal/payload/testdata/sample-otelcollectorpayload.json
+++ b/extension/datadogextension/internal/payload/testdata/sample-otelcollectorpayload.json
@@ -52,7 +52,7 @@
       "description": "OpenTelemetry Collector",
       "version": "0.125.0"
     },
-    "full_configuration": "{\"receivers\":{\"otlp\":{}},\"exporters\":{\"debug\":{}},\"service\":{\"pipelines\":{\"metrics\":{\"receivers\":[\"otlp\"],\"exporters\":[\"debug\"]}}}}",
+    "full_configuration": "receivers:\n  otlp: {}\nexporters:\n  debug: {}\nservice:\n  pipelines:\n    metrics:\n      receivers:\n        - otlp\n      exporters:\n        - debug\n",
     "health_status": "{\"status\":\"healthy\"}",
     "collector_resource_attributes": {},
     "collector_deployment_type": "gateway"


### PR DESCRIPTION
#### Description
Align datadog extension configuration format with opamp extension. ie sends the configuration as a yaml instead of a json.

#### Link to tracking issue
Fixes

#### Testing
Datadog backend handle string, regardless if it's a yaml or json

#### Documentation
None

#### Authorship

- [x] I, a human, wrote this pull request description myself.