### PR TITLE
[extension/ecsobserver]: fix multiple deployments detection

### DIFF
--- a/.chloggen/ecs-observer-fix-multiple-deployments.yaml
+++ b/.chloggen/ecs-observer-fix-multiple-deployments.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/ecs_observer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handle multiple deployments for a service when attaching service to task.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49801]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -405,7 +405,6 @@ func (*taskFetcher) attachService(tasks []*taskAnnotated, services []ecstypes.Se
 			status := *deployment.Status
 			if status == deploymentStatusActive || status == deploymentStatusPrimary {
 				idToService[*deployment.Id] = svc
-				break
 			}
 		}
 	}

--- a/extension/observer/ecsobserver/fetcher_test.go
+++ b/extension/observer/ecsobserver/fetcher_test.go
@@ -281,3 +281,49 @@ func TestFetcher_AttachService(t *testing.T) {
 	assert.NotNil(t, tasks[nTasks-2].Service)
 	assert.Nil(t, tasks[nTasks-1].Service)
 }
+
+func TestFetcher_AttachServiceMultipleDeployments(t *testing.T) {
+	c := ecsmock.NewCluster()
+	f := newTestTaskFetcher(t, c, c)
+	// Single service with two deployments to simulate an update
+	const nServices = 1
+	c.SetServices(ecsmock.GenServices("s", nServices, func(i int, s *ecstypes.Service) {
+		s.Deployments = []ecstypes.Deployment{
+			{
+				Status: aws.String("ACTIVE"),
+				Id:     aws.String(fmt.Sprintf("deploy-active-%d", i)),
+			},
+			{
+				Status: aws.String("PRIMARY"),
+				Id:     aws.String(fmt.Sprintf("deploy-primary-%d", i)),
+			},
+		}
+	}))
+	c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("def", nServices, 1, nil))
+	const nTasks = 3
+	c.SetTasks(ecsmock.GenTasks("t", nTasks, func(i int, task *ecstypes.Task) {
+		deployID := 0
+		task.TaskDefinitionArn = aws.String(fmt.Sprintf("def%d:1", deployID))
+		switch i % 3 {
+		case 0:
+			task.StartedBy = aws.String(fmt.Sprintf("deploy-active-%d", deployID))
+		case 1:
+			task.StartedBy = aws.String(fmt.Sprintf("deploy-primary-%d", deployID))
+		}
+	}))
+
+	ctx := t.Context()
+	rawTasks, err := f.getDiscoverableTasks(ctx)
+	require.NoError(t, err)
+	tasks, err := f.attachTaskDefinition(ctx, rawTasks)
+	require.NoError(t, err)
+	services, err := f.getAllServices(ctx)
+	require.NoError(t, err)
+	f.attachService(tasks, services)
+
+	assert.Len(t, tasks, nTasks)
+	assert.Equal(t, "s0", *tasks[0].Service.ServiceArn)
+	assert.Equal(t, "s0", *tasks[1].Service.ServiceArn)
+	assert.NotNil(t, tasks[nTasks-2].Service)
+	assert.Nil(t, tasks[nTasks-1].Service)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes a bug that occurred when multiple deployments were associated with an ECS service: only the first deployment was considered for matching tasks to services.

During an update deployment, tasks run simultaneously from both the old and new deployments. With this `break` statement, only certain tasks are associated with the service; others are excluded from the observer output if a filter based on service properties is configured.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
None

<!--Describe what testing was performed and which tests were added.-->
#### Testing

`make test`

<!--Describe the documentation added.-->
#### Documentation

None 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
