### PR TITLE
[chore][pkg/signalfx/translator] fix allocation

### DIFF
--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1801,7 +1802,15 @@ func newLocalHTTPSTestServer(handler http.Handler) (*httptest.Server, error) {
 	return ts, nil
 }
 
+func BenchmarkExporterConsumeDataWithSFxHistograms(b *testing.B) {
+	benchmarkExporterConsumeDataWithHistograms(b, false, "application/x-protobuf")
+}
+
 func BenchmarkExporterConsumeDataWithOTLPHistograms(b *testing.B) {
+	benchmarkExporterConsumeDataWithHistograms(b, true, otlpProtobufContentType)
+}
+
+func benchmarkExporterConsumeDataWithHistograms(b *testing.B, sendOTLPHistograms bool, expectedContentType string) {
 	batchSize := 1000
 	metrics := pmetric.NewMetrics()
 	tmd := testMetricsData(true)
@@ -1809,19 +1818,28 @@ func BenchmarkExporterConsumeDataWithOTLPHistograms(b *testing.B) {
 		tmd.ResourceMetrics().At(0).CopyTo(metrics.ResourceMetrics().AppendEmpty())
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var requestCount atomic.Int64
+	var invalidContentType atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if r.Header.Get("Content-Type") != expectedContentType {
+			invalidContentType.Store(true)
+		}
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()
 	serverURL, err := url.Parse(server.URL)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "", false, false)
+	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "", false, !sendOTLPHistograms)
 	require.NoError(b, err)
 	require.NotNil(b, c)
 	dpClient := &sfxDPClient{
 		sfxClientBase: sfxClientBase{
 			ingestURL: serverURL,
+			headers: map[string]string{
+				contentTypeHeader: "application/x-protobuf",
+			},
 			client: &http.Client{
 				Timeout: 1 * time.Second,
 			},
@@ -1829,14 +1847,26 @@ func BenchmarkExporterConsumeDataWithOTLPHistograms(b *testing.B) {
 				return gzip.NewWriter(nil)
 			}},
 		},
-		logger:    zap.NewNop(),
-		converter: c,
+		logger:             zap.NewNop(),
+		converter:          c,
+		sendOTLPHistograms: sendOTLPHistograms,
 	}
 
+	b.ReportAllocs()
 	for b.Loop() {
 		numDroppedTimeSeries, err := dpClient.pushMetricsData(b.Context(), metrics)
-		assert.NoError(b, err)
-		assert.Equal(b, 0, numDroppedTimeSeries)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if numDroppedTimeSeries != 0 {
+			b.Fatalf("dropped %d time series", numDroppedTimeSeries)
+		}
+	}
+	if invalidContentType.Load() {
+		b.Fatalf("expected Content-Type %q", expectedContentType)
+	}
+	if got := requestCount.Load(); got != int64(b.N) {
+		b.Fatalf("sent %d requests, expected %d", got, b.N)
 	}
 }
 

--- a/exporter/signalfxexporter/histogram_utils_test.go
+++ b/exporter/signalfxexporter/histogram_utils_test.go
@@ -43,7 +43,7 @@ func buildHistogramDP(dp pmetric.HistogramDataPoint, timestamp pcommon.Timestamp
 	dp.SetMax(2)
 	dp.SetCount(5)
 	dp.SetSum(7.0)
-	dp.BucketCounts().FromRaw([]uint64{3, 2})
+	dp.BucketCounts().FromRaw([]uint64{3, 2, 0})
 	dp.ExplicitBounds().FromRaw([]float64{1, 2})
 	dp.Attributes().PutStr("k1", "v1")
 }

--- a/pkg/translator/signalfx/from_metrics.go
+++ b/pkg/translator/signalfx/from_metrics.go
@@ -288,14 +288,15 @@ func newDpsBuilder(capacity int) dpsBuilder {
 }
 
 func (dp *dpsBuilder) appendPoint(name string, mt *sfxpb.MetricType, ts int64, dims []*sfxpb.Dimension) *sfxpb.DataPoint {
-	base := dp.baseOut[dp.pos]
+	// Taking the address of a copied element allocates once per point.
+	base := &dp.baseOut[dp.pos]
 	dp.pos++
-	dp.out = append(dp.out, &base)
+	dp.out = append(dp.out, base)
 	base.Metric = name
 	base.Timestamp = ts
 	base.MetricType = mt
 	base.Dimensions = dims
-	return &base
+	return base
 }
 
 // Is equivalent to strconv.FormatFloat(f, 'g', -1, 64), but hard-codes a few common cases for increased efficiency.

--- a/pkg/translator/signalfx/from_metrics_test.go
+++ b/pkg/translator/signalfx/from_metrics_test.go
@@ -521,6 +521,16 @@ func Test_FromMetrics(t *testing.T) {
 	}
 }
 
+func TestDpsBuilderAppendPointUsesBackingArray(t *testing.T) {
+	builder := newDpsBuilder(2)
+
+	first := builder.appendPoint("first", &sfxMetricTypeGauge, 1, nil)
+	second := builder.appendPoint("second", &sfxMetricTypeGauge, 2, nil)
+
+	require.Same(t, &builder.baseOut[0], first)
+	require.Same(t, &builder.baseOut[1], second)
+}
+
 func sortDimensions(points []*sfxpb.DataPoint) {
 	for _, point := range points {
 		if point.Dimensions == nil {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
`dpsBuilder` preallocates a backing array for SignalFx data points, but `appendPoint` copied each element into a local variable and stored a pointer to that copy. This caused one heap allocation per generated data point and defeated the purpose of the preallocated array.

Use the data point directly from the backing array instead. The regression test verifies that returned pointers reference the backing array.

This also splits the histogram exporter benchmark into SignalFx and OTLP variants. The existing benchmark included histogram data but was not configured to send it through either histogram path. Both benchmarks now verify the expected request content type and request count.

There is no user-facing behavior or configuration change.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added regression test and updated benchmark tests to include both types of histograms.

Ran the SignalFx histogram benchmark five times before and after the allocation fix using the same histogram fixture:

```shell
go test . -run '^$' \
  -bench '^BenchmarkExporterConsumeDataWithSFxHistograms$' \
  -benchmem -count=5
```

Median results:

| Version | Time/op | Bytes/op | Allocations/op |
|---|---:|---:|---:|
| Before | 63.28 ms | 147,140,677 B | 1,104,176 |
| After | 50.91 ms | 102,339,587 B | 824,174 |
| Change | -19.5% | -30.4% | -25.4% |

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
