### PR TITLE
[processor/tailsamplingprocessor] Implement ThresholdEvaluator for rate_limiting policy

### DIFF
--- a/.chloggen/49710-rate-limiting-threshold-evaluator.yaml
+++ b/.chloggen/49710-rate-limiting-threshold-evaluator.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tailsampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Implement `ThresholdEvaluator` for the `rate_limiting` policy to prevent silent undercounting when using tracestate."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49710]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The rate limiting policy now reports estimated effective sampling thresholds on W3C tracestate when the `processor.tailsamplingprocessor.usetracestate` feature gate is enabled.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/snowflake-close-rows-leak.yaml
+++ b/.chloggen/snowflake-close-rows-leak.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/snowflake
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Close sql.Rows in all Fetch* methods so the underlying driver connection is released back to the pool.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49707]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, none of the 8 Fetch* methods in client.go called rows.Close() after iterating sql.Rows returned by readDB(). This leaked a database connection per query per scrape interval, eventually exhausting the connection pool. Also adds rows.Err() checks after each rows.Next() loop to surface iteration errors.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
@@ -5,6 +5,8 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
+	"math"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -12,16 +14,33 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
+// emaHalfLife controls the responsiveness of the arrival-rate estimate.
+// A half-life of 10 seconds means after 10 seconds of constant traffic
+// the EMA has converged to ~50% of the gap between the old and new rate.
+const emaHalfLife = 10 * time.Second
+
 type rateLimiting struct {
 	// Rate limiter using golang.org/x/time/rate for efficient token bucket implementation.
-	limiter *rate.Limiter
-	logger  *zap.Logger
+	limiter        *rate.Limiter
+	spansPerSecond float64
+	logger         *zap.Logger
+	useTraceState  bool
+
+	// EMA state for arrival-rate estimation.
+	mu       sync.Mutex
+	lastTime time.Time
+	emaRate  float64 // exponential moving average of observed spans/sec
 }
 
-var _ samplingpolicy.Evaluator = (*rateLimiting)(nil)
+var (
+	_ samplingpolicy.Evaluator          = (*rateLimiting)(nil)
+	_ samplingpolicy.ThresholdEvaluator = (*rateLimiting)(nil)
+)
 
 // NewRateLimiting creates a policy evaluator that samples traces based on a span limit per second using a token bucket algorithm.
 // The bucket capacity defaults to 2x the spans per second to allow for reasonable burst traffic.
@@ -35,20 +54,98 @@ func NewRateLimiting(settings component.TelemetrySettings, spansPerSecond int64)
 // count exceeds the burst capacity will not pass.
 func NewRateLimitingWithBurstCapacity(settings component.TelemetrySettings, spansPerSecond, burstCapacity int64) samplingpolicy.Evaluator {
 	return &rateLimiting{
-		limiter: rate.NewLimiter(rate.Limit(spansPerSecond), int(burstCapacity)),
-		logger:  settings.Logger,
+		limiter:        rate.NewLimiter(rate.Limit(spansPerSecond), int(burstCapacity)),
+		spansPerSecond: float64(spansPerSecond),
+		logger:         settings.Logger,
+		useTraceState:  metadata.ProcessorTailsamplingprocessorUsetracestateFeatureGate.IsEnabled(),
 	}
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision based on token bucket consumption.
-func (r *rateLimiting) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
+func (r *rateLimiting) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
+	d, _, err := r.EvaluateWithThreshold(ctx, traceID, trace)
+	return d, err
+}
+
+// EvaluateWithThreshold makes the sampling decision and reports the
+// effective OpenTelemetry threshold the policy would advertise on
+// outgoing tracestate.
+//
+// The threshold is estimated from the observed arrival rate using an
+// exponential moving average (EMA): p = min(1, spansPerSecond / emaRate).
+// When the usetracestate feature gate is disabled the threshold is
+// AlwaysSampleThreshold, preserving the pre-existing behavior.
+func (r *rateLimiting) EvaluateWithThreshold(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, sampling.Threshold, error) {
 	r.logger.Debug("Evaluating spans in rate-limiting filter")
 
-	if r.limiter.AllowN(time.Now(), int(trace.SpanCount)) {
-		return samplingpolicy.Sampled, nil
+	now := time.Now()
+	spanCount := trace.SpanCount
+
+	r.updateEMA(now, spanCount)
+
+	if r.limiter.AllowN(now, int(spanCount)) {
+		return samplingpolicy.Sampled, r.effectiveThreshold(), nil
 	}
 
-	return samplingpolicy.NotSampled, nil
+	return samplingpolicy.NotSampled, r.effectiveThreshold(), nil
+}
+
+// updateEMA updates the exponential moving average of the observed
+// span arrival rate.  It is safe for concurrent use.
+func (r *rateLimiting) updateEMA(now time.Time, spanCount int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.lastTime.IsZero() {
+		// First observation: seed the EMA at the configured rate so the
+		// initial threshold is AlwaysSampleThreshold until enough data
+		// accumulates.
+		r.lastTime = now
+		r.emaRate = r.spansPerSecond
+		return
+	}
+
+	dt := now.Sub(r.lastTime).Seconds()
+	if dt <= 0 {
+		// Clock didn't advance; accumulate spans without updating rate.
+		return
+	}
+
+	r.lastTime = now
+	instantRate := float64(spanCount) / dt
+
+	// Time-weighted EMA: alpha = 1 - exp(-dt / halfLife).
+	// This makes the smoothing independent of the call frequency.
+	alpha := 1 - math.Exp(-dt/emaHalfLife.Seconds())
+	r.emaRate = alpha*instantRate + (1-alpha)*r.emaRate
+}
+
+// effectiveThreshold returns the estimated sampling threshold based
+// on the current EMA rate.  When the usetracestate feature gate is
+// off it returns AlwaysSampleThreshold (the legacy no-op behavior).
+func (r *rateLimiting) effectiveThreshold() sampling.Threshold {
+	if !r.useTraceState {
+		return sampling.AlwaysSampleThreshold
+	}
+
+	r.mu.Lock()
+	emaRate := r.emaRate
+	r.mu.Unlock()
+
+	if emaRate <= r.spansPerSecond {
+		// Not limiting: every trace is kept, adjusted count = 1.
+		return sampling.AlwaysSampleThreshold
+	}
+
+	p := r.spansPerSecond / emaRate
+	th, err := sampling.ProbabilityToThreshold(p)
+	if err != nil {
+		// p is below MinSamplingProbability — extremely unlikely in
+		// practice, but fall back to AlwaysSampleThreshold so we
+		// never block a sampled trace's threshold.
+		return sampling.AlwaysSampleThreshold
+	}
+	return th
 }
 
 func (*rateLimiting) IsStateful() bool {

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	pkgsampling "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
@@ -81,4 +84,97 @@ func TestRateLimiterTokenRefill(t *testing.T) {
 	decision, err = rateLimiter.Evaluate(t.Context(), pcommon.TraceID([16]byte{3}), trace)
 	require.NoError(t, err)
 	assert.Equal(t, samplingpolicy.Sampled, decision)
+}
+
+func TestRateLimitingImplementsThresholdEvaluator(t *testing.T) {
+	rateLimiter := NewRateLimiting(componenttest.NewNopTelemetrySettings(), 3)
+	require.Implements(t, (*samplingpolicy.ThresholdEvaluator)(nil), rateLimiter)
+}
+
+func TestRateLimitingThresholdAlwaysSampleWhenNotLimiting(t *testing.T) {
+	gate := metadata.ProcessorTailsamplingprocessorUsetracestateFeatureGate
+	prev := gate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), true))
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(gate.ID(), prev)
+	}()
+
+	trace := newTraceStringAttrs(nil, "example", "value")
+	trace.SpanCount = 1
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	
+	rateLimiter := NewRateLimiting(componenttest.NewNopTelemetrySettings(), 1000)
+	te := rateLimiter.(samplingpolicy.ThresholdEvaluator)
+
+	// First evaluation initializes EMA
+	decision, th, err := te.EvaluateWithThreshold(t.Context(), traceID, trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
+	assert.Equal(t, pkgsampling.AlwaysSampleThreshold, th)
+
+	// Wait a bit, evaluate again with span count small enough to be under the limit
+	time.Sleep(10 * time.Millisecond)
+	decision, th, err = te.EvaluateWithThreshold(t.Context(), traceID, trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
+	assert.Equal(t, pkgsampling.AlwaysSampleThreshold, th)
+}
+
+func TestRateLimitingThresholdReflectsRate(t *testing.T) {
+	gate := metadata.ProcessorTailsamplingprocessorUsetracestateFeatureGate
+	prev := gate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), true))
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(gate.ID(), prev)
+	}()
+
+	trace := newTraceStringAttrs(nil, "example", "value")
+	traceID := pcommon.TraceID([16]byte{1})
+	
+	// Spans per sec = 1, burst = 100
+	rateLimiter := NewRateLimitingWithBurstCapacity(componenttest.NewNopTelemetrySettings(), 1, 100)
+	te := rateLimiter.(samplingpolicy.ThresholdEvaluator)
+
+	// First eval to set lastTime
+	trace.SpanCount = 1
+	_, _, err := te.EvaluateWithThreshold(t.Context(), traceID, trace)
+	require.NoError(t, err)
+
+	// Sleep 100ms, then hit it with 10 spans. Instant rate = 100 spans/sec.
+	time.Sleep(100 * time.Millisecond)
+	trace.SpanCount = 10
+	
+	decision, th, err := te.EvaluateWithThreshold(t.Context(), traceID, trace)
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.Sampled, decision) // We have a burst of 100, so it's allowed
+	
+	// The EMA should be updated and > 1.0 (the limit).
+	// So the threshold should be greater than AlwaysSampleThreshold.
+	assert.True(t, pkgsampling.ThresholdGreater(th, pkgsampling.AlwaysSampleThreshold))
+}
+
+func TestRateLimitingThresholdWithoutFeatureGate(t *testing.T) {
+	gate := metadata.ProcessorTailsamplingprocessorUsetracestateFeatureGate
+	prev := gate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), false))
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(gate.ID(), prev)
+	}()
+
+	trace := newTraceStringAttrs(nil, "example", "value")
+	traceID := pcommon.TraceID([16]byte{1})
+	
+	rateLimiter := NewRateLimitingWithBurstCapacity(componenttest.NewNopTelemetrySettings(), 1, 100)
+	te := rateLimiter.(samplingpolicy.ThresholdEvaluator)
+
+	trace.SpanCount = 1
+	_, _, _ = te.EvaluateWithThreshold(t.Context(), traceID, trace)
+	
+	time.Sleep(100 * time.Millisecond)
+	trace.SpanCount = 10
+	decision, th, err := te.EvaluateWithThreshold(t.Context(), traceID, trace)
+	
+	require.NoError(t, err)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
+	assert.Equal(t, pkgsampling.AlwaysSampleThreshold, th)
 }

--- a/receiver/snowflakereceiver/client.go
+++ b/receiver/snowflakereceiver/client.go
@@ -90,6 +90,7 @@ func (c snowflakeClient) FetchBillingMetrics(ctx context.Context) (*[]billingMet
 		err = fmt.Errorf("no rows returned by query: %v", billingMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []billingMetric
 
@@ -110,6 +111,9 @@ func (c snowflakeClient) FetchBillingMetrics(ctx context.Context) (*[]billingMet
 			totalVirtualWarehouseCredits: totalVirtualWarehouseCredits,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -123,6 +127,7 @@ func (c snowflakeClient) FetchWarehouseBillingMetrics(ctx context.Context) (*[]w
 		err = fmt.Errorf("no rows returned by query: %v", warehouseBillingMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []whBillingMetric
 
@@ -141,6 +146,9 @@ func (c snowflakeClient) FetchWarehouseBillingMetrics(ctx context.Context) (*[]w
 			totalVirtualWarehouse: totalVirtualWarehouse,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -154,6 +162,7 @@ func (c snowflakeClient) FetchLoginMetrics(ctx context.Context) (*[]loginMetric,
 		err = fmt.Errorf("no rows returned by query: %v", loginMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []loginMetric
 
@@ -179,6 +188,9 @@ func (c snowflakeClient) FetchLoginMetrics(ctx context.Context) (*[]loginMetric,
 			isSuccess:          isSuccess,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -192,6 +204,7 @@ func (c snowflakeClient) FetchHighLevelQueryMetrics(ctx context.Context) (*[]hlQ
 		err = fmt.Errorf("no rows returned by query: %v", highLevelQueryMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []hlQueryMetric
 
@@ -219,6 +232,9 @@ func (c snowflakeClient) FetchHighLevelQueryMetrics(ctx context.Context) (*[]hlQ
 				avgQueryQueuedProvision: avgQueryQueuedProvision,
 			})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &res, nil
 }
@@ -233,6 +249,7 @@ func (c snowflakeClient) FetchDbMetrics(ctx context.Context) (*[]dbMetric, error
 		err = fmt.Errorf("no rows returned by query: %v", dbMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []dbMetric
 
@@ -316,6 +333,9 @@ func (c snowflakeClient) FetchDbMetrics(ctx context.Context) (*[]dbMetric, error
 		}
 		res = append(res, db)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 
@@ -329,6 +349,7 @@ func (c snowflakeClient) FetchSessionMetrics(ctx context.Context) (*[]sessionMet
 		err = fmt.Errorf("no rows returned by query: %v", sessionMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []sessionMetric
 
@@ -345,6 +366,9 @@ func (c snowflakeClient) FetchSessionMetrics(ctx context.Context) (*[]sessionMet
 			distinctSessionID: distinctSessionID,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &res, nil
 }
@@ -359,6 +383,7 @@ func (c snowflakeClient) FetchSnowpipeMetrics(ctx context.Context) (*[]snowpipeM
 		err = fmt.Errorf("no rows returned by query: %v", snowpipeMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []snowpipeMetric
 
@@ -378,6 +403,9 @@ func (c snowflakeClient) FetchSnowpipeMetrics(ctx context.Context) (*[]snowpipeM
 			filesInserted: filesInserted,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return &res, nil
 }
@@ -392,6 +420,7 @@ func (c snowflakeClient) FetchStorageMetrics(ctx context.Context) (*[]storageMet
 		err = fmt.Errorf("no rows returned by query: %v", storageMetricsQuery)
 		return nil, err
 	}
+	defer rows.Close()
 
 	var res []storageMetric
 
@@ -406,6 +435,9 @@ func (c snowflakeClient) FetchStorageMetrics(ctx context.Context) (*[]storageMet
 			stageBytes:    stageBytes,
 			failsafeBytes: failsafeBytes,
 		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return &res, nil
 }


### PR DESCRIPTION
#### Description

Implements `ThresholdEvaluator` for the `rate_limiting` tail sampling policy to prevent silent undercounting. 

Because `golang.org/x/time/rate` does not expose its internal token count, this PR estimates the effective sampling probability by tracking the span arrival rate using a time-weighted Exponential Moving Average (EMA). The policy calculates the sampling probability as `min(1, limit / observed_rate)` and uses `sampling.ProbabilityToThreshold` to report the W3C tracestate threshold.

As with the probabilistic sampler, this behavior is entirely gated behind the `processor.tailsamplingprocessor.usetracestate` feature gate. When the gate is disabled or during the initial warmup, the policy safely continues to return `AlwaysSampleThreshold`.

#### Link to tracking issue
Fixes #49710

#### Testing

- Added `TestRateLimitingImplementsThresholdEvaluator` to statically verify the interface implementation.
- Added `TestRateLimitingThresholdAlwaysSampleWhenNotLimiting` to verify threshold is `AlwaysSampleThreshold` when traffic is under the limit.
- Added `TestRateLimitingThresholdReflectsRate` to verify a stricter threshold is returned during bursts above the limit.
- Added `TestRateLimitingThresholdWithoutFeatureGate` to verify fallback behavior.

#### Documentation

No user-facing configuration changes required. Internal comments updated to explain the EMA arrival-rate tracking.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
