### PR TITLE
Add v$sysmetric workload rate metrics

### DIFF
--- a/.chloggen/feat_add-oracledb-sysmetric-workload-rate-metrics.yaml
+++ b/.chloggen/feat_add-oracledb-sysmetric-workload-rate-metrics.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: receiver/oracledb
+
+note: "Add real-time workload rate metrics."
+
+issues: [49749]
+
+subtext:
+
+change_logs: [user]

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -381,6 +381,14 @@ Number of currently open cursors in the Oracle instance.
 | ---- | ----------- | ---------- | --------- |
 | {cursor} | Gauge | Int | Development |
 
+### oracledb.cursor.open.rate
+
+Rate of cursors opened.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {cursor}/s | Gauge | Double | Development |
+
 ### oracledb.data_dictionary.hit_ratio
 
 Data dictionary cache hit ratio from v$rowcache.
@@ -443,6 +451,14 @@ Number of DML statements that were executed in parallel
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {statements} | Sum | Int | Cumulative | true | Development |
 
+### oracledb.enqueue.deadlocks.rate
+
+Rate of enqueue deadlocks.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {deadlock}/s | Gauge | Double | Development |
+
 ### oracledb.enqueue.operations
 
 Total count of enqueue (lock) operations.
@@ -456,6 +472,14 @@ Total count of enqueue (lock) operations.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | oracledb.enqueue.type | Type of enqueue (lock) operation reported by Oracle. | Str: ``conversions``, ``releases``, ``requests``, ``timeouts``, ``waits`` | Recommended | - |
+
+### oracledb.enqueue.timeouts.rate
+
+Rate of enqueue timeouts.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {timeout}/s | Gauge | Double | Development |
 
 ### oracledb.execution.utilization
 
@@ -471,6 +495,14 @@ Fraction of executions that did not require a parse, as computed by Oracle V$SYS
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | oracledb.parse.type | Type of parse operation (e.g., soft). | Str: ``soft`` | Recommended | - |
 
+### oracledb.executions.rate
+
+Rate of SQL statement executions.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {execution}/s | Gauge | Double | Development |
+
 ### oracledb.gc.current_block.time
 
 Cumulative time spent transferring current blocks between instances over RAC cache fusion.
@@ -484,6 +516,14 @@ Cumulative time spent transferring current blocks between instances over RAC cac
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | network.io.direction | Direction of the network transfer. | Str: ``receive``, ``transmit`` | Recommended | - |
+
+### oracledb.hard_parses.rate
+
+Rate of hard parses.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {parse}/s | Gauge | Double | Development |
 
 ### oracledb.host.cpu.usage.rate
 
@@ -600,6 +640,14 @@ Number of logon operations
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {operation} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.logons.rate
+
+Rate of logon operations.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {logon}/s | Gauge | Double | Development |
 
 ### oracledb.os.swaps
 
@@ -1172,6 +1220,20 @@ Total number of transactions rolled back.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {rollback} | Sum | Int | Cumulative | true | Development |
+
+### oracledb.transactions.rate
+
+Rate of user transactions.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transaction}/s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.transaction.type | The type of user transaction. | Str: ``commit``, ``rollback`` | Recommended | - |
 
 ## Default Events
 

--- a/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/config.schema.yaml
@@ -132,6 +132,13 @@ $defs:
           enabled:
             type: boolean
             default: false
+      oracledb.cursor.open.rate:
+        description: "OracledbCursorOpenRateMetricConfig provides config for the oracledb.cursor.open.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.data_dictionary.hit_ratio:
         description: "OracledbDataDictionaryHitRatioMetricConfig provides config for the oracledb.data_dictionary.hit_ratio metric."
         type: object
@@ -197,6 +204,13 @@ $defs:
           enabled:
             type: boolean
             default: false
+      oracledb.enqueue.deadlocks.rate:
+        description: "OracledbEnqueueDeadlocksRateMetricConfig provides config for the oracledb.enqueue.deadlocks.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.enqueue.operations:
         description: "OracledbEnqueueOperationsMetricConfig provides config for the oracledb.enqueue.operations metric."
         type: object
@@ -220,6 +234,13 @@ $defs:
                 - "oracledb.enqueue.type"
             default:
               - "oracledb.enqueue.type"
+      oracledb.enqueue.timeouts.rate:
+        description: "OracledbEnqueueTimeoutsRateMetricConfig provides config for the oracledb.enqueue.timeouts.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.enqueue_deadlocks:
         description: "OracledbEnqueueDeadlocksMetricConfig provides config for the oracledb.enqueue_deadlocks metric."
         type: object
@@ -269,6 +290,13 @@ $defs:
           enabled:
             type: boolean
             default: true
+      oracledb.executions.rate:
+        description: "OracledbExecutionsRateMetricConfig provides config for the oracledb.executions.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.gc.current_block.time:
         description: "OracledbGcCurrentBlockTimeMetricConfig provides config for the oracledb.gc.current_block.time metric."
         type: object
@@ -283,6 +311,13 @@ $defs:
           enabled:
             type: boolean
             default: true
+      oracledb.hard_parses.rate:
+        description: "OracledbHardParsesRateMetricConfig provides config for the oracledb.hard_parses.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.host.cpu.usage.rate:
         description: "OracledbHostCPUUsageRateMetricConfig provides config for the oracledb.host.cpu.usage.rate metric."
         type: object
@@ -378,6 +413,13 @@ $defs:
             default: false
       oracledb.logons:
         description: "OracledbLogonsMetricConfig provides config for the oracledb.logons metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+      oracledb.logons.rate:
+        description: "OracledbLogonsRateMetricConfig provides config for the oracledb.logons.rate metric."
         type: object
         properties:
           enabled:
@@ -906,6 +948,13 @@ $defs:
           enabled:
             type: boolean
             default: true
+      oracledb.transactions.rate:
+        description: "OracledbTransactionsRateMetricConfig provides config for the oracledb.transactions.rate metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       oracledb.transactions.usage:
         description: "OracledbTransactionsUsageMetricConfig provides config for the oracledb.transactions.usage metric."
         type: object

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -406,6 +406,26 @@ func (ms *OracledbCursorOpenMetricConfig) Unmarshal(parser *confmap.Conf) error 
 	return nil
 }
 
+// OracledbCursorOpenRateMetricConfig provides config for the oracledb.cursor.open.rate metric.
+type OracledbCursorOpenRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbCursorOpenRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // OracledbDataDictionaryHitRatioMetricConfig provides config for the oracledb.data_dictionary.hit_ratio metric.
 type OracledbDataDictionaryHitRatioMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -614,6 +634,26 @@ func (ms *OracledbDmlStatementsParallelizedMetricConfig) Unmarshal(parser *confm
 	return nil
 }
 
+// OracledbEnqueueDeadlocksRateMetricConfig provides config for the oracledb.enqueue.deadlocks.rate metric.
+type OracledbEnqueueDeadlocksRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbEnqueueDeadlocksRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // OracledbEnqueueOperationsMetricAttributeKey specifies the key of an attribute for the oracledb.enqueue.operations metric.
 type OracledbEnqueueOperationsMetricAttributeKey string
 
@@ -659,6 +699,26 @@ func (ms *OracledbEnqueueOperationsMetricConfig) Validate() error {
 		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
 	}
 
+	return nil
+}
+
+// OracledbEnqueueTimeoutsRateMetricConfig provides config for the oracledb.enqueue.timeouts.rate metric.
+type OracledbEnqueueTimeoutsRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbEnqueueTimeoutsRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -850,6 +910,26 @@ func (ms *OracledbExecutionsMetricConfig) Unmarshal(parser *confmap.Conf) error 
 	return nil
 }
 
+// OracledbExecutionsRateMetricConfig provides config for the oracledb.executions.rate metric.
+type OracledbExecutionsRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbExecutionsRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // OracledbGcCurrentBlockTimeMetricAttributeKey specifies the key of an attribute for the oracledb.gc.current_block.time metric.
 type OracledbGcCurrentBlockTimeMetricAttributeKey string
 
@@ -905,6 +985,26 @@ type OracledbHardParsesMetricConfig struct {
 }
 
 func (ms *OracledbHardParsesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbHardParsesRateMetricConfig provides config for the oracledb.hard_parses.rate metric.
+type OracledbHardParsesRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbHardParsesRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1241,6 +1341,26 @@ type OracledbLogonsMetricConfig struct {
 }
 
 func (ms *OracledbLogonsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// OracledbLogonsRateMetricConfig provides config for the oracledb.logons.rate metric.
+type OracledbLogonsRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *OracledbLogonsRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -3223,6 +3343,54 @@ func (ms *OracledbTransactionsLimitMetricConfig) Unmarshal(parser *confmap.Conf)
 	return nil
 }
 
+// OracledbTransactionsRateMetricAttributeKey specifies the key of an attribute for the oracledb.transactions.rate metric.
+type OracledbTransactionsRateMetricAttributeKey string
+
+const (
+	OracledbTransactionsRateMetricAttributeKeyOracledbTransactionType OracledbTransactionsRateMetricAttributeKey = "oracledb.transaction.type"
+)
+
+// OracledbTransactionsRateMetricConfig provides config for the oracledb.transactions.rate metric.
+type OracledbTransactionsRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbTransactionsRateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbTransactionsRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbTransactionsRateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbTransactionsRateMetricAttributeKeyOracledbTransactionType:
+		default:
+			return fmt.Errorf("metric oracledb.transactions.rate doesn't have an attribute %v, valid attributes: [oracledb.transaction.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // OracledbTransactionsUsageMetricConfig provides config for the oracledb.transactions.usage metric.
 type OracledbTransactionsUsageMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -3302,6 +3470,7 @@ type MetricsConfig struct {
 	OracledbCursorCacheSize                       OracledbCursorCacheSizeMetricConfig                       `mapstructure:"oracledb.cursor.cache.size"`
 	OracledbCursorCacheUtilization                OracledbCursorCacheUtilizationMetricConfig                `mapstructure:"oracledb.cursor.cache.utilization"`
 	OracledbCursorOpen                            OracledbCursorOpenMetricConfig                            `mapstructure:"oracledb.cursor.open"`
+	OracledbCursorOpenRate                        OracledbCursorOpenRateMetricConfig                        `mapstructure:"oracledb.cursor.open.rate"`
 	OracledbDataDictionaryHitRatio                OracledbDataDictionaryHitRatioMetricConfig                `mapstructure:"oracledb.data_dictionary.hit_ratio"`
 	OracledbDatabaseCPUUtilization                OracledbDatabaseCPUUtilizationMetricConfig                `mapstructure:"oracledb.database.cpu.utilization"`
 	OracledbDatabaseWaitUtilization               OracledbDatabaseWaitUtilizationMetricConfig               `mapstructure:"oracledb.database.wait.utilization"`
@@ -3311,7 +3480,9 @@ type MetricsConfig struct {
 	OracledbDmlLocksLimit                         OracledbDmlLocksLimitMetricConfig                         `mapstructure:"oracledb.dml_locks.limit"`
 	OracledbDmlLocksUsage                         OracledbDmlLocksUsageMetricConfig                         `mapstructure:"oracledb.dml_locks.usage"`
 	OracledbDmlStatementsParallelized             OracledbDmlStatementsParallelizedMetricConfig             `mapstructure:"oracledb.dml_statements_parallelized"`
+	OracledbEnqueueDeadlocksRate                  OracledbEnqueueDeadlocksRateMetricConfig                  `mapstructure:"oracledb.enqueue.deadlocks.rate"`
 	OracledbEnqueueOperations                     OracledbEnqueueOperationsMetricConfig                     `mapstructure:"oracledb.enqueue.operations"`
+	OracledbEnqueueTimeoutsRate                   OracledbEnqueueTimeoutsRateMetricConfig                   `mapstructure:"oracledb.enqueue.timeouts.rate"`
 	OracledbEnqueueDeadlocks                      OracledbEnqueueDeadlocksMetricConfig                      `mapstructure:"oracledb.enqueue_deadlocks"`
 	OracledbEnqueueLocksLimit                     OracledbEnqueueLocksLimitMetricConfig                     `mapstructure:"oracledb.enqueue_locks.limit"`
 	OracledbEnqueueLocksUsage                     OracledbEnqueueLocksUsageMetricConfig                     `mapstructure:"oracledb.enqueue_locks.usage"`
@@ -3320,8 +3491,10 @@ type MetricsConfig struct {
 	OracledbExchangeDeadlocks                     OracledbExchangeDeadlocksMetricConfig                     `mapstructure:"oracledb.exchange_deadlocks"`
 	OracledbExecutionUtilization                  OracledbExecutionUtilizationMetricConfig                  `mapstructure:"oracledb.execution.utilization"`
 	OracledbExecutions                            OracledbExecutionsMetricConfig                            `mapstructure:"oracledb.executions"`
+	OracledbExecutionsRate                        OracledbExecutionsRateMetricConfig                        `mapstructure:"oracledb.executions.rate"`
 	OracledbGcCurrentBlockTime                    OracledbGcCurrentBlockTimeMetricConfig                    `mapstructure:"oracledb.gc.current_block.time"`
 	OracledbHardParses                            OracledbHardParsesMetricConfig                            `mapstructure:"oracledb.hard_parses"`
+	OracledbHardParsesRate                        OracledbHardParsesRateMetricConfig                        `mapstructure:"oracledb.hard_parses.rate"`
 	OracledbHostCPUUsageRate                      OracledbHostCPUUsageRateMetricConfig                      `mapstructure:"oracledb.host.cpu.usage.rate"`
 	OracledbHostCPUUtilization                    OracledbHostCPUUtilizationMetricConfig                    `mapstructure:"oracledb.host.cpu.utilization"`
 	OracledbIoRequestsRate                        OracledbIoRequestsRateMetricConfig                        `mapstructure:"oracledb.io.requests.rate"`
@@ -3336,6 +3509,7 @@ type MetricsConfig struct {
 	OracledbLogicalReads                          OracledbLogicalReadsMetricConfig                          `mapstructure:"oracledb.logical_reads"`
 	OracledbLogicalReadsRate                      OracledbLogicalReadsRateMetricConfig                      `mapstructure:"oracledb.logical_reads.rate"`
 	OracledbLogons                                OracledbLogonsMetricConfig                                `mapstructure:"oracledb.logons"`
+	OracledbLogonsRate                            OracledbLogonsRateMetricConfig                            `mapstructure:"oracledb.logons.rate"`
 	OracledbOsSwaps                               OracledbOsSwapsMetricConfig                               `mapstructure:"oracledb.os.swaps"`
 	OracledbParallelOperationsDowngraded1To25Pct  OracledbParallelOperationsDowngraded1To25PctMetricConfig  `mapstructure:"oracledb.parallel_operations_downgraded_1_to_25_pct"`
 	OracledbParallelOperationsDowngraded25To50Pct OracledbParallelOperationsDowngraded25To50PctMetricConfig `mapstructure:"oracledb.parallel_operations_downgraded_25_to_50_pct"`
@@ -3402,6 +3576,7 @@ type MetricsConfig struct {
 	OracledbTransactionResponseTime               OracledbTransactionResponseTimeMetricConfig               `mapstructure:"oracledb.transaction.response.time"`
 	OracledbTransactionRollbacks                  OracledbTransactionRollbacksMetricConfig                  `mapstructure:"oracledb.transaction.rollbacks"`
 	OracledbTransactionsLimit                     OracledbTransactionsLimitMetricConfig                     `mapstructure:"oracledb.transactions.limit"`
+	OracledbTransactionsRate                      OracledbTransactionsRateMetricConfig                      `mapstructure:"oracledb.transactions.rate"`
 	OracledbTransactionsUsage                     OracledbTransactionsUsageMetricConfig                     `mapstructure:"oracledb.transactions.usage"`
 	OracledbUserCommits                           OracledbUserCommitsMetricConfig                           `mapstructure:"oracledb.user_commits"`
 	OracledbUserRollbacks                         OracledbUserRollbacksMetricConfig                         `mapstructure:"oracledb.user_rollbacks"`
@@ -3464,6 +3639,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbCursorOpen: OracledbCursorOpenMetricConfig{
 			Enabled: false,
 		},
+		OracledbCursorOpenRate: OracledbCursorOpenRateMetricConfig{
+			Enabled: false,
+		},
 		OracledbDataDictionaryHitRatio: OracledbDataDictionaryHitRatioMetricConfig{
 			Enabled: false,
 		},
@@ -3493,10 +3671,16 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbDmlStatementsParallelized: OracledbDmlStatementsParallelizedMetricConfig{
 			Enabled: false,
 		},
+		OracledbEnqueueDeadlocksRate: OracledbEnqueueDeadlocksRateMetricConfig{
+			Enabled: false,
+		},
 		OracledbEnqueueOperations: OracledbEnqueueOperationsMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []OracledbEnqueueOperationsMetricAttributeKey{OracledbEnqueueOperationsMetricAttributeKeyOracledbEnqueueType},
+		},
+		OracledbEnqueueTimeoutsRate: OracledbEnqueueTimeoutsRateMetricConfig{
+			Enabled: false,
 		},
 		OracledbEnqueueDeadlocks: OracledbEnqueueDeadlocksMetricConfig{
 			Enabled: true,
@@ -3524,6 +3708,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbExecutions: OracledbExecutionsMetricConfig{
 			Enabled: true,
 		},
+		OracledbExecutionsRate: OracledbExecutionsRateMetricConfig{
+			Enabled: false,
+		},
 		OracledbGcCurrentBlockTime: OracledbGcCurrentBlockTimeMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
@@ -3531,6 +3718,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		OracledbHardParses: OracledbHardParsesMetricConfig{
 			Enabled: true,
+		},
+		OracledbHardParsesRate: OracledbHardParsesRateMetricConfig{
+			Enabled: false,
 		},
 		OracledbHostCPUUsageRate: OracledbHostCPUUsageRateMetricConfig{
 			Enabled: false,
@@ -3576,6 +3766,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		OracledbLogons: OracledbLogonsMetricConfig{
+			Enabled: false,
+		},
+		OracledbLogonsRate: OracledbLogonsRateMetricConfig{
 			Enabled: false,
 		},
 		OracledbOsSwaps: OracledbOsSwapsMetricConfig{
@@ -3821,6 +4014,11 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		OracledbTransactionsLimit: OracledbTransactionsLimitMetricConfig{
 			Enabled: true,
+		},
+		OracledbTransactionsRate: OracledbTransactionsRateMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OracledbTransactionsRateMetricAttributeKey{OracledbTransactionsRateMetricAttributeKeyOracledbTransactionType},
 		},
 		OracledbTransactionsUsage: OracledbTransactionsUsageMetricConfig{
 			Enabled: true,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -82,6 +82,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbCursorOpen: OracledbCursorOpenMetricConfig{
 						Enabled: true,
 					},
+					OracledbCursorOpenRate: OracledbCursorOpenRateMetricConfig{
+						Enabled: true,
+					},
 					OracledbDataDictionaryHitRatio: OracledbDataDictionaryHitRatioMetricConfig{
 						Enabled: true,
 					},
@@ -111,10 +114,16 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbDmlStatementsParallelized: OracledbDmlStatementsParallelizedMetricConfig{
 						Enabled: true,
 					},
+					OracledbEnqueueDeadlocksRate: OracledbEnqueueDeadlocksRateMetricConfig{
+						Enabled: true,
+					},
 					OracledbEnqueueOperations: OracledbEnqueueOperationsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbEnqueueOperationsMetricAttributeKey{OracledbEnqueueOperationsMetricAttributeKeyOracledbEnqueueType},
+					},
+					OracledbEnqueueTimeoutsRate: OracledbEnqueueTimeoutsRateMetricConfig{
+						Enabled: true,
 					},
 					OracledbEnqueueDeadlocks: OracledbEnqueueDeadlocksMetricConfig{
 						Enabled: true,
@@ -142,12 +151,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbExecutions: OracledbExecutionsMetricConfig{
 						Enabled: true,
 					},
+					OracledbExecutionsRate: OracledbExecutionsRateMetricConfig{
+						Enabled: true,
+					},
 					OracledbGcCurrentBlockTime: OracledbGcCurrentBlockTimeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbGcCurrentBlockTimeMetricAttributeKey{OracledbGcCurrentBlockTimeMetricAttributeKeyNetworkIoDirection},
 					},
 					OracledbHardParses: OracledbHardParsesMetricConfig{
+						Enabled: true,
+					},
+					OracledbHardParsesRate: OracledbHardParsesRateMetricConfig{
 						Enabled: true,
 					},
 					OracledbHostCPUUsageRate: OracledbHostCPUUsageRateMetricConfig{
@@ -194,6 +209,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: true,
 					},
 					OracledbLogons: OracledbLogonsMetricConfig{
+						Enabled: true,
+					},
+					OracledbLogonsRate: OracledbLogonsRateMetricConfig{
 						Enabled: true,
 					},
 					OracledbOsSwaps: OracledbOsSwapsMetricConfig{
@@ -439,6 +457,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					OracledbTransactionsLimit: OracledbTransactionsLimitMetricConfig{
 						Enabled: true,
+					},
+					OracledbTransactionsRate: OracledbTransactionsRateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbTransactionsRateMetricAttributeKey{OracledbTransactionsRateMetricAttributeKeyOracledbTransactionType},
 					},
 					OracledbTransactionsUsage: OracledbTransactionsUsageMetricConfig{
 						Enabled: true,
@@ -523,6 +546,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbCursorOpen: OracledbCursorOpenMetricConfig{
 						Enabled: false,
 					},
+					OracledbCursorOpenRate: OracledbCursorOpenRateMetricConfig{
+						Enabled: false,
+					},
 					OracledbDataDictionaryHitRatio: OracledbDataDictionaryHitRatioMetricConfig{
 						Enabled: false,
 					},
@@ -552,10 +578,16 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbDmlStatementsParallelized: OracledbDmlStatementsParallelizedMetricConfig{
 						Enabled: false,
 					},
+					OracledbEnqueueDeadlocksRate: OracledbEnqueueDeadlocksRateMetricConfig{
+						Enabled: false,
+					},
 					OracledbEnqueueOperations: OracledbEnqueueOperationsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbEnqueueOperationsMetricAttributeKey{OracledbEnqueueOperationsMetricAttributeKeyOracledbEnqueueType},
+					},
+					OracledbEnqueueTimeoutsRate: OracledbEnqueueTimeoutsRateMetricConfig{
+						Enabled: false,
 					},
 					OracledbEnqueueDeadlocks: OracledbEnqueueDeadlocksMetricConfig{
 						Enabled: false,
@@ -583,12 +615,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbExecutions: OracledbExecutionsMetricConfig{
 						Enabled: false,
 					},
+					OracledbExecutionsRate: OracledbExecutionsRateMetricConfig{
+						Enabled: false,
+					},
 					OracledbGcCurrentBlockTime: OracledbGcCurrentBlockTimeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbGcCurrentBlockTimeMetricAttributeKey{OracledbGcCurrentBlockTimeMetricAttributeKeyNetworkIoDirection},
 					},
 					OracledbHardParses: OracledbHardParsesMetricConfig{
+						Enabled: false,
+					},
+					OracledbHardParsesRate: OracledbHardParsesRateMetricConfig{
 						Enabled: false,
 					},
 					OracledbHostCPUUsageRate: OracledbHostCPUUsageRateMetricConfig{
@@ -635,6 +673,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled: false,
 					},
 					OracledbLogons: OracledbLogonsMetricConfig{
+						Enabled: false,
+					},
+					OracledbLogonsRate: OracledbLogonsRateMetricConfig{
 						Enabled: false,
 					},
 					OracledbOsSwaps: OracledbOsSwapsMetricConfig{
@@ -881,6 +922,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbTransactionsLimit: OracledbTransactionsLimitMetricConfig{
 						Enabled: false,
 					},
+					OracledbTransactionsRate: OracledbTransactionsRateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbTransactionsRateMetricAttributeKey{OracledbTransactionsRateMetricAttributeKeyOracledbTransactionType},
+					},
 					OracledbTransactionsUsage: OracledbTransactionsUsageMetricConfig{
 						Enabled: false,
 					},
@@ -909,7 +955,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbPdbResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbPdbResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -1282,6 +1328,18 @@ func TestOracledbTablespaceSizeUsageMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric oracledb.tablespace_size.usage doesn't have an attribute invalid, valid attributes: [tablespace_name]")
 
 	cfg = DefaultMetricsConfig().OracledbTablespaceSizeUsage
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbTransactionsRateMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbTransactionsRate
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbTransactionsRateMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.transactions.rate doesn't have an attribute invalid, valid attributes: [oracledb.transaction.type]")
+
+	cfg = DefaultMetricsConfig().OracledbTransactionsRate
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -578,6 +578,32 @@ var MapAttributeOracledbSortType = map[string]AttributeOracledbSortType{
 	"memory": AttributeOracledbSortTypeMemory,
 }
 
+// AttributeOracledbTransactionType specifies the value oracledb.transaction.type attribute.
+type AttributeOracledbTransactionType int
+
+const (
+	_ AttributeOracledbTransactionType = iota
+	AttributeOracledbTransactionTypeCommit
+	AttributeOracledbTransactionTypeRollback
+)
+
+// String returns the string representation of the AttributeOracledbTransactionType.
+func (av AttributeOracledbTransactionType) String() string {
+	switch av {
+	case AttributeOracledbTransactionTypeCommit:
+		return "commit"
+	case AttributeOracledbTransactionTypeRollback:
+		return "rollback"
+	}
+	return ""
+}
+
+// MapAttributeOracledbTransactionType is a helper map of string to AttributeOracledbTransactionType attribute value.
+var MapAttributeOracledbTransactionType = map[string]AttributeOracledbTransactionType{
+	"commit":   AttributeOracledbTransactionTypeCommit,
+	"rollback": AttributeOracledbTransactionTypeRollback,
+}
+
 var MetricsInfo = metricsInfo{
 	OracledbBufferInspected: metricInfo{
 		Name:       "oracledb.buffer.inspected",
@@ -632,6 +658,9 @@ var MetricsInfo = metricsInfo{
 	OracledbCursorOpen: metricInfo{
 		Name: "oracledb.cursor.open",
 	},
+	OracledbCursorOpenRate: metricInfo{
+		Name: "oracledb.cursor.open.rate",
+	},
 	OracledbDataDictionaryHitRatio: metricInfo{
 		Name: "oracledb.data_dictionary.hit_ratio",
 	},
@@ -660,9 +689,15 @@ var MetricsInfo = metricsInfo{
 	OracledbDmlStatementsParallelized: metricInfo{
 		Name: "oracledb.dml_statements_parallelized",
 	},
+	OracledbEnqueueDeadlocksRate: metricInfo{
+		Name: "oracledb.enqueue.deadlocks.rate",
+	},
 	OracledbEnqueueOperations: metricInfo{
 		Name:       "oracledb.enqueue.operations",
 		Attributes: []string{"oracledb.enqueue.type"},
+	},
+	OracledbEnqueueTimeoutsRate: metricInfo{
+		Name: "oracledb.enqueue.timeouts.rate",
 	},
 	OracledbEnqueueDeadlocks: metricInfo{
 		Name: "oracledb.enqueue_deadlocks",
@@ -689,12 +724,18 @@ var MetricsInfo = metricsInfo{
 	OracledbExecutions: metricInfo{
 		Name: "oracledb.executions",
 	},
+	OracledbExecutionsRate: metricInfo{
+		Name: "oracledb.executions.rate",
+	},
 	OracledbGcCurrentBlockTime: metricInfo{
 		Name:       "oracledb.gc.current_block.time",
 		Attributes: []string{"network.io.direction"},
 	},
 	OracledbHardParses: metricInfo{
 		Name: "oracledb.hard_parses",
+	},
+	OracledbHardParsesRate: metricInfo{
+		Name: "oracledb.hard_parses.rate",
 	},
 	OracledbHostCPUUsageRate: metricInfo{
 		Name: "oracledb.host.cpu.usage.rate",
@@ -739,6 +780,9 @@ var MetricsInfo = metricsInfo{
 	},
 	OracledbLogons: metricInfo{
 		Name: "oracledb.logons",
+	},
+	OracledbLogonsRate: metricInfo{
+		Name: "oracledb.logons.rate",
 	},
 	OracledbOsSwaps: metricInfo{
 		Name: "oracledb.os.swaps",
@@ -961,6 +1005,10 @@ var MetricsInfo = metricsInfo{
 	OracledbTransactionsLimit: metricInfo{
 		Name: "oracledb.transactions.limit",
 	},
+	OracledbTransactionsRate: metricInfo{
+		Name:       "oracledb.transactions.rate",
+		Attributes: []string{"oracledb.transaction.type"},
+	},
 	OracledbTransactionsUsage: metricInfo{
 		Name: "oracledb.transactions.usage",
 	},
@@ -990,6 +1038,7 @@ type metricsInfo struct {
 	OracledbCursorCacheSize                       metricInfo
 	OracledbCursorCacheUtilization                metricInfo
 	OracledbCursorOpen                            metricInfo
+	OracledbCursorOpenRate                        metricInfo
 	OracledbDataDictionaryHitRatio                metricInfo
 	OracledbDatabaseCPUUtilization                metricInfo
 	OracledbDatabaseWaitUtilization               metricInfo
@@ -999,7 +1048,9 @@ type metricsInfo struct {
 	OracledbDmlLocksLimit                         metricInfo
 	OracledbDmlLocksUsage                         metricInfo
 	OracledbDmlStatementsParallelized             metricInfo
+	OracledbEnqueueDeadlocksRate                  metricInfo
 	OracledbEnqueueOperations                     metricInfo
+	OracledbEnqueueTimeoutsRate                   metricInfo
 	OracledbEnqueueDeadlocks                      metricInfo
 	OracledbEnqueueLocksLimit                     metricInfo
 	OracledbEnqueueLocksUsage                     metricInfo
@@ -1008,8 +1059,10 @@ type metricsInfo struct {
 	OracledbExchangeDeadlocks                     metricInfo
 	OracledbExecutionUtilization                  metricInfo
 	OracledbExecutions                            metricInfo
+	OracledbExecutionsRate                        metricInfo
 	OracledbGcCurrentBlockTime                    metricInfo
 	OracledbHardParses                            metricInfo
+	OracledbHardParsesRate                        metricInfo
 	OracledbHostCPUUsageRate                      metricInfo
 	OracledbHostCPUUtilization                    metricInfo
 	OracledbIoRequestsRate                        metricInfo
@@ -1024,6 +1077,7 @@ type metricsInfo struct {
 	OracledbLogicalReads                          metricInfo
 	OracledbLogicalReadsRate                      metricInfo
 	OracledbLogons                                metricInfo
+	OracledbLogonsRate                            metricInfo
 	OracledbOsSwaps                               metricInfo
 	OracledbParallelOperationsDowngraded1To25Pct  metricInfo
 	OracledbParallelOperationsDowngraded25To50Pct metricInfo
@@ -1090,6 +1144,7 @@ type metricsInfo struct {
 	OracledbTransactionResponseTime               metricInfo
 	OracledbTransactionRollbacks                  metricInfo
 	OracledbTransactionsLimit                     metricInfo
+	OracledbTransactionsRate                      metricInfo
 	OracledbTransactionsUsage                     metricInfo
 	OracledbUserCommits                           metricInfo
 	OracledbUserRollbacks                         metricInfo
@@ -2050,6 +2105,56 @@ func newMetricOracledbCursorOpen(cfg OracledbCursorOpenMetricConfig) metricOracl
 	return m
 }
 
+type metricOracledbCursorOpenRate struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   OracledbCursorOpenRateMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.cursor.open.rate metric with initial data.
+func (m *metricOracledbCursorOpenRate) init() {
+	m.data.SetName("oracledb.cursor.open.rate")
+	m.data.SetDescription("Rate of cursors opened.")
+	m.data.SetUnit("{cursor}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricOracledbCursorOpenRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbCursorOpenRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbCursorOpenRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbCursorOpenRate(cfg OracledbCursorOpenRateMetricConfig) metricOracledbCursorOpenRate {
+	m := metricOracledbCursorOpenRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbDataDictionaryHitRatio struct {
 	data     pmetric.Metric                             // data buffer for generated metric.
 	config   OracledbDataDictionaryHitRatioMetricConfig // metric config provided by user.
@@ -2547,6 +2652,56 @@ func newMetricOracledbDmlStatementsParallelized(cfg OracledbDmlStatementsParalle
 	return m
 }
 
+type metricOracledbEnqueueDeadlocksRate struct {
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   OracledbEnqueueDeadlocksRateMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.enqueue.deadlocks.rate metric with initial data.
+func (m *metricOracledbEnqueueDeadlocksRate) init() {
+	m.data.SetName("oracledb.enqueue.deadlocks.rate")
+	m.data.SetDescription("Rate of enqueue deadlocks.")
+	m.data.SetUnit("{deadlock}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricOracledbEnqueueDeadlocksRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbEnqueueDeadlocksRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbEnqueueDeadlocksRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbEnqueueDeadlocksRate(cfg OracledbEnqueueDeadlocksRateMetricConfig) metricOracledbEnqueueDeadlocksRate {
+	m := metricOracledbEnqueueDeadlocksRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbEnqueueOperations struct {
 	data          pmetric.Metric                        // data buffer for generated metric.
 	config        OracledbEnqueueOperationsMetricConfig // metric config provided by user.
@@ -2630,6 +2785,56 @@ func (m *metricOracledbEnqueueOperations) emit(metrics pmetric.MetricSlice) {
 
 func newMetricOracledbEnqueueOperations(cfg OracledbEnqueueOperationsMetricConfig) metricOracledbEnqueueOperations {
 	m := metricOracledbEnqueueOperations{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbEnqueueTimeoutsRate struct {
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   OracledbEnqueueTimeoutsRateMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.enqueue.timeouts.rate metric with initial data.
+func (m *metricOracledbEnqueueTimeoutsRate) init() {
+	m.data.SetName("oracledb.enqueue.timeouts.rate")
+	m.data.SetDescription("Rate of enqueue timeouts.")
+	m.data.SetUnit("{timeout}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricOracledbEnqueueTimeoutsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbEnqueueTimeoutsRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbEnqueueTimeoutsRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbEnqueueTimeoutsRate(cfg OracledbEnqueueTimeoutsRateMetricConfig) metricOracledbEnqueueTimeoutsRate {
+	m := metricOracledbEnqueueTimeoutsRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3083,6 +3288,56 @@ func newMetricOracledbExecutions(cfg OracledbExecutionsMetricConfig) metricOracl
 	return m
 }
 
+type metricOracledbExecutionsRate struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   OracledbExecutionsRateMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.executions.rate metric with initial data.
+func (m *metricOracledbExecutionsRate) init() {
+	m.data.SetName("oracledb.executions.rate")
+	m.data.SetDescription("Rate of SQL statement executions.")
+	m.data.SetUnit("{execution}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricOracledbExecutionsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbExecutionsRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbExecutionsRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbExecutionsRate(cfg OracledbExecutionsRateMetricConfig) metricOracledbExecutionsRate {
+	m := metricOracledbExecutionsRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbGcCurrentBlockTime struct {
 	data          pmetric.Metric                         // data buffer for generated metric.
 	config        OracledbGcCurrentBlockTimeMetricConfig // metric config provided by user.
@@ -3218,6 +3473,56 @@ func (m *metricOracledbHardParses) emit(metrics pmetric.MetricSlice) {
 
 func newMetricOracledbHardParses(cfg OracledbHardParsesMetricConfig) metricOracledbHardParses {
 	m := metricOracledbHardParses{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbHardParsesRate struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   OracledbHardParsesRateMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.hard_parses.rate metric with initial data.
+func (m *metricOracledbHardParsesRate) init() {
+	m.data.SetName("oracledb.hard_parses.rate")
+	m.data.SetDescription("Rate of hard parses.")
+	m.data.SetUnit("{parse}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricOracledbHardParsesRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbHardParsesRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbHardParsesRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbHardParsesRate(cfg OracledbHardParsesRateMetricConfig) metricOracledbHardParsesRate {
+	m := metricOracledbHardParsesRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4004,6 +4309,56 @@ func (m *metricOracledbLogons) emit(metrics pmetric.MetricSlice) {
 
 func newMetricOracledbLogons(cfg OracledbLogonsMetricConfig) metricOracledbLogons {
 	m := metricOracledbLogons{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbLogonsRate struct {
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   OracledbLogonsRateMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
+}
+
+// init fills oracledb.logons.rate metric with initial data.
+func (m *metricOracledbLogonsRate) init() {
+	m.data.SetName("oracledb.logons.rate")
+	m.data.SetDescription("Rate of logon operations.")
+	m.data.SetUnit("{logon}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricOracledbLogonsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbLogonsRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbLogonsRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbLogonsRate(cfg OracledbLogonsRateMetricConfig) metricOracledbLogonsRate {
+	m := metricOracledbLogonsRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -8298,6 +8653,95 @@ func newMetricOracledbTransactionsLimit(cfg OracledbTransactionsLimitMetricConfi
 	return m
 }
 
+type metricOracledbTransactionsRate struct {
+	data          pmetric.Metric                       // data buffer for generated metric.
+	config        OracledbTransactionsRateMetricConfig // metric config provided by user.
+	capacity      int                                  // max observed number of data points added to the metric.
+	aggDataPoints []float64                            // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.transactions.rate metric with initial data.
+func (m *metricOracledbTransactionsRate) init() {
+	m.data.SetName("oracledb.transactions.rate")
+	m.data.SetDescription("Rate of user transactions.")
+	m.data.SetUnit("{transaction}/s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbTransactionsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, oracledbTransactionTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbTransactionsRateMetricAttributeKeyOracledbTransactionType) {
+		dp.Attributes().PutStr("oracledb.transaction.type", oracledbTransactionTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbTransactionsRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbTransactionsRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbTransactionsRate(cfg OracledbTransactionsRateMetricConfig) metricOracledbTransactionsRate {
+	m := metricOracledbTransactionsRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbTransactionsUsage struct {
 	data     pmetric.Metric                        // data buffer for generated metric.
 	config   OracledbTransactionsUsageMetricConfig // metric config provided by user.
@@ -8479,6 +8923,7 @@ type MetricsBuilder struct {
 	metricOracledbCursorCacheSize                       metricOracledbCursorCacheSize
 	metricOracledbCursorCacheUtilization                metricOracledbCursorCacheUtilization
 	metricOracledbCursorOpen                            metricOracledbCursorOpen
+	metricOracledbCursorOpenRate                        metricOracledbCursorOpenRate
 	metricOracledbDataDictionaryHitRatio                metricOracledbDataDictionaryHitRatio
 	metricOracledbDatabaseCPUUtilization                metricOracledbDatabaseCPUUtilization
 	metricOracledbDatabaseWaitUtilization               metricOracledbDatabaseWaitUtilization
@@ -8488,7 +8933,9 @@ type MetricsBuilder struct {
 	metricOracledbDmlLocksLimit                         metricOracledbDmlLocksLimit
 	metricOracledbDmlLocksUsage                         metricOracledbDmlLocksUsage
 	metricOracledbDmlStatementsParallelized             metricOracledbDmlStatementsParallelized
+	metricOracledbEnqueueDeadlocksRate                  metricOracledbEnqueueDeadlocksRate
 	metricOracledbEnqueueOperations                     metricOracledbEnqueueOperations
+	metricOracledbEnqueueTimeoutsRate                   metricOracledbEnqueueTimeoutsRate
 	metricOracledbEnqueueDeadlocks                      metricOracledbEnqueueDeadlocks
 	metricOracledbEnqueueLocksLimit                     metricOracledbEnqueueLocksLimit
 	metricOracledbEnqueueLocksUsage                     metricOracledbEnqueueLocksUsage
@@ -8497,8 +8944,10 @@ type MetricsBuilder struct {
 	metricOracledbExchangeDeadlocks                     metricOracledbExchangeDeadlocks
 	metricOracledbExecutionUtilization                  metricOracledbExecutionUtilization
 	metricOracledbExecutions                            metricOracledbExecutions
+	metricOracledbExecutionsRate                        metricOracledbExecutionsRate
 	metricOracledbGcCurrentBlockTime                    metricOracledbGcCurrentBlockTime
 	metricOracledbHardParses                            metricOracledbHardParses
+	metricOracledbHardParsesRate                        metricOracledbHardParsesRate
 	metricOracledbHostCPUUsageRate                      metricOracledbHostCPUUsageRate
 	metricOracledbHostCPUUtilization                    metricOracledbHostCPUUtilization
 	metricOracledbIoRequestsRate                        metricOracledbIoRequestsRate
@@ -8513,6 +8962,7 @@ type MetricsBuilder struct {
 	metricOracledbLogicalReads                          metricOracledbLogicalReads
 	metricOracledbLogicalReadsRate                      metricOracledbLogicalReadsRate
 	metricOracledbLogons                                metricOracledbLogons
+	metricOracledbLogonsRate                            metricOracledbLogonsRate
 	metricOracledbOsSwaps                               metricOracledbOsSwaps
 	metricOracledbParallelOperationsDowngraded1To25Pct  metricOracledbParallelOperationsDowngraded1To25Pct
 	metricOracledbParallelOperationsDowngraded25To50Pct metricOracledbParallelOperationsDowngraded25To50Pct
@@ -8579,6 +9029,7 @@ type MetricsBuilder struct {
 	metricOracledbTransactionResponseTime               metricOracledbTransactionResponseTime
 	metricOracledbTransactionRollbacks                  metricOracledbTransactionRollbacks
 	metricOracledbTransactionsLimit                     metricOracledbTransactionsLimit
+	metricOracledbTransactionsRate                      metricOracledbTransactionsRate
 	metricOracledbTransactionsUsage                     metricOracledbTransactionsUsage
 	metricOracledbUserCommits                           metricOracledbUserCommits
 	metricOracledbUserRollbacks                         metricOracledbUserRollbacks
@@ -8624,6 +9075,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbCursorCacheSize:                       newMetricOracledbCursorCacheSize(mbc.Metrics.OracledbCursorCacheSize),
 		metricOracledbCursorCacheUtilization:                newMetricOracledbCursorCacheUtilization(mbc.Metrics.OracledbCursorCacheUtilization),
 		metricOracledbCursorOpen:                            newMetricOracledbCursorOpen(mbc.Metrics.OracledbCursorOpen),
+		metricOracledbCursorOpenRate:                        newMetricOracledbCursorOpenRate(mbc.Metrics.OracledbCursorOpenRate),
 		metricOracledbDataDictionaryHitRatio:                newMetricOracledbDataDictionaryHitRatio(mbc.Metrics.OracledbDataDictionaryHitRatio),
 		metricOracledbDatabaseCPUUtilization:                newMetricOracledbDatabaseCPUUtilization(mbc.Metrics.OracledbDatabaseCPUUtilization),
 		metricOracledbDatabaseWaitUtilization:               newMetricOracledbDatabaseWaitUtilization(mbc.Metrics.OracledbDatabaseWaitUtilization),
@@ -8633,7 +9085,9 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbDmlLocksLimit:                         newMetricOracledbDmlLocksLimit(mbc.Metrics.OracledbDmlLocksLimit),
 		metricOracledbDmlLocksUsage:                         newMetricOracledbDmlLocksUsage(mbc.Metrics.OracledbDmlLocksUsage),
 		metricOracledbDmlStatementsParallelized:             newMetricOracledbDmlStatementsParallelized(mbc.Metrics.OracledbDmlStatementsParallelized),
+		metricOracledbEnqueueDeadlocksRate:                  newMetricOracledbEnqueueDeadlocksRate(mbc.Metrics.OracledbEnqueueDeadlocksRate),
 		metricOracledbEnqueueOperations:                     newMetricOracledbEnqueueOperations(mbc.Metrics.OracledbEnqueueOperations),
+		metricOracledbEnqueueTimeoutsRate:                   newMetricOracledbEnqueueTimeoutsRate(mbc.Metrics.OracledbEnqueueTimeoutsRate),
 		metricOracledbEnqueueDeadlocks:                      newMetricOracledbEnqueueDeadlocks(mbc.Metrics.OracledbEnqueueDeadlocks),
 		metricOracledbEnqueueLocksLimit:                     newMetricOracledbEnqueueLocksLimit(mbc.Metrics.OracledbEnqueueLocksLimit),
 		metricOracledbEnqueueLocksUsage:                     newMetricOracledbEnqueueLocksUsage(mbc.Metrics.OracledbEnqueueLocksUsage),
@@ -8642,8 +9096,10 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbExchangeDeadlocks:                     newMetricOracledbExchangeDeadlocks(mbc.Metrics.OracledbExchangeDeadlocks),
 		metricOracledbExecutionUtilization:                  newMetricOracledbExecutionUtilization(mbc.Metrics.OracledbExecutionUtilization),
 		metricOracledbExecutions:                            newMetricOracledbExecutions(mbc.Metrics.OracledbExecutions),
+		metricOracledbExecutionsRate:                        newMetricOracledbExecutionsRate(mbc.Metrics.OracledbExecutionsRate),
 		metricOracledbGcCurrentBlockTime:                    newMetricOracledbGcCurrentBlockTime(mbc.Metrics.OracledbGcCurrentBlockTime),
 		metricOracledbHardParses:                            newMetricOracledbHardParses(mbc.Metrics.OracledbHardParses),
+		metricOracledbHardParsesRate:                        newMetricOracledbHardParsesRate(mbc.Metrics.OracledbHardParsesRate),
 		metricOracledbHostCPUUsageRate:                      newMetricOracledbHostCPUUsageRate(mbc.Metrics.OracledbHostCPUUsageRate),
 		metricOracledbHostCPUUtilization:                    newMetricOracledbHostCPUUtilization(mbc.Metrics.OracledbHostCPUUtilization),
 		metricOracledbIoRequestsRate:                        newMetricOracledbIoRequestsRate(mbc.Metrics.OracledbIoRequestsRate),
@@ -8658,6 +9114,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbLogicalReads:                          newMetricOracledbLogicalReads(mbc.Metrics.OracledbLogicalReads),
 		metricOracledbLogicalReadsRate:                      newMetricOracledbLogicalReadsRate(mbc.Metrics.OracledbLogicalReadsRate),
 		metricOracledbLogons:                                newMetricOracledbLogons(mbc.Metrics.OracledbLogons),
+		metricOracledbLogonsRate:                            newMetricOracledbLogonsRate(mbc.Metrics.OracledbLogonsRate),
 		metricOracledbOsSwaps:                               newMetricOracledbOsSwaps(mbc.Metrics.OracledbOsSwaps),
 		metricOracledbParallelOperationsDowngraded1To25Pct:  newMetricOracledbParallelOperationsDowngraded1To25Pct(mbc.Metrics.OracledbParallelOperationsDowngraded1To25Pct),
 		metricOracledbParallelOperationsDowngraded25To50Pct: newMetricOracledbParallelOperationsDowngraded25To50Pct(mbc.Metrics.OracledbParallelOperationsDowngraded25To50Pct),
@@ -8724,6 +9181,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricOracledbTransactionResponseTime:               newMetricOracledbTransactionResponseTime(mbc.Metrics.OracledbTransactionResponseTime),
 		metricOracledbTransactionRollbacks:                  newMetricOracledbTransactionRollbacks(mbc.Metrics.OracledbTransactionRollbacks),
 		metricOracledbTransactionsLimit:                     newMetricOracledbTransactionsLimit(mbc.Metrics.OracledbTransactionsLimit),
+		metricOracledbTransactionsRate:                      newMetricOracledbTransactionsRate(mbc.Metrics.OracledbTransactionsRate),
 		metricOracledbTransactionsUsage:                     newMetricOracledbTransactionsUsage(mbc.Metrics.OracledbTransactionsUsage),
 		metricOracledbUserCommits:                           newMetricOracledbUserCommits(mbc.Metrics.OracledbUserCommits),
 		metricOracledbUserRollbacks:                         newMetricOracledbUserRollbacks(mbc.Metrics.OracledbUserRollbacks),
@@ -8876,6 +9334,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbCursorCacheSize.emit(ils.Metrics())
 	mb.metricOracledbCursorCacheUtilization.emit(ils.Metrics())
 	mb.metricOracledbCursorOpen.emit(ils.Metrics())
+	mb.metricOracledbCursorOpenRate.emit(ils.Metrics())
 	mb.metricOracledbDataDictionaryHitRatio.emit(ils.Metrics())
 	mb.metricOracledbDatabaseCPUUtilization.emit(ils.Metrics())
 	mb.metricOracledbDatabaseWaitUtilization.emit(ils.Metrics())
@@ -8885,7 +9344,9 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbDmlLocksLimit.emit(ils.Metrics())
 	mb.metricOracledbDmlLocksUsage.emit(ils.Metrics())
 	mb.metricOracledbDmlStatementsParallelized.emit(ils.Metrics())
+	mb.metricOracledbEnqueueDeadlocksRate.emit(ils.Metrics())
 	mb.metricOracledbEnqueueOperations.emit(ils.Metrics())
+	mb.metricOracledbEnqueueTimeoutsRate.emit(ils.Metrics())
 	mb.metricOracledbEnqueueDeadlocks.emit(ils.Metrics())
 	mb.metricOracledbEnqueueLocksLimit.emit(ils.Metrics())
 	mb.metricOracledbEnqueueLocksUsage.emit(ils.Metrics())
@@ -8894,8 +9355,10 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbExchangeDeadlocks.emit(ils.Metrics())
 	mb.metricOracledbExecutionUtilization.emit(ils.Metrics())
 	mb.metricOracledbExecutions.emit(ils.Metrics())
+	mb.metricOracledbExecutionsRate.emit(ils.Metrics())
 	mb.metricOracledbGcCurrentBlockTime.emit(ils.Metrics())
 	mb.metricOracledbHardParses.emit(ils.Metrics())
+	mb.metricOracledbHardParsesRate.emit(ils.Metrics())
 	mb.metricOracledbHostCPUUsageRate.emit(ils.Metrics())
 	mb.metricOracledbHostCPUUtilization.emit(ils.Metrics())
 	mb.metricOracledbIoRequestsRate.emit(ils.Metrics())
@@ -8910,6 +9373,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbLogicalReads.emit(ils.Metrics())
 	mb.metricOracledbLogicalReadsRate.emit(ils.Metrics())
 	mb.metricOracledbLogons.emit(ils.Metrics())
+	mb.metricOracledbLogonsRate.emit(ils.Metrics())
 	mb.metricOracledbOsSwaps.emit(ils.Metrics())
 	mb.metricOracledbParallelOperationsDowngraded1To25Pct.emit(ils.Metrics())
 	mb.metricOracledbParallelOperationsDowngraded25To50Pct.emit(ils.Metrics())
@@ -8976,6 +9440,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricOracledbTransactionResponseTime.emit(ils.Metrics())
 	mb.metricOracledbTransactionRollbacks.emit(ils.Metrics())
 	mb.metricOracledbTransactionsLimit.emit(ils.Metrics())
+	mb.metricOracledbTransactionsRate.emit(ils.Metrics())
 	mb.metricOracledbTransactionsUsage.emit(ils.Metrics())
 	mb.metricOracledbUserCommits.emit(ils.Metrics())
 	mb.metricOracledbUserRollbacks.emit(ils.Metrics())
@@ -9150,6 +9615,11 @@ func (mb *MetricsBuilder) RecordOracledbCursorOpenDataPoint(ts pcommon.Timestamp
 	return nil
 }
 
+// RecordOracledbCursorOpenRateDataPoint adds a data point to oracledb.cursor.open.rate metric.
+func (mb *MetricsBuilder) RecordOracledbCursorOpenRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricOracledbCursorOpenRate.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordOracledbDataDictionaryHitRatioDataPoint adds a data point to oracledb.data_dictionary.hit_ratio metric.
 func (mb *MetricsBuilder) RecordOracledbDataDictionaryHitRatioDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricOracledbDataDictionaryHitRatio.recordDataPoint(mb.startTime, ts, val)
@@ -9220,6 +9690,11 @@ func (mb *MetricsBuilder) RecordOracledbDmlStatementsParallelizedDataPoint(ts pc
 	return nil
 }
 
+// RecordOracledbEnqueueDeadlocksRateDataPoint adds a data point to oracledb.enqueue.deadlocks.rate metric.
+func (mb *MetricsBuilder) RecordOracledbEnqueueDeadlocksRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricOracledbEnqueueDeadlocksRate.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordOracledbEnqueueOperationsDataPoint adds a data point to oracledb.enqueue.operations metric.
 func (mb *MetricsBuilder) RecordOracledbEnqueueOperationsDataPoint(ts pcommon.Timestamp, inputVal string, oracledbEnqueueTypeAttributeValue AttributeOracledbEnqueueType) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -9228,6 +9703,11 @@ func (mb *MetricsBuilder) RecordOracledbEnqueueOperationsDataPoint(ts pcommon.Ti
 	}
 	mb.metricOracledbEnqueueOperations.recordDataPoint(mb.startTime, ts, val, oracledbEnqueueTypeAttributeValue.String())
 	return nil
+}
+
+// RecordOracledbEnqueueTimeoutsRateDataPoint adds a data point to oracledb.enqueue.timeouts.rate metric.
+func (mb *MetricsBuilder) RecordOracledbEnqueueTimeoutsRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricOracledbEnqueueTimeoutsRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordOracledbEnqueueDeadlocksDataPoint adds a data point to oracledb.enqueue_deadlocks metric.
@@ -9305,6 +9785,11 @@ func (mb *MetricsBuilder) RecordOracledbExecutionsDataPoint(ts pcommon.Timestamp
 	return nil
 }
 
+// RecordOracledbExecutionsRateDataPoint adds a data point to oracledb.executions.rate metric.
+func (mb *MetricsBuilder) RecordOracledbExecutionsRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricOracledbExecutionsRate.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordOracledbGcCurrentBlockTimeDataPoint adds a data point to oracledb.gc.current_block.time metric.
 func (mb *MetricsBuilder) RecordOracledbGcCurrentBlockTimeDataPoint(ts pcommon.Timestamp, val float64, networkIoDirectionAttributeValue AttributeNetworkIoDirection) {
 	mb.metricOracledbGcCurrentBlockTime.recordDataPoint(mb.startTime, ts, val, networkIoDirectionAttributeValue.String())
@@ -9318,6 +9803,11 @@ func (mb *MetricsBuilder) RecordOracledbHardParsesDataPoint(ts pcommon.Timestamp
 	}
 	mb.metricOracledbHardParses.recordDataPoint(mb.startTime, ts, val)
 	return nil
+}
+
+// RecordOracledbHardParsesRateDataPoint adds a data point to oracledb.hard_parses.rate metric.
+func (mb *MetricsBuilder) RecordOracledbHardParsesRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricOracledbHardParsesRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordOracledbHostCPUUsageRateDataPoint adds a data point to oracledb.host.cpu.usage.rate metric.
@@ -9418,6 +9908,11 @@ func (mb *MetricsBuilder) RecordOracledbLogonsDataPoint(ts pcommon.Timestamp, in
 	}
 	mb.metricOracledbLogons.recordDataPoint(mb.startTime, ts, val)
 	return nil
+}
+
+// RecordOracledbLogonsRateDataPoint adds a data point to oracledb.logons.rate metric.
+func (mb *MetricsBuilder) RecordOracledbLogonsRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricOracledbLogonsRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordOracledbOsSwapsDataPoint adds a data point to oracledb.os.swaps metric.
@@ -9943,6 +10438,11 @@ func (mb *MetricsBuilder) RecordOracledbTransactionsLimitDataPoint(ts pcommon.Ti
 	}
 	mb.metricOracledbTransactionsLimit.recordDataPoint(mb.startTime, ts, val)
 	return nil
+}
+
+// RecordOracledbTransactionsRateDataPoint adds a data point to oracledb.transactions.rate metric.
+func (mb *MetricsBuilder) RecordOracledbTransactionsRateDataPoint(ts pcommon.Timestamp, val float64, oracledbTransactionTypeAttributeValue AttributeOracledbTransactionType) {
+	mb.metricOracledbTransactionsRate.recordDataPoint(mb.startTime, ts, val, oracledbTransactionTypeAttributeValue.String())
 }
 
 // RecordOracledbTransactionsUsageDataPoint adds a data point to oracledb.transactions.usage metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -98,6 +98,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["oracledb.sqlnet.io.transferred"] = mb.metricOracledbSqlnetIoTransferred.config.AggregationStrategy
 			aggMap["oracledb.tablespace_size.limit"] = mb.metricOracledbTablespaceSizeLimit.config.AggregationStrategy
 			aggMap["oracledb.tablespace_size.usage"] = mb.metricOracledbTablespaceSizeUsage.config.AggregationStrategy
+			aggMap["oracledb.transactions.rate"] = mb.metricOracledbTransactionsRate.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet != testDataSetReag {
@@ -165,6 +166,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbCursorOpenDataPoint(ts, "1")
 
 			allMetricsCount++
+			mb.RecordOracledbCursorOpenRateDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordOracledbDataDictionaryHitRatioDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -195,10 +199,16 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbDmlStatementsParallelizedDataPoint(ts, "1")
 
 			allMetricsCount++
+			mb.RecordOracledbEnqueueDeadlocksRateDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordOracledbEnqueueOperationsDataPoint(ts, "1", AttributeOracledbEnqueueTypeConversions)
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbEnqueueOperationsDataPoint(ts, "3", AttributeOracledbEnqueueTypeReleases)
 			}
+
+			allMetricsCount++
+			mb.RecordOracledbEnqueueTimeoutsRateDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordOracledbEnqueueDeadlocksDataPoint(ts, "1")
@@ -228,6 +238,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbExecutionsDataPoint(ts, "1")
 
 			allMetricsCount++
+			mb.RecordOracledbExecutionsRateDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordOracledbGcCurrentBlockTimeDataPoint(ts, 1, AttributeNetworkIoDirectionReceive)
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbGcCurrentBlockTimeDataPoint(ts, 3, AttributeNetworkIoDirectionTransmit)
@@ -235,6 +248,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordOracledbHardParsesDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbHardParsesRateDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordOracledbHostCPUUsageRateDataPoint(ts, 1)
@@ -283,6 +299,9 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordOracledbLogonsDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbLogonsRateDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordOracledbOsSwapsDataPoint(ts, "1")
@@ -550,6 +569,12 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordOracledbTransactionsLimitDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordOracledbTransactionsRateDataPoint(ts, 1, AttributeOracledbTransactionTypeCommit)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbTransactionsRateDataPoint(ts, 3, AttributeOracledbTransactionTypeRollback)
+			}
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordOracledbTransactionsUsageDataPoint(ts, "1")
@@ -605,6 +630,7 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricOracledbSqlnetIoTransferred.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbTablespaceSizeLimit.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbTablespaceSizeUsage.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbTransactionsRate.aggDataPoints)
 			}
 
 			if tt.expectEmpty {
@@ -918,6 +944,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.cursor.open.rate":
+					assert.False(t, validatedMetrics["oracledb.cursor.open.rate"], "Found a duplicate in the metrics slice: oracledb.cursor.open.rate")
+					validatedMetrics["oracledb.cursor.open.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Rate of cursors opened.", mi.Description())
+					assert.Equal(t, "{cursor}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.data_dictionary.hit_ratio":
 					assert.False(t, validatedMetrics["oracledb.data_dictionary.hit_ratio"], "Found a duplicate in the metrics slice: oracledb.data_dictionary.hit_ratio")
 					validatedMetrics["oracledb.data_dictionary.hit_ratio"] = true
@@ -1064,6 +1102,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.enqueue.deadlocks.rate":
+					assert.False(t, validatedMetrics["oracledb.enqueue.deadlocks.rate"], "Found a duplicate in the metrics slice: oracledb.enqueue.deadlocks.rate")
+					validatedMetrics["oracledb.enqueue.deadlocks.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Rate of enqueue deadlocks.", mi.Description())
+					assert.Equal(t, "{deadlock}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.enqueue.operations":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["oracledb.enqueue.operations"], "Found a duplicate in the metrics slice: oracledb.enqueue.operations")
@@ -1108,6 +1158,18 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("oracledb.enqueue.type")
 						assert.False(t, ok)
 					}
+				case "oracledb.enqueue.timeouts.rate":
+					assert.False(t, validatedMetrics["oracledb.enqueue.timeouts.rate"], "Found a duplicate in the metrics slice: oracledb.enqueue.timeouts.rate")
+					validatedMetrics["oracledb.enqueue.timeouts.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Rate of enqueue timeouts.", mi.Description())
+					assert.Equal(t, "{timeout}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.enqueue_deadlocks":
 					assert.False(t, validatedMetrics["oracledb.enqueue_deadlocks"], "Found a duplicate in the metrics slice: oracledb.enqueue_deadlocks")
 					validatedMetrics["oracledb.enqueue_deadlocks"] = true
@@ -1238,6 +1300,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.executions.rate":
+					assert.False(t, validatedMetrics["oracledb.executions.rate"], "Found a duplicate in the metrics slice: oracledb.executions.rate")
+					validatedMetrics["oracledb.executions.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Rate of SQL statement executions.", mi.Description())
+					assert.Equal(t, "{execution}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.gc.current_block.time":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["oracledb.gc.current_block.time"], "Found a duplicate in the metrics slice: oracledb.gc.current_block.time")
@@ -1296,6 +1370,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.hard_parses.rate":
+					assert.False(t, validatedMetrics["oracledb.hard_parses.rate"], "Found a duplicate in the metrics slice: oracledb.hard_parses.rate")
+					validatedMetrics["oracledb.hard_parses.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Rate of hard parses.", mi.Description())
+					assert.Equal(t, "{parse}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.host.cpu.usage.rate":
 					assert.False(t, validatedMetrics["oracledb.host.cpu.usage.rate"], "Found a duplicate in the metrics slice: oracledb.host.cpu.usage.rate")
 					validatedMetrics["oracledb.host.cpu.usage.rate"] = true
@@ -1532,6 +1618,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.logons.rate":
+					assert.False(t, validatedMetrics["oracledb.logons.rate"], "Found a duplicate in the metrics slice: oracledb.logons.rate")
+					validatedMetrics["oracledb.logons.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Rate of logon operations.", mi.Description())
+					assert.Equal(t, "{logon}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "oracledb.os.swaps":
 					assert.False(t, validatedMetrics["oracledb.os.swaps"], "Found a duplicate in the metrics slice: oracledb.os.swaps")
 					validatedMetrics["oracledb.os.swaps"] = true
@@ -3093,6 +3191,46 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "oracledb.transactions.rate":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.transactions.rate"], "Found a duplicate in the metrics slice: oracledb.transactions.rate")
+						validatedMetrics["oracledb.transactions.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Rate of user transactions.", mi.Description())
+						assert.Equal(t, "{transaction}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						oracledbTransactionTypeAttrVal, ok := dp.Attributes().Get("oracledb.transaction.type")
+						assert.True(t, ok)
+						assert.Equal(t, "commit", oracledbTransactionTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.transactions.rate"], "Found a duplicate in the metrics slice: oracledb.transactions.rate")
+						validatedMetrics["oracledb.transactions.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Rate of user transactions.", mi.Description())
+						assert.Equal(t, "{transaction}/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["oracledb.transactions.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("oracledb.transaction.type")
+						assert.False(t, ok)
+					}
 				case "oracledb.transactions.usage":
 					assert.False(t, validatedMetrics["oracledb.transactions.usage"], "Found a duplicate in the metrics slice: oracledb.transactions.usage")
 					validatedMetrics["oracledb.transactions.usage"] = true

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -37,6 +37,8 @@ all_set:
       enabled: true
     oracledb.cursor.open:
       enabled: true
+    oracledb.cursor.open.rate:
+      enabled: true
     oracledb.data_dictionary.hit_ratio:
       enabled: true
     oracledb.database.cpu.utilization:
@@ -56,9 +58,13 @@ all_set:
       enabled: true
     oracledb.dml_statements_parallelized:
       enabled: true
+    oracledb.enqueue.deadlocks.rate:
+      enabled: true
     oracledb.enqueue.operations:
       enabled: true
       attributes: ["oracledb.enqueue.type"]
+    oracledb.enqueue.timeouts.rate:
+      enabled: true
     oracledb.enqueue_deadlocks:
       enabled: true
     oracledb.enqueue_locks.limit:
@@ -76,10 +82,14 @@ all_set:
       attributes: ["oracledb.parse.type"]
     oracledb.executions:
       enabled: true
+    oracledb.executions.rate:
+      enabled: true
     oracledb.gc.current_block.time:
       enabled: true
       attributes: ["network.io.direction"]
     oracledb.hard_parses:
+      enabled: true
+    oracledb.hard_parses.rate:
       enabled: true
     oracledb.host.cpu.usage.rate:
       enabled: true
@@ -110,6 +120,8 @@ all_set:
     oracledb.logical_reads.rate:
       enabled: true
     oracledb.logons:
+      enabled: true
+    oracledb.logons.rate:
       enabled: true
     oracledb.os.swaps:
       enabled: true
@@ -266,6 +278,9 @@ all_set:
       enabled: true
     oracledb.transactions.limit:
       enabled: true
+    oracledb.transactions.rate:
+      enabled: true
+      attributes: ["oracledb.transaction.type"]
     oracledb.transactions.usage:
       enabled: true
     oracledb.user_commits:
@@ -338,6 +353,8 @@ reaggregate_set:
       enabled: true
     oracledb.cursor.open:
       enabled: true
+    oracledb.cursor.open.rate:
+      enabled: true
     oracledb.data_dictionary.hit_ratio:
       enabled: true
     oracledb.database.cpu.utilization:
@@ -357,9 +374,13 @@ reaggregate_set:
       enabled: true
     oracledb.dml_statements_parallelized:
       enabled: true
+    oracledb.enqueue.deadlocks.rate:
+      enabled: true
     oracledb.enqueue.operations:
       enabled: true
       attributes: []
+    oracledb.enqueue.timeouts.rate:
+      enabled: true
     oracledb.enqueue_deadlocks:
       enabled: true
     oracledb.enqueue_locks.limit:
@@ -377,10 +398,14 @@ reaggregate_set:
       attributes: []
     oracledb.executions:
       enabled: true
+    oracledb.executions.rate:
+      enabled: true
     oracledb.gc.current_block.time:
       enabled: true
       attributes: []
     oracledb.hard_parses:
+      enabled: true
+    oracledb.hard_parses.rate:
       enabled: true
     oracledb.host.cpu.usage.rate:
       enabled: true
@@ -411,6 +436,8 @@ reaggregate_set:
     oracledb.logical_reads.rate:
       enabled: true
     oracledb.logons:
+      enabled: true
+    oracledb.logons.rate:
       enabled: true
     oracledb.os.swaps:
       enabled: true
@@ -567,6 +594,9 @@ reaggregate_set:
       enabled: true
     oracledb.transactions.limit:
       enabled: true
+    oracledb.transactions.rate:
+      enabled: true
+      attributes: []
     oracledb.transactions.usage:
       enabled: true
     oracledb.user_commits:
@@ -639,6 +669,8 @@ none_set:
       enabled: false
     oracledb.cursor.open:
       enabled: false
+    oracledb.cursor.open.rate:
+      enabled: false
     oracledb.data_dictionary.hit_ratio:
       enabled: false
     oracledb.database.cpu.utilization:
@@ -658,9 +690,13 @@ none_set:
       enabled: false
     oracledb.dml_statements_parallelized:
       enabled: false
+    oracledb.enqueue.deadlocks.rate:
+      enabled: false
     oracledb.enqueue.operations:
       enabled: false
       attributes: ["oracledb.enqueue.type"]
+    oracledb.enqueue.timeouts.rate:
+      enabled: false
     oracledb.enqueue_deadlocks:
       enabled: false
     oracledb.enqueue_locks.limit:
@@ -678,10 +714,14 @@ none_set:
       attributes: ["oracledb.parse.type"]
     oracledb.executions:
       enabled: false
+    oracledb.executions.rate:
+      enabled: false
     oracledb.gc.current_block.time:
       enabled: false
       attributes: ["network.io.direction"]
     oracledb.hard_parses:
+      enabled: false
+    oracledb.hard_parses.rate:
       enabled: false
     oracledb.host.cpu.usage.rate:
       enabled: false
@@ -712,6 +752,8 @@ none_set:
     oracledb.logical_reads.rate:
       enabled: false
     oracledb.logons:
+      enabled: false
+    oracledb.logons.rate:
       enabled: false
     oracledb.os.swaps:
       enabled: false
@@ -868,6 +910,9 @@ none_set:
       enabled: false
     oracledb.transactions.limit:
       enabled: false
+    oracledb.transactions.rate:
+      enabled: false
+      attributes: ["oracledb.transaction.type"]
     oracledb.transactions.usage:
       enabled: false
     oracledb.user_commits:

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -333,6 +333,10 @@ attributes:
   oracledb.status:
     description: Execution state or result of a database query or session.
     type: string
+  oracledb.transaction.type:
+    description: The type of user transaction.
+    type: string
+    enum: [commit, rollback]
   oracledb.user_io_wait_time:
     description: The total time (in seconds) a query spent waiting for user I/O operations—such as reading or writing data to disk or network file systems (reporting delta).
     type: double
@@ -614,6 +618,13 @@ metrics:
       value_type: int
       input_type: string
     unit: "{cursor}"
+  oracledb.cursor.open.rate:
+    description: Rate of cursors opened.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{cursor}/s"
   oracledb.data_dictionary.hit_ratio:
     description: Data dictionary cache hit ratio from v$rowcache.
     enabled: false
@@ -691,6 +702,13 @@ metrics:
       value_type: int
       input_type: string
     unit: "{statements}"
+  oracledb.enqueue.deadlocks.rate:
+    description: Rate of enqueue deadlocks.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{deadlock}/s"
   oracledb.enqueue.operations:
     description: Total count of enqueue (lock) operations.
     enabled: false
@@ -702,6 +720,13 @@ metrics:
       input_type: string
     unit: "{operation}"
     attributes: [oracledb.enqueue.type]
+  oracledb.enqueue.timeouts.rate:
+    description: Rate of enqueue timeouts.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{timeout}/s"
   oracledb.enqueue_deadlocks:
     description: Total number of deadlocks between table or row locks in different sessions.
     enabled: true
@@ -773,6 +798,13 @@ metrics:
       value_type: int
       input_type: string
     unit: "{executions}"
+  oracledb.executions.rate:
+    description: Rate of SQL statement executions.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{execution}/s"
   oracledb.gc.current_block.time:
     attributes:
       - network.io.direction
@@ -794,6 +826,13 @@ metrics:
       value_type: int
       input_type: string
     unit: "{parses}"
+  oracledb.hard_parses.rate:
+    description: Rate of hard parses.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{parse}/s"
   oracledb.host.cpu.usage.rate:
     description: Host CPU consumption rate across all cores, in CPU-seconds used per second.
     enabled: false
@@ -909,6 +948,13 @@ metrics:
       value_type: int
       input_type: string
     unit: "{operation}"
+  oracledb.logons.rate:
+    description: Rate of logon operations.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{logon}/s"
   oracledb.os.swaps:
     description: Number of OS swap operations.
     enabled: false
@@ -1517,6 +1563,14 @@ metrics:
       value_type: int
       input_type: string
     unit: "{transactions}"
+  oracledb.transactions.rate:
+    description: Rate of user transactions.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: double
+    unit: "{transaction}/s"
+    attributes: [oracledb.transaction.type]
   oracledb.transactions.usage:
     description: Current count of active transactions.
     enabled: true

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -75,6 +75,16 @@ const (
 	sysmetricPhysicalWritesPerSec               = "Physical Writes Per Sec"
 	sysmetricRedoGeneratedPerSec                = "Redo Generated Per Sec" // #nosec G101 -- Oracle V$SYSMETRIC metric name, not a credential
 
+	// V$SYSMETRIC workload rates (group_id=2, ~60s interval)
+	sysmetricEnqueueDeadlocksPerSec = "Enqueue Deadlocks Per Sec"
+	sysmetricEnqueueTimeoutsPerSec  = "Enqueue Timeouts Per Sec"
+	sysmetricExecutionsPerSec       = "Executions Per Sec"
+	sysmetricHardParseCountPerSec   = "Hard Parse Count Per Sec"
+	sysmetricLogonsPerSec           = "Logons Per Sec"
+	sysmetricOpenCursorsPerSec      = "Open Cursors Per Sec"
+	sysmetricUserCommitsPerSec      = "User Commits Per Sec"
+	sysmetricUserRollbacksPerSec    = "User Rollbacks Per Sec"
+
 	consistentGets                 = "consistent gets"
 	cpuTime                        = "CPU used by this session"
 	dbBlockGets                    = "db block gets"
@@ -1265,7 +1275,14 @@ func (s *oracleScraper) collectSysMetrics(ctx context.Context, scrapeErrors *[]e
 		s.metricsBuilderConfig.Metrics.OracledbPhysicalIoRequestsRate.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbPhysicalIoTransferredRate.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbPhysicalOperationsRate.Enabled ||
-		s.metricsBuilderConfig.Metrics.OracledbRedoSizeRate.Enabled
+		s.metricsBuilderConfig.Metrics.OracledbRedoSizeRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbCursorOpenRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbEnqueueDeadlocksRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbEnqueueTimeoutsRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbExecutionsRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbHardParsesRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbLogonsRate.Enabled ||
+		s.metricsBuilderConfig.Metrics.OracledbTransactionsRate.Enabled
 	if !anySysmetricEnabled {
 		return
 	}
@@ -1408,6 +1425,39 @@ func (s *oracleScraper) collectSysMetrics(ctx context.Context, scrapeErrors *[]e
 		case sysmetricRedoGeneratedPerSec:
 			if s.metricsBuilderConfig.Metrics.OracledbRedoSizeRate.Enabled {
 				s.mb.RecordOracledbRedoSizeRateDataPoint(now, val)
+			}
+		// V$SYSMETRIC workload rates
+		case sysmetricEnqueueDeadlocksPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbEnqueueDeadlocksRate.Enabled {
+				s.mb.RecordOracledbEnqueueDeadlocksRateDataPoint(now, val)
+			}
+		case sysmetricEnqueueTimeoutsPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbEnqueueTimeoutsRate.Enabled {
+				s.mb.RecordOracledbEnqueueTimeoutsRateDataPoint(now, val)
+			}
+		case sysmetricExecutionsPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbExecutionsRate.Enabled {
+				s.mb.RecordOracledbExecutionsRateDataPoint(now, val)
+			}
+		case sysmetricHardParseCountPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbHardParsesRate.Enabled {
+				s.mb.RecordOracledbHardParsesRateDataPoint(now, val)
+			}
+		case sysmetricLogonsPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbLogonsRate.Enabled {
+				s.mb.RecordOracledbLogonsRateDataPoint(now, val)
+			}
+		case sysmetricOpenCursorsPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbCursorOpenRate.Enabled {
+				s.mb.RecordOracledbCursorOpenRateDataPoint(now, val)
+			}
+		case sysmetricUserCommitsPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbTransactionsRate.Enabled {
+				s.mb.RecordOracledbTransactionsRateDataPoint(now, val, metadata.AttributeOracledbTransactionTypeCommit)
+			}
+		case sysmetricUserRollbacksPerSec:
+			if s.metricsBuilderConfig.Metrics.OracledbTransactionsRate.Enabled {
+				s.mb.RecordOracledbTransactionsRateDataPoint(now, val, metadata.AttributeOracledbTransactionTypeRollback)
 			}
 		}
 	}

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -196,6 +196,14 @@ var queryResponses = map[string][]metricRow{
 		{"METRIC_NAME": "Physical Write Total IO Requests Per Sec", "VALUE": "17.0"},
 		{"METRIC_NAME": "Physical Writes Per Sec", "VALUE": "64.0"},
 		{"METRIC_NAME": "Redo Generated Per Sec", "VALUE": "2048.0"},
+		{"METRIC_NAME": "Enqueue Deadlocks Per Sec", "VALUE": "0.05"},
+		{"METRIC_NAME": "Enqueue Timeouts Per Sec", "VALUE": "0.50"},
+		{"METRIC_NAME": "Executions Per Sec", "VALUE": "1500.50"},
+		{"METRIC_NAME": "Hard Parse Count Per Sec", "VALUE": "3.75"},
+		{"METRIC_NAME": "Logons Per Sec", "VALUE": "1.20"},
+		{"METRIC_NAME": "Open Cursors Per Sec", "VALUE": "42.10"},
+		{"METRIC_NAME": "User Commits Per Sec", "VALUE": "85.60"},
+		{"METRIC_NAME": "User Rollbacks Per Sec", "VALUE": "2.40"},
 	},
 }
 
@@ -1473,6 +1481,13 @@ func TestScraper_ScrapeSysMetrics(t *testing.T) {
 			cfg.Metrics.OracledbPhysicalIoTransferredRate.Enabled = true
 			cfg.Metrics.OracledbPhysicalOperationsRate.Enabled = true
 			cfg.Metrics.OracledbRedoSizeRate.Enabled = true
+			cfg.Metrics.OracledbCursorOpenRate.Enabled = true
+			cfg.Metrics.OracledbEnqueueDeadlocksRate.Enabled = true
+			cfg.Metrics.OracledbEnqueueTimeoutsRate.Enabled = true
+			cfg.Metrics.OracledbExecutionsRate.Enabled = true
+			cfg.Metrics.OracledbHardParsesRate.Enabled = true
+			cfg.Metrics.OracledbLogonsRate.Enabled = true
+			cfg.Metrics.OracledbTransactionsRate.Enabled = true
 
 			scrpr := oracleScraper{
 				logger: zap.NewNop(),
@@ -1554,6 +1569,32 @@ func TestScraper_ScrapeSysMetrics(t *testing.T) {
 			assert.InDelta(t, 17.0, dirMap["oracledb.physical_io.requests.rate"]["write"], floatDelta)
 			assert.InDelta(t, 128.0, dirMap["oracledb.physical_operations.rate"]["read"], floatDelta)
 			assert.InDelta(t, 64.0, dirMap["oracledb.physical_operations.rate"]["write"], floatDelta)
+
+			// V$SYSMETRIC workload rates.
+			assert.InDelta(t, 1500.50, metricMap["oracledb.executions.rate"], floatDelta)
+			assert.InDelta(t, 3.75, metricMap["oracledb.hard_parses.rate"], floatDelta)
+			assert.InDelta(t, 42.10, metricMap["oracledb.cursor.open.rate"], floatDelta)
+			assert.InDelta(t, 1.20, metricMap["oracledb.logons.rate"], floatDelta)
+			assert.InDelta(t, 0.50, metricMap["oracledb.enqueue.timeouts.rate"], floatDelta)
+			assert.InDelta(t, 0.05, metricMap["oracledb.enqueue.deadlocks.rate"], floatDelta)
+
+			// oracledb.transactions.rate carries commit and rollback data points.
+			txnRates := make(map[string]float64)
+			for i := 0; i < metrics.Len(); i++ {
+				metric := metrics.At(i)
+				if metric.Name() != "oracledb.transactions.rate" {
+					continue
+				}
+				dps := metric.Gauge().DataPoints()
+				for j := 0; j < dps.Len(); j++ {
+					dp := dps.At(j)
+					txnType, ok := dp.Attributes().Get("oracledb.transaction.type")
+					require.True(t, ok)
+					txnRates[txnType.Str()] = dp.DoubleValue()
+				}
+			}
+			assert.InDelta(t, 85.60, txnRates["commit"], floatDelta)
+			assert.InDelta(t, 2.40, txnRates["rollback"], floatDelta)
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Cumulative workload counters are already exposed (for example `oracledb.executions`, `oracledb.hard_parses`, `oracledb.logons`, `oracledb.enqueue.operations`, `oracledb.cursor.open`), but none of Oracle's pre-computed **per-second workload rates** from `v$sysmetric` — the executions/s, hard-parses/s, transactions/s and enqueue-timeouts/s figures Oracle Enterprise Manager and AWR display, which operators use to triage load.

This change adds **7 new opt-in gauge metrics** (disabled by default, `stability: development`), all sourced from the existing `v$sysmetric` query (`SELECT metric_name, value FROM v$sysmetric WHERE group_id = 2`, added in #49096) via new `case` branches in the existing `collectSysMetrics` method — **no new SQL**. Commit and rollback rates are consolidated into one metric with a new `oracledb.transaction.type` attribute:

| Metric | Type | Unit | Attribute | Source `v$sysmetric` METRIC_NAME |
|---|---|---|---|---|
| `oracledb.executions.rate` | Gauge (double) | `{execution}/s` | — | Executions Per Sec |
| `oracledb.hard_parses.rate` | Gauge (double) | `{parse}/s` | — | Hard Parse Count Per Sec |
| `oracledb.cursor.open.rate` | Gauge (double) | `{cursor}/s` | — | Open Cursors Per Sec |
| `oracledb.logons.rate` | Gauge (double) | `{logon}/s` | — | Logons Per Sec |
| `oracledb.transactions.rate` | Gauge (double) | `{transaction}/s` | `oracledb.transaction.type` (commit, rollback) | User Commits Per Sec / User Rollbacks Per Sec |
| `oracledb.enqueue.timeouts.rate` | Gauge (double) | `{timeout}/s` | — | Enqueue Timeouts Per Sec |
| `oracledb.enqueue.deadlocks.rate` | Gauge (double) | `{deadlock}/s` | — | Enqueue Deadlocks Per Sec |

These are forwarded native Gauge values — Oracle's MMON computes the per-second rate; the receiver performs no rate math or unit conversion. Each per-second metric carries a `.rate` suffix on the stem of its cumulative counterpart so the gauge is unambiguously distinct from the counter. Oracle's separate *User Commits Per Sec* and *User Rollbacks Per Sec* are consolidated into `oracledb.transactions.rate` with an `oracledb.transaction.type` attribute (following the receiver's `oracledb.enqueue.operations` + `oracledb.enqueue.type` and `oracledb.call.count` + `oracledb.call.type` convention); the standalone *User Transaction Per Sec* is dropped as redundant with the sum over the attribute.

**New attribute:** `oracledb.transaction.type` (enum: `commit`, `rollback`).

These metrics can be enabled in the collector configuration:

```yaml
receivers:
  oracledb:
    datasource: "oracle://user:password@host:1521/service"
    metrics:
      oracledb.executions.rate:
        enabled: true
      oracledb.hard_parses.rate:
        enabled: true
      oracledb.cursor.open.rate:
        enabled: true
      oracledb.logons.rate:
        enabled: true
      oracledb.transactions.rate:
        enabled: true
      oracledb.enqueue.timeouts.rate:
        enabled: true
      oracledb.enqueue.deadlocks.rate:
        enabled: true
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49749

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`TestScraper_ScrapeSysMetrics` in `scraper_test.go` is extended to enable and exercise all 7 new metrics through the scraper using the existing fake DB client, with new fake `v$sysmetric` rows (one per source `METRIC_NAME`, including both commit and rollback rows for `oracledb.transactions.rate`). The test asserts one expected value per data point, including the commit/rollback split via the `oracledb.transaction.type` attribute. Auto-generated tests in `internal/metadata/generated_metrics_test.go` and `generated_config_test.go` are regenerated by `make generate`.

<!--Describe the documentation added.-->
#### Documentation
Auto-generated `documentation.md` updated with descriptions and metadata for the 7 new metrics and the new `oracledb.transaction.type` attribute. `internal/metadata/generated_*.go` and `internal/metadata/testdata/config.yaml` regenerated via `make generate`. `internal/metadata/config.schema.yaml` was updated by hand with the 7 new metric stanzas, as that file is not produced by `make generate`.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
