### PR TITLE
[processor/k8sattributes] Attach k8s.cluster.uid to non-pod telemetry

### DIFF
--- a/.chloggen/k8sattributes-cluster-uid-non-pod.yaml
+++ b/.chloggen/k8sattributes-cluster-uid-non-pod.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/k8s_attributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Attach `k8s.cluster.uid` to all telemetry originating from the cluster, not only to pod-associated telemetry.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49717]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously `k8s.cluster.uid` was only set as part of the pod-association attribute bundle, so cluster- and
+  node-scoped telemetry that carries no pod identifier (for example node and namespace metrics from the
+  k8sclusterreceiver, or node metrics from the kubeletstatsreceiver) was never enriched with it. The cluster UID
+  (the kube-system namespace UID) identifies the cluster the telemetry originates from and is now stamped on all
+  telemetry originating from within the cluster when the `k8s.cluster.uid` metadata rule is enabled. Existing
+  `k8s.cluster.uid` values are never overwritten.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -104,6 +104,10 @@ are then also available for the use within association rules. Available attribut
 Not all the attributes are guaranteed to be added. Only attribute names from `metadata` should be used for
 pod_association's `resource_attribute`, because empty or non-existing values will be ignored.
 
+**Note:** Extracting `k8s.cluster.uid` assumes the collector observes a single cluster and stamps all
+Kubernetes-related telemetry with the cluster's uid. Do not enable it in multi-cluster gateway pipelines
+that process telemetry from more than one cluster.
+
 Additional container level attributes can be extracted. If a pod contains more than one container,
 either the `container.id`, or the `k8s.container.name` attribute must be provided in the incoming resource attributes to
 correctly associate the matching container to the resource:

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -306,6 +306,10 @@ func (c *WatchClient) Start() error {
 	synced = append(synced, reg.HasSynced)
 	go c.namespaceInformer.Run(c.stopCh)
 
+	if c.Rules.ClusterUID {
+		go c.warnIfClusterUIDUnavailable(reg.HasSynced)
+	}
+
 	if c.nodeInformer != nil {
 		reg, err = c.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.handleNodeAdd,
@@ -402,6 +406,18 @@ func (c *WatchClient) Start() error {
 // Stop signals the k8s watcher/informer to stop watching for new events.
 func (c *WatchClient) Stop() {
 	close(c.stopCh)
+}
+
+// warnIfClusterUIDUnavailable waits for the namespace cache to sync and then logs a single warning
+// if the cluster UID (derived from the kube-system namespace) cannot be determined.
+func (c *WatchClient) warnIfClusterUIDUnavailable(namespaceSynced cache.InformerSynced) {
+	if !cache.WaitForCacheSync(c.stopCh, namespaceSynced) {
+		// The client was stopped before the cache synced; nothing to report.
+		return
+	}
+	if GetClusterUID(c, nil) == "" {
+		c.logger.Warn("unable to find kube-system namespace, k8s.cluster.uid will not be available")
+	}
 }
 
 func (c *WatchClient) handlePodAdd(obj any) {
@@ -838,6 +854,20 @@ func (c *WatchClient) GetNamespace(namespace string) (*Namespace, bool) {
 	return nil, false
 }
 
+// GetClusterUID returns the cluster UID, using the UID of the kube-system namespace as a proxy
+// (Kubernetes does not expose a native cluster identifier). It returns an empty string if the
+// kube-system namespace is not known to the client, logging a debug message via the given logger
+// when one is provided.
+func GetClusterUID(c Client, logger *zap.Logger) string {
+	if ns, ok := c.GetNamespace(kubeSystemNamespace); ok {
+		return ns.NamespaceUID
+	}
+	if logger != nil {
+		logger.Debug("unable to find kube-system namespace, cluster uid will not be available")
+	}
+	return ""
+}
+
 // GetNode takes a node name and returns the node object the node name is associated with.
 func (c *WatchClient) GetNode(nodeName string) (*Node, bool) {
 	c.m.RLock()
@@ -1059,10 +1089,8 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 	}
 
 	if c.Rules.ClusterUID {
-		if val, ok := c.GetNamespace("kube-system"); ok {
-			tags[string(conventions.K8SClusterUIDKey)] = val.NamespaceUID
-		} else {
-			c.logger.Debug("unable to find kube-system namespace, cluster uid will not be available")
+		if uid := GetClusterUID(c, c.logger); uid != "" {
+			tags[string(conventions.K8SClusterUIDKey)] = uid
 		}
 	}
 

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -4875,6 +4875,46 @@ func TestExtractPodAttributesClusterUIDRace(t *testing.T) {
 	wg.Wait()
 }
 
+func TestWarnIfClusterUIDUnavailable(t *testing.T) {
+	synced := func() bool { return true }
+
+	t.Run("logs a warning when kube-system namespace is not available", func(t *testing.T) {
+		c, logs := newTestClient(t)
+		c.Rules = ExtractionRules{ClusterUID: true}
+
+		c.warnIfClusterUIDUnavailable(synced)
+
+		warnings := logs.FilterMessageSnippet("k8s.cluster.uid will not be available").All()
+		require.Len(t, warnings, 1)
+		assert.Equal(t, zapcore.WarnLevel, warnings[0].Level)
+	})
+
+	t.Run("does not log a warning when the cluster UID is available", func(t *testing.T) {
+		c, logs := newTestClient(t)
+		c.Rules = ExtractionRules{ClusterUID: true}
+		c.handleNamespaceAdd(&meta_v1.PartialObjectMetadata{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "kube-system",
+				UID:  "kube-system-uid",
+			},
+		})
+
+		c.warnIfClusterUIDUnavailable(synced)
+
+		assert.Empty(t, logs.FilterMessageSnippet("k8s.cluster.uid will not be available").All())
+	})
+
+	t.Run("does not log a warning when the client is stopped before the cache syncs", func(t *testing.T) {
+		c, logs := newTestClient(t)
+		c.Rules = ExtractionRules{ClusterUID: true}
+		close(c.stopCh)
+
+		c.warnIfClusterUIDUnavailable(func() bool { return false })
+
+		assert.Empty(t, logs.FilterMessageSnippet("k8s.cluster.uid will not be available").All())
+	})
+}
+
 func TestPodDeleteIPMissingFromDeleteEvent(t *testing.T) {
 	c, _ := newTestClient(t)
 

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -282,6 +283,28 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 			setResourceAttribute(resource.Attributes(), key, val)
 		}
 	}
+
+	// Unlike the attributes above, k8s.cluster.uid is not tied to a specific pod, node or namespace, so it is stamped on any
+	// resource that belongs to this cluster rather than only on pod-associated telemetry. This is relevant for node/namespace
+	// metrics from k8sclusterreceiver or kubeletstatsreceiver, which are not pod-scoped. We only stamp it when the resource
+	// carries at least one k8s.* attribute, to avoid adding it to telemetry collected from outside the cluster
+	// (e.g. awscloudwatchreceiver or similar).
+	if kp.rules.ClusterUID && hasKubernetesAttribute(resource.Attributes()) {
+		if clusterUID := kube.GetClusterUID(kp.kc, kp.logger); clusterUID != "" {
+			setResourceAttribute(resource.Attributes(), string(conventions.K8SClusterUIDKey), clusterUID)
+		}
+	}
+}
+
+// hasKubernetesAttribute reports whether the resource carries at least one attribute in the "k8s." semantic-convention
+// namespace, which is used as a signal that the resource belongs to the cluster the collector runs in.
+func hasKubernetesAttribute(attrs pcommon.Map) bool {
+	for k := range attrs.All() {
+		if strings.HasPrefix(k, "k8s.") {
+			return true
+		}
+	}
+	return false
 }
 
 func setResourceAttribute(attributes pcommon.Map, key, val string) {

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1102,6 +1102,95 @@ func TestAddNodeUID(t *testing.T) {
 	})
 }
 
+// TestAddClusterUID verifies that k8s.cluster.uid is attached to telemetry that has no pod association but does carry a
+// k8s.* resource attribute, such as cluster- or node-scoped metrics from the k8sclusterreceiver/kubeletstatsreceiver. The
+// cluster UID is derived from the kube-system namespace UID and identifies the cluster the telemetry originates from, so it
+// is stamped on any resource that belongs to the cluster, not only on pod-associated telemetry.
+func TestAddClusterUID(t *testing.T) {
+	clusterUID := "cluster-uid-1234"
+	m := newMultiTest(
+		t,
+		func() component.Config {
+			cfg := createDefaultConfig().(*Config)
+			cfg.Extract.Metadata = []string{"k8s.cluster.uid"}
+			cfg.Extract.Labels = []FieldExtractConfig{}
+			return cfg
+		}(),
+		nil,
+	)
+
+	// No pod is present and no pod association matches, mimicking cluster-scoped telemetry that carries no pod
+	// identifier but does carry a k8s.* attribute (here k8s.node.name, as emitted for node-scoped metrics). The
+	// kube-system namespace is known to the client so its UID can be used as the cluster UID.
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.kc.(*fakeClient).Namespaces = map[string]*kube.Namespace{
+			"kube-system": {Name: "kube-system", NamespaceUID: clusterUID},
+		}
+	})
+
+	withNodeName := func(nodeName string) generateResourceFunc {
+		return func(res pcommon.Resource) {
+			res.Attributes().PutStr("k8s.node.name", nodeName)
+		}
+	}
+
+	m.testConsume(
+		t.Context(),
+		generateTraces(withNodeName("node-1")),
+		generateMetrics(withNodeName("node-1")),
+		generateLogs(withNodeName("node-1")),
+		generateProfiles(withNodeName("node-1")),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResource(0, func(res pcommon.Resource) {
+		assertResourceHasStringAttribute(t, res, "k8s.cluster.uid", clusterUID)
+	})
+}
+
+// TestClusterUIDNotAddedToExternalTelemetry verifies that k8s.cluster.uid is not attached to telemetry that carries no
+// k8s.* resource attribute, i.e. telemetry that was not identified as belonging to the collector's cluster (for example
+// telemetry collected from outside the cluster via a cloud receiver). Stamping it with this cluster's UID would be wrong.
+func TestClusterUIDNotAddedToExternalTelemetry(t *testing.T) {
+	clusterUID := "cluster-uid-1234"
+	m := newMultiTest(
+		t,
+		func() component.Config {
+			cfg := createDefaultConfig().(*Config)
+			cfg.Extract.Metadata = []string{"k8s.cluster.uid"}
+			cfg.Extract.Labels = []FieldExtractConfig{}
+			return cfg
+		}(),
+		nil,
+	)
+
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.kc.(*fakeClient).Namespaces = map[string]*kube.Namespace{
+			"kube-system": {Name: "kube-system", NamespaceUID: clusterUID},
+		}
+	})
+
+	// The generated telemetry carries no k8s.* attribute and no pod association matches, so the resource is not
+	// identified as belonging to this cluster.
+	m.testConsume(
+		t.Context(),
+		generateTraces(),
+		generateMetrics(),
+		generateLogs(),
+		generateProfiles(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResource(0, func(res pcommon.Resource) {
+		_, ok := res.Attributes().Get("k8s.cluster.uid")
+		assert.False(t, ok, "k8s.cluster.uid must not be added to telemetry with no k8s.* attribute")
+	})
+}
+
 func TestProcessorAddContainerAttributes(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1191,6 +1191,54 @@ func TestClusterUIDNotAddedToExternalTelemetry(t *testing.T) {
 	})
 }
 
+// TestClusterUIDNotOverwritten verifies that a k8s.cluster.uid already present on incoming telemetry is preserved and not
+// replaced with this collector's cluster UID. This matters for gateway/central-collector setups where telemetry forwarded
+// from another cluster may already carry its own (correct) cluster UID, which must win over the local kube-system UID.
+// Note that this setup is not recommended anyway, the multi-cluster gateway should not extract k8s.cluster.uid.
+func TestClusterUIDNotOverwritten(t *testing.T) {
+	localClusterUID := "cluster-uid-1234"
+	existingClusterUID := "preexisting-cluster-uid"
+	m := newMultiTest(
+		t,
+		func() component.Config {
+			cfg := createDefaultConfig().(*Config)
+			cfg.Extract.Metadata = []string{"k8s.cluster.uid"}
+			cfg.Extract.Labels = []FieldExtractConfig{}
+			return cfg
+		}(),
+		nil,
+	)
+
+	// The kube-system namespace is known to the client so a local cluster UID could be resolved, but the incoming
+	// telemetry already carries its own k8s.cluster.uid which must not be overwritten.
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.kc.(*fakeClient).Namespaces = map[string]*kube.Namespace{
+			"kube-system": {Name: "kube-system", NamespaceUID: localClusterUID},
+		}
+	})
+
+	withExistingClusterUID := func(uid string) generateResourceFunc {
+		return func(res pcommon.Resource) {
+			res.Attributes().PutStr("k8s.cluster.uid", uid)
+		}
+	}
+
+	m.testConsume(
+		t.Context(),
+		generateTraces(withExistingClusterUID(existingClusterUID)),
+		generateMetrics(withExistingClusterUID(existingClusterUID)),
+		generateLogs(withExistingClusterUID(existingClusterUID)),
+		generateProfiles(withExistingClusterUID(existingClusterUID)),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResource(0, func(res pcommon.Resource) {
+		assertResourceHasStringAttribute(t, res, "k8s.cluster.uid", existingClusterUID)
+	})
+}
+
 func TestProcessorAddContainerAttributes(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
#### Description

The k8s.cluster.uid resource attribute was only ever set inside extractPodAttributes, i.e. as part of the pod-association attribute bundle. It was missing on cluster- and node-scoped telemetry that carries no pod identifier - for example node and namespace metrics from the k8sclusterreceiver, or node metrics from the kubeletstatsreceiver. This is rather surprising and counter-intuitive. All telemetry from the cluster should have the k8s.cluster.uid attribute.

Conceptually, k8s.cluster.uid is not a per-pod attribute. This moves the enrichment so it is applied to all telemetry: processResource now stamps k8s.cluster.uid whenever the rule is enabled, independently of pod association.

#### Link to tracking issue

Fixes: #49717

#### Testing

Tested in a local K8s cluster. 
* No `k8s.cluster.uid` on `k8s.node.condition_ready` without the fix.
* With the fix, `k8s.cluster.uid` is present on the `k8s.node.condition_ready` data points.

Results:                                                                                                                                                                         
                                                                                                                                                                                   
|                    | distinct resources | with k8s.cluster.uid | without k8s.cluster.uid  |                                                                                                     
| ------------------ | ------------------ | -------------------- | ------- |                                                                                                     
| current_main       | 80                 | 68                   | 12      |                                                                                                     
| with_fix_pr_49718  | 77                 | 77                   | 0       |                                                                                                     
                                                                                
This is from running the collector in a local cluster for a few minutes with a couple of deployments, daemonsets, etc., exporting all collected telemetry locally to jsonl files with the `file` exporter, then aggregating over all unique resources (e.g. distinct sets of resource attributes). (The difference of 77 to 80 resources is test noise and not related to the fix.)

#### Authorship

- [x] I, a human, wrote this pull request description myself.

Parts of the change have been authored using Claude Opus 4.8. All changes have been self-reviewed by me manually before creating the PR.
