### PR TITLE
[receiver/icmpcheckreceiver] Change RTT metrics to double

### DIFF
--- a/.chloggen/icmpcheckreceiver-rtt-double.yaml
+++ b/.chloggen/icmpcheckreceiver-rtt-double.yaml
@@ -1,0 +1,5 @@
+change_type: breaking
+component: receiver/icmpcheckreceiver
+note: "Change RTT metric value type from int to double for sub-millisecond precision"
+issues: [49960]
+change_logs: [user]

--- a/receiver/icmpcheckreceiver/documentation.md
+++ b/receiver/icmpcheckreceiver/documentation.md
@@ -26,7 +26,7 @@ Average round-trip time in milliseconds.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-| ms | Gauge | Int | Development |
+| ms | Gauge | Double | Development |
 
 ### ping.rtt.max
 
@@ -34,7 +34,7 @@ Maximum round-trip time in milliseconds.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-| ms | Gauge | Int | Development |
+| ms | Gauge | Double | Development |
 
 ### ping.rtt.min
 
@@ -42,7 +42,7 @@ Minimum round-trip time in milliseconds.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-| ms | Gauge | Int | Development |
+| ms | Gauge | Double | Development |
 
 ### ping.rtt.stddev
 
@@ -50,7 +50,7 @@ Standard deviation of round-trip time in milliseconds.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
-| ms | Gauge | Int | Development |
+| ms | Gauge | Double | Development |
 
 ## Resource Attributes
 

--- a/receiver/icmpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/icmpcheckreceiver/internal/metadata/generated_metrics.go
@@ -114,14 +114,14 @@ func (m *metricPingRttAvg) init() {
 	m.data.SetEmptyGauge()
 }
 
-func (m *metricPingRttAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricPingRttAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
+	dp.SetDoubleValue(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -164,14 +164,14 @@ func (m *metricPingRttMax) init() {
 	m.data.SetEmptyGauge()
 }
 
-func (m *metricPingRttMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricPingRttMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
+	dp.SetDoubleValue(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -214,14 +214,14 @@ func (m *metricPingRttMin) init() {
 	m.data.SetEmptyGauge()
 }
 
-func (m *metricPingRttMin) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricPingRttMin) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
+	dp.SetDoubleValue(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -264,14 +264,14 @@ func (m *metricPingRttStddev) init() {
 	m.data.SetEmptyGauge()
 }
 
-func (m *metricPingRttStddev) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricPingRttStddev) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetIntValue(val)
+	dp.SetDoubleValue(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -471,22 +471,22 @@ func (mb *MetricsBuilder) RecordPingLossRatioDataPoint(ts pcommon.Timestamp, val
 }
 
 // RecordPingRttAvgDataPoint adds a data point to ping.rtt.avg metric.
-func (mb *MetricsBuilder) RecordPingRttAvgDataPoint(ts pcommon.Timestamp, val int64) {
+func (mb *MetricsBuilder) RecordPingRttAvgDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricPingRttAvg.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordPingRttMaxDataPoint adds a data point to ping.rtt.max metric.
-func (mb *MetricsBuilder) RecordPingRttMaxDataPoint(ts pcommon.Timestamp, val int64) {
+func (mb *MetricsBuilder) RecordPingRttMaxDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricPingRttMax.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordPingRttMinDataPoint adds a data point to ping.rtt.min metric.
-func (mb *MetricsBuilder) RecordPingRttMinDataPoint(ts pcommon.Timestamp, val int64) {
+func (mb *MetricsBuilder) RecordPingRttMinDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricPingRttMin.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordPingRttStddevDataPoint adds a data point to ping.rtt.stddev metric.
-func (mb *MetricsBuilder) RecordPingRttStddevDataPoint(ts pcommon.Timestamp, val int64) {
+func (mb *MetricsBuilder) RecordPingRttStddevDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricPingRttStddev.recordDataPoint(mb.startTime, ts, val)
 }
 

--- a/receiver/icmpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/icmpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -135,8 +135,8 @@ func TestMetricsBuilder(t *testing.T) {
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "ping.rtt.max":
 					assert.False(t, validatedMetrics["ping.rtt.max"], "Found a duplicate in the metrics slice: ping.rtt.max")
 					validatedMetrics["ping.rtt.max"] = true
@@ -147,8 +147,8 @@ func TestMetricsBuilder(t *testing.T) {
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "ping.rtt.min":
 					assert.False(t, validatedMetrics["ping.rtt.min"], "Found a duplicate in the metrics slice: ping.rtt.min")
 					validatedMetrics["ping.rtt.min"] = true
@@ -159,8 +159,8 @@ func TestMetricsBuilder(t *testing.T) {
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "ping.rtt.stddev":
 					assert.False(t, validatedMetrics["ping.rtt.stddev"], "Found a duplicate in the metrics slice: ping.rtt.stddev")
 					validatedMetrics["ping.rtt.stddev"] = true
@@ -171,8 +171,8 @@ func TestMetricsBuilder(t *testing.T) {
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				}
 			}
 		})

--- a/receiver/icmpcheckreceiver/metadata.yaml
+++ b/receiver/icmpcheckreceiver/metadata.yaml
@@ -37,26 +37,26 @@ metrics:
     enabled: true
     stability: development
     gauge:
-      value_type: int
+      value_type: double
     unit: ms
   ping.rtt.max:
     description: Maximum round-trip time in milliseconds.
     enabled: true
     stability: development
     gauge:
-      value_type: int
+      value_type: double
     unit: ms
   ping.rtt.min:
     description: Minimum round-trip time in milliseconds.
     enabled: true
     stability: development
     gauge:
-      value_type: int
+      value_type: double
     unit: ms
   ping.rtt.stddev:
     description: Standard deviation of round-trip time in milliseconds.
     enabled: true
     stability: development
     gauge:
-      value_type: int
+      value_type: double
     unit: ms

--- a/receiver/icmpcheckreceiver/scraper.go
+++ b/receiver/icmpcheckreceiver/scraper.go
@@ -109,10 +109,10 @@ func addMetrics(result pingResult, mb *metadata.MetricsBuilder, logger *zap.Logg
 	}
 
 	// Record all metrics - they will be filtered by MetricsBuilderConfig
-	mb.RecordPingRttMinDataPoint(now, result.stats.minRtt.Milliseconds())
-	mb.RecordPingRttMaxDataPoint(now, result.stats.maxRtt.Milliseconds())
-	mb.RecordPingRttAvgDataPoint(now, result.stats.avgRtt.Milliseconds())
-	mb.RecordPingRttStddevDataPoint(now, result.stats.stdDevRtt.Milliseconds())
+	mb.RecordPingRttMinDataPoint(now, result.stats.minRtt.Seconds()*1000)
+	mb.RecordPingRttMaxDataPoint(now, result.stats.maxRtt.Seconds()*1000)
+	mb.RecordPingRttAvgDataPoint(now, result.stats.avgRtt.Seconds()*1000)
+	mb.RecordPingRttStddevDataPoint(now, result.stats.stdDevRtt.Seconds()*1000)
 	mb.RecordPingLossRatioDataPoint(now, result.stats.lossRatio)
 
 	// Record resource attributes

--- a/receiver/icmpcheckreceiver/scraper_test.go
+++ b/receiver/icmpcheckreceiver/scraper_test.go
@@ -170,11 +170,33 @@ func TestAddMetrics(t *testing.T) {
 				err: nil,
 			},
 			expected: map[string]any{
-				"ping.rtt.min":    int64(10),
-				"ping.rtt.max":    int64(20),
-				"ping.rtt.avg":    int64(15),
-				"ping.rtt.stddev": int64(5),
+				"ping.rtt.min":    float64(10),
+				"ping.rtt.max":    float64(20),
+				"ping.rtt.avg":    float64(15),
+				"ping.rtt.stddev": float64(5),
 				"ping.loss.ratio": 0.1,
+			},
+		},
+		{
+			name: "sub-millisecond RTT values",
+			given: pingResult{
+				targetHost: "example.com",
+				targetIP:   "192.168.1.1",
+				stats: &pingStats{
+					minRtt:    150 * time.Microsecond,
+					maxRtt:    750 * time.Microsecond,
+					avgRtt:    500 * time.Microsecond,
+					stdDevRtt: 100 * time.Microsecond,
+					lossRatio: 0.0,
+				},
+				err: nil,
+			},
+			expected: map[string]any{
+				"ping.rtt.min":    0.15,
+				"ping.rtt.max":    0.75,
+				"ping.rtt.avg":    0.5,
+				"ping.rtt.stddev": 0.1,
+				"ping.loss.ratio": 0.0,
 			},
 		},
 		{
@@ -199,9 +221,9 @@ func TestAddMetrics(t *testing.T) {
 				err: nil,
 			},
 			expected: map[string]any{
-				"ping.rtt.min":    int64(10),
-				"ping.rtt.max":    int64(20),
-				"ping.rtt.stddev": int64(5),
+				"ping.rtt.min":    float64(10),
+				"ping.rtt.max":    float64(20),
+				"ping.rtt.stddev": float64(5),
 			},
 			customizeConfig: func(cfg *Config) {
 				cfg.Metrics.PingRttAvg.Enabled = false

--- a/receiver/icmpcheckreceiver/testdata/integration/expected.yaml
+++ b/receiver/icmpcheckreceiver/testdata/integration/expected.yaml
@@ -18,25 +18,25 @@ resourceMetrics:
           - description: Average round-trip time in milliseconds.
             gauge:
               dataPoints:
-                - asInt: "44"
+                - asDouble: 44
             name: ping.rtt.avg
             unit: ms
           - description: Maximum round-trip time in milliseconds.
             gauge:
               dataPoints:
-                - asInt: "47"
+                - asDouble: 47
             name: ping.rtt.max
             unit: ms
           - description: Minimum round-trip time in milliseconds.
             gauge:
               dataPoints:
-                - asInt: "42"
+                - asDouble: 42
             name: ping.rtt.min
             unit: ms
           - description: Standard deviation of round-trip time in milliseconds.
             gauge:
               dataPoints:
-                - asInt: "5"
+                - asDouble: 5
             name: ping.rtt.stddev
             unit: ms
         scope:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The RTT metrics (ping.rtt.min, ping.rtt.max, ping.rtt.avg, ping.rtt.stddev) used int64 milliseconds via Duration.Milliseconds(), which truncates sub-ms ping times to 0. Change value_type from int to double, using Duration.Seconds()*1000 to preserve fractional ms values.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49960

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Configured the receiver to ping hosts on a local network where RTT is consistently under 1ms and verified the emitted metrics now show fractional millisecond values (e.g., 0.22ms) instead of 0

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
