### PR TITLE
[exporter/elasticsearch] Fix Elasticsearch retry attempts incorrectly sharing a single `timeout` deadline

### DIFF
--- a/.chloggen/elasticsearchexporter-timeout_not_shared_between_retries.yaml
+++ b/.chloggen/elasticsearchexporter-timeout_not_shared_between_retries.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: exporter/elasticsearch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Do not share `timeout` between retries
+note: Fix Elasticsearch retry attempts incorrectly sharing a single `timeout` deadline
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [45747]
@@ -15,7 +15,7 @@ issues: [45747]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: The configured timeout now applies independently to each HTTP request attempt.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/elasticsearchexporter-timeout_not_shared_between_retries.yaml
+++ b/.chloggen/elasticsearchexporter-timeout_not_shared_between_retries.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not share `timeout` between retries
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45747]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -76,7 +76,12 @@ service:
 The Elasticsearch exporter supports common [HTTP Configuration Settings][confighttp]. Gzip compression is enabled by default. To disable compression, set `compression` to `none`. Default Compression Level is set to 1 (gzip.BestSpeed).
 As a consequence of supporting [confighttp], the Elasticsearch exporter also supports common [TLS Configuration Settings][configtls].
 
+```yaml
+timeout: 90s
+```
+
 The Elasticsearch exporter sets `timeout` (HTTP request timeout) to 90s by default.
+Note that this is per request and is independent between HTTP request retries.
 All other defaults are as defined by [confighttp].
 
 ### Queuing and batching

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -158,7 +158,6 @@ func newSyncBulkIndexer(
 	return &syncBulkIndexer{
 		config:                 bulkIndexerConfig(client, config, false, logger),
 		maxFlushBytes:          maxFlushBytes,
-		flushTimeout:           config.ClientConfig.Timeout,
 		retryConfig:            config.Retry,
 		metadataKeys:           config.MetadataKeys,
 		telemetryBuilder:       tb,
@@ -173,7 +172,6 @@ func newSyncBulkIndexer(
 type syncBulkIndexer struct {
 	config                 docappender.BulkIndexerConfig
 	maxFlushBytes          int64
-	flushTimeout           time.Duration
 	retryConfig            RetrySettings
 	metadataKeys           []string
 	telemetryBuilder       *metadata.TelemetryBuilder
@@ -252,7 +250,6 @@ func (s *syncBulkIndexerSession) Flush(ctx context.Context) error {
 		if err := flushBulkIndexer(
 			ctx,
 			s.bi,
-			s.s.flushTimeout,
 			s.s.retryConfig.RetryOnStatus,
 			s.s.metadataKeys,
 			s.s.telemetryBuilder,
@@ -290,7 +287,6 @@ func (s *syncBulkIndexerSession) Flush(ctx context.Context) error {
 func flushBulkIndexer(
 	ctx context.Context,
 	bi *docappender.BulkIndexer,
-	timeout time.Duration,
 	retryOnStatus []int,
 	tMetaKeys []string,
 	tb *metadata.TelemetryBuilder,
@@ -302,11 +298,6 @@ func flushBulkIndexer(
 	itemsCount := bi.Items()
 	if itemsCount == 0 {
 		return nil
-	}
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
 	}
 
 	// Create context with attempt counter to track http requests

--- a/exporter/elasticsearchexporter/integrationtest/exporter_test.go
+++ b/exporter/elasticsearchexporter/integrationtest/exporter_test.go
@@ -148,3 +148,115 @@ func runner(t *testing.T, eventType string, restartCollector bool, mockESErr err
 	)
 	tc.ValidateData()
 }
+
+type outageDataReceiver struct {
+	*esDataReceiver
+	storage string
+}
+
+func (r *outageDataReceiver) GenConfigYAMLStr() string {
+	storage := ""
+	if r.storage != "" {
+		storage = fmt.Sprintf("      storage: %s\n", r.storage)
+	}
+	return fmt.Sprintf(`
+  elasticsearch:
+    endpoint: %q
+    logs_index: %s
+    retry:
+      enabled: true
+      max_retries: 200
+      initial_interval: 500ms
+      max_interval: 1s
+    timeout: 5s
+    sending_queue:
+      enabled: true
+%s      block_on_overflow: false
+      num_consumers: 10
+      queue_size: 10000
+      sizer: requests
+      wait_for_result: false
+      batch:
+        flush_timeout: 10m
+        min_size: 5000
+        max_size: 10000
+        sizer: items
+`, r.endpoint, TestLogsIndex, storage)
+}
+
+// TestExporterRetriesAfterElasticsearchRecovers verifies that data remains
+// queued while Elasticsearch is unavailable and is exported when it recovers.
+// The retry intervals are short enough for testing, while the exporter timeout
+// is long enough to inspect retry behavior with a debugger.
+func TestExporterRetriesAfterElasticsearchRecovers(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		persistent bool
+	}{
+		{name: "persistent_queue", persistent: true},
+		{name: "in_memory_queue"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testExporterRetriesAfterElasticsearchRecovers(t, tc.persistent)
+		})
+	}
+}
+
+func testExporterRetriesAfterElasticsearchRecovers(t *testing.T, persistent bool) {
+	senderPort := testutil.GetAvailablePort(t)
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", senderPort))
+	require.NoError(t, err, "port is expected to be free")
+
+	sender := testbed.NewOTLPLogsDataSender(testbed.DefaultHost, senderPort)
+	receiver := &outageDataReceiver{esDataReceiver: newElasticsearchDataReceiver(t)}
+	loadOpts := testbed.LoadOptions{
+		DataItemsPerSecond: 5_000,
+		ItemsPerBatch:      5_000,
+	}
+	provider := testbed.NewPerfTestDataProvider(loadOpts)
+
+	require.NoError(t, listener.Close())
+
+	var extensions map[string]string
+	if persistent {
+		receiver.storage = "file_storage"
+		extensions = map[string]string{
+			"file_storage": fmt.Sprintf("file_storage:\n    directory: %q", t.TempDir()),
+		}
+	}
+	cfg := createConfigYaml(t, sender, receiver, nil, extensions, "logs", getDebugFlag(t))
+	t.Log("test otel collector configuration:", cfg)
+	collector := newRecreatableOtelCol(t)
+	cleanup, err := collector.PrepareConfig(t, cfg)
+	require.NoError(t, err)
+	defer cleanup()
+
+	tc := testbed.NewTestCase(
+		t,
+		provider,
+		sender,
+		receiver,
+		collector,
+		newCountValidator(t, provider),
+		&testbed.CorrectnessResults{},
+		testbed.WithSkipResults(),
+	)
+	defer tc.Stop()
+
+	// Start the collector without the mock Elasticsearch backend, send one
+	// full batch, and allow the first export attempt to time out.
+	tc.StartAgent()
+	tc.StartLoad(loadOpts)
+	require.Eventually(t, func() bool {
+		return tc.LoadGenerator.DataItemsSent() == 5_000
+	}, 3*time.Second, 10*time.Millisecond)
+	tc.StopLoad()
+	time.Sleep(5500 * time.Millisecond)
+
+	// Once Elasticsearch recovers, the queue should retry the request and
+	// deliver every log in the batch.
+	tc.StartBackend()
+	require.Eventually(t, func() bool {
+		return tc.MockBackend.DataItemsReceived() == tc.LoadGenerator.DataItemsSent()
+	}, 3*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`timeout` was applied per-request and per-flush, which causes issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45747.

Now only apply `timeout` to per-request and do not share it between retries.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45747

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
