### PR TITLE
[processor/resource_detection] Add `cloud.region` to GKE resource detection by deriving it from `cloud.availability_zone`

### DIFF
--- a/.chloggen/dylan_add-cloud-region.yaml
+++ b/.chloggen/dylan_add-cloud-region.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resource_detection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add cloud.region to GKE resource detection by deriving it from cloud.availability_zone
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49694]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -201,7 +201,7 @@ The list of the populated resource attributes can be found at [GCP Detector Reso
     * cloud.provider ("gcp")
     * cloud.platform ("gcp_kubernetes_engine")
     * cloud.account.id (project id)
-    * cloud.region (only for regional GKE clusters; e.g. "us-central1")
+    * cloud.region (e.g. "us-central1")
     * cloud.availability_zone (only for zonal GKE clusters; e.g. "us-central1-c")
     * k8s.cluster.name
     * host.id (instance id)

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -75,6 +75,7 @@ func TestDetect(t *testing.T) {
 				"cloud.platform":          "gcp_kubernetes_engine",
 				"k8s.cluster.name":        "my-cluster",
 				"cloud.availability_zone": "us-central1-c",
+				"cloud.region":            "us-central1",
 				"host.id":                 "1472385723456792345",
 				"host.name":               "my-gke-node-1234",
 			},

--- a/processor/resourcedetectionprocessor/internal/gcp/internal/metadata/resource.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/internal/metadata/resource.go
@@ -5,6 +5,7 @@ package metadata // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp"
 )
@@ -36,6 +37,9 @@ func (rb *ResourceBuilder) SetZoneOrRegion(detect func() (string, gcp.LocationTy
 	switch locType {
 	case gcp.Zone:
 		rb.SetCloudAvailabilityZone(v)
+		if idx := strings.LastIndex(v, "-"); idx != -1 {
+			rb.SetCloudRegion(v[:idx])
+		}
 	case gcp.Region:
 		rb.SetCloudRegion(v)
 	default:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
In the resource detection processor if we have an availability zone then we can easily derive the region

```
us-central1-a -> us-central1
europe-west3-c -> europe-west3
northamerica-northeast2-b -> northamerica-northeast2
us-west4-ai2b -> us-west4
```

Previously we omitted the region attribute. This PR adds it by stripping off the last `-` and everything after it

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49694

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Test added confirming the parsing is correct

#### Documentation
Updated readme

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
