### PR TITLE
[receiver/statsd] Fix timing explicit bucket mapping

### DIFF
--- a/.chloggen/49747-statsd-timing-explicit-buckets.yaml
+++ b/.chloggen/49747-statsd-timing-explicit-buckets.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: receiver/statsd
+
+note: Fix explicit bucket histogram mapping for StatsD timing metrics.
+
+issues: [49747]
+
+change_logs: [user]

--- a/receiver/statsdreceiver/internal/parser/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser.go
@@ -228,7 +228,7 @@ func (p *StatsDParser) Initialize(enableMetricType, enableSimpleTags, isMonotoni
 		case protocol.TimingTypeName, protocol.TimingAltTypeName:
 			p.timerEvents.method = eachMap.ObserverType
 			if eachMap.Histogram.ExplicitBuckets != nil {
-				p.histogramEvents.explicitBucketConfigs = explicitBucketInitializeRegex(eachMap.Histogram)
+				p.timerEvents.explicitBucketConfigs = explicitBucketInitializeRegex(eachMap.Histogram)
 			}
 			p.timerEvents.histogramConfig = expoHistogramConfig(eachMap.Histogram)
 			p.timerEvents.summaryPercentiles = eachMap.Summary.Percentiles

--- a/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
@@ -2169,6 +2169,60 @@ func TestStatsDParser_HistogramExplicitBucket(t *testing.T) {
 	}
 }
 
+func TestStatsDParser_TimingExplicitBucket(t *testing.T) {
+	originalTimeNowFunc := timeNowFunc
+	timeNowFunc = func() time.Time {
+		return time.Unix(711, 0)
+	}
+	t.Cleanup(func() {
+		timeNowFunc = originalTimeNowFunc
+	})
+
+	expected := pmetric.NewMetrics()
+	ilm := expected.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	m := ilm.Metrics().AppendEmpty()
+	m.SetName("timer.duration")
+	histogram := m.SetEmptyHistogram()
+	histogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := histogram.DataPoints().AppendEmpty()
+	dp.SetCount(4)
+	dp.SetSum(555.5)
+	dp.SetMin(0.5)
+	dp.SetMax(500)
+	dp.BucketCounts().FromRaw([]uint64{1, 1, 1, 1})
+	dp.ExplicitBounds().FromRaw([]float64{1, 10, 100})
+
+	p := &StatsDParser{}
+	require.NoError(t, p.Initialize(false, false, false, false, false, []protocol.TimerHistogramMapping{
+		{
+			StatsdType:   "timing",
+			ObserverType: "histogram",
+			Histogram: protocol.HistogramConfig{
+				ExplicitBuckets: []protocol.ExplicitBucket{
+					{
+						MatcherPattern: "timer.*",
+						Buckets:        []float64{1, 10, 100},
+					},
+				},
+				MaxSize: 10,
+			},
+		},
+	}, protocol.CounterTypeInt))
+
+	addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+	for _, input := range []string{
+		"timer.duration:0.5|ms",
+		"timer.duration:5|ms",
+		"timer.duration:50|ms",
+		"timer.duration:500|ms",
+	} {
+		require.NoError(t, p.Aggregate(input, addr))
+	}
+
+	var nodiffs []*metricstestutil.MetricDiff
+	assert.Equal(t, nodiffs, metricstestutil.DiffMetrics(nodiffs, expected, p.GetMetrics()[0].Metrics))
+}
+
 func TestStatsDParser_IPOnlyAggregation(t *testing.T) {
 	const devVersion = "dev-0.0.1"
 	p := &StatsDParser{


### PR DESCRIPTION
#### Description
- Timing metrics with explicit_buckets were not using the configured buckets.
- The parser was putting those bucket configs on the histogram path instead of the timing path.
- The fix stores them on timerEvents.

#### Link to tracking issue
Fixes #49747

#### Testing
- `go test ./internal/parser -run 'TestStatsDParser_(TimingExplicitBucket|HistogramExplicitBucket)'`
- `go test ./...`

#### Documentation
No documentation changes were needed. This is a bug fix for the existing StatsD timing histogram mapping behavior.

#### Authorship
- [x] I, a human, wrote this pull request description myself.