### PR TITLE
[chore][receiver/postgresql] correct relation attribute description

### DIFF
--- a/.chloggen/49731-postgresql-relation-attr-desc.yaml
+++ b/.chloggen/49731-postgresql-relation-attr-desc.yaml
@@ -1,9 +1,0 @@
-change_type: bug_fix
-
-component: receiver/postgresql
-
-note: Correct the `relation` attribute description to reflect that its value is the relation name (from `pg_class.relname`), not an OID.
-
-issues: [49731]
-
-change_logs: [user]

--- a/.chloggen/49731-postgresql-relation-attr-desc.yaml
+++ b/.chloggen/49731-postgresql-relation-attr-desc.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: receiver/postgresql
+
+note: Correct the `relation` attribute description to reflect that its value is the relation name (from `pg_class.relname`), not an OID.
+
+issues: [49731]
+
+change_logs: [user]

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -357,7 +357,7 @@ The number of database locks.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| relation | OID of the relation targeted by the lock, or null if the target is not a relation or part of a relation. | Any Str | Recommended | - |
+| relation | The name of the relation (table, index, view, etc.) targeted by the lock, or null if the target is not a relation or part of a relation. | Any Str | Recommended | - |
 | mode | Name of the lock mode held or desired by the process. | Any Str | Recommended | - |
 | lock_type | Type of the lockable object. | Any Str | Recommended | - |
 

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -249,7 +249,7 @@ attributes:
     description: The type of event for which the backend is waiting, if any; otherwise NULL.
     type: string
   relation:
-    description: OID of the relation targeted by the lock, or null if the target is not a relation or part of a relation.
+    description: The name of the relation (table, index, view, etc.) targeted by the lock, or null if the target is not a relation or part of a relation.
     type: string
     requirement_level: recommended
   replication_client:


### PR DESCRIPTION
#### Description

The `relation` attribute (used by the `postgresql.database.locks` metric) was described in `metadata.yaml` as:

> OID of the relation targeted by the lock, or null if the target is not a relation or part of a relation.

However, the scrape query populates it from `pg_class.relname`, i.e. the **relation name**, not an OID:

```sql
SELECT relname AS relation, mode, locktype, COUNT(pid) AS locks
FROM pg_locks
JOIN pg_class ON pg_locks.relation = pg_class.oid
GROUP BY relname, mode, locktype;
```

This corrects the attribute description in `metadata.yaml` and regenerates `documentation.md`. Documentation/metadata only; no runtime behavior change.

#### Link to tracking issue
Fixes #49731

#### Testing
`go build ./...` and `go test ./...` pass in the `receiver/postgresqlreceiver` module; `gofmt -l .` is clean. The existing scraper test already asserts the attribute value is a relation name (`relation: "pg_class"`), confirming the corrected description.

#### Documentation
Regenerated `documentation.md` via `make mdatagen`.