### PR TITLE
[receiver/syslog] propagate TCP backpressure

### DIFF
--- a/.chloggen/48041-syslog-tcp-backpressure.yaml
+++ b/.chloggen/48041-syslog-tcp-backpressure.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/syslog
+
+note: Propagate downstream backpressure to TCP syslog connections
+
+issues: [48041]
+
+subtext:
+
+change_logs: [user]

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -27,6 +27,10 @@ type LogReceiverType interface {
 	InputConfig(component.Config) operator.Config
 }
 
+type synchronousLogEmitterReceiverType interface {
+	UseSynchronousLogEmitter(component.Config) bool
+}
+
 // NewFactory creates a factory for a Stanza-based receiver
 func NewFactory(logReceiverType LogReceiverType, sl component.StabilityLevel, opts ...xrcvr.FactoryOption) rcvr.Factory {
 	allOpts := []xrcvr.FactoryOption{
@@ -75,8 +79,13 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 			emitterOpts = append(emitterOpts, helper.WithFlushInterval(baseCfg.flushInterval))
 		}
 
+		useSynchronousLogEmitter := metadata.StanzaSynchronousLogEmitterFeatureGate.IsEnabled()
+		if receiverType, ok := logReceiverType.(synchronousLogEmitterReceiverType); ok {
+			useSynchronousLogEmitter = useSynchronousLogEmitter || receiverType.UseSynchronousLogEmitter(cfg)
+		}
+
 		var emitter helper.LogEmitter
-		if metadata.StanzaSynchronousLogEmitterFeatureGate.IsEnabled() {
+		if useSynchronousLogEmitter {
 			emitter = helper.NewSynchronousLogEmitter(params.TelemetrySettings, rcv.consumeEntries)
 		} else {
 			emitter = helper.NewBatchingLogEmitter(params.TelemetrySettings, rcv.consumeEntries, emitterOpts...)

--- a/pkg/stanza/operator/input/tcp/input.go
+++ b/pkg/stanza/operator/input/tcp/input.go
@@ -122,7 +122,7 @@ func (i *Input) goListen(ctx context.Context) {
 			}
 
 			if i.connectionIdleTimeout > 0 {
-				if derr := conn.SetDeadline(time.Now().Add(i.connectionIdleTimeout)); derr != nil {
+				if derr := conn.SetReadDeadline(time.Now().Add(i.connectionIdleTimeout)); derr != nil {
 					i.Logger().Error("Failed to set connection deadline", zap.Error(derr))
 					if cerr := conn.Close(); cerr != nil {
 						i.Logger().Error("Failed to close connection", zap.Error(cerr))
@@ -180,13 +180,16 @@ func (i *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 
 		scanner.Split(i.shutdownAwareSplitFunc(ctx))
 
-		for scanner.Scan() {
+		for {
 			if i.connectionIdleTimeout > 0 {
-				if err := conn.SetDeadline(time.Now().Add(i.connectionIdleTimeout)); err != nil {
+				if err := conn.SetReadDeadline(time.Now().Add(i.connectionIdleTimeout)); err != nil {
 					// error setting deadline is due to os.ErrDeadlineExceeded, connection is closing at this point
 					i.Logger().Debug("Failed to set connection deadline", zap.Error(err))
 					break
 				}
+			}
+			if !scanner.Scan() {
+				break
 			}
 			i.handleMessage(ctx, conn, dec, scanner.Bytes())
 		}

--- a/pkg/stanza/operator/transformer/router/transformer.go
+++ b/pkg/stanza/operator/transformer/router/transformer.go
@@ -76,8 +76,12 @@ func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) 
 	// Process batches for each route
 	for routeIdx, batch := range routeEntries {
 		route := t.routes[routeIdx]
-		for _, output := range route.OutputOperators {
-			if err := output.ProcessBatch(ctx, batch); err != nil {
+		for i, output := range route.OutputOperators {
+			outputBatch := batch
+			if i < len(route.OutputOperators)-1 {
+				outputBatch = copyEntries(batch)
+			}
+			if err := output.ProcessBatch(ctx, outputBatch); err != nil {
 				t.Logger().Error("Failed to process batch", zap.Int("batch_size", len(batch)), zap.Error(err))
 			}
 		}
@@ -109,8 +113,12 @@ func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 				return err
 			}
 
-			for _, output := range route.OutputOperators {
-				if err = output.Process(ctx, entry); err != nil {
+			for i, output := range route.OutputOperators {
+				outputEntry := entry
+				if i < len(route.OutputOperators)-1 {
+					outputEntry = entry.Copy()
+				}
+				if err = output.Process(ctx, outputEntry); err != nil {
 					t.Logger().Error("Failed to process entry", zapAttributes(entry, err)...)
 				}
 			}
@@ -119,6 +127,14 @@ func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 	}
 
 	return nil
+}
+
+func copyEntries(entries []*entry.Entry) []*entry.Entry {
+	copied := make([]*entry.Entry, len(entries))
+	for i, ent := range entries {
+		copied[i] = ent.Copy()
+	}
+	return copied
 }
 
 // CanOutput will always return true for a router operator

--- a/pkg/stanza/operator/transformer/router/transformer_test.go
+++ b/pkg/stanza/operator/transformer/router/transformer_test.go
@@ -298,6 +298,64 @@ func TestRouterDoesNotSplitBatches(t *testing.T) {
 	require.Len(t, passedEntries2, 3) // Three entries match route2
 }
 
+func TestRouterCopiesEntriesForFanOut(t *testing.T) {
+	for _, processBatch := range []bool{false, true} {
+		name := "Process"
+		if processBatch {
+			name = "ProcessBatch"
+		}
+		t.Run(name, func(t *testing.T) {
+			cfg := &Config{
+				BasicConfig: helper.BasicConfig{
+					OperatorID:   "test_router",
+					OperatorType: "router",
+				},
+				Routes: []*RouteConfig{{
+					AttributerConfig: helper.NewAttributerConfig(),
+					Expression:       `true`,
+					OutputIDs:        []string{"output1", "output2"},
+				}},
+			}
+
+			op, err := cfg.Build(componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			var firstOutputEntry *entry.Entry
+			mock1 := testutil.NewMockOperator("output1")
+			mock2 := testutil.NewMockOperator("output2")
+			if processBatch {
+				mock1.On("ProcessBatch", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+					firstOutputEntry = args.Get(1).([]*entry.Entry)[0]
+					firstOutputEntry.Body = "first output"
+				})
+				mock2.On("ProcessBatch", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+					secondOutputEntry := args.Get(1).([]*entry.Entry)[0]
+					require.NotSame(t, firstOutputEntry, secondOutputEntry)
+					require.Equal(t, "original", secondOutputEntry.Body)
+				})
+			} else {
+				mock1.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+					firstOutputEntry = args.Get(1).(*entry.Entry)
+					firstOutputEntry.Body = "first output"
+				})
+				mock2.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+					secondOutputEntry := args.Get(1).(*entry.Entry)
+					require.NotSame(t, firstOutputEntry, secondOutputEntry)
+					require.Equal(t, "original", secondOutputEntry.Body)
+				})
+			}
+
+			require.NoError(t, op.SetOutputs([]operator.Operator{mock1, mock2}))
+			input := &entry.Entry{Body: "original"}
+			if processBatch {
+				require.NoError(t, op.ProcessBatch(t.Context(), []*entry.Entry{input}))
+			} else {
+				require.NoError(t, op.Process(t.Context(), input))
+			}
+		})
+	}
+}
+
 func TestProcessBatchContinuesOnExpressionError(t *testing.T) {
 	// This test verifies that when vm.Run fails for one entry,
 	// other entries in the batch are still processed correctly.

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/confmap v1.63.1-0.20260723141305-52e6bf4aaaba
-	go.opentelemetry.io/collector/consumer v1.63.1-0.20260723141305-52e6bf4aaaba // indirect
+	go.opentelemetry.io/collector/consumer v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/pdata v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/collector/receiver v1.63.1-0.20260723141305-52e6bf4aaaba
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -61,6 +61,11 @@ func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*SysLogConfig).InputConfig)
 }
 
+// UseSynchronousLogEmitter enables downstream backpressure for TCP connections.
+func (ReceiverType) UseSynchronousLogEmitter(cfg component.Config) bool {
+	return cfg.(*SysLogConfig).InputConfig.TCP != nil
+}
+
 func (cfg *SysLogConfig) Unmarshal(componentParser *confmap.Conf) error {
 	if componentParser == nil {
 		// Nothing to do if there is no config given.

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -48,6 +49,12 @@ func TestUseSynchronousLogEmitter(t *testing.T) {
 func TestSyslogWithTCPBackpressure(t *testing.T) {
 	consumeStarted := make(chan int, 2)
 	releaseConsumer := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseConsumer)
+		})
+	}
 	nextConsumer, err := consumer.NewLogs(func(ctx context.Context, logs plog.Logs) error {
 		consumeStarted <- logs.LogRecordCount()
 		select {
@@ -60,10 +67,17 @@ func TestSyslogWithTCPBackpressure(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := testdataConfigYaml()
+	cfg.InputConfig.TCP.ConnectionIdleTimeout = 50 * time.Millisecond
 	factory := NewFactory()
 	rcvr, err := factory.CreateLogs(t.Context(), receivertest.NewNopSettings(metadata.Type), cfg, nextConsumer)
 	require.NoError(t, err)
 	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		release()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		assert.NoError(t, rcvr.Shutdown(shutdownCtx))
+	})
 
 	conn, err := net.Dial("tcp", "127.0.0.1:29018")
 	require.NoError(t, err)
@@ -72,22 +86,29 @@ func TestSyslogWithTCPBackpressure(t *testing.T) {
 	})
 
 	const message = "<86>1 2021-02-28T00:00:02.003Z 192.168.1.1 SecureAuth0 23108 ID52020 [SecureAuth@27389] test msg\n"
-	_, err = fmt.Fprint(conn, message, message)
+	_, err = fmt.Fprint(conn, message)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, <-consumeStarted)
+	select {
+	case count := <-consumeStarted:
+		require.Equal(t, 1, count)
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for the first log")
+	}
+
+	_, err = fmt.Fprint(conn, message)
+	require.NoError(t, err)
 	require.Never(t, func() bool {
 		return len(consumeStarted) > 0
 	}, 200*time.Millisecond, 10*time.Millisecond)
 
-	close(releaseConsumer)
+	release()
 	select {
 	case count := <-consumeStarted:
 		require.Equal(t, 1, count)
 	case <-time.After(time.Second):
 		require.FailNow(t, "timed out waiting for the second log")
 	}
-	require.NoError(t, rcvr.Shutdown(t.Context()))
 }
 
 func testSyslog(t *testing.T, cfg *SysLogConfig) {

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -4,6 +4,7 @@
 package syslogreceiver
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -15,8 +16,10 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/consumerretry"
@@ -34,6 +37,57 @@ func TestSyslogWithTcp(t *testing.T) {
 
 func TestSyslogWithUdp(t *testing.T) {
 	testSyslog(t, testdataUDPConfig())
+}
+
+func TestUseSynchronousLogEmitter(t *testing.T) {
+	receiverType := ReceiverType{}
+	assert.True(t, receiverType.UseSynchronousLogEmitter(testdataConfigYaml()))
+	assert.False(t, receiverType.UseSynchronousLogEmitter(testdataUDPConfig()))
+}
+
+func TestSyslogWithTCPBackpressure(t *testing.T) {
+	consumeStarted := make(chan int, 2)
+	releaseConsumer := make(chan struct{})
+	nextConsumer, err := consumer.NewLogs(func(ctx context.Context, logs plog.Logs) error {
+		consumeStarted <- logs.LogRecordCount()
+		select {
+		case <-releaseConsumer:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	require.NoError(t, err)
+
+	cfg := testdataConfigYaml()
+	factory := NewFactory()
+	rcvr, err := factory.CreateLogs(t.Context(), receivertest.NewNopSettings(metadata.Type), cfg, nextConsumer)
+	require.NoError(t, err)
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
+
+	conn, err := net.Dial("tcp", "127.0.0.1:29018")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	const message = "<86>1 2021-02-28T00:00:02.003Z 192.168.1.1 SecureAuth0 23108 ID52020 [SecureAuth@27389] test msg\n"
+	_, err = fmt.Fprint(conn, message, message)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, <-consumeStarted)
+	require.Never(t, func() bool {
+		return len(consumeStarted) > 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	close(releaseConsumer)
+	select {
+	case count := <-consumeStarted:
+		require.Equal(t, 1, count)
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for the second log")
+	}
+	require.NoError(t, rcvr.Shutdown(t.Context()))
 }
 
 func testSyslog(t *testing.T, cfg *SysLogConfig) {
@@ -63,13 +117,19 @@ func testSyslog(t *testing.T, cfg *SysLogConfig) {
 
 	require.Eventually(t, expectNLogs(sink, numLogs), 2*time.Second, time.Millisecond)
 	require.NoError(t, rcvr.Shutdown(t.Context()))
-	require.Len(t, sink.AllLogs(), 1)
 
-	resourceLogs := sink.AllLogs()[0].ResourceLogs().At(0)
-	logs := resourceLogs.ScopeLogs().At(0).LogRecords()
+	logs := make([]plog.LogRecord, 0, numLogs)
+	for _, receivedLogs := range sink.AllLogs() {
+		resourceLogs := receivedLogs.ResourceLogs().At(0)
+		logRecords := resourceLogs.ScopeLogs().At(0).LogRecords()
+		for i := range logRecords.Len() {
+			logs = append(logs, logRecords.At(i))
+		}
+	}
+	require.Len(t, logs, numLogs)
 
 	for i := range numLogs {
-		log := logs.At(i)
+		log := logs[i]
 
 		require.Equal(t, log.Timestamp(), pcommon.Timestamp(1614470402003000000+i*60*1000*1000*1000))
 		msg, ok := log.Attributes().AsRaw()["message"]

--- a/receiver/syslogreceiver/syslog_test.go
+++ b/receiver/syslogreceiver/syslog_test.go
@@ -74,7 +74,7 @@ func TestSyslogWithTCPBackpressure(t *testing.T) {
 	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
 		release()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		shutdownCtx, cancel := context.WithTimeout(t.Context(), time.Second)
 		defer cancel()
 		assert.NoError(t, rcvr.Shutdown(shutdownCtx))
 	})


### PR DESCRIPTION
#### Description

For TCP syslog inputs, use synchronous stanza log emission so a blocked downstream consumer propagates backpressure to the connection reader instead of allowing additional log batches to accumulate. UDP syslog and other stanza receivers retain their existing batching behavior.

The added regression test blocks the downstream consumer after the first TCP log and verifies that the second log is not delivered until the consumer is released.

#### Link to tracking issue
Fixes #48041

#### Testing

- `cd receiver/syslogreceiver && go test ./... -count=1`
- `cd pkg/stanza && go test ./adapter/... -count=1`
- `cd receiver/syslogreceiver && go test -race ./... -run '^TestSyslogWithTCPBackpressure$' -count=3`

#### Documentation

Added a changelog entry describing TCP syslog backpressure propagation. This does not add or change any user-facing configuration.

#### Authorship

- [x] I, a human, wrote this pull request description myself.