### PR TITLE
[processor/tailsampling] Give composite sub-policies omitted from rat…

### DIFF
--- a/.chloggen/tailsampling-composite-omitted-rate-allocation.yaml
+++ b/.chloggen/tailsampling-composite-omitted-rate-allocation.yaml
@@ -1,0 +1,18 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: In the composite policy, a sub-policy omitted from `rate_allocation` now receives its default equal share of the budget instead of a zero sampling rate that permanently blocked it from sampling.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49828]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -33,15 +33,25 @@ func getNewCompositePolicy(settings component.TelemetrySettings, config *Composi
 
 // Apply rate allocations to the sub-policies
 func getRateAllocationMap(config *CompositeCfg) map[string]float64 {
-	rateAllocationsMap := make(map[string]float64)
+	rateAllocationsMap := make(map[string]float64, len(config.SubPolicyCfg))
 	maxTotalSPS := float64(config.MaxTotalSpansPerSecond)
 	// Default SPS determined by equally diving number of sub policies
 	defaultSPS := maxTotalSPS / float64(len(config.SubPolicyCfg))
+
+	percentByPolicy := make(map[string]int64, len(config.RateAllocation))
 	for _, rAlloc := range config.RateAllocation {
-		if rAlloc.Percent > 0 {
-			rateAllocationsMap[rAlloc.Policy] = (float64(rAlloc.Percent) / 100) * maxTotalSPS
+		percentByPolicy[rAlloc.Policy] = rAlloc.Percent
+	}
+
+	// Iterate over every configured sub-policy, not just the ones listed in
+	// RateAllocation, so a sub-policy left out of RateAllocation still gets
+	// its equal-share default instead of silently falling back to a zero
+	// value MaxSpansPerSecond (which permanently blocks it from sampling).
+	for _, subPolicy := range config.SubPolicyCfg {
+		if percent, ok := percentByPolicy[subPolicy.Name]; ok && percent > 0 {
+			rateAllocationsMap[subPolicy.Name] = (float64(percent) / 100) * maxTotalSPS
 		} else {
-			rateAllocationsMap[rAlloc.Policy] = defaultSPS
+			rateAllocationsMap[subPolicy.Name] = defaultSPS
 		}
 	}
 	return rateAllocationsMap

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -47,7 +47,8 @@ func getRateAllocationMap(config *CompositeCfg) map[string]float64 {
 	// RateAllocation, so a sub-policy left out of RateAllocation still gets
 	// its equal-share default instead of silently falling back to a zero
 	// value MaxSpansPerSecond (which permanently blocks it from sampling).
-	for _, subPolicy := range config.SubPolicyCfg {
+	for i := range config.SubPolicyCfg {
+		subPolicy := &config.SubPolicyCfg[i]
 		if percent, ok := percentByPolicy[subPolicy.Name]; ok && percent > 0 {
 			rateAllocationsMap[subPolicy.Name] = (float64(percent) / 100) * maxTotalSPS
 		} else {

--- a/processor/tailsamplingprocessor/composite_helper_test.go
+++ b/processor/tailsamplingprocessor/composite_helper_test.go
@@ -63,6 +63,52 @@ func TestCompositeHelper(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("sub-policy omitted from rate_allocation gets the default share", func(t *testing.T) {
+		actual, err := getNewCompositePolicy(componenttest.NewNopTelemetrySettings(), &CompositeCfg{
+			MaxTotalSpansPerSecond: 1000,
+			PolicyOrder:            []string{"test-composite-policy-1", "test-composite-policy-2"},
+			SubPolicyCfg: []CompositeSubPolicyCfg{
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:       "test-composite-policy-1",
+						Type:       Latency,
+						LatencyCfg: LatencyCfg{ThresholdMs: 100},
+					},
+				},
+				{
+					sharedPolicyCfg: sharedPolicyCfg{
+						Name:       "test-composite-policy-2",
+						Type:       Latency,
+						LatencyCfg: LatencyCfg{ThresholdMs: 200},
+					},
+				},
+			},
+			// test-composite-policy-2 is intentionally left out of RateAllocation
+			// entirely, not just given Percent: 0.
+			RateAllocation: []RateAllocationCfg{
+				{
+					Policy:  "test-composite-policy-1",
+					Percent: 25,
+				},
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		expected := sampling.NewComposite(zap.NewNop(), 1000, []sampling.SubPolicyEvalParams{
+			{
+				Evaluator:         sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 100, 0),
+				MaxSpansPerSecond: 250,
+				Name:              "test-composite-policy-1",
+			},
+			{
+				Evaluator:         sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 200, 0),
+				MaxSpansPerSecond: 500,
+				Name:              "test-composite-policy-2",
+			},
+		}, sampling.MonotonicClock{}, false)
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run("unsupported sampling policy type", func(t *testing.T) {
 		_, err := getNewCompositePolicy(componenttest.NewNopTelemetrySettings(), &CompositeCfg{
 			SubPolicyCfg: []CompositeSubPolicyCfg{


### PR DESCRIPTION
#### Description

`getRateAllocationMap` previously iterated only over entries in `rate_allocation`. As a result, any configured composite sub-policy that was omitted from `rate_allocation` was never assigned a `MaxSpansPerSecond` value and implicitly defaulted to `0`, preventing it from sampling any spans.

The documented behavior is that sub-policies without an explicit allocation receive the default equal share (`max_total_spans_per_second / number of sub-policies`). This is also the behavior already applied to entries with `percent: 0`.

This change iterates over every configured sub-policy, applying the configured percentage when present and falling back to the default equal-share allocation otherwise.

#### Link to tracking issue

Fixes #49828

#### Testing

Added a `TestCompositeHelper` test case covering the scenario where a configured sub-policy is omitted from `rate_allocation`. The test configures two sub-policies with a total rate of `1000` spans/second, assigns one policy an explicit allocation of `25%`, and verifies that the omitted policy receives the default allocation of `500` (`1000 / 2`) rather than `0`.

The test fails with the previous implementation and passes with this change.

#### Documentation

No documentation changes were required. This change aligns the implementation with the existing documented behavior for composite rate allocation.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
