### PR TITLE
[bug] Fixed silent log drops for more than 1000 items within a stream for text encoding

### DIFF
--- a/extension/encoding/textencodingextension/text.go
+++ b/extension/encoding/textencodingextension/text.go
@@ -27,7 +27,7 @@ type textLogCodec struct {
 
 func (r *textLogCodec) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 	// Decode as a stream but flush all at once using flush options
-	decoder, err := r.NewLogsDecoder(bytes.NewReader(buf), encoding.WithOffset(0), encoding.WithFlushBytes(0))
+	decoder, err := r.NewLogsDecoder(bytes.NewReader(buf), encoding.WithOffset(0), encoding.WithFlushBytes(0), encoding.WithFlushItems(0))
 	if err != nil {
 		return plog.Logs{}, err
 	}

--- a/extension/encoding/textencodingextension/text_test.go
+++ b/extension/encoding/textencodingextension/text_test.go
@@ -5,8 +5,10 @@ package textencodingextension
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +44,25 @@ func TestTextRoundtripMissingNewline(t *testing.T) {
 	b, err := codec.MarshalLogs(ld)
 	require.NoError(t, err)
 	require.Equal(t, "foo\nbar", string(b))
+}
+
+func TestUnmarshalLogsAcrossMultipleBatches(t *testing.T) {
+	// Regression test: inputs with more than the default 1000-item flush
+	// threshold must not be silently truncated by UnmarshalLogs.
+	enc, err := textutils.LookupEncoding("utf8")
+	require.NoError(t, err)
+	r := regexp.MustCompile(`\r?\n`)
+	codec := &textLogCodec{decoder: enc.NewDecoder(), unmarshalingSeparator: r, marshalingSeparator: "\n"}
+
+	var input strings.Builder
+	const recordCount = 1863
+	for i := 0; i < recordCount; i++ {
+		fmt.Fprintf(&input, "record-%d\n", i)
+	}
+
+	logs, err := codec.UnmarshalLogs([]byte(input.String()))
+	require.NoError(t, err)
+	require.Equal(t, recordCount, logs.LogRecordCount())
 }
 
 func TestNoSeparator(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
