### PR TITLE
[chore] add Dylan Strohschein as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For more information about the approver role, see the [community repository](htt
 - [Constança Manteigas](https://github.com/constanca-m), Elastic
 - [Dónal O'Sullivan](https://github.com/osullivandonal), Elastic
 - [Douglas Camata](https://github.com/douglascamata), Coralogix
+- [Dylan Strohschein](https://github.com/dyl10s), Dynatrace
 - [James Moessis](https://github.com/jamesmoessis), Atlassian
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
 - [Murphy Chen](https://github.com/Frapschen), DaoCloud


### PR DESCRIPTION
This proposes adding Dylan as a new triager to the project.

Dylan is an active contributor to the project, with an impact across contributions, reviews, issues as shown below:

PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Adyl10s+
PRs authored: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Adyl10s+
Issues commented: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20commenter%3Adyl10s
Issues opened: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20author%3Adyl10s
Commits: https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?since=2021-05-31&until=now&author=dyl10s
