### PR TITLE
[receiver/cloudflare] Bound decompressed size of gzip request bodies

### DIFF
--- a/.chloggen/49232-cloudflarereceiver-gzip-decompression-limit.yaml
+++ b/.chloggen/49232-cloudflarereceiver-gzip-decompression-limit.yaml
@@ -1,0 +1,16 @@
+change_type: bug_fix
+
+component: receiver/cloudflare
+
+note: Apply `max_request_body_size` to the decompressed size of gzip-encoded request bodies
+
+issues: [49232]
+
+subtext: |
+  `max_request_body_size` was enforced with `http.MaxBytesReader`, which bounds the
+  compressed bytes only. A small gzip-encoded request could therefore still expand
+  without limit while being buffered in memory. The decompressed stream is now bounded
+  by the same setting, and a request whose decompressed body exceeds it is rejected with
+  422 rather than read in full.
+
+change_logs: [user]

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -177,11 +177,25 @@ func (l *logsReceiver) handleRequest(rw http.ResponseWriter, req *http.Request) 
 			return
 		}
 		defer reader.Close()
-		// Read the decompressed response body
-		payload, err = io.ReadAll(reader)
+		// Read the decompressed response body. MaxBytesReader above bounds the
+		// compressed bytes only, so the decompressed stream needs its own limit:
+		// a small gzip payload can otherwise expand without bound. Read one byte
+		// past the limit so exceeding it can be distinguished from meeting it.
+		var decompressed io.Reader = reader
+		if l.cfg.MaxRequestBodySize > 0 {
+			decompressed = io.LimitReader(reader, l.cfg.MaxRequestBodySize+1)
+		}
+		payload, err = io.ReadAll(decompressed)
 		if err != nil {
 			rw.WriteHeader(http.StatusUnprocessableEntity)
 			l.logger.Debug("Got payload with gzip, but failed to read", zap.Error(err))
+			return
+		}
+		if l.cfg.MaxRequestBodySize > 0 && int64(len(payload)) > l.cfg.MaxRequestBodySize {
+			rw.WriteHeader(http.StatusUnprocessableEntity)
+			l.logger.Debug("Got gzip payload whose decompressed size exceeds max_request_body_size, dropping...",
+				zap.Int64("max_request_body_size", l.cfg.MaxRequestBodySize),
+				zap.String("remote", req.RemoteAddr))
 			return
 		}
 	} else {

--- a/receiver/cloudflarereceiver/logs_test.go
+++ b/receiver/cloudflarereceiver/logs_test.go
@@ -771,3 +771,73 @@ func TestArrayAttributesArePreserved(t *testing.T) {
 	require.Equal(t, 11.0, nestedIDs.Slice().At(0).Double())
 	require.Equal(t, 22.0, nestedIDs.Slice().At(1).Double())
 }
+
+// TestMaxRequestBodySizeGzip covers the compressed path. MaxBytesReader bounds
+// the compressed bytes, but the decompressed stream is read separately, so a
+// small gzip payload that expands past the limit must still be rejected rather
+// than buffered in full.
+func TestMaxRequestBodySizeGzip(t *testing.T) {
+	tests := []struct {
+		name               string
+		maxRequestBodySize int64
+		decompressedSize   int
+		expectedStatus     int
+	}{
+		{
+			name:               "decompressed_within_limit",
+			maxRequestBodySize: 4096,
+			decompressedSize:   512,
+			expectedStatus:     http.StatusOK,
+		},
+		{
+			name:               "decompressed_exceeds_limit",
+			maxRequestBodySize: 1024,
+			decompressedSize:   512 * 1024,
+			expectedStatus:     http.StatusUnprocessableEntity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Highly compressible padding, so the compressed body stays far below
+			// the limit while the decompressed payload does not.
+			padding := strings.Repeat("a", tt.decompressedSize)
+			logEntry := map[string]any{
+				"ClientIP":           "127.0.0.1",
+				"EdgeStartTimestamp": "2023-03-03T05:29:05Z",
+				"padding":            padding,
+			}
+			body, err := json.Marshal(logEntry)
+			require.NoError(t, err)
+
+			var compressed bytes.Buffer
+			gw := gzip.NewWriter(&compressed)
+			_, err = gw.Write(body)
+			require.NoError(t, err)
+			require.NoError(t, gw.Close())
+
+			require.Less(t, int64(compressed.Len()), tt.maxRequestBodySize,
+				"compressed body must fit under the limit for this test to exercise decompression")
+
+			cfg := &Config{
+				Logs: LogsConfig{
+					Endpoint:           "localhost:0",
+					MaxRequestBodySize: tt.maxRequestBodySize,
+					TimestampField:     "EdgeStartTimestamp",
+					Secret:             "abc123",
+				},
+			}
+
+			r := newReceiver(t, cfg, consumertest.NewNop())
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(compressed.Bytes()))
+			req.Header.Add(secretHeaderName, "abc123")
+			req.Header.Add("Content-Encoding", "gzip")
+
+			w := httptest.NewRecorder()
+			r.handleRequest(w, req)
+
+			require.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}


### PR DESCRIPTION
#### Description

`handleRequest` wraps the request body in `http.MaxBytesReader`, which bounds the **compressed** bytes. The gzip branch then reads the **decompressed** stream with `io.ReadAll` and no limit of its own:

```go
req.Body = http.MaxBytesReader(rw, req.Body, l.cfg.MaxRequestBodySize)
...
reader, err := gzip.NewReader(req.Body)
payload, err = io.ReadAll(reader)   // decompressed size unbounded
```

So a request whose compressed body sits comfortably under `max_request_body_size` can still expand without bound while being buffered in memory.

This bounds the decompressed stream with the same setting and rejects a request whose decompressed body exceeds it, returning 422 to match how the uncompressed path already behaves when it trips `MaxBytesReader`. When `max_request_body_size` is 0 (documented as "no limit") the behaviour is unchanged.

**Note on scope:** #49232 describes both the plain and gzip paths as unbounded. The plain path is already bounded by the `MaxBytesReader` call and is covered by `TestMaxRequestBodySize`, so only the decompression half remained. This PR fixes that half.

#### Link to tracking issue

Fixes #49232

#### Testing

Added `TestMaxRequestBodySizeGzip`, which posts highly compressible gzip payloads and asserts the compressed body is under the limit so the test genuinely exercises decompression rather than the compressed-byte guard. Against the previous behaviour the over-limit case is accepted:

```
--- FAIL: TestMaxRequestBodySizeGzip/decompressed_exceeds_limit
    Error: Not equal:
           expected: 422
           actual  : 200
```

The full `receiver/cloudflarereceiver` package passes with the fix, and `gofmt` is clean.

#### Documentation

No user-facing configuration change — `max_request_body_size` now covers the decompressed size as well, which is described in the changelog entry.

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and test were verified against the source and the existing test suite before submitting.