### PR TITLE
[exporter/datadog,pkg/datadog] Unembed confighttp structs

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -306,9 +306,9 @@ func (f *factory) createMetricsExporter(
 				Metrics: cfg.Metrics,
 			},
 			TimeoutConfig: exporterhelper.TimeoutConfig{
-				Timeout: cfg.Timeout,
+				Timeout: cfg.ClientConfig.Timeout,
 			},
-			ClientConfig:     cfg.TLS,
+			ClientConfig:     cfg.ClientConfig.TLS,
 			QueueBatchConfig: cfg.QueueSettings,
 			RetryConfig:      cfg.BackOffConfig,
 			API:              cfg.API,

--- a/exporter/datadogexporter/hostmetadata.go
+++ b/exporter/datadogexporter/hostmetadata.go
@@ -18,7 +18,7 @@ func newMetadataConfigfromConfig(cfg *datadogconfig.Config) hostmetadata.PusherC
 		MetricsEndpoint:     cfg.Metrics.Endpoint,
 		APIKey:              string(cfg.API.Key),
 		UseResourceMetadata: cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource,
-		InsecureSkipVerify:  cfg.TLS.InsecureSkipVerify,
+		InsecureSkipVerify:  cfg.ClientConfig.TLS.InsecureSkipVerify,
 		ClientConfig:        cfg.ClientConfig,
 		RetrySettings:       cfg.BackOffConfig,
 		ReporterPeriod:      cfg.HostMetadata.ReporterPeriod,

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -200,7 +200,7 @@ func newTraceAgentConfig(ctx context.Context, params exporter.Settings, cfg *dat
 	acfg.Ignore["resource"] = cfg.Traces.IgnoreResources
 	acfg.ReceiverEnabled = false // disable HTTP receiver
 	acfg.AgentVersion = fmt.Sprintf("datadogexporter-%s-%s", params.BuildInfo.Command, params.BuildInfo.Version)
-	acfg.SkipSSLValidation = cfg.TLS.InsecureSkipVerify
+	acfg.SkipSSLValidation = cfg.ClientConfig.TLS.InsecureSkipVerify
 	acfg.ComputeStatsBySpanKind = cfg.Traces.ComputeStatsBySpanKind
 	acfg.PeerTagsAggregation = cfg.Traces.PeerTagsAggregation
 	acfg.PeerTags = cfg.Traces.PeerTags

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -276,9 +276,9 @@ func setProxy(cfg *datadogconfig.Config, pkgconfig pkgconfigmodel.Config) {
 	}
 
 	// proxy_url takes precedence over proxy environment variables if set
-	if cfg.ProxyURL != "" {
-		pkgconfig.Set("proxy.http", cfg.ProxyURL, pkgconfigmodel.SourceFile)
-		pkgconfig.Set("proxy.https", cfg.ProxyURL, pkgconfigmodel.SourceFile)
+	if cfg.ClientConfig.ProxyURL != "" {
+		pkgconfig.Set("proxy.http", cfg.ClientConfig.ProxyURL, pkgconfigmodel.SourceFile)
+		pkgconfig.Set("proxy.https", cfg.ClientConfig.ProxyURL, pkgconfigmodel.SourceFile)
 	}
 
 	// If this is set to an empty []string, viper will have a type conflict when merging
@@ -294,8 +294,8 @@ func setProxy(cfg *datadogconfig.Config, pkgconfig pkgconfigmodel.Config) {
 }
 
 func setTLSSetting(cfg *datadogconfig.Config, pkgconfig pkgconfigmodel.Config) {
-	if cfg.TLS.InsecureSkipVerify {
-		pkgconfig.Set("skip_ssl_validation", cfg.TLS.InsecureSkipVerify, pkgconfigmodel.SourceFile)
+	if cfg.ClientConfig.TLS.InsecureSkipVerify {
+		pkgconfig.Set("skip_ssl_validation", cfg.ClientConfig.TLS.InsecureSkipVerify, pkgconfigmodel.SourceFile)
 	}
 }
 

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -73,7 +73,7 @@ type TagsConfig struct {
 
 // Config defines configuration for the Datadog exporter.
 type Config struct {
-	confighttp.ClientConfig   `mapstructure:",squash"`                                 // squash ensures fields are correctly decoded in embedded struct.
+	ClientConfig              confighttp.ClientConfig                                  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	QueueSettings             configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:"sending_queue"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 

--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -300,15 +300,15 @@ func TestUnmarshal(t *testing.T) {
 	maxIdleConn := 300
 	maxIdleConnPerHost := 150
 	maxConnPerHost := 250
-	cfgWithHTTPConfigs.ReadBufferSize = 100
-	cfgWithHTTPConfigs.WriteBufferSize = 200
-	cfgWithHTTPConfigs.Timeout = 10 * time.Second
-	cfgWithHTTPConfigs.MaxIdleConns = maxIdleConn
-	cfgWithHTTPConfigs.MaxIdleConnsPerHost = maxIdleConnPerHost
-	cfgWithHTTPConfigs.MaxConnsPerHost = maxConnPerHost
-	cfgWithHTTPConfigs.IdleConnTimeout = idleConnTimeout
-	cfgWithHTTPConfigs.DisableKeepAlives = true
-	cfgWithHTTPConfigs.TLS.InsecureSkipVerify = true
+	cfgWithHTTPConfigs.ClientConfig.ReadBufferSize = 100
+	cfgWithHTTPConfigs.ClientConfig.WriteBufferSize = 200
+	cfgWithHTTPConfigs.ClientConfig.Timeout = 10 * time.Second
+	cfgWithHTTPConfigs.ClientConfig.MaxIdleConns = maxIdleConn
+	cfgWithHTTPConfigs.ClientConfig.MaxIdleConnsPerHost = maxIdleConnPerHost
+	cfgWithHTTPConfigs.ClientConfig.MaxConnsPerHost = maxConnPerHost
+	cfgWithHTTPConfigs.ClientConfig.IdleConnTimeout = idleConnTimeout
+	cfgWithHTTPConfigs.ClientConfig.DisableKeepAlives = true
+	cfgWithHTTPConfigs.ClientConfig.TLS.InsecureSkipVerify = true
 	cfgWithHTTPConfigs.warnings = nil
 
 	tests := []struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Stops embedding `confighttp` structs on the `pkg/datadog` and `exporter/datadog` structs.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Test for open-telemetry/opentelemetry-collector/pull/15308.

It is otherwise a noop.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
