### PR TITLE
[receiver/aws_cloudwatch] Add credentials_provider option

### DIFF
--- a/.chloggen/awscloudwatchreceiver-auth.yaml
+++ b/.chloggen/awscloudwatchreceiver-auth.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/aws_cloudwatch
+note: Add `credentials_provider` option to resolve AWS credentials from an `awscredentialsprovider` extension instead of the default SDK credential chain.
+issues: [49358]
+change_logs: []

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -33,6 +33,7 @@ This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/devel
 | `logs`          | *optional* | `Logs`    | Configuration for logs collection. See [Logs Parameters](#logs-parameters).       |
 | `metrics`       | *optional* | `Metrics` | Configuration for metrics collection via GetMetricData. See [Metrics Parameters](#metrics-parameters-getmetricdata--listmetrics). |
 | `storage`       | *optional* | string    | The ID of a storage extension to be used for state persistence.                   |
+| `credentials_provider` | *optional* | string | The ID of an `awscredentialsprovider` extension that supplies AWS credentials (static keys, profile, or STS assume-role) instead of the default SDK credential chain. Note: this is a credentials-provider extension, not a `configauth` authenticator. |
 
 ### Logs Parameters
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -33,6 +33,11 @@ type Config struct {
 	Logs         LogsConfig    `mapstructure:"logs"`
 	Metrics      MetricsConfig `mapstructure:"metrics"`
 	StorageID    *component.ID `mapstructure:"storage"`
+	// CredentialsProvider optionally references an awscredentialsprovider extension by
+	// component ID. When set, the extension's resolved credentials are used for the
+	// CloudWatch clients instead of the default SDK credential chain. This is not a
+	// configauth authenticator; the extension only supplies an aws.CredentialsProvider.
+	CredentialsProvider *component.ID `mapstructure:"credentials_provider"`
 }
 
 // MetricsConfig is the configuration for the metrics (GetMetricData) portion of this receiver.

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -121,6 +121,11 @@ $defs:
 description: Config is the overall config structure for the awscloudwatchreceiver
 type: object
 properties:
+  credentials_provider:
+    description: CredentialsProvider optionally references an awscredentialsprovider extension by component ID. When set, the extension's resolved credentials are used for the CloudWatch clients instead of the default SDK credential chain. This is not a configauth authenticator; the extension only supplies an aws.CredentialsProvider.
+    x-pointer: true
+    type: string
+    x-customType: go.opentelemetry.io/collector/component.ID
   imds_endpoint:
     type: string
   logs:

--- a/receiver/awscloudwatchreceiver/credentialsprovider.go
+++ b/receiver/awscloudwatchreceiver/credentialsprovider.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awscloudwatchreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver"
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"go.opentelemetry.io/collector/component"
+)
+
+// awsCredentialsProvider is implemented by the awscredentialsprovider extension. It is
+// declared locally (structural typing) to avoid a module dependency on the extension.
+type awsCredentialsProvider interface {
+	GetCredentialsProvider() aws.CredentialsProvider
+}
+
+// resolveCredentialsProvider returns the credentials provider from the
+// awscredentialsprovider extension referenced by id, or nil when none is configured.
+func resolveCredentialsProvider(host component.Host, id *component.ID) (aws.CredentialsProvider, error) {
+	if id == nil {
+		return nil, nil
+	}
+	ext, ok := host.GetExtensions()[*id]
+	if !ok {
+		return nil, fmt.Errorf("unknown credentials_provider extension %q", id)
+	}
+	provider, ok := ext.(awsCredentialsProvider)
+	if !ok {
+		return nil, fmt.Errorf("extension %q does not provide AWS credentials", id)
+	}
+	return provider.GetCredentialsProvider(), nil
+}

--- a/receiver/awscloudwatchreceiver/credentialsprovider_test.go
+++ b/receiver/awscloudwatchreceiver/credentialsprovider_test.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awscloudwatchreceiver
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+)
+
+// fakeCredentialsProvider stands in for the awscredentialsprovider extension; the
+// receiver matches it structurally via the awsCredentialsProvider interface.
+type fakeCredentialsProvider struct {
+	component.StartFunc
+	component.ShutdownFunc
+	creds aws.CredentialsProvider
+}
+
+func (f *fakeCredentialsProvider) GetCredentialsProvider() aws.CredentialsProvider {
+	return f.creds
+}
+
+// fakeHost serves extensions to components during Start.
+type fakeHost struct {
+	extensions map[component.ID]component.Component
+}
+
+func (h *fakeHost) GetExtensions() map[component.ID]component.Component { return h.extensions }
+
+func TestResolveCredentialsProvider(t *testing.T) {
+	provID := component.MustNewID("awscredentialsprovider")
+	staticCreds := credentials.NewStaticCredentialsProvider("AKID", "SECRET", "TOKEN")
+	host := &fakeHost{extensions: map[component.ID]component.Component{
+		provID: &fakeCredentialsProvider{creds: staticCreds},
+	}}
+
+	t.Run("none configured", func(t *testing.T) {
+		creds, err := resolveCredentialsProvider(host, nil)
+		require.NoError(t, err)
+		require.Nil(t, creds)
+	})
+
+	t.Run("resolves provider", func(t *testing.T) {
+		creds, err := resolveCredentialsProvider(host, &provID)
+		require.NoError(t, err)
+		retrieved, err := creds.Retrieve(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "AKID", retrieved.AccessKeyID)
+	})
+
+	t.Run("unknown extension", func(t *testing.T) {
+		unknown := component.MustNewID("missing")
+		_, err := resolveCredentialsProvider(host, &unknown)
+		require.ErrorContains(t, err, "unknown credentials_provider extension")
+	})
+
+	t.Run("extension without provider interface", func(t *testing.T) {
+		wrongID := component.MustNewID("other")
+		wrongHost := &fakeHost{extensions: map[component.ID]component.Component{
+			wrongID: &fakeOtherExtension{},
+		}}
+		_, err := resolveCredentialsProvider(wrongHost, &wrongID)
+		require.ErrorContains(t, err, "does not provide AWS credentials")
+	})
+}
+
+type fakeOtherExtension struct {
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+func TestMetricsScraperUsesCredentialsProvider(t *testing.T) {
+	provID := component.MustNewID("awscredentialsprovider")
+	host := &fakeHost{extensions: map[component.ID]component.Component{
+		provID: &fakeCredentialsProvider{creds: credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")},
+	}}
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-2"
+	cfg.CredentialsProvider = &provID
+
+	scraper := newCloudWatchMetricsScraper(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	})
+	require.NoError(t, scraper.start(t.Context(), host))
+	require.NotNil(t, scraper.client)
+}
+
+func TestLogsReceiverUsesCredentialsProvider(t *testing.T) {
+	provID := component.MustNewID("awscredentialsprovider")
+	host := &fakeHost{extensions: map[component.ID]component.Component{
+		provID: &fakeCredentialsProvider{creds: credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")},
+	}}
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-2"
+	cfg.CredentialsProvider = &provID
+	cfg.Logs.Groups.AutodiscoverConfig = nil
+
+	rcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, consumertest.NewNop())
+
+	require.NoError(t, rcvr.Start(t.Context(), host))
+	require.NoError(t, rcvr.ensureSession())
+	require.NotNil(t, rcvr.client)
+
+	creds, err := rcvr.credsProvider.Retrieve(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "AKID", creds.AccessKeyID)
+
+	require.NoError(t, rcvr.Shutdown(t.Context()))
+}

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.29
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.28
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0
 	github.com/goccy/go-json v0.10.6
@@ -33,7 +34,6 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.28 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -34,6 +34,8 @@ type logsReceiver struct {
 	region                        string
 	profile                       string
 	imdsEndpoint                  string
+	credentialsProviderID         *component.ID
+	credsProvider                 aws.CredentialsProvider
 	pollInterval                  time.Duration
 	maxEventsPerRequest           int
 	initialStartTime              time.Time
@@ -143,24 +145,31 @@ func newLogsReceiver(cfg *Config, settings receiver.Settings, consumer consumer.
 	}
 
 	return &logsReceiver{
-		settings:            settings,
-		region:              cfg.Region,
-		profile:             cfg.Profile,
-		consumer:            consumer,
-		maxEventsPerRequest: cfg.Logs.MaxEventsPerRequest,
-		imdsEndpoint:        cfg.IMDSEndpoint,
-		autodiscover:        autodiscover,
-		pollInterval:        cfg.Logs.PollInterval,
-		initialStartTime:    startTime,
-		groupNextStartTimes: map[string]time.Time{},
-		groupRequests:       groups,
-		wg:                  &sync.WaitGroup{},
-		doneChan:            make(chan bool),
-		storageID:           cfg.StorageID,
+		settings:              settings,
+		region:                cfg.Region,
+		profile:               cfg.Profile,
+		consumer:              consumer,
+		maxEventsPerRequest:   cfg.Logs.MaxEventsPerRequest,
+		imdsEndpoint:          cfg.IMDSEndpoint,
+		credentialsProviderID: cfg.CredentialsProvider,
+		autodiscover:          autodiscover,
+		pollInterval:          cfg.Logs.PollInterval,
+		initialStartTime:      startTime,
+		groupNextStartTimes:   map[string]time.Time{},
+		groupRequests:         groups,
+		wg:                    &sync.WaitGroup{},
+		doneChan:              make(chan bool),
+		storageID:             cfg.StorageID,
 	}
 }
 
 func (l *logsReceiver) Start(ctx context.Context, host component.Host) error {
+	creds, err := resolveCredentialsProvider(host, l.credentialsProviderID)
+	if err != nil {
+		return err
+	}
+	l.credsProvider = creds
+
 	if l.cloudwatchCheckpointPersister == nil {
 		storageClient, err := adapter.GetStorageClient(ctx, host, l.storageID, l.settings.ID)
 		if err != nil {
@@ -498,6 +507,12 @@ func (l *logsReceiver) ensureSession() error {
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
+	if err != nil {
+		return err
+	}
+	if l.credsProvider != nil {
+		cfg.Credentials = l.credsProvider
+	}
 	l.client = cloudwatchlogs.NewFromConfig(cfg)
-	return err
+	return nil
 }

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -75,7 +75,7 @@ func newCloudWatchMetricsScraper(cfg *Config, settings receiver.Settings) *cloud
 	}
 }
 
-func (s *cloudWatchMetricsScraper) start(ctx context.Context, _ component.Host) error {
+func (s *cloudWatchMetricsScraper) start(ctx context.Context, host component.Host) error {
 	s.settings.Logger.Debug("initializing CloudWatch client", zap.String("region", s.cfg.Region))
 	opts := []func(*config.LoadOptions) error{config.WithRegion(s.cfg.Region)}
 	if s.cfg.IMDSEndpoint != "" {
@@ -87,6 +87,13 @@ func (s *cloudWatchMetricsScraper) start(ctx context.Context, _ component.Host) 
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return err
+	}
+	creds, err := resolveCredentialsProvider(host, s.cfg.CredentialsProvider)
+	if err != nil {
+		return err
+	}
+	if creds != nil {
+		cfg.Credentials = creds
 	}
 	s.client = cloudwatch.NewFromConfig(cfg)
 	return nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR is intended to illustrate usage of the awscredentialsprovider extension, which is in progress [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49716).

We a `credentials_provider` config field that references the extension by ID. When set, the extension's resolved AWS credentials are used for the CloudWatch metrics and logs clients instead of the default SDK credential chain.

The extension is referenced via structural typing (a locally declared interface), so the receiver does not take a module dependency on it.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Blocked by 49358

Waiting on that to be resolved before opening an issue for the receiver(s) itself.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Functional testing proves the credentials are overridden when using the extension.

<!--Describe the documentation added.-->
#### Documentation

README updated.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
