### PR TITLE
receiver/fluentforwardreceiver: Fix unbounded pre-allocation DoS

### DIFF
--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -239,7 +239,7 @@ func parseOptions(dc *msgp.Reader) (optionsMap, error) {
 	if err != nil {
 		return nil, msgp.WrapError(err, "Option")
 	}
-	out := make(optionsMap, optionLen)
+	out := make(optionsMap)
 
 	for optionLen > 0 {
 		optionLen--
@@ -286,7 +286,6 @@ func (fe *forwardEventLogRecords) DecodeMsg(dc *msgp.Reader) error {
 		return msgp.WrapError(err, "Record")
 	}
 
-	fe.EnsureCapacity(int(entryLen))
 	for i := 0; i < int(entryLen); i++ {
 		lr := fe.AppendEmpty()
 


### PR DESCRIPTION
#### Description
This PR resolves the memory-exhaustion DoS vulnerability reported in the Fluent Forward receiver.
By removing the unbounded `fe.EnsureCapacity(int(entryLen))` pre-allocation call for the entries array in `forwardEventLogRecords.DecodeMsg` and removing the `optionLen` argument from `make(optionsMap, optionLen)`, the collections will now grow dynamically as bytes are consumed rather than instantly allocating gigabytes of memory based on an attacker-controlled msgpack header.
#### Link to tracking issue
Fixes #49231
#### Testing
Executed `go test -v ./...` in `receiver/fluentforwardreceiver/`. All existing tests (including the DoS negative controls) pass successfully.
#### Documentation
No documentation changes are required.
#### Authorship
- [x] I, a human, wrote this pull request description myself.