### PR TITLE
[chore][processor/k8sattributes] Un-embed k8sconfig.APIConfig config struct

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -18,7 +18,7 @@ import (
 
 // Config defines configuration for k8s attributes processor.
 type Config struct {
-	k8sconfig.APIConfig `mapstructure:",squash"`
+	APIConfig k8sconfig.APIConfig `mapstructure:",squash"`
 
 	// Passthrough mode only annotates resources with the pod IP and
 	// does not try to extract any other metadata. It does not need


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Avoids embedding config struct since it doesn't work well with mapstructure.

I am going to mark this as release blocker since it must be done before k8sattributes processor 1.0

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
