### PR TITLE
[chore] Run broken make targets

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -172,6 +172,7 @@ components:
     - pkg/stanza
     - pkg/stanza/operator/input/journald
     - pkg/status
+    - pkg/tcp_input
     - pkg/topic
     - pkg/translator/azure
     - pkg/translator/loki

--- a/.github/component_labels.txt
+++ b/.github/component_labels.txt
@@ -162,6 +162,7 @@ pkg/sampling pkg/sampling
 pkg/stanza pkg/stanza
 pkg/stanza/fileconsumer pkg/stanza/fileconsumer
 pkg/stanza/operator/input/journald pkg/stanza/operator/input/journald
+pkg/stanza/operator/input/tcp pkg/stanza/operator/input/tcp
 pkg/status pkg/status
 pkg/translator/azure pkg/translator/azure
 pkg/translator/azurelogs pkg/translator/azurelogs

--- a/pkg/stanza/operator/input/tcp/config.schema.yaml
+++ b/pkg/stanza/operator/input/tcp/config.schema.yaml
@@ -5,10 +5,15 @@ $defs:
     properties:
       add_attributes:
         type: boolean
+      connection_idle_timeout:
+        type: string
+        format: duration
       encoding:
         type: string
       listen_address:
         type: string
+      max_connections:
+        type: integer
       max_log_size:
         $ref: /pkg/stanza/operator/helper.byte_size
       multiline:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes CI by running `make generate-schemas` and `make genlabels`. #49611 broke this (probably a race condition with some other PR)

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
