### PR TITLE
[oracledbreceiver] Fix resource leak in metricRows query execution

### DIFF
--- a/.chloggen/oracledb-close-rows-leak.yaml
+++ b/.chloggen/oracledb-close-rows-leak.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: receiver/oracledb
+note: "Fix database connection and cursor leak by properly closing `sql.Rows` in `metricRows`."
+issues: [49705]
+change_logs: [user]

--- a/receiver/oracledbreceiver/db_client.go
+++ b/receiver/oracledbreceiver/db_client.go
@@ -40,6 +40,7 @@ func (cl dbSQLClient) metricRows(ctx context.Context, args ...any) ([]metricRow,
 	if err != nil {
 		return nil, err
 	}
+	defer sqlRows.Close()
 	var out []metricRow
 	row := reusableRow{
 		attrs: map[string]func() string{},

--- a/receiver/oracledbreceiver/db_client.go
+++ b/receiver/oracledbreceiver/db_client.go
@@ -40,6 +40,7 @@ func (cl dbSQLClient) metricRows(ctx context.Context, args ...any) ([]metricRow,
 	if err != nil {
 		return nil, err
 	}
+	defer sqlRows.Close()
 	var out []metricRow
 	row := reusableRow{
 		attrs: map[string]func() string{},
@@ -72,6 +73,9 @@ func (cl dbSQLClient) metricRows(ctx context.Context, args ...any) ([]metricRow,
 			return nil, err
 		}
 		out = append(out, row.toMetricRow())
+	}
+	if err := sqlRows.Err(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/receiver/oracledbreceiver/db_client_test.go
+++ b/receiver/oracledbreceiver/db_client_test.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oracledbreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestMetricRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"COL1", "COL2"}).
+			AddRow("val1", "val2")).
+		RowsWillBeClosed()
+
+	client := newDbClient(db, "SELECT * FROM dual", zap.NewNop())
+	rows, err := client.metricRows(context.Background())
+	require.NoError(t, err)
+
+	expected := []metricRow{
+		{
+			"COL1": "val1",
+			"COL2": "val2",
+		},
+	}
+	assert.Equal(t, expected, rows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/receiver/oracledbreceiver/go.mod
+++ b/receiver/oracledbreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracle
 go 1.25.0
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/receiver/oracledbreceiver/go.sum
+++ b/receiver/oracledbreceiver/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.77.0-devel.0.20260213154712-e02b9359151a h1:/xtQjxLk5vwsBsiBAnoz8qTdntvp6DX41AteNrbns5Y=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.77.0-devel.0.20260213154712-e02b9359151a/go.mod h1:TcvPatbygfZy2wH7n259LZuYUz3TIe3o/Dv53Su7uqM=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
@@ -43,6 +45,7 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
 github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/knadh/koanf/providers/confmap v1.0.0 h1:mHKLJTE7iXEys6deO5p6olAiZdG5zwp8Aebir+/EaRE=


### PR DESCRIPTION
### PR Description 
Database Connection Leak in oracledbreceiver due to unclosed sql.Rows

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->




<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49705



<!--Describe what testing was performed and which tests were added.-->
#### Testing



<!--Describe the documentation added.-->
#### Documentation



<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
