### PR TITLE
[chore][internal/coreinternal] Fix panic when `strptime.Parse` is called with trailing input for certain format strings

### DIFF
--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
@@ -183,14 +183,14 @@ func iterativeParse(partialLayout, format string, startIndex int, indexes [][]in
 	tryElements := func(elements ...string) (int, string) {
 		out, layout, err = iterativeParse(partialLayout+strings.Join(elements, ""), format, indexes[0][1], indexes[1:], parse)
 		var timeErr *time.ParseError
-		if errors.As(err, &timeErr) {
+		if errors.As(err, &timeErr) && timeErr.LayoutElem != "" {
 			if i := slices.Index(elements, timeErr.LayoutElem); i >= 0 {
 				timeErr.LayoutElem = directive
 				return i, timeErr.ValueElem
 			}
 		}
 		var lunesErr *lunes.ErrLayoutMismatch
-		if errors.As(err, &lunesErr) {
+		if errors.As(err, &lunesErr) && lunesErr.LayoutElem != "" {
 			if i := slices.Index(elements, lunesErr.LayoutElem); i >= 0 {
 				lunesErr.LayoutElem = directive
 				return i, "unknown"
@@ -237,7 +237,7 @@ func iterativeParse(partialLayout, format string, startIndex int, indexes [][]in
 		return out, layout, err
 	}
 	if subst, ok := ctimeSubstitutes[directive]; ok {
-		try("", subst)
+		try(subst)
 		return out, layout, err
 	}
 	return time.Time{}, "", fmt.Errorf("unsupported ctimefmt.FlexibleParse() directive: %s", directive)

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -72,6 +72,28 @@ func TestFlexibleParse(t *testing.T) {
 		{"X", "%Y-%m-%dT%X%z", "2019-1-2T15:4:5Z"},
 		{"g", "%Y-%m-%gT%H:%M:%S%z", "2019-1-2T15:4:5Z"},
 		{"r", "%Y-%m-%d %r", "2019-1-2 3:4:5 pm"},
+		{"L", "%Y-%m-%dT%H:%M:%S.%L%z", "2019-1-2T15:4:5.000000000Z"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := Parse(tc.format, func(native string) (time.Time, error) { return time.Parse(native, tc.input) })
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestParseFractionalSeconds(t *testing.T) {
+	// %L does not exist in strptime.
+	// In Fluentd, %L means milliseconds.
+	// In Fluent Bit, %L means any length fractional seconds.
+	// Verify that we can parse any length with %L.
+	want := time.Date(2019, 1, 2, 15, 4, 5, 123000000, time.UTC)
+	for _, tc := range []struct {
+		name, format, input string
+	}{
+		{"milliseconds", "%Y-%m-%dT%H:%M:%S.%L%z", "2019-1-2T15:4:5.123Z"},
+		{"microseconds", "%Y-%m-%dT%H:%M:%S.%L%z", "2019-1-2T15:4:5.123000Z"},
+		{"nanoseconds", "%Y-%m-%dT%H:%M:%S.%L%z", "2019-1-2T15:4:5.123000000Z"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, _, err := Parse(tc.format, func(native string) (time.Time, error) { return time.Parse(native, tc.input) })

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -81,6 +81,19 @@ func TestFlexibleParse(t *testing.T) {
 	}
 }
 
+func TestFailedParse(t *testing.T) {
+	for _, tc := range []struct {
+		name, format, input, wantErr string
+	}{
+		{"extra text", "%Y-%m-%dT%H:%M:%S.%L", "2022-12-31T23:59:59.000000000-0800", "extra text"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Parse(tc.format, func(native string) (time.Time, error) { return time.Parse(native, tc.input) })
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
 func TestZulu(t *testing.T) {
 	format := "%Y-%m-%dT%H:%M:%S.%L%z"
 	// These time should all parse as UTC.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

A couple of bugs in `ctimefmt.iterativeParse` combined to result in a panic when parsing specific inputs with specific format strings.

I noticed this when one of our internal tests tried to parse `2022-12-31T23:59:59.000000000-0800` with the format string `%Y-%m-%dT%H:%M:%S.%L`. The combination of inputs that can cause a panic is:

- All directives must successfully parse
- There must be leftover timestamp string after the parsed directives (`-0800` in this example)
- The format string must end in a directive not found in `ctimeParseSubstitutes`

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`strptime` didn't have any test cases for failed parsing. I added a new `TestFailedParse` and used the example above, verified that test paniced before any fixes, and then failed with the correct error after the fix. I also added a few positive tests for `%L`, since I saw those were lacking.

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
