### PR TITLE
[receiver/elasticsearch] Emit index shards size for the primary_shards aggregation

### DIFF
--- a/.chloggen/elasticsearch-index-shards-primary-shards.yaml
+++ b/.chloggen/elasticsearch-index-shards-primary-shards.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/elasticsearch
+
+note: "Emit the `elasticsearch.index.shards.size` metric with `aggregation: primary_shards` in addition to `aggregation: total`"
+
+issues: [48918]
+
+subtext: |
+  The index shards size metric only reported the `total` aggregation, unlike the other index
+  metrics and its own documented attributes. It now also reports the `primary_shards` aggregation.

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -406,7 +406,7 @@ func (r *elasticsearchScraper) scrapeIndicesMetrics(ctx context.Context, now pco
 
 	indexStats, err := r.client.IndexStats(ctx, r.cfg.Indices)
 	if err != nil {
-		errs.AddPartial(63, err)
+		errs.AddPartial(64, err)
 		return
 	}
 
@@ -568,6 +568,9 @@ func (r *elasticsearchScraper) scrapeOneIndexMetrics(now pcommon.Timestamp, name
 
 	r.mb.RecordElasticsearchIndexShardsSizeDataPoint(
 		now, stats.Total.StoreInfo.SizeInBy, metadata.AttributeIndexAggregationTypeTotal,
+	)
+	r.mb.RecordElasticsearchIndexShardsSizeDataPoint(
+		now, stats.Primaries.StoreInfo.SizeInBy, metadata.AttributeIndexAggregationTypePrimaryShards,
 	)
 
 	r.mb.RecordElasticsearchIndexSegmentsCountDataPoint(

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
@@ -526,7 +526,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:
@@ -1071,7 +1071,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
@@ -530,6 +530,13 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
                         stringValue: total
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -1064,6 +1071,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "40230884"
                   attributes:
                     - key: aggregation

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_linux.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_linux.yaml
@@ -903,7 +903,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:
@@ -1702,7 +1702,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_linux.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_linux.yaml
@@ -907,6 +907,13 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
                         stringValue: total
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -1695,6 +1702,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "40230884"
                   attributes:
                     - key: aggregation

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
@@ -903,7 +903,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:
@@ -1702,7 +1702,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
@@ -907,6 +907,13 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
                         stringValue: total
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -1695,6 +1702,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "40230884"
                   attributes:
                     - key: aggregation

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
@@ -651,6 +651,13 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
                         stringValue: total
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -1185,6 +1192,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "40230884"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "40230884"
                   attributes:
                     - key: aggregation

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
@@ -647,7 +647,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:
@@ -1192,7 +1192,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40230884"
+                - asInt: "20115442"
                   attributes:
                     - key: aggregation
                       value:

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
@@ -662,6 +662,13 @@ resourceMetrics:
                         stringValue: total
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
+                - asInt: "32473664"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
@@ -1198,6 +1205,13 @@ resourceMetrics:
                     - key: aggregation
                       value:
                         stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "32473664"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.yaml
@@ -662,6 +662,13 @@ resourceMetrics:
                         stringValue: total
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver

--- a/receiver/elasticsearchreceiver/testdata/sample_payloads/indices.json
+++ b/receiver/elasticsearchreceiver/testdata/sample_payloads/indices.json
@@ -14,8 +14,8 @@
           "total_count" : 1
         },
         "store" : {
-          "size_in_bytes" : 40230884,
-          "total_data_set_size_in_bytes" : 40230884,
+          "size_in_bytes" : 20115442,
+          "total_data_set_size_in_bytes" : 20115442,
           "reserved_in_bytes" : 0
         },
         "indexing" : {
@@ -274,8 +274,8 @@
             "total_count" : 1
           },
           "store" : {
-            "size_in_bytes" : 40230884,
-            "total_data_set_size_in_bytes" : 40230884,
+            "size_in_bytes" : 20115442,
+            "total_data_set_size_in_bytes" : 20115442,
             "reserved_in_bytes" : 0
           },
           "indexing" : {


### PR DESCRIPTION
The `elasticsearch.index.shards.size` metric was only emitted with `aggregation: total`, even though its metadata attribute enum and documentation also list `primary_shards`, and the sibling index metrics (documents, operations, segments.count) already emit both.

This records the `primary_shards` data point from the primary shards store size, mirroring the segments.count pattern, and regenerates the affected golden files.

#### Description
Emit `elasticsearch.index.shards.size` with `aggregation: primary_shards` in addition to `total`.

#### Link to tracking issue
Fixes #48918

#### Testing
`go test ./receiver/elasticsearchreceiver/...` passes. The `full_linux`, `full_other`, `clusterSkip` and `noNodes` golden files were regenerated to include the new data point.

#### Documentation
No documentation changes; the metric already documents both aggregations.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
