### PR TITLE
[chore] Un-embed configgrpc config structs

### DIFF
--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -35,7 +35,7 @@ const (
 // TransportConfig extends configgrpc.ClientConfig with additional HTTP-specific settings
 type TransportConfig struct {
 	// Embed the gRPC configuration to ensure backward compatibility
-	configgrpc.ClientConfig `mapstructure:",squash"`
+	ClientConfig configgrpc.ClientConfig `mapstructure:",squash"`
 
 	// The following fields are only used when protocol is "http"
 	ProxyURL string        `mapstructure:"proxy_url,omitempty"` // Used only if protocol is http
@@ -47,7 +47,7 @@ type TransportConfig struct {
 }
 
 func (c *TransportConfig) ToHTTPClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
-	c.Headers.Set("Content-Type", "application/x-protobuf")
+	c.ClientConfig.Headers.Set("Content-Type", "application/x-protobuf")
 
 	httpClientConfig := confighttp.NewDefaultClientConfig()
 	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
@@ -55,12 +55,12 @@ func (c *TransportConfig) ToHTTPClient(ctx context.Context, host component.Host,
 	httpClientConfig.IdleConnTimeout = 0
 	httpClientConfig.ForceAttemptHTTP2 = false
 	httpClientConfig.ProxyURL = c.ProxyURL
-	httpClientConfig.TLS = c.TLS
-	httpClientConfig.ReadBufferSize = c.ReadBufferSize
-	httpClientConfig.WriteBufferSize = c.WriteBufferSize
+	httpClientConfig.TLS = c.ClientConfig.TLS
+	httpClientConfig.ReadBufferSize = c.ClientConfig.ReadBufferSize
+	httpClientConfig.WriteBufferSize = c.ClientConfig.WriteBufferSize
 	httpClientConfig.Timeout = c.Timeout
-	httpClientConfig.Headers = c.Headers
-	httpClientConfig.Compression = c.Compression
+	httpClientConfig.Headers = c.ClientConfig.Headers
+	httpClientConfig.Compression = c.ClientConfig.Compression
 	return httpClientConfig.ToClient(ctx, host.GetExtensions(), settings)
 }
 
@@ -138,43 +138,43 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 	_ = setDomainGrpcSettings(c)
 	var err error
 
-	if !isEmpty(c.Domain) && isEmpty(c.Metrics.Endpoint) {
+	if !isEmpty(c.Domain) && isEmpty(c.Metrics.ClientConfig.Endpoint) {
 		c.Metrics, err = setMergedTransportConfigWithConf(conf, c, "metrics", &c.Metrics)
 		if err != nil {
 			return err
 		}
 	}
 
-	if isEmpty(c.Metrics.Endpoint) {
-		c.Metrics.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
+	if isEmpty(c.Metrics.ClientConfig.Endpoint) {
+		c.Metrics.ClientConfig.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
 	} else if c.Protocol == httpProtocol {
-		c.Metrics.Endpoint = ensureHTTPScheme(c.Metrics.Endpoint)
+		c.Metrics.ClientConfig.Endpoint = ensureHTTPScheme(c.Metrics.ClientConfig.Endpoint)
 	}
 
-	if !isEmpty(c.Domain) && isEmpty(c.Traces.Endpoint) {
+	if !isEmpty(c.Domain) && isEmpty(c.Traces.ClientConfig.Endpoint) {
 		c.Traces, err = setMergedTransportConfigWithConf(conf, c, "traces", &c.Traces)
 		if err != nil {
 			return err
 		}
 	}
 
-	if isEmpty(c.Traces.Endpoint) {
-		c.Traces.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
+	if isEmpty(c.Traces.ClientConfig.Endpoint) {
+		c.Traces.ClientConfig.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
 	} else if c.Protocol == httpProtocol {
-		c.Traces.Endpoint = ensureHTTPScheme(c.Traces.Endpoint)
+		c.Traces.ClientConfig.Endpoint = ensureHTTPScheme(c.Traces.ClientConfig.Endpoint)
 	}
 
-	if !isEmpty(c.Domain) && isEmpty(c.Logs.Endpoint) {
+	if !isEmpty(c.Domain) && isEmpty(c.Logs.ClientConfig.Endpoint) {
 		c.Logs, err = setMergedTransportConfigWithConf(conf, c, "logs", &c.Logs)
 		if err != nil {
 			return err
 		}
 	}
 
-	if isEmpty(c.Logs.Endpoint) {
-		c.Logs.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
+	if isEmpty(c.Logs.ClientConfig.Endpoint) {
+		c.Logs.ClientConfig.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
 	} else if c.Protocol == httpProtocol {
-		c.Logs.Endpoint = ensureHTTPScheme(c.Logs.Endpoint)
+		c.Logs.ClientConfig.Endpoint = ensureHTTPScheme(c.Logs.ClientConfig.Endpoint)
 	}
 
 	// Only auto-populate profiles endpoint if protocol is not HTTP (profiles only support gRPC)
@@ -188,8 +188,8 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 
 	// Only set profiles endpoint fallback if protocol is not HTTP and we have something to fallback to
 	// This avoid validation issues
-	if c.Protocol != httpProtocol && isEmpty(c.Profiles.Endpoint) && !isEmpty(c.DomainSettings.Endpoint) {
-		c.Profiles.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
+	if c.Protocol != httpProtocol && isEmpty(c.Profiles.Endpoint) && !isEmpty(c.DomainSettings.ClientConfig.Endpoint) {
+		c.Profiles.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
 	}
 	return nil
 }
@@ -214,9 +214,9 @@ func (c *Config) Validate() error {
 
 	// validate that at least one endpoint is set up correctly
 	if isEmpty(c.Domain) &&
-		isEmpty(c.Traces.Endpoint) &&
-		isEmpty(c.Metrics.Endpoint) &&
-		isEmpty(c.Logs.Endpoint) &&
+		isEmpty(c.Traces.ClientConfig.Endpoint) &&
+		isEmpty(c.Metrics.ClientConfig.Endpoint) &&
+		isEmpty(c.Logs.ClientConfig.Endpoint) &&
 		isEmpty(c.Profiles.Endpoint) {
 		return errors.New("`domain` or `traces.endpoint` or `metrics.endpoint` or `logs.endpoint` or `profiles.endpoint` not specified, please fix the configuration")
 	}
@@ -376,51 +376,51 @@ func setMergedTransportConfig(c *Config, merged *TransportConfig, signalSub *con
 	}
 
 	if signalSub != nil && signalSub.IsSet("compression") {
-		merged.Compression = signalConfig.Compression
+		merged.ClientConfig.Compression = signalConfig.ClientConfig.Compression
 	}
 	if signalSub != nil && signalSub.IsSet("accept_encoding") {
 		merged.AcceptEncoding = signalConfig.AcceptEncoding
 	}
-	if signalConfig.TLS.Insecure || signalConfig.TLS.InsecureSkipVerify || signalConfig.TLS.CAFile != "" {
-		merged.TLS = signalConfig.TLS
+	if signalConfig.ClientConfig.TLS.Insecure || signalConfig.ClientConfig.TLS.InsecureSkipVerify || signalConfig.ClientConfig.TLS.CAFile != "" {
+		merged.ClientConfig.TLS = signalConfig.ClientConfig.TLS
 	}
-	if len(signalConfig.Headers) > 0 {
+	if len(signalConfig.ClientConfig.Headers) > 0 {
 		// MapList.Set copies the backing array, so this does not mutate c.DomainSettings
-		for k, v := range signalConfig.Headers.Iter {
-			merged.Headers.Set(k, v)
+		for k, v := range signalConfig.ClientConfig.Headers.Iter {
+			merged.ClientConfig.Headers.Set(k, v)
 		}
 	}
-	if signalConfig.WriteBufferSize > 0 {
-		merged.WriteBufferSize = signalConfig.WriteBufferSize
+	if signalConfig.ClientConfig.WriteBufferSize > 0 {
+		merged.ClientConfig.WriteBufferSize = signalConfig.ClientConfig.WriteBufferSize
 	}
-	if signalConfig.ReadBufferSize > 0 {
-		merged.ReadBufferSize = signalConfig.ReadBufferSize
+	if signalConfig.ClientConfig.ReadBufferSize > 0 {
+		merged.ClientConfig.ReadBufferSize = signalConfig.ClientConfig.ReadBufferSize
 	}
-	if signalConfig.WaitForReady {
-		merged.WaitForReady = signalConfig.WaitForReady
+	if signalConfig.ClientConfig.WaitForReady {
+		merged.ClientConfig.WaitForReady = signalConfig.ClientConfig.WaitForReady
 	}
-	if signalConfig.BalancerName != "" {
-		merged.BalancerName = signalConfig.BalancerName
+	if signalConfig.ClientConfig.BalancerName != "" {
+		merged.ClientConfig.BalancerName = signalConfig.ClientConfig.BalancerName
 	}
-	if signalConfig.Keepalive.HasValue() {
-		merged.Keepalive = signalConfig.Keepalive
+	if signalConfig.ClientConfig.Keepalive.HasValue() {
+		merged.ClientConfig.Keepalive = signalConfig.ClientConfig.Keepalive
 	}
-	if signalConfig.Auth.HasValue() {
-		merged.Auth = signalConfig.Auth
+	if signalConfig.ClientConfig.Auth.HasValue() {
+		merged.ClientConfig.Auth = signalConfig.ClientConfig.Auth
 	}
 
-	if isEmpty(signalConfig.Endpoint) {
-		merged.Endpoint = setDomainGrpcSettings(c)
+	if isEmpty(signalConfig.ClientConfig.Endpoint) {
+		merged.ClientConfig.Endpoint = setDomainGrpcSettings(c)
 	} else {
-		merged.Endpoint = signalConfig.Endpoint
+		merged.ClientConfig.Endpoint = signalConfig.ClientConfig.Endpoint
 	}
 
 	return merged
 }
 
 func applyTransportDefaults(cfg *TransportConfig) {
-	if cfg.Compression == "" {
-		cfg.Compression = configcompression.TypeGzip
+	if cfg.ClientConfig.Compression == "" {
+		cfg.ClientConfig.Compression = configcompression.TypeGzip
 	}
 	if cfg.AcceptEncoding == "" {
 		cfg.AcceptEncoding = gzip.Name

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -301,17 +301,17 @@ func TestHTTPProtocolDoesNotAutoPopulateProfilesEndpoint(t *testing.T) {
 
 	assert.Equal(t, "http", oCfg.Protocol)
 	assert.True(t, isEmpty(oCfg.Profiles.Endpoint), "profiles endpoint should not be auto-populated when using HTTP protocol")
-	assert.False(t, isEmpty(oCfg.Logs.Endpoint), "logs endpoint should be auto-populated")
-	assert.False(t, isEmpty(oCfg.Metrics.Endpoint), "metrics endpoint should be auto-populated")
-	assert.False(t, isEmpty(oCfg.Traces.Endpoint), "traces endpoint should be auto-populated")
+	assert.False(t, isEmpty(oCfg.Logs.ClientConfig.Endpoint), "logs endpoint should be auto-populated")
+	assert.False(t, isEmpty(oCfg.Metrics.ClientConfig.Endpoint), "metrics endpoint should be auto-populated")
+	assert.False(t, isEmpty(oCfg.Traces.ClientConfig.Endpoint), "traces endpoint should be auto-populated")
 
-	assert.Contains(t, oCfg.Logs.Endpoint, "https://", "logs endpoint should have https:// scheme")
-	assert.Contains(t, oCfg.Metrics.Endpoint, "https://", "metrics endpoint should have https:// scheme")
-	assert.Contains(t, oCfg.Traces.Endpoint, "https://", "traces endpoint should have https:// scheme")
+	assert.Contains(t, oCfg.Logs.ClientConfig.Endpoint, "https://", "logs endpoint should have https:// scheme")
+	assert.Contains(t, oCfg.Metrics.ClientConfig.Endpoint, "https://", "metrics endpoint should have https:// scheme")
+	assert.Contains(t, oCfg.Traces.ClientConfig.Endpoint, "https://", "traces endpoint should have https:// scheme")
 
-	assert.Equal(t, "https://ingress.coralogix.com:443", oCfg.Traces.Endpoint)
-	assert.Equal(t, "https://ingress.coralogix.com:443", oCfg.Metrics.Endpoint)
-	assert.Equal(t, "https://ingress.coralogix.com:443", oCfg.Logs.Endpoint)
+	assert.Equal(t, "https://ingress.coralogix.com:443", oCfg.Traces.ClientConfig.Endpoint)
+	assert.Equal(t, "https://ingress.coralogix.com:443", oCfg.Metrics.ClientConfig.Endpoint)
+	assert.Equal(t, "https://ingress.coralogix.com:443", oCfg.Logs.ClientConfig.Endpoint)
 
 	assert.NoError(t, oCfg.Validate())
 
@@ -796,9 +796,9 @@ func TestDomainSettingsCompressionMerge(t *testing.T) {
 			cfg := createDefaultConfig().(*Config)
 			require.NoError(t, cfg.Unmarshal(conf))
 
-			assert.Equal(t, tt.wantLogsCompression, cfg.Logs.Compression)
-			assert.Equal(t, tt.wantMetricsCompression, cfg.Metrics.Compression)
-			assert.Equal(t, tt.wantTracesCompression, cfg.Traces.Compression)
+			assert.Equal(t, tt.wantLogsCompression, cfg.Logs.ClientConfig.Compression)
+			assert.Equal(t, tt.wantMetricsCompression, cfg.Metrics.ClientConfig.Compression)
+			assert.Equal(t, tt.wantTracesCompression, cfg.Traces.ClientConfig.Compression)
 			assert.Equal(t, tt.wantProfilesCompression, cfg.Profiles.Compression)
 			assert.Equal(t, tt.wantLogsAcceptEncoding, cfg.Logs.AcceptEncoding)
 			assert.Equal(t, tt.wantMetricsAcceptEncoding, cfg.Metrics.AcceptEncoding)

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -38,7 +38,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetrics(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Metrics.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Metrics.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopSettings(metadata.Type)
 	oexp, err := factory.CreateMetrics(t.Context(), set, cfg)
@@ -61,7 +61,7 @@ func TestCreateMetricsWithDomain(t *testing.T) {
 func TestCreateLogs(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Logs.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Logs.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopSettings(metadata.Type)
 	oexp, err := factory.CreateLogs(t.Context(), set, cfg)
@@ -247,7 +247,7 @@ func TestCreateLogsWithDomainAndEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.Domain = "	bad domain"
 
-	cfg.Logs.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Logs.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopSettings(metadata.Type)
 	consumer, err := factory.CreateLogs(t.Context(), set, cfg)

--- a/exporter/coralogixexporter/http_exporter.go
+++ b/exporter/coralogixexporter/http_exporter.go
@@ -48,7 +48,7 @@ func newHTTPLogsExporter(client *http.Client, config *Config) httpLogsExporter {
 	return httpLogsExporter{
 		httpExporter: httpExporter{
 			Client:   client,
-			Endpoint: config.Logs.Endpoint,
+			Endpoint: config.Logs.ClientConfig.Endpoint,
 		},
 	}
 }
@@ -57,7 +57,7 @@ func newHTTPMetricsExporter(client *http.Client, config *Config) httpMetricsExpo
 	return httpMetricsExporter{
 		httpExporter: httpExporter{
 			Client:   client,
-			Endpoint: config.Metrics.Endpoint,
+			Endpoint: config.Metrics.ClientConfig.Endpoint,
 		},
 	}
 }
@@ -66,7 +66,7 @@ func newHTTPTracesExporter(client *http.Client, config *Config) httpTracesExport
 	return httpTracesExporter{
 		httpExporter: httpExporter{
 			Client:   client,
-			Endpoint: config.Traces.Endpoint,
+			Endpoint: config.Traces.ClientConfig.Endpoint,
 		},
 	}
 }

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -20,7 +20,7 @@ func newLogsExporter(cfg component.Config, set exp.Settings) (*logsExporter, err
 		return nil, fmt.Errorf("invalid config exporter, expect type: %T, got: %T", &Config{}, cfg)
 	}
 
-	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Logs.Endpoint, oCfg.Logs.Headers)
+	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Logs.ClientConfig.Endpoint, oCfg.Logs.ClientConfig.Headers)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -91,7 +91,7 @@ func TestLogsExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.grpcLogsExporter)
-	_, ok := exp.config.Logs.Headers.Get("Authorization")
+	_, ok := exp.config.Logs.ClientConfig.Headers.Get("Authorization")
 	assert.True(t, ok)
 
 	// Test shutdown

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -20,7 +20,7 @@ func newMetricsExporter(cfg component.Config, set exporter.Settings) (*metricsEx
 		return nil, fmt.Errorf("invalid config exporter, expect type: %T, got: %T", &Config{}, cfg)
 	}
 
-	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Metrics.Endpoint, oCfg.Metrics.Headers)
+	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Metrics.ClientConfig.Endpoint, oCfg.Metrics.ClientConfig.Headers)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/coralogixexporter/metrics_client_test.go
+++ b/exporter/coralogixexporter/metrics_client_test.go
@@ -91,7 +91,7 @@ func TestMetricsExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.grpcMetricsExporter)
-	_, ok := exp.config.Metrics.Headers.Get("Authorization")
+	_, ok := exp.config.Metrics.ClientConfig.Headers.Get("Authorization")
 	assert.True(t, ok)
 
 	// Test shutdown

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -38,7 +38,7 @@ type signalConfigWrapper struct {
 }
 
 func (w *signalConfigWrapper) ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, opts ...configgrpc.ToClientConnOption) (*grpc.ClientConn, error) {
-	return w.config.ToClientConn(ctx, host.GetExtensions(), settings, opts...)
+	return w.config.ClientConfig.ToClientConn(ctx, host.GetExtensions(), settings, opts...)
 }
 
 func (w *signalConfigWrapper) ToHTTPClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
@@ -46,11 +46,11 @@ func (w *signalConfigWrapper) ToHTTPClient(ctx context.Context, host component.H
 }
 
 func (w *signalConfigWrapper) GetWaitForReady() bool {
-	return w.config.WaitForReady
+	return w.config.ClientConfig.WaitForReady
 }
 
 func (w *signalConfigWrapper) GetEndpoint() string {
-	return w.config.Endpoint
+	return w.config.ClientConfig.Endpoint
 }
 
 func (w *signalConfigWrapper) GetAcceptEncoding() string {
@@ -126,9 +126,9 @@ func (e *signalExporter) enhanceContext(ctx context.Context) context.Context {
 
 func (e *signalExporter) startSignalExporter(ctx context.Context, host component.Host, signalConfig signalConfig) (err error) {
 	if signalConfigWrapper, ok := signalConfig.(*signalConfigWrapper); ok {
-		signalConfigWrapper.config.Headers.Set("Authorization", configopaque.String("Bearer "+string(e.config.PrivateKey)))
+		signalConfigWrapper.config.ClientConfig.Headers.Set("Authorization", configopaque.String("Bearer "+string(e.config.PrivateKey)))
 		if e.config.Protocol != httpProtocol {
-			for k, v := range signalConfigWrapper.config.Headers.Iter {
+			for k, v := range signalConfigWrapper.config.ClientConfig.Headers.Iter {
 				e.metadata.Set(k, string(v))
 			}
 		}
@@ -145,7 +145,7 @@ func (e *signalExporter) startSignalExporter(ctx context.Context, host component
 			return err
 		}
 	} else {
-		if e.clientConn, err = signalConfigWrapper.config.ToClientConn(ctx, host.GetExtensions(), e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
+		if e.clientConn, err = signalConfigWrapper.config.ClientConfig.ToClientConn(ctx, host.GetExtensions(), e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
 			return err
 		}
 		callOptions := []grpc.CallOption{

--- a/exporter/coralogixexporter/signals_test.go
+++ b/exporter/coralogixexporter/signals_test.go
@@ -181,7 +181,7 @@ func TestSignalExporter_AuthorizationHeader(t *testing.T) {
 		require.NoError(t, exp.shutdown(t.Context()))
 	}()
 
-	authHeader, ok := wrapper.config.Headers.Get("Authorization")
+	authHeader, ok := wrapper.config.ClientConfig.Headers.Get("Authorization")
 	require.True(t, ok, "Authorization header should be present")
 	assert.Equal(t, configopaque.String("Bearer "+privateKey), authHeader, "Authorization header should be in Bearer format")
 
@@ -263,7 +263,7 @@ func TestSignalExporter_CustomHeadersAndAuthorization(t *testing.T) {
 				require.NoError(t, exp.shutdown(t.Context()))
 			}()
 
-			headers := wrapper.config.Headers
+			headers := wrapper.config.ClientConfig.Headers
 			require.Len(t, headers, 3)
 
 			authHeader, ok := headers.Get("Authorization")
@@ -348,7 +348,7 @@ func TestSignalExporter_HTTPClientWithDomainAndSignalSettings(t *testing.T) {
 			}
 
 			if tt.signalEndpoint != "" {
-				cfg.Logs.Endpoint = tt.signalEndpoint
+				cfg.Logs.ClientConfig.Endpoint = tt.signalEndpoint
 			}
 
 			exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
@@ -425,7 +425,7 @@ func TestSignalExporter_GRPCClientWithDomainAndSignalSettings(t *testing.T) {
 			}
 
 			if tt.signalEndpoint != "" {
-				cfg.Logs.Endpoint = tt.signalEndpoint
+				cfg.Logs.ClientConfig.Endpoint = tt.signalEndpoint
 			}
 
 			exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -22,7 +22,7 @@ func newTracesExporter(cfg component.Config, set exporter.Settings) (*tracesExpo
 		return nil, fmt.Errorf("invalid config exporter, expect type: %T, got: %T", &Config{}, cfg)
 	}
 
-	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Traces.Endpoint, oCfg.Traces.Headers)
+	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Traces.ClientConfig.Endpoint, oCfg.Traces.ClientConfig.Headers)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -93,7 +93,7 @@ func TestTracesExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.grpcTracesExporter)
-	_, ok := exp.config.Traces.Headers.Get("Authorization")
+	_, ok := exp.config.Traces.ClientConfig.Headers.Get("Authorization")
 	assert.True(t, ok)
 
 	err = exp.shutdown(t.Context())

--- a/exporter/otelarrowexporter/config.go
+++ b/exporter/otelarrowexporter/config.go
@@ -33,7 +33,7 @@ type Config struct {
 
 	RetryConfig configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 
-	configgrpc.ClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	ClientConfig configgrpc.ClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
 	// Arrow includes settings specific to OTel Arrow.
 	Arrow ArrowConfig `mapstructure:"arrow"`

--- a/exporter/otelarrowexporter/config_test.go
+++ b/exporter/otelarrowexporter/config_test.go
@@ -35,7 +35,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.NoError(t, cm.Unmarshal(cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
-	assert.Equal(t, "round_robin", cfg.(*Config).BalancerName)
+	assert.Equal(t, "round_robin", cfg.(*Config).ClientConfig.BalancerName)
 	assert.Equal(t, arrow.DefaultPrioritizer, cfg.(*Config).Arrow.Prioritizer)
 }
 

--- a/exporter/otelarrowexporter/factory_test.go
+++ b/exporter/otelarrowexporter/factory_test.go
@@ -39,7 +39,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NotEqual(t, ocfg.QueueSettings, exporterhelper.NewDefaultQueueConfig())
 
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutConfig())
-	assert.Equal(t, configcompression.TypeZstd, ocfg.Compression)
+	assert.Equal(t, configcompression.TypeZstd, ocfg.ClientConfig.Compression)
 	assert.Equal(t, ArrowConfig{
 		Disabled:           false,
 		NumStreams:         max(1, runtime.NumCPU()/2),
@@ -53,7 +53,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetrics(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopSettings(metadata.Type)
 	oexp, err := factory.CreateMetrics(t.Context(), set, cfg)
@@ -219,7 +219,7 @@ func TestCreateTraces(t *testing.T) {
 func TestCreateLogs(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopSettings(metadata.Type)
 	oexp, err := factory.CreateLogs(t.Context(), set, cfg)
@@ -230,7 +230,7 @@ func TestCreateLogs(t *testing.T) {
 func TestCreateArrowTracesExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.ClientConfig.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.Arrow = ArrowConfig{
 		NumStreams: 1,
 	}

--- a/exporter/otelarrowexporter/otelarrow.go
+++ b/exporter/otelarrowexporter/otelarrow.go
@@ -79,7 +79,7 @@ type streamClientFactory func(conn *grpc.ClientConn) arrow.StreamClientFunc
 func newExporter(cfg component.Config, set exporter.Settings, streamClientFactory streamClientFactory, userAgent string, netReporter *netstats.NetworkReporter) (exp, error) {
 	oCfg := cfg.(*Config)
 
-	if oCfg.Endpoint == "" {
+	if oCfg.ClientConfig.Endpoint == "" {
 		return nil, errors.New("OTLP exporter config requires an Endpoint")
 	}
 
@@ -117,20 +117,20 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 		dialOpts = append(dialOpts, configgrpc.WithGrpcDialOption(opt))
 	}
 
-	if e.clientConn, err = e.config.ToClientConn(ctx, host.GetExtensions(), e.settings.TelemetrySettings, dialOpts...); err != nil {
+	if e.clientConn, err = e.config.ClientConfig.ToClientConn(ctx, host.GetExtensions(), e.settings.TelemetrySettings, dialOpts...); err != nil {
 		return err
 	}
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)
 	headers := map[string]string{}
-	for k, v := range e.config.Headers.Iter {
+	for k, v := range e.config.ClientConfig.Headers.Iter {
 		headers[k] = string(v)
 	}
 	headerMetadata := metadata.New(headers)
 	e.metadata = metadata.Join(e.metadata, headerMetadata)
 	e.callOptions = []grpc.CallOption{
-		grpc.WaitForReady(e.config.WaitForReady),
+		grpc.WaitForReady(e.config.ClientConfig.WaitForReady),
 	}
 
 	if !e.config.Arrow.Disabled {
@@ -138,9 +138,9 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 		ctx := e.enhanceContext(context.Background())
 
 		var perRPCCreds credentials.PerRPCCredentials
-		if e.config.Auth.HasValue() {
+		if e.config.ClientConfig.Auth.HasValue() {
 			// Get the auth extension, we'll use it to enrich the request context.
-			authClient, err := e.config.Auth.Get().GetGRPCClientAuthenticator(ctx, host.GetExtensions())
+			authClient, err := e.config.ClientConfig.Auth.Get().GetGRPCClientAuthenticator(ctx, host.GetExtensions())
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 
 		arrowCallOpts := e.callOptions
 
-		if e.config.Compression == configcompression.TypeZstd {
+		if e.config.ClientConfig.Compression == configcompression.TypeZstd {
 			// ignore the error below b/c Validate() was called
 			_ = zstd.SetEncoderConfig(e.config.Arrow.Zstd)
 			// use the configured compressor.

--- a/exporter/otelarrowexporter/otelarrow_test.go
+++ b/exporter/otelarrowexporter/otelarrow_test.go
@@ -464,10 +464,10 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.ClientConfig = test.gRPCClientSettings
-			cfg.Endpoint = test.scheme + ln.Addr().String()
+			cfg.ClientConfig.Endpoint = test.scheme + ln.Addr().String()
 			cfg.Arrow.MaxStreamLifetime = 100 * time.Second
 			if test.useTLS {
-				cfg.TLS.InsecureSkipVerify = true
+				cfg.ClientConfig.TLS.InsecureSkipVerify = true
 			}
 			set := exportertest.NewNopSettings(factory.Type())
 			exp, err := factory.CreateTraces(t.Context(), set, cfg)

--- a/exporter/stefexporter/config.go
+++ b/exporter/stefexporter/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	QueueConfig                  configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:"sending_queue"`
 	RetryConfig                  configretry.BackOffConfig                                `mapstructure:"retry_on_failure"`
-	configgrpc.ClientConfig      `mapstructure:",squash"`
+	ClientConfig                 configgrpc.ClientConfig                                  `mapstructure:",squash"`
 }
 
 var _ component.Config = (*Config)(nil)
@@ -44,11 +44,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf(`invalid port "%s"`, port)
 	}
 
-	switch c.Compression {
+	switch c.ClientConfig.Compression {
 	case "":
 	case "zstd":
 	default:
-		return fmt.Errorf("unsupported compression method %q", c.Compression)
+		return fmt.Errorf("unsupported compression method %q", c.ClientConfig.Compression)
 	}
 
 	return nil
@@ -57,14 +57,14 @@ func (c *Config) Validate() error {
 // TODO: move this to configgrpc.ClientConfig to avoid this code duplication (copied from OTLP exporter).
 func (c *Config) sanitizedEndpoint() string {
 	switch {
-	case strings.HasPrefix(c.Endpoint, "http://"):
-		return strings.TrimPrefix(c.Endpoint, "http://")
-	case strings.HasPrefix(c.Endpoint, "https://"):
-		return strings.TrimPrefix(c.Endpoint, "https://")
-	case strings.HasPrefix(c.Endpoint, "dns://"):
+	case strings.HasPrefix(c.ClientConfig.Endpoint, "http://"):
+		return strings.TrimPrefix(c.ClientConfig.Endpoint, "http://")
+	case strings.HasPrefix(c.ClientConfig.Endpoint, "https://"):
+		return strings.TrimPrefix(c.ClientConfig.Endpoint, "https://")
+	case strings.HasPrefix(c.ClientConfig.Endpoint, "dns://"):
 		r := regexp.MustCompile(`^dns:///?`)
-		return r.ReplaceAllString(c.Endpoint, "")
+		return r.ReplaceAllString(c.ClientConfig.Endpoint, "")
 	default:
-		return c.Endpoint
+		return c.ClientConfig.Endpoint
 	}
 }

--- a/exporter/stefexporter/exporter.go
+++ b/exporter/stefexporter/exporter.go
@@ -55,18 +55,18 @@ func newStefExporter(set component.TelemetrySettings, cfg *Config) *stefExporter
 	}
 
 	exp.compression = stefpkg.CompressionNone
-	if exp.cfg.Compression == "zstd" {
+	if exp.cfg.ClientConfig.Compression == "zstd" {
 		exp.compression = stefpkg.CompressionZstd
 	}
 	// Disable built-in grpc compression. STEF has its own zstd compression support.
-	exp.cfg.Compression = ""
+	exp.cfg.ClientConfig.Compression = ""
 	return exp
 }
 
 func (s *stefExporter) Start(ctx context.Context, host component.Host) error {
 	// Prepare gRPC connection.
 	var err error
-	s.grpcConn, err = s.cfg.ToClientConn(ctx, host.GetExtensions(), s.set)
+	s.grpcConn, err = s.cfg.ClientConfig.ToClientConn(ctx, host.GetExtensions(), s.set)
 	if err != nil {
 		return err
 	}

--- a/exporter/stefexporter/exporter_test.go
+++ b/exporter/stefexporter/exporter_test.go
@@ -143,9 +143,9 @@ func runTest(
 	if cfg == nil {
 		cfg = factory.CreateDefaultConfig().(*Config)
 	}
-	cfg.Endpoint = mockSrv.endpoint
+	cfg.ClientConfig.Endpoint = mockSrv.endpoint
 	// Use insecure mode for tests so that we don't bother with certificates.
-	cfg.TLS.Insecure = true
+	cfg.ClientConfig.TLS.Insecure = true
 
 	// Make retries quick. We will be testing failure modes and don't want test to take too long.
 	cfg.RetryConfig.InitialInterval = 10 * time.Millisecond
@@ -174,7 +174,7 @@ func TestExport(t *testing.T) {
 			compression, func(t *testing.T) {
 				factory := NewFactory()
 				cfg := factory.CreateDefaultConfig().(*Config)
-				cfg.Compression = configcompression.Type(compression)
+				cfg.ClientConfig.Compression = configcompression.Type(compression)
 
 				runTest(
 					t,

--- a/internal/healthcheck/config.go
+++ b/internal/healthcheck/config.go
@@ -96,7 +96,7 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	if c.GRPCConfig != nil && c.GRPCConfig.NetAddr.Endpoint == "" {
+	if c.GRPCConfig != nil && c.GRPCConfig.ServerConfig.NetAddr.Endpoint == "" {
 		return ErrGRPCEndpointRequired
 	}
 

--- a/internal/healthcheck/extension_test.go
+++ b/internal/healthcheck/extension_test.go
@@ -30,7 +30,7 @@ import (
 func TestComponentStatus(t *testing.T) {
 	cfg := NewDefaultConfig().(*Config)
 	cfg.HTTPConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
-	cfg.GRPCConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCConfig.ServerConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.UseV2 = true
 	ext := NewHealthCheckExtension(*cfg, extensiontest.NewNopSettings(extensiontest.NopType))
 
@@ -170,7 +170,7 @@ func TestNotifyConfig(t *testing.T) {
 func TestComponentStatusChangedAfterShutdownDoesNotDeadlock(t *testing.T) {
 	cfg := NewDefaultConfig().(*Config)
 	cfg.HTTPConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
-	cfg.GRPCConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCConfig.ServerConfig.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.UseV2 = true
 	ext := NewHealthCheckExtension(*cfg, extensiontest.NewNopSettings(extensiontest.NopType))
 

--- a/internal/healthcheck/internal/grpc/config.go
+++ b/internal/healthcheck/internal/grpc/config.go
@@ -6,5 +6,5 @@ package grpc // import "github.com/open-telemetry/opentelemetry-collector-contri
 import "go.opentelemetry.io/collector/config/configgrpc"
 
 type Config struct {
-	configgrpc.ServerConfig `mapstructure:",squash"`
+	ServerConfig configgrpc.ServerConfig `mapstructure:",squash"`
 }

--- a/internal/healthcheck/internal/grpc/server.go
+++ b/internal/healthcheck/internal/grpc/server.go
@@ -52,13 +52,13 @@ func NewServer(
 // Start implements the component.Component interface.
 func (s *Server) Start(ctx context.Context, host component.Host) error {
 	var err error
-	s.grpcServer, err = s.config.ToServer(ctx, host.GetExtensions(), s.telemetry)
+	s.grpcServer, err = s.config.ServerConfig.ToServer(ctx, host.GetExtensions(), s.telemetry)
 	if err != nil {
 		return err
 	}
 
 	healthpb.RegisterHealthServer(s.grpcServer, s)
-	ln, err := s.config.NetAddr.Listen(context.Background())
+	ln, err := s.config.ServerConfig.NetAddr.Listen(context.Background())
 	if err != nil {
 		// Server never started, ensure doneCh is closed so shutdown doesn't block
 		s.doneOnce.Do(func() { close(s.doneCh) })

--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -137,9 +137,9 @@ func basicTestConfig(t *testing.T, tp testParams, cfgF CfgFunc) (*testConsumer, 
 
 	receiverCfg.GRPC.NetAddr.Endpoint = addr
 
-	exporterCfg.Endpoint = addr
-	exporterCfg.WaitForReady = true
-	exporterCfg.TLS.Insecure = true
+	exporterCfg.ClientConfig.Endpoint = addr
+	exporterCfg.ClientConfig.WaitForReady = true
+	exporterCfg.ClientConfig.TLS.Insecure = true
 	exporterCfg.TimeoutSettings.Timeout = time.Minute
 	exporterCfg.QueueSettings = configoptional.None[exporterhelper.QueueBatchConfig]()
 	exporterCfg.RetryConfig.Enabled = true

--- a/receiver/envoyalsreceiver/als.go
+++ b/receiver/envoyalsreceiver/als.go
@@ -31,7 +31,7 @@ type alsReceiver struct {
 
 func (r *alsReceiver) Start(ctx context.Context, host component.Host) error {
 	var err error
-	r.serverGRPC, err = r.conf.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings)
+	r.serverGRPC, err = r.conf.ServerConfig.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings)
 	if err != nil {
 		return fmt.Errorf("failed create grpc server error: %w", err)
 	}
@@ -47,8 +47,8 @@ func (r *alsReceiver) Start(ctx context.Context, host component.Host) error {
 }
 
 func (r *alsReceiver) startGRPCServer(ctx context.Context, host component.Host) error {
-	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", r.conf.NetAddr.Endpoint))
-	listener, err := r.conf.NetAddr.Listen(ctx)
+	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", r.conf.ServerConfig.NetAddr.Endpoint))
+	listener, err := r.conf.ServerConfig.NetAddr.Listen(ctx)
 	if err != nil {
 		return err
 	}

--- a/receiver/envoyalsreceiver/als_test.go
+++ b/receiver/envoyalsreceiver/als_test.go
@@ -46,7 +46,7 @@ func startGRPCServer(t *testing.T) (*grpc.ClientConn, *consumertest.LogsSink) {
 	require.NoError(t, lr.Start(t.Context(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, lr.Shutdown(t.Context())) })
 
-	conn, err := grpc.NewClient(config.NetAddr.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(config.ServerConfig.NetAddr.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	return conn, sink
 }

--- a/receiver/envoyalsreceiver/config.go
+++ b/receiver/envoyalsreceiver/config.go
@@ -10,6 +10,8 @@ import (
 
 type Config struct {
 	ServerConfig configgrpc.ServerConfig `mapstructure:",squash"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 var _ component.Config = (*Config)(nil)

--- a/receiver/envoyalsreceiver/config.go
+++ b/receiver/envoyalsreceiver/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Config struct {
-	configgrpc.ServerConfig `mapstructure:",squash"`
+	ServerConfig configgrpc.ServerConfig `mapstructure:",squash"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -26,10 +26,10 @@ const (
 
 // RemoteSamplingConfig defines config key for remote sampling fetch endpoint
 type RemoteSamplingConfig struct {
-	HostEndpoint               string        `mapstructure:"host_endpoint"`
-	StrategyFile               string        `mapstructure:"strategy_file"`
-	StrategyFileReloadInterval time.Duration `mapstructure:"strategy_file_reload_interval"`
-	configgrpc.ClientConfig    `mapstructure:",squash"`
+	HostEndpoint               string                  `mapstructure:"host_endpoint"`
+	StrategyFile               string                  `mapstructure:"strategy_file"`
+	StrategyFileReloadInterval time.Duration           `mapstructure:"strategy_file_reload_interval"`
+	ClientConfig               configgrpc.ClientConfig `mapstructure:",squash"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/receiver/stefreceiver/config.go
+++ b/receiver/stefreceiver/config.go
@@ -11,8 +11,8 @@ import (
 
 // Config defines configuration for STEF receiver.
 type Config struct {
-	configgrpc.ServerConfig `mapstructure:",squash"`
-	AckInterval             time.Duration `mapstructure:"ack_interval"`
+	ServerConfig configgrpc.ServerConfig `mapstructure:",squash"`
+	AckInterval  time.Duration           `mapstructure:"ack_interval"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/receiver/stefreceiver/config_test.go
+++ b/receiver/stefreceiver/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 			name: "endpoint",
 			expectedConfig: func() *Config {
 				cfg := createDefaultConfig().(*Config)
-				cfg.NetAddr.Endpoint = "0.0.0.0:3456"
+				cfg.ServerConfig.NetAddr.Endpoint = "0.0.0.0:3456"
 				return cfg
 			}(),
 		},
@@ -32,8 +32,8 @@ func TestConfig(t *testing.T) {
 			expectedConfig: func() *Config {
 				cfg := createDefaultConfig().(*Config)
 				tls := configtls.NewDefaultServerConfig()
-				cfg.TLS = configoptional.Some(tls)
-				cfg.TLS.Get().KeyFile = "server.key"
+				cfg.ServerConfig.TLS = configoptional.Some(tls)
+				cfg.ServerConfig.TLS.Get().KeyFile = "server.key"
 				return cfg
 			}(),
 		},

--- a/receiver/stefreceiver/e2e_test.go
+++ b/receiver/stefreceiver/e2e_test.go
@@ -40,7 +40,7 @@ func createReceiver(t *testing.T, endpoint string) (receiver.Metrics, *consumert
 	settings := receivertest.NewNopSettings(metadata.Type)
 	settings.Logger, _ = zap.NewDevelopment()
 	rcvCfg := createDefaultConfig()
-	rcvCfg.(*Config).NetAddr.Endpoint = endpoint
+	rcvCfg.(*Config).ServerConfig.NetAddr.Endpoint = endpoint
 	m, err := NewFactory().CreateMetrics(t.Context(), settings, rcvCfg, sink)
 	require.NoError(t, m.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, err)
@@ -49,8 +49,8 @@ func createReceiver(t *testing.T, endpoint string) (receiver.Metrics, *consumert
 
 func createExporter(t *testing.T, endpoint string) exporter.Metrics {
 	cfg := stefexporter.NewFactory().CreateDefaultConfig().(*stefexporter.Config)
-	cfg.Endpoint = endpoint
-	cfg.TLS.Insecure = true
+	cfg.ClientConfig.Endpoint = endpoint
+	cfg.ClientConfig.TLS.Insecure = true
 	settings := exportertest.NewNopSettings(metadata.Type)
 	settings.Logger, _ = zap.NewDevelopment()
 	exp, err := stefexporter.NewFactory().CreateMetrics(t.Context(), settings, cfg)

--- a/receiver/stefreceiver/stef.go
+++ b/receiver/stefreceiver/stef.go
@@ -43,11 +43,11 @@ func (r *stefReceiver) Start(ctx context.Context, host component.Host) error {
 	r.stopping.Store(false)
 
 	var err error
-	if r.serverGRPC, err = r.cfg.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings); err != nil {
+	if r.serverGRPC, err = r.cfg.ServerConfig.ToServer(ctx, host.GetExtensions(), r.settings.TelemetrySettings); err != nil {
 		return err
 	}
 
-	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", r.cfg.NetAddr.Endpoint))
+	r.settings.Logger.Info("Starting GRPC server", zap.String("endpoint", r.cfg.ServerConfig.NetAddr.Endpoint))
 
 	schema, err := otelstef.MetricsWireSchema()
 	if err != nil {
@@ -55,7 +55,7 @@ func (r *stefReceiver) Start(ctx context.Context, host component.Host) error {
 	}
 
 	var gln net.Listener
-	if gln, err = r.cfg.NetAddr.Listen(context.Background()); err != nil {
+	if gln, err = r.cfg.ServerConfig.NetAddr.Listen(context.Background()); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func (r *stefReceiver) Shutdown(context.Context) error {
 	r.stopping.Store(true)
 
 	if r.serverGRPC != nil {
-		r.settings.Logger.Info("Stopping STEF/gRPC server", zap.String("endpoint", r.cfg.NetAddr.Endpoint))
+		r.settings.Logger.Info("Stopping STEF/gRPC server", zap.String("endpoint", r.cfg.ServerConfig.NetAddr.Endpoint))
 
 		// Give graceful stop a second to finish.
 		timer := time.AfterFunc(

--- a/receiver/yanggrpcreceiver/config.go
+++ b/receiver/yanggrpcreceiver/config.go
@@ -72,7 +72,7 @@ type YANGConfig struct {
 
 // Config defines configuration for yanggrpc receiver.
 type Config struct {
-	configgrpc.ServerConfig `mapstructure:",squash"`
+	ServerConfig configgrpc.ServerConfig `mapstructure:",squash"`
 
 	// YANG contains YANG parser configuration
 	YANG YANGConfig `mapstructure:"yang"`

--- a/receiver/yanggrpcreceiver/detailed_validation_test.go
+++ b/receiver/yanggrpcreceiver/detailed_validation_test.go
@@ -67,8 +67,8 @@ func TestDetailedTelemetryValidation(t *testing.T) {
 	// Create receiver configuration
 	config := createDefaultConfig().(*Config)
 
-	config.NetAddr.Endpoint = "localhost:57403"
-	config.NetAddr.Transport = "tcp"
+	config.ServerConfig.NetAddr.Endpoint = "localhost:57403"
+	config.ServerConfig.NetAddr.Transport = "tcp"
 
 	settings := receiver.Settings{
 		ID:                component.NewID(metadata.Type),

--- a/receiver/yanggrpcreceiver/factory.go
+++ b/receiver/yanggrpcreceiver/factory.go
@@ -46,12 +46,12 @@ func createDefaultConfig() component.Config {
 			MaxModules:      1000,
 		},
 	}
-	config.NetAddr.Transport = "tcp"
-	config.NetAddr.Endpoint = "localhost:57500"
-	config.MaxRecvMsgSizeMiB = 4
-	config.MaxConcurrentStreams = 100
-	config.Keepalive.GetOrInsertDefault().ServerParameters.GetOrInsertDefault().Time = 30 * time.Second
-	config.Keepalive.GetOrInsertDefault().ServerParameters.GetOrInsertDefault().Timeout = 10 * time.Second
+	config.ServerConfig.NetAddr.Transport = "tcp"
+	config.ServerConfig.NetAddr.Endpoint = "localhost:57500"
+	config.ServerConfig.MaxRecvMsgSizeMiB = 4
+	config.ServerConfig.MaxConcurrentStreams = 100
+	config.ServerConfig.Keepalive.GetOrInsertDefault().ServerParameters.GetOrInsertDefault().Time = 30 * time.Second
+	config.ServerConfig.Keepalive.GetOrInsertDefault().ServerParameters.GetOrInsertDefault().Timeout = 10 * time.Second
 
 	return config
 }

--- a/receiver/yanggrpcreceiver/grpc_service_test.go
+++ b/receiver/yanggrpcreceiver/grpc_service_test.go
@@ -23,7 +23,7 @@ import (
 func TestGrpcService_ProcessTelemetryData(t *testing.T) {
 	// Create a test receiver
 	config := createValidTestConfig()
-	config.NetAddr.Endpoint = "localhost:0" // Use a random port
+	config.ServerConfig.NetAddr.Endpoint = "localhost:0" // Use a random port
 
 	mockConsumer := &consumertest.MetricsSink{}
 	settings := createTestSettings()

--- a/receiver/yanggrpcreceiver/receiver.go
+++ b/receiver/yanggrpcreceiver/receiver.go
@@ -40,7 +40,7 @@ func createMetricsReceiver(_ context.Context, settings receiver.Settings, cfg co
 
 func (y *yangReceiver) Start(ctx context.Context, host component.Host) error {
 	// 1. Setup Network Listener
-	listener, err := y.config.NetAddr.Listen(ctx)
+	listener, err := y.config.ServerConfig.NetAddr.Listen(ctx)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (y *yangReceiver) Start(ctx context.Context, host component.Host) error {
 	)
 
 	// 3. Configure gRPC Server with Security Interceptors
-	server, err := y.config.ToServer(ctx, host.GetExtensions(), y.settings.TelemetrySettings,
+	server, err := y.config.ServerConfig.ToServer(ctx, host.GetExtensions(), y.settings.TelemetrySettings,
 		configgrpc.WithGrpcServerOption(grpc.UnaryInterceptor(y.securityManager.CreateSecurityInterceptor())))
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (y *yangReceiver) Start(ctx context.Context, host component.Host) error {
 	// 6. Start Serving
 	y.wg.Go(func() {
 		y.settings.Logger.Info("Starting YANG gRPC receiver",
-			zap.String("endpoint", y.config.NetAddr.Endpoint))
+			zap.String("endpoint", y.config.ServerConfig.NetAddr.Endpoint))
 		if err := y.server.Serve(listener); err != nil {
 			y.settings.Logger.Error("gRPC server error", zap.Error(err))
 		}

--- a/receiver/yanggrpcreceiver/sample_telemetry_test.go
+++ b/receiver/yanggrpcreceiver/sample_telemetry_test.go
@@ -50,8 +50,8 @@ func TestSampleTelemetryData(t *testing.T) {
 
 	// Create receiver configuration
 	config := createDefaultConfig().(*Config)
-	config.NetAddr.Endpoint = "localhost:57404"
-	config.NetAddr.Transport = "tcp"
+	config.ServerConfig.NetAddr.Endpoint = "localhost:57404"
+	config.ServerConfig.NetAddr.Transport = "tcp"
 
 	settings := receiver.Settings{
 		ID:                component.NewID(metadata.Type),
@@ -73,7 +73,7 @@ func TestSampleTelemetryData(t *testing.T) {
 	// Wait until the gRPC server is ready to accept connections instead of using
 	// a fixed sleep, which is unreliable on slow or loaded CI machines.
 	require.Eventually(t, func() bool {
-		conn, err := net.DialTimeout(string(config.NetAddr.Transport), config.NetAddr.Endpoint, 100*time.Millisecond)
+		conn, err := net.DialTimeout(string(config.ServerConfig.NetAddr.Transport), config.ServerConfig.NetAddr.Endpoint, 100*time.Millisecond)
 		if err != nil {
 			return false
 		}

--- a/testbed/datareceivers/stefdatareceiver/receiver.go
+++ b/testbed/datareceivers/stefdatareceiver/receiver.go
@@ -38,7 +38,7 @@ func (sr *StefDataReceiver) Start(_ consumer.Traces, mc consumer.Metrics, _ cons
 	var err error
 	f := stefreceiver.NewFactory()
 	config := f.CreateDefaultConfig()
-	config.(*stefreceiver.Config).NetAddr.Endpoint = fmt.Sprintf("127.0.0.1:%d", sr.Port)
+	config.(*stefreceiver.Config).ServerConfig.NetAddr.Endpoint = fmt.Sprintf("127.0.0.1:%d", sr.Port)
 
 	set := receivertest.NewNopSettings(f.Type())
 	if sr.Logger != nil {

--- a/testbed/datasenders/jaegerdatasender/sender.go
+++ b/testbed/datasenders/jaegerdatasender/sender.go
@@ -79,14 +79,14 @@ type jaegerConfig struct {
 	QueueSettings             configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:"sending_queue"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 
-	configgrpc.ClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	ClientConfig configgrpc.ClientConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }
 
 var _ component.Config = (*jaegerConfig)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *jaegerConfig) Validate() error {
-	if cfg.Endpoint == "" {
+	if cfg.ClientConfig.Endpoint == "" {
 		return errors.New("must have a non-empty \"endpoint\"")
 	}
 	return nil
@@ -97,8 +97,8 @@ func (cfg *jaegerConfig) Validate() error {
 // The collectorEndpoint should be of the form "hostname:14250" (a gRPC target).
 func (je *jaegerGRPCDataSender) newTracesExporter(set exporter.Settings) (exporter.Traces, error) {
 	cfg := jaegerConfig{}
-	cfg.Endpoint = je.GetEndpoint().String()
-	cfg.TLS = configtls.ClientConfig{
+	cfg.ClientConfig.Endpoint = je.GetEndpoint().String()
+	cfg.ClientConfig.TLS = configtls.ClientConfig{
 		Insecure: true,
 	}
 
@@ -106,7 +106,7 @@ func (je *jaegerGRPCDataSender) newTracesExporter(set exporter.Settings) (export
 		name:                      set.ID.String(),
 		settings:                  set.TelemetrySettings,
 		metadata:                  metadata.New(nil),
-		waitForReady:              cfg.WaitForReady,
+		waitForReady:              cfg.ClientConfig.WaitForReady,
 		connStateReporterInterval: time.Second,
 		stopCh:                    make(chan struct{}),
 		clientSettings:            &cfg.ClientConfig,

--- a/testbed/datasenders/otelarrowdatasender/sender.go
+++ b/testbed/datasenders/otelarrowdatasender/sender.go
@@ -36,11 +36,11 @@ func NewOtelarrowDataSender(host string, port int) testbed.MetricDataSender {
 func (ds *otelarrowDataSender) Start() error {
 	factory := otelarrowexporter.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*otelarrowexporter.Config)
-	cfg.Endpoint = ds.GetEndpoint().String()
-	cfg.TLS = configtls.ClientConfig{
+	cfg.ClientConfig.Endpoint = ds.GetEndpoint().String()
+	cfg.ClientConfig.TLS = configtls.ClientConfig{
 		Insecure: true,
 	}
-	cfg.Compression = "none"
+	cfg.ClientConfig.Compression = "none"
 	params := exportertest.NewNopSettings(factory.Type())
 	params.Logger = zap.L()
 

--- a/testbed/datasenders/stefdatasender/sender.go
+++ b/testbed/datasenders/stefdatasender/sender.go
@@ -37,8 +37,8 @@ func NewStefDataSender(host string, port int) *StefDataSender {
 func (sds *StefDataSender) Start() error {
 	factory := stefexporter.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*stefexporter.Config)
-	cfg.Endpoint = sds.GetEndpoint().String()
-	cfg.TLS = configtls.ClientConfig{
+	cfg.ClientConfig.Endpoint = sds.GetEndpoint().String()
+	cfg.ClientConfig.TLS = configtls.ClientConfig{
 		Insecure: true,
 	}
 	params := exportertest.NewNopSettings(factory.Type())


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Stops embedding  `configgrpc.ClientConfig` / `configgrpc.ServerConfig` fields.

This was fully generated with Opus 4.8 following open-telemetry/opentelemetry-collector#12718. The bulk of it was done by running this script https://gist.github.com/mx-psi/c5243da22050b763f041a491ce339ea3, with manual (AI) edits afterwards.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Possible solution for open-telemetry/opentelemetry-collector/pull/15308

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
