### PR TITLE
[receiver/snowflake] Close sql.Rows in Fetch* methods to prevent connection pool leak

### DIFF
--- a/.chloggen/snowflake-close-rows-leak.yaml
+++ b/.chloggen/snowflake-close-rows-leak.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/snowflake
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Close sql.Rows in all Fetch* methods so the underlying driver connection is released back to the pool.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49707]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, none of the 8 Fetch* methods in client.go called rows.Close() after iterating sql.Rows returned by readDB(). This leaked a database connection per query per scrape interval, eventually exhausting the connection pool. Also adds rows.Err() checks after each rows.Next() loop to surface iteration errors.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/snowflakereceiver/client.go
+++ b/receiver/snowflakereceiver/client.go
@@ -90,6 +90,7 @@ func (c snowflakeClient) FetchBillingMetrics(ctx context.Context) (*[]billingMet
 		err = fmt.Errorf("no rows returned by query: %v", billingMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []billingMetric
 
@@ -110,6 +111,9 @@ func (c snowflakeClient) FetchBillingMetrics(ctx context.Context) (*[]billingMet
 			totalVirtualWarehouseCredits: totalVirtualWarehouseCredits,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -123,6 +127,7 @@ func (c snowflakeClient) FetchWarehouseBillingMetrics(ctx context.Context) (*[]w
 		err = fmt.Errorf("no rows returned by query: %v", warehouseBillingMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []whBillingMetric
 
@@ -141,6 +146,9 @@ func (c snowflakeClient) FetchWarehouseBillingMetrics(ctx context.Context) (*[]w
 			totalVirtualWarehouse: totalVirtualWarehouse,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -154,6 +162,7 @@ func (c snowflakeClient) FetchLoginMetrics(ctx context.Context) (*[]loginMetric,
 		err = fmt.Errorf("no rows returned by query: %v", loginMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []loginMetric
 
@@ -179,6 +188,9 @@ func (c snowflakeClient) FetchLoginMetrics(ctx context.Context) (*[]loginMetric,
 			isSuccess:          isSuccess,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -192,6 +204,7 @@ func (c snowflakeClient) FetchHighLevelQueryMetrics(ctx context.Context) (*[]hlQ
 		err = fmt.Errorf("no rows returned by query: %v", highLevelQueryMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []hlQueryMetric
 
@@ -219,6 +232,9 @@ func (c snowflakeClient) FetchHighLevelQueryMetrics(ctx context.Context) (*[]hlQ
 				avgQueryQueuedProvision: avgQueryQueuedProvision,
 			})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &res, nil
 }
@@ -233,6 +249,7 @@ func (c snowflakeClient) FetchDbMetrics(ctx context.Context) (*[]dbMetric, error
 		err = fmt.Errorf("no rows returned by query: %v", dbMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []dbMetric
 
@@ -316,6 +333,9 @@ func (c snowflakeClient) FetchDbMetrics(ctx context.Context) (*[]dbMetric, error
 		}
 		res = append(res, db)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -329,6 +349,7 @@ func (c snowflakeClient) FetchSessionMetrics(ctx context.Context) (*[]sessionMet
 		err = fmt.Errorf("no rows returned by query: %v", sessionMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []sessionMetric
 
@@ -345,6 +366,9 @@ func (c snowflakeClient) FetchSessionMetrics(ctx context.Context) (*[]sessionMet
 			distinctSessionID: distinctSessionID,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &res, nil
 }
@@ -359,6 +383,7 @@ func (c snowflakeClient) FetchSnowpipeMetrics(ctx context.Context) (*[]snowpipeM
 		err = fmt.Errorf("no rows returned by query: %v", snowpipeMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []snowpipeMetric
 
@@ -378,6 +403,9 @@ func (c snowflakeClient) FetchSnowpipeMetrics(ctx context.Context) (*[]snowpipeM
 			filesInserted: filesInserted,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &res, nil
 }
@@ -392,6 +420,7 @@ func (c snowflakeClient) FetchStorageMetrics(ctx context.Context) (*[]storageMet
 		err = fmt.Errorf("no rows returned by query: %v", storageMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []storageMetric
 
@@ -406,6 +435,9 @@ func (c snowflakeClient) FetchStorageMetrics(ctx context.Context) (*[]storageMet
 			stageBytes:    stageBytes,
 			failsafeBytes: failsafeBytes,
 		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return &res, nil
 }

--- a/receiver/snowflakereceiver/client_test.go
+++ b/receiver/snowflakereceiver/client_test.go
@@ -6,6 +6,7 @@ package snowflakereceiver
 import (
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"reflect"
 	"regexp"
 	"testing"
@@ -310,6 +311,38 @@ func TestMetricQueries(t *testing.T) {
 
 			// Value Check
 			assert.Equal(t, test.expect, actualMetric, "Metric values should match expected values")
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("Unfulfilled mock expectations: %s", err)
+			}
+		})
+
+		t.Run(test.desc+"_RowErr", func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			if err != nil {
+				t.Fatal("an error was not expected when opening mock db", err)
+			}
+
+			expectedErr := errors.New("mock row error")
+			rows := mock.NewRows(test.columns).AddRow(test.params...).AddRow(test.params...).RowError(1, expectedErr)
+			mock.ExpectQuery(test.query).WillReturnRows(rows)
+			defer db.Close()
+
+			client := snowflakeClient{
+				client: db,
+				logger: receivertest.NewNopSettings(metadata.Type).Logger,
+			}
+			ctx := t.Context()
+
+			clientVal := reflect.ValueOf(&client)
+			clientObj := reflect.Indirect(clientVal)
+			returnVal := clientObj.MethodByName(test.desc).Call([]reflect.Value{reflect.ValueOf(ctx)})
+
+			errInterface := returnVal[1].Interface()
+			assert.NotNil(t, errInterface)
+			err, ok := errInterface.(error)
+			assert.True(t, ok)
+			assert.Equal(t, expectedErr, err)
 
 			if err := mock.ExpectationsWereMet(); err != nil {
 				t.Errorf("Unfulfilled mock expectations: %s", err)


### PR DESCRIPTION
#### Description

Fix a `sql.Rows` resource leak in all 8 `Fetch*` methods in `client.go`. None of these methods called `rows.Close()` after iterating the rows returned by `readDB()`, causing database connections to leak every scrape interval. Also adds `rows.Err()` checks after each `rows.Next()` loop to detect and surface iteration errors that were previously silently ignored.

This follows the established pattern used consistently in `postgresqlreceiver`, `mysqlreceiver`, and `saphanareceiver`.

#### Link to tracking issue
Fixes #49707

#### Testing

- Existing unit tests (`TestMetricQueries`) pass with no changes needed — the fix is purely additive resource cleanup.
- Verified via `go test ./...` — all tests pass.
- Verified 8 `rows.Close()` and 8 `rows.Err()` calls via grep.

#### Documentation

No documentation changes needed — this is a bug fix with no user-facing configuration changes.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
