### PR TITLE
receiver/datadogreceiver: add support for Datadog v3 series intake

### DIFF
--- a/receiver/datadogreceiver/.chloggen/datadogreceiver-v3-series-support.yaml
+++ b/receiver/datadogreceiver/.chloggen/datadogreceiver-v3-series-support.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for Datadog Agent v3 series metrics endpoint `/api/intake/metrics/v3/series` to prevent silent data loss with Datadog Agent 7.81.0+
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [REPLACE_WITH_ISSUE_NUMBER]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Datadog Agent 7.81.0+ defaults to sending series metrics to `/api/intake/metrics/v3/series`.
+  Without this fix, metrics from agents >= 7.81.0 were silently discarded (returned 200 OK but not processed).
+  The v3 endpoint now uses the same payload format and translation logic as v2.

--- a/receiver/datadogreceiver/README.md
+++ b/receiver/datadogreceiver/README.md
@@ -157,15 +157,16 @@ Format example can be found [here](./internal/translator/traces_translator_test.
 
 **Metrics**
 
-| Datadog API Endpoint        | Status      | Notes                      |
-|-----------------------------|-------------|----------------------------|
-| /api/v1/series              | Development |                            |
-| /api/v2/series              | Development |                            |
-| /api/v1/check_run           | Development |                            |
-| /api/v1/sketches            | Development |                            |
-| /api/beta/sketches          | Development |                            |
-| /api/v1/distribution_points | Development |                            |
-| /intake                     | Development | Support for proxying calls |
+| Datadog API Endpoint              | Status      | Notes                      |
+|-----------------------------------|-------------|----------------------------|
+| /api/v1/series                    | Development |                            |
+| /api/v2/series                    | Development |                            |
+| /api/intake/metrics/v3/series     | Development | Added in v0.157.0          |
+| /api/v1/check_run                 | Development |                            |
+| /api/v1/sketches                  | Development |                            |
+| /api/beta/sketches                | Development |                            |
+| /api/v1/distribution_points       | Development |                            |
+| /intake                           | Development | Support for proxying calls |
 
 **Logs**
 

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -115,6 +115,10 @@ func (ddr *datadogReceiver) getEndpoints() []endpoint {
 				Handler: ddr.handleV2Series,
 			},
 			{
+				Pattern: "/api/intake/metrics/v3/series",
+				Handler: ddr.handleV3Series,
+			},
+			{
 				Pattern: "/api/v1/check_run",
 				Handler: ddr.handleCheckRun,
 			},
@@ -546,6 +550,41 @@ func (ddr *datadogReceiver) handleV1Series(w http.ResponseWriter, req *http.Requ
 
 // handleV2Series handles the v2 series endpoint https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
 func (ddr *datadogReceiver) handleV2Series(w http.ResponseWriter, req *http.Request) {
+	obsCtx := ddr.tReceiver.StartMetricsOp(req.Context())
+	var err error
+	var metricsCount int
+	defer func(metricsCount *int) {
+		ddr.tReceiver.EndMetricsOp(obsCtx, "datadog", *metricsCount, err)
+	}(&metricsCount)
+
+	series, err := ddr.metricsTranslator.HandleSeriesV2Payload(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		ddr.params.Logger.Error(err.Error())
+		return
+	}
+
+	metrics := ddr.metricsTranslator.TranslateSeriesV2(series)
+	metricsCount = metrics.DataPointCount()
+
+	err = ddr.nextMetricsConsumer.ConsumeMetrics(obsCtx, metrics)
+	if err != nil {
+		errorutil.HTTPError(w, err)
+		ddr.params.Logger.Error("metrics consumer errored out", zap.Error(err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	response := map[string]any{
+		"errors": []string{},
+	}
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// handleV3Series handles the v3 series endpoint https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
+// V3 endpoint introduced in Datadog Agent 7.81.0 uses the same MetricPayload format as V2.
+func (ddr *datadogReceiver) handleV3Series(w http.ResponseWriter, req *http.Request) {
 	obsCtx := ddr.tReceiver.StartMetricsOp(req.Context())
 	var err error
 	var metricsCount int

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -264,6 +264,7 @@ func TestDatadogInfoEndpoint(t *testing.T) {
 		"/",
 		"/api/v1/series",
 		"/api/v2/series",
+		"/api/intake/metrics/v3/series",
 		"/api/v1/check_run",
 		"/api/v1/sketches",
 		"/api/beta/sketches",
@@ -294,6 +295,7 @@ func TestDatadogInfoEndpoint(t *testing.T) {
 		"/api/v0.2/traces",
 		"/api/v1/series",
 		"/api/v2/series",
+		"/api/intake/metrics/v3/series",
 		"/api/v1/check_run",
 		"/api/v1/sketches",
 		"/api/beta/sketches",
@@ -546,6 +548,171 @@ func TestDatadogMetricsV2_EndToEndJSON(t *testing.T) {
 		http.MethodPost,
 		fmt.Sprintf("http://%s/api/v2/series", dd.(*datadogReceiver).address),
 		io.NopCloser(bytes.NewReader(metricsPayloadV2)),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	require.NoError(t, err, "Must not error when creating request")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "Must not error performing request")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, multierr.Combine(err, resp.Body.Close()), "Must not error when reading body")
+	require.JSONEq(t, `{"errors": []}`, string(body), "Expected JSON response to be `{\"errors\": []}`, got %s", string(body))
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+	mds := sink.AllMetrics()
+	require.Len(t, mds, 1)
+	got := mds[0]
+	require.Equal(t, 1, got.ResourceMetrics().Len())
+	metrics := got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	assert.Equal(t, 1, metrics.Len())
+	metric := metrics.At(0)
+	assert.Equal(t, pmetric.MetricTypeSum, metric.Type())
+	assert.Equal(t, "system.load.1", metric.Name())
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, metric.Sum().AggregationTemporality())
+	assert.False(t, metric.Sum().IsMonotonic())
+	assert.Equal(t, pcommon.Timestamp(1636629071*1_000_000_000), metric.Sum().DataPoints().At(0).Timestamp())
+	assert.Equal(t, 1.5, metric.Sum().DataPoints().At(0).DoubleValue())
+	assert.Equal(t, pcommon.Timestamp(0), metric.Sum().DataPoints().At(0).StartTimestamp())
+	assert.Equal(t, pcommon.Timestamp(1636629081*1_000_000_000), metric.Sum().DataPoints().At(1).Timestamp())
+	assert.Equal(t, 2.0, metric.Sum().DataPoints().At(1).DoubleValue())
+	assert.Equal(t, pcommon.Timestamp(1636629071*1_000_000_000), metric.Sum().DataPoints().At(1).StartTimestamp())
+}
+
+func TestDatadogMetricsV3_EndToEnd(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.NetAddr.Endpoint = "localhost:0" // Using a randomly assigned address
+	sink := new(consumertest.MetricsSink)
+
+	ctx := t.Context()
+
+	dd, err := newDataDogReceiver(
+		ctx,
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err, "Must not error when creating receiver")
+	dd.(*datadogReceiver).nextMetricsConsumer = sink
+
+	require.NoError(t, dd.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, dd.Shutdown(t.Context()))
+	}()
+
+	metricsPayloadV3 := gogen.MetricPayload{
+		Series: []*gogen.MetricPayload_MetricSeries{
+			{
+				Resources: []*gogen.MetricPayload_Resource{
+					{
+						Type: "host",
+						Name: "Host1",
+					},
+				},
+				Metric: "system.load.1",
+				Tags:   []string{"env:test"},
+				Points: []*gogen.MetricPayload_MetricPoint{
+					{
+						Timestamp: 1636629071,
+						Value:     1.5,
+					},
+					{
+						Timestamp: 1636629081,
+						Value:     2.0,
+					},
+				},
+				Type: gogen.MetricPayload_COUNT,
+			},
+		},
+	}
+
+	pb, err := metricsPayloadV3.Marshal()
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("http://%s/api/intake/metrics/v3/series", dd.(*datadogReceiver).address),
+		io.NopCloser(bytes.NewReader(pb)),
+	)
+	require.NoError(t, err, "Must not error when creating request")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "Must not error performing request")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, multierr.Combine(err, resp.Body.Close()), "Must not error when reading body")
+	require.JSONEq(t, `{"errors": []}`, string(body), "Expected JSON response to be `{\"errors\": []}`, got %s", string(body))
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+	mds := sink.AllMetrics()
+	require.Len(t, mds, 1)
+	got := mds[0]
+	require.Equal(t, 1, got.ResourceMetrics().Len())
+	metrics := got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	assert.Equal(t, 1, metrics.Len())
+	metric := metrics.At(0)
+	assert.Equal(t, pmetric.MetricTypeSum, metric.Type())
+	assert.Equal(t, "system.load.1", metric.Name())
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, metric.Sum().AggregationTemporality())
+	assert.False(t, metric.Sum().IsMonotonic())
+	assert.Equal(t, pcommon.Timestamp(1636629071*1_000_000_000), metric.Sum().DataPoints().At(0).Timestamp())
+	assert.Equal(t, 1.5, metric.Sum().DataPoints().At(0).DoubleValue())
+	assert.Equal(t, pcommon.Timestamp(0), metric.Sum().DataPoints().At(0).StartTimestamp())
+	assert.Equal(t, pcommon.Timestamp(1636629081*1_000_000_000), metric.Sum().DataPoints().At(1).Timestamp())
+	assert.Equal(t, 2.0, metric.Sum().DataPoints().At(1).DoubleValue())
+	assert.Equal(t, pcommon.Timestamp(1636629071*1_000_000_000), metric.Sum().DataPoints().At(1).StartTimestamp())
+}
+
+func TestDatadogMetricsV3_EndToEndJSON(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.NetAddr.Endpoint = "localhost:0" // Using a randomly assigned address
+	sink := new(consumertest.MetricsSink)
+
+	ctx := t.Context()
+
+	dd, err := newDataDogReceiver(
+		ctx,
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	require.NoError(t, err, "Must not error when creating receiver")
+	dd.(*datadogReceiver).nextMetricsConsumer = sink
+
+	require.NoError(t, dd.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, dd.Shutdown(t.Context()))
+	}()
+
+	metricsPayloadV3 := []byte(`{
+		"series": [
+			{
+				"metric": "system.load.1",
+				"type": 1,
+				"points": [
+					{
+						"timestamp": 1636629071,
+						"value":     1.5
+					},
+					{
+						"timestamp": 1636629081,
+						"value":     2.0
+					}
+				],
+				"resources": [
+					{
+						"name": "dummyhost",
+						"type": "host"
+					}
+				]
+			}
+		]
+	}`)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("http://%s/api/intake/metrics/v3/series", dd.(*datadogReceiver).address),
+		io.NopCloser(bytes.NewReader(metricsPayloadV3)),
 	)
 
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
## Description

This PR adds support for the Datadog Agent v3 series intake endpoint.

Datadog Agent 7.81.0+ sends series metrics to `/api/intake/metrics/v3/series`.
The Datadog receiver currently does not handle this endpoint, causing series metrics sent to it to be ignored.

This change:

- registers the `/api/intake/metrics/v3/series` endpoint
- reuses the existing v2 series translation logic
- adds tests covering protobuf and JSON payloads
- updates the receiver documentation

## Link to tracking issue

Fixes #49698

## Testing

- Added tests for protobuf v3 series payloads
- Added tests for JSON v3 series payloads
- Updated endpoint registration tests
- Existing receiver tests continue to pass

## Documentation

- Updated the Datadog receiver README
- Added a changelog entry