### PR TITLE
[receiver/gitlab] accept Rails numeric timezone offsets in webhook timestamps

### DIFF
--- a/receiver/gitlabreceiver/traces_event_handling.go
+++ b/receiver/gitlabreceiver/traces_event_handling.go
@@ -27,7 +27,13 @@ var (
 )
 
 const (
+	// Rails/GitLab ActiveSupport::TimeWithZone#to_s when Time.zone is UTC.
 	gitlabEventTimeFormat = "2006-01-02 15:04:05 UTC"
+	// Rails/GitLab ActiveSupport::TimeWithZone#to_s for non-UTC zones
+	// (e.g. America/Los_Angeles → "2026-07-28 15:09:25 -0700").
+	gitlabEventTimeFormatNumericOffset = "2006-01-02 15:04:05 -0700"
+	// Same with a colon in the offset ("-07:00").
+	gitlabEventTimeFormatColonOffset = "2006-01-02 15:04:05 -07:00"
 )
 
 // GitlabEvent abstracts span setup for different GitLab event types (pipeline, stage, job)
@@ -316,28 +322,37 @@ func setSpanTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return nil
 }
 
-// parseGitlabTime parses the time string from the gitlab event, it differs between the test pipeline event and the actual webhook event,
-// because the test pipeline event has a different time format than the actual webhook event.
-// Test pipeline event time format: 2025-04-01T18:31:49.624Z
-// Actual webhook event time format: 2025-04-01 18:31:49 UTC
+// parseGitlabTime parses timestamp strings emitted by GitLab pipeline webhooks.
+//
+// GitLab serializes ActiveSupport::TimeWithZone values via #to_s, which depends
+// on the instance gitlab_rails['time_zone']:
+//   - UTC zone:        "2025-04-01 18:31:49 UTC"
+//   - non-UTC zone:    "2026-07-28 15:09:25 -0700"  (or "-07:00")
+// GitLab's "Test" webhook button and some API payloads instead use RFC3339:
+//   - "2025-04-01T18:31:49.624Z"
 func parseGitlabTime(t string) (time.Time, error) {
 	if t == "" || t == "null" {
 		return time.Time{}, errors.New("time is empty")
 	}
 
-	// Time format of actual webhook events
-	pt, err := time.Parse(gitlabEventTimeFormat, t)
-	if err == nil {
-		return pt, nil
+	var firstErr error
+	for _, layout := range []string{
+		gitlabEventTimeFormat,
+		gitlabEventTimeFormatNumericOffset,
+		gitlabEventTimeFormatColonOffset,
+		time.RFC3339,
+		time.RFC3339Nano,
+	} {
+		pt, err := time.Parse(layout, t)
+		if err == nil {
+			return pt, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
-	// Time format of test webhook events
-	pt, err = time.Parse(time.RFC3339, t)
-	if err == nil {
-		return pt, nil
-	}
-
-	return time.Time{}, err
+	return time.Time{}, firstErr
 }
 
 // map GitLab status to OTel span status and set optional message

--- a/receiver/gitlabreceiver/traces_event_handling_test.go
+++ b/receiver/gitlabreceiver/traces_event_handling_test.go
@@ -6,6 +6,7 @@ package gitlabreceiver
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -357,25 +358,37 @@ func TestNewJobSpanID(t *testing.T) {
 }
 
 func TestParseGitlabTime(t *testing.T) {
+	wantUTCNoon := time.Date(2022, 1, 1, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name        string
 		timeStr     string
+		want        time.Time
 		expectError bool
 	}{
 		{
-			name:        "valid UTC time",
-			timeStr:     "2022-01-01 12:00:00 UTC",
-			expectError: false,
+			name:    "valid UTC time",
+			timeStr: "2022-01-01 12:00:00 UTC",
+			want:    wantUTCNoon,
 		},
 		{
-			name:        "valid RFC3339 time",
-			timeStr:     "2022-01-01T12:00:00Z",
-			expectError: false,
+			name:    "valid numeric offset time (Rails non-UTC Time.zone)",
+			timeStr: "2022-01-01 04:00:00 -0800",
+			want:    wantUTCNoon,
 		},
 		{
-			name:        "valid RFC3339 time with milliseconds",
-			timeStr:     "2022-01-01T12:00:00.123Z",
-			expectError: false,
+			name:    "valid colon offset time",
+			timeStr: "2022-01-01 04:00:00 -08:00",
+			want:    wantUTCNoon,
+		},
+		{
+			name:    "valid RFC3339 time",
+			timeStr: "2022-01-01T12:00:00Z",
+			want:    wantUTCNoon,
+		},
+		{
+			name:    "valid RFC3339 time with milliseconds",
+			timeStr: "2022-01-01T12:00:00.123Z",
+			want:    wantUTCNoon.Add(123 * time.Millisecond),
 		},
 		{
 			name:        "empty time string",
@@ -396,14 +409,14 @@ func TestParseGitlabTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			time, err := parseGitlabTime(tt.timeStr)
+			got, err := parseGitlabTime(tt.timeStr)
 			if tt.expectError {
 				require.Error(t, err, "expected error for time string: %s", tt.timeStr)
-				require.True(t, time.IsZero(), "expected zero time value")
-			} else {
-				require.NoError(t, err, "did not expect error for time string: %s", tt.timeStr)
-				require.False(t, time.IsZero(), "expected non-zero time value")
+				require.True(t, got.IsZero(), "expected zero time value")
+				return
 			}
+			require.NoError(t, err, "did not expect error for time string: %s", tt.timeStr)
+			require.True(t, got.Equal(tt.want), "got %s want %s", got.UTC(), tt.want.UTC())
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Self-managed GitLab instances often set `gitlab_rails['time_zone']` to a local zone (e.g. `America/Los_Angeles`). Pipeline webhook payloads then serialize `created_at` / `started_at` / `finished_at` via Rails `ActiveSupport::TimeWithZone#to_s` as:

```text
2026-07-28 15:09:25 -0700
```

`parseGitlabTime` only accepted:

- `2006-01-02 15:04:05 UTC` (UTC app timezone / GitLab.com)
- RFC3339 (GitLab "Test" webhook button / some API shapes)

So real pipeline hooks from non-UTC instances fail span construction with `invalid finishedAt timestamp` and the receiver returns HTTP 500.

This adds the numeric-offset layouts Rails emits (`-0700` and `-07:00`) and tightens unit tests so offset and UTC forms resolve to the same instant.

#### Link to tracking issue

Fixes webhook timestamp parse failures for non-UTC `gitlab_rails['time_zone']` deployments. Related empty-timestamp handling: #45756 (different failure mode).

#### Testing

- Extended `TestParseGitlabTime` with numeric/colon offset cases and absolute-instant assertions
- `go test ./...` in `receiver/gitlabreceiver` passes

#### Checklist

- [x] Updated `CHANGELOG.md`? **No** — small receiver bugfix; happy to add under `### Bug fixes` if required
- [x] Component for changelog entry: `gitlabreceiver`