### PR TITLE
[bug_fix] Fixed silent log drops when more than 1000 lines.

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug in the text encoding extension where logs were silently truncated if the input had more than 1000 records.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49817]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/textencodingextension/text.go
+++ b/extension/encoding/textencodingextension/text.go
@@ -27,7 +27,7 @@ type textLogCodec struct {
 
 func (r *textLogCodec) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 	// Decode as a stream but flush all at once using flush options
-	decoder, err := r.NewLogsDecoder(bytes.NewReader(buf), encoding.WithOffset(0), encoding.WithFlushBytes(0))
+	decoder, err := r.NewLogsDecoder(bytes.NewReader(buf), encoding.WithOffset(0), encoding.WithFlushBytes(0), encoding.WithFlushItems(0))
 	if err != nil {
 		return plog.Logs{}, err
 	}

--- a/extension/encoding/textencodingextension/text_test.go
+++ b/extension/encoding/textencodingextension/text_test.go
@@ -5,6 +5,8 @@ package textencodingextension
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"io"
 	"regexp"
 	"testing"
@@ -175,4 +177,23 @@ func TestStreamDecoding_flushAll(t *testing.T) {
 	ld, err = decoder.DecodeLogs()
 	assert.ErrorIs(t, err, io.EOF)
 	assert.Equal(t, 0, ld.LogRecordCount())
+}
+
+func TestUnmarshalLogsAcrossMultipleBatches(t *testing.T) {
+	// Regression test: inputs with more than the default 1000-item flush
+	// threshold must not be silently truncated by UnmarshalLogs.
+	enc, err := textutils.LookupEncoding("utf8")
+	require.NoError(t, err)
+	r := regexp.MustCompile(`\r?\n`)
+	codec := &textLogCodec{decoder: enc.NewDecoder(), unmarshalingSeparator: r, marshalingSeparator: "\n"}
+
+	var input strings.Builder
+	const recordCount = 1863
+	for i := 0; i < recordCount; i++ {
+		fmt.Fprintf(&input, "record-%d\n", i)
+	}
+
+	logs, err := codec.UnmarshalLogs([]byte(input.String()))
+	require.NoError(t, err)
+	require.Equal(t, recordCount, logs.LogRecordCount())
 }


### PR DESCRIPTION
#### Description
When extracting lines of logs with text encoding, the [code](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/602d31cd344334865e78843878460e2d0e4390e2/extension/encoding/textencodingextension/text.go#L30) ensures that logs are processed in chunks but flushed at once. The default flush values are 1000x1024x1024 bytes or 1000 items. During streaming, we override the defaults so that flushes happen at once. We override the default for bytes, but the items override was missed. This causes logs greater than 1000 lines to silently drop.
The PR adds a change to override the default items to 0 so that the flush happens for all logs once they are prepared. There were two ways to fix this:

- The current implementation.
- Flushing in chunks instead of holding everything in memory.

I chose the first approach because I may not have proper context on why flush-all was done in the first place.


##### History (How I came across this, and design choices)
I am using OTEL for extracting AWS ELB logs. As per the standard AWS setup, these logs are delivered as S3 objects that I need to onboard into my DB. For this, I use the `awss3receiver` with a queue in place via which notifications come for every new S3 file creation. Since these are compressed objects, we need extensions to extract and process each line of the log separately.

I am using `textencoding` instead of the `awslogencoding` extension because that has two major blockers for me:

- The body is not propagated further after the receiver layer.
- Not all data is extracted (for example, received_at time is not extracted).

By using text encoding, I wrote a transformer over it to mimic the extraction layer at my config end. This helps me with any type of customization as well.

While doing this, I noticed logs were getting dropped. After debugging, I found this bug.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I've added a test to verify that if the streamed log is more than 1000, then it shouldn't drop it, and all logs are to be flushed. (AI-generated test case)

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

