### PR TITLE
[receiver/mysql] Add DDL command types to mysql.commands metric

### DIFF
--- a/.chloggen/mysql-commands-enum-enhancement.yaml
+++ b/.chloggen/mysql-commands-enum-enhancement.yaml
@@ -10,7 +10,7 @@ component: receiver/mysql
 note: Add `alter_table`, `create_index`, `create_table`, and `optimize` command types to the `mysql.commands` metric.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0]
+issues: [49863]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysql-commands-enum-enhancement.yaml
+++ b/.chloggen/mysql-commands-enum-enhancement.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `alter_table`, `create_index`, `create_table`, and `optimize` command types to the `mysql.commands` metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -392,7 +392,7 @@ The number of times each type of command has been executed.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| command | The command types. | Str: ``delete``, ``delete_multi``, ``insert``, ``select``, ``update``, ``update_multi`` | Recommended | - |
+| command | The command types. | Str: ``alter_table``, ``create_index``, ``create_table``, ``delete``, ``delete_multi``, ``insert``, ``optimize``, ``select``, ``update``, ``update_multi`` | Recommended | - |
 
 ### mysql.connection.count
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -163,9 +163,13 @@ type AttributeCommand int
 
 const (
 	_ AttributeCommand = iota
+	AttributeCommandAlterTable
+	AttributeCommandCreateIndex
+	AttributeCommandCreateTable
 	AttributeCommandDelete
 	AttributeCommandDeleteMulti
 	AttributeCommandInsert
+	AttributeCommandOptimize
 	AttributeCommandSelect
 	AttributeCommandUpdate
 	AttributeCommandUpdateMulti
@@ -174,12 +178,20 @@ const (
 // String returns the string representation of the AttributeCommand.
 func (av AttributeCommand) String() string {
 	switch av {
+	case AttributeCommandAlterTable:
+		return "alter_table"
+	case AttributeCommandCreateIndex:
+		return "create_index"
+	case AttributeCommandCreateTable:
+		return "create_table"
 	case AttributeCommandDelete:
 		return "delete"
 	case AttributeCommandDeleteMulti:
 		return "delete_multi"
 	case AttributeCommandInsert:
 		return "insert"
+	case AttributeCommandOptimize:
+		return "optimize"
 	case AttributeCommandSelect:
 		return "select"
 	case AttributeCommandUpdate:
@@ -192,9 +204,13 @@ func (av AttributeCommand) String() string {
 
 // MapAttributeCommand is a helper map of string to AttributeCommand attribute value.
 var MapAttributeCommand = map[string]AttributeCommand{
+	"alter_table":  AttributeCommandAlterTable,
+	"create_index": AttributeCommandCreateIndex,
+	"create_table": AttributeCommandCreateTable,
 	"delete":       AttributeCommandDelete,
 	"delete_multi": AttributeCommandDeleteMulti,
 	"insert":       AttributeCommandInsert,
+	"optimize":     AttributeCommandOptimize,
 	"select":       AttributeCommandSelect,
 	"update":       AttributeCommandUpdate,
 	"update_multi": AttributeCommandUpdateMulti,

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -150,9 +150,9 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
-			mb.RecordMysqlCommandsDataPoint(ts, "1", AttributeCommandDelete)
+			mb.RecordMysqlCommandsDataPoint(ts, "1", AttributeCommandAlterTable)
 			if tt.name == "reaggregate_set" {
-				mb.RecordMysqlCommandsDataPoint(ts, "3", AttributeCommandDeleteMulti)
+				mb.RecordMysqlCommandsDataPoint(ts, "3", AttributeCommandCreateIndex)
 			}
 
 			allMetricsCount++
@@ -707,7 +707,7 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, int64(1), dp.IntValue())
 						commandAttrVal, ok := dp.Attributes().Get("command")
 						assert.True(t, ok)
-						assert.Equal(t, "delete", commandAttrVal.Str())
+						assert.Equal(t, "alter_table", commandAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["mysql.commands"], "Found a duplicate in the metrics slice: mysql.commands")
 						validatedMetrics["mysql.commands"] = true

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -74,7 +74,7 @@ attributes:
   command:
     description: The command types.
     type: string
-    enum: [delete, delete_multi, insert, select, update, update_multi]
+    enum: [alter_table, create_index, create_table, delete, delete_multi, insert, optimize, select, update, update_multi]
     requirement_level: recommended
   connection_error:
     name_override: error

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -372,12 +372,20 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 				metadata.AttributePreparedStatementsCommandSendLongData))
 
 		// commands
+		case "Com_alter_table":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandAlterTable))
+		case "Com_create_index":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandCreateIndex))
+		case "Com_create_table":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandCreateTable))
 		case "Com_delete":
 			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandDelete))
 		case "Com_delete_multi":
 			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandDeleteMulti))
 		case "Com_insert":
 			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandInsert))
+		case "Com_optimize":
+			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandOptimize))
 		case "Com_select":
 			addPartialIfError(errs, m.mb.RecordMysqlCommandsDataPoint(now, v, metadata.AttributeCommandSelect))
 		case "Com_update":

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -1709,7 +1709,7 @@ resourceMetrics:
                         stringValue: index
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            unit: "By"
+            unit: By
           - description: The number of hits, misses or overflows for open tables cache lookups.
             name: mysql.table_open_cache
             sum:

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -184,6 +184,27 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "19"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: alter_table
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "38"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: create_index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: create_table
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "50"
                   attributes:
                     - key: command
@@ -203,6 +224,13 @@ resourceMetrics:
                     - key: command
                       value:
                         stringValue: insert
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "86"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: optimize
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "106"
@@ -1231,7 +1259,7 @@ resourceMetrics:
                         stringValue: a_table
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            unit: "By"
+            unit: By
           - description: The total count of I/O wait events for a table.
             name: mysql.table.io.wait.count
             sum:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds the alter_table, create_index, create_table, and optimize command types to the mysql.commands metric

#### Testing
Updated the scraper golden test (testdata/scraper/expected.yaml) so the new command dimensions are asserted end-to-end; generated metrics tests cover the new enum values.
Verified live against a MySQL 8.4 instance: generated DDL load and confirmed the debug exporter emitted each new dimension with values matching SHOW GLOBAL STATUS.

#### Documentation
documentation.md was regenerated via mdatagen to include the new command values. No manual documentation changes.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
