### PR TITLE
[processor/k8sattributes] validate uniqueness of pod_association rules

### DIFF
--- a/.chloggen/k8sattributes-validate-unique-pod-associations.yaml
+++ b/.chloggen/k8sattributes-validate-unique-pod-associations.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject configurations with duplicate `pod_association` rules during validation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49269]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Two associations that resolve to the same set of sources (ignoring source order) now cause a
+  validation error. This enforces the uniqueness of `PodIdentifier`s that the cache relies on.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/k8sattributes-validate-unique-pod-associations.yaml
+++ b/.chloggen/k8sattributes-validate-unique-pod-associations.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: k8sattributesprocessor
+component: processor/k8s_attributes
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Reject configurations with duplicate `pod_association` rules during validation.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -36,6 +36,7 @@ to the Pod IP. But for cases where this approach doesn't work (sending through a
 Each association is specified as a list of sources of associations. The maximum number of sources within an association is 4.
 A source is a rule that matches metadata from the datapoint to pod metadata.
 In order to get an association applied, all the sources specified need to match.
+Each association must be unique: two associations with the same set of sources (regardless of the order they are listed in) are rejected during configuration validation.
 
 Each sources rule is specified as a pair of `from` (representing the rule type) and `name` (representing the attribute name if `from` is set to `resource_attribute`).
 The following rule types are available:

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	conventions "go.opentelemetry.io/otel/semconv/v1.42.0"
@@ -69,10 +71,17 @@ func (cfg *Config) Validate() error {
 		return errors.New("pod_delete_grace_period must be greater than or equal to 0")
 	}
 
+	seenAssociations := make(map[string]struct{}, len(cfg.Association))
 	for _, assoc := range cfg.Association {
 		if len(assoc.Sources) > kube.PodIdentifierMaxLength {
 			return fmt.Errorf("too many association sources. limit is %v", kube.PodIdentifierMaxLength)
 		}
+
+		key := podAssociationKey(assoc)
+		if _, ok := seenAssociations[key]; ok {
+			return fmt.Errorf("duplicate pod association: %s", key)
+		}
+		seenAssociations[key] = struct{}{}
 	}
 
 	for _, f := range append(cfg.Extract.Labels, cfg.Extract.Annotations...) {
@@ -132,6 +141,20 @@ func (cfg *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// podAssociationKey builds a stable, order-independent key for a pod association
+// from its sources. Sources are sorted by "from" and "name" so that two
+// associations listing the same sources in a different order resolve to the same
+// key. A PodIdentifier resolves the same regardless of source order, so such
+// associations are duplicates.
+func podAssociationKey(assoc PodAssociationConfig) string {
+	parts := make([]string, 0, len(assoc.Sources))
+	for _, source := range assoc.Sources {
+		parts = append(parts, source.From+"/"+source.Name)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
 }
 
 // ExtractConfig section allows specifying extraction rules to extract

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -171,6 +171,39 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "too_many_sources"),
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "duplicate_association_single_source"),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "duplicate_association_reordered_sources"),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "distinct_associations"),
+			expected: &Config{
+				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
+				Extract: ExtractConfig{
+					Metadata:                     enabledAttributes(),
+					DeploymentNameFromReplicaSet: true,
+				},
+				Association: []PodAssociationConfig{
+					{
+						Sources: []PodAssociationSourceConfig{
+							{From: "resource_attribute", Name: "k8s.pod.uid"},
+							{From: "resource_attribute", Name: "container.id"},
+						},
+					},
+					{
+						Sources: []PodAssociationSourceConfig{
+							{From: "resource_attribute", Name: "k8s.pod.uid"},
+						},
+					},
+				},
+				Exclude:                defaultExcludes,
+				WaitForMetadataTimeout: 10 * time.Second,
+				WatchSyncPeriod:        5 * time.Minute,
+				PodDeleteGracePeriod:   120 * time.Second,
+			},
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "bad_keys_labels"),
 		},
 		{
@@ -482,6 +515,84 @@ func TestLoadConfig(t *testing.T) {
 
 			assert.NoError(t, xconfmap.Validate(cfg))
 			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestConfigValidateDuplicatePodAssociations(t *testing.T) {
+	newSource := func(from, name string) PodAssociationSourceConfig {
+		return PodAssociationSourceConfig{From: from, Name: name}
+	}
+
+	tests := []struct {
+		name        string
+		association []PodAssociationConfig
+		wantErr     bool
+	}{
+		{
+			name: "identical single source",
+			association: []PodAssociationConfig{
+				{Sources: []PodAssociationSourceConfig{newSource("resource_attribute", "container.id")}},
+				{Sources: []PodAssociationSourceConfig{newSource("resource_attribute", "container.id")}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "same multi-source set in different order",
+			association: []PodAssociationConfig{
+				{Sources: []PodAssociationSourceConfig{
+					newSource("resource_attribute", "k8s.pod.uid"),
+					newSource("resource_attribute", "container.id"),
+				}},
+				{Sources: []PodAssociationSourceConfig{
+					newSource("resource_attribute", "container.id"),
+					newSource("resource_attribute", "k8s.pod.uid"),
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "differ by one source",
+			association: []PodAssociationConfig{
+				{Sources: []PodAssociationSourceConfig{
+					newSource("resource_attribute", "k8s.pod.uid"),
+					newSource("resource_attribute", "container.id"),
+				}},
+				{Sources: []PodAssociationSourceConfig{
+					newSource("resource_attribute", "k8s.pod.uid"),
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "same name different source type",
+			association: []PodAssociationConfig{
+				{Sources: []PodAssociationSourceConfig{newSource("resource_attribute", "ip")}},
+				{Sources: []PodAssociationSourceConfig{newSource("connection", "ip")}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single valid association",
+			association: []PodAssociationConfig{
+				{Sources: []PodAssociationSourceConfig{newSource("resource_attribute", "k8s.pod.ip")}},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				APIConfig:   k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
+				Association: tt.association,
+			}
+			err := cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -104,6 +104,39 @@ k8s_attributes/too_many_sources:
         - from: connection
           name: ip
 
+k8s_attributes/duplicate_association_single_source:
+  pod_association:
+    - sources:
+        - from: resource_attribute
+          name: container.id
+    - sources:
+        - from: resource_attribute
+          name: container.id
+
+k8s_attributes/duplicate_association_reordered_sources:
+  pod_association:
+    - sources:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: container.id
+    - sources:
+        - from: resource_attribute
+          name: container.id
+        - from: resource_attribute
+          name: k8s.pod.uid
+
+k8s_attributes/distinct_associations:
+  pod_association:
+    - sources:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: container.id
+    - sources:
+        - from: resource_attribute
+          name: k8s.pod.uid
+
 k8s_attributes/bad_keys_labels:
   extract:
     labels:


### PR DESCRIPTION
#### Description

`config.Validate()` now rejects duplicate `pod_association` rules.

`extractPodID` walks associations in order and returns the first one whose sources all resolve. Two rules with the same set of sources therefore always produce the same `PodIdentifier`, so the second rule is unreachable dead config. PR #48398 (container.id cache cleanup) also relies on `PodIdentifier`s being unique, as noted in [this review comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48398#discussion_r3424027552).

Sources are compared as an unordered set, so rules that list the same sources in a different order are also flagged as duplicates.

#### Link to tracking issue
Fixes #49269

#### Testing

- `TestConfigValidateDuplicatePodAssociations`: table-driven cases for identical single-source rules, same multi-source set in different order, rules differing by one source, same name with different source type, and a single valid rule.
- `TestLoadConfig`: new `testdata/config.yaml` entries `duplicate_association_single_source` and `duplicate_association_reordered_sources` (expect validation error) and `distinct_associations` (expect success).

#### Documentation

- README: documented that each association must be unique.
- Added a changelog entry.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
