### PR TITLE
[pkg/ottl]: properly handle nil for maps, slices, and pcommon.Value.

### DIFF
--- a/.chloggen/ctxutil-nil-setters.yaml
+++ b/.chloggen/ctxutil-nil-setters.yaml
@@ -10,7 +10,7 @@ component: pkg/ottl
 note: OTTL context path setters now handle nil values based on the path type
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [49728]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/ctxutil-nil-setters.yaml
+++ b/.chloggen/ctxutil-nil-setters.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: pkg/ottl

--- a/.chloggen/ctxutil-nil-setters.yaml
+++ b/.chloggen/ctxutil-nil-setters.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: OTTL context path setters now handle nil values based on the path type
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/ottl/contexts/internal/ctxcache/cache_test.go
+++ b/pkg/ottl/contexts/internal/ctxcache/cache_test.go
@@ -108,6 +108,19 @@ func Test_PathExpressionParser(t *testing.T) {
 		require.NotEqual(t, cache, val)
 	})
 
+	t.Run("modify entire cache nil clears", func(t *testing.T) {
+		path := &pathtest.Path[testContext]{
+			N: "cache",
+		}
+
+		getter, err := parser(path)
+		require.NoError(t, err)
+
+		err = getter.Set(t.Context(), ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, ctx.cache.Len())
+	})
+
 	t.Run("modify specific cache key", func(t *testing.T) {
 		path := &pathtest.Path[testContext]{
 			N: "cache",
@@ -148,6 +161,27 @@ func Test_PathExpressionParser(t *testing.T) {
 		v, ok := ctx.cache.Get("key3")
 		assert.True(t, ok)
 		assert.Equal(t, "value3", v.Str())
+	})
+
+	t.Run("modify specific cache key nil does not error", func(t *testing.T) {
+		path := &pathtest.Path[testContext]{
+			N: "cache",
+			KeySlice: []ottl.Key[testContext]{
+				&pathtest.Key[testContext]{
+					S: ottltest.Strp("key1"),
+				},
+			},
+		}
+
+		getter, err := parser(path)
+		require.NoError(t, err)
+
+		err = getter.Set(t.Context(), ctx, nil)
+		require.NoError(t, err)
+
+		v, ok := ctx.cache.Get("key1")
+		assert.True(t, ok)
+		assert.Equal(t, pcommon.ValueTypeEmpty, v.Type())
 	})
 
 	t.Run("access nested key", func(t *testing.T) {

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
@@ -359,21 +359,16 @@ func accessExemplars[K Context]() ottl.StandardGetSetter[K] {
 			return nil, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			newExemplars, err := ctxutil.ExpectType[pmetric.ExemplarSlice](val)
-			if err != nil {
-				return err
-			}
 			switch dp := tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				newExemplars.CopyTo(dp.Exemplars())
+				return ctxutil.SetPSliceValue(dp.Exemplars(), pmetric.NewExemplarSlice, val)
 			case pmetric.HistogramDataPoint:
-				newExemplars.CopyTo(dp.Exemplars())
+				return ctxutil.SetPSliceValue(dp.Exemplars(), pmetric.NewExemplarSlice, val)
 			case pmetric.ExponentialHistogramDataPoint:
-				newExemplars.CopyTo(dp.Exemplars())
+				return ctxutil.SetPSliceValue(dp.Exemplars(), pmetric.NewExemplarSlice, val)
 			default:
 				return fmt.Errorf("unsupported data point type: %T", dp)
 			}
-			return nil
 		},
 	}
 }
@@ -700,16 +695,11 @@ func accessQuantileValues[K Context]() ottl.StandardGetSetter[K] {
 			return nil, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			newQuantileValues, err := ctxutil.ExpectType[pmetric.SummaryDataPointValueAtQuantileSlice](val)
-			if err != nil {
-				return err
-			}
 			summaryDataPoint, err := ctxutil.ExpectType[pmetric.SummaryDataPoint](tCtx.GetDataPoint())
 			if err != nil {
 				return err
 			}
-			newQuantileValues.CopyTo(summaryDataPoint.QuantileValues())
-			return nil
+			return ctxutil.SetPSliceValue(summaryDataPoint.QuantileValues(), pmetric.NewSummaryDataPointValueAtQuantileSlice, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -122,7 +122,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "exemplars",
+			name:       "exemplars",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "exemplars",
 			},
@@ -631,7 +632,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "exemplars",
+			name:       "exemplars",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "exemplars",
 			},
@@ -1224,7 +1226,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "exemplars",
+			name:       "exemplars",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "exemplars",
 			},
@@ -1715,7 +1718,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "quantile_values",
+			name:       "quantile_values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "quantile_values",
 			},

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -35,12 +35,13 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 	newMap["k2"] = newMap2
 
 	tests := []struct {
-		name      string
-		path      ottl.Path[*testContext]
-		orig      any
-		newVal    any
-		modified  func(pmetric.NumberDataPoint)
-		valueType pmetric.NumberDataPointValueType
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(pmetric.NumberDataPoint)
+		valueType  pmetric.NumberDataPointValueType
+		nilNoError bool
 	}{
 		{
 			name: "start_time_unix_nano",
@@ -132,7 +133,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -143,7 +145,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -154,7 +157,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes string",
+			name:       "attributes string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -170,7 +174,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bool",
+			name:       "attributes bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -186,7 +191,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes int",
+			name:       "attributes int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -202,7 +208,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes float",
+			name:       "attributes float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -218,7 +225,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bytes",
+			name:       "attributes bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -234,7 +242,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array string",
+			name:       "attributes array string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -253,7 +262,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bool",
+			name:       "attributes array bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -272,7 +282,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array int",
+			name:       "attributes array int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -291,7 +302,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array float",
+			name:       "attributes array float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -310,7 +322,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bytes",
+			name:       "attributes array bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -329,7 +342,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes pcommon.Map",
+			name:       "attributes pcommon.Map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -350,7 +364,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes map[string]any",
+			name:       "attributes map[string]any",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -371,7 +386,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested",
+			name:       "attributes nested",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -397,7 +413,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested new values",
+			name:       "attributes nested new values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -458,6 +475,15 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), ctx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }
@@ -496,11 +522,12 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 	newMap["k2"] = newMap2
 
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(pmetric.HistogramDataPoint)
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(pmetric.HistogramDataPoint)
+		nilNoError bool
 	}{
 		{
 			name: "start_time_unix_nano",
@@ -580,7 +607,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "bucket_counts",
+			name:       "bucket_counts",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "bucket_counts",
 			},
@@ -591,7 +619,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "explicit_bounds",
+			name:       "explicit_bounds",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "explicit_bounds",
 			},
@@ -613,7 +642,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -624,7 +654,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes raw map",
+			name:       "attributes raw map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -635,7 +666,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes string",
+			name:       "attributes string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -651,7 +683,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bool",
+			name:       "attributes bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -667,7 +700,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes int",
+			name:       "attributes int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -683,7 +717,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes float",
+			name:       "attributes float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -699,7 +734,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bytes",
+			name:       "attributes bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -715,7 +751,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array string",
+			name:       "attributes array string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -734,7 +771,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bool",
+			name:       "attributes array bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -753,7 +791,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array int",
+			name:       "attributes array int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -772,7 +811,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array float",
+			name:       "attributes array float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -791,7 +831,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bytes",
+			name:       "attributes array bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -810,7 +851,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes pcommon.Map",
+			name:       "attributes pcommon.Map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -831,7 +873,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes map[string]any",
+			name:       "attributes map[string]any",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -852,7 +895,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested",
+			name:       "attributes nested",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -878,7 +922,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested new values",
+			name:       "attributes nested new values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -939,6 +984,15 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), ctx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }
@@ -983,11 +1037,12 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 	newMap["k2"] = newMap2
 
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(pmetric.ExponentialHistogramDataPoint)
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(pmetric.ExponentialHistogramDataPoint)
+		nilNoError bool
 	}{
 		{
 			name: "start_time_unix_nano",
@@ -1114,7 +1169,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "positive bucket_counts",
+			name:       "positive bucket_counts",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "positive",
 				NextPath: &pathtest.Path[*testContext]{
@@ -1153,7 +1209,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "negative bucket_counts",
+			name:       "negative bucket_counts",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "negative",
 				NextPath: &pathtest.Path[*testContext]{
@@ -1178,7 +1235,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -1189,7 +1247,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes raw map",
+			name:       "attributes raw map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -1200,7 +1259,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes string",
+			name:       "attributes string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1216,7 +1276,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bool",
+			name:       "attributes bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1232,7 +1293,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes int",
+			name:       "attributes int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1248,7 +1310,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes float",
+			name:       "attributes float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1264,7 +1327,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bytes",
+			name:       "attributes bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1280,7 +1344,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array string",
+			name:       "attributes array string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1299,7 +1364,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bool",
+			name:       "attributes array bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1318,7 +1384,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array int",
+			name:       "attributes array int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1337,7 +1404,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array float",
+			name:       "attributes array float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1356,7 +1424,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bytes",
+			name:       "attributes array bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1375,7 +1444,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes pcommon.Map",
+			name:       "attributes pcommon.Map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1396,7 +1466,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes map[string]any",
+			name:       "attributes map[string]any",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1417,7 +1488,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested",
+			name:       "attributes nested",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1443,7 +1515,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested new values",
+			name:       "attributes nested new values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1504,6 +1577,15 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), ctx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }
@@ -1548,11 +1630,12 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 	newMap["k2"] = newMap2
 
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(pmetric.SummaryDataPoint)
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(pmetric.SummaryDataPoint)
+		nilNoError bool
 	}{
 		{
 			name: "start_time_unix_nano",
@@ -1643,7 +1726,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -1654,7 +1738,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes raw map",
+			name:       "attributes raw map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -1665,7 +1750,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes string",
+			name:       "attributes string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1681,7 +1767,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bool",
+			name:       "attributes bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1697,7 +1784,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes int",
+			name:       "attributes int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1713,7 +1801,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes float",
+			name:       "attributes float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1729,7 +1818,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bytes",
+			name:       "attributes bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1745,7 +1835,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array string",
+			name:       "attributes array string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1764,7 +1855,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bool",
+			name:       "attributes array bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1783,7 +1875,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array int",
+			name:       "attributes array int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1802,7 +1895,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array float",
+			name:       "attributes array float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1821,7 +1915,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bytes",
+			name:       "attributes array bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1840,7 +1935,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes pcommon.Map",
+			name:       "attributes pcommon.Map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1861,7 +1957,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes map[string]any",
+			name:       "attributes map[string]any",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1882,7 +1979,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested",
+			name:       "attributes nested",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1908,7 +2006,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested new values",
+			name:       "attributes nested new values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -1969,6 +2068,15 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), ctx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -476,8 +476,8 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), ctx, nil)
 			if tt.nilNoError {
 				require.NoError(t, err)
@@ -985,8 +985,8 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), ctx, nil)
 			if tt.nilNoError {
 				require.NoError(t, err)
@@ -1578,8 +1578,8 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), ctx, nil)
 			if tt.nilNoError {
 				require.NoError(t, err)
@@ -2069,8 +2069,8 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), ctx, nil)
 			if tt.nilNoError {
 				require.NoError(t, err)

--- a/pkg/ottl/contexts/internal/ctxexemplar/exemplar_test.go
+++ b/pkg/ottl/contexts/internal/ctxexemplar/exemplar_test.go
@@ -48,6 +48,7 @@ func TestPathGetSetter(t *testing.T) {
 		orig              any
 		newVal            any
 		expectSetterError bool
+		nilNoError        bool
 		modified          func(exemplar pmetric.Exemplar)
 	}{
 		{
@@ -145,8 +146,9 @@ func TestPathGetSetter(t *testing.T) {
 			path: &pathtest.Path[*testContext]{
 				N: "filtered_attributes",
 			},
-			orig:   refExemplar.FilteredAttributes(),
-			newVal: newFilteredAttrs,
+			orig:       refExemplar.FilteredAttributes(),
+			newVal:     newFilteredAttrs,
+			nilNoError: true,
 			modified: func(exemplar pmetric.Exemplar) {
 				newFilteredAttrs.CopyTo(exemplar.FilteredAttributes())
 			},
@@ -156,8 +158,9 @@ func TestPathGetSetter(t *testing.T) {
 			path: &pathtest.Path[*testContext]{
 				N: "filtered_attributes",
 			},
-			orig:   refExemplar.FilteredAttributes(),
-			newVal: newFilteredAttrs.AsRaw(),
+			orig:       refExemplar.FilteredAttributes(),
+			newVal:     newFilteredAttrs.AsRaw(),
+			nilNoError: true,
 			modified: func(exemplar pmetric.Exemplar) {
 				_ = exemplar.FilteredAttributes().FromRaw(newFilteredAttrs.AsRaw())
 			},
@@ -172,8 +175,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   "val",
-			newVal: "newVal",
+			orig:       "val",
+			newVal:     "newVal",
+			nilNoError: true,
 			modified: func(exemplar pmetric.Exemplar) {
 				exemplar.FilteredAttributes().PutStr("str", "newVal")
 			},
@@ -188,8 +192,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   int64(10),
-			newVal: int64(20),
+			orig:       int64(10),
+			newVal:     int64(20),
+			nilNoError: true,
 			modified: func(exemplar pmetric.Exemplar) {
 				exemplar.FilteredAttributes().PutInt("int", 20)
 			},
@@ -231,6 +236,13 @@ func TestPathGetSetter(t *testing.T) {
 
 			err = accessor.Set(t.Context(), tCtx, struct{}{})
 			require.Error(t, err)
+
+			err = accessor.Set(t.Context(), tCtx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxlog/log_test.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log_test.go
@@ -56,12 +56,13 @@ func TestPathGetSetter(t *testing.T) {
 	newMap["k2"] = newMap2
 
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(log plog.LogRecord)
-		bodyType string
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(log plog.LogRecord)
+		bodyType   string
+		nilNoError bool // true if the setter accepts nil without returning an error
 	}{
 		{
 			name: "time_unix_nano",
@@ -130,7 +131,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "body is string",
+			name:       "body is string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "body",
 			},
@@ -142,7 +144,8 @@ func TestPathGetSetter(t *testing.T) {
 			bodyType: "string",
 		},
 		{
-			name: "body is int",
+			name:       "body is int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "body",
 			},
@@ -154,7 +157,8 @@ func TestPathGetSetter(t *testing.T) {
 			bodyType: "int",
 		},
 		{
-			name: "body is slice",
+			name:       "body is slice",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "body",
 			},
@@ -169,7 +173,8 @@ func TestPathGetSetter(t *testing.T) {
 			bodyType: "slice",
 		},
 		{
-			name: "body is map",
+			name:       "body is map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "body",
 			},
@@ -199,7 +204,8 @@ func TestPathGetSetter(t *testing.T) {
 			bodyType: "string",
 		},
 		{
-			name: "body slice index",
+			name:       "body slice index",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "body",
 				KeySlice: []ottl.Key[*testContext]{
@@ -216,7 +222,8 @@ func TestPathGetSetter(t *testing.T) {
 			bodyType: "slice",
 		},
 		{
-			name: "body.map[key]",
+			name:       "body.map[key]",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "body",
 				KeySlice: []ottl.Key[*testContext]{
@@ -233,7 +240,8 @@ func TestPathGetSetter(t *testing.T) {
 			bodyType: "map",
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -244,7 +252,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes raw map",
+			name:       "attributes raw map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -255,7 +264,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes.key",
+			name:       "attributes.key",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -372,6 +382,15 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), newTestContext(createTelemetry(tt.bodyType)), nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 
 			expectedLog := createTelemetry(tt.bodyType)
 			tt.modified(expectedLog)

--- a/pkg/ottl/contexts/internal/ctxlog/log_test.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log_test.go
@@ -383,8 +383,8 @@ func TestPathGetSetter(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), newTestContext(createTelemetry(tt.bodyType)), nil)
 			if tt.nilNoError {
 				require.NoError(t, err)

--- a/pkg/ottl/contexts/internal/ctxmetric/metric.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric.go
@@ -181,35 +181,15 @@ func accessDataPoints[K Context]() ottl.StandardGetSetter[K] {
 			metric := tCtx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
-				newDataPoints, err := ctxutil.ExpectType[pmetric.NumberDataPointSlice](val)
-				if err != nil {
-					return err
-				}
-				newDataPoints.CopyTo(metric.Sum().DataPoints())
+				return ctxutil.SetPSliceValue(metric.Sum().DataPoints(), pmetric.NewNumberDataPointSlice, val)
 			case pmetric.MetricTypeGauge:
-				newDataPoints, err := ctxutil.ExpectType[pmetric.NumberDataPointSlice](val)
-				if err != nil {
-					return err
-				}
-				newDataPoints.CopyTo(metric.Gauge().DataPoints())
+				return ctxutil.SetPSliceValue(metric.Gauge().DataPoints(), pmetric.NewNumberDataPointSlice, val)
 			case pmetric.MetricTypeHistogram:
-				newDataPoints, err := ctxutil.ExpectType[pmetric.HistogramDataPointSlice](val)
-				if err != nil {
-					return err
-				}
-				newDataPoints.CopyTo(metric.Histogram().DataPoints())
+				return ctxutil.SetPSliceValue(metric.Histogram().DataPoints(), pmetric.NewHistogramDataPointSlice, val)
 			case pmetric.MetricTypeExponentialHistogram:
-				newDataPoints, err := ctxutil.ExpectType[pmetric.ExponentialHistogramDataPointSlice](val)
-				if err != nil {
-					return err
-				}
-				newDataPoints.CopyTo(metric.ExponentialHistogram().DataPoints())
+				return ctxutil.SetPSliceValue(metric.ExponentialHistogram().DataPoints(), pmetric.NewExponentialHistogramDataPointSlice, val)
 			case pmetric.MetricTypeSummary:
-				newDataPoints, err := ctxutil.ExpectType[pmetric.SummaryDataPointSlice](val)
-				if err != nil {
-					return err
-				}
-				newDataPoints.CopyTo(metric.Summary().DataPoints())
+				return ctxutil.SetPSliceValue(metric.Summary().DataPoints(), pmetric.NewSummaryDataPointSlice, val)
 			}
 			return nil
 		},

--- a/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func TestPathGetSetter(t *testing.T) {
@@ -126,6 +127,23 @@ func TestPathGetSetter(t *testing.T) {
 			nilNoError: true,
 			modified: func(metric pmetric.Metric) {
 				newMetadata.CopyTo(metric.Metadata())
+			},
+		},
+		{
+			name: "metric metadata key",
+			path: &pathtest.Path[*testContext]{
+				N: "metadata",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("key"),
+					},
+				},
+			},
+			orig:       nil,
+			newVal:     "value",
+			nilNoError: true,
+			modified: func(metric pmetric.Metric) {
+				metric.Metadata().PutStr("key", "value")
 			},
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
@@ -107,7 +107,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "metric data points",
+			name:       "metric data points",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "data_points",
 			},

--- a/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
@@ -36,6 +36,7 @@ func TestPathGetSetter(t *testing.T) {
 		newVal              any
 		modified            func(metric pmetric.Metric)
 		skipSetterTypeCheck bool
+		nilNoError          bool
 	}{
 		{
 			name: "metric name",
@@ -80,6 +81,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(_ pmetric.Metric) {
 			},
 			skipSetterTypeCheck: true, // metric type setter is a no-op
+			nilNoError:          true,
 		},
 		{
 			name: "metric aggregation_temporality",
@@ -119,8 +121,9 @@ func TestPathGetSetter(t *testing.T) {
 			path: &pathtest.Path[*testContext]{
 				N: "metadata",
 			},
-			orig:   pcommon.NewMap(),
-			newVal: newMetadata,
+			orig:       pcommon.NewMap(),
+			newVal:     newMetadata,
+			nilNoError: true,
 			modified: func(metric pmetric.Metric) {
 				newMetadata.CopyTo(metric.Metadata())
 			},
@@ -143,6 +146,13 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			if !tt.skipSetterTypeCheck {
 				err = accessor.Set(t.Context(), newTestContext(metric), struct{}{})
+				require.Error(t, err)
+			}
+
+			err = accessor.Set(t.Context(), newTestContext(createTelemetry()), nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
 				require.Error(t, err)
 			}
 

--- a/pkg/ottl/contexts/internal/ctxotelcol/otelcol_test.go
+++ b/pkg/ottl/contexts/internal/ctxotelcol/otelcol_test.go
@@ -58,6 +58,10 @@ func TestContextClientMetadata(t *testing.T) {
 		contentType, ok := result.Get("content-type")
 		require.True(t, ok)
 		require.Equal(t, []any{"application/json"}, contentType.Slice().AsRaw())
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("access specific metadata key", func(t *testing.T) {
@@ -81,6 +85,10 @@ func TestContextClientMetadata(t *testing.T) {
 		result, ok := val.(pcommon.Slice)
 		require.True(t, ok)
 		assert.Equal(t, []any{"Bearer token123"}, result.AsRaw())
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("access non-existent metadata key", func(t *testing.T) {
@@ -102,6 +110,10 @@ func TestContextClientMetadata(t *testing.T) {
 		val, err := getter.Get(ctx, testContext{})
 		require.NoError(t, err)
 		assert.Nil(t, val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("access empty metadata key", func(t *testing.T) {
@@ -123,6 +135,10 @@ func TestContextClientMetadata(t *testing.T) {
 		val, err := getter.Get(ctx, testContext{})
 		require.NoError(t, err)
 		assert.Nil(t, val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("access metadata key with multiple values", func(t *testing.T) {
@@ -146,6 +162,10 @@ func TestContextClientMetadata(t *testing.T) {
 		result, ok := val.(pcommon.Slice)
 		require.True(t, ok)
 		assert.Equal(t, []any{"value1", "value2"}, result.AsRaw())
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("access metadata key with multiple values by index", func(t *testing.T) {
@@ -172,6 +192,10 @@ func TestContextClientMetadata(t *testing.T) {
 		result, ok := val.(string)
 		require.True(t, ok)
 		assert.Equal(t, "value1", result)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("cannot set entire metadata", func(t *testing.T) {
@@ -192,6 +216,10 @@ func TestContextClientMetadata(t *testing.T) {
 		err = getter.Set(ctx, testContext{}, newMetadata)
 		require.Error(t, err)
 		assert.Equal(t, `"otelcol.client.metadata" is read-only and cannot be modified`, err.Error())
+
+		// setter is read-only; setting nil also returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("cannot set specific metadata key", func(t *testing.T) {
@@ -213,6 +241,10 @@ func TestContextClientMetadata(t *testing.T) {
 		err = getter.Set(ctx, testContext{}, "new-value")
 		require.Error(t, err)
 		assert.Equal(t, `"otelcol.client.metadata" is read-only and cannot be modified`, err.Error())
+
+		// setter is read-only; setting nil also returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("error when accessing metadata key without keys", func(t *testing.T) {
@@ -222,6 +254,10 @@ func TestContextClientMetadata(t *testing.T) {
 		_, err := getter.Get(ctx, testContext{})
 		require.Error(t, err)
 		assert.Equal(t, "cannot get map value without keys", err.Error())
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("no client in context", func(t *testing.T) {
@@ -243,6 +279,10 @@ func TestContextClientMetadata(t *testing.T) {
 		// Should return empty pcommon.Map when no client is in context
 		emptyMap := pcommon.NewMap()
 		assert.Equal(t, emptyMap, val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(emptyCtx, testContext{}, nil)
+		require.Error(t, err)
 	})
 }
 
@@ -267,6 +307,10 @@ func TestContextClientAddr(t *testing.T) {
 	err = getter.Set(ctx, testContext{}, "ignored")
 	require.Error(t, err)
 	assert.Equal(t, `"otelcol.client.addr" is read-only and cannot be modified`, err.Error())
+
+	// setter is read-only; setting nil also returns an error
+	err = getter.Set(ctx, testContext{}, nil)
+	require.Error(t, err)
 }
 
 func TestContextClientAuthAttributes_AllAndKey(t *testing.T) {
@@ -306,6 +350,10 @@ func TestContextClientAuthAttributes_AllAndKey(t *testing.T) {
 		err = getter.Set(ctx, testContext{}, map[string]string{"k": "v"})
 		require.Error(t, err)
 		assert.Equal(t, `"otelcol.client.auth.attributes" is read-only and cannot be modified`, err.Error())
+
+		// setter is read-only; setting nil also returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("specific attribute key present", func(t *testing.T) {
@@ -326,6 +374,10 @@ func TestContextClientAuthAttributes_AllAndKey(t *testing.T) {
 		val, err := getter.Get(ctx, testContext{})
 		require.NoError(t, err)
 		assert.Equal(t, "user-123", val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("specific attribute key present with index", func(t *testing.T) {
@@ -347,6 +399,10 @@ func TestContextClientAuthAttributes_AllAndKey(t *testing.T) {
 		val, err := getter.Get(ctx, testContext{})
 		require.NoError(t, err)
 		assert.Equal(t, "user", val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("specific attribute key missing returns empty string", func(t *testing.T) {
@@ -367,6 +423,10 @@ func TestContextClientAuthAttributes_AllAndKey(t *testing.T) {
 		val, err := getter.Get(ctx, testContext{})
 		require.NoError(t, err)
 		assert.Empty(t, val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("attributes key without keys error", func(t *testing.T) {
@@ -374,6 +434,10 @@ func TestContextClientAuthAttributes_AllAndKey(t *testing.T) {
 		_, err := getter.Get(ctx, testContext{})
 		require.Error(t, err)
 		assert.Equal(t, "cannot get map value without keys", err.Error())
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctx, testContext{}, nil)
+		require.Error(t, err)
 	})
 }
 
@@ -413,6 +477,10 @@ func TestContextGrpcMetadata(t *testing.T) {
 		err = getter.Set(ctxWithMD, testContext{}, metadata.MD{})
 		require.Error(t, err)
 		assert.Equal(t, `"otelcol.grpc.metadata" is read-only and cannot be modified`, err.Error())
+
+		// setter is read-only; setting nil also returns an error
+		err = getter.Set(ctxWithMD, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("get specific grpc metadata key values", func(t *testing.T) {
@@ -436,6 +504,10 @@ func TestContextGrpcMetadata(t *testing.T) {
 		err = getter.Set(ctxWithMD, testContext{}, []string{"x"})
 		require.Error(t, err)
 		assert.Equal(t, `"otelcol.grpc.metadata" is read-only and cannot be modified`, err.Error())
+
+		// setter is read-only; setting nil also returns an error
+		err = getter.Set(ctxWithMD, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("grpc metadata key missing returns nil", func(t *testing.T) {
@@ -453,6 +525,10 @@ func TestContextGrpcMetadata(t *testing.T) {
 		val, err := getter.Get(ctxWithMD, testContext{})
 		require.NoError(t, err)
 		assert.Nil(t, val)
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctxWithMD, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("grpc metadata without keys error", func(t *testing.T) {
@@ -460,6 +536,10 @@ func TestContextGrpcMetadata(t *testing.T) {
 		_, err := getter.Get(ctxWithMD, testContext{})
 		require.Error(t, err)
 		assert.Equal(t, "cannot get map value without keys", err.Error())
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(ctxWithMD, testContext{}, nil)
+		require.Error(t, err)
 	})
 
 	t.Run("no grpc metadata in context returns Map", func(t *testing.T) {
@@ -474,6 +554,10 @@ func TestContextGrpcMetadata(t *testing.T) {
 		val, err := getter.Get(t.Context(), testContext{})
 		require.NoError(t, err)
 		require.Equal(t, pcommon.NewMap(), val.(pcommon.Map))
+
+		// setter is read-only; setting nil returns an error
+		err = getter.Set(t.Context(), testContext{}, nil)
+		require.Error(t, err)
 	})
 }
 

--- a/pkg/ottl/contexts/internal/ctxprofile/profile.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/profile.go
@@ -76,12 +76,7 @@ func accessSample[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetProfile().Samples(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			v, err := ctxutil.ExpectType[pprofile.SampleSlice](val)
-			if err != nil {
-				return err
-			}
-			v.CopyTo(tCtx.GetProfile().Samples())
-			return nil
+			return ctxutil.SetPSliceValue(tCtx.GetProfile().Samples(), pprofile.NewSampleSlice, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
@@ -194,8 +194,8 @@ func TestPathGetSetter(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			// Use a fresh context so the nil write does not disturb the assertion below.
 			nilCtx := newProfileContext(pprofile.NewProfile(), pprofile.NewProfilesDictionary())
 			err = accessor.Set(t.Context(), nilCtx, nil)

--- a/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
@@ -41,8 +41,9 @@ func TestPathGetSetter(t *testing.T) {
 			val:  "cycles",
 		},
 		{
-			path: "sample",
-			val:  createSampleSlice(),
+			path:       "sample",
+			val:        createSampleSlice(),
+			nilNoError: true,
 		},
 		{
 			path: "time_unix_nano",

--- a/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
@@ -22,10 +22,11 @@ import (
 func TestPathGetSetter(t *testing.T) {
 	// create tests
 	tests := []struct {
-		path     string
-		val      any
-		keys     []ottl.Key[*profileContext]
-		setFails bool
+		path       string
+		val        any
+		keys       []ottl.Key[*profileContext]
+		setFails   bool
+		nilNoError bool // true if the setter accepts nil without returning an error
 	}{
 		{
 			path: "sample_type",
@@ -97,8 +98,9 @@ func TestPathGetSetter(t *testing.T) {
 			setFails: true,
 		},
 		{
-			path: "attribute_indices",
-			val:  []int64{567},
+			path:       "attribute_indices",
+			val:        []int64{567},
+			nilNoError: true,
 		},
 		{
 			path: "dropped_attributes_count",
@@ -119,6 +121,7 @@ func TestPathGetSetter(t *testing.T) {
 				m.PutStr("akey", "val")
 				return m
 			}(),
+			nilNoError: true,
 		},
 		{
 			path: "attributes",
@@ -127,7 +130,8 @@ func TestPathGetSetter(t *testing.T) {
 					S: ottltest.Strp("akey"),
 				},
 			},
-			val: "val",
+			val:        "val",
+			nilNoError: true,
 		},
 		{
 			path: "attributes",
@@ -139,7 +143,8 @@ func TestPathGetSetter(t *testing.T) {
 					S: ottltest.Strp("bkey"),
 				},
 			},
-			val: "val",
+			val:        "val",
+			nilNoError: true,
 		},
 		{
 			path: "attributes",
@@ -155,7 +160,8 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			val: "val",
+			val:        "val",
+			nilNoError: true,
 		},
 	}
 
@@ -187,6 +193,17 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			// Use a fresh context so the nil write does not disturb the assertion below.
+			nilCtx := newProfileContext(pprofile.NewProfile(), pprofile.NewProfilesDictionary())
+			err = accessor.Set(t.Context(), nilCtx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)

--- a/pkg/ottl/contexts/internal/ctxprofile/value_type_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/value_type_test.go
@@ -135,6 +135,12 @@ func TestAccessValueTypeRoot_Setter(t *testing.T) {
 			wantErr:  true,
 			errMsg:   "path \"sample_type\" expects pprofile.ValueType but got string",
 		},
+		{
+			name:     "nil value",
+			setValue: nil,
+			wantErr:  true,
+			errMsg:   "setting a value to nil is not supported",
+		},
 	}
 
 	for _, tt := range tests {
@@ -280,6 +286,17 @@ func TestAccessValueTypeType_Setter(t *testing.T) {
 			setValue: 123,
 			wantErr:  true,
 			errMsg:   "path \"type\" expects string but got int",
+		},
+		{
+			name: "nil value",
+			setupFunc: func() *mockValueTypeContext {
+				dict := newEmptyProfilesDictionary()
+				valueType := pprofile.NewValueType()
+				return &mockValueTypeContext{dictionary: dict, valueType: valueType}
+			},
+			setValue: nil,
+			wantErr:  true,
+			errMsg:   "setting a value to nil is not supported",
 		},
 	}
 
@@ -433,6 +450,17 @@ func TestAccessValueTypeUnit_Setter(t *testing.T) {
 			setValue: 456,
 			wantErr:  true,
 			errMsg:   "path \"unit\" expects string but got int",
+		},
+		{
+			name: "nil value",
+			setupFunc: func() *mockValueTypeContext {
+				dict := newEmptyProfilesDictionary()
+				valueType := pprofile.NewValueType()
+				return &mockValueTypeContext{dictionary: dict, valueType: valueType}
+			},
+			setValue: nil,
+			wantErr:  true,
+			errMsg:   "setting a value to nil is not supported",
 		},
 	}
 

--- a/pkg/ottl/contexts/internal/ctxprofilecommon/attributes_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofilecommon/attributes_test.go
@@ -188,6 +188,10 @@ func TestAccessAttributes_Setter_InvalidValue(t *testing.T) {
 	// Pass a value that is not a ctxutil.Map
 	err := getSetter.Setter(t.Context(), ctx, "not_a_map")
 	assert.Error(t, err)
+
+	// Passing nil clears the attributes to empty via ctxutil.GetMap, so it must not error.
+	err = getSetter.Setter(t.Context(), ctx, nil)
+	require.NoError(t, err)
 }
 
 func TestAccessAttributesKey_Getter(t *testing.T) {
@@ -374,6 +378,21 @@ func TestAccessAttributesKey_Setter(t *testing.T) {
 			}
 		}
 		assert.True(t, foundUpdatedFoo, "Should find updated 'foo' attribute with new value")
+	})
+
+	t.Run("nil-value", func(t *testing.T) {
+		path := pathtest.Path[*mockAttributeContext]{
+			KeySlice: []ottl.Key[*mockAttributeContext]{
+				&pathtest.Key[*mockAttributeContext]{
+					S: ottltest.Strp("foo"),
+				},
+			},
+		}
+		getSetter := AccessAttributesKey[*mockAttributeContext](path.Keys(), mockAttributeSource)
+		// Keyed access routes through ctxutil.SetValue, which accepts nil and
+		// sets an empty value, so nil must not error.
+		err := getSetter.Setter(t.Context(), ctx, nil)
+		require.NoError(t, err)
 	})
 
 	t.Run("insert-new-key", func(t *testing.T) {

--- a/pkg/ottl/contexts/internal/ctxprofilesample/profilesample.go
+++ b/pkg/ottl/contexts/internal/ctxprofilesample/profilesample.go
@@ -109,6 +109,11 @@ func accessTimestamps[K Context]() ottl.StandardGetSetter[K] {
 			return ts, nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
+			if val == nil {
+				// timestamps is a view over the repeated TimestampsUnixNano list, so nil clears it.
+				tCtx.GetProfileSample().TimestampsUnixNano().FromRaw(nil)
+				return nil
+			}
 			ts, err := ctxutil.ExpectType[[]time.Time](val)
 			if err != nil {
 				return err

--- a/pkg/ottl/contexts/internal/ctxprofilesample/profilesample_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofilesample/profilesample_test.go
@@ -20,25 +20,29 @@ import (
 func TestPathGetSetter(t *testing.T) {
 	tsNow := time.Now().UTC()
 	tests := []struct {
-		path string
-		val  any
-		keys []ottl.Key[*profileSampleContext]
+		path       string
+		val        any
+		keys       []ottl.Key[*profileSampleContext]
+		nilNoError bool
 	}{
 		{
-			path: "values",
-			val:  []int64{73, 74, 75},
+			path:       "values",
+			val:        []int64{73, 74, 75},
+			nilNoError: true,
 		},
 		{
-			path: "attribute_indices",
-			val:  []int64{97, 98, 99},
+			path:       "attribute_indices",
+			val:        []int64{97, 98, 99},
+			nilNoError: true,
 		},
 		{
 			path: "link_index",
 			val:  int64(44),
 		},
 		{
-			path: "timestamps_unix_nano",
-			val:  []int64{tsNow.Unix(), 2, 3},
+			path:       "timestamps_unix_nano",
+			val:        []int64{tsNow.Unix(), 2, 3},
+			nilNoError: true,
 		},
 		{
 			path: "timestamps",
@@ -74,6 +78,14 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), newProfileSampleContext(sample, dictionary), struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling
+			err = accessor.Set(t.Context(), newProfileSampleContext(sample, dictionary), nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxprofilesample/profilesample_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofilesample/profilesample_test.go
@@ -45,8 +45,9 @@ func TestPathGetSetter(t *testing.T) {
 			nilNoError: true,
 		},
 		{
-			path: "timestamps",
-			val:  []time.Time{tsNow},
+			path:       "timestamps",
+			val:        []time.Time{tsNow},
+			nilNoError: true,
 		},
 	}
 

--- a/pkg/ottl/contexts/internal/ctxresource/resource_test.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource_test.go
@@ -25,11 +25,12 @@ func TestPathGetSetter(t *testing.T) {
 	newAttrs.PutStr("hello", "world")
 
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(resource pcommon.Resource)
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(resource pcommon.Resource)
+		nilNoError bool
 	}{
 		{
 			name: "resource schema_url",
@@ -52,6 +53,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				newAttrs.CopyTo(resource.Attributes())
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes raw map",
@@ -63,6 +65,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				_ = resource.Attributes().FromRaw(newAttrs.AsRaw())
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes string",
@@ -79,6 +82,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutStr("str", "newVal")
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes bool",
@@ -95,6 +99,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutBool("bool", false)
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes int",
@@ -111,6 +116,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutInt("int", 20)
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes float",
@@ -127,6 +133,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutDouble("double", 2.4)
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes bytes",
@@ -143,6 +150,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes array empty",
@@ -162,6 +170,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(_ pcommon.Resource) {
 				// no-op
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes array string",
@@ -181,6 +190,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes array bool",
@@ -200,6 +210,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes array int",
@@ -219,6 +230,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes array float",
@@ -238,6 +250,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes array bytes",
@@ -257,6 +270,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes nested",
@@ -283,6 +297,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(resource pcommon.Resource) {
 				resource.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes nested new values",
@@ -310,6 +325,7 @@ func TestPathGetSetter(t *testing.T) {
 				s.AppendEmpty()
 				s.AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("new")
 			},
+			nilNoError: true,
 		},
 		{
 			name: "dropped_attributes_count",
@@ -346,6 +362,14 @@ func TestPathGetSetter(t *testing.T) {
 			tt.modified(expectedResource)
 
 			assert.Equal(t, expectedResource, resource)
+
+			// Verify nil handling
+			err = accessor.Set(t.Context(), ctx, nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxscope/scope_test.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope_test.go
@@ -24,11 +24,12 @@ func TestPathGetSetter(t *testing.T) {
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(is pcommon.InstrumentationScope)
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(is pcommon.InstrumentationScope)
+		nilNoError bool // true if the setter accepts nil without returning an error
 	}{
 		{
 			name: "instrumentation_scope name",
@@ -64,7 +65,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -75,7 +77,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes raw map",
+			name:       "attributes raw map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -86,7 +89,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes string",
+			name:       "attributes string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -113,7 +117,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bool",
+			name:       "attributes bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -129,7 +134,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes int",
+			name:       "attributes int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -145,7 +151,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes float",
+			name:       "attributes float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -161,7 +168,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bytes",
+			name:       "attributes bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -177,7 +185,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array empty",
+			name:       "attributes array empty",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -196,7 +205,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array string",
+			name:       "attributes array string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -216,7 +226,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bool",
+			name:       "attributes array bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -236,7 +247,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array int",
+			name:       "attributes array int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -256,7 +268,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array float",
+			name:       "attributes array float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -276,7 +289,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bytes",
+			name:       "attributes array bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -296,7 +310,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested",
+			name:       "attributes nested",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -322,7 +337,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested new values",
+			name:       "attributes nested new values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -379,6 +395,15 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), newTestContext(createInstrumentationScope()), nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 
 			expectedIS := createInstrumentationScope()
 			tt.modified(expectedIS)

--- a/pkg/ottl/contexts/internal/ctxscope/scope_test.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope_test.go
@@ -396,8 +396,8 @@ func TestPathGetSetter(t *testing.T) {
 			err = accessor.Set(t.Context(), ctx, struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), newTestContext(createInstrumentationScope()), nil)
 			if tt.nilNoError {
 				require.NoError(t, err)

--- a/pkg/ottl/contexts/internal/ctxspan/span.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span.go
@@ -492,15 +492,7 @@ func accessEvents[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetSpan().Events(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			slc, err := ctxutil.ExpectType[ptrace.SpanEventSlice](val)
-			if err != nil {
-				return err
-			}
-			tCtx.GetSpan().Events().RemoveIf(func(_ ptrace.SpanEvent) bool {
-				return true
-			})
-			slc.CopyTo(tCtx.GetSpan().Events())
-			return nil
+			return ctxutil.SetPSliceValue(tCtx.GetSpan().Events(), ptrace.NewSpanEventSlice, val)
 		},
 	}
 }
@@ -527,15 +519,7 @@ func accessLinks[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetSpan().Links(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			slc, err := ctxutil.ExpectType[ptrace.SpanLinkSlice](val)
-			if err != nil {
-				return err
-			}
-			tCtx.GetSpan().Links().RemoveIf(func(_ ptrace.SpanLink) bool {
-				return true
-			})
-			slc.CopyTo(tCtx.GetSpan().Links())
-			return nil
+			return ctxutil.SetPSliceValue(tCtx.GetSpan().Links(), ptrace.NewSpanLinkSlice, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxspan/span_test.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span_test.go
@@ -629,6 +629,17 @@ func TestPathGetSetter(t *testing.T) {
 				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
+		{
+			name: "flags",
+			path: &pathtest.Path[*testContext]{
+				N: "flags",
+			},
+			orig:   int64(0),
+			newVal: int64(1),
+			modified: func(span ptrace.Span) {
+				span.SetFlags(1)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/contexts/internal/ctxspan/span_test.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span_test.go
@@ -42,11 +42,12 @@ func TestPathGetSetter(t *testing.T) {
 	newStatus.SetMessage("new status")
 
 	tests := []struct {
-		name     string
-		path     ottl.Path[*testContext]
-		orig     any
-		newVal   any
-		modified func(span ptrace.Span)
+		name       string
+		path       ottl.Path[*testContext]
+		orig       any
+		newVal     any
+		modified   func(span ptrace.Span)
+		nilNoError bool // true if the setter accepts nil without returning an error
 	}{
 		{
 			name: "trace_id",
@@ -223,7 +224,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes",
+			name:       "attributes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -234,7 +236,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes raw map",
+			name:       "attributes raw map",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
@@ -245,7 +248,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes string",
+			name:       "attributes string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -261,7 +265,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bool",
+			name:       "attributes bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -277,7 +282,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes int",
+			name:       "attributes int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -293,7 +299,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes float",
+			name:       "attributes float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -309,7 +316,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes bytes",
+			name:       "attributes bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -325,7 +333,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array empty",
+			name:       "attributes array empty",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -344,7 +353,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array string",
+			name:       "attributes array string",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -363,7 +373,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bool",
+			name:       "attributes array bool",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -382,7 +393,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array int",
+			name:       "attributes array int",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -401,7 +413,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array float",
+			name:       "attributes array float",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -420,7 +433,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes array bytes",
+			name:       "attributes array bytes",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -439,7 +453,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested",
+			name:       "attributes nested",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -465,7 +480,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "attributes nested new values",
+			name:       "attributes nested new values",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 				KeySlice: []ottl.Key[*testContext]{
@@ -636,6 +652,15 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), newTestContext(span), struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling: setters that cannot represent nil return an error,
+			// while value-typed paths accept nil (represented as an empty value).
+			err = accessor.Set(t.Context(), newTestContext(createTelemetry()), nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxspan/span_test.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span_test.go
@@ -519,7 +519,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "events",
+			name:       "events",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "events",
 			},
@@ -544,7 +545,8 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "links",
+			name:       "links",
+			nilNoError: true,
 			path: &pathtest.Path[*testContext]{
 				N: "links",
 			},

--- a/pkg/ottl/contexts/internal/ctxspan/span_test.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span_test.go
@@ -664,8 +664,8 @@ func TestPathGetSetter(t *testing.T) {
 			err = accessor.Set(t.Context(), newTestContext(span), struct{}{})
 			require.Error(t, err)
 
-			// Verify nil handling: setters that cannot represent nil return an error,
-			// while value-typed paths accept nil (represented as an empty value).
+			// Verify nil handling: setters for scalar and struct paths return an error, while
+			// setters for pcommon.Value, map, and slice paths accept nil and clear to empty.
 			err = accessor.Set(t.Context(), newTestContext(createTelemetry()), nil)
 			if tt.nilNoError {
 				require.NoError(t, err)

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
@@ -54,6 +54,7 @@ func TestPathGetSetter(t *testing.T) {
 		orig              any
 		newVal            any
 		expectSetterError bool
+		nilNoError        bool
 		modified          func(spanEvent ptrace.SpanEvent)
 	}{
 		{
@@ -99,6 +100,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(spanEvent ptrace.SpanEvent) {
 				newAttrs.CopyTo(spanEvent.Attributes())
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes raw map",
@@ -110,6 +112,7 @@ func TestPathGetSetter(t *testing.T) {
 			modified: func(spanEvent ptrace.SpanEvent) {
 				_ = spanEvent.Attributes().FromRaw(newAttrs.AsRaw())
 			},
+			nilNoError: true,
 		},
 		{
 			name: "attributes string",
@@ -121,8 +124,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   "val",
-			newVal: "newVal",
+			orig:       "val",
+			newVal:     "newVal",
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutStr("str", "newVal")
 			},
@@ -137,8 +141,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   true,
-			newVal: false,
+			orig:       true,
+			newVal:     false,
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutBool("bool", false)
 			},
@@ -153,8 +158,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   int64(10),
-			newVal: int64(20),
+			orig:       int64(10),
+			newVal:     int64(20),
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutInt("int", 20)
 			},
@@ -169,8 +175,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   float64(1.2),
-			newVal: float64(2.4),
+			orig:       float64(1.2),
+			newVal:     float64(2.4),
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutDouble("double", 2.4)
 			},
@@ -185,8 +192,9 @@ func TestPathGetSetter(t *testing.T) {
 					},
 				},
 			},
-			orig:   []byte{1, 3, 2},
-			newVal: []byte{2, 3, 4},
+			orig:       []byte{1, 3, 2},
+			newVal:     []byte{2, 3, 4},
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
@@ -205,7 +213,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("arr_str")
 				return val.Slice()
 			}(),
-			newVal: []string{"new"},
+			newVal:     []string{"new"},
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
@@ -224,7 +233,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("arr_bool")
 				return val.Slice()
 			}(),
-			newVal: []bool{false},
+			newVal:     []bool{false},
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
@@ -243,7 +253,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("arr_int")
 				return val.Slice()
 			}(),
-			newVal: []int64{20},
+			newVal:     []int64{20},
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
@@ -262,7 +273,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("arr_float")
 				return val.Slice()
 			}(),
-			newVal: []float64{2.0},
+			newVal:     []float64{2.0},
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
@@ -281,7 +293,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("arr_bytes")
 				return val.Slice()
 			}(),
-			newVal: [][]byte{{9, 6, 4}},
+			newVal:     [][]byte{{9, 6, 4}},
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
@@ -300,7 +313,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("pMap")
 				return val.Map()
 			}(),
-			newVal: newPMap,
+			newVal:     newPMap,
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				m := spanEvent.Attributes().PutEmptyMap("pMap")
 				m2 := m.PutEmptyMap("k2")
@@ -321,7 +335,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ := refSpanEvent.Attributes().Get("map")
 				return val.Map()
 			}(),
-			newVal: newMap,
+			newVal:     newMap,
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				m := spanEvent.Attributes().PutEmptyMap("map")
 				m2 := m.PutEmptyMap("k2")
@@ -349,7 +364,8 @@ func TestPathGetSetter(t *testing.T) {
 				val, _ = val.Slice().At(0).Map().Get("map")
 				return val.Str()
 			}(),
-			newVal: "new",
+			newVal:     "new",
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				spanEvent.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
@@ -373,7 +389,8 @@ func TestPathGetSetter(t *testing.T) {
 			orig: func() any {
 				return nil
 			}(),
-			newVal: "new",
+			newVal:     "new",
+			nilNoError: true,
 			modified: func(spanEvent ptrace.SpanEvent) {
 				s := spanEvent.Attributes().PutEmptySlice("new")
 				s.AppendEmpty()
@@ -426,6 +443,14 @@ func TestPathGetSetter(t *testing.T) {
 			// Verify that setting an invalid type returns an error
 			err = accessor.Set(t.Context(), tCtx, struct{}{})
 			require.Error(t, err)
+
+			// Verify nil handling
+			err = accessor.Set(t.Context(), newTestContext(createTelemetry()), nil)
+			if tt.nilNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 
 			exSpanEvent := createTelemetry()
 			tt.modified(exSpanEvent)

--- a/pkg/ottl/contexts/internal/ctxutil/map.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map.go
@@ -83,7 +83,8 @@ func FetchValueFromExpression[K any, T int64 | string](ctx context.Context, tCtx
 
 func SetMap(target pcommon.Map, val any) error {
 	if val == nil {
-		return nil
+		// A map represents nil as an empty map.
+		return target.FromRaw(nil)
 	}
 	if cm, ok := val.(pcommon.Map); ok {
 		cm.CopyTo(target)
@@ -96,6 +97,10 @@ func SetMap(target pcommon.Map, val any) error {
 }
 
 func GetMap(val any) (pcommon.Map, error) {
+	if val == nil {
+		// A map represents nil as an empty map.
+		return pcommon.NewMap(), nil
+	}
 	if m, ok := val.(pcommon.Map); ok {
 		return m, nil
 	}

--- a/pkg/ottl/contexts/internal/ctxutil/map_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map_test.go
@@ -312,14 +312,39 @@ func Test_SetMapValue_NilKey(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_SetMap_NilIsNoop(t *testing.T) {
+func Test_SetMapValue_NilClearsValue(t *testing.T) {
+	m := pcommon.NewMap()
+	keys := []ottl.Key[any]{
+		&pathtest.Key[any]{
+			S: ottltest.Strp("test"),
+		},
+	}
+	err := ctxutil.SetMapValue[any](t.Context(), nil, m, keys, nil)
+	require.NoError(t, err)
+
+	val, ok := m.Get("test")
+	require.True(t, ok)
+	assert.Equal(t, pcommon.ValueTypeEmpty, val.Type())
+}
+
+func Test_SetMap_NilClearsMap(t *testing.T) {
 	m := pcommon.NewMap()
 	m.PutStr("foo", "bar")
 	err := ctxutil.SetMap(m, nil)
 	require.NoError(t, err)
-	val, ok := m.Get("foo")
-	assert.True(t, ok)
-	assert.Equal(t, "bar", val.Str())
+	assert.Equal(t, 0, m.Len())
+}
+
+func Test_GetMap_NilReturnsEmptyMap(t *testing.T) {
+	m, err := ctxutil.GetMap(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, m.Len())
+}
+
+func Test_GetMap_FromRawError(t *testing.T) {
+	// A map[string]any containing an unsupported value type causes FromRaw to error.
+	_, err := ctxutil.GetMap(map[string]any{"key": struct{}{}})
+	require.Error(t, err)
 }
 
 func Test_SetMap(t *testing.T) {

--- a/pkg/ottl/contexts/internal/ctxutil/slice.go
+++ b/pkg/ottl/contexts/internal/ctxutil/slice.go
@@ -166,6 +166,23 @@ func SetCommonTypedSliceValues[V any](s CommonTypedSlice[V], val any) error {
 	return nil
 }
 
+// SetPSliceValue sets a pdata message slice (such as ptrace.SpanEventSlice or
+// pmetric.ExemplarSlice) from val by copying it into dest. These are list-like values
+// even though they are not pcommon.Slice, so a nil val clears dest to an empty slice
+// (created via newEmpty). Any value that is not a [T] returns an error.
+func SetPSliceValue[T interface{ CopyTo(dest T) }](dest T, newEmpty func() T, val any) error {
+	if val == nil {
+		newEmpty().CopyTo(dest)
+		return nil
+	}
+	src, err := ExpectType[T](val)
+	if err != nil {
+		return err
+	}
+	src.CopyTo(dest)
+	return nil
+}
+
 // GetCommonIntSliceValues converts a pdata typed slice of [constraints.Integer] into
 // []int64, which is the standard OTTL type for integer slices.
 func GetCommonIntSliceValues[V constraints.Integer](val CommonTypedSlice[V]) []int64 {

--- a/pkg/ottl/contexts/internal/ctxutil/slice.go
+++ b/pkg/ottl/contexts/internal/ctxutil/slice.go
@@ -129,6 +129,11 @@ func SetCommonTypedSliceValue[K, V any](ctx context.Context, tCtx K, s CommonTyp
 // If the value is a slice of [any] or pcommon.Slice, and it has an element that the type
 // is not [V], an error is returned.
 func SetCommonTypedSliceValues[V any](s CommonTypedSlice[V], val any) error {
+	if val == nil {
+		// A slice represents nil as an empty slice.
+		s.FromRaw(nil)
+		return nil
+	}
 	switch typeVal := val.(type) {
 	case CommonTypedSlice[V]:
 		s.FromRaw(typeVal.AsRaw())
@@ -220,6 +225,11 @@ func SetCommonIntSliceValue[K any, V constraints.Integer](ctx context.Context, t
 // or a pcommon.Slice which elements are type inferable to int64, otherwise an error is
 // returned.
 func SetCommonIntSliceValues[V constraints.Integer](s CommonTypedSlice[V], val any) error {
+	if val == nil {
+		// A slice represents nil as an empty slice.
+		s.FromRaw(nil)
+		return nil
+	}
 	switch typeVal := val.(type) {
 	case CommonTypedSlice[V]:
 		s.FromRaw(typeVal.AsRaw())

--- a/pkg/ottl/contexts/internal/ctxutil/slice_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/slice_test.go
@@ -659,3 +659,30 @@ func Test_GetCommonIntSliceValues(t *testing.T) {
 	st.FromRaw([]int32{1, 2, 3})
 	assert.Equal(t, []int64{1, 2, 3}, ctxutil.GetCommonIntSliceValues[int32](st))
 }
+
+func Test_SetPSliceValue(t *testing.T) {
+	src := pcommon.NewSlice()
+	require.NoError(t, src.FromRaw([]any{"a", "b"}))
+
+	t.Run("copies the slice, replacing existing contents", func(t *testing.T) {
+		dest := pcommon.NewSlice()
+		dest.AppendEmpty().SetStr("old")
+		err := ctxutil.SetPSliceValue(dest, pcommon.NewSlice, src)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"a", "b"}, dest.AsRaw())
+	})
+
+	t.Run("nil clears to an empty slice", func(t *testing.T) {
+		dest := pcommon.NewSlice()
+		dest.AppendEmpty().SetStr("old")
+		err := ctxutil.SetPSliceValue(dest, pcommon.NewSlice, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, dest.Len())
+	})
+
+	t.Run("invalid type returns an error", func(t *testing.T) {
+		dest := pcommon.NewSlice()
+		err := ctxutil.SetPSliceValue(dest, pcommon.NewSlice, "not a slice")
+		require.Error(t, err)
+	})
+}

--- a/pkg/ottl/contexts/internal/ctxutil/slice_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/slice_test.go
@@ -429,6 +429,11 @@ func Test_SetCommonTypedSliceValues(t *testing.T) {
 			want: []string{"one", "two", "three"},
 		},
 		{
+			name: "from nil",
+			val:  nil,
+			want: nil,
+		},
+		{
 			name:      "from invalid type",
 			val:       1,
 			wantError: "invalid type provided for setting a slice of int: string",
@@ -612,6 +617,11 @@ func Test_SetCommonIntSliceValues(t *testing.T) {
 			name: "from pcommon.Slice",
 			val:  ps,
 			want: []int32{1, 2, 3},
+		},
+		{
+			name: "from nil",
+			val:  nil,
+			want: nil,
 		},
 		{
 			name:      "from invalid type",

--- a/pkg/ottl/contexts/internal/ctxutil/typecheck.go
+++ b/pkg/ottl/contexts/internal/ctxutil/typecheck.go
@@ -3,10 +3,23 @@
 
 package ctxutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrSetNil is returned by context setters for paths that cannot represent a nil
+// value, such as scalar and struct-typed fields. Container paths represent nil as
+// an empty value instead: pcommon.Value becomes an empty value, and maps and slices
+// become empty.
+var ErrSetNil = errors.New("setting a value to nil is not supported")
 
 // ExpectType ensures val can be asserted to T, returning a descriptive error when it cannot.
 func ExpectType[T any](val any) (T, error) {
+	if val == nil {
+		var zero T
+		return zero, ErrSetNil
+	}
 	typed, ok := val.(T)
 	if !ok {
 		var zero T

--- a/pkg/ottl/contexts/internal/ctxutil/typecheck_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/typecheck_test.go
@@ -3,7 +3,10 @@
 
 package ctxutil
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestExpectTypeSuccess(t *testing.T) {
 	got, err := ExpectType[int](42)
@@ -19,5 +22,12 @@ func TestExpectTypeError(t *testing.T) {
 	_, err := ExpectType[string](123)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestExpectTypeNil(t *testing.T) {
+	_, err := ExpectType[string](nil)
+	if !errors.Is(err, ErrSetNil) {
+		t.Fatalf("expected ErrSetNil, got %v", err)
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxutil/value.go
+++ b/pkg/ottl/contexts/internal/ctxutil/value.go
@@ -16,6 +16,9 @@ import (
 
 func SetValue(value pcommon.Value, val any) error {
 	if val == nil {
+		// A pcommon.Value can represent nil, so the most meaningful outcome is an
+		// empty value (ValueTypeEmpty) rather than an error.
+		pcommon.NewValueEmpty().CopyTo(value)
 		return nil
 	}
 	var err error

--- a/pkg/ottl/contexts/internal/ctxutil/value_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/value_test.go
@@ -76,7 +76,7 @@ func Test_SetValue(t *testing.T) {
 		{
 			name: "[]byte",
 			val:  func(*testing.T) any { return []byte{1, 2, 3} },
-			want: func(t *testing.T) pcommon.Value {
+			want: func(*testing.T) pcommon.Value {
 				v := pcommon.NewValueEmpty()
 				v.SetEmptyBytes().FromRaw([]byte{1, 2, 3})
 				return v

--- a/pkg/ottl/contexts/internal/ctxutil/value_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/value_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -22,15 +23,166 @@ func Test_SetIndexableValue_InvalidValue(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_SetValue_NilIsNoop(t *testing.T) {
-	value := pcommon.NewValueStr("original")
-	err := ctxutil.SetValue(value, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "original", value.Str())
-}
+func Test_SetValue(t *testing.T) {
+	// valueFromRaw builds a pcommon.Value from a raw representation, failing the test on error.
+	valueFromRaw := func(t *testing.T, raw any) pcommon.Value {
+		v := pcommon.NewValueEmpty()
+		require.NoError(t, v.FromRaw(raw))
+		return v
+	}
+	sliceFromRaw := func(t *testing.T, raw []any) pcommon.Slice {
+		s := pcommon.NewSlice()
+		require.NoError(t, s.FromRaw(raw))
+		return s
+	}
+	mapFromRaw := func(t *testing.T, raw map[string]any) pcommon.Map {
+		m := pcommon.NewMap()
+		require.NoError(t, m.FromRaw(raw))
+		return m
+	}
 
-func Test_SetValue_UnsupportedType(t *testing.T) {
-	value := pcommon.NewValueStr("test")
-	err := ctxutil.SetValue(value, struct{}{})
-	assert.EqualError(t, err, "unsupported type struct {} for set operation; current value type is Str")
+	tests := []struct {
+		name            string
+		initial         func(t *testing.T) pcommon.Value
+		val             func(t *testing.T) any
+		want            func(t *testing.T) pcommon.Value
+		wantErrContains string
+	}{
+		{
+			name: "nil clears to empty value",
+			val:  func(*testing.T) any { return nil },
+			want: func(*testing.T) pcommon.Value { return pcommon.NewValueEmpty() },
+		},
+		{
+			name: "string",
+			val:  func(*testing.T) any { return "foo" },
+			want: func(*testing.T) pcommon.Value { return pcommon.NewValueStr("foo") },
+		},
+		{
+			name: "bool",
+			val:  func(*testing.T) any { return true },
+			want: func(*testing.T) pcommon.Value { return pcommon.NewValueBool(true) },
+		},
+		{
+			name: "int64",
+			val:  func(*testing.T) any { return int64(5) },
+			want: func(*testing.T) pcommon.Value { return pcommon.NewValueInt(5) },
+		},
+		{
+			name: "float64",
+			val:  func(*testing.T) any { return 1.5 },
+			want: func(*testing.T) pcommon.Value { return pcommon.NewValueDouble(1.5) },
+		},
+		{
+			name: "[]byte",
+			val:  func(*testing.T) any { return []byte{1, 2, 3} },
+			want: func(t *testing.T) pcommon.Value {
+				v := pcommon.NewValueEmpty()
+				v.SetEmptyBytes().FromRaw([]byte{1, 2, 3})
+				return v
+			},
+		},
+		{
+			name: "[]string",
+			val:  func(*testing.T) any { return []string{"a", "b"} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{"a", "b"}) },
+		},
+		{
+			name: "[]bool",
+			val:  func(*testing.T) any { return []bool{true, false} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{true, false}) },
+		},
+		{
+			name: "[]int64",
+			val:  func(*testing.T) any { return []int64{1, 2} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{int64(1), int64(2)}) },
+		},
+		{
+			name: "[]float64",
+			val:  func(*testing.T) any { return []float64{1.5, 2.5} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{1.5, 2.5}) },
+		},
+		{
+			name: "[][]byte",
+			val:  func(*testing.T) any { return [][]byte{{1, 2}, {3}} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{[]byte{1, 2}, []byte{3}}) },
+		},
+		{
+			name: "[]any",
+			val:  func(*testing.T) any { return []any{"x", int64(2)} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{"x", int64(2)}) },
+		},
+		{
+			name: "[]any with nil element becomes empty",
+			val:  func(*testing.T) any { return []any{"x", nil} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{"x", nil}) },
+		},
+		{
+			name:            "[]any with unsupported element",
+			val:             func(*testing.T) any { return []any{struct{}{}} },
+			wantErrContains: "unsupported type struct {} for set operation",
+		},
+		{
+			name: "pcommon.Slice into non-slice value",
+			val:  func(t *testing.T) any { return sliceFromRaw(t, []any{"a", "b"}) },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{"a", "b"}) },
+		},
+		{
+			name:    "pcommon.Slice into existing slice value",
+			initial: func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{int64(999)}) },
+			val:     func(t *testing.T) any { return sliceFromRaw(t, []any{"a", "b"}) },
+			want:    func(t *testing.T) pcommon.Value { return valueFromRaw(t, []any{"a", "b"}) },
+		},
+		{
+			name: "pcommon.Map into non-map value",
+			val:  func(t *testing.T) any { return mapFromRaw(t, map[string]any{"k": "v"}) },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, map[string]any{"k": "v"}) },
+		},
+		{
+			name:    "pcommon.Map into existing map value",
+			initial: func(t *testing.T) pcommon.Value { return valueFromRaw(t, map[string]any{"old": "gone"}) },
+			val:     func(t *testing.T) any { return mapFromRaw(t, map[string]any{"k": "v"}) },
+			want:    func(t *testing.T) pcommon.Value { return valueFromRaw(t, map[string]any{"k": "v"}) },
+		},
+		{
+			name: "map[string]any",
+			val:  func(*testing.T) any { return map[string]any{"k": "v"} },
+			want: func(t *testing.T) pcommon.Value { return valueFromRaw(t, map[string]any{"k": "v"}) },
+		},
+		{
+			name:            "map[string]any with unsupported value",
+			val:             func(*testing.T) any { return map[string]any{"k": struct{}{}} },
+			wantErrContains: "",
+		},
+		{
+			name:            "unsupported type",
+			val:             func(*testing.T) any { return struct{}{} },
+			wantErrContains: "unsupported type struct {} for set operation; current value type is Str",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := pcommon.NewValueStr("original")
+			if tt.initial != nil {
+				value = tt.initial(t)
+			}
+
+			err := ctxutil.SetValue(value, tt.val(t))
+
+			// The "map[string]any with unsupported value" case relies only on FromRaw
+			// returning an error, whose message may vary; assert an error without a message.
+			if tt.wantErrContains == "" && tt.want == nil {
+				require.Error(t, err)
+				return
+			}
+			if tt.wantErrContains != "" {
+				require.ErrorContains(t, err, tt.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want(t), value)
+		})
+	}
 }

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -454,6 +454,8 @@ func Test_newPathGetSetter(t *testing.T) {
 			err = accessor.Set(t.Context(), tCtx, tt.newVal)
 			if tt.expectSetterError {
 				assert.Error(t, err)
+				// A read-only setter (e.g. event_index) must also reject a nil value.
+				assert.Error(t, accessor.Set(t.Context(), tCtx, nil))
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Updates OTTL setters that use maps, slices, or pcommon.Value to properly handle nil. Mainly:

- setting a `pcommon.Value` to `nil` is equivalent to `pcommon.NewEmptyValue()`
- setting a map to `nil` is equivalent to `.FromRaw(nil)` 
- setting a slice to `nil` is equivalent to `.FromRaw(nil)`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48714

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added test cases for `nil` handling for every single ottl setter.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
