### PR TITLE
[cmd/opampsupervisor] chore: Unify package capability config options

### DIFF
--- a/.chloggen/dpaasman00_unify-upgrade-capabilities.yaml
+++ b/.chloggen/dpaasman00_unify-upgrade-capabilities.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: opampsupervisor
+component: cmd/opampsupervisor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove the `reports_package_statuses` capability config option. The `accepts_packages` option now enables both the AcceptsPackages and ReportsPackageStatuses OpAMP capabilities.

--- a/.chloggen/dpaasman00_unify-upgrade-capabilities.yaml
+++ b/.chloggen/dpaasman00_unify-upgrade-capabilities.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the `reports_package_statuses` capability config option. The `accepts_packages` option now enables both the AcceptsPackages and ReportsPackageStatuses OpAMP capabilities.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49762]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Neither capability was functional; the supervisor exits with an error at startup when configured, so no working configuration is affected.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1568,7 +1568,7 @@ func TestSupervisorConfiguresCapabilities(t *testing.T) {
 }
 
 func TestSupervisorPackageCapabilitiesReturnError(t *testing.T) {
-	// Verifies that when accepts_packages or reports_package_statuses are enabled,
+	// Verifies that when accepts_packages is enabled,
 	// the supervisor fails to start and never connects to the server.
 	if runtime.GOOS == "windows" {
 		t.Skip("Zap does not close the log file and Windows disallows removing files that are still opened.")
@@ -1599,7 +1599,7 @@ func TestSupervisorPackageCapabilitiesReturnError(t *testing.T) {
 	s, err := supervisor.NewSupervisor(t.Context(), logger, cfg)
 	require.NoError(t, err)
 	err = s.Start(t.Context())
-	require.ErrorContains(t, err, "accepts_packages and reports_package_statuses capabilities are not yet fully implemented")
+	require.ErrorContains(t, err, "accepts_packages capability is not yet fully implemented")
 	require.False(t, connected.Load(), "Supervisor should not have connected to the server")
 }
 

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -91,15 +91,13 @@ capabilities:
   accepts_opamp_connection_settings: # false if unspecified
 
   # The Supervisor can accept Collector executable package updates.
+  # Enables both the AcceptsPackages and ReportsPackageStatuses OpAMP
+  # capabilities.
   # NOTE: This capability is not yet fully implemented.
   accepts_packages: # false if unspecified
 
   # The Supervisor will report EffectiveConfig to the Server.
   reports_effective_config: # true if unspecified
-
-  # The Supervisor can report the status of Collector package updates.
-  # NOTE: This capability is not yet fully implemented.
-  reports_package_statuses: # false if unspecified
 
   # The Collector will report own metrics to the destination specified by
   # the Server.
@@ -636,8 +634,9 @@ included in AgentDescription is expected to change after the executable
 is updated).
 
 > **Note:** The collector executable update flow is not yet fully implemented.
-> The `accepts_packages` and `reports_package_statuses` capabilities are accepted
-> in configuration but are currently disabled at runtime. See
+> The `accepts_packages` capability (which enables both the AcceptsPackages and
+> ReportsPackageStatuses OpAMP capabilities) is accepted
+> in configuration but is currently disabled at runtime. See
 > [#47272](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47272)
 > for implementation progress.
 

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -118,7 +118,6 @@ type Capabilities struct {
 	ReportsAvailableComponents     bool `mapstructure:"reports_available_components"`
 	ReportsHeartbeat               bool `mapstructure:"reports_heartbeat"`
 	AcceptsPackages                bool `mapstructure:"accepts_packages"`
-	ReportsPackageStatuses         bool `mapstructure:"reports_package_statuses"`
 }
 
 func (c Capabilities) SupportedCapabilities() protobufs.AgentCapabilities {
@@ -167,14 +166,13 @@ func (c Capabilities) SupportedCapabilities() protobufs.AgentCapabilities {
 		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat
 	}
 
-	// AcceptsPackages and ReportsPackageStatuses are not yet fully implemented.
-	// They are included here for completeness.
+	// AcceptsPackages is not yet fully implemented. It is included here for completeness.
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47272
+	// AcceptsPackages enables both the AcceptsPackages and ReportsPackageStatuses
+	// OpAMP capabilities; accepting packages without reporting their statuses is not useful.
 	if c.AcceptsPackages {
-		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_AcceptsPackages
-	}
-	if c.ReportsPackageStatuses {
-		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses
+		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_AcceptsPackages |
+			protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses
 	}
 
 	return supportedCapabilities
@@ -475,7 +473,6 @@ func DefaultSupervisor() Supervisor {
 			ReportsAvailableComponents:     false,
 			ReportsHeartbeat:               true,
 			AcceptsPackages:                false,
-			ReportsPackageStatuses:         false,
 		},
 		Storage: Storage{
 			Directory: defaultStorageDir,

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -981,10 +981,9 @@ func TestCapabilities_SupportedCapabilities(t *testing.T) {
 			expectedAgentCapabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus,
 		},
 		{
-			name: "Package capabilities are reported",
+			name: "AcceptsPackages enables both package capabilities",
 			capabilities: Capabilities{
-				AcceptsPackages:        true,
-				ReportsPackageStatuses: true,
+				AcceptsPackages: true,
 			},
 			expectedAgentCapabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus |
 				protobufs.AgentCapabilities_AgentCapabilities_AcceptsPackages |
@@ -1005,7 +1004,6 @@ func TestCapabilities_SupportedCapabilities(t *testing.T) {
 				ReportsAvailableComponents:     true,
 				ReportsHeartbeat:               true,
 				AcceptsPackages:                true,
-				ReportsPackageStatuses:         true,
 			},
 			expectedAgentCapabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig |

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -382,12 +382,12 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return err
 	}
 
-	if s.config.Capabilities.AcceptsPackages || s.config.Capabilities.ReportsPackageStatuses {
+	if s.config.Capabilities.AcceptsPackages {
 		s.telemetrySettings.Logger.Error(
-			"accepts_packages and reports_package_statuses capabilities are not yet fully implemented. " +
+			"accepts_packages capability is not yet fully implemented. " +
 				"See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47272 for progress.",
 		)
-		return errors.New("accepts_packages and reports_package_statuses capabilities are not yet fully implemented")
+		return errors.New("accepts_packages capability is not yet fully implemented")
 	}
 
 	if err = s.getFeatureGates(); err != nil {

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_packages_cap.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_packages_cap.yaml
@@ -5,7 +5,6 @@ capabilities:
   reports_effective_config: true
   reports_health: true
   accepts_packages: true
-  reports_package_statuses: true
 
 storage:
   directory: '{{.storage_dir}}'


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Remove the `reports_package_statuses` capability config option. The `accepts_packages` option now enables both the AcceptsPackages and ReportsPackageStatuses OpAMP capabilities.

Neither capability was functional. The supervisor exits with an error at startup when configured, so no working configuration is affected.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Resolves #49762

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- e2e tests updated
- Unit tests updated

<!--Describe the documentation added.-->
#### Documentation
- Documentation updated

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
