### PR TITLE
fix: make the k8s_events receiver watcher retry when fails to fetch resource version

### DIFF
--- a/.chloggen/49962-k8sevents-watch-relist-retry.yaml
+++ b/.chloggen/49962-k8sevents-watch-relist-retry.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: receiver/k8s_events
+note: "Keep the watcher in the Kubernetes events receiver retry when retrieving fresh resource version after a 410 Gone response but fails transiently."
+issues: [49962]
+subtext:
+change_logs: [user]

--- a/.chloggen/49962-k8sobjects-watch-relist-retry.yaml
+++ b/.chloggen/49962-k8sobjects-watch-relist-retry.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: receiver/k8s_objects
+note: "Keep the watcher in the Kubernetes objects receiver retry when retrieving fresh resource version after a 410 Gone response but fails transiently."
+issues: [49962]
+subtext:
+change_logs: [user]

--- a/internal/k8sinventory/checkpoint/checkpointer.go
+++ b/internal/k8sinventory/checkpoint/checkpointer.go
@@ -23,6 +23,17 @@ type Checkpointer struct {
 	mu      sync.Mutex
 	pending map[string]string
 
+	// storageMu orders persistent writes and deletes without blocking
+	// SetCheckpoint from buffering new resourceVersions.
+	storageMu sync.Mutex
+
+	// deleted is a tombstone set of storage keys removed by DeleteCheckpoint.
+	// It is guarded by mu. Flush skips any key present here so that an in-flight
+	// flush (which snapshotted pending before the delete) cannot resurrect a
+	// checkpoint that was just deleted from storage. A subsequent SetCheckpoint
+	// clears the tombstone, marking the key alive again.
+	deleted map[string]bool
+
 	// persistedRVs holds RVs loaded from storage at startup for dedup.
 	// Populated by Load(); read by AlreadySeen().
 	persistedMu  sync.RWMutex
@@ -36,6 +47,7 @@ func New(client storage.Client, logger *zap.Logger) *Checkpointer {
 		client:  client,
 		logger:  logger,
 		pending: make(map[string]string),
+		deleted: make(map[string]bool),
 	}
 }
 
@@ -94,6 +106,9 @@ func (c *Checkpointer) SetCheckpoint(
 		}
 	}
 	c.pending[key] = resourceVersion
+	// A fresh resourceVersion means the key is alive again; clear any tombstone
+	// left by a prior DeleteCheckpoint so this value is allowed to flush.
+	delete(c.deleted, key)
 	c.mu.Unlock()
 
 	c.logger.Debug("buffered resourceVersion checkpoint",
@@ -124,7 +139,24 @@ func (c *Checkpointer) Flush(ctx context.Context) error {
 
 	failed := false
 	for key, rv := range snapshot {
-		if err := c.client.Set(ctx, key, []byte(rv)); err != nil {
+		c.storageMu.Lock()
+
+		// Skip keys tombstoned by DeleteCheckpoint after this snapshot was taken.
+		// Without this, an in-flight flush could re-Set a key that was just
+		// deleted from storage, resurrecting a stale resourceVersion.
+		c.mu.Lock()
+		tombstoned := c.deleted[key]
+		c.mu.Unlock()
+		if tombstoned {
+			c.storageMu.Unlock()
+			c.logger.Debug("skipping flush of deleted checkpoint",
+				zap.String("key", key),
+				zap.String("resourceVersion", rv))
+			continue
+		}
+		err := c.client.Set(ctx, key, []byte(rv))
+		c.storageMu.Unlock()
+		if err != nil {
 			c.logger.Error("failed to flush checkpoint",
 				zap.String("key", key),
 				zap.String("resourceVersion", rv),
@@ -193,7 +225,19 @@ func (c *Checkpointer) DeleteCheckpoint(
 		return fmt.Errorf("checkpoint key is empty: %s, %s", namespace, objectType)
 	}
 
-	if err := c.client.Delete(ctx, key); err != nil {
+	// When deleting a checkpoint, make sure it won't be flushed again in Flush()
+	// by clearing the in-memory pending state first. Also set a tombstone so an
+	// in-flight flush (which already snapshotted pending) cannot resurrect the
+	// key. The tombstone is cleared by the next SetCheckpoint for this key.
+	c.mu.Lock()
+	delete(c.pending, key)
+	c.deleted[key] = true
+	c.mu.Unlock()
+
+	c.storageMu.Lock()
+	err := c.client.Delete(ctx, key)
+	c.storageMu.Unlock()
+	if err != nil {
 		return fmt.Errorf("failed to delete resourceVersion with key %s: %w", key, err)
 	}
 

--- a/internal/k8sinventory/checkpoint/checkpointer_test.go
+++ b/internal/k8sinventory/checkpoint/checkpointer_test.go
@@ -4,11 +4,15 @@
 package checkpoint
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
@@ -231,6 +235,90 @@ func TestCheckpointerDelete(t *testing.T) {
 	assert.Empty(t, rv)
 }
 
+func TestDeleteCheckpointClearsPendingCheckpoint(t *testing.T) {
+	client := storagetest.NewInMemoryClient(component.KindReceiver, component.MustNewID("test"), "test")
+	checkpointer := New(client, zap.NewNop())
+
+	ctx := t.Context()
+
+	require.NoError(t, checkpointer.SetCheckpoint(ctx, "default", "pods", "12345"))
+	require.NoError(t, checkpointer.DeleteCheckpoint(ctx, "default", "pods"))
+	require.NoError(t, checkpointer.Flush(ctx))
+
+	rv, err := checkpointer.GetCheckpoint(ctx, "default", "pods")
+	require.NoError(t, err)
+	assert.Empty(t, rv)
+}
+
+func TestDeleteCheckpointWinsAgainstInFlightFlush(t *testing.T) {
+	client := newBlockingSetClient(
+		storagetest.NewInMemoryClient(component.KindReceiver, component.MustNewID("test"), "test"),
+	)
+	checkpointer := New(client, zap.NewNop())
+
+	ctx := t.Context()
+	require.NoError(t, checkpointer.SetCheckpoint(ctx, "default", "pods", "12345"))
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- checkpointer.Flush(ctx)
+	}()
+	<-client.setStarted
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- checkpointer.DeleteCheckpoint(ctx, "default", "pods")
+	}()
+
+	key := checkpointer.checkpointKey("default", "pods")
+	require.Eventually(t, func() bool {
+		checkpointer.mu.Lock()
+		defer checkpointer.mu.Unlock()
+		return checkpointer.deleted[key]
+	}, time.Second, time.Millisecond)
+
+	client.releaseSet()
+	require.NoError(t, <-flushDone)
+	require.NoError(t, <-deleteDone)
+
+	rv, err := checkpointer.GetCheckpoint(ctx, "default", "pods")
+	require.NoError(t, err)
+	assert.Empty(t, rv, "delete must win against an in-flight flush")
+}
+
+// TestDeleteSetsTombstoneClearedBySet verifies the tombstone lifecycle:
+// DeleteCheckpoint sets it (and clears pending), and a subsequent SetCheckpoint
+// clears it so the fresh resourceVersion is allowed to flush.
+func TestDeleteSetsTombstoneClearedBySet(t *testing.T) {
+	client := storagetest.NewInMemoryClient(component.KindReceiver, component.MustNewID("test"), "test")
+	checkpointer := New(client, zap.NewNop())
+
+	ctx := t.Context()
+	key := checkpointer.checkpointKey("default", "pods")
+
+	require.NoError(t, checkpointer.SetCheckpoint(ctx, "default", "pods", "100"))
+	require.NoError(t, checkpointer.DeleteCheckpoint(ctx, "default", "pods"))
+
+	checkpointer.mu.Lock()
+	_, tombstoned := checkpointer.deleted[key]
+	_, stillPending := checkpointer.pending[key]
+	checkpointer.mu.Unlock()
+	assert.True(t, tombstoned, "DeleteCheckpoint should set a tombstone")
+	assert.False(t, stillPending, "DeleteCheckpoint should clear pending")
+
+	// A fresh resourceVersion marks the key alive again and clears the tombstone.
+	require.NoError(t, checkpointer.SetCheckpoint(ctx, "default", "pods", "200"))
+	checkpointer.mu.Lock()
+	_, tombstoned = checkpointer.deleted[key]
+	checkpointer.mu.Unlock()
+	assert.False(t, tombstoned, "SetCheckpoint should clear the tombstone")
+
+	require.NoError(t, checkpointer.Flush(ctx))
+	rv, err := checkpointer.GetCheckpoint(ctx, "default", "pods")
+	require.NoError(t, err)
+	assert.Equal(t, "200", rv, "post-delete SetCheckpoint value should flush")
+}
+
 func TestCheckpointerDeleteNonExistent(t *testing.T) {
 	client := storagetest.NewInMemoryClient(component.KindReceiver, component.MustNewID("test"), "test")
 	checkpointer := New(client, zap.NewNop())
@@ -413,4 +501,39 @@ func TestCheckpointerAlreadySeenUnparseableRV(t *testing.T) {
 	seen, err := cp.AlreadySeen("not-a-number", "default")
 	require.Error(t, err, "unparseable RV must surface a parse error")
 	assert.False(t, seen, "unparseable RV must not be marked seen")
+}
+
+type blockingSetClient struct {
+	storage.Client
+
+	setStarted chan struct{}
+	setRelease chan struct{}
+	startOnce  sync.Once
+	release    sync.Once
+}
+
+func newBlockingSetClient(client storage.Client) *blockingSetClient {
+	return &blockingSetClient{
+		Client:     client,
+		setStarted: make(chan struct{}),
+		setRelease: make(chan struct{}),
+	}
+}
+
+func (c *blockingSetClient) Set(ctx context.Context, key string, value []byte) error {
+	c.startOnce.Do(func() {
+		close(c.setStarted)
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.setRelease:
+		return c.Client.Set(ctx, key, value)
+	}
+}
+
+func (c *blockingSetClient) releaseSet() {
+	c.release.Do(func() {
+		close(c.setRelease)
+	})
 }

--- a/internal/k8sinventory/watch/observer.go
+++ b/internal/k8sinventory/watch/observer.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
+	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -28,8 +28,12 @@ import (
 )
 
 const (
-	defaultResourceVersion    = "1"
-	defaultCheckpointInterval = 5 * time.Second
+	defaultResourceVersion       = "1"
+	defaultCheckpointInterval    = 5 * time.Second
+	resourceVersionRetryInterval = 5 * time.Second
+	resourceVersionRetryCap      = 60 * time.Second
+	resourceVersionRetryFactor   = 2
+	resourceVersionRetryJitter   = 0.2
 )
 
 type Config struct {
@@ -45,7 +49,8 @@ type Observer struct {
 	client dynamic.Interface
 	logger *zap.Logger
 
-	handleWatchEventFunc func(event *apiWatch.Event)
+	handleWatchEventFunc        func(event *apiWatch.Event)
+	resourceVersionRetryBackoff wait.Backoff
 }
 
 func New(client dynamic.Interface, config Config, logger *zap.Logger, storageClient storage.Client, handleWatchEventFunc func(event *apiWatch.Event)) (*Observer, error) {
@@ -54,6 +59,13 @@ func New(client dynamic.Interface, config Config, logger *zap.Logger, storageCli
 		config:               config,
 		logger:               logger,
 		handleWatchEventFunc: handleWatchEventFunc,
+		resourceVersionRetryBackoff: wait.Backoff{
+			Duration: resourceVersionRetryInterval,
+			Factor:   resourceVersionRetryFactor,
+			Jitter:   resourceVersionRetryJitter,
+			Cap:      resourceVersionRetryCap,
+			Steps:    math.MaxInt32,
+		},
 	}
 
 	// Initialize checkpointer if a storage client is provided
@@ -180,7 +192,7 @@ func (o *Observer) startWatch(ctx context.Context, resource dynamic.ResourceInte
 			initialListRV = ""
 		} else {
 			var err error
-			resourceVersion, err = o.getResourceVersion(newCtx, resource, namespace)
+			resourceVersion, err = o.getResourceVersionWithRetry(newCtx, resource, namespace, stopperChan)
 			if err != nil {
 				o.logger.Error("could not retrieve a resourceVersion",
 					zap.String("resource", o.config.Gvr.String()),
@@ -212,6 +224,42 @@ func (o *Observer) startWatch(ctx context.Context, resource dynamic.ResourceInte
 			}
 		}
 	}, 0)
+}
+
+// getResourceVersionWithRetry retries getResourceVersion using an exponential
+// backoff until it succeeds, the context is cancelled, or the stopper is signaled.
+func (o *Observer) getResourceVersionWithRetry(ctx context.Context, resource dynamic.ResourceInterface, namespace string, stopperChan chan struct{}) (string, error) {
+	backoff := o.resourceVersionRetryBackoff
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-stopperChan:
+			return "", context.Canceled
+		default:
+		}
+
+		resourceVersion, err := o.getResourceVersion(ctx, resource, namespace)
+		if err == nil {
+			return resourceVersion, nil
+		}
+
+		o.logger.Warn("could not retrieve a resourceVersion, will retry",
+			zap.String("resource", o.config.Gvr.String()),
+			zap.String("namespace", namespace),
+			zap.Error(err))
+
+		timer := time.NewTimer(backoff.Step())
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-stopperChan:
+			timer.Stop()
+			return "", context.Canceled
+		case <-timer.C:
+		}
+	}
 }
 
 // sendInitialState sends the current state of objects as synthetic Added events.
@@ -325,21 +373,17 @@ func (o *Observer) doWatch(ctx context.Context, resourceVersion, _ string, watch
 	for {
 		select {
 		case data, ok := <-res:
-			if data.Type == apiWatch.Error {
-				errObject := apierrors.FromObject(data.Object)
-				//nolint:errorlint
-				if errObject.(*apierrors.StatusError).ErrStatus.Code == http.StatusGone {
-					o.logger.Info("received a 410, grabbing new resource version",
-						zap.Any("data", data))
-					// we received a 410 so we need to restart
-					return false
-				}
-			}
-
 			if !ok {
 				o.logger.Warn("Watch channel closed unexpectedly",
 					zap.String("resource", o.config.Gvr.String()))
 				return true
+			}
+
+			if isExpiredResourceVersionEvent(data) {
+				o.logger.Info("received a 410, grabbing new resource version",
+					zap.Any("data", data))
+				// we received a 410 so we need to restart
+				return false
 			}
 
 			if o.config.Exclude[data.Type] {
@@ -374,12 +418,21 @@ func (o *Observer) doWatch(ctx context.Context, resourceVersion, _ string, watch
 	}
 }
 
+func isExpiredResourceVersionEvent(data apiWatch.Event) bool {
+	if data.Type != apiWatch.Error {
+		return false
+	}
+	errObject := apierrors.FromObject(data.Object)
+	return apierrors.IsResourceExpired(errObject) || apierrors.IsGone(errObject)
+}
+
 // fetchListResourceVersion performs a List operation and returns the latest resourceVersion.
 // Returns defaultResourceVersion if the API returns an empty or zero version.
 func (o *Observer) fetchListResourceVersion(ctx context.Context, resource dynamic.ResourceInterface) (string, error) {
 	objects, err := resource.List(ctx, metav1.ListOptions{
 		FieldSelector: o.config.FieldSelector,
 		LabelSelector: o.config.LabelSelector,
+		Limit:         1,
 	})
 	if err != nil {
 		return "", fmt.Errorf("could not perform initial list for watch on %s, %w", o.config.Gvr.String(), err)

--- a/internal/k8sinventory/watch/observer.go
+++ b/internal/k8sinventory/watch/observer.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
+	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -28,8 +28,12 @@ import (
 )
 
 const (
-	defaultResourceVersion    = "1"
-	defaultCheckpointInterval = 5 * time.Second
+	defaultResourceVersion       = "1"
+	defaultCheckpointInterval    = 5 * time.Second
+	resourceVersionRetryInterval = 5 * time.Second
+	resourceVersionRetryCap      = 60 * time.Second
+	resourceVersionRetryFactor   = 2
+	resourceVersionRetryJitter   = 0.2
 )
 
 type Config struct {
@@ -45,7 +49,8 @@ type Observer struct {
 	client dynamic.Interface
 	logger *zap.Logger
 
-	handleWatchEventFunc func(event *apiWatch.Event)
+	handleWatchEventFunc        func(event *apiWatch.Event)
+	resourceVersionRetryBackoff wait.Backoff
 }
 
 func New(client dynamic.Interface, config Config, logger *zap.Logger, storageClient storage.Client, handleWatchEventFunc func(event *apiWatch.Event)) (*Observer, error) {
@@ -54,6 +59,13 @@ func New(client dynamic.Interface, config Config, logger *zap.Logger, storageCli
 		config:               config,
 		logger:               logger,
 		handleWatchEventFunc: handleWatchEventFunc,
+		resourceVersionRetryBackoff: wait.Backoff{
+			Duration: resourceVersionRetryInterval,
+			Factor:   resourceVersionRetryFactor,
+			Jitter:   resourceVersionRetryJitter,
+			Cap:      resourceVersionRetryCap,
+			Steps:    math.MaxInt32,
+		},
 	}
 
 	// Initialize checkpointer if a storage client is provided
@@ -180,7 +192,7 @@ func (o *Observer) startWatch(ctx context.Context, resource dynamic.ResourceInte
 			initialListRV = ""
 		} else {
 			var err error
-			resourceVersion, err = o.getResourceVersion(newCtx, resource, namespace)
+			resourceVersion, err = o.getResourceVersionWithRetry(newCtx, resource, namespace, stopperChan)
 			if err != nil {
 				o.logger.Error("could not retrieve a resourceVersion",
 					zap.String("resource", o.config.Gvr.String()),
@@ -212,6 +224,42 @@ func (o *Observer) startWatch(ctx context.Context, resource dynamic.ResourceInte
 			}
 		}
 	}, 0)
+}
+
+// getResourceVersionWithRetry retries getResourceVersion using an exponential
+// backoff until it succeeds, the context is cancelled, or the stopper is signaled.
+func (o *Observer) getResourceVersionWithRetry(ctx context.Context, resource dynamic.ResourceInterface, namespace string, stopperChan chan struct{}) (string, error) {
+	backoff := o.resourceVersionRetryBackoff
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-stopperChan:
+			return "", context.Canceled
+		default:
+		}
+
+		resourceVersion, err := o.getResourceVersion(ctx, resource, namespace)
+		if err == nil {
+			return resourceVersion, nil
+		}
+
+		o.logger.Warn("could not retrieve a resourceVersion, will retry",
+			zap.String("resource", o.config.Gvr.String()),
+			zap.String("namespace", namespace),
+			zap.Error(err))
+
+		timer := time.NewTimer(backoff.Step())
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-stopperChan:
+			timer.Stop()
+			return "", context.Canceled
+		case <-timer.C:
+		}
+	}
 }
 
 // sendInitialState sends the current state of objects as synthetic Added events.
@@ -327,21 +375,17 @@ func (o *Observer) doWatch(ctx context.Context, resourceVersion, _ string, watch
 	for {
 		select {
 		case data, ok := <-res:
-			if data.Type == apiWatch.Error {
-				errObject := apierrors.FromObject(data.Object)
-				//nolint:errorlint
-				if errObject.(*apierrors.StatusError).ErrStatus.Code == http.StatusGone {
-					o.logger.Info("received a 410, grabbing new resource version",
-						zap.Any("data", data))
-					// we received a 410 so we need to restart
-					return false
-				}
-			}
-
 			if !ok {
 				o.logger.Warn("Watch channel closed unexpectedly",
 					zap.String("resource", o.config.Gvr.String()))
 				return true
+			}
+
+			if isExpiredResourceVersionEvent(data) {
+				o.logger.Info("received a 410, grabbing new resource version",
+					zap.Any("data", data))
+				// we received a 410 so we need to restart
+				return false
 			}
 
 			if o.config.Exclude[data.Type] {
@@ -376,12 +420,21 @@ func (o *Observer) doWatch(ctx context.Context, resourceVersion, _ string, watch
 	}
 }
 
+func isExpiredResourceVersionEvent(data apiWatch.Event) bool {
+	if data.Type != apiWatch.Error {
+		return false
+	}
+	errObject := apierrors.FromObject(data.Object)
+	return apierrors.IsResourceExpired(errObject) || apierrors.IsGone(errObject)
+}
+
 // fetchListResourceVersion performs a List operation and returns the latest resourceVersion.
 // Returns defaultResourceVersion if the API returns an empty or zero version.
 func (o *Observer) fetchListResourceVersion(ctx context.Context, resource dynamic.ResourceInterface) (string, error) {
 	objects, err := resource.List(ctx, metav1.ListOptions{
 		FieldSelector: o.config.FieldSelector,
 		LabelSelector: o.config.LabelSelector,
+		Limit:         1,
 	})
 	if err != nil {
 		return "", fmt.Errorf("could not perform initial list for watch on %s, %w", o.config.Gvr.String(), err)

--- a/internal/k8sinventory/watch/observer_test.go
+++ b/internal/k8sinventory/watch/observer_test.go
@@ -6,6 +6,7 @@ package watch
 import (
 	"context"
 	"errors"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory/checkpoint"
 )
+
+func setResourceVersionRetryDelay(observer *Observer, delay time.Duration) {
+	observer.resourceVersionRetryBackoff.Duration = delay
+	observer.resourceVersionRetryBackoff.Jitter = 0
+}
 
 func TestObserver(t *testing.T) {
 	mockClient := newMockDynamicClient()
@@ -368,6 +374,201 @@ func TestObserverInitialStateNoObjects(t *testing.T) {
 	wg.Wait()
 }
 
+func TestObserverRetriesResourceVersionRelistPastBackoffCap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+
+	listCalls := 0
+	fakeClient.PrependReactor("list", "pods", func(_ k8s_testing.Action) (bool, runtime.Object, error) {
+		listCalls++
+		switch listCalls {
+		case 1:
+			return true, podListWithResourceVersion("100"), nil
+		case 2, 3, 4, 5:
+			return true, nil, errors.New("transient list error")
+		default:
+			return true, podListWithResourceVersion("200"), nil
+		}
+	})
+
+	watchResourceVersions := make(chan string, 2)
+	watchCalls := 0
+	fakeClient.PrependWatchReactor("pods", func(action k8s_testing.Action) (bool, apiWatch.Interface, error) {
+		watchCalls++
+		watchAction := action.(k8s_testing.WatchAction)
+		watchResourceVersions <- watchAction.GetWatchRestrictions().ResourceVersion
+
+		watcher := apiWatch.NewFakeWithChanSize(1, false)
+		switch watchCalls {
+		case 1:
+			go watcher.Error(resourceVersionExpiredStatus())
+		case 2:
+			go watcher.Add(generatePod("pod-after-relist", "default", nil, "201"))
+		}
+		return true, watcher, nil
+	})
+
+	cfg := Config{
+		Config: k8sinventory.Config{
+			Gvr:        schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Namespaces: []string{"default"},
+		},
+	}
+
+	receivedEventsChan := make(chan *apiWatch.Event, 1)
+	obs, err := New(mockDynamicClient{client: fakeClient}, cfg, zap.NewNop(), nil, func(event *apiWatch.Event) {
+		receivedEventsChan <- event
+	})
+	require.NoError(t, err)
+	setResourceVersionRetryDelay(obs, time.Millisecond)
+	obs.resourceVersionRetryBackoff.Cap = 2 * time.Millisecond
+
+	wg := sync.WaitGroup{}
+	stopChan, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+
+	select {
+	case event := <-receivedEventsChan:
+		assert.Equal(t, apiWatch.Added, event.Type)
+	case <-time.After(2 * time.Second):
+		close(stopChan)
+		wg.Wait()
+		t.Fatal("timeout waiting for event after relist retry")
+	}
+
+	close(stopChan)
+	wg.Wait()
+
+	assert.Equal(t, "100", <-watchResourceVersions)
+	assert.Equal(t, "200", <-watchResourceVersions)
+	assert.GreaterOrEqual(t, listCalls, 6)
+}
+
+func TestResourceVersionRetryStopsPromptly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{gvr: "PodList"},
+	)
+
+	listCalled := make(chan struct{}, 1)
+	fakeClient.PrependReactor("list", "pods", func(_ k8s_testing.Action) (bool, runtime.Object, error) {
+		listCalled <- struct{}{}
+		return true, nil, errors.New("persistent list error")
+	})
+
+	obs, err := New(
+		mockDynamicClient{client: fakeClient},
+		Config{Config: k8sinventory.Config{Gvr: gvr}},
+		zap.NewNop(),
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	setResourceVersionRetryDelay(obs, time.Hour)
+
+	stopperChan := make(chan struct{})
+	retryDone := make(chan error, 1)
+	go func() {
+		_, err := obs.getResourceVersionWithRetry(
+			t.Context(),
+			fakeClient.Resource(gvr),
+			"",
+			stopperChan,
+		)
+		retryDone <- err
+	}()
+
+	<-listCalled
+	close(stopperChan)
+
+	select {
+	case err := <-retryDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("resourceVersion retry did not stop promptly")
+	}
+}
+
+func TestObserverBypassesPersistedResourceVersionAfter410(t *testing.T) {
+	storageClient := storagetest.NewInMemoryClient(component.KindReceiver, component.MustNewID("test"), "test")
+	cp := checkpoint.New(storageClient, zap.NewNop())
+	require.NoError(t, cp.SetCheckpoint(t.Context(), "default", "pods", "50"))
+	require.NoError(t, cp.Flush(t.Context()))
+
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+	fakeClient.PrependReactor("list", "pods", func(_ k8s_testing.Action) (bool, runtime.Object, error) {
+		return true, podListWithResourceVersion("200"), nil
+	})
+
+	watchResourceVersions := make(chan string, 2)
+	watchCalls := 0
+	fakeClient.PrependWatchReactor("pods", func(action k8s_testing.Action) (bool, apiWatch.Interface, error) {
+		watchCalls++
+		watchAction := action.(k8s_testing.WatchAction)
+		watchResourceVersions <- watchAction.GetWatchRestrictions().ResourceVersion
+
+		watcher := apiWatch.NewFakeWithChanSize(1, false)
+		switch watchCalls {
+		case 1:
+			go watcher.Error(resourceVersionExpiredStatus())
+		case 2:
+			go watcher.Add(generatePod("pod-after-relist", "default", nil, "201"))
+		}
+		return true, watcher, nil
+	})
+
+	cfg := Config{
+		Config: k8sinventory.Config{
+			Gvr:        schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Namespaces: []string{"default"},
+		},
+	}
+
+	receivedEventsChan := make(chan *apiWatch.Event, 1)
+	obs, err := New(mockDynamicClient{client: fakeClient}, cfg, zap.NewNop(), storageClient, func(event *apiWatch.Event) {
+		receivedEventsChan <- event
+	})
+	require.NoError(t, err)
+	setResourceVersionRetryDelay(obs, 10*time.Millisecond)
+
+	wg := sync.WaitGroup{}
+	stopChan, err := obs.Start(t.Context(), &wg)
+	require.NoError(t, err)
+
+	select {
+	case event := <-receivedEventsChan:
+		assert.Equal(t, apiWatch.Added, event.Type)
+	case <-time.After(2 * time.Second):
+		close(stopChan)
+		wg.Wait()
+		t.Fatal("timeout waiting for event after stale checkpoint was deleted")
+	}
+
+	close(stopChan)
+	wg.Wait()
+
+	assert.Equal(t, "50", <-watchResourceVersions)
+	assert.Equal(t, "200", <-watchResourceVersions)
+}
+
+func TestObserverNonStatusWatchErrorDoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		assert.False(t, isExpiredResourceVersionEvent(apiWatch.Event{
+			Type:   apiWatch.Error,
+			Object: generatePod("not-a-status", "default", nil, "1"),
+		}))
+	})
+}
+
 // TestSendInitialStateReturnsListRV verifies that sendInitialState returns the
 // list's own ResourceVersion, not just the highest individual object RV.
 // The list RV is always >= any individual object RV and is the correct starting
@@ -637,6 +838,21 @@ func generatePod(name, namespace string, labels map[string]any, resourceVersion 
 
 	pod.SetResourceVersion(resourceVersion)
 	return &pod
+}
+
+func podListWithResourceVersion(resourceVersion string) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetResourceVersion(resourceVersion)
+	return list
+}
+
+func resourceVersionExpiredStatus() *v1.Status {
+	return &v1.Status{
+		Status:  v1.StatusFailure,
+		Reason:  v1.StatusReasonExpired,
+		Message: "The resourceVersion for the provided watch is too old.",
+		Code:    http.StatusGone,
+	}
 }
 
 func TestObserverWithPersistence(t *testing.T) {


### PR DESCRIPTION
#### Description

See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49962 for more details.

The watcher quits with an error `could not retrieve a resourceVersion` after receiving HTTP401 with expired local RV but fails when re-lists the objects. After that, the event emitting stops.

This PR makes the watcher to retry when fails to list objects with an interval. 

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49962

#### Authorship

- [x] I, a human, wrote this pull request description myself.

