### PR TITLE
[receiver/mysql] Mysql metric enhancement

### DIFF
--- a/.chloggen/mysql-open-resources-slow-launch-threads.yaml
+++ b/.chloggen/mysql-open-resources-slow-launch-threads.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add mysql.resources.open and mysql.slow_launch_threads metrics, disabled by default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/mysql-open-resources-slow-launch-threads.yaml
+++ b/.chloggen/mysql-open-resources-slow-launch-threads.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/mysql
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add mysql.resources.open and mysql.slow_launch_threads metrics, disabled by default.
+note: Add mysql.resources.open and mysql.threads.slow_launch metrics, disabled by default.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49867]

--- a/.chloggen/mysql-open-resources-slow-launch-threads.yaml
+++ b/.chloggen/mysql-open-resources-slow-launch-threads.yaml
@@ -10,7 +10,7 @@ component: receiver/mysql
 note: Add mysql.resources.open and mysql.slow_launch_threads metrics, disabled by default.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0]
+issues: [49867]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysql-open-resources-slow-launch-threads.yaml
+++ b/.chloggen/mysql-open-resources-slow-launch-threads.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/mysql
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add mysql.resources.open and mysql.threads.slow_launch metrics, disabled by default.
+note: Add mysql.resources.open and mysql.thread.slow_launch metrics, disabled by default.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49867]

--- a/.chloggen/mysql-open-resources-slow-launch-threads.yaml
+++ b/.chloggen/mysql-open-resources-slow-launch-threads.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/mysql
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add mysql.resources.open and mysql.thread.slow_launch metrics, disabled by default.
+note: Add mysql.file.open, mysql.table.open, and mysql.thread.slow_launch metrics, disabled by default.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49867]

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -416,6 +416,14 @@ Errors that occur during the client connection process.
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | error | The connection error type. | Str: ``accept``, ``internal``, ``max_connections``, ``peer_address``, ``select``, ``tcpwrap``, ``aborted``, ``aborted_clients``, ``locked`` | Recommended | - |
 
+### mysql.file.open
+
+The number of currently open files.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
 ### mysql.joins
 
 The number of joins that perform table scans.
@@ -501,20 +509,6 @@ This field is an indication of how “late” the replica is.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Int | Cumulative | false | Development |
-
-### mysql.resources.open
-
-The number of currently open resources.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| 1 | Sum | Int | Cumulative | false | Development |
-
-#### Attributes
-
-| Name | Description | Values | Requirement Level | Semantic Convention |
-| ---- | ----------- | ------ | ----------------- | ------------------- |
-| kind | The kind of the resource. | Str: ``file``, ``table`` | Recommended | - |
 
 ### mysql.statement_event.count
 
@@ -627,6 +621,14 @@ The total table lock wait write events times.
 | schema | The schema of the object. | Any Str | Recommended | - |
 | table | Table name for event or process. | Any Str | Recommended | - |
 | kind | Write operation types. | Str: ``allow_write``, ``concurrent_insert``, ``low_priority``, ``normal``, ``external`` | Recommended | - |
+
+### mysql.table.open
+
+The number of currently open tables.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
 
 ### mysql.table.rows
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -502,6 +502,28 @@ This field is an indication of how “late” the replica is.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Int | Cumulative | false | Development |
 
+### mysql.resources.open
+
+The number of open resources.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| kind | The kind of the resource. | Str: ``file``, ``table`` | Recommended | - |
+
+### mysql.slow_launch_threads
+
+The number of threads that have taken more than slow_launch_time seconds to create.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | Development |
+
 ### mysql.statement_event.count
 
 Summary of current and recent statement events.

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -516,14 +516,6 @@ The number of currently open resources.
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | kind | The kind of the resource. | Str: ``file``, ``table`` | Recommended | - |
 
-### mysql.slow_launch_threads
-
-The number of threads that have taken more than slow_launch_time seconds to create.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| 1 | Sum | Int | Cumulative | true | Development |
-
 ### mysql.statement_event.count
 
 Summary of current and recent statement events.
@@ -680,6 +672,14 @@ The number of hits, misses or overflows for open tables cache lookups.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | status | The status of cache access. | Str: ``hit``, ``miss``, ``overflow`` | Recommended | - |
+
+### mysql.threads.slow_launch
+
+The number of threads that have taken more than slow_launch_time seconds to create.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | Development |
 
 ## Default Events
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -506,9 +506,9 @@ This field is an indication of how “late” the replica is.
 
 The number of currently open resources.
 
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Gauge | Int | Development |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | Development |
 
 #### Attributes
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -673,7 +673,7 @@ The number of hits, misses or overflows for open tables cache lookups.
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | status | The status of cache access. | Str: ``hit``, ``miss``, ``overflow`` | Recommended | - |
 
-### mysql.threads.slow_launch
+### mysql.thread.slow_launch
 
 The number of threads that have taken more than slow_launch_time seconds to create.
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -504,7 +504,7 @@ This field is an indication of how “late” the replica is.
 
 ### mysql.resources.open
 
-The number of open resources.
+The number of currently open resources.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -1320,26 +1320,6 @@ func (ms *MysqlRowOperationsMetricConfig) Validate() error {
 	return nil
 }
 
-// MysqlSlowLaunchThreadsMetricConfig provides config for the mysql.slow_launch_threads metric.
-type MysqlSlowLaunchThreadsMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *MysqlSlowLaunchThreadsMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
 // MysqlSortsMetricAttributeKey specifies the key of an attribute for the mysql.sorts metric.
 type MysqlSortsMetricAttributeKey string
 
@@ -2033,6 +2013,26 @@ func (ms *MysqlThreadsMetricConfig) Validate() error {
 	return nil
 }
 
+// MysqlThreadsSlowLaunchMetricConfig provides config for the mysql.threads.slow_launch metric.
+type MysqlThreadsSlowLaunchMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlThreadsSlowLaunchMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MysqlTmpResourcesMetricAttributeKey specifies the key of an attribute for the mysql.tmp_resources metric.
 type MysqlTmpResourcesMetricAttributeKey string
 
@@ -2136,7 +2136,6 @@ type MetricsConfig struct {
 	MysqlResourcesOpen           MysqlResourcesOpenMetricConfig           `mapstructure:"mysql.resources.open"`
 	MysqlRowLocks                MysqlRowLocksMetricConfig                `mapstructure:"mysql.row_locks"`
 	MysqlRowOperations           MysqlRowOperationsMetricConfig           `mapstructure:"mysql.row_operations"`
-	MysqlSlowLaunchThreads       MysqlSlowLaunchThreadsMetricConfig       `mapstructure:"mysql.slow_launch_threads"`
 	MysqlSorts                   MysqlSortsMetricConfig                   `mapstructure:"mysql.sorts"`
 	MysqlStatementEventCount     MysqlStatementEventCountMetricConfig     `mapstructure:"mysql.statement_event.count"`
 	MysqlStatementEventWaitTime  MysqlStatementEventWaitTimeMetricConfig  `mapstructure:"mysql.statement_event.wait.time"`
@@ -2151,6 +2150,7 @@ type MetricsConfig struct {
 	MysqlTableSize               MysqlTableSizeMetricConfig               `mapstructure:"mysql.table.size"`
 	MysqlTableOpenCache          MysqlTableOpenCacheMetricConfig          `mapstructure:"mysql.table_open_cache"`
 	MysqlThreads                 MysqlThreadsMetricConfig                 `mapstructure:"mysql.threads"`
+	MysqlThreadsSlowLaunch       MysqlThreadsSlowLaunchMetricConfig       `mapstructure:"mysql.threads.slow_launch"`
 	MysqlTmpResources            MysqlTmpResourcesMetricConfig            `mapstructure:"mysql.tmp_resources"`
 	MysqlUptime                  MysqlUptimeMetricConfig                  `mapstructure:"mysql.uptime"`
 }
@@ -2302,9 +2302,6 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlRowOperationsMetricAttributeKey{MysqlRowOperationsMetricAttributeKeyRowOperations},
 		},
-		MysqlSlowLaunchThreads: MysqlSlowLaunchThreadsMetricConfig{
-			Enabled: false,
-		},
 		MysqlSorts: MysqlSortsMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
@@ -2374,6 +2371,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlThreadsMetricAttributeKey{MysqlThreadsMetricAttributeKeyThreads},
+		},
+		MysqlThreadsSlowLaunch: MysqlThreadsSlowLaunchMetricConfig{
+			Enabled: false,
 		},
 		MysqlTmpResources: MysqlTmpResourcesMetricConfig{
 			Enabled:             true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -454,6 +454,26 @@ func (ms *MysqlDoubleWritesMetricConfig) Validate() error {
 	return nil
 }
 
+// MysqlFileOpenMetricConfig provides config for the mysql.file.open metric.
+type MysqlFileOpenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlFileOpenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MysqlHandlersMetricAttributeKey specifies the key of an attribute for the mysql.handlers metric.
 type MysqlHandlersMetricAttributeKey string
 
@@ -1176,54 +1196,6 @@ func (ms *MysqlReplicaTimeBehindSourceMetricConfig) Unmarshal(parser *confmap.Co
 	return nil
 }
 
-// MysqlResourcesOpenMetricAttributeKey specifies the key of an attribute for the mysql.resources.open metric.
-type MysqlResourcesOpenMetricAttributeKey string
-
-const (
-	MysqlResourcesOpenMetricAttributeKeyOpenResources MysqlResourcesOpenMetricAttributeKey = "kind"
-)
-
-// MysqlResourcesOpenMetricConfig provides config for the mysql.resources.open metric.
-type MysqlResourcesOpenMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-
-	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []MysqlResourcesOpenMetricAttributeKey `mapstructure:"attributes"`
-}
-
-func (ms *MysqlResourcesOpenMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
-func (ms *MysqlResourcesOpenMetricConfig) Validate() error {
-	for _, val := range ms.EnabledAttributes {
-		switch val {
-		case MysqlResourcesOpenMetricAttributeKeyOpenResources:
-		default:
-			return fmt.Errorf("metric mysql.resources.open doesn't have an attribute %v, valid attributes: [kind]", val)
-		}
-	}
-
-	switch ms.AggregationStrategy {
-	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
-	default:
-		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
-	}
-
-	return nil
-}
-
 // MysqlRowLocksMetricAttributeKey specifies the key of an attribute for the mysql.row_locks metric.
 type MysqlRowLocksMetricAttributeKey string
 
@@ -1818,6 +1790,26 @@ func (ms *MysqlTableLockWaitWriteTimeMetricConfig) Validate() error {
 	return nil
 }
 
+// MysqlTableOpenMetricConfig provides config for the mysql.table.open metric.
+type MysqlTableOpenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlTableOpenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MysqlTableRowsMetricAttributeKey specifies the key of an attribute for the mysql.table.rows metric.
 type MysqlTableRowsMetricAttributeKey string
 
@@ -2114,6 +2106,7 @@ type MetricsConfig struct {
 	MysqlConnectionCount         MysqlConnectionCountMetricConfig         `mapstructure:"mysql.connection.count"`
 	MysqlConnectionErrors        MysqlConnectionErrorsMetricConfig        `mapstructure:"mysql.connection.errors"`
 	MysqlDoubleWrites            MysqlDoubleWritesMetricConfig            `mapstructure:"mysql.double_writes"`
+	MysqlFileOpen                MysqlFileOpenMetricConfig                `mapstructure:"mysql.file.open"`
 	MysqlHandlers                MysqlHandlersMetricConfig                `mapstructure:"mysql.handlers"`
 	MysqlIndexIoWaitCount        MysqlIndexIoWaitCountMetricConfig        `mapstructure:"mysql.index.io.wait.count"`
 	MysqlIndexIoWaitTime         MysqlIndexIoWaitTimeMetricConfig         `mapstructure:"mysql.index.io.wait.time"`
@@ -2133,7 +2126,6 @@ type MetricsConfig struct {
 	MysqlQuerySlowCount          MysqlQuerySlowCountMetricConfig          `mapstructure:"mysql.query.slow.count"`
 	MysqlReplicaSQLDelay         MysqlReplicaSQLDelayMetricConfig         `mapstructure:"mysql.replica.sql_delay"`
 	MysqlReplicaTimeBehindSource MysqlReplicaTimeBehindSourceMetricConfig `mapstructure:"mysql.replica.time_behind_source"`
-	MysqlResourcesOpen           MysqlResourcesOpenMetricConfig           `mapstructure:"mysql.resources.open"`
 	MysqlRowLocks                MysqlRowLocksMetricConfig                `mapstructure:"mysql.row_locks"`
 	MysqlRowOperations           MysqlRowOperationsMetricConfig           `mapstructure:"mysql.row_operations"`
 	MysqlSorts                   MysqlSortsMetricConfig                   `mapstructure:"mysql.sorts"`
@@ -2146,6 +2138,7 @@ type MetricsConfig struct {
 	MysqlTableLockWaitReadTime   MysqlTableLockWaitReadTimeMetricConfig   `mapstructure:"mysql.table.lock_wait.read.time"`
 	MysqlTableLockWaitWriteCount MysqlTableLockWaitWriteCountMetricConfig `mapstructure:"mysql.table.lock_wait.write.count"`
 	MysqlTableLockWaitWriteTime  MysqlTableLockWaitWriteTimeMetricConfig  `mapstructure:"mysql.table.lock_wait.write.time"`
+	MysqlTableOpen               MysqlTableOpenMetricConfig               `mapstructure:"mysql.table.open"`
 	MysqlTableRows               MysqlTableRowsMetricConfig               `mapstructure:"mysql.table.rows"`
 	MysqlTableSize               MysqlTableSizeMetricConfig               `mapstructure:"mysql.table.size"`
 	MysqlTableOpenCache          MysqlTableOpenCacheMetricConfig          `mapstructure:"mysql.table_open_cache"`
@@ -2205,6 +2198,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlDoubleWritesMetricAttributeKey{MysqlDoubleWritesMetricAttributeKeyDoubleWrites},
+		},
+		MysqlFileOpen: MysqlFileOpenMetricConfig{
+			Enabled: false,
 		},
 		MysqlHandlers: MysqlHandlersMetricConfig{
 			Enabled:             true,
@@ -2287,11 +2283,6 @@ func DefaultMetricsConfig() MetricsConfig {
 		MysqlReplicaTimeBehindSource: MysqlReplicaTimeBehindSourceMetricConfig{
 			Enabled: false,
 		},
-		MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
-			Enabled:             false,
-			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
-		},
 		MysqlRowLocks: MysqlRowLocksMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
@@ -2351,6 +2342,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlTableLockWaitWriteTimeMetricAttributeKey{MysqlTableLockWaitWriteTimeMetricAttributeKeySchema, MysqlTableLockWaitWriteTimeMetricAttributeKeyTableName, MysqlTableLockWaitWriteTimeMetricAttributeKeyWriteLockType},
+		},
+		MysqlTableOpen: MysqlTableOpenMetricConfig{
+			Enabled: false,
 		},
 		MysqlTableRows: MysqlTableRowsMetricConfig{
 			Enabled:             false,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -1965,6 +1965,26 @@ func (ms *MysqlTableOpenCacheMetricConfig) Validate() error {
 	return nil
 }
 
+// MysqlThreadSlowLaunchMetricConfig provides config for the mysql.thread.slow_launch metric.
+type MysqlThreadSlowLaunchMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlThreadSlowLaunchMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MysqlThreadsMetricAttributeKey specifies the key of an attribute for the mysql.threads metric.
 type MysqlThreadsMetricAttributeKey string
 
@@ -2010,26 +2030,6 @@ func (ms *MysqlThreadsMetricConfig) Validate() error {
 		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
 	}
 
-	return nil
-}
-
-// MysqlThreadsSlowLaunchMetricConfig provides config for the mysql.threads.slow_launch metric.
-type MysqlThreadsSlowLaunchMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-}
-
-func (ms *MysqlThreadsSlowLaunchMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -2149,8 +2149,8 @@ type MetricsConfig struct {
 	MysqlTableRows               MysqlTableRowsMetricConfig               `mapstructure:"mysql.table.rows"`
 	MysqlTableSize               MysqlTableSizeMetricConfig               `mapstructure:"mysql.table.size"`
 	MysqlTableOpenCache          MysqlTableOpenCacheMetricConfig          `mapstructure:"mysql.table_open_cache"`
+	MysqlThreadSlowLaunch        MysqlThreadSlowLaunchMetricConfig        `mapstructure:"mysql.thread.slow_launch"`
 	MysqlThreads                 MysqlThreadsMetricConfig                 `mapstructure:"mysql.threads"`
-	MysqlThreadsSlowLaunch       MysqlThreadsSlowLaunchMetricConfig       `mapstructure:"mysql.threads.slow_launch"`
 	MysqlTmpResources            MysqlTmpResourcesMetricConfig            `mapstructure:"mysql.tmp_resources"`
 	MysqlUptime                  MysqlUptimeMetricConfig                  `mapstructure:"mysql.uptime"`
 }
@@ -2367,13 +2367,13 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlTableOpenCacheMetricAttributeKey{MysqlTableOpenCacheMetricAttributeKeyCacheStatus},
 		},
+		MysqlThreadSlowLaunch: MysqlThreadSlowLaunchMetricConfig{
+			Enabled: false,
+		},
 		MysqlThreads: MysqlThreadsMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlThreadsMetricAttributeKey{MysqlThreadsMetricAttributeKeyThreads},
-		},
-		MysqlThreadsSlowLaunch: MysqlThreadsSlowLaunchMetricConfig{
-			Enabled: false,
 		},
 		MysqlTmpResources: MysqlTmpResourcesMetricConfig{
 			Enabled:             true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -1176,6 +1176,54 @@ func (ms *MysqlReplicaTimeBehindSourceMetricConfig) Unmarshal(parser *confmap.Co
 	return nil
 }
 
+// MysqlResourcesOpenMetricAttributeKey specifies the key of an attribute for the mysql.resources.open metric.
+type MysqlResourcesOpenMetricAttributeKey string
+
+const (
+	MysqlResourcesOpenMetricAttributeKeyOpenResources MysqlResourcesOpenMetricAttributeKey = "kind"
+)
+
+// MysqlResourcesOpenMetricConfig provides config for the mysql.resources.open metric.
+type MysqlResourcesOpenMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                 `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MysqlResourcesOpenMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MysqlResourcesOpenMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MysqlResourcesOpenMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MysqlResourcesOpenMetricAttributeKeyOpenResources:
+		default:
+			return fmt.Errorf("metric mysql.resources.open doesn't have an attribute %v, valid attributes: [kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // MysqlRowLocksMetricAttributeKey specifies the key of an attribute for the mysql.row_locks metric.
 type MysqlRowLocksMetricAttributeKey string
 
@@ -1269,6 +1317,26 @@ func (ms *MysqlRowOperationsMetricConfig) Validate() error {
 		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
 	}
 
+	return nil
+}
+
+// MysqlSlowLaunchThreadsMetricConfig provides config for the mysql.slow_launch_threads metric.
+type MysqlSlowLaunchThreadsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlSlowLaunchThreadsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -2065,8 +2133,10 @@ type MetricsConfig struct {
 	MysqlQuerySlowCount          MysqlQuerySlowCountMetricConfig          `mapstructure:"mysql.query.slow.count"`
 	MysqlReplicaSQLDelay         MysqlReplicaSQLDelayMetricConfig         `mapstructure:"mysql.replica.sql_delay"`
 	MysqlReplicaTimeBehindSource MysqlReplicaTimeBehindSourceMetricConfig `mapstructure:"mysql.replica.time_behind_source"`
+	MysqlResourcesOpen           MysqlResourcesOpenMetricConfig           `mapstructure:"mysql.resources.open"`
 	MysqlRowLocks                MysqlRowLocksMetricConfig                `mapstructure:"mysql.row_locks"`
 	MysqlRowOperations           MysqlRowOperationsMetricConfig           `mapstructure:"mysql.row_operations"`
+	MysqlSlowLaunchThreads       MysqlSlowLaunchThreadsMetricConfig       `mapstructure:"mysql.slow_launch_threads"`
 	MysqlSorts                   MysqlSortsMetricConfig                   `mapstructure:"mysql.sorts"`
 	MysqlStatementEventCount     MysqlStatementEventCountMetricConfig     `mapstructure:"mysql.statement_event.count"`
 	MysqlStatementEventWaitTime  MysqlStatementEventWaitTimeMetricConfig  `mapstructure:"mysql.statement_event.wait.time"`
@@ -2217,6 +2287,11 @@ func DefaultMetricsConfig() MetricsConfig {
 		MysqlReplicaTimeBehindSource: MysqlReplicaTimeBehindSourceMetricConfig{
 			Enabled: false,
 		},
+		MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
+		},
 		MysqlRowLocks: MysqlRowLocksMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
@@ -2226,6 +2301,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlRowOperationsMetricAttributeKey{MysqlRowOperationsMetricAttributeKeyRowOperations},
+		},
+		MysqlSlowLaunchThreads: MysqlSlowLaunchThreadsMetricConfig{
+			Enabled: false,
 		},
 		MysqlSorts: MysqlSortsMetricConfig{
 			Enabled:             true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -2289,7 +2289,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
 			Enabled:             false,
-			AggregationStrategy: AggregationStrategyAvg,
+			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
 		},
 		MysqlRowLocks: MysqlRowLocksMetricConfig{

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -157,6 +157,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MysqlReplicaTimeBehindSource: MysqlReplicaTimeBehindSourceMetricConfig{
 						Enabled: true,
 					},
+					MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
+					},
 					MysqlRowLocks: MysqlRowLocksMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -166,6 +171,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlRowOperationsMetricAttributeKey{MysqlRowOperationsMetricAttributeKeyRowOperations},
+					},
+					MysqlSlowLaunchThreads: MysqlSlowLaunchThreadsMetricConfig{
+						Enabled: true,
 					},
 					MysqlSorts: MysqlSortsMetricConfig{
 						Enabled:             true,
@@ -390,6 +398,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MysqlReplicaTimeBehindSource: MysqlReplicaTimeBehindSourceMetricConfig{
 						Enabled: false,
 					},
+					MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
+					},
 					MysqlRowLocks: MysqlRowLocksMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -399,6 +412,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlRowOperationsMetricAttributeKey{MysqlRowOperationsMetricAttributeKeyRowOperations},
+					},
+					MysqlSlowLaunchThreads: MysqlSlowLaunchThreadsMetricConfig{
+						Enabled: false,
 					},
 					MysqlSorts: MysqlSortsMetricConfig{
 						Enabled:             false,
@@ -493,7 +509,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlResourcesOpenMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSlowLaunchThreadsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -734,6 +750,18 @@ func TestMysqlPreparedStatementsMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric mysql.prepared_statements doesn't have an attribute invalid, valid attributes: [command]")
 
 	cfg = DefaultMetricsConfig().MysqlPreparedStatements
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMysqlResourcesOpenMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MysqlResourcesOpen
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MysqlResourcesOpenMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mysql.resources.open doesn't have an attribute invalid, valid attributes: [kind]")
+
+	cfg = DefaultMetricsConfig().MysqlResourcesOpen
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -159,7 +159,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
 						Enabled:             true,
-						AggregationStrategy: AggregationStrategyAvg,
+						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
 					},
 					MysqlRowLocks: MysqlRowLocksMetricConfig{
@@ -400,7 +400,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
 						Enabled:             false,
-						AggregationStrategy: AggregationStrategyAvg,
+						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
 					},
 					MysqlRowLocks: MysqlRowLocksMetricConfig{

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -76,6 +76,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlDoubleWritesMetricAttributeKey{MysqlDoubleWritesMetricAttributeKeyDoubleWrites},
 					},
+					MysqlFileOpen: MysqlFileOpenMetricConfig{
+						Enabled: true,
+					},
 					MysqlHandlers: MysqlHandlersMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -157,11 +160,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MysqlReplicaTimeBehindSource: MysqlReplicaTimeBehindSourceMetricConfig{
 						Enabled: true,
 					},
-					MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
-						Enabled:             true,
-						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
-					},
 					MysqlRowLocks: MysqlRowLocksMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -221,6 +219,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlTableLockWaitWriteTimeMetricAttributeKey{MysqlTableLockWaitWriteTimeMetricAttributeKeySchema, MysqlTableLockWaitWriteTimeMetricAttributeKeyTableName, MysqlTableLockWaitWriteTimeMetricAttributeKeyWriteLockType},
+					},
+					MysqlTableOpen: MysqlTableOpenMetricConfig{
+						Enabled: true,
 					},
 					MysqlTableRows: MysqlTableRowsMetricConfig{
 						Enabled:             true,
@@ -317,6 +318,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlDoubleWritesMetricAttributeKey{MysqlDoubleWritesMetricAttributeKeyDoubleWrites},
 					},
+					MysqlFileOpen: MysqlFileOpenMetricConfig{
+						Enabled: false,
+					},
 					MysqlHandlers: MysqlHandlersMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -398,11 +402,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MysqlReplicaTimeBehindSource: MysqlReplicaTimeBehindSourceMetricConfig{
 						Enabled: false,
 					},
-					MysqlResourcesOpen: MysqlResourcesOpenMetricConfig{
-						Enabled:             false,
-						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MysqlResourcesOpenMetricAttributeKey{MysqlResourcesOpenMetricAttributeKeyOpenResources},
-					},
 					MysqlRowLocks: MysqlRowLocksMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -463,6 +462,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlTableLockWaitWriteTimeMetricAttributeKey{MysqlTableLockWaitWriteTimeMetricAttributeKeySchema, MysqlTableLockWaitWriteTimeMetricAttributeKeyTableName, MysqlTableLockWaitWriteTimeMetricAttributeKeyWriteLockType},
 					},
+					MysqlTableOpen: MysqlTableOpenMetricConfig{
+						Enabled: false,
+					},
 					MysqlTableRows: MysqlTableRowsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -509,7 +511,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlResourcesOpenMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadSlowLaunchMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlFileOpenMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableOpenMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadSlowLaunchMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -750,18 +752,6 @@ func TestMysqlPreparedStatementsMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric mysql.prepared_statements doesn't have an attribute invalid, valid attributes: [command]")
 
 	cfg = DefaultMetricsConfig().MysqlPreparedStatements
-	cfg.AggregationStrategy = "invalid"
-	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
-}
-
-func TestMysqlResourcesOpenMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().MysqlResourcesOpen
-	require.NoError(t, cfg.Validate())
-
-	cfg.EnabledAttributes = []MysqlResourcesOpenMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric mysql.resources.open doesn't have an attribute invalid, valid attributes: [kind]")
-
-	cfg = DefaultMetricsConfig().MysqlResourcesOpen
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -172,9 +172,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlRowOperationsMetricAttributeKey{MysqlRowOperationsMetricAttributeKeyRowOperations},
 					},
-					MysqlSlowLaunchThreads: MysqlSlowLaunchThreadsMetricConfig{
-						Enabled: true,
-					},
 					MysqlSorts: MysqlSortsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -244,6 +241,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlThreadsMetricAttributeKey{MysqlThreadsMetricAttributeKeyThreads},
+					},
+					MysqlThreadsSlowLaunch: MysqlThreadsSlowLaunchMetricConfig{
+						Enabled: true,
 					},
 					MysqlTmpResources: MysqlTmpResourcesMetricConfig{
 						Enabled:             true,
@@ -413,9 +413,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlRowOperationsMetricAttributeKey{MysqlRowOperationsMetricAttributeKeyRowOperations},
 					},
-					MysqlSlowLaunchThreads: MysqlSlowLaunchThreadsMetricConfig{
-						Enabled: false,
-					},
 					MysqlSorts: MysqlSortsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -486,6 +483,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlThreadsMetricAttributeKey{MysqlThreadsMetricAttributeKeyThreads},
 					},
+					MysqlThreadsSlowLaunch: MysqlThreadsSlowLaunchMetricConfig{
+						Enabled: false,
+					},
 					MysqlTmpResources: MysqlTmpResourcesMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -509,7 +509,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlResourcesOpenMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSlowLaunchThreadsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlResourcesOpenMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlThreadsSlowLaunchMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -237,13 +237,13 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlTableOpenCacheMetricAttributeKey{MysqlTableOpenCacheMetricAttributeKeyCacheStatus},
 					},
+					MysqlThreadSlowLaunch: MysqlThreadSlowLaunchMetricConfig{
+						Enabled: true,
+					},
 					MysqlThreads: MysqlThreadsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlThreadsMetricAttributeKey{MysqlThreadsMetricAttributeKeyThreads},
-					},
-					MysqlThreadsSlowLaunch: MysqlThreadsSlowLaunchMetricConfig{
-						Enabled: true,
 					},
 					MysqlTmpResources: MysqlTmpResourcesMetricConfig{
 						Enabled:             true,
@@ -478,13 +478,13 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlTableOpenCacheMetricAttributeKey{MysqlTableOpenCacheMetricAttributeKeyCacheStatus},
 					},
+					MysqlThreadSlowLaunch: MysqlThreadSlowLaunchMetricConfig{
+						Enabled: false,
+					},
 					MysqlThreads: MysqlThreadsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlThreadsMetricAttributeKey{MysqlThreadsMetricAttributeKeyThreads},
-					},
-					MysqlThreadsSlowLaunch: MysqlThreadsSlowLaunchMetricConfig{
-						Enabled: false,
 					},
 					MysqlTmpResources: MysqlTmpResourcesMetricConfig{
 						Enabled:             false,
@@ -509,7 +509,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlResourcesOpenMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlThreadsSlowLaunchMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlResourcesOpenMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadSlowLaunchMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, DbSystemNameResourceAttributeConfig{}, DbSystemVersionResourceAttributeConfig{}, MysqlInstanceEndpointResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -664,32 +664,6 @@ var MapAttributeMysqlxThreads = map[string]AttributeMysqlxThreads{
 	"active":    AttributeMysqlxThreadsActive,
 }
 
-// AttributeOpenResources specifies the value open_resources attribute.
-type AttributeOpenResources int
-
-const (
-	_ AttributeOpenResources = iota
-	AttributeOpenResourcesFile
-	AttributeOpenResourcesTable
-)
-
-// String returns the string representation of the AttributeOpenResources.
-func (av AttributeOpenResources) String() string {
-	switch av {
-	case AttributeOpenResourcesFile:
-		return "file"
-	case AttributeOpenResourcesTable:
-		return "table"
-	}
-	return ""
-}
-
-// MapAttributeOpenResources is a helper map of string to AttributeOpenResources attribute value.
-var MapAttributeOpenResources = map[string]AttributeOpenResources{
-	"file":  AttributeOpenResourcesFile,
-	"table": AttributeOpenResourcesTable,
-}
-
 // AttributeOpenedResources specifies the value opened_resources attribute.
 type AttributeOpenedResources int
 
@@ -1124,6 +1098,9 @@ var MetricsInfo = metricsInfo{
 		Name:       "mysql.double_writes",
 		Attributes: []string{"double_writes"},
 	},
+	MysqlFileOpen: metricInfo{
+		Name: "mysql.file.open",
+	},
 	MysqlHandlers: metricInfo{
 		Name:       "mysql.handlers",
 		Attributes: []string{"handler"},
@@ -1193,10 +1170,6 @@ var MetricsInfo = metricsInfo{
 	MysqlReplicaTimeBehindSource: metricInfo{
 		Name: "mysql.replica.time_behind_source",
 	},
-	MysqlResourcesOpen: metricInfo{
-		Name:       "mysql.resources.open",
-		Attributes: []string{"open_resources"},
-	},
 	MysqlRowLocks: metricInfo{
 		Name:       "mysql.row_locks",
 		Attributes: []string{"row_locks"},
@@ -1245,6 +1218,9 @@ var MetricsInfo = metricsInfo{
 		Name:       "mysql.table.lock_wait.write.time",
 		Attributes: []string{"schema", "table_name", "write_lock_type"},
 	},
+	MysqlTableOpen: metricInfo{
+		Name: "mysql.table.open",
+	},
 	MysqlTableRows: metricInfo{
 		Name:       "mysql.table.rows",
 		Attributes: []string{"table_name", "schema"},
@@ -1285,6 +1261,7 @@ type metricsInfo struct {
 	MysqlConnectionCount         metricInfo
 	MysqlConnectionErrors        metricInfo
 	MysqlDoubleWrites            metricInfo
+	MysqlFileOpen                metricInfo
 	MysqlHandlers                metricInfo
 	MysqlIndexIoWaitCount        metricInfo
 	MysqlIndexIoWaitTime         metricInfo
@@ -1304,7 +1281,6 @@ type metricsInfo struct {
 	MysqlQuerySlowCount          metricInfo
 	MysqlReplicaSQLDelay         metricInfo
 	MysqlReplicaTimeBehindSource metricInfo
-	MysqlResourcesOpen           metricInfo
 	MysqlRowLocks                metricInfo
 	MysqlRowOperations           metricInfo
 	MysqlSorts                   metricInfo
@@ -1317,6 +1293,7 @@ type metricsInfo struct {
 	MysqlTableLockWaitReadTime   metricInfo
 	MysqlTableLockWaitWriteCount metricInfo
 	MysqlTableLockWaitWriteTime  metricInfo
+	MysqlTableOpen               metricInfo
 	MysqlTableRows               metricInfo
 	MysqlTableSize               metricInfo
 	MysqlTableOpenCache          metricInfo
@@ -2207,6 +2184,56 @@ func (m *metricMysqlDoubleWrites) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMysqlDoubleWrites(cfg MysqlDoubleWritesMetricConfig) metricMysqlDoubleWrites {
 	m := metricMysqlDoubleWrites{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMysqlFileOpen struct {
+	data     pmetric.Metric            // data buffer for generated metric.
+	config   MysqlFileOpenMetricConfig // metric config provided by user.
+	capacity int                       // max observed number of data points added to the metric.
+}
+
+// init fills mysql.file.open metric with initial data.
+func (m *metricMysqlFileOpen) init() {
+	m.data.SetName("mysql.file.open")
+	m.data.SetDescription("The number of currently open files.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricMysqlFileOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlFileOpen) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlFileOpen) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlFileOpen(cfg MysqlFileOpenMetricConfig) metricMysqlFileOpen {
+	m := metricMysqlFileOpen{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3689,97 +3716,6 @@ func newMetricMysqlReplicaTimeBehindSource(cfg MysqlReplicaTimeBehindSourceMetri
 	return m
 }
 
-type metricMysqlResourcesOpen struct {
-	data          pmetric.Metric                 // data buffer for generated metric.
-	config        MysqlResourcesOpenMetricConfig // metric config provided by user.
-	capacity      int                            // max observed number of data points added to the metric.
-	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
-}
-
-// init fills mysql.resources.open metric with initial data.
-func (m *metricMysqlResourcesOpen) init() {
-	m.data.SetName("mysql.resources.open")
-	m.data.SetDescription("The number of currently open resources.")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
-	m.aggDataPoints = m.aggDataPoints[:0]
-}
-
-func (m *metricMysqlResourcesOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, openResourcesAttributeValue string) {
-	if !m.config.Enabled {
-		return
-	}
-
-	dp := pmetric.NewNumberDataPoint()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, MysqlResourcesOpenMetricAttributeKeyOpenResources) {
-		dp.Attributes().PutStr("kind", openResourcesAttributeValue)
-	}
-
-	var s string
-	dps := m.data.Sum().DataPoints()
-	for i := 0; i < dps.Len(); i++ {
-		dpi := dps.At(i)
-		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
-			switch s = m.config.AggregationStrategy; s {
-			case AggregationStrategySum, AggregationStrategyAvg:
-				dpi.SetIntValue(dpi.IntValue() + val)
-				m.aggDataPoints[i] += 1
-				return
-			case AggregationStrategyMin:
-				if dpi.IntValue() > val {
-					dpi.SetIntValue(val)
-				}
-				return
-			case AggregationStrategyMax:
-				if dpi.IntValue() < val {
-					dpi.SetIntValue(val)
-				}
-				return
-			}
-		}
-	}
-
-	dp.SetIntValue(val)
-	m.aggDataPoints = append(m.aggDataPoints, 1)
-	dp.MoveTo(dps.AppendEmpty())
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMysqlResourcesOpen) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMysqlResourcesOpen) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		if m.config.AggregationStrategy == AggregationStrategyAvg {
-			for i, aggCount := range m.aggDataPoints {
-				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
-			}
-		}
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMysqlResourcesOpen(cfg MysqlResourcesOpenMetricConfig) metricMysqlResourcesOpen {
-	m := metricMysqlResourcesOpen{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricMysqlRowLocks struct {
 	data          pmetric.Metric            // data buffer for generated metric.
 	config        MysqlRowLocksMetricConfig // metric config provided by user.
@@ -4926,6 +4862,56 @@ func newMetricMysqlTableLockWaitWriteTime(cfg MysqlTableLockWaitWriteTimeMetricC
 	return m
 }
 
+type metricMysqlTableOpen struct {
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   MysqlTableOpenMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
+}
+
+// init fills mysql.table.open metric with initial data.
+func (m *metricMysqlTableOpen) init() {
+	m.data.SetName("mysql.table.open")
+	m.data.SetDescription("The number of currently open tables.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricMysqlTableOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlTableOpen) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlTableOpen) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlTableOpen(cfg MysqlTableOpenMetricConfig) metricMysqlTableOpen {
+	m := metricMysqlTableOpen{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMysqlTableRows struct {
 	data          pmetric.Metric             // data buffer for generated metric.
 	config        MysqlTableRowsMetricConfig // metric config provided by user.
@@ -5515,6 +5501,7 @@ type MetricsBuilder struct {
 	metricMysqlConnectionCount         metricMysqlConnectionCount
 	metricMysqlConnectionErrors        metricMysqlConnectionErrors
 	metricMysqlDoubleWrites            metricMysqlDoubleWrites
+	metricMysqlFileOpen                metricMysqlFileOpen
 	metricMysqlHandlers                metricMysqlHandlers
 	metricMysqlIndexIoWaitCount        metricMysqlIndexIoWaitCount
 	metricMysqlIndexIoWaitTime         metricMysqlIndexIoWaitTime
@@ -5534,7 +5521,6 @@ type MetricsBuilder struct {
 	metricMysqlQuerySlowCount          metricMysqlQuerySlowCount
 	metricMysqlReplicaSQLDelay         metricMysqlReplicaSQLDelay
 	metricMysqlReplicaTimeBehindSource metricMysqlReplicaTimeBehindSource
-	metricMysqlResourcesOpen           metricMysqlResourcesOpen
 	metricMysqlRowLocks                metricMysqlRowLocks
 	metricMysqlRowOperations           metricMysqlRowOperations
 	metricMysqlSorts                   metricMysqlSorts
@@ -5547,6 +5533,7 @@ type MetricsBuilder struct {
 	metricMysqlTableLockWaitReadTime   metricMysqlTableLockWaitReadTime
 	metricMysqlTableLockWaitWriteCount metricMysqlTableLockWaitWriteCount
 	metricMysqlTableLockWaitWriteTime  metricMysqlTableLockWaitWriteTime
+	metricMysqlTableOpen               metricMysqlTableOpen
 	metricMysqlTableRows               metricMysqlTableRows
 	metricMysqlTableSize               metricMysqlTableSize
 	metricMysqlTableOpenCache          metricMysqlTableOpenCache
@@ -5590,6 +5577,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlConnectionCount:         newMetricMysqlConnectionCount(mbc.Metrics.MysqlConnectionCount),
 		metricMysqlConnectionErrors:        newMetricMysqlConnectionErrors(mbc.Metrics.MysqlConnectionErrors),
 		metricMysqlDoubleWrites:            newMetricMysqlDoubleWrites(mbc.Metrics.MysqlDoubleWrites),
+		metricMysqlFileOpen:                newMetricMysqlFileOpen(mbc.Metrics.MysqlFileOpen),
 		metricMysqlHandlers:                newMetricMysqlHandlers(mbc.Metrics.MysqlHandlers),
 		metricMysqlIndexIoWaitCount:        newMetricMysqlIndexIoWaitCount(mbc.Metrics.MysqlIndexIoWaitCount),
 		metricMysqlIndexIoWaitTime:         newMetricMysqlIndexIoWaitTime(mbc.Metrics.MysqlIndexIoWaitTime),
@@ -5609,7 +5597,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlQuerySlowCount:          newMetricMysqlQuerySlowCount(mbc.Metrics.MysqlQuerySlowCount),
 		metricMysqlReplicaSQLDelay:         newMetricMysqlReplicaSQLDelay(mbc.Metrics.MysqlReplicaSQLDelay),
 		metricMysqlReplicaTimeBehindSource: newMetricMysqlReplicaTimeBehindSource(mbc.Metrics.MysqlReplicaTimeBehindSource),
-		metricMysqlResourcesOpen:           newMetricMysqlResourcesOpen(mbc.Metrics.MysqlResourcesOpen),
 		metricMysqlRowLocks:                newMetricMysqlRowLocks(mbc.Metrics.MysqlRowLocks),
 		metricMysqlRowOperations:           newMetricMysqlRowOperations(mbc.Metrics.MysqlRowOperations),
 		metricMysqlSorts:                   newMetricMysqlSorts(mbc.Metrics.MysqlSorts),
@@ -5622,6 +5609,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlTableLockWaitReadTime:   newMetricMysqlTableLockWaitReadTime(mbc.Metrics.MysqlTableLockWaitReadTime),
 		metricMysqlTableLockWaitWriteCount: newMetricMysqlTableLockWaitWriteCount(mbc.Metrics.MysqlTableLockWaitWriteCount),
 		metricMysqlTableLockWaitWriteTime:  newMetricMysqlTableLockWaitWriteTime(mbc.Metrics.MysqlTableLockWaitWriteTime),
+		metricMysqlTableOpen:               newMetricMysqlTableOpen(mbc.Metrics.MysqlTableOpen),
 		metricMysqlTableRows:               newMetricMysqlTableRows(mbc.Metrics.MysqlTableRows),
 		metricMysqlTableSize:               newMetricMysqlTableSize(mbc.Metrics.MysqlTableSize),
 		metricMysqlTableOpenCache:          newMetricMysqlTableOpenCache(mbc.Metrics.MysqlTableOpenCache),
@@ -5748,6 +5736,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlConnectionCount.emit(ils.Metrics())
 	mb.metricMysqlConnectionErrors.emit(ils.Metrics())
 	mb.metricMysqlDoubleWrites.emit(ils.Metrics())
+	mb.metricMysqlFileOpen.emit(ils.Metrics())
 	mb.metricMysqlHandlers.emit(ils.Metrics())
 	mb.metricMysqlIndexIoWaitCount.emit(ils.Metrics())
 	mb.metricMysqlIndexIoWaitTime.emit(ils.Metrics())
@@ -5767,7 +5756,6 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlQuerySlowCount.emit(ils.Metrics())
 	mb.metricMysqlReplicaSQLDelay.emit(ils.Metrics())
 	mb.metricMysqlReplicaTimeBehindSource.emit(ils.Metrics())
-	mb.metricMysqlResourcesOpen.emit(ils.Metrics())
 	mb.metricMysqlRowLocks.emit(ils.Metrics())
 	mb.metricMysqlRowOperations.emit(ils.Metrics())
 	mb.metricMysqlSorts.emit(ils.Metrics())
@@ -5780,6 +5768,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlTableLockWaitReadTime.emit(ils.Metrics())
 	mb.metricMysqlTableLockWaitWriteCount.emit(ils.Metrics())
 	mb.metricMysqlTableLockWaitWriteTime.emit(ils.Metrics())
+	mb.metricMysqlTableOpen.emit(ils.Metrics())
 	mb.metricMysqlTableRows.emit(ils.Metrics())
 	mb.metricMysqlTableSize.emit(ils.Metrics())
 	mb.metricMysqlTableOpenCache.emit(ils.Metrics())
@@ -5915,6 +5904,16 @@ func (mb *MetricsBuilder) RecordMysqlDoubleWritesDataPoint(ts pcommon.Timestamp,
 		return fmt.Errorf("failed to parse int64 for MysqlDoubleWrites, value was %s: %w", inputVal, err)
 	}
 	mb.metricMysqlDoubleWrites.recordDataPoint(mb.startTime, ts, val, doubleWritesAttributeValue.String())
+	return nil
+}
+
+// RecordMysqlFileOpenDataPoint adds a data point to mysql.file.open metric.
+func (mb *MetricsBuilder) RecordMysqlFileOpenDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlFileOpen, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlFileOpen.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 
@@ -6088,16 +6087,6 @@ func (mb *MetricsBuilder) RecordMysqlReplicaTimeBehindSourceDataPoint(ts pcommon
 	mb.metricMysqlReplicaTimeBehindSource.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordMysqlResourcesOpenDataPoint adds a data point to mysql.resources.open metric.
-func (mb *MetricsBuilder) RecordMysqlResourcesOpenDataPoint(ts pcommon.Timestamp, inputVal string, openResourcesAttributeValue AttributeOpenResources) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for MysqlResourcesOpen, value was %s: %w", inputVal, err)
-	}
-	mb.metricMysqlResourcesOpen.recordDataPoint(mb.startTime, ts, val, openResourcesAttributeValue.String())
-	return nil
-}
-
 // RecordMysqlRowLocksDataPoint adds a data point to mysql.row_locks metric.
 func (mb *MetricsBuilder) RecordMysqlRowLocksDataPoint(ts pcommon.Timestamp, inputVal string, rowLocksAttributeValue AttributeRowLocks) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -6171,6 +6160,16 @@ func (mb *MetricsBuilder) RecordMysqlTableLockWaitWriteCountDataPoint(ts pcommon
 // RecordMysqlTableLockWaitWriteTimeDataPoint adds a data point to mysql.table.lock_wait.write.time metric.
 func (mb *MetricsBuilder) RecordMysqlTableLockWaitWriteTimeDataPoint(ts pcommon.Timestamp, val int64, schemaAttributeValue string, tableNameAttributeValue string, writeLockTypeAttributeValue AttributeWriteLockType) {
 	mb.metricMysqlTableLockWaitWriteTime.recordDataPoint(mb.startTime, ts, val, schemaAttributeValue, tableNameAttributeValue, writeLockTypeAttributeValue.String())
+}
+
+// RecordMysqlTableOpenDataPoint adds a data point to mysql.table.open metric.
+func (mb *MetricsBuilder) RecordMysqlTableOpenDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlTableOpen, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlTableOpen.recordDataPoint(mb.startTime, ts, val)
+	return nil
 }
 
 // RecordMysqlTableRowsDataPoint adds a data point to mysql.table.rows metric.

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -664,6 +664,32 @@ var MapAttributeMysqlxThreads = map[string]AttributeMysqlxThreads{
 	"active":    AttributeMysqlxThreadsActive,
 }
 
+// AttributeOpenResources specifies the value open_resources attribute.
+type AttributeOpenResources int
+
+const (
+	_ AttributeOpenResources = iota
+	AttributeOpenResourcesFile
+	AttributeOpenResourcesTable
+)
+
+// String returns the string representation of the AttributeOpenResources.
+func (av AttributeOpenResources) String() string {
+	switch av {
+	case AttributeOpenResourcesFile:
+		return "file"
+	case AttributeOpenResourcesTable:
+		return "table"
+	}
+	return ""
+}
+
+// MapAttributeOpenResources is a helper map of string to AttributeOpenResources attribute value.
+var MapAttributeOpenResources = map[string]AttributeOpenResources{
+	"file":  AttributeOpenResourcesFile,
+	"table": AttributeOpenResourcesTable,
+}
+
 // AttributeOpenedResources specifies the value opened_resources attribute.
 type AttributeOpenedResources int
 
@@ -1167,6 +1193,10 @@ var MetricsInfo = metricsInfo{
 	MysqlReplicaTimeBehindSource: metricInfo{
 		Name: "mysql.replica.time_behind_source",
 	},
+	MysqlResourcesOpen: metricInfo{
+		Name:       "mysql.resources.open",
+		Attributes: []string{"open_resources"},
+	},
 	MysqlRowLocks: metricInfo{
 		Name:       "mysql.row_locks",
 		Attributes: []string{"row_locks"},
@@ -1174,6 +1204,9 @@ var MetricsInfo = metricsInfo{
 	MysqlRowOperations: metricInfo{
 		Name:       "mysql.row_operations",
 		Attributes: []string{"row_operations"},
+	},
+	MysqlSlowLaunchThreads: metricInfo{
+		Name: "mysql.slow_launch_threads",
 	},
 	MysqlSorts: metricInfo{
 		Name:       "mysql.sorts",
@@ -1271,8 +1304,10 @@ type metricsInfo struct {
 	MysqlQuerySlowCount          metricInfo
 	MysqlReplicaSQLDelay         metricInfo
 	MysqlReplicaTimeBehindSource metricInfo
+	MysqlResourcesOpen           metricInfo
 	MysqlRowLocks                metricInfo
 	MysqlRowOperations           metricInfo
+	MysqlSlowLaunchThreads       metricInfo
 	MysqlSorts                   metricInfo
 	MysqlStatementEventCount     metricInfo
 	MysqlStatementEventWaitTime  metricInfo
@@ -3654,6 +3689,95 @@ func newMetricMysqlReplicaTimeBehindSource(cfg MysqlReplicaTimeBehindSourceMetri
 	return m
 }
 
+type metricMysqlResourcesOpen struct {
+	data          pmetric.Metric                 // data buffer for generated metric.
+	config        MysqlResourcesOpenMetricConfig // metric config provided by user.
+	capacity      int                            // max observed number of data points added to the metric.
+	aggDataPoints []int64                        // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mysql.resources.open metric with initial data.
+func (m *metricMysqlResourcesOpen) init() {
+	m.data.SetName("mysql.resources.open")
+	m.data.SetDescription("The number of open resources.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMysqlResourcesOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, openResourcesAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MysqlResourcesOpenMetricAttributeKeyOpenResources) {
+		dp.Attributes().PutStr("kind", openResourcesAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlResourcesOpen) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlResourcesOpen) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlResourcesOpen(cfg MysqlResourcesOpenMetricConfig) metricMysqlResourcesOpen {
+	m := metricMysqlResourcesOpen{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMysqlRowLocks struct {
 	data          pmetric.Metric            // data buffer for generated metric.
 	config        MysqlRowLocksMetricConfig // metric config provided by user.
@@ -3828,6 +3952,58 @@ func (m *metricMysqlRowOperations) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMysqlRowOperations(cfg MysqlRowOperationsMetricConfig) metricMysqlRowOperations {
 	m := metricMysqlRowOperations{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMysqlSlowLaunchThreads struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   MysqlSlowLaunchThreadsMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills mysql.slow_launch_threads metric with initial data.
+func (m *metricMysqlSlowLaunchThreads) init() {
+	m.data.SetName("mysql.slow_launch_threads")
+	m.data.SetDescription("The number of threads that have taken more than slow_launch_time seconds to create.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMysqlSlowLaunchThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlSlowLaunchThreads) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlSlowLaunchThreads) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlSlowLaunchThreads(cfg MysqlSlowLaunchThreadsMetricConfig) metricMysqlSlowLaunchThreads {
+	m := metricMysqlSlowLaunchThreads{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5356,8 +5532,10 @@ type MetricsBuilder struct {
 	metricMysqlQuerySlowCount          metricMysqlQuerySlowCount
 	metricMysqlReplicaSQLDelay         metricMysqlReplicaSQLDelay
 	metricMysqlReplicaTimeBehindSource metricMysqlReplicaTimeBehindSource
+	metricMysqlResourcesOpen           metricMysqlResourcesOpen
 	metricMysqlRowLocks                metricMysqlRowLocks
 	metricMysqlRowOperations           metricMysqlRowOperations
+	metricMysqlSlowLaunchThreads       metricMysqlSlowLaunchThreads
 	metricMysqlSorts                   metricMysqlSorts
 	metricMysqlStatementEventCount     metricMysqlStatementEventCount
 	metricMysqlStatementEventWaitTime  metricMysqlStatementEventWaitTime
@@ -5429,8 +5607,10 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlQuerySlowCount:          newMetricMysqlQuerySlowCount(mbc.Metrics.MysqlQuerySlowCount),
 		metricMysqlReplicaSQLDelay:         newMetricMysqlReplicaSQLDelay(mbc.Metrics.MysqlReplicaSQLDelay),
 		metricMysqlReplicaTimeBehindSource: newMetricMysqlReplicaTimeBehindSource(mbc.Metrics.MysqlReplicaTimeBehindSource),
+		metricMysqlResourcesOpen:           newMetricMysqlResourcesOpen(mbc.Metrics.MysqlResourcesOpen),
 		metricMysqlRowLocks:                newMetricMysqlRowLocks(mbc.Metrics.MysqlRowLocks),
 		metricMysqlRowOperations:           newMetricMysqlRowOperations(mbc.Metrics.MysqlRowOperations),
+		metricMysqlSlowLaunchThreads:       newMetricMysqlSlowLaunchThreads(mbc.Metrics.MysqlSlowLaunchThreads),
 		metricMysqlSorts:                   newMetricMysqlSorts(mbc.Metrics.MysqlSorts),
 		metricMysqlStatementEventCount:     newMetricMysqlStatementEventCount(mbc.Metrics.MysqlStatementEventCount),
 		metricMysqlStatementEventWaitTime:  newMetricMysqlStatementEventWaitTime(mbc.Metrics.MysqlStatementEventWaitTime),
@@ -5585,8 +5765,10 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlQuerySlowCount.emit(ils.Metrics())
 	mb.metricMysqlReplicaSQLDelay.emit(ils.Metrics())
 	mb.metricMysqlReplicaTimeBehindSource.emit(ils.Metrics())
+	mb.metricMysqlResourcesOpen.emit(ils.Metrics())
 	mb.metricMysqlRowLocks.emit(ils.Metrics())
 	mb.metricMysqlRowOperations.emit(ils.Metrics())
+	mb.metricMysqlSlowLaunchThreads.emit(ils.Metrics())
 	mb.metricMysqlSorts.emit(ils.Metrics())
 	mb.metricMysqlStatementEventCount.emit(ils.Metrics())
 	mb.metricMysqlStatementEventWaitTime.emit(ils.Metrics())
@@ -5904,6 +6086,16 @@ func (mb *MetricsBuilder) RecordMysqlReplicaTimeBehindSourceDataPoint(ts pcommon
 	mb.metricMysqlReplicaTimeBehindSource.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordMysqlResourcesOpenDataPoint adds a data point to mysql.resources.open metric.
+func (mb *MetricsBuilder) RecordMysqlResourcesOpenDataPoint(ts pcommon.Timestamp, inputVal string, openResourcesAttributeValue AttributeOpenResources) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlResourcesOpen, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlResourcesOpen.recordDataPoint(mb.startTime, ts, val, openResourcesAttributeValue.String())
+	return nil
+}
+
 // RecordMysqlRowLocksDataPoint adds a data point to mysql.row_locks metric.
 func (mb *MetricsBuilder) RecordMysqlRowLocksDataPoint(ts pcommon.Timestamp, inputVal string, rowLocksAttributeValue AttributeRowLocks) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -5921,6 +6113,16 @@ func (mb *MetricsBuilder) RecordMysqlRowOperationsDataPoint(ts pcommon.Timestamp
 		return fmt.Errorf("failed to parse int64 for MysqlRowOperations, value was %s: %w", inputVal, err)
 	}
 	mb.metricMysqlRowOperations.recordDataPoint(mb.startTime, ts, val, rowOperationsAttributeValue.String())
+	return nil
+}
+
+// RecordMysqlSlowLaunchThreadsDataPoint adds a data point to mysql.slow_launch_threads metric.
+func (mb *MetricsBuilder) RecordMysqlSlowLaunchThreadsDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlSlowLaunchThreads, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlSlowLaunchThreads.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -3699,7 +3699,7 @@ type metricMysqlResourcesOpen struct {
 // init fills mysql.resources.open metric with initial data.
 func (m *metricMysqlResourcesOpen) init() {
 	m.data.SetName("mysql.resources.open")
-	m.data.SetDescription("The number of open resources.")
+	m.data.SetDescription("The number of currently open resources.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -1257,12 +1257,12 @@ var MetricsInfo = metricsInfo{
 		Name:       "mysql.table_open_cache",
 		Attributes: []string{"cache_status"},
 	},
+	MysqlThreadSlowLaunch: metricInfo{
+		Name: "mysql.thread.slow_launch",
+	},
 	MysqlThreads: metricInfo{
 		Name:       "mysql.threads",
 		Attributes: []string{"threads"},
-	},
-	MysqlThreadsSlowLaunch: metricInfo{
-		Name: "mysql.threads.slow_launch",
 	},
 	MysqlTmpResources: metricInfo{
 		Name:       "mysql.tmp_resources",
@@ -1320,8 +1320,8 @@ type metricsInfo struct {
 	MysqlTableRows               metricInfo
 	MysqlTableSize               metricInfo
 	MysqlTableOpenCache          metricInfo
+	MysqlThreadSlowLaunch        metricInfo
 	MysqlThreads                 metricInfo
-	MysqlThreadsSlowLaunch       metricInfo
 	MysqlTmpResources            metricInfo
 	MysqlUptime                  metricInfo
 }
@@ -5208,6 +5208,58 @@ func newMetricMysqlTableOpenCache(cfg MysqlTableOpenCacheMetricConfig) metricMys
 	return m
 }
 
+type metricMysqlThreadSlowLaunch struct {
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   MysqlThreadSlowLaunchMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
+}
+
+// init fills mysql.thread.slow_launch metric with initial data.
+func (m *metricMysqlThreadSlowLaunch) init() {
+	m.data.SetName("mysql.thread.slow_launch")
+	m.data.SetDescription("The number of threads that have taken more than slow_launch_time seconds to create.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMysqlThreadSlowLaunch) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlThreadSlowLaunch) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlThreadSlowLaunch) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlThreadSlowLaunch(cfg MysqlThreadSlowLaunchMetricConfig) metricMysqlThreadSlowLaunch {
+	m := metricMysqlThreadSlowLaunch{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMysqlThreads struct {
 	data          pmetric.Metric           // data buffer for generated metric.
 	config        MysqlThreadsMetricConfig // metric config provided by user.
@@ -5291,58 +5343,6 @@ func (m *metricMysqlThreads) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMysqlThreads(cfg MysqlThreadsMetricConfig) metricMysqlThreads {
 	m := metricMysqlThreads{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricMysqlThreadsSlowLaunch struct {
-	data     pmetric.Metric                     // data buffer for generated metric.
-	config   MysqlThreadsSlowLaunchMetricConfig // metric config provided by user.
-	capacity int                                // max observed number of data points added to the metric.
-}
-
-// init fills mysql.threads.slow_launch metric with initial data.
-func (m *metricMysqlThreadsSlowLaunch) init() {
-	m.data.SetName("mysql.threads.slow_launch")
-	m.data.SetDescription("The number of threads that have taken more than slow_launch_time seconds to create.")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricMysqlThreadsSlowLaunch) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMysqlThreadsSlowLaunch) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMysqlThreadsSlowLaunch) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMysqlThreadsSlowLaunch(cfg MysqlThreadsSlowLaunchMetricConfig) metricMysqlThreadsSlowLaunch {
-	m := metricMysqlThreadsSlowLaunch{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5550,8 +5550,8 @@ type MetricsBuilder struct {
 	metricMysqlTableRows               metricMysqlTableRows
 	metricMysqlTableSize               metricMysqlTableSize
 	metricMysqlTableOpenCache          metricMysqlTableOpenCache
+	metricMysqlThreadSlowLaunch        metricMysqlThreadSlowLaunch
 	metricMysqlThreads                 metricMysqlThreads
-	metricMysqlThreadsSlowLaunch       metricMysqlThreadsSlowLaunch
 	metricMysqlTmpResources            metricMysqlTmpResources
 	metricMysqlUptime                  metricMysqlUptime
 }
@@ -5625,8 +5625,8 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlTableRows:               newMetricMysqlTableRows(mbc.Metrics.MysqlTableRows),
 		metricMysqlTableSize:               newMetricMysqlTableSize(mbc.Metrics.MysqlTableSize),
 		metricMysqlTableOpenCache:          newMetricMysqlTableOpenCache(mbc.Metrics.MysqlTableOpenCache),
+		metricMysqlThreadSlowLaunch:        newMetricMysqlThreadSlowLaunch(mbc.Metrics.MysqlThreadSlowLaunch),
 		metricMysqlThreads:                 newMetricMysqlThreads(mbc.Metrics.MysqlThreads),
-		metricMysqlThreadsSlowLaunch:       newMetricMysqlThreadsSlowLaunch(mbc.Metrics.MysqlThreadsSlowLaunch),
 		metricMysqlTmpResources:            newMetricMysqlTmpResources(mbc.Metrics.MysqlTmpResources),
 		metricMysqlUptime:                  newMetricMysqlUptime(mbc.Metrics.MysqlUptime),
 		resourceAttributeIncludeFilter:     make(map[string]filter.Filter),
@@ -5783,8 +5783,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlTableRows.emit(ils.Metrics())
 	mb.metricMysqlTableSize.emit(ils.Metrics())
 	mb.metricMysqlTableOpenCache.emit(ils.Metrics())
+	mb.metricMysqlThreadSlowLaunch.emit(ils.Metrics())
 	mb.metricMysqlThreads.emit(ils.Metrics())
-	mb.metricMysqlThreadsSlowLaunch.emit(ils.Metrics())
 	mb.metricMysqlTmpResources.emit(ils.Metrics())
 	mb.metricMysqlUptime.emit(ils.Metrics())
 
@@ -6193,6 +6193,16 @@ func (mb *MetricsBuilder) RecordMysqlTableOpenCacheDataPoint(ts pcommon.Timestam
 	return nil
 }
 
+// RecordMysqlThreadSlowLaunchDataPoint adds a data point to mysql.thread.slow_launch metric.
+func (mb *MetricsBuilder) RecordMysqlThreadSlowLaunchDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlThreadSlowLaunch, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlThreadSlowLaunch.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
 // RecordMysqlThreadsDataPoint adds a data point to mysql.threads metric.
 func (mb *MetricsBuilder) RecordMysqlThreadsDataPoint(ts pcommon.Timestamp, inputVal string, threadsAttributeValue AttributeThreads) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -6200,16 +6210,6 @@ func (mb *MetricsBuilder) RecordMysqlThreadsDataPoint(ts pcommon.Timestamp, inpu
 		return fmt.Errorf("failed to parse int64 for MysqlThreads, value was %s: %w", inputVal, err)
 	}
 	mb.metricMysqlThreads.recordDataPoint(mb.startTime, ts, val, threadsAttributeValue.String())
-	return nil
-}
-
-// RecordMysqlThreadsSlowLaunchDataPoint adds a data point to mysql.threads.slow_launch metric.
-func (mb *MetricsBuilder) RecordMysqlThreadsSlowLaunchDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for MysqlThreadsSlowLaunch, value was %s: %w", inputVal, err)
-	}
-	mb.metricMysqlThreadsSlowLaunch.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -3701,8 +3701,10 @@ func (m *metricMysqlResourcesOpen) init() {
 	m.data.SetName("mysql.resources.open")
 	m.data.SetDescription("The number of currently open resources.")
 	m.data.SetUnit("1")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
@@ -3719,7 +3721,7 @@ func (m *metricMysqlResourcesOpen) recordDataPoint(start pcommon.Timestamp, ts p
 	}
 
 	var s string
-	dps := m.data.Gauge().DataPoints()
+	dps := m.data.Sum().DataPoints()
 	for i := 0; i < dps.Len(); i++ {
 		dpi := dps.At(i)
 		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
@@ -3749,17 +3751,17 @@ func (m *metricMysqlResourcesOpen) recordDataPoint(start pcommon.Timestamp, ts p
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricMysqlResourcesOpen) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlResourcesOpen) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
-				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
 			}
 		}
 		m.updateCapacity()

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -1205,9 +1205,6 @@ var MetricsInfo = metricsInfo{
 		Name:       "mysql.row_operations",
 		Attributes: []string{"row_operations"},
 	},
-	MysqlSlowLaunchThreads: metricInfo{
-		Name: "mysql.slow_launch_threads",
-	},
 	MysqlSorts: metricInfo{
 		Name:       "mysql.sorts",
 		Attributes: []string{"sorts"},
@@ -1264,6 +1261,9 @@ var MetricsInfo = metricsInfo{
 		Name:       "mysql.threads",
 		Attributes: []string{"threads"},
 	},
+	MysqlThreadsSlowLaunch: metricInfo{
+		Name: "mysql.threads.slow_launch",
+	},
 	MysqlTmpResources: metricInfo{
 		Name:       "mysql.tmp_resources",
 		Attributes: []string{"tmp_resource"},
@@ -1307,7 +1307,6 @@ type metricsInfo struct {
 	MysqlResourcesOpen           metricInfo
 	MysqlRowLocks                metricInfo
 	MysqlRowOperations           metricInfo
-	MysqlSlowLaunchThreads       metricInfo
 	MysqlSorts                   metricInfo
 	MysqlStatementEventCount     metricInfo
 	MysqlStatementEventWaitTime  metricInfo
@@ -1322,6 +1321,7 @@ type metricsInfo struct {
 	MysqlTableSize               metricInfo
 	MysqlTableOpenCache          metricInfo
 	MysqlThreads                 metricInfo
+	MysqlThreadsSlowLaunch       metricInfo
 	MysqlTmpResources            metricInfo
 	MysqlUptime                  metricInfo
 }
@@ -3960,58 +3960,6 @@ func newMetricMysqlRowOperations(cfg MysqlRowOperationsMetricConfig) metricMysql
 	return m
 }
 
-type metricMysqlSlowLaunchThreads struct {
-	data     pmetric.Metric                     // data buffer for generated metric.
-	config   MysqlSlowLaunchThreadsMetricConfig // metric config provided by user.
-	capacity int                                // max observed number of data points added to the metric.
-}
-
-// init fills mysql.slow_launch_threads metric with initial data.
-func (m *metricMysqlSlowLaunchThreads) init() {
-	m.data.SetName("mysql.slow_launch_threads")
-	m.data.SetDescription("The number of threads that have taken more than slow_launch_time seconds to create.")
-	m.data.SetUnit("1")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-}
-
-func (m *metricMysqlSlowLaunchThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.config.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMysqlSlowLaunchThreads) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMysqlSlowLaunchThreads) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMysqlSlowLaunchThreads(cfg MysqlSlowLaunchThreadsMetricConfig) metricMysqlSlowLaunchThreads {
-	m := metricMysqlSlowLaunchThreads{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricMysqlSorts struct {
 	data          pmetric.Metric         // data buffer for generated metric.
 	config        MysqlSortsMetricConfig // metric config provided by user.
@@ -5349,6 +5297,58 @@ func newMetricMysqlThreads(cfg MysqlThreadsMetricConfig) metricMysqlThreads {
 	return m
 }
 
+type metricMysqlThreadsSlowLaunch struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   MysqlThreadsSlowLaunchMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills mysql.threads.slow_launch metric with initial data.
+func (m *metricMysqlThreadsSlowLaunch) init() {
+	m.data.SetName("mysql.threads.slow_launch")
+	m.data.SetDescription("The number of threads that have taken more than slow_launch_time seconds to create.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMysqlThreadsSlowLaunch) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlThreadsSlowLaunch) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlThreadsSlowLaunch) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlThreadsSlowLaunch(cfg MysqlThreadsSlowLaunchMetricConfig) metricMysqlThreadsSlowLaunch {
+	m := metricMysqlThreadsSlowLaunch{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMysqlTmpResources struct {
 	data          pmetric.Metric                // data buffer for generated metric.
 	config        MysqlTmpResourcesMetricConfig // metric config provided by user.
@@ -5535,7 +5535,6 @@ type MetricsBuilder struct {
 	metricMysqlResourcesOpen           metricMysqlResourcesOpen
 	metricMysqlRowLocks                metricMysqlRowLocks
 	metricMysqlRowOperations           metricMysqlRowOperations
-	metricMysqlSlowLaunchThreads       metricMysqlSlowLaunchThreads
 	metricMysqlSorts                   metricMysqlSorts
 	metricMysqlStatementEventCount     metricMysqlStatementEventCount
 	metricMysqlStatementEventWaitTime  metricMysqlStatementEventWaitTime
@@ -5550,6 +5549,7 @@ type MetricsBuilder struct {
 	metricMysqlTableSize               metricMysqlTableSize
 	metricMysqlTableOpenCache          metricMysqlTableOpenCache
 	metricMysqlThreads                 metricMysqlThreads
+	metricMysqlThreadsSlowLaunch       metricMysqlThreadsSlowLaunch
 	metricMysqlTmpResources            metricMysqlTmpResources
 	metricMysqlUptime                  metricMysqlUptime
 }
@@ -5610,7 +5610,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlResourcesOpen:           newMetricMysqlResourcesOpen(mbc.Metrics.MysqlResourcesOpen),
 		metricMysqlRowLocks:                newMetricMysqlRowLocks(mbc.Metrics.MysqlRowLocks),
 		metricMysqlRowOperations:           newMetricMysqlRowOperations(mbc.Metrics.MysqlRowOperations),
-		metricMysqlSlowLaunchThreads:       newMetricMysqlSlowLaunchThreads(mbc.Metrics.MysqlSlowLaunchThreads),
 		metricMysqlSorts:                   newMetricMysqlSorts(mbc.Metrics.MysqlSorts),
 		metricMysqlStatementEventCount:     newMetricMysqlStatementEventCount(mbc.Metrics.MysqlStatementEventCount),
 		metricMysqlStatementEventWaitTime:  newMetricMysqlStatementEventWaitTime(mbc.Metrics.MysqlStatementEventWaitTime),
@@ -5625,6 +5624,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlTableSize:               newMetricMysqlTableSize(mbc.Metrics.MysqlTableSize),
 		metricMysqlTableOpenCache:          newMetricMysqlTableOpenCache(mbc.Metrics.MysqlTableOpenCache),
 		metricMysqlThreads:                 newMetricMysqlThreads(mbc.Metrics.MysqlThreads),
+		metricMysqlThreadsSlowLaunch:       newMetricMysqlThreadsSlowLaunch(mbc.Metrics.MysqlThreadsSlowLaunch),
 		metricMysqlTmpResources:            newMetricMysqlTmpResources(mbc.Metrics.MysqlTmpResources),
 		metricMysqlUptime:                  newMetricMysqlUptime(mbc.Metrics.MysqlUptime),
 		resourceAttributeIncludeFilter:     make(map[string]filter.Filter),
@@ -5768,7 +5768,6 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlResourcesOpen.emit(ils.Metrics())
 	mb.metricMysqlRowLocks.emit(ils.Metrics())
 	mb.metricMysqlRowOperations.emit(ils.Metrics())
-	mb.metricMysqlSlowLaunchThreads.emit(ils.Metrics())
 	mb.metricMysqlSorts.emit(ils.Metrics())
 	mb.metricMysqlStatementEventCount.emit(ils.Metrics())
 	mb.metricMysqlStatementEventWaitTime.emit(ils.Metrics())
@@ -5783,6 +5782,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlTableSize.emit(ils.Metrics())
 	mb.metricMysqlTableOpenCache.emit(ils.Metrics())
 	mb.metricMysqlThreads.emit(ils.Metrics())
+	mb.metricMysqlThreadsSlowLaunch.emit(ils.Metrics())
 	mb.metricMysqlTmpResources.emit(ils.Metrics())
 	mb.metricMysqlUptime.emit(ils.Metrics())
 
@@ -6116,16 +6116,6 @@ func (mb *MetricsBuilder) RecordMysqlRowOperationsDataPoint(ts pcommon.Timestamp
 	return nil
 }
 
-// RecordMysqlSlowLaunchThreadsDataPoint adds a data point to mysql.slow_launch_threads metric.
-func (mb *MetricsBuilder) RecordMysqlSlowLaunchThreadsDataPoint(ts pcommon.Timestamp, inputVal string) error {
-	val, err := strconv.ParseInt(inputVal, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse int64 for MysqlSlowLaunchThreads, value was %s: %w", inputVal, err)
-	}
-	mb.metricMysqlSlowLaunchThreads.recordDataPoint(mb.startTime, ts, val)
-	return nil
-}
-
 // RecordMysqlSortsDataPoint adds a data point to mysql.sorts metric.
 func (mb *MetricsBuilder) RecordMysqlSortsDataPoint(ts pcommon.Timestamp, inputVal string, sortsAttributeValue AttributeSorts) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -6208,6 +6198,16 @@ func (mb *MetricsBuilder) RecordMysqlThreadsDataPoint(ts pcommon.Timestamp, inpu
 		return fmt.Errorf("failed to parse int64 for MysqlThreads, value was %s: %w", inputVal, err)
 	}
 	mb.metricMysqlThreads.recordDataPoint(mb.startTime, ts, val, threadsAttributeValue.String())
+	return nil
+}
+
+// RecordMysqlThreadsSlowLaunchDataPoint adds a data point to mysql.threads.slow_launch metric.
+func (mb *MetricsBuilder) RecordMysqlThreadsSlowLaunchDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlThreadsSlowLaunch, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlThreadsSlowLaunch.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -1509,7 +1509,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["mysql.resources.open"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "The number of open resources.", mi.Description())
+						assert.Equal(t, "The number of currently open resources.", mi.Description())
 						assert.Equal(t, "1", mi.Unit())
 						dp := mi.Gauge().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
@@ -1524,7 +1524,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["mysql.resources.open"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "The number of open resources.", mi.Description())
+						assert.Equal(t, "The number of currently open resources.", mi.Description())
 						assert.Equal(t, "1", mi.Unit())
 						dp := mi.Gauge().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -87,6 +87,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["mysql.operations"] = mb.metricMysqlOperations.config.AggregationStrategy
 			aggMap["mysql.page_operations"] = mb.metricMysqlPageOperations.config.AggregationStrategy
 			aggMap["mysql.prepared_statements"] = mb.metricMysqlPreparedStatements.config.AggregationStrategy
+			aggMap["mysql.resources.open"] = mb.metricMysqlResourcesOpen.config.AggregationStrategy
 			aggMap["mysql.row_locks"] = mb.metricMysqlRowLocks.config.AggregationStrategy
 			aggMap["mysql.row_operations"] = mb.metricMysqlRowOperations.config.AggregationStrategy
 			aggMap["mysql.sorts"] = mb.metricMysqlSorts.config.AggregationStrategy
@@ -262,6 +263,12 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordMysqlReplicaTimeBehindSourceDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordMysqlResourcesOpenDataPoint(ts, "1", AttributeOpenResourcesFile)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMysqlResourcesOpenDataPoint(ts, "3", AttributeOpenResourcesTable)
+			}
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlRowLocksDataPoint(ts, "1", AttributeRowLocksWaits)
@@ -274,6 +281,9 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlRowOperationsDataPoint(ts, "3", AttributeRowOperationsInserted)
 			}
+
+			allMetricsCount++
+			mb.RecordMysqlSlowLaunchThreadsDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlSortsDataPoint(ts, "1", AttributeSortsMergePasses)
@@ -398,6 +408,7 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricMysqlOperations.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlPageOperations.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlPreparedStatements.aggDataPoints)
+				assert.Empty(t, mb.metricMysqlResourcesOpen.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlRowLocks.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlRowOperations.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlSorts.aggDataPoints)
@@ -1492,6 +1503,46 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "mysql.resources.open":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mysql.resources.open"], "Found a duplicate in the metrics slice: mysql.resources.open")
+						validatedMetrics["mysql.resources.open"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of open resources.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						openResourcesAttrVal, ok := dp.Attributes().Get("kind")
+						assert.True(t, ok)
+						assert.Equal(t, "file", openResourcesAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mysql.resources.open"], "Found a duplicate in the metrics slice: mysql.resources.open")
+						validatedMetrics["mysql.resources.open"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of open resources.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["mysql.resources.open"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("kind")
+						assert.False(t, ok)
+					}
 				case "mysql.row_locks":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.row_locks"], "Found a duplicate in the metrics slice: mysql.row_locks")
@@ -1580,6 +1631,20 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("operation")
 						assert.False(t, ok)
 					}
+				case "mysql.slow_launch_threads":
+					assert.False(t, validatedMetrics["mysql.slow_launch_threads"], "Found a duplicate in the metrics slice: mysql.slow_launch_threads")
+					validatedMetrics["mysql.slow_launch_threads"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The number of threads that have taken more than slow_launch_time seconds to create.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.sorts":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.sorts"], "Found a duplicate in the metrics slice: mysql.sorts")

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -359,15 +359,15 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlTableOpenCacheDataPoint(ts, "3", AttributeCacheStatusMiss)
 			}
+
+			allMetricsCount++
+			mb.RecordMysqlThreadSlowLaunchDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlThreadsDataPoint(ts, "1", AttributeThreadsCached)
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlThreadsDataPoint(ts, "3", AttributeThreadsConnected)
 			}
-
-			allMetricsCount++
-			mb.RecordMysqlThreadsSlowLaunchDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlTmpResourcesDataPoint(ts, "1", AttributeTmpResourceDiskTables)
@@ -2312,6 +2312,20 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("status")
 						assert.False(t, ok)
 					}
+				case "mysql.thread.slow_launch":
+					assert.False(t, validatedMetrics["mysql.thread.slow_launch"], "Found a duplicate in the metrics slice: mysql.thread.slow_launch")
+					validatedMetrics["mysql.thread.slow_launch"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The number of threads that have taken more than slow_launch_time seconds to create.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.threads":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.threads"], "Found a duplicate in the metrics slice: mysql.threads")
@@ -2356,20 +2370,6 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("kind")
 						assert.False(t, ok)
 					}
-				case "mysql.threads.slow_launch":
-					assert.False(t, validatedMetrics["mysql.threads.slow_launch"], "Found a duplicate in the metrics slice: mysql.threads.slow_launch")
-					validatedMetrics["mysql.threads.slow_launch"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of threads that have taken more than slow_launch_time seconds to create.", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.tmp_resources":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.tmp_resources"], "Found a duplicate in the metrics slice: mysql.tmp_resources")

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -281,9 +281,6 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlRowOperationsDataPoint(ts, "3", AttributeRowOperationsInserted)
 			}
-
-			allMetricsCount++
-			mb.RecordMysqlSlowLaunchThreadsDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlSortsDataPoint(ts, "1", AttributeSortsMergePasses)
@@ -368,6 +365,9 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlThreadsDataPoint(ts, "3", AttributeThreadsConnected)
 			}
+
+			allMetricsCount++
+			mb.RecordMysqlThreadsSlowLaunchDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlTmpResourcesDataPoint(ts, "1", AttributeTmpResourceDiskTables)
@@ -1631,20 +1631,6 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("operation")
 						assert.False(t, ok)
 					}
-				case "mysql.slow_launch_threads":
-					assert.False(t, validatedMetrics["mysql.slow_launch_threads"], "Found a duplicate in the metrics slice: mysql.slow_launch_threads")
-					validatedMetrics["mysql.slow_launch_threads"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-					assert.Equal(t, "The number of threads that have taken more than slow_launch_time seconds to create.", mi.Description())
-					assert.Equal(t, "1", mi.Unit())
-					assert.True(t, mi.Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-					dp := mi.Sum().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.sorts":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.sorts"], "Found a duplicate in the metrics slice: mysql.sorts")
@@ -2366,6 +2352,20 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("kind")
 						assert.False(t, ok)
 					}
+				case "mysql.threads.slow_launch":
+					assert.False(t, validatedMetrics["mysql.threads.slow_launch"], "Found a duplicate in the metrics slice: mysql.threads.slow_launch")
+					validatedMetrics["mysql.threads.slow_launch"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The number of threads that have taken more than slow_launch_time seconds to create.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.tmp_resources":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.tmp_resources"], "Found a duplicate in the metrics slice: mysql.tmp_resources")

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -1507,11 +1507,13 @@ func TestMetricsBuilder(t *testing.T) {
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.resources.open"], "Found a duplicate in the metrics slice: mysql.resources.open")
 						validatedMetrics["mysql.resources.open"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "The number of currently open resources.", mi.Description())
 						assert.Equal(t, "1", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
@@ -1522,11 +1524,13 @@ func TestMetricsBuilder(t *testing.T) {
 					} else {
 						assert.False(t, validatedMetrics["mysql.resources.open"], "Found a duplicate in the metrics slice: mysql.resources.open")
 						validatedMetrics["mysql.resources.open"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "The number of currently open resources.", mi.Description())
 						assert.Equal(t, "1", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -87,7 +87,6 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["mysql.operations"] = mb.metricMysqlOperations.config.AggregationStrategy
 			aggMap["mysql.page_operations"] = mb.metricMysqlPageOperations.config.AggregationStrategy
 			aggMap["mysql.prepared_statements"] = mb.metricMysqlPreparedStatements.config.AggregationStrategy
-			aggMap["mysql.resources.open"] = mb.metricMysqlResourcesOpen.config.AggregationStrategy
 			aggMap["mysql.row_locks"] = mb.metricMysqlRowLocks.config.AggregationStrategy
 			aggMap["mysql.row_operations"] = mb.metricMysqlRowOperations.config.AggregationStrategy
 			aggMap["mysql.sorts"] = mb.metricMysqlSorts.config.AggregationStrategy
@@ -170,6 +169,9 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlDoubleWritesDataPoint(ts, "3", AttributeDoubleWritesWrites)
 			}
+
+			allMetricsCount++
+			mb.RecordMysqlFileOpenDataPoint(ts, "1")
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlHandlersDataPoint(ts, "1", AttributeHandlerCommit)
@@ -263,12 +265,6 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordMysqlReplicaTimeBehindSourceDataPoint(ts, 1)
-
-			allMetricsCount++
-			mb.RecordMysqlResourcesOpenDataPoint(ts, "1", AttributeOpenResourcesFile)
-			if tt.name == "reaggregate_set" {
-				mb.RecordMysqlResourcesOpenDataPoint(ts, "3", AttributeOpenResourcesTable)
-			}
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlRowLocksDataPoint(ts, "1", AttributeRowLocksWaits)
@@ -343,6 +339,9 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordMysqlTableOpenDataPoint(ts, "1")
+
+			allMetricsCount++
 			mb.RecordMysqlTableRowsDataPoint(ts, 1, "table_name-val", "schema-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlTableRowsDataPoint(ts, 3, "table_name-val-2", "schema-val-2")
@@ -408,7 +407,6 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricMysqlOperations.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlPageOperations.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlPreparedStatements.aggDataPoints)
-				assert.Empty(t, mb.metricMysqlResourcesOpen.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlRowLocks.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlRowOperations.aggDataPoints)
 				assert.Empty(t, mb.metricMysqlSorts.aggDataPoints)
@@ -847,6 +845,18 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("kind")
 						assert.False(t, ok)
 					}
+				case "mysql.file.open":
+					assert.False(t, validatedMetrics["mysql.file.open"], "Found a duplicate in the metrics slice: mysql.file.open")
+					validatedMetrics["mysql.file.open"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "The number of currently open files.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.handlers":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.handlers"], "Found a duplicate in the metrics slice: mysql.handlers")
@@ -1503,50 +1513,6 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-				case "mysql.resources.open":
-					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["mysql.resources.open"], "Found a duplicate in the metrics slice: mysql.resources.open")
-						validatedMetrics["mysql.resources.open"] = true
-						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "The number of currently open resources.", mi.Description())
-						assert.Equal(t, "1", mi.Unit())
-						assert.False(t, mi.Sum().IsMonotonic())
-						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-						dp := mi.Sum().DataPoints().At(0)
-						assert.Equal(t, start, dp.StartTimestamp())
-						assert.Equal(t, ts, dp.Timestamp())
-						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						assert.Equal(t, int64(1), dp.IntValue())
-						openResourcesAttrVal, ok := dp.Attributes().Get("kind")
-						assert.True(t, ok)
-						assert.Equal(t, "file", openResourcesAttrVal.Str())
-					} else {
-						assert.False(t, validatedMetrics["mysql.resources.open"], "Found a duplicate in the metrics slice: mysql.resources.open")
-						validatedMetrics["mysql.resources.open"] = true
-						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
-						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "The number of currently open resources.", mi.Description())
-						assert.Equal(t, "1", mi.Unit())
-						assert.False(t, mi.Sum().IsMonotonic())
-						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
-						dp := mi.Sum().DataPoints().At(0)
-						assert.Equal(t, start, dp.StartTimestamp())
-						assert.Equal(t, ts, dp.Timestamp())
-						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["mysql.resources.open"] {
-						case "sum":
-							assert.Equal(t, int64(4), dp.IntValue())
-						case "avg":
-							assert.Equal(t, int64(2), dp.IntValue())
-						case "min":
-							assert.Equal(t, int64(1), dp.IntValue())
-						case "max":
-							assert.Equal(t, int64(3), dp.IntValue())
-						}
-						_, ok := dp.Attributes().Get("kind")
-						assert.False(t, ok)
-					}
 				case "mysql.row_locks":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.row_locks"], "Found a duplicate in the metrics slice: mysql.row_locks")
@@ -2165,6 +2131,18 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("kind")
 						assert.False(t, ok)
 					}
+				case "mysql.table.open":
+					assert.False(t, validatedMetrics["mysql.table.open"], "Found a duplicate in the metrics slice: mysql.table.open")
+					validatedMetrics["mysql.table.open"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "The number of currently open tables.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.table.rows":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.table.rows"], "Found a duplicate in the metrics slice: mysql.table.rows")

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -81,12 +81,17 @@ all_set:
       enabled: true
     mysql.replica.time_behind_source:
       enabled: true
+    mysql.resources.open:
+      enabled: true
+      attributes: ["kind"]
     mysql.row_locks:
       enabled: true
       attributes: ["kind"]
     mysql.row_operations:
       enabled: true
       attributes: ["operation"]
+    mysql.slow_launch_threads:
+      enabled: true
     mysql.sorts:
       enabled: true
       attributes: ["kind"]
@@ -234,12 +239,17 @@ reaggregate_set:
       enabled: true
     mysql.replica.time_behind_source:
       enabled: true
+    mysql.resources.open:
+      enabled: true
+      attributes: []
     mysql.row_locks:
       enabled: true
       attributes: []
     mysql.row_operations:
       enabled: true
       attributes: []
+    mysql.slow_launch_threads:
+      enabled: true
     mysql.sorts:
       enabled: true
       attributes: []
@@ -387,12 +397,17 @@ none_set:
       enabled: false
     mysql.replica.time_behind_source:
       enabled: false
+    mysql.resources.open:
+      enabled: false
+      attributes: ["kind"]
     mysql.row_locks:
       enabled: false
       attributes: ["kind"]
     mysql.row_operations:
       enabled: false
       attributes: ["operation"]
+    mysql.slow_launch_threads:
+      enabled: false
     mysql.sorts:
       enabled: false
       attributes: ["kind"]

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -129,11 +129,11 @@ all_set:
     mysql.table_open_cache:
       enabled: true
       attributes: ["status"]
+    mysql.thread.slow_launch:
+      enabled: true
     mysql.threads:
       enabled: true
       attributes: ["kind"]
-    mysql.threads.slow_launch:
-      enabled: true
     mysql.tmp_resources:
       enabled: true
       attributes: ["resource"]
@@ -287,11 +287,11 @@ reaggregate_set:
     mysql.table_open_cache:
       enabled: true
       attributes: []
+    mysql.thread.slow_launch:
+      enabled: true
     mysql.threads:
       enabled: true
       attributes: []
-    mysql.threads.slow_launch:
-      enabled: true
     mysql.tmp_resources:
       enabled: true
       attributes: []
@@ -445,11 +445,11 @@ none_set:
     mysql.table_open_cache:
       enabled: false
       attributes: ["status"]
+    mysql.thread.slow_launch:
+      enabled: false
     mysql.threads:
       enabled: false
       attributes: ["kind"]
-    mysql.threads.slow_launch:
-      enabled: false
     mysql.tmp_resources:
       enabled: false
       attributes: ["resource"]

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -90,8 +90,6 @@ all_set:
     mysql.row_operations:
       enabled: true
       attributes: ["operation"]
-    mysql.slow_launch_threads:
-      enabled: true
     mysql.sorts:
       enabled: true
       attributes: ["kind"]
@@ -134,6 +132,8 @@ all_set:
     mysql.threads:
       enabled: true
       attributes: ["kind"]
+    mysql.threads.slow_launch:
+      enabled: true
     mysql.tmp_resources:
       enabled: true
       attributes: ["resource"]
@@ -248,8 +248,6 @@ reaggregate_set:
     mysql.row_operations:
       enabled: true
       attributes: []
-    mysql.slow_launch_threads:
-      enabled: true
     mysql.sorts:
       enabled: true
       attributes: []
@@ -292,6 +290,8 @@ reaggregate_set:
     mysql.threads:
       enabled: true
       attributes: []
+    mysql.threads.slow_launch:
+      enabled: true
     mysql.tmp_resources:
       enabled: true
       attributes: []
@@ -406,8 +406,6 @@ none_set:
     mysql.row_operations:
       enabled: false
       attributes: ["operation"]
-    mysql.slow_launch_threads:
-      enabled: false
     mysql.sorts:
       enabled: false
       attributes: ["kind"]
@@ -450,6 +448,8 @@ none_set:
     mysql.threads:
       enabled: false
       attributes: ["kind"]
+    mysql.threads.slow_launch:
+      enabled: false
     mysql.tmp_resources:
       enabled: false
       attributes: ["resource"]

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -31,6 +31,8 @@ all_set:
     mysql.double_writes:
       enabled: true
       attributes: ["kind"]
+    mysql.file.open:
+      enabled: true
     mysql.handlers:
       enabled: true
       attributes: ["kind"]
@@ -81,9 +83,6 @@ all_set:
       enabled: true
     mysql.replica.time_behind_source:
       enabled: true
-    mysql.resources.open:
-      enabled: true
-      attributes: ["kind"]
     mysql.row_locks:
       enabled: true
       attributes: ["kind"]
@@ -120,6 +119,8 @@ all_set:
     mysql.table.lock_wait.write.time:
       enabled: true
       attributes: ["schema","table","kind"]
+    mysql.table.open:
+      enabled: true
     mysql.table.rows:
       enabled: true
       attributes: ["table","schema"]
@@ -189,6 +190,8 @@ reaggregate_set:
     mysql.double_writes:
       enabled: true
       attributes: []
+    mysql.file.open:
+      enabled: true
     mysql.handlers:
       enabled: true
       attributes: []
@@ -239,9 +242,6 @@ reaggregate_set:
       enabled: true
     mysql.replica.time_behind_source:
       enabled: true
-    mysql.resources.open:
-      enabled: true
-      attributes: []
     mysql.row_locks:
       enabled: true
       attributes: []
@@ -278,6 +278,8 @@ reaggregate_set:
     mysql.table.lock_wait.write.time:
       enabled: true
       attributes: []
+    mysql.table.open:
+      enabled: true
     mysql.table.rows:
       enabled: true
       attributes: []
@@ -347,6 +349,8 @@ none_set:
     mysql.double_writes:
       enabled: false
       attributes: ["kind"]
+    mysql.file.open:
+      enabled: false
     mysql.handlers:
       enabled: false
       attributes: ["kind"]
@@ -397,9 +401,6 @@ none_set:
       enabled: false
     mysql.replica.time_behind_source:
       enabled: false
-    mysql.resources.open:
-      enabled: false
-      attributes: ["kind"]
     mysql.row_locks:
       enabled: false
       attributes: ["kind"]
@@ -436,6 +437,8 @@ none_set:
     mysql.table.lock_wait.write.time:
       enabled: false
       attributes: ["schema","table","kind"]
+    mysql.table.open:
+      enabled: false
     mysql.table.rows:
       enabled: false
       attributes: ["table","schema"]

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -217,12 +217,6 @@ attributes:
   network.peer.port:
     description: TCP port used by the peer client.
     type: int
-  open_resources:
-    name_override: kind
-    description: The kind of the resource.
-    type: string
-    enum: [file, table]
-    requirement_level: recommended
   opened_resources:
     name_override: kind
     description: The kind of the resource.
@@ -466,6 +460,15 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [double_writes]
+  mysql.file.open:
+    enabled: false
+    description: The number of currently open files.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
   mysql.handlers:
     enabled: true
     description: The number of requests to various MySQL handlers.
@@ -669,17 +672,6 @@ metrics:
       monotonic: false
       aggregation_temporality: cumulative
     attributes: []
-  mysql.resources.open:
-    enabled: false
-    description: The number of currently open resources.
-    stability: development
-    unit: "1"
-    sum:
-      value_type: int
-      input_type: string
-      monotonic: false
-      aggregation_temporality: cumulative
-    attributes: [open_resources]
   mysql.row_locks:
     enabled: true
     description: The number of InnoDB row locks.
@@ -803,6 +795,15 @@ metrics:
       monotonic: false
       aggregation_temporality: cumulative
     attributes: [schema, table_name, write_lock_type]
+  mysql.table.open:
+    enabled: false
+    description: The number of currently open tables.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
   mysql.table.rows:
     enabled: false
     description: The number of rows for a given table.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -671,7 +671,7 @@ metrics:
     attributes: []
   mysql.resources.open:
     enabled: false
-    description: The number of open resources.
+    description: The number of currently open resources.
     stability: development
     unit: "1"
     gauge:

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -700,17 +700,6 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [row_operations]
-  mysql.slow_launch_threads:
-    enabled: false
-    description: The number of threads that have taken more than slow_launch_time seconds to create.
-    stability: development
-    unit: "1"
-    sum:
-      value_type: int
-      input_type: string
-      monotonic: true
-      aggregation_temporality: cumulative
-    attributes: []
   mysql.sorts:
     enabled: true
     description: The number of MySQL sorts.
@@ -854,6 +843,17 @@ metrics:
       monotonic: false
       aggregation_temporality: cumulative
     attributes: [threads]
+  mysql.threads.slow_launch:
+    enabled: false
+    description: The number of threads that have taken more than slow_launch_time seconds to create.
+    stability: development
+    unit: "1"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
   mysql.tmp_resources:
     enabled: true
     description: The number of created temporary resources.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -217,6 +217,12 @@ attributes:
   network.peer.port:
     description: TCP port used by the peer client.
     type: int
+  open_resources:
+    name_override: kind
+    description: The kind of the resource.
+    type: string
+    enum: [file, table]
+    requirement_level: recommended
   opened_resources:
     name_override: kind
     description: The kind of the resource.
@@ -663,6 +669,15 @@ metrics:
       monotonic: false
       aggregation_temporality: cumulative
     attributes: []
+  mysql.resources.open:
+    enabled: false
+    description: The number of open resources.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [open_resources]
   mysql.row_locks:
     enabled: true
     description: The number of InnoDB row locks.
@@ -685,6 +700,17 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [row_operations]
+  mysql.slow_launch_threads:
+    enabled: false
+    description: The number of threads that have taken more than slow_launch_time seconds to create.
+    stability: development
+    unit: "1"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
   mysql.sorts:
     enabled: true
     description: The number of MySQL sorts.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -834,6 +834,17 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [cache_status]
+  mysql.thread.slow_launch:
+    enabled: false
+    description: The number of threads that have taken more than slow_launch_time seconds to create.
+    stability: development
+    unit: "1"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
   mysql.threads:
     enabled: true
     description: The state of MySQL threads.
@@ -845,17 +856,6 @@ metrics:
       monotonic: false
       aggregation_temporality: cumulative
     attributes: [threads]
-  mysql.threads.slow_launch:
-    enabled: false
-    description: The number of threads that have taken more than slow_launch_time seconds to create.
-    stability: development
-    unit: "1"
-    sum:
-      value_type: int
-      input_type: string
-      monotonic: true
-      aggregation_temporality: cumulative
-    attributes: []
   mysql.tmp_resources:
     enabled: true
     description: The number of created temporary resources.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -674,9 +674,11 @@ metrics:
     description: The number of currently open resources.
     stability: development
     unit: "1"
-    gauge:
+    sum:
       value_type: int
       input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
     attributes: [open_resources]
   mysql.row_locks:
     enabled: true

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -543,9 +543,9 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 
 		// open resources
 		case "Open_files":
-			addPartialIfError(errs, m.mb.RecordMysqlResourcesOpenDataPoint(now, v, metadata.AttributeOpenResourcesFile))
+			addPartialIfError(errs, m.mb.RecordMysqlFileOpenDataPoint(now, v))
 		case "Open_tables":
-			addPartialIfError(errs, m.mb.RecordMysqlResourcesOpenDataPoint(now, v, metadata.AttributeOpenResourcesTable))
+			addPartialIfError(errs, m.mb.RecordMysqlTableOpenDataPoint(now, v))
 
 		// opened resources
 		case "Opened_files":

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -529,7 +529,7 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 
 		// slow launch threads
 		case "Slow_launch_threads":
-			addPartialIfError(errs, m.mb.RecordMysqlSlowLaunchThreadsDataPoint(now, v))
+			addPartialIfError(errs, m.mb.RecordMysqlThreadsSlowLaunchDataPoint(now, v))
 
 		// threads
 		case "Threads_cached":

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -529,7 +529,7 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 
 		// slow launch threads
 		case "Slow_launch_threads":
-			addPartialIfError(errs, m.mb.RecordMysqlThreadsSlowLaunchDataPoint(now, v))
+			addPartialIfError(errs, m.mb.RecordMysqlThreadSlowLaunchDataPoint(now, v))
 
 		// threads
 		case "Threads_cached":

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -527,6 +527,10 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 		case "Sort_scan":
 			addPartialIfError(errs, m.mb.RecordMysqlSortsDataPoint(now, v, metadata.AttributeSortsScan))
 
+		// slow launch threads
+		case "Slow_launch_threads":
+			addPartialIfError(errs, m.mb.RecordMysqlSlowLaunchThreadsDataPoint(now, v))
+
 		// threads
 		case "Threads_cached":
 			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsCached))
@@ -536,6 +540,12 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsCreated))
 		case "Threads_running":
 			addPartialIfError(errs, m.mb.RecordMysqlThreadsDataPoint(now, v, metadata.AttributeThreadsRunning))
+
+		// open resources
+		case "Open_files":
+			addPartialIfError(errs, m.mb.RecordMysqlResourcesOpenDataPoint(now, v, metadata.AttributeOpenResourcesFile))
+		case "Open_tables":
+			addPartialIfError(errs, m.mb.RecordMysqlResourcesOpenDataPoint(now, v, metadata.AttributeOpenResourcesTable))
 
 		// opened resources
 		case "Opened_files":

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -61,6 +61,8 @@ func TestScrape(t *testing.T) {
 		cfg.MetricsBuilderConfig.Metrics.MysqlClientNetworkIo.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlPreparedStatements.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlCommands.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlResourcesOpen.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlSlowLaunchThreads.Enabled = true
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaSQLDelay.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaTimeBehindSource.Enabled = true

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -62,7 +62,7 @@ func TestScrape(t *testing.T) {
 		cfg.MetricsBuilderConfig.Metrics.MysqlPreparedStatements.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlCommands.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlResourcesOpen.Enabled = true
-		cfg.MetricsBuilderConfig.Metrics.MysqlSlowLaunchThreads.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlThreadsSlowLaunch.Enabled = true
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaSQLDelay.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaTimeBehindSource.Enabled = true

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -61,7 +61,8 @@ func TestScrape(t *testing.T) {
 		cfg.MetricsBuilderConfig.Metrics.MysqlClientNetworkIo.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlPreparedStatements.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlCommands.Enabled = true
-		cfg.MetricsBuilderConfig.Metrics.MysqlResourcesOpen.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlFileOpen.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlTableOpen.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlThreadSlowLaunch.Enabled = true
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaSQLDelay.Enabled = true

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -62,7 +62,7 @@ func TestScrape(t *testing.T) {
 		cfg.MetricsBuilderConfig.Metrics.MysqlPreparedStatements.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlCommands.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlResourcesOpen.Enabled = true
-		cfg.MetricsBuilderConfig.Metrics.MysqlThreadsSlowLaunch.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlThreadSlowLaunch.Enabled = true
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaSQLDelay.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaTimeBehindSource.Enabled = true

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -941,7 +941,9 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: s
           - description: The number of currently open resources.
-            gauge:
+            name: mysql.resources.open
+            sum:
+              aggregationTemporality: 2
               dataPoints:
                 - asInt: "367"
                   attributes:
@@ -957,7 +959,6 @@ resourceMetrics:
                         stringValue: table
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: mysql.resources.open
             unit: "1"
           - description: The number of InnoDB row locks.
             name: mysql.row_locks

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -940,6 +940,25 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: s
+          - description: The number of open resources.
+            gauge:
+              dataPoints:
+                - asInt: "367"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: file
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "370"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: table
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mysql.resources.open
+            unit: "1"
           - description: The number of InnoDB row locks.
             name: mysql.row_locks
             sum:
@@ -992,6 +1011,16 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: updated
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of threads that have taken more than slow_launch_time seconds to create.
+            name: mysql.slow_launch_threads
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "414"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -940,7 +940,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: s
-          - description: The number of open resources.
+          - description: The number of currently open resources.
             gauge:
               dataPoints:
                 - asInt: "367"

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -1730,6 +1730,16 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: The number of threads that have taken more than slow_launch_time seconds to create.
+            name: mysql.thread.slow_launch
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "414"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
           - description: The state of MySQL threads.
             name: mysql.threads
             sum:
@@ -1763,16 +1773,6 @@ resourceMetrics:
                         stringValue: running
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of threads that have taken more than slow_launch_time seconds to create.
-            name: mysql.threads.slow_launch
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "414"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
             unit: "1"
           - description: The number of created temporary resources.
             name: mysql.tmp_resources

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -329,6 +329,14 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: The number of currently open files.
+            gauge:
+              dataPoints:
+                - asInt: "367"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mysql.file.open
+            unit: "1"
           - description: The number of requests to various MySQL handlers.
             name: mysql.handlers
             sum:
@@ -940,26 +948,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: s
-          - description: The number of currently open resources.
-            name: mysql.resources.open
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "367"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: file
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "370"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: table
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
           - description: The number of InnoDB row locks.
             name: mysql.row_locks
             sum:
@@ -1654,6 +1642,14 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
+          - description: The number of currently open tables.
+            gauge:
+              dataPoints:
+                - asInt: "370"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mysql.table.open
+            unit: "1"
           - description: The number of rows for a given table.
             name: mysql.table.rows
             sum:

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -6,7 +6,7 @@ resourceMetrics:
             stringValue: localhost:3306
         - key: service.instance.id
           value:
-            stringValue: placeholder
+            stringValue: 24770532-5e1e-5d8a-8f7c-d5d61b1baf28
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.
@@ -672,6 +672,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "256"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fsyncs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "253"
                   attributes:
                     - key: operation
@@ -691,13 +698,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: writes
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "256"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fsyncs
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -1015,16 +1015,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
-          - description: The number of threads that have taken more than slow_launch_time seconds to create.
-            name: mysql.slow_launch_threads
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "414"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of MySQL sorts.
             name: mysql.sorts
             sum:
@@ -1260,7 +1250,7 @@ resourceMetrics:
                         stringValue: a_table
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            unit: "By"
+            unit: By
           - description: The total count of I/O wait events for a table.
             name: mysql.table.io.wait.count
             sum:
@@ -1686,31 +1676,31 @@ resourceMetrics:
               dataPoints:
                 - asInt: "734976"
                   attributes:
+                    - key: kind
+                      value:
+                        stringValue: data
                     - key: schema
                       value:
                         stringValue: a_schema
                     - key: table
                       value:
                         stringValue: a_table
-                    - key: kind
-                      value:
-                        stringValue: data
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: kind
+                      value:
+                        stringValue: index
                     - key: schema
                       value:
                         stringValue: a_schema
                     - key: table
                       value:
                         stringValue: a_table
-                    - key: kind
-                      value:
-                        stringValue: index
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            unit: "By"
+            unit: By
           - description: The number of hits, misses or overflows for open tables cache lookups.
             name: mysql.table_open_cache
             sum:
@@ -1773,6 +1763,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
+          - description: The number of threads that have taken more than slow_launch_time seconds to create.
+            name: mysql.threads.slow_launch
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "414"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
           - description: The number of created temporary resources.
             name: mysql.tmp_resources
             sum:
@@ -1814,4 +1814,3 @@ resourceMetrics:
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
           version: latest
-        


### PR DESCRIPTION
#### Description
Adds two new metrics to the MySQL receiver, both disabled by default:
- `mysql.file.open` (gauge) — current number of open file resources.
- `mysql.table.open` (gauge) — current number of open table resources.
- `mysql.thread.slow_launch` (monotonic sum) — sourced from `Slow_launch_threads`.

#### Testing
- Extended `TestScrape` to enable both metrics and assert their datapoints via the golden file.
- Regenerated metric unit tests.

#### Documentation
Regenerated `documentation.md`; both metrics appear under "Optional Metrics" (disabled by default).

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
