### PR TITLE
[exporter/prometheus_remote_write] Add exporter ID to WAL telemetry attributes

### DIFF
--- a/.chloggen/prw-wal-exporter-attribute.yaml
+++ b/.chloggen/prw-wal-exporter-attribute.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: exporter/prometheus_remote_write
+
+note: Add the exporter ID as an attribute on WAL telemetry metrics to disambiguate multiple PRW exporters sharing a collector.
+
+issues: [49130]
+
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -84,7 +84,9 @@ func newPRWWalTelemetry(set exporter.Settings) (prwWalTelemetry, error) {
 	}
 	return &prwWalTelemetryOTel{
 		telemetryBuilder: telemetryBuilder,
-		otelAttrs:        []attribute.KeyValue{},
+		otelAttrs: []attribute.KeyValue{
+			attribute.String("exporter", set.ID.String()),
+		},
 	}, nil
 }
 

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
@@ -306,8 +307,9 @@ func TestWALWrite_Telemetry(t *testing.T) {
 	// Test successful WAL write
 	err = prw.handleExport(t.Context(), metrics, nil)
 	require.NoError(t, err)
+	exporterAttr := attribute.NewSet(attribute.String("exporter", set.ID.String()))
 	metadatatest.AssertEqualExporterPrometheusremotewriteWalWrites(t, tel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
+		[]metricdata.DataPoint[int64]{{Value: 1, Attributes: exporterAttr}},
 		metricdatatest.IgnoreTimestamp())
 
 	// Test failed WAL write by causing an out-of-order write error
@@ -317,7 +319,7 @@ func TestWALWrite_Telemetry(t *testing.T) {
 	err = prw.handleExport(t.Context(), metrics, nil)
 	require.Error(t, err)
 	metadatatest.AssertEqualExporterPrometheusremotewriteWalWritesFailures(t, tel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
+		[]metricdata.DataPoint[int64]{{Value: 1, Attributes: exporterAttr}},
 		metricdatatest.IgnoreTimestamp())
 
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_write_latency")
@@ -458,8 +460,15 @@ func TestWALLag_Telemetry(t *testing.T) {
 	// Wait for lag recording to happen (longer than lagRecordFrequency)
 	time.Sleep(5 * cfg.WAL.Get().LagRecordFrequency)
 
-	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_lag")
-	require.NoError(t, err)
+	// The wal_lag metric must carry the exporter attribute set to the
+	// component ID supplied by the test settings. We ideally would use
+	// otelcol.component.id, but the rest of the PRW exporter self-observability
+	// metrics currently use "exporter"; this can be switched for the whole
+	// exporter at a future point.
+	exporterAttr := attribute.NewSet(attribute.String("exporter", set.ID.String()))
+	metadatatest.AssertEqualExporterPrometheusremotewriteWalLag(t, tel,
+		[]metricdata.DataPoint[int64]{{Attributes: exporterAttr}},
+		metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }
 
 // TestWAL_IdleFlush verifies that buffered WAL entries are flushed to the


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When running multiple prometheusremotewrite exporter instances (e.g.,
prometheusremotewrite/ext and prometheusremotewrite/internal), the WAL telemetry
metrics (like wal_lag) have no exporter label, making it impossible to tell which
instance they belong to. The exporter-level metrics correctly include this label,
but the WAL metrics initialize otelAttrs as an empty slice.

For example, otelcol_exporter_prometheusremotewrite_wal_lag currently has no
component identifier:
otelcol_exporter_prometheusremotewrite_wal_lag{instance="ip:port", job="https",
namespace="test", pod_name="collector-6b97f867d4-dhds4", service_name="collector"}

This change sets the "exporter" attribute (the component ID) on the WAL telemetry
so the metrics can be distinguished per exporter instance.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
#49130 
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [✓ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
