### PR TITLE
[exporter/elasticsearch] Allow traces, profiles, synthetics as data_stream.type values

### DIFF
--- a/.chloggen/49337-elasticsearch-datastream-type.yaml
+++ b/.chloggen/49337-elasticsearch-datastream-type.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow `traces`, `profiles`, and `synthetics` as valid `data_stream.type` values when overriding via attributes in `bodymap` mapping mode, in addition to the existing `logs` and `metrics`."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49337]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -107,7 +107,7 @@ Documents are statically or dynamically routed to the target index / data stream
 2. "Dynamic - Index attribute mode": Route to index name specified in `elasticsearch.index` attribute (precedence: log record / data point / span attribute > scope attribute > resource attribute) if the attribute exists. [^3]
 3. "Dynamic - Data stream routing mode": Route to data stream constructed from `${data_stream.type}-${data_stream.dataset}-${data_stream.namespace}`,
 where `data_stream.type` is `logs` for log records, `metrics` for data points, and `traces` for spans, and is static. [^3]
-In a special case with `mapping::mode: bodymap`, `data_stream.type` field (valid values: `logs`, `metrics`) can be dynamically set from attributes.
+In a special case with `mapping::mode: bodymap`, `data_stream.type` field (valid values: `logs`, `metrics`, `traces`, `profiles`, `synthetics`) can be dynamically set from attributes.
 The resulting documents will contain the corresponding `data_stream.*` fields, see restrictions applied to [Data Stream Fields](https://www.elastic.co/guide/en/ecs/current/ecs-data_stream.html).
    1. `data_stream.dataset` or `data_stream.namespace` in attributes (precedence: log record / data point / span attribute > scope attribute > resource attribute)
    2. Otherwise, if a scope attribute with the name `encoding.format` exists and contains a string value, `data_stream.dataset` will be set to this value. 

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -107,8 +107,8 @@ Documents are statically or dynamically routed to the target index / data stream
 2. "Dynamic - Index attribute mode": Route to index name specified in `elasticsearch.index` attribute (precedence: log record / data point / span attribute > scope attribute > resource attribute) if the attribute exists. [^3]
 3. "Dynamic - Data stream routing mode": Route to data stream constructed from `${data_stream.type}-${data_stream.dataset}-${data_stream.namespace}`,
 where `data_stream.type` is `logs` for log records, `metrics` for data points, and `traces` for spans, and is static. [^3]
-In a special case with `mapping::mode: bodymap`, `data_stream.type` field (valid values: `logs`, `metrics`, `traces`, `profiles`, `synthetics`) can be dynamically set from attributes.
-The resulting documents will contain the corresponding `data_stream.*` fields, see restrictions applied to [Data Stream Fields](https://www.elastic.co/guide/en/ecs/current/ecs-data_stream.html).
+  In a special case with `mapping::mode: bodymap`, `data_stream.type` field (valid values: `logs`, `metrics`, `traces`, `profiles`, `synthetics`) can be dynamically set from attributes.
+  The resulting documents will contain the corresponding `data_stream.*` fields, see restrictions applied to [Data Stream Fields](https://www.elastic.co/guide/en/ecs/current/ecs-data_stream.html).
    1. `data_stream.dataset` or `data_stream.namespace` in attributes (precedence: log record / data point / span attribute > scope attribute > resource attribute)
    2. Otherwise, if a scope attribute with the name `encoding.format` exists and contains a string value, `data_stream.dataset` will be set to this value. 
 

--- a/exporter/elasticsearchexporter/attribute.go
+++ b/exporter/elasticsearchexporter/attribute.go
@@ -14,6 +14,7 @@ const (
 	defaultDataStreamTypeMetrics            = "metrics"
 	defaultDataStreamTypeTraces             = "traces"
 	defaultDataStreamTypeProfiles           = "profiles"
+	defaultDataStreamTypeSynthetics         = "synthetics"
 )
 
 func getFromAttributes(name, defaultValue string, attributeMaps ...pcommon.Map) (string, bool) {

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -35,14 +35,19 @@ const (
 	encodingFormatAttributeName = "encoding.format"
 )
 
-// allowedDataStreamTypes lists the data_stream.type values that users are
-// allowed to set via attributes when using the 'bodymap' mapping mode.
-var allowedDataStreamTypes = map[string]bool{
-	defaultDataStreamTypeLogs:       true,
-	defaultDataStreamTypeMetrics:    true,
-	defaultDataStreamTypeTraces:     true,
-	defaultDataStreamTypeProfiles:   true,
-	defaultDataStreamTypeSynthetics: true,
+// isAllowedDataStreamType reports whether dsType is a valid data_stream.type
+// value that users may set via attributes when using the 'bodymap' mapping mode.
+func isAllowedDataStreamType(dsType string) bool {
+	switch dsType {
+	case defaultDataStreamTypeLogs,
+		defaultDataStreamTypeMetrics,
+		defaultDataStreamTypeTraces,
+		defaultDataStreamTypeProfiles,
+		defaultDataStreamTypeSynthetics:
+		return true
+	default:
+		return false
+	}
 }
 
 // Sanitize the datastream fields (dataset, namespace) to apply restrictions
@@ -195,7 +200,7 @@ func routeRecord(
 	// if mapping mode is bodymap, allow overriding data_stream.type
 	if mode == MappingBodyMap {
 		dsType, _ = getFromAttributes(elasticsearch.DataStreamType, defaultDSType, recordAttr, scopeAttr, resourceAttr)
-		if !allowedDataStreamTypes[dsType] {
+		if !isAllowedDataStreamType(dsType) {
 			return elasticsearch.Index{}, fmt.Errorf("data_stream.type %q is not allowed for 'bodymap' mapping mode", dsType)
 		}
 	}

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -4,7 +4,7 @@
 package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 
 import (
-	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -34,6 +34,16 @@ const (
 	disallowedDatasetRunes      = "-\\/*?\"<>| ,#:"
 	encodingFormatAttributeName = "encoding.format"
 )
+
+// allowedDataStreamTypes lists the data_stream.type values that users are
+// allowed to set via attributes when using the 'bodymap' mapping mode.
+var allowedDataStreamTypes = map[string]bool{
+	defaultDataStreamTypeLogs:       true,
+	defaultDataStreamTypeMetrics:    true,
+	defaultDataStreamTypeTraces:     true,
+	defaultDataStreamTypeProfiles:   true,
+	defaultDataStreamTypeSynthetics: true,
+}
 
 // Sanitize the datastream fields (dataset, namespace) to apply restrictions
 // as outlined in https://www.elastic.co/guide/en/ecs/current/ecs-data_stream.html
@@ -185,8 +195,8 @@ func routeRecord(
 	// if mapping mode is bodymap, allow overriding data_stream.type
 	if mode == MappingBodyMap {
 		dsType, _ = getFromAttributes(elasticsearch.DataStreamType, defaultDSType, recordAttr, scopeAttr, resourceAttr)
-		if dsType != "logs" && dsType != "metrics" {
-			return elasticsearch.Index{}, errors.New("data_stream.type cannot be other than logs or metrics")
+		if !allowedDataStreamTypes[dsType] {
+			return elasticsearch.Index{}, fmt.Errorf("data_stream.type %q is not allowed for 'bodymap' mapping mode", dsType)
 		}
 	}
 

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -141,7 +141,7 @@ func TestRouteLogRecord(t *testing.T) {
 		attrs := pcommon.NewMap()
 		attrs.PutStr("data_stream.type", dsType)
 		_, err := router.routeLogRecord(pcommon.NewResource(), pcommon.NewInstrumentationScope(), attrs)
-		require.Error(t, err, `data_stream.type "random" is not allowed for 'bodymap' mapping mode`)
+		require.EqualError(t, err, `data_stream.type "random" is not allowed for 'bodymap' mapping mode`)
 	})
 }
 

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -124,13 +124,24 @@ func TestRouteLogRecord(t *testing.T) {
 		assert.Equal(t, "logs", ds.Type) // should equal to logs
 	})
 
-	t.Run("test data_stream.type does not accept values other than logs/metrics", func(t *testing.T) {
+	t.Run("test data_stream.type accepts traces/profiles/synthetics for bodymap mode", func(t *testing.T) {
+		for _, dsType := range []string{"traces", "profiles", "synthetics"} {
+			router := dynamicDocumentRouter{mode: MappingBodyMap}
+			attrs := pcommon.NewMap()
+			attrs.PutStr("data_stream.type", dsType)
+			ds, err := router.routeLogRecord(pcommon.NewResource(), pcommon.NewInstrumentationScope(), attrs)
+			require.NoError(t, err)
+			assert.Equal(t, dsType, ds.Type)
+		}
+	})
+
+	t.Run("test data_stream.type does not accept arbitrary values", func(t *testing.T) {
 		dsType := "random"
 		router := dynamicDocumentRouter{mode: MappingBodyMap}
 		attrs := pcommon.NewMap()
 		attrs.PutStr("data_stream.type", dsType)
 		_, err := router.routeLogRecord(pcommon.NewResource(), pcommon.NewInstrumentationScope(), attrs)
-		require.Error(t, err, "data_stream.type cannot be other than logs or metrics")
+		require.Error(t, err, `data_stream.type "random" is not allowed for 'bodymap' mapping mode`)
 	})
 }
 


### PR DESCRIPTION
#### Description
The elasticsearch exporter's `bodymap` mapping mode only allowed `data_stream.type` to be `logs` or `metrics`. Elasticsearch itself accepts other data stream types like `synthetics` (used by heartbeat), `traces`, and `profiles`. This PR removes that restriction and allows these additional values.

#### Link to tracking issue
Fixes #49337

#### Testing
Added a test case that checks `traces`, `profiles`, and `synthetics` are all accepted and routed correctly in bodymap mode. Updated the existing invalid-value test to match the new error message.

#### Documentation
Updated the README to list the newly allowed `data_stream.type` values.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

