### PR TITLE
[pkg/ottl] Add ToJSON converter function

### DIFF
--- a/.chloggen/ottl-tojson.yaml
+++ b/.chloggen/ottl-tojson.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: pkg/ottl
+note: Add ToJSON converter that serializes any OTTL value to a compact JSON string
+issues: [49715]

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -1062,6 +1062,30 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], ToJSON(attributes["foo"]))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", `{"bar":"pass","flags":"pass","nested":{"test":"pass"},"slice":["val"]}`)
+			},
+		},
+		{
+			statement: `set(attributes["test"], ToJSON(attributes["slices"]))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", `["slice1","slice2",{"name":"foo"}]`)
+			},
+		},
+		{
+			statement: `set(attributes["test"], ToJSON("hello world"))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", `"hello world"`)
+			},
+		},
+		{
+			statement: `set(attributes["test"], ToJSON([attributes["foo"], "x"]))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", `[{"bar":"pass","flags":"pass","nested":{"test":"pass"},"slice":["val"]},"x"]`)
+			},
+		},
+		{
 			statement: `set(attributes["test"], ParseKeyValue("k1=v1 k2=v2"))`,
 			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -580,6 +580,7 @@ Available Converters:
 - [Substring](#substring)
 - [Time](#time)
 - [ToCamelCase](#tocamelcase)
+- [ToJSON](#tojson)
 - [ToKeyValueString](#tokeyvaluestring)
 - [ToLowerCase](#tolowercase)
 - [ToSnakeCase](#tosnakecase)
@@ -2803,6 +2804,38 @@ The `ToCamelCase` Converter converts the `target` string into camel case (e.g. `
 Examples:
 
 - `ToCamelCase(metric.name)`
+
+### ToJSON
+
+`ToJSON(target)`
+
+The `ToJSON` Converter serializes any value to a compact JSON string.
+It is the inverse of [`ParseJSON`](#parsejson): where `ParseJSON` converts a JSON string into a `pcommon.Map` or `pcommon.Slice`, `ToJSON` converts any value back into its JSON string representation.
+
+`target` is a Getter that returns any value. Supported types include:
+
+- `pcommon.Map` → JSON object string
+- `pcommon.Slice` → JSON array string
+- `pcommon.Value` → JSON value string (delegates based on underlying type)
+- `map[string]any` → JSON object string
+- `[]any` → JSON array string
+- Primitives (`string`, `int64`, `float64`, `bool`) → JSON primitive string
+
+If the input is `nil` (e.g. a missing map key), `ToJSON` returns `nil`, consistent with other OTTL converters.
+An explicit `pcommon.ValueTypeEmpty` serializes as the JSON string `"null"`.
+`pcommon.ValueTypeBytes` values are serialized as base64-encoded JSON strings.
+
+Serialization is done using [goccy/go-json](https://github.com/goccy/go-json).
+
+Examples:
+
+- `ToJSON(log.body)`
+
+
+- `ToJSON(log.attributes)`
+
+
+- `ToJSON(["a","b","c"])`
 
 ### ToKeyValueString
 

--- a/pkg/ottl/ottlfuncs/func_to_json.go
+++ b/pkg/ottl/ottlfuncs/func_to_json.go
@@ -1,0 +1,139 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/goccy/go-json"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type ToJSONArguments[K any] struct {
+	Target ottl.Getter[K]
+}
+
+func NewToJSONFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("ToJSON", &ToJSONArguments[K]{}, createToJSONFunction[K])
+}
+
+func createToJSONFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*ToJSONArguments[K])
+
+	if !ok {
+		return nil, errors.New("ToJSONFactory args must be of type *ToJSONArguments[K]")
+	}
+
+	return toJSON(args.Target), nil
+}
+
+// toJSON converts a value to its JSON string representation.
+// It is the inverse of ParseJSON: while ParseJSON converts a JSON string into
+// a pcommon.Map or pcommon.Slice, ToJSON serializes any value back into a
+// compact JSON string.
+//
+// Supported input types:
+//
+//	pcommon.Map    -> JSON object string
+//	pcommon.Slice  -> JSON array string
+//	pcommon.Value  -> JSON value string (delegates based on underlying type)
+//	map[string]any -> JSON object string
+//	[]any          -> JSON array string
+//	primitives     -> JSON primitive string (string, number, bool)
+//
+// If the input is nil (e.g. a missing map key), ToJSON returns nil, nil,
+// consistent with other OTTL converters such as String and Int.
+// An explicit pcommon.ValueTypeEmpty serializes as the JSON string "null".
+// pcommon.ValueTypeBytes values are serialized as base64-encoded JSON strings.
+func toJSON[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		if val == nil {
+			return nil, nil
+		}
+
+		// Convert pdata types to raw Go types before marshalling.
+		raw, err := toRaw(val)
+		if err != nil {
+			return nil, fmt.Errorf("unsupported type for ToJSON: %w", err)
+		}
+
+		jsonBytes, err := json.Marshal(raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal %T to JSON: %w", raw, err)
+		}
+
+		return string(jsonBytes), nil
+	}
+}
+
+// toRaw converts pdata types to raw Go types suitable for JSON marshalling.
+// It recurses into []any and map[string]any so that pdata types nested inside
+// list/map literals (e.g. ToJSON([attributes["m"], "x"])) are converted too,
+// rather than only the top-level value.
+// Non-pdata types are returned as-is.
+func toRaw(val any) (any, error) {
+	switch v := val.(type) {
+	case pcommon.Map:
+		return v.AsRaw(), nil
+	case pcommon.Slice:
+		return v.AsRaw(), nil
+	case pcommon.Value:
+		return convertValue(v)
+	case []any:
+		result := make([]any, len(v))
+		for i, elem := range v {
+			raw, err := toRaw(elem)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = raw
+		}
+		return result, nil
+	case map[string]any:
+		result := make(map[string]any, len(v))
+		for k, elem := range v {
+			raw, err := toRaw(elem)
+			if err != nil {
+				return nil, err
+			}
+			result[k] = raw
+		}
+		return result, nil
+	default:
+		return val, nil
+	}
+}
+
+// convertValue converts a pcommon.Value to a raw Go type.
+func convertValue(v pcommon.Value) (any, error) {
+	switch v.Type() {
+	case pcommon.ValueTypeMap:
+		return v.Map().AsRaw(), nil
+	case pcommon.ValueTypeSlice:
+		return v.Slice().AsRaw(), nil
+	case pcommon.ValueTypeStr:
+		return v.Str(), nil
+	case pcommon.ValueTypeBool:
+		return v.Bool(), nil
+	case pcommon.ValueTypeDouble:
+		return v.Double(), nil
+	case pcommon.ValueTypeInt:
+		return v.Int(), nil
+	case pcommon.ValueTypeBytes:
+		return v.Bytes().AsRaw(), nil
+	case pcommon.ValueTypeEmpty:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported pcommon.Value type: %v", v.Type())
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_to_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_to_json_test.go
@@ -1,0 +1,509 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_toJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   ottl.Getter[any]
+		expected any
+	}{
+		{
+			name: "simple map",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					m := pcommon.NewMap()
+					m.PutStr("key1", "value1")
+					return m, nil
+				},
+			},
+			expected: `{"key1":"value1"}`,
+		},
+		{
+			name: "nested map",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					m := pcommon.NewMap()
+					m.PutStr("key1", "value1")
+					nested := m.PutEmptyMap("key2")
+					nested.PutStr("nested1", "nestedval1")
+					return m, nil
+				},
+			},
+			expected: `{"key1":"value1","key2":{"nested1":"nestedval1"}}`,
+		},
+		{
+			name: "simple slice",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					s := pcommon.NewSlice()
+					s.AppendEmpty().SetStr("a")
+					s.AppendEmpty().SetStr("b")
+					s.AppendEmpty().SetStr("c")
+					return s, nil
+				},
+			},
+			expected: `["a","b","c"]`,
+		},
+		{
+			name: "slice of mixed types",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					s := pcommon.NewSlice()
+					s.AppendEmpty().SetStr("hello")
+					s.AppendEmpty().SetInt(42)
+					s.AppendEmpty().SetBool(true)
+					s.AppendEmpty().SetDouble(3.14)
+					return s, nil
+				},
+			},
+			expected: `["hello",42,true,3.14]`,
+		},
+		{
+			name: "pcommon.Value string",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueStr("hello world")
+					return v, nil
+				},
+			},
+			expected: `"hello world"`,
+		},
+		{
+			name: "pcommon.Value int",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueInt(42)
+					return v, nil
+				},
+			},
+			expected: `42`,
+		},
+		{
+			name: "pcommon.Value double",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueDouble(3.14)
+					return v, nil
+				},
+			},
+			expected: `3.14`,
+		},
+		{
+			name: "pcommon.Value bool",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueBool(true)
+					return v, nil
+				},
+			},
+			expected: `true`,
+		},
+		{
+			name: "pcommon.Value bytes",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueBytes()
+					v.Bytes().FromRaw([]byte("hello"))
+					return v, nil
+				},
+			},
+			expected: `"aGVsbG8="`,
+		},
+		{
+			name: "pcommon.Value empty (null)",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueEmpty()
+					return v, nil
+				},
+			},
+			expected: `null`,
+		},
+		{
+			name: "pcommon.Value map",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueEmpty()
+					m := v.SetEmptyMap()
+					m.PutStr("key", "val")
+					return v, nil
+				},
+			},
+			expected: `{"key":"val"}`,
+		},
+		{
+			name: "pcommon.Value slice",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueEmpty()
+					s := v.SetEmptySlice()
+					s.AppendEmpty().SetStr("x")
+					s.AppendEmpty().SetStr("y")
+					return v, nil
+				},
+			},
+			expected: `["x","y"]`,
+		},
+		{
+			name: "raw Go map",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return map[string]any{
+						"key1": "value1",
+						"key2": float64(42),
+					}, nil
+				},
+			},
+			expected: `{"key1":"value1","key2":42}`,
+		},
+		{
+			name: "raw Go slice",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []any{"a", "b", "c"}, nil
+				},
+			},
+			expected: `["a","b","c"]`,
+		},
+		{
+			name: "raw Go slice containing a pcommon.Map (list literal with a path element)",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					m := pcommon.NewMap()
+					m.PutStr("key", "val")
+					return []any{m, "x"}, nil
+				},
+			},
+			expected: `[{"key":"val"},"x"]`,
+		},
+		{
+			name: "raw Go map containing a pcommon.Slice (map literal with a path element)",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					s := pcommon.NewSlice()
+					s.AppendEmpty().SetStr("a")
+					return map[string]any{"items": s}, nil
+				},
+			},
+			expected: `{"items":["a"]}`,
+		},
+		{
+			name: "raw Go string",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return "hello", nil
+				},
+			},
+			expected: `"hello"`,
+		},
+		{
+			name: "raw Go int",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return 42, nil
+				},
+			},
+			expected: `42`,
+		},
+		{
+			name: "raw Go float64",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return float64(3.14), nil
+				},
+			},
+			expected: `3.14`,
+		},
+		{
+			name: "raw Go bool",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return true, nil
+				},
+			},
+			expected: `true`,
+		},
+		{
+			name: "nil value",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return nil, nil
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "empty map",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return pcommon.NewMap(), nil
+				},
+			},
+			expected: `{}`,
+		},
+		{
+			name: "empty slice",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return pcommon.NewSlice(), nil
+				},
+			},
+			expected: `[]`,
+		},
+		{
+			name: "complex nested structure",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					m := pcommon.NewMap()
+					m.PutStr("name", "test")
+					m.PutInt("count", 5)
+					m.PutBool("active", true)
+					m.PutDouble("ratio", 0.75)
+					m.PutEmpty("nothing")
+
+					tags := m.PutEmptySlice("tags")
+					tags.AppendEmpty().SetStr("tag1")
+					tags.AppendEmpty().SetStr("tag2")
+
+					nested := m.PutEmptyMap("metadata")
+					nested.PutStr("source", "ottl")
+					inner := nested.PutEmptyMap("details")
+					inner.PutInt("level", 3)
+
+					return m, nil
+				},
+			},
+			expected: `{"active":true,"count":5,"metadata":{"details":{"level":3},"source":"ottl"},"name":"test","nothing":null,"ratio":0.75,"tags":["tag1","tag2"]}`,
+		},
+		{
+			name: "map with special characters in values",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					m := pcommon.NewMap()
+					m.PutStr("msg", `value with "quotes" and \backslash`)
+					m.PutStr("newline", "line1\nline2")
+					return m, nil
+				},
+			},
+			expected: `{"msg":"value with \"quotes\" and \\backslash","newline":"line1\nline2"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := toJSON[any](tt.target)
+			result, err := exprFunc(t.Context(), nil)
+			require.NoError(t, err)
+
+			if tt.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			actual, ok := result.(string)
+			require.True(t, ok)
+			assert.JSONEq(t, tt.expected.(string), actual)
+		})
+	}
+}
+
+func Test_toJSON_Error(t *testing.T) {
+	target := ottl.StandardGetSetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return nil, assert.AnError
+		},
+	}
+	exprFunc := toJSON[any](target)
+	_, err := exprFunc(t.Context(), nil)
+	assert.Error(t, err)
+}
+
+func Test_toJSON_MarshalError(t *testing.T) {
+	// Unlike Test_toJSON_Error, these cases exercise the json.Marshal failure
+	// path itself (an unmarshalable value), not the upstream Getter error path.
+	tests := []struct {
+		name   string
+		target ottl.Getter[any]
+	}{
+		{
+			name: "NaN double",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return pcommon.NewValueDouble(math.NaN()), nil
+				},
+			},
+		},
+		{
+			name: "positive infinity double",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return pcommon.NewValueDouble(math.Inf(1)), nil
+				},
+			},
+		},
+		{
+			name: "negative infinity double nested in a slice",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []any{math.Inf(-1)}, nil
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := toJSON[any](tt.target)
+			_, err := exprFunc(t.Context(), nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to marshal")
+		})
+	}
+}
+
+func Test_toJSON_roundtrip_with_ParseJSON(t *testing.T) {
+	// Test that ToJSON is truly the inverse of ParseJSON.
+	// ParseJSON(ToJSON(value)) should return the original structure.
+	tests := []struct {
+		name   string
+		target ottl.Getter[any]
+		verify func(t *testing.T, result any)
+	}{
+		{
+			name: "roundtrip map",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					m := pcommon.NewMap()
+					m.PutStr("key1", "value1")
+					m.PutBool("key2", true)
+					m.PutDouble("key3", 42.5)
+					return m, nil
+				},
+			},
+			verify: func(t *testing.T, result any) {
+				resultMap, ok := result.(pcommon.Map)
+				require.True(t, ok)
+
+				v1, ok := resultMap.Get("key1")
+				require.True(t, ok)
+				assert.Equal(t, "value1", v1.Str())
+
+				v2, ok := resultMap.Get("key2")
+				require.True(t, ok)
+				assert.Equal(t, true, v2.Bool())
+
+				v3, ok := resultMap.Get("key3")
+				require.True(t, ok)
+				assert.InDelta(t, 42.5, v3.Double(), 0.001)
+			},
+		},
+		{
+			name: "roundtrip slice",
+			target: ottl.StandardGetSetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					s := pcommon.NewSlice()
+					s.AppendEmpty().SetStr("a")
+					s.AppendEmpty().SetStr("b")
+					return s, nil
+				},
+			},
+			verify: func(t *testing.T, result any) {
+				resultSlice, ok := result.(pcommon.Slice)
+				require.True(t, ok)
+				assert.Equal(t, 2, resultSlice.Len())
+				assert.Equal(t, "a", resultSlice.At(0).Str())
+				assert.Equal(t, "b", resultSlice.At(1).Str())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Step 1: ToJSON
+			toJSONFunc := toJSON[any](tt.target)
+			jsonResult, err := toJSONFunc(t.Context(), nil)
+			require.NoError(t, err)
+			jsonStr, ok := jsonResult.(string)
+			require.True(t, ok)
+
+			// Step 2: ParseJSON (feed the JSON string back)
+			parseTarget := ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return jsonStr, nil
+				},
+			}
+			parseJSONFunc := parseJSON[any](parseTarget)
+			parseResult, err := parseJSONFunc(t.Context(), nil)
+			require.NoError(t, err)
+
+			// Step 3: Verify the roundtrip preserved the structure
+			tt.verify(t, parseResult)
+		})
+	}
+}
+
+func Test_createToJSONFunction(t *testing.T) {
+	// Test that the factory function validates argument types correctly.
+	factory := NewToJSONFactory[any]()
+	assert.Equal(t, "ToJSON", factory.Name())
+}
+
+func BenchmarkToJSON(b *testing.B) {
+	ctx := b.Context()
+	b.ReportAllocs()
+
+	target := ottl.StandardGetSetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			m := pcommon.NewMap()
+			m.PutStr("_id", "667cb0db02f4dfc7648b0f6b")
+			m.PutInt("index", 0)
+			m.PutStr("guid", "2e419732-8214-4e36-a158-d3ced0217ab6")
+			m.PutBool("isActive", true)
+			m.PutStr("balance", "$1,105.05")
+			m.PutInt("age", 22)
+			m.PutStr("eyeColor", "blue")
+			m.PutStr("name", "Vincent Knox")
+			m.PutStr("gender", "male")
+			m.PutStr("company", "ANIVET")
+			m.PutStr("email", "vincentknox@anivet.com")
+			m.PutStr("phone", "+1 (914) 599-2454")
+
+			tags := m.PutEmptySlice("tags")
+			tags.AppendEmpty().SetStr("pariatur")
+			tags.AppendEmpty().SetStr("anim")
+			tags.AppendEmpty().SetStr("id")
+			tags.AppendEmpty().SetStr("duis")
+
+			friends := m.PutEmptySlice("friends")
+			f0 := friends.AppendEmpty().SetEmptyMap()
+			f0.PutInt("id", 0)
+			f0.PutStr("name", "Hester Bruce")
+			f1 := friends.AppendEmpty().SetEmptyMap()
+			f1.PutInt("id", 1)
+			f1.PutStr("name", "Laurel Mcknight")
+
+			return m, nil
+		},
+	}
+
+	exprFunc := toJSON[any](target)
+
+	for b.Loop() {
+		_, err := exprFunc(ctx, nil)
+		require.NoError(b, err)
+	}
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -115,6 +115,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewTrimFactory[K](),
 		NewTrimPrefixFactory[K](),
 		NewTrimSuffixFactory[K](),
+		NewToJSONFactory[K](),
 		NewToKeyValueStringFactory[K](),
 		NewToCamelCaseFactory[K](),
 		NewToLowerCaseFactory[K](),


### PR DESCRIPTION
Adds a new `ToJSON` OTTL converter function that serializes a value to its compact JSON string representation. It is the inverse of `ParseJSON`: where `ParseJSON` turns a JSON string into a `pcommon.Map`/`pcommon.Slice`, `ToJSON` turns OTTL values back into a JSON string.

Supported input types:
- `pcommon.Map` -> JSON object string
- `pcommon.Slice` -> JSON array string
- `pcommon.Value` -> JSON value string (dispatched on the underlying value type; `pcommon.ValueTypeBytes` is base64-encoded)
- `map[string]any` / `[]any` -> JSON object/array string, recursing into any pdata values nested inside (e.g. `ToJSON([attributes["m"], "x"])`)
- primitives (`string`, `int64`, `float64`, `bool`) -> JSON primitive string

`nil` input (e.g. a missing map key) returns `nil`, consistent with other converters; an explicit `pcommon.ValueTypeEmpty` still serializes as `"null"`.

This closes a gap in the existing serialization converters: `ToKeyValueString` was previously the only way to serialize structured OTTL data, producing `k=v`-style text that downstream systems with native JSON parsing (e.g. log pipelines feeding a JSON-aware SIEM) have to decode with bespoke rules. `ToJSON` lets those pipelines emit plain JSON instead.

Fixes #49715
