### PR TITLE
fix: setting IsMonotonic to true during Cumulative metric conversion

### DIFF
--- a/.chloggen/fix_googlecloudmonitoring-cumulative-metrics.yaml
+++ b/.chloggen/fix_googlecloudmonitoring-cumulative-metrics.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/googlecloudmonitoringreceiver
+component: receiver/googlecloudmonitoring
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fix cumulative metrics to be marked as monotonic"

--- a/.chloggen/fix_googlecloudmonitoring-cumulative-metrics.yaml
+++ b/.chloggen/fix_googlecloudmonitoring-cumulative-metrics.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudmonitoringreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix cumulative metrics to be marked as monotonic"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49804]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix_googlecloudmonitoring-cumulative-metrics.yaml
+++ b/.chloggen/fix_googlecloudmonitoring-cumulative-metrics.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: receiver/googlecloudmonitoring
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Fix cumulative metrics to be marked as monotonic"
+note: "CUMULATIVE metrics from Cloud Monitoring will now be properly marked as monotonic upon conversion"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49804]

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -83,6 +83,8 @@ func (mb *MetricsBuilder) ConvertSumToMetrics(ts *monitoringpb.TimeSeries, m pme
 	m.SetUnit(ts.GetUnit())
 	sum := m.SetEmptySum()
 	sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	// GCP's cumulative metric kind maps to OTel's monotonic sum
+	sum.SetIsMonotonic(true)
 
 	metricAttributes := convertLabelsToMetricAttributes(ts.GetMetric().GetLabels())
 	for _, point := range ts.GetPoints() {

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -124,6 +124,38 @@ func TestConvertGaugeToMetrics(t *testing.T) {
 	}
 }
 
+func TestConvertSumToMetrics(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	ts := &monitoringpb.TimeSeries{
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 10},
+					EndTime:   &timestamppb.Timestamp{Seconds: 20},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 100},
+				},
+			},
+		},
+		Metric: &metric.Metric{
+			Labels: map[string]string{"labelKey": "labelValue"},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertSumToMetrics(ts, m)
+
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	sum := m.Sum()
+	assert.Equal(t, pmetric.AggregationTemporalityCumulative, sum.AggregationTemporality())
+	assert.True(t, sum.IsMonotonic(), "cumulative sums must be marked monotonic")
+	require.Equal(t, 1, sum.DataPoints().Len())
+	assert.Equal(t, int64(100), sum.DataPoints().At(0).IntValue())
+}
+
 func TestConvertDistributionToMetrics_NoDataPoints(t *testing.T) {
 	logger := zap.NewNop()
 	mb := NewMetricsBuilder(logger)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
receiver/googlecloudmonitoring: GCP's cumulative metric kind maps to OTel's Monotonic Sum, but during conversion to OTel metric `IsMonotonic` value is not being set. This PR adds the `SetIsMonotonic` call and a test for it.

Please check the issue attached below for more context.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49804

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I have added test case which checks the converted metric has `IsMonotonic` set to true

<!--Describe the documentation added.-->
#### Documentation
Not Applicable

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
