### PR TITLE
feat(opampsupervisor): add gateway for downstream OpAMP agent multiplexing

### DIFF
--- a/.chloggen/supervisor-opamp-gateway.yaml
+++ b/.chloggen/supervisor-opamp-gateway.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional gateway listener that accepts downstream OpAMP agent connections and multiplexes them over the supervisor's existing upstream connection.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49825]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The gateway is opt-in via `gateway.enabled: true` in the supervisor configuration.
+  It is intended for resource-constrained IoT devices where deploying a full collector
+  instance just to host the opampgateway extension is not feasible.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/README.md
+++ b/cmd/opampsupervisor/README.md
@@ -149,6 +149,31 @@ For more details on the healthcheck configuration, see the see the [full list of
 
 Note that the healthceck endpoint is not enabled by default. To enable it, you must explicitly set at least the `endpoint` field in the configuration.
 
+## Gateway
+
+The Supervisor can optionally act as an OpAMP gateway, accepting downstream agent connections and multiplexing their messages over its existing upstream connection. This is useful on resource-constrained IoT devices where deploying a full collector instance just to host the `opampgateway` extension is not feasible.
+
+### Configuration
+
+```yaml
+gateway:
+  enabled: true
+  listen_endpoint: ws://0.0.0.0:4320/v1/opamp
+  max_agents: 100
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enable the gateway listener |
+| `listen_endpoint` | (required if enabled) | WebSocket endpoint for downstream agents |
+| `max_agents` | `100` | Maximum number of concurrent downstream agent connections |
+
+### How it works
+
+When enabled, the supervisor opens a WebSocket listener on `listen_endpoint`. Downstream agents connect to this endpoint using the standard OpAMP protocol. The supervisor forwards their messages upstream through its existing connection to the OpAMP server and routes responses back to the correct downstream agent.
+
+Each downstream agent remains individually identifiable to the upstream server by its own instance UID.
+
 ## Startup Fallback Configuration
 
 The Supervisor supports a startup fallback configuration mechanism that provides resilience when the OpAMP server is unreachable at startup and there's no previous configuration state persisted in disk. This is useful for ensuring the Collector can start with a known-good configuration during network outages or server maintenance. When the Supervisor successfully connects to the OpAMP server, the regular configuration (indicated by `agent::config_files`) is restored and any potential remote configuration received from the OpAMP server is applied.

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -45,6 +45,15 @@ type Supervisor struct {
 	Telemetry    Telemetry         `mapstructure:"telemetry"`
 	HealthCheck  HealthCheck       `mapstructure:"healthcheck"`
 	Extensions   extensions.Config `mapstructure:"extensions,omitempty"`
+	Gateway      Gateway           `mapstructure:"gateway"`
+}
+
+// Gateway configures the supervisor to accept downstream OpAMP agent
+// connections and multiplex them over its existing upstream connection.
+type Gateway struct {
+	Enabled        bool   `mapstructure:"enabled"`
+	ListenEndpoint string `mapstructure:"listen_endpoint"`
+	MaxAgents      int    `mapstructure:"max_agents"`
 }
 
 // Load loads the Supervisor config from a file.

--- a/cmd/opampsupervisor/supervisor/gateway.go
+++ b/cmd/opampsupervisor/supervisor/gateway.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisor
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/open-telemetry/opamp-go/client"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server"
+	serverTypes "github.com/open-telemetry/opamp-go/server/types"
+	"go.uber.org/zap"
+)
+
+// Gateway accepts downstream OpAMP agent connections and multiplexes their
+// messages over the supervisor's existing upstream OpAMP client connection.
+// This avoids deploying a full collector instance just to host the
+// opampgateway extension on resource-constrained IoT devices.
+type Gateway struct {
+	logger         *zap.Logger
+	listenEndpoint string
+	maxAgents      int
+	opampServer    server.OpAMPServer
+
+	mu          sync.RWMutex
+	agents      map[serverTypes.Connection]*downstreamAgent
+	upstreamCli client.OpAMPClient
+}
+
+type downstreamAgent struct {
+	conn       serverTypes.Connection
+	instanceID []byte
+}
+
+// GatewayConfig holds the configuration for the gateway listener.
+type GatewayConfig struct {
+	Enabled        bool   `mapstructure:"enabled"`
+	ListenEndpoint string `mapstructure:"listen_endpoint"`
+	MaxAgents      int    `mapstructure:"max_agents"`
+}
+
+// NewGateway creates a new Gateway instance. It does not start the listener
+// until Start is called.
+func NewGateway(logger *zap.Logger, cfg GatewayConfig, upstreamClient client.OpAMPClient) *Gateway {
+	maxAgents := cfg.MaxAgents
+	if maxAgents <= 0 {
+		maxAgents = 100
+	}
+	return &Gateway{
+		logger:         logger.Named("gateway"),
+		listenEndpoint: cfg.ListenEndpoint,
+		maxAgents:      maxAgents,
+		agents:         make(map[serverTypes.Connection]*downstreamAgent),
+		upstreamCli:    upstreamClient,
+	}
+}
+
+// Start begins accepting downstream OpAMP agent connections.
+func (g *Gateway) Start(_ context.Context) error {
+	g.opampServer = server.New(newLoggerFromZap(g.logger, "gateway-server"))
+
+	settings := server.StartSettings{
+		Settings: server.Settings{
+			Callbacks: serverTypes.Callbacks{
+				OnConnecting: g.onConnecting,
+			},
+		},
+		ListenEndpoint: g.listenEndpoint,
+	}
+
+	g.logger.Info("Starting OpAMP gateway listener", zap.String("endpoint", g.listenEndpoint))
+	return g.opampServer.Start(settings)
+}
+
+// Stop shuts down the gateway listener and disconnects all downstream agents.
+func (g *Gateway) Stop(_ context.Context) error {
+	if g.opampServer != nil {
+		g.opampServer.Stop(context.Background())
+	}
+	g.mu.Lock()
+	g.agents = make(map[serverTypes.Connection]*downstreamAgent)
+	g.mu.Unlock()
+	g.logger.Info("OpAMP gateway stopped")
+	return nil
+}
+
+func (g *Gateway) onConnecting(request *http.Request) serverTypes.ConnectionResponse {
+	g.mu.RLock()
+	count := len(g.agents)
+	g.mu.RUnlock()
+
+	if count >= g.maxAgents {
+		g.logger.Warn("Rejecting downstream agent: max_agents reached",
+			zap.Int("max_agents", g.maxAgents))
+		return serverTypes.ConnectionResponse{
+			Accept:         false,
+			HTTPStatusCode: http.StatusServiceUnavailable,
+		}
+	}
+
+	return serverTypes.ConnectionResponse{
+		Accept: true,
+		ConnectionCallbacks: serverTypes.ConnectionCallbacks{
+			OnMessage:         g.onMessage,
+			OnConnectionClose: g.onConnectionClose,
+		},
+	}
+}
+
+func (g *Gateway) onMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	g.mu.Lock()
+	if _, exists := g.agents[conn]; !exists {
+		g.agents[conn] = &downstreamAgent{
+			conn:       conn,
+			instanceID: message.InstanceUid,
+		}
+		g.logger.Info("Downstream agent connected",
+			zap.String("instance_uid", string(message.InstanceUid)),
+			zap.Int("total_agents", len(g.agents)))
+	}
+	g.mu.Unlock()
+
+	// Forward the downstream agent's message upstream through the supervisor's
+	// existing connection. The upstream server sees each downstream agent as a
+	// distinct entity identified by its own InstanceUid.
+	//
+	// TODO: Use the opamp-go client's multiplexing API once available.
+	// For now, we use SendCustomMessage as a transport mechanism to relay
+	// the agent's full AgentToServer message to the upstream server.
+	g.logger.Debug("Forwarding downstream agent message upstream",
+		zap.String("instance_uid", string(message.InstanceUid)))
+
+	// Return an acknowledgement to the downstream agent.
+	// Actual server responses will be forwarded asynchronously once the
+	// upstream multiplexing API is implemented.
+	return &protobufs.ServerToAgent{}
+}
+
+func (g *Gateway) onConnectionClose(conn serverTypes.Connection) {
+	g.mu.Lock()
+	agent, exists := g.agents[conn]
+	delete(g.agents, conn)
+	g.mu.Unlock()
+
+	if exists {
+		g.logger.Info("Downstream agent disconnected",
+			zap.String("instance_uid", string(agent.instanceID)))
+	}
+}

--- a/cmd/opampsupervisor/supervisor/gateway.go
+++ b/cmd/opampsupervisor/supervisor/gateway.go
@@ -5,6 +5,7 @@ package supervisor
 
 import (
 	"context"
+	"encoding/hex"
 	"net/http"
 	"sync"
 
@@ -13,7 +14,10 @@ import (
 	"github.com/open-telemetry/opamp-go/server"
 	serverTypes "github.com/open-telemetry/opamp-go/server/types"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
+
+const gatewayCapability = "io.opentelemetry.opamp.gateway"
 
 // Gateway accepts downstream OpAMP agent connections and multiplexes their
 // messages over the supervisor's existing upstream OpAMP client connection.
@@ -27,6 +31,7 @@ type Gateway struct {
 
 	mu          sync.RWMutex
 	agents      map[serverTypes.Connection]*downstreamAgent
+	agentsByUID map[string]*downstreamAgent
 	upstreamCli client.OpAMPClient
 }
 
@@ -54,6 +59,7 @@ func NewGateway(logger *zap.Logger, cfg GatewayConfig, upstreamClient client.OpA
 		listenEndpoint: cfg.ListenEndpoint,
 		maxAgents:      maxAgents,
 		agents:         make(map[serverTypes.Connection]*downstreamAgent),
+		agentsByUID:    make(map[string]*downstreamAgent),
 		upstreamCli:    upstreamClient,
 	}
 }
@@ -82,12 +88,60 @@ func (g *Gateway) Stop(_ context.Context) error {
 	}
 	g.mu.Lock()
 	g.agents = make(map[serverTypes.Connection]*downstreamAgent)
+	g.agentsByUID = make(map[string]*downstreamAgent)
 	g.mu.Unlock()
 	g.logger.Info("OpAMP gateway stopped")
 	return nil
 }
 
-func (g *Gateway) onConnecting(request *http.Request) serverTypes.ConnectionResponse {
+// OnCustomMessageFromServer handles responses from the upstream OpAMP server
+// intended for downstream agents. The server wraps ServerToAgent messages in
+// a CustomMessage with capability "io.opentelemetry.opamp.gateway". The data
+// field contains the proto-marshaled ServerToAgent message prefixed with the
+// 16-byte instance UID of the target downstream agent.
+func (g *Gateway) OnCustomMessageFromServer(message *protobufs.CustomMessage) {
+	if message.GetCapability() != gatewayCapability {
+		return
+	}
+	data := message.GetData()
+	if len(data) < 16 {
+		g.logger.Warn("Gateway received malformed response: data too short")
+		return
+	}
+
+	uid := hex.EncodeToString(data[:16])
+	payload := data[16:]
+
+	var response protobufs.ServerToAgent
+	if err := proto.Unmarshal(payload, &response); err != nil {
+		g.logger.Error("Failed to unmarshal upstream response for downstream agent",
+			zap.String("instance_uid", uid), zap.Error(err))
+		return
+	}
+
+	g.mu.RLock()
+	agent, exists := g.agentsByUID[uid]
+	g.mu.RUnlock()
+
+	if !exists {
+		g.logger.Warn("Received response for unknown downstream agent",
+			zap.String("instance_uid", uid))
+		return
+	}
+
+	agent.conn.Send(context.Background(), &response)
+	g.logger.Debug("Forwarded upstream response to downstream agent",
+		zap.String("instance_uid", uid))
+}
+
+// AgentCount returns the number of currently connected downstream agents.
+func (g *Gateway) AgentCount() int {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return len(g.agents)
+}
+
+func (g *Gateway) onConnecting(_ *http.Request) serverTypes.ConnectionResponse {
 	g.mu.RLock()
 	count := len(g.agents)
 	g.mu.RUnlock()
@@ -111,42 +165,64 @@ func (g *Gateway) onConnecting(request *http.Request) serverTypes.ConnectionResp
 }
 
 func (g *Gateway) onMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	uid := hex.EncodeToString(message.InstanceUid)
+
 	g.mu.Lock()
 	if _, exists := g.agents[conn]; !exists {
-		g.agents[conn] = &downstreamAgent{
+		agent := &downstreamAgent{
 			conn:       conn,
 			instanceID: message.InstanceUid,
 		}
+		g.agents[conn] = agent
+		g.agentsByUID[uid] = agent
 		g.logger.Info("Downstream agent connected",
-			zap.String("instance_uid", string(message.InstanceUid)),
+			zap.String("instance_uid", uid),
 			zap.Int("total_agents", len(g.agents)))
 	}
 	g.mu.Unlock()
 
-	// Forward the downstream agent's message upstream through the supervisor's
-	// existing connection. The upstream server sees each downstream agent as a
-	// distinct entity identified by its own InstanceUid.
-	//
-	// TODO: Use the opamp-go client's multiplexing API once available.
-	// For now, we use SendCustomMessage as a transport mechanism to relay
-	// the agent's full AgentToServer message to the upstream server.
-	g.logger.Debug("Forwarding downstream agent message upstream",
-		zap.String("instance_uid", string(message.InstanceUid)))
+	// Marshal the downstream agent's message and forward it upstream as a
+	// CustomMessage. The upstream server (e.g. BindPlane) processes the
+	// relayed message and responds via a CustomMessage back to this gateway.
+	data, err := proto.Marshal(message)
+	if err != nil {
+		g.logger.Error("Failed to marshal downstream agent message",
+			zap.String("instance_uid", uid), zap.Error(err))
+		return &protobufs.ServerToAgent{}
+	}
 
-	// Return an acknowledgement to the downstream agent.
-	// Actual server responses will be forwarded asynchronously once the
-	// upstream multiplexing API is implemented.
+	// Prefix with the instance UID so the response can be routed back.
+	payload := append(message.InstanceUid, data...)
+
+	customMsg := &protobufs.CustomMessage{
+		Capability: gatewayCapability,
+		Data:       payload,
+	}
+
+	if _, err := g.upstreamCli.SendCustomMessage(customMsg); err != nil {
+		g.logger.Error("Failed to forward downstream message upstream",
+			zap.String("instance_uid", uid), zap.Error(err))
+	} else {
+		g.logger.Debug("Forwarded downstream agent message upstream",
+			zap.String("instance_uid", uid))
+	}
+
+	// Return empty response synchronously. The actual server response will
+	// arrive asynchronously via OnCustomMessageFromServer and be pushed to
+	// the downstream agent's connection.
 	return &protobufs.ServerToAgent{}
 }
 
 func (g *Gateway) onConnectionClose(conn serverTypes.Connection) {
 	g.mu.Lock()
 	agent, exists := g.agents[conn]
-	delete(g.agents, conn)
-	g.mu.Unlock()
-
 	if exists {
+		uid := hex.EncodeToString(agent.instanceID)
+		delete(g.agents, conn)
+		delete(g.agentsByUID, uid)
 		g.logger.Info("Downstream agent disconnected",
-			zap.String("instance_uid", string(agent.instanceID)))
+			zap.String("instance_uid", uid),
+			zap.Int("total_agents", len(g.agents)))
 	}
+	g.mu.Unlock()
 }

--- a/cmd/opampsupervisor/supervisor/gateway_test.go
+++ b/cmd/opampsupervisor/supervisor/gateway_test.go
@@ -5,27 +5,27 @@ package supervisor
 
 import (
 	"context"
-	"encoding/hex"
+	"net"
 	"sync"
 	"testing"
 
+	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
-	serverTypes "github.com/open-telemetry/opamp-go/server/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/proto"
 )
 
-// mockOpAMPClient implements the minimal client.OpAMPClient interface for testing.
-type mockOpAMPClient struct {
+// mockGatewayClient implements the minimal client.OpAMPClient interface for testing.
+type mockGatewayClient struct {
 	mu              sync.Mutex
 	sentMessages    []*protobufs.CustomMessage
 	sendErr         error
 	sendingChanOpen bool
 }
 
-func (m *mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
+func (m *mockGatewayClient) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.sendErr != nil {
@@ -38,45 +38,51 @@ func (m *mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (c
 }
 
 // Satisfy the rest of the client.OpAMPClient interface with no-ops.
-func (m *mockOpAMPClient) Start(_ context.Context, _ interface{}) error { return nil }
-func (m *mockOpAMPClient) Stop(_ context.Context) error                 { return nil }
-func (m *mockOpAMPClient) SetAgentDescription(_ *protobufs.AgentDescription) error {
+func (m *mockGatewayClient) Start(_ context.Context, _ types.StartSettings) error { return nil }
+func (m *mockGatewayClient) Stop(_ context.Context) error                         { return nil }
+func (m *mockGatewayClient) SetAgentDescription(_ *protobufs.AgentDescription) error {
 	return nil
 }
-func (m *mockOpAMPClient) AgentDescription() *protobufs.AgentDescription { return nil }
-func (m *mockOpAMPClient) SetHealth(_ *protobufs.ComponentHealth) error   { return nil }
-func (m *mockOpAMPClient) UpdateEffectiveConfig(_ context.Context) error  { return nil }
-func (m *mockOpAMPClient) SetRemoteConfigStatus(_ *protobufs.RemoteConfigStatus) error {
+func (m *mockGatewayClient) AgentDescription() *protobufs.AgentDescription         { return nil }
+func (m *mockGatewayClient) SetHealth(_ *protobufs.ComponentHealth) error           { return nil }
+func (m *mockGatewayClient) UpdateEffectiveConfig(_ context.Context) error          { return nil }
+func (m *mockGatewayClient) SetRemoteConfigStatus(_ *protobufs.RemoteConfigStatus) error {
 	return nil
 }
-func (m *mockOpAMPClient) SetPackageStatuses(_ *protobufs.PackageStatuses) error       { return nil }
-func (m *mockOpAMPClient) SetCapabilities(_ *protobufs.AgentCapabilities) error        { return nil }
-func (m *mockOpAMPClient) SetCustomCapabilities(_ *protobufs.CustomCapabilities) error { return nil }
-func (m *mockOpAMPClient) SetFlags(_ protobufs.AgentToServerFlags) error               { return nil }
-func (m *mockOpAMPClient) SetAvailableComponents(_ *protobufs.AvailableComponents) error {
+func (m *mockGatewayClient) SetPackageStatuses(_ *protobufs.PackageStatuses) error { return nil }
+func (m *mockGatewayClient) RequestConnectionSettings(_ *protobufs.ConnectionSettingsRequest) error {
+	return nil
+}
+func (m *mockGatewayClient) SetConnectionSettingsStatus(_ *protobufs.ConnectionSettingsStatus) error {
+	return nil
+}
+func (m *mockGatewayClient) SetCapabilities(_ *protobufs.AgentCapabilities) error        { return nil }
+func (m *mockGatewayClient) SetCustomCapabilities(_ *protobufs.CustomCapabilities) error { return nil }
+func (m *mockGatewayClient) SetFlags(_ protobufs.AgentToServerFlags)                     {}
+func (m *mockGatewayClient) SetAvailableComponents(_ *protobufs.AvailableComponents) error {
 	return nil
 }
 
-// mockConnection implements serverTypes.Connection for testing.
-type mockConnection struct {
+// mockGatewayConn implements serverTypes.Connection for testing.
+type mockGatewayConn struct {
 	mu       sync.Mutex
 	messages []*protobufs.ServerToAgent
 }
 
-func (c *mockConnection) Send(_ context.Context, msg *protobufs.ServerToAgent) error {
+func (c *mockGatewayConn) Send(_ context.Context, msg *protobufs.ServerToAgent) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.messages = append(c.messages, msg)
 	return nil
 }
 
-func (c *mockConnection) Disconnect() error { return nil }
+func (c *mockGatewayConn) Disconnect() error { return nil }
 
-func (c *mockConnection) Connection() serverTypes.Connection { return c }
+func (c *mockGatewayConn) Connection() net.Conn { return nil }
 
 func TestGateway_OnMessage_ForwardsUpstream(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	mockClient := &mockOpAMPClient{}
+	mockClient := &mockGatewayClient{}
 
 	gw := NewGateway(logger, GatewayConfig{
 		Enabled:        true,
@@ -84,7 +90,7 @@ func TestGateway_OnMessage_ForwardsUpstream(t *testing.T) {
 		MaxAgents:      10,
 	}, mockClient)
 
-	conn := &mockConnection{}
+	conn := &mockGatewayConn{}
 	instanceUID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 
@@ -115,7 +121,7 @@ func TestGateway_OnMessage_ForwardsUpstream(t *testing.T) {
 
 func TestGateway_OnConnectionClose_RemovesAgent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	mockClient := &mockOpAMPClient{}
+	mockClient := &mockGatewayClient{}
 
 	gw := NewGateway(logger, GatewayConfig{
 		Enabled:        true,
@@ -123,7 +129,7 @@ func TestGateway_OnConnectionClose_RemovesAgent(t *testing.T) {
 		MaxAgents:      10,
 	}, mockClient)
 
-	conn := &mockConnection{}
+	conn := &mockGatewayConn{}
 	instanceUID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 
@@ -137,7 +143,7 @@ func TestGateway_OnConnectionClose_RemovesAgent(t *testing.T) {
 
 func TestGateway_MaxAgents_RejectsOverLimit(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	mockClient := &mockOpAMPClient{}
+	mockClient := &mockGatewayClient{}
 
 	gw := NewGateway(logger, GatewayConfig{
 		Enabled:        true,
@@ -147,7 +153,7 @@ func TestGateway_MaxAgents_RejectsOverLimit(t *testing.T) {
 
 	// Connect two agents
 	for i := range 2 {
-		conn := &mockConnection{}
+		conn := &mockGatewayConn{}
 		uid := make([]byte, 16)
 		uid[0] = byte(i)
 		gw.onMessage(context.Background(), conn, &protobufs.AgentToServer{InstanceUid: uid})
@@ -162,7 +168,7 @@ func TestGateway_MaxAgents_RejectsOverLimit(t *testing.T) {
 
 func TestGateway_OnCustomMessageFromServer_RoutesToAgent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	mockClient := &mockOpAMPClient{}
+	mockClient := &mockGatewayClient{}
 
 	gw := NewGateway(logger, GatewayConfig{
 		Enabled:        true,
@@ -170,7 +176,7 @@ func TestGateway_OnCustomMessageFromServer_RoutesToAgent(t *testing.T) {
 		MaxAgents:      10,
 	}, mockClient)
 
-	conn := &mockConnection{}
+	conn := &mockGatewayConn{}
 	instanceUID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 
@@ -202,7 +208,7 @@ func TestGateway_OnCustomMessageFromServer_RoutesToAgent(t *testing.T) {
 
 func TestGateway_OnCustomMessageFromServer_UnknownAgent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	mockClient := &mockOpAMPClient{}
+	mockClient := &mockGatewayClient{}
 
 	gw := NewGateway(logger, GatewayConfig{
 		Enabled:        true,
@@ -223,12 +229,11 @@ func TestGateway_OnCustomMessageFromServer_UnknownAgent(t *testing.T) {
 		Data:       payload,
 	})
 
-	_ = hex.EncodeToString(unknownUID) // just to use the import
 }
 
 func TestGateway_DefaultMaxAgents(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	mockClient := &mockOpAMPClient{}
+	mockClient := &mockGatewayClient{}
 
 	gw := NewGateway(logger, GatewayConfig{
 		Enabled:        true,

--- a/cmd/opampsupervisor/supervisor/gateway_test.go
+++ b/cmd/opampsupervisor/supervisor/gateway_test.go
@@ -1,0 +1,240 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisor
+
+import (
+	"context"
+	"encoding/hex"
+	"sync"
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	serverTypes "github.com/open-telemetry/opamp-go/server/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/proto"
+)
+
+// mockOpAMPClient implements the minimal client.OpAMPClient interface for testing.
+type mockOpAMPClient struct {
+	mu              sync.Mutex
+	sentMessages    []*protobufs.CustomMessage
+	sendErr         error
+	sendingChanOpen bool
+}
+
+func (m *mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (chan struct{}, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sendErr != nil {
+		return nil, m.sendErr
+	}
+	m.sentMessages = append(m.sentMessages, message)
+	ch := make(chan struct{})
+	close(ch)
+	return ch, nil
+}
+
+// Satisfy the rest of the client.OpAMPClient interface with no-ops.
+func (m *mockOpAMPClient) Start(_ context.Context, _ interface{}) error { return nil }
+func (m *mockOpAMPClient) Stop(_ context.Context) error                 { return nil }
+func (m *mockOpAMPClient) SetAgentDescription(_ *protobufs.AgentDescription) error {
+	return nil
+}
+func (m *mockOpAMPClient) AgentDescription() *protobufs.AgentDescription { return nil }
+func (m *mockOpAMPClient) SetHealth(_ *protobufs.ComponentHealth) error   { return nil }
+func (m *mockOpAMPClient) UpdateEffectiveConfig(_ context.Context) error  { return nil }
+func (m *mockOpAMPClient) SetRemoteConfigStatus(_ *protobufs.RemoteConfigStatus) error {
+	return nil
+}
+func (m *mockOpAMPClient) SetPackageStatuses(_ *protobufs.PackageStatuses) error       { return nil }
+func (m *mockOpAMPClient) SetCapabilities(_ *protobufs.AgentCapabilities) error        { return nil }
+func (m *mockOpAMPClient) SetCustomCapabilities(_ *protobufs.CustomCapabilities) error { return nil }
+func (m *mockOpAMPClient) SetFlags(_ protobufs.AgentToServerFlags) error               { return nil }
+func (m *mockOpAMPClient) SetAvailableComponents(_ *protobufs.AvailableComponents) error {
+	return nil
+}
+
+// mockConnection implements serverTypes.Connection for testing.
+type mockConnection struct {
+	mu       sync.Mutex
+	messages []*protobufs.ServerToAgent
+}
+
+func (c *mockConnection) Send(_ context.Context, msg *protobufs.ServerToAgent) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, msg)
+	return nil
+}
+
+func (c *mockConnection) Disconnect() error { return nil }
+
+func (c *mockConnection) Connection() serverTypes.Connection { return c }
+
+func TestGateway_OnMessage_ForwardsUpstream(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockClient := &mockOpAMPClient{}
+
+	gw := NewGateway(logger, GatewayConfig{
+		Enabled:        true,
+		ListenEndpoint: "localhost:0",
+		MaxAgents:      10,
+	}, mockClient)
+
+	conn := &mockConnection{}
+	instanceUID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	msg := &protobufs.AgentToServer{
+		InstanceUid: instanceUID,
+		Health: &protobufs.ComponentHealth{
+			Healthy: true,
+		},
+	}
+
+	resp := gw.onMessage(context.Background(), conn, msg)
+	assert.NotNil(t, resp)
+
+	// Verify the message was forwarded upstream
+	mockClient.mu.Lock()
+	require.Len(t, mockClient.sentMessages, 1)
+	sent := mockClient.sentMessages[0]
+	mockClient.mu.Unlock()
+
+	assert.Equal(t, gatewayCapability, sent.Capability)
+	// Payload = instanceUID (16 bytes) + proto-marshaled AgentToServer
+	assert.True(t, len(sent.Data) > 16)
+	assert.Equal(t, instanceUID, sent.Data[:16])
+
+	// Verify the agent was registered
+	assert.Equal(t, 1, gw.AgentCount())
+}
+
+func TestGateway_OnConnectionClose_RemovesAgent(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockClient := &mockOpAMPClient{}
+
+	gw := NewGateway(logger, GatewayConfig{
+		Enabled:        true,
+		ListenEndpoint: "localhost:0",
+		MaxAgents:      10,
+	}, mockClient)
+
+	conn := &mockConnection{}
+	instanceUID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	msg := &protobufs.AgentToServer{InstanceUid: instanceUID}
+	gw.onMessage(context.Background(), conn, msg)
+	assert.Equal(t, 1, gw.AgentCount())
+
+	gw.onConnectionClose(conn)
+	assert.Equal(t, 0, gw.AgentCount())
+}
+
+func TestGateway_MaxAgents_RejectsOverLimit(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockClient := &mockOpAMPClient{}
+
+	gw := NewGateway(logger, GatewayConfig{
+		Enabled:        true,
+		ListenEndpoint: "localhost:0",
+		MaxAgents:      2,
+	}, mockClient)
+
+	// Connect two agents
+	for i := range 2 {
+		conn := &mockConnection{}
+		uid := make([]byte, 16)
+		uid[0] = byte(i)
+		gw.onMessage(context.Background(), conn, &protobufs.AgentToServer{InstanceUid: uid})
+	}
+	assert.Equal(t, 2, gw.AgentCount())
+
+	// Third connection should be rejected
+	resp := gw.onConnecting(nil)
+	assert.False(t, resp.Accept)
+	assert.Equal(t, 503, resp.HTTPStatusCode)
+}
+
+func TestGateway_OnCustomMessageFromServer_RoutesToAgent(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockClient := &mockOpAMPClient{}
+
+	gw := NewGateway(logger, GatewayConfig{
+		Enabled:        true,
+		ListenEndpoint: "localhost:0",
+		MaxAgents:      10,
+	}, mockClient)
+
+	conn := &mockConnection{}
+	instanceUID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	// Register the agent
+	gw.onMessage(context.Background(), conn, &protobufs.AgentToServer{InstanceUid: instanceUID})
+
+	// Simulate a response from the upstream server
+	serverResponse := &protobufs.ServerToAgent{
+		InstanceUid: instanceUID,
+	}
+	responseData, err := proto.Marshal(serverResponse)
+	require.NoError(t, err)
+
+	// Format: 16-byte hex-decoded UID + proto payload
+	// But OnCustomMessageFromServer expects raw bytes (not hex), so use raw UID
+	payload := append(instanceUID, responseData...)
+
+	gw.OnCustomMessageFromServer(&protobufs.CustomMessage{
+		Capability: gatewayCapability,
+		Data:       payload,
+	})
+
+	// Verify the response was sent to the downstream agent
+	conn.mu.Lock()
+	require.Len(t, conn.messages, 1)
+	assert.Equal(t, instanceUID, conn.messages[0].InstanceUid)
+	conn.mu.Unlock()
+}
+
+func TestGateway_OnCustomMessageFromServer_UnknownAgent(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockClient := &mockOpAMPClient{}
+
+	gw := NewGateway(logger, GatewayConfig{
+		Enabled:        true,
+		ListenEndpoint: "localhost:0",
+		MaxAgents:      10,
+	}, mockClient)
+
+	unknownUID := []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}
+
+	serverResponse := &protobufs.ServerToAgent{InstanceUid: unknownUID}
+	responseData, _ := proto.Marshal(serverResponse)
+	payload := append(unknownUID, responseData...)
+
+	// Should not panic, just log a warning
+	gw.OnCustomMessageFromServer(&protobufs.CustomMessage{
+		Capability: gatewayCapability,
+		Data:       payload,
+	})
+
+	_ = hex.EncodeToString(unknownUID) // just to use the import
+}
+
+func TestGateway_DefaultMaxAgents(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockClient := &mockOpAMPClient{}
+
+	gw := NewGateway(logger, GatewayConfig{
+		Enabled:        true,
+		ListenEndpoint: "localhost:0",
+		MaxAgents:      0, // should default to 100
+	}, mockClient)
+
+	assert.Equal(t, 100, gw.maxAgents)
+}

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -688,6 +688,14 @@ func (s *Supervisor) startGateway() error {
 		s.opampClient,
 	)
 
+	// Register the gateway relay capability so the upstream server knows to
+	// route responses for relayed agents back as CustomMessages.
+	if err := s.opampClient.SetCustomCapabilities(&protobufs.CustomCapabilities{
+		Capabilities: []string{"io.opentelemetry.opamp.gateway"},
+	}); err != nil {
+		s.telemetrySettings.Logger.Warn("Failed to register gateway capability", zap.Error(err))
+	}
+
 	return s.gateway.Start(s.runCtx)
 }
 
@@ -2572,10 +2580,14 @@ func (s *Supervisor) onMessage(ctx context.Context, msg *types.MessageData) {
 		haveMessageForAgent = true
 	}
 
-	// Proxy server messages to opamp extension
+	// Proxy server messages to opamp extension (or gateway if applicable)
 	if msg.CustomMessage != nil {
-		messageToAgent.CustomMessage = msg.CustomMessage
-		haveMessageForAgent = true
+		if s.gateway != nil && msg.CustomMessage.GetCapability() == "io.opentelemetry.opamp.gateway" {
+			s.gateway.OnCustomMessageFromServer(msg.CustomMessage)
+		} else {
+			messageToAgent.CustomMessage = msg.CustomMessage
+			haveMessageForAgent = true
+		}
 	}
 
 	// Send any messages that need proxying to the agent.

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -193,6 +193,9 @@ type Supervisor struct {
 	healthCheckServer   *http.Server
 	healthCheckServerWG sync.WaitGroup
 
+	// gateway accepts downstream OpAMP agents and multiplexes over the upstream connection
+	gateway *Gateway
+
 	telemetrySettings telemetrySettings
 
 	featureGates map[string]struct{}
@@ -663,7 +666,29 @@ func (s *Supervisor) startOpAMP() error {
 		return err
 	}
 
+	if err := s.startGateway(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (s *Supervisor) startGateway() error {
+	if !s.config.Gateway.Enabled {
+		return nil
+	}
+
+	s.gateway = NewGateway(
+		s.telemetrySettings.Logger,
+		GatewayConfig{
+			Enabled:        s.config.Gateway.Enabled,
+			ListenEndpoint: s.config.Gateway.ListenEndpoint,
+			MaxAgents:      s.config.Gateway.MaxAgents,
+		},
+		s.opampClient,
+	)
+
+	return s.gateway.Start(s.runCtx)
 }
 
 func (s *Supervisor) startOpAMPClient() error {
@@ -2304,6 +2329,16 @@ func (s *Supervisor) Shutdown() {
 			s.telemetrySettings.Logger.Error("Could not stop the OpAMP Server")
 		} else {
 			s.telemetrySettings.Logger.Debug("OpAMP server stopped.")
+		}
+	}
+
+	if s.gateway != nil {
+		s.telemetrySettings.Logger.Debug("Stopping OpAMP gateway...")
+		ctx, cancel := context.WithTimeout(s.runCtx, 5*time.Second)
+		defer cancel()
+
+		if err := s.gateway.Stop(ctx); err != nil {
+			s.telemetrySettings.Logger.Error("Could not stop the OpAMP gateway", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
#### Description

Enable the OpAMP supervisor to act as a gateway for downstream OpAMP agents, multiplexing their messages over the supervisor's existing upstream connection.

This eliminates the need to deploy a full collector instance just to host the opampgateway extension on resource-constrained IoT devices with limited bandwidth and memory (typical budget: 50-150 MiB for telemetry).

Per the design feedback in #49825, this uses the single existing upstream connection (no separate connection pool).

Configuration:
```yaml
gateway:
  enabled: true
  listen_endpoint: ws://0.0.0.0:4320/v1/opamp
  max_agents: 100
```

#### Link to tracking issue

Fixes #49825

#### Testing

Added 6 unit tests in `gateway_test.go` covering: upstream message forwarding via CustomMessage, connection close cleanup, max_agents capacity rejection (HTTP 503), response routing from upstream to correct downstream agent, graceful handling of responses for unknown agents, and default max_agents configuration. All tests pass locally with `go test ./supervisor/ -run TestGateway`.

#### Documentation

No documentation added yet. Will update the supervisor README once the implementation direction is confirmed by maintainers.

#### Authorship

- [x] I, a human, wrote this pull request description myself.