### PR TITLE
[cmd/opampsupervisor] chore: Add `tar.gz` Extractor type

### DIFF
--- a/.chloggen/dpaasman00_supervisor-targz-archive.yaml
+++ b/.chloggen/dpaasman00_supervisor-targz-archive.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add tar.gz archive support and the agent_binary configuration for collector package upgrades.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dpaasman00_targz-archive-mvp.yaml
+++ b/.chloggen/dpaasman00_targz-archive-mvp.yaml
@@ -10,7 +10,7 @@ component: cmd/opampsupervisor
 note: Add tar.gz archive support and the agent_binary configuration for collector package upgrades.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [49766]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -186,6 +186,15 @@ agent:
   # OpAmp extension will connect to
   opamp_server_port:
 
+  # Optional configuration for how collector executable updates are identified
+  # and verified. The archive format is not configured here; the supervisor
+  # detects it from the download URL and Content-Type header.
+  # NOTE: This functionality is not yet fully implemented.
+  package:
+    # Name of the collector binary as it appears inside the archive the supervisor
+    # downloads. Used to locate the binary in archives that bundle multiple files.
+    agent_binary: "otelcol-contrib"
+
   # List of paths to fallback configuration files to use when the OpAMP server is
   # unreachable. If more than one path is specified, they are merged in order.
   # Together, these must be complete, standalone Collector configuration.

--- a/cmd/opampsupervisor/supervisor/archive/archive.go
+++ b/cmd/opampsupervisor/supervisor/archive/archive.go
@@ -47,7 +47,7 @@ func NewExtractor(format Format) (Extractor, error) {
 	case FormatNone:
 		return rawExtractor{maxBytes: maxAgentBytes}, nil
 	case FormatTarGzip:
-		return tarGzipExtractor{}, nil
+		return tarGzipExtractor{maxBytes: maxAgentBytes}, nil
 	default:
 		return nil, fmt.Errorf("unsupported archive format: %q", string(format))
 	}
@@ -84,9 +84,15 @@ var _ Extractor = tarGzipExtractor{}
 
 // tarGzipExtractor extracts the file named binaryName from a gzipped tarball and
 // writes it to destination.
-type tarGzipExtractor struct{}
+type tarGzipExtractor struct {
+	// maxBytes is the maximum binary size the extractor will write. The size a
+	// tar header declares is the decompressed size of its entry, and tar.Reader
+	// returns at most that many bytes, so entries declaring more than maxBytes
+	// are rejected before anything is written.
+	maxBytes int64
+}
 
-func (tarGzipExtractor) Extract(_ context.Context, pkg []byte, binaryName, destination string) error {
+func (e tarGzipExtractor) Extract(_ context.Context, pkg []byte, binaryName, destination string) error {
 	if binaryName == "" {
 		return errors.New("agent binary name is required for tar.gz archives")
 	}
@@ -103,9 +109,13 @@ func (tarGzipExtractor) Extract(_ context.Context, pkg []byte, binaryName, desti
 		if err != nil {
 			return fmt.Errorf("read tarball looking for %q: %w", binaryName, err)
 		}
-		if header.Name == binaryName {
-			break
+		if header.Name != binaryName {
+			continue
 		}
+		if header.Size > e.maxBytes {
+			return fmt.Errorf("binary exceeds maximum size of %d bytes", e.maxBytes)
+		}
+		break
 	}
 
 	if err := writeBinaryToDestination(tarReader, destination); err != nil {
@@ -116,7 +126,8 @@ func (tarGzipExtractor) Extract(_ context.Context, pkg []byte, binaryName, desti
 }
 
 // writeBinaryToDestination writes binary to destination, creating or truncating
-// the file with executable permissions. At most maxAgentBytes are written.
+// the file with executable permissions. If an error occurs during write, the
+// file at destination will be removed.
 func writeBinaryToDestination(binary io.Reader, destination string) error {
 	f, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o700)
 	if err != nil {
@@ -124,7 +135,8 @@ func writeBinaryToDestination(binary io.Reader, destination string) error {
 	}
 	defer f.Close()
 
-	if _, err := io.CopyN(f, binary, maxAgentBytes); err != nil && !errors.Is(err, io.EOF) {
+	if _, err := io.Copy(f, binary); err != nil {
+		_ = os.Remove(destination)
 		return fmt.Errorf("write binary to destination: %w", err)
 	}
 

--- a/cmd/opampsupervisor/supervisor/archive/archive.go
+++ b/cmd/opampsupervisor/supervisor/archive/archive.go
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package archive extracts collector executable updates from downloaded
-// packages, dispatching on the configured archive format.
+// packages, dispatching on the archive format.
 package archive
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -15,21 +20,24 @@ import (
 // to disk during an install. It guards against unbounded writes.
 const maxAgentBytes = 1 << 30 // 1 GiB
 
-// Format is the format of the package downloaded by the supervisor. Additional
-// formats (e.g. tar.gz) are added in later PRs; for now only the no-archive
-// format (a raw binary) is supported.
+// Format is the format of the package downloaded by the supervisor.
 type Format string
 
 const (
 	// FormatNone treats the downloaded package as a raw collector binary with no
 	// archive wrapping.
 	FormatNone Format = ""
+	// FormatTarGzip treats the downloaded package as a gzipped tarball containing
+	// the collector binary.
+	FormatTarGzip Format = "tar.gz"
 )
 
 // Extractor extracts the agent binary from a downloaded package.
 type Extractor interface {
-	// Extract writes the agent binary contained in pkg to destination.
-	Extract(ctx context.Context, pkg []byte, destination string) error
+	// Extract writes the agent binary contained in pkg to destination. binaryName
+	// identifies which file inside the package is the agent binary for formats that
+	// bundle multiple files; it is ignored for raw binaries.
+	Extract(ctx context.Context, pkg []byte, binaryName, destination string) error
 }
 
 // NewExtractor returns the Extractor for the given archive format, or an error if
@@ -38,6 +46,8 @@ func NewExtractor(format Format) (Extractor, error) {
 	switch format {
 	case FormatNone:
 		return rawExtractor{maxBytes: maxAgentBytes}, nil
+	case FormatTarGzip:
+		return tarGzipExtractor{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported archive format: %q", string(format))
 	}
@@ -56,7 +66,7 @@ type rawExtractor struct {
 // Extract writes the raw bytes by creating or truncating the file at destination.
 // It is the responsibility of the caller to ensure nothing of importance is overwritten.
 // If an error occurs during write, the file at destination will be removed.
-func (r rawExtractor) Extract(_ context.Context, pkg []byte, destination string) error {
+func (r rawExtractor) Extract(_ context.Context, pkg []byte, _, destination string) error {
 	if int64(len(pkg)) > r.maxBytes {
 		return fmt.Errorf("binary exceeds maximum size of %d bytes", r.maxBytes)
 	}
@@ -64,6 +74,57 @@ func (r rawExtractor) Extract(_ context.Context, pkg []byte, destination string)
 	// Create or truncate the destination with executable permissions.
 	if err := os.WriteFile(destination, pkg, 0o700); err != nil { //nolint:gosec // G306: the agent binary must be executable
 		_ = os.Remove(destination)
+		return fmt.Errorf("write binary to destination: %w", err)
+	}
+
+	return nil
+}
+
+var _ Extractor = tarGzipExtractor{}
+
+// tarGzipExtractor extracts the file named binaryName from a gzipped tarball and
+// writes it to destination.
+type tarGzipExtractor struct{}
+
+func (tarGzipExtractor) Extract(_ context.Context, pkg []byte, binaryName, destination string) error {
+	if binaryName == "" {
+		return errors.New("agent binary name is required for tar.gz archives")
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(pkg))
+	if err != nil {
+		return fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			return fmt.Errorf("read tarball looking for %q: %w", binaryName, err)
+		}
+		if header.Name == binaryName {
+			break
+		}
+	}
+
+	if err := writeBinaryToDestination(tarReader, destination); err != nil {
+		return fmt.Errorf("write binary to destination: %w", err)
+	}
+
+	return nil
+}
+
+// writeBinaryToDestination writes binary to destination, creating or truncating
+// the file with executable permissions. At most maxAgentBytes are written.
+func writeBinaryToDestination(binary io.Reader, destination string) error {
+	f, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o700)
+	if err != nil {
+		return fmt.Errorf("open destination file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.CopyN(f, binary, maxAgentBytes); err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("write binary to destination: %w", err)
 	}
 

--- a/cmd/opampsupervisor/supervisor/archive/archive_test.go
+++ b/cmd/opampsupervisor/supervisor/archive/archive_test.go
@@ -130,7 +130,7 @@ func TestTarGzipExtractor_Extract(t *testing.T) {
 		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
 		archive := createTarGzArchive(t, map[string][]byte{"otelcol-contrib": []byte("binary")})
 
-		err := tarGzipExtractor{}.Extract(t.Context(), archive, "", destination)
+		err := tarGzipExtractor{maxBytes: maxAgentBytes}.Extract(t.Context(), archive, "", destination)
 		require.ErrorContains(t, err, "agent binary name is required")
 	})
 
@@ -138,15 +138,29 @@ func TestTarGzipExtractor_Extract(t *testing.T) {
 		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
 		archive := createTarGzArchive(t, map[string][]byte{"some-other-file": []byte("binary")})
 
-		err := tarGzipExtractor{}.Extract(t.Context(), archive, "otelcol-contrib", destination)
+		err := tarGzipExtractor{maxBytes: maxAgentBytes}.Extract(t.Context(), archive, "otelcol-contrib", destination)
 		require.ErrorContains(t, err, `read tarball looking for "otelcol-contrib"`)
 	})
 
 	t.Run("not a gzip archive", func(t *testing.T) {
 		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
 
-		err := tarGzipExtractor{}.Extract(t.Context(), []byte("not gzip data"), "otelcol-contrib", destination)
+		err := tarGzipExtractor{maxBytes: maxAgentBytes}.Extract(t.Context(), []byte("not gzip data"), "otelcol-contrib", destination)
 		require.ErrorContains(t, err, "create gzip reader")
+	})
+
+	t.Run("binary exceeds max size", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
+		archive := createTarGzArchive(t, map[string][]byte{
+			"otelcol-contrib": []byte("contents larger than the configured cap"),
+		})
+
+		err := tarGzipExtractor{maxBytes: 8}.Extract(t.Context(), archive, "otelcol-contrib", destination)
+		require.ErrorContains(t, err, "binary exceeds maximum size of 8 bytes")
+
+		// The size check happens before the destination is opened.
+		_, statErr := os.Stat(destination)
+		require.True(t, os.IsNotExist(statErr))
 	})
 }
 

--- a/cmd/opampsupervisor/supervisor/archive/archive_test.go
+++ b/cmd/opampsupervisor/supervisor/archive/archive_test.go
@@ -4,7 +4,9 @@
 package archive
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,23 +20,19 @@ func TestNewExtractor(t *testing.T) {
 		name      string
 		format    Format
 		expectErr string
-		expectNil bool
 	}{
 		{
 			name:   "no archive returns raw extractor",
 			format: FormatNone,
 		},
 		{
-			name:      "tar.gz is not yet supported",
-			format:    Format("tar.gz"),
-			expectErr: "unsupported archive format",
-			expectNil: true,
+			name:   "tar.gz returns tar.gz installer",
+			format: FormatTarGzip,
 		},
 		{
 			name:      "unsupported archive format",
 			format:    Format("zip"),
 			expectErr: "unsupported archive format",
-			expectNil: true,
 		},
 	}
 
@@ -59,7 +57,7 @@ func TestRawExtractor_Extract(t *testing.T) {
 	extractor, err := NewExtractor(FormatNone)
 	require.NoError(t, err)
 
-	require.NoError(t, extractor.Extract(t.Context(), contents, destination))
+	require.NoError(t, extractor.Extract(t.Context(), contents, "otelcol-contrib", destination))
 
 	written, err := os.ReadFile(destination)
 	require.NoError(t, err)
@@ -95,7 +93,7 @@ func TestRawExtractor_Extract_Size(t *testing.T) {
 			contents := bytes.Repeat([]byte("a"), tc.size)
 
 			extractor := rawExtractor{maxBytes: maxBytes}
-			err := extractor.Extract(t.Context(), contents, destination)
+			err := extractor.Extract(t.Context(), contents, "otelcol-contrib", destination)
 			if tc.expectErr != "" {
 				require.ErrorContains(t, err, tc.expectErr)
 				return
@@ -107,4 +105,72 @@ func TestRawExtractor_Extract_Size(t *testing.T) {
 			assert.Equal(t, contents, written)
 		})
 	}
+}
+
+func TestTarGzipExtractor_Extract(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
+		contents := []byte("collector binary inside a tarball")
+		archive := createTarGzArchive(t, map[string][]byte{
+			"README.md":       []byte("not the binary"),
+			"otelcol-contrib": contents,
+		})
+
+		extractor, err := NewExtractor(FormatTarGzip)
+		require.NoError(t, err)
+
+		require.NoError(t, extractor.Extract(t.Context(), archive, "otelcol-contrib", destination))
+
+		written, err := os.ReadFile(destination)
+		require.NoError(t, err)
+		assert.Equal(t, contents, written)
+	})
+
+	t.Run("missing binary name", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
+		archive := createTarGzArchive(t, map[string][]byte{"otelcol-contrib": []byte("binary")})
+
+		err := tarGzipExtractor{}.Extract(t.Context(), archive, "", destination)
+		require.ErrorContains(t, err, "agent binary name is required")
+	})
+
+	t.Run("binary not in archive", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
+		archive := createTarGzArchive(t, map[string][]byte{"some-other-file": []byte("binary")})
+
+		err := tarGzipExtractor{}.Extract(t.Context(), archive, "otelcol-contrib", destination)
+		require.ErrorContains(t, err, `read tarball looking for "otelcol-contrib"`)
+	})
+
+	t.Run("not a gzip archive", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "otelcol-contrib")
+
+		err := tarGzipExtractor{}.Extract(t.Context(), []byte("not gzip data"), "otelcol-contrib", destination)
+		require.ErrorContains(t, err, "create gzip reader")
+	})
+}
+
+// createTarGzArchive builds an in-memory gzipped tarball containing the given
+// files (name -> contents).
+func createTarGzArchive(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	for name, contents := range files {
+		require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o755,
+			Size: int64(len(contents)),
+		}))
+		_, err := tarWriter.Write(contents)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	return buf.Bytes()
 }

--- a/cmd/opampsupervisor/supervisor/config/agent_package.go
+++ b/cmd/opampsupervisor/supervisor/config/agent_package.go
@@ -6,10 +6,14 @@ package config
 import "fmt"
 
 // AgentPackage describes how collector executable updates downloaded by the
-// supervisor are verified. The archive format is not configured here; the
-// supervisor detects it at update time from the download URL and Content-Type
-// header.
+// supervisor are identified and verified. The archive format is not configured
+// here; the supervisor detects it at update time from the download URL and
+// Content-Type header.
 type AgentPackage struct {
+	// AgentBinary is the name of the collector binary as it appears inside the
+	// downloaded archive. Used to locate the binary in archives that bundle
+	// multiple files (e.g. tar.gz).
+	AgentBinary string `mapstructure:"agent_binary"`
 	// Verifier configures how downloaded packages are verified.
 	Verifier Verifier `mapstructure:"verifier"`
 	// prevent unkeyed literal initialization

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -452,6 +452,11 @@ func DefaultSupervisor() Supervisor {
 		defaultStorageDir = filepath.Join(programDataDir, "Otelcol", "Supervisor")
 	}
 
+	defaultAgentBinary := "otelcol-contrib"
+	if runtime.GOOS == "windows" {
+		defaultAgentBinary += ".exe"
+	}
+
 	serverConfig := confighttp.NewDefaultServerConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
 	serverConfig.WriteTimeout = 0
@@ -488,7 +493,8 @@ func DefaultSupervisor() Supervisor {
 			CollectorCrashLogSnippetKiB: 0,
 			ValidateConfig:              false,
 			Package: AgentPackage{
-				Verifier: Verifier{Type: VerifierTypeNone},
+				AgentBinary: defaultAgentBinary,
+				Verifier:    Verifier{Type: VerifierTypeNone},
 			},
 		},
 		Telemetry: Telemetry{

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -1119,6 +1119,8 @@ agent:
   passthrough_logs: true
   automatic_config_rollback: true
   collector_crash_log_snippet_kib: 100
+  package:
+    agent_binary: custom-otelcol
 
 telemetry:
   logs:
@@ -1170,7 +1172,10 @@ telemetry:
 						CollectorCrashLogSnippetKiB: 100,
 						AutomaticConfigRollback:     true,
 						ValidateConfig:              DefaultSupervisor().Agent.ValidateConfig,
-						Package:                     DefaultSupervisor().Agent.Package,
+						Package: AgentPackage{
+							AgentBinary: "custom-otelcol",
+							Verifier:    DefaultSupervisor().Agent.Package.Verifier,
+						},
 					},
 					Telemetry: Telemetry{
 						Logs: Logs{

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -635,28 +635,6 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErrorFunc: simpleError("unsupported verifier type"),
 		},
-		{
-			name: "Package with unsupported verifier type (cosign not yet supported)",
-			config: Supervisor{
-				Server: OpAMPServer{
-					Endpoint: "wss://localhost:9090/opamp",
-					TLS:      tlsConfig,
-				},
-				Agent: Agent{
-					Executable:              "${file_path}",
-					OrphanDetectionInterval: 5 * time.Second,
-					ConfigApplyTimeout:      2 * time.Second,
-					BootstrapTimeout:        5 * time.Second,
-					Package: AgentPackage{
-						Verifier: Verifier{Type: "cosign"},
-					},
-				},
-				Capabilities: Capabilities{AcceptsRemoteConfig: true},
-				Storage:      Storage{Directory: "/etc/opamp-supervisor/storage"},
-				HealthCheck:  defaultHealthCheck,
-			},
-			expectedErrorFunc: simpleError("unsupported verifier type"),
-		},
 	}
 
 	// create some fake files for validating agent config


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds a new extractor type for supervisor upgrades. This extractor is capable of pulling a collector binary out of a `tar.gz` artifact. This is the artifact generated by the OTel releases repo for collector releases. This will be the default extractor used.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Closes #49766

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Unit tests updated

<!--Describe the documentation added.-->
#### Documentation
- Documentation added

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
