### PR TITLE
[processor/cumulativetodelta] Recover exponential histograms after a counter reset

### DIFF
--- a/.chloggen/49869-cumulativetodelta-exphisto-reset.yaml
+++ b/.chloggen/49869-cumulativetodelta-exphisto-reset.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/cumulativetodelta
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Recover exponential histogram streams after a counter reset instead of silently dropping all subsequent points.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49869]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if the change is relevant to users of libraries or exported APIs.
+# Include 'developer' if the change is relevant only for developers of this repo.
+# Default: '[user]'
+change_logs: []

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -214,38 +214,42 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool, rea
 
 		// Count and ZeroThreshold should only increase when merging, and Scale should only decrease.
 		if value.Count < prevValue.Count || value.ZeroThreshold < prevValue.ZeroThreshold || value.Scale > prevValue.Scale {
-			return out, false, ReasonReset
+			// Reset detected. Like the sum and plain-histogram paths, fall through to
+			// adopt the restarted value as the new baseline (state.prevPoint below), so
+			// the next point produces a correct delta instead of re-triggering a reset.
+			valid = false
+			reason = ReasonReset
+		} else {
+			delta := value.Clone()
+			delta.Count -= prevValue.Count
+			delta.Sum -= prevValue.Sum
+
+			if value.ZeroThreshold > prevValue.ZeroThreshold {
+				// Coarsen previous histogram zero bucket to match the new histogram.
+				// Find the bucket the threshold falls into, i.e.
+				// the greatest i such that 2**(2**(-scale) * index) < threshold
+				scaleFactor := math.Ldexp(math.Log2E, int(prevValue.Scale))
+				thresholdBucket := int32(math.Ceil(math.Log(value.ZeroThreshold)*scaleFactor) - 1)
+				// If the bucket the threshold falls into is populated in the old histogram,
+				// then it must also be populated in the new histogram, which has ill-defined semantics,
+				// so we will assume this doesn't happen instead of adjusting the threshold as recommended in the spec.
+				prevValue.ZeroCount += prevValue.Positive.TrimZeros(thresholdBucket)
+				prevValue.ZeroCount += prevValue.Negative.TrimZeros(thresholdBucket)
+			}
+			delta.ZeroCount -= prevValue.ZeroCount
+
+			if value.Scale < prevValue.Scale {
+				// Coarsen previous histogram buckets to match the new histogram.
+				bitsLost := prevValue.Scale - value.Scale
+				prevValue.Scale = value.Scale
+				prevValue.Positive = prevValue.Positive.Coarsen(bitsLost)
+				prevValue.Negative = prevValue.Negative.Coarsen(bitsLost)
+			}
+			delta.Positive = value.Positive.Diff(&prevValue.Positive)
+			delta.Negative = value.Negative.Diff(&prevValue.Negative)
+
+			out.ExponentialHistogramPoint = &delta
 		}
-
-		delta := value.Clone()
-		delta.Count -= prevValue.Count
-		delta.Sum -= prevValue.Sum
-
-		if value.ZeroThreshold > prevValue.ZeroThreshold {
-			// Coarsen previous histogram zero bucket to match the new histogram.
-			// Find the bucket the threshold falls into, i.e.
-			// the greatest i such that 2**(2**(-scale) * index) < threshold
-			scaleFactor := math.Ldexp(math.Log2E, int(prevValue.Scale))
-			thresholdBucket := int32(math.Ceil(math.Log(value.ZeroThreshold)*scaleFactor) - 1)
-			// If the bucket the threshold falls into is populated in the old histogram,
-			// then it must also be populated in the new histogram, which has ill-defined semantics,
-			// so we will assume this doesn't happen instead of adjusting the threshold as recommended in the spec.
-			prevValue.ZeroCount += prevValue.Positive.TrimZeros(thresholdBucket)
-			prevValue.ZeroCount += prevValue.Negative.TrimZeros(thresholdBucket)
-		}
-		delta.ZeroCount -= prevValue.ZeroCount
-
-		if value.Scale < prevValue.Scale {
-			// Coarsen previous histogram buckets to match the new histogram.
-			bitsLost := prevValue.Scale - value.Scale
-			prevValue.Scale = value.Scale
-			prevValue.Positive = prevValue.Positive.Coarsen(bitsLost)
-			prevValue.Negative = prevValue.Negative.Coarsen(bitsLost)
-		}
-		delta.Positive = value.Positive.Diff(&prevValue.Positive)
-		delta.Negative = value.Negative.Diff(&prevValue.Negative)
-
-		out.ExponentialHistogramPoint = &delta
 
 	case pmetric.MetricTypeSum:
 		if metricID.IsFloatVal() {

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -268,6 +268,52 @@ func TestMetricTracker_Convert(t *testing.T) {
 	})
 }
 
+func TestMetricTracker_Convert_ExponentialHistogramReset(t *testing.T) {
+	miExpHist := MetricIdentity{
+		Resource:               pcommon.NewResource(),
+		InstrumentationLibrary: pcommon.NewInstrumentationScope(),
+		MetricType:             pmetric.MetricTypeExponentialHistogram,
+		MetricIsMonotonic:      true,
+		Attributes:             pcommon.NewMap(),
+	}
+
+	expHist := func(count uint64) ValuePoint {
+		return ValuePoint{
+			ObservedTimestamp: pcommon.NewTimestampFromTime(time.Now()),
+			ExponentialHistogramValue: &ExponentialHistogramPoint{
+				Count:    count,
+				Sum:      float64(count),
+				Positive: ExponentialBuckets{Offset: 0, BucketCounts: []uint64{count}},
+			},
+		}
+	}
+
+	m := NewMetricTracker(t.Context(), zap.NewNop(), 0, InitialValueKeep)
+	convert := func(count uint64) (DeltaValue, bool, string) {
+		return m.Convert(MetricPoint{Identity: miExpHist, Value: expHist(count)})
+	}
+
+	// Baseline, then a normal increasing point.
+	_, valid, _ := convert(100)
+	require.True(t, valid)
+	out, valid, reason := convert(150)
+	require.True(t, valid)
+	assert.Empty(t, reason)
+	assert.EqualValues(t, 50, out.ExponentialHistogramPoint.Count)
+
+	// Counter restart: cumulative count drops, so this point is a reset and is dropped.
+	_, valid, reason = convert(20)
+	assert.False(t, valid)
+	assert.Equal(t, ReasonReset, reason)
+
+	// The point after a reset must be converted against the restarted baseline (20),
+	// exactly like the sum and plain-histogram paths recover on the very next point.
+	out, valid, reason = convert(40)
+	require.True(t, valid, "point after reset should convert, not be dropped as another reset")
+	assert.Empty(t, reason)
+	assert.EqualValues(t, 20, out.ExponentialHistogramPoint.Count)
+}
+
 func Test_metricTracker_removeStale(t *testing.T) {
 	currentTime := pcommon.Timestamp(100)
 	freshPoint := ValuePoint{


### PR DESCRIPTION
#### Description

The exponential-histogram reset branch in `MetricTracker.Convert` early-returned without updating `state.prevPoint`, so after a counter restart the baseline stayed frozen at the pre-reset peak and every subsequent point re-triggered the reset predicate and was dropped — silently losing all data on the stream until its cumulative count climbed back above the old peak. The sum and plain-histogram paths already fall through to `state.prevPoint = metricPoint` on reset and recover on the next point; this makes the exponential-histogram path do the same.

#### Link to tracking issue

Fixes #49869

#### Testing

Added `TestMetricTracker_Convert_ExponentialHistogramReset`, which feeds a reset followed by a point above the restart value and asserts a correct delta is produced (the test fails against the previous behavior). Existing exponential-histogram cases continue to pass.

#### Documentation

None; internal bug fix, no user-facing config or behavior-contract change beyond correct output.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.
