### PR TITLE
[chore][pkg/datadog] Make test more resilient

### DIFF
--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -295,20 +295,20 @@ func TestValidateConnectorComponentConfig(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
+	httpConfigs := map[string]any{
+		"read_buffer_size":        100,
+		"write_buffer_size":       200,
+		"timeout":                 "10s",
+		"max_idle_conns":          300,
+		"max_idle_conns_per_host": 150,
+		"max_conns_per_host":      250,
+		"disable_keep_alives":     true,
+		"idle_conn_timeout":       "30s",
+		"tls":                     map[string]any{"insecure_skip_verify": true},
+	}
+	// Create confighttp.ClientConfig via unmarshaling to preserve internal state.
 	cfgWithHTTPConfigs := CreateDefaultConfig().(*Config)
-	idleConnTimeout := 30 * time.Second
-	maxIdleConn := 300
-	maxIdleConnPerHost := 150
-	maxConnPerHost := 250
-	cfgWithHTTPConfigs.ClientConfig.ReadBufferSize = 100
-	cfgWithHTTPConfigs.ClientConfig.WriteBufferSize = 200
-	cfgWithHTTPConfigs.ClientConfig.Timeout = 10 * time.Second
-	cfgWithHTTPConfigs.ClientConfig.MaxIdleConns = maxIdleConn
-	cfgWithHTTPConfigs.ClientConfig.MaxIdleConnsPerHost = maxIdleConnPerHost
-	cfgWithHTTPConfigs.ClientConfig.MaxConnsPerHost = maxConnPerHost
-	cfgWithHTTPConfigs.ClientConfig.IdleConnTimeout = idleConnTimeout
-	cfgWithHTTPConfigs.ClientConfig.DisableKeepAlives = true
-	cfgWithHTTPConfigs.ClientConfig.TLS.InsecureSkipVerify = true
+	require.NoError(t, confmap.NewFromStringMap(httpConfigs).Unmarshal(&cfgWithHTTPConfigs.ClientConfig))
 	cfgWithHTTPConfigs.warnings = nil
 
 	tests := []struct {
@@ -452,19 +452,9 @@ func TestUnmarshal(t *testing.T) {
 			err: "\"metrics::sums::initial_cumulative_monotonic_value\" can only be configured when \"metrics::sums::cumulative_monotonic_mode\" is set to \"to_delta\"",
 		},
 		{
-			name: "unmarshall confighttp client configs",
-			configMap: confmap.NewFromStringMap(map[string]any{
-				"read_buffer_size":        100,
-				"write_buffer_size":       200,
-				"timeout":                 "10s",
-				"max_idle_conns":          300,
-				"max_idle_conns_per_host": 150,
-				"max_conns_per_host":      250,
-				"disable_keep_alives":     true,
-				"idle_conn_timeout":       "30s",
-				"tls":                     map[string]any{"insecure_skip_verify": true},
-			}),
-			cfg: cfgWithHTTPConfigs,
+			name:      "unmarshall confighttp client configs",
+			configMap: confmap.NewFromStringMap(httpConfigs),
+			cfg:       cfgWithHTTPConfigs,
 		},
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Uses `Unmarshal` to make sure internal fields are set in test.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates to open-telemetry/opentelemetry-collector/pull/15308

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
