### PR TITLE
[exporter/awscloudwatchlogsexporter] resolve {PodName} placeholder via k8s.pod.name attribute

### DIFF
--- a/.chloggen/46202-awscloudwatchlogs-podname-k8s-attr.yaml
+++ b/.chloggen/46202-awscloudwatchlogs-podname-k8s-attr.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/awscloudwatchlogs
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Resolve the `{PodName}` placeholder in `log_group_name`/`log_stream_name` from the `k8s.pod.name` resource attribute as well as the legacy `pod` attribute.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46202]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `k8sattributesprocessor` sets the semantic convention attribute
+  `k8s.pod.name`, not the legacy `pod` attribute that `{PodName}` previously
+  looked up. This left `{PodName}` resolving to `undefined` for standard EKS
+  pipelines unless users added an extra processor to rename the attribute.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awscloudwatchlogsexporter/README.md
+++ b/exporter/awscloudwatchlogsexporter/README.md
@@ -28,7 +28,7 @@ The following settings are required:
     - `{ClusterName}`: `aws.ecs.cluster.name`
     - `{TaskId}`:               `aws.ecs.task.id`
     - `{NodeName}`:             `k8s.node.name`
-    - `{PodName}`:              `pod`
+    - `{PodName}`:              `pod` or `k8s.pod.name`
     - `{ServiceName}`:          `service.name`
     - `{ContainerInstanceId}`:  `aws.ecs.container.instance.id`
     - `{TaskDefinitionFamily}`: `aws.ecs.task.family`

--- a/exporter/awscloudwatchlogsexporter/util.go
+++ b/exporter/awscloudwatchlogsexporter/util.go
@@ -12,17 +12,19 @@ import (
 	"go.uber.org/zap"
 )
 
-var patternKeyToAttributeMap = map[string]string{
-	"ClusterName":          "aws.ecs.cluster.name",
-	"TaskId":               "aws.ecs.task.id",
-	"NodeName":             "k8s.node.name",
-	"PodName":              "pod",
-	"ServiceName":          "service.name",
-	"ContainerInstanceId":  "aws.ecs.container.instance.id",
-	"TaskDefinitionFamily": "aws.ecs.task.family",
-	"InstanceId":           "service.instance.id",
-	"FaasName":             "faas.name",
-	"FaasVersion":          "faas.version",
+// patternKeyToAttributeMap maps each placeholder key to the resource attribute names
+// that are searched, in order, to resolve its value.
+var patternKeyToAttributeMap = map[string][]string{
+	"ClusterName":          {"aws.ecs.cluster.name"},
+	"TaskId":               {"aws.ecs.task.id"},
+	"NodeName":             {"k8s.node.name"},
+	"PodName":              {"pod", "k8s.pod.name"},
+	"ServiceName":          {"service.name"},
+	"ContainerInstanceId":  {"aws.ecs.container.instance.id"},
+	"TaskDefinitionFamily": {"aws.ecs.task.family"},
+	"InstanceId":           {"service.instance.id"},
+	"FaasName":             {"faas.name"},
+	"FaasVersion":          {"faas.version"},
 }
 
 func isPatternValid(s string) (bool, string) {
@@ -59,8 +61,11 @@ func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string
 	if strings.Contains(s, pattern) {
 		if value, ok := attrMap[patternKey]; ok {
 			return replace(s, pattern, value, logger)
-		} else if value, ok := attrMap[patternKeyToAttributeMap[patternKey]]; ok {
-			return replace(s, pattern, value, logger)
+		}
+		for _, attrName := range patternKeyToAttributeMap[patternKey] {
+			if value, ok := attrMap[attrName]; ok {
+				return replace(s, pattern, value, logger)
+			}
 		}
 		logger.Debug("No resource attribute found for pattern " + pattern)
 		return strings.ReplaceAll(s, pattern, "undefined"), false

--- a/exporter/awscloudwatchlogsexporter/util_test.go
+++ b/exporter/awscloudwatchlogsexporter/util_test.go
@@ -104,6 +104,38 @@ func TestReplacePatternValidPod(t *testing.T) {
 	assert.True(t, success)
 }
 
+func TestReplacePatternValidPodNameFromK8sSemconv(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/eks/containerinsights/{PodName}/performance"
+
+	attrMap := map[string]any{
+		"aws.eks.cluster.name": "test-cluster-name",
+		"k8s.pod.name":         "test-pod-001",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/eks/containerinsights/test-pod-001/performance", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternPodNamePrefersLegacyPodAttribute(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/eks/containerinsights/{PodName}/performance"
+
+	attrMap := map[string]any{
+		"pod":          "legacy-pod-name",
+		"k8s.pod.name": "semconv-pod-name",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/eks/containerinsights/legacy-pod-name/performance", s)
+	assert.True(t, success)
+}
+
 func TestReplacePatternMissingPodName(t *testing.T) {
 	logger := zap.NewNop()
 

--- a/exporter/awscloudwatchlogsexporter/util_test.go
+++ b/exporter/awscloudwatchlogsexporter/util_test.go
@@ -95,7 +95,7 @@ func TestReplacePatternValidPod(t *testing.T) {
 
 	attrMap := map[string]any{
 		"aws.eks.cluster.name": "test-cluster-name",
-		"PodName":              "test-pod-001",
+		"pod":                  "test-pod-001",
 	}
 
 	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)


### PR DESCRIPTION
Motivation:
Issue #46202 reports that the `{PodName}` placeholder in
`log_group_name`/`log_stream_name` does not resolve for standard EKS
pipelines. The root cause, identified in the issue thread, is that
`patternKeyToAttributeMap` only mapped `PodName` to the legacy attribute
name `pod`. The `k8sattributesprocessor` sets the semantic-convention
attribute `k8s.pod.name` (confirmed in
processor/k8sattributesprocessor/metadata.yaml, enabled by default), not
`pod`, so `{PodName}` silently resolved to `undefined` for the common
case of a k8sattributesprocessor + awscloudwatchlogsexporter pipeline,
unless users added an extra processor to rename the attribute.

Approach:
Change `patternKeyToAttributeMap` from `map[string]string` to
`map[string][]string` so each placeholder can list multiple candidate
resource attribute names, checked in order. `PodName` now checks `pod`
first (preserving existing behavior), then falls back to `k8s.pod.name`.
All other placeholders keep their single existing attribute name, just
wrapped in a one-element slice, so their behavior is unchanged.

Validation:
Ran `go test ./...` and `go vet ./...` in
exporter/awscloudwatchlogsexporter — all tests pass, including the new
TestReplacePatternValidPodNameFromK8sSemconv (verifies `{PodName}`
resolves from `k8s.pod.name` alone) and
TestReplacePatternPodNamePrefersLegacyPodAttribute (verifies `pod` still
wins over `k8s.pod.name` when both are present, preserving backwards
compatibility).

Fixes #46202

Assisted-by: Claude Sonnet 5
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.