### PR TITLE
[chore] Un-embed remaining config structs in scrapers and nested configs

### DIFF
--- a/exporter/sematextexporter/config.go
+++ b/exporter/sematextexporter/config.go
@@ -34,9 +34,9 @@ type Config struct {
 	// - US
 	Region string `mapstructure:"region"`
 	// MetricsConfig defines the configuration specific to metrics
-	MetricsConfig `mapstructure:"metrics"`
+	MetricsConfig MetricsConfig `mapstructure:"metrics"`
 	// LogsConfig defines the configuration specific to logs
-	LogsConfig `mapstructure:"logs"`
+	LogsConfig LogsConfig `mapstructure:"logs"`
 }
 type MetricsConfig struct {
 	// App token is the token of Sematext Monitoring App to which you want to send the metrics.
@@ -81,12 +81,12 @@ func (cfg *Config) Validate() error {
 	}
 
 	if strings.EqualFold(cfg.Region, euRegion) {
-		cfg.MetricsEndpoint = euMetricsEndpoint
-		cfg.LogsEndpoint = euLogsEndpoint
+		cfg.MetricsConfig.MetricsEndpoint = euMetricsEndpoint
+		cfg.LogsConfig.LogsEndpoint = euLogsEndpoint
 	}
 	if strings.EqualFold(cfg.Region, usRegion) {
-		cfg.MetricsEndpoint = usMetricsEndpoint
-		cfg.LogsEndpoint = usLogsEndpoint
+		cfg.MetricsConfig.MetricsEndpoint = usMetricsEndpoint
+		cfg.LogsConfig.LogsEndpoint = usLogsEndpoint
 	}
 
 	return nil

--- a/exporter/sematextexporter/config.schema.yaml
+++ b/exporter/sematextexporter/config.schema.yaml
@@ -19,6 +19,12 @@ $defs:
         type: integer
 type: object
 properties:
+  logs:
+    description: LogsConfig defines the configuration specific to logs
+    $ref: logs_config
+  metrics:
+    description: MetricsConfig defines the configuration specific to metrics
+    $ref: metrics_config
   region:
     description: 'Region specifies the Sematext region the user is operating in Options: - EU - US'
     type: string
@@ -29,5 +35,3 @@ properties:
     $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config
 allOf:
   - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
-  - $ref: metrics_config
-  - $ref: logs_config

--- a/exporter/sematextexporter/factory.go
+++ b/exporter/sematextexporter/factory.go
@@ -78,9 +78,9 @@ func createMetricsExporter(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Sematext HTTP writer: %w", err)
 	}
-	schema, found := common.MetricsSchemata[cfg.MetricsSchema]
+	schema, found := common.MetricsSchemata[cfg.MetricsConfig.MetricsSchema]
 	if !found {
-		return nil, fmt.Errorf("schema '%s' not recognized", cfg.MetricsSchema)
+		return nil, fmt.Errorf("schema '%s' not recognized", cfg.MetricsConfig.MetricsSchema)
 	}
 
 	expConfig := otel2influx.DefaultOtelMetricsToLineProtocolConfig()

--- a/exporter/sematextexporter/writer.go
+++ b/exporter/sematextexporter/writer.go
@@ -60,8 +60,8 @@ func newSematextHTTPWriter(logger common.Logger, config *Config, telemetrySettin
 		},
 		telemetrySettings: telemetrySettings,
 		writeURL:          writeURL,
-		payloadMaxLines:   config.PayloadMaxLines,
-		payloadMaxBytes:   config.PayloadMaxBytes,
+		payloadMaxLines:   config.MetricsConfig.PayloadMaxLines,
+		payloadMaxBytes:   config.MetricsConfig.PayloadMaxBytes,
 		logger:            logger,
 		hostname:          hostname,
 		token:             config.MetricsConfig.AppToken,
@@ -69,7 +69,7 @@ func newSematextHTTPWriter(logger common.Logger, config *Config, telemetrySettin
 }
 
 func composeWriteURL(config *Config) (string, error) {
-	writeURL, err := url.Parse(config.MetricsEndpoint)
+	writeURL, err := url.Parse(config.MetricsConfig.MetricsEndpoint)
 	if err != nil {
 		return "", err
 	}

--- a/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/config.go
+++ b/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/config.go
@@ -10,6 +10,6 @@ import (
 
 // Config holds configuration for the interfaces scraper
 type Config struct {
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
-	Device                        connection.DeviceConfig `mapstructure:"-"` // Passed from receiver config
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	Device               connection.DeviceConfig       `mapstructure:"-"` // Passed from receiver config
 }

--- a/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/factory_test.go
+++ b/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/factory_test.go
@@ -30,9 +30,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NotNil(t, config)
 
 	// Verify default metrics are enabled
-	assert.True(t, config.Metrics.SystemNetworkIo.Enabled)
-	assert.True(t, config.Metrics.SystemNetworkErrors.Enabled)
-	assert.True(t, config.Metrics.SystemNetworkInterfaceStatus.Enabled)
+	assert.True(t, config.MetricsBuilderConfig.Metrics.SystemNetworkIo.Enabled)
+	assert.True(t, config.MetricsBuilderConfig.Metrics.SystemNetworkErrors.Enabled)
+	assert.True(t, config.MetricsBuilderConfig.Metrics.SystemNetworkInterfaceStatus.Enabled)
 }
 
 func TestFactory_ConfigWithDevice(t *testing.T) {
@@ -65,7 +65,7 @@ func TestConfig_AllMetricsEnabled(t *testing.T) {
 	}
 
 	// Verify all interface metrics are enabled by default
-	metrics := config.Metrics
+	metrics := config.MetricsBuilderConfig.Metrics
 	assert.True(t, metrics.SystemNetworkIo.Enabled)
 	assert.True(t, metrics.SystemNetworkErrors.Enabled)
 	assert.True(t, metrics.SystemNetworkPacketDropped.Enabled)
@@ -79,13 +79,13 @@ func TestConfig_DisableMetrics(t *testing.T) {
 	}
 
 	// Test disabling specific metrics
-	config.Metrics.SystemNetworkIo.Enabled = false
-	config.Metrics.SystemNetworkErrors.Enabled = false
+	config.MetricsBuilderConfig.Metrics.SystemNetworkIo.Enabled = false
+	config.MetricsBuilderConfig.Metrics.SystemNetworkErrors.Enabled = false
 
-	assert.False(t, config.Metrics.SystemNetworkIo.Enabled)
-	assert.False(t, config.Metrics.SystemNetworkErrors.Enabled)
+	assert.False(t, config.MetricsBuilderConfig.Metrics.SystemNetworkIo.Enabled)
+	assert.False(t, config.MetricsBuilderConfig.Metrics.SystemNetworkErrors.Enabled)
 	// Others should still be enabled
-	assert.True(t, config.Metrics.SystemNetworkInterfaceStatus.Enabled)
+	assert.True(t, config.MetricsBuilderConfig.Metrics.SystemNetworkInterfaceStatus.Enabled)
 }
 
 func TestDeviceConfig_Structure(t *testing.T) {
@@ -198,7 +198,7 @@ func TestCreateDefaultConfig_AllInterfaceMetrics(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	// Verify all 5 interface metrics are enabled
-	metrics := cfg.Metrics
+	metrics := cfg.MetricsBuilderConfig.Metrics
 	assert.True(t, metrics.SystemNetworkIo.Enabled)
 	assert.True(t, metrics.SystemNetworkErrors.Enabled)
 	assert.True(t, metrics.SystemNetworkPacketDropped.Enabled)

--- a/receiver/ciscoosreceiver/internal/scraper/systemscraper/config.go
+++ b/receiver/ciscoosreceiver/internal/scraper/systemscraper/config.go
@@ -10,7 +10,7 @@ import (
 
 // Config holds configuration for the system scraper.
 type Config struct {
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	// Device is passed from the main receiver config (not from YAML)
 	Device connection.DeviceConfig `mapstructure:"-"`
 }

--- a/receiver/ciscoosreceiver/internal/scraper/systemscraper/factory_test.go
+++ b/receiver/ciscoosreceiver/internal/scraper/systemscraper/factory_test.go
@@ -30,7 +30,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NotNil(t, config)
 
 	// Verify default metrics are enabled
-	assert.True(t, config.Metrics.CiscoDeviceUp.Enabled)
+	assert.True(t, config.MetricsBuilderConfig.Metrics.CiscoDeviceUp.Enabled)
 }
 
 func TestFactory_CreateScraperMethod(t *testing.T) {
@@ -102,11 +102,11 @@ func TestConfig_MetricsConfiguration(t *testing.T) {
 	}
 
 	// Verify metrics are configurable
-	assert.True(t, config.Metrics.CiscoDeviceUp.Enabled)
+	assert.True(t, config.MetricsBuilderConfig.Metrics.CiscoDeviceUp.Enabled)
 
 	// Test disabling metrics
-	config.Metrics.CiscoDeviceUp.Enabled = false
-	assert.False(t, config.Metrics.CiscoDeviceUp.Enabled)
+	config.MetricsBuilderConfig.Metrics.CiscoDeviceUp.Enabled = false
+	assert.False(t, config.MetricsBuilderConfig.Metrics.CiscoDeviceUp.Enabled)
 }
 
 func TestDeviceConfig_Structure(t *testing.T) {
@@ -179,6 +179,6 @@ func TestCreateDefaultConfig_MetricsEnabled(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	// Verify all default metrics are enabled
-	metrics := cfg.Metrics
+	metrics := cfg.MetricsBuilderConfig.Metrics
 	assert.True(t, metrics.CiscoDeviceUp.Enabled)
 }

--- a/receiver/ciscoosreceiver/internal/scraper/systemscraper/system_scraper.go
+++ b/receiver/ciscoosreceiver/internal/scraper/systemscraper/system_scraper.go
@@ -31,7 +31,7 @@ type systemScraper struct {
 
 func (s *systemScraper) Start(_ context.Context, _ component.Host) error {
 	s.logger.Info("Starting system scraper with metric configuration",
-		zap.Bool("device_up_enabled", s.config.Metrics.CiscoDeviceUp.Enabled))
+		zap.Bool("device_up_enabled", s.config.MetricsBuilderConfig.Metrics.CiscoDeviceUp.Enabled))
 
 	s.mb = metadata.NewMetricsBuilder(s.config.MetricsBuilderConfig, scraper.Settings{
 		ID:                component.MustNewIDWithName(metadata.Type.String(), "system"),

--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -20,8 +20,8 @@ import (
 
 // Config defines configuration for HostMetrics receiver.
 type Config struct {
-	scraperhelper.ControllerConfig `mapstructure:",squash"`
-	Scrapers                       map[component.Type]component.Config `mapstructure:"-"`
+	ControllerConfig scraperhelper.ControllerConfig      `mapstructure:",squash"`
+	Scrapers         map[component.Type]component.Config `mapstructure:"-"`
 	// RootPath is the host's root directory (linux only).
 	RootPath string `mapstructure:"root_path"`
 

--- a/receiver/hostmetricsreceiver/integration_test.go
+++ b/receiver/hostmetricsreceiver/integration_test.go
@@ -33,7 +33,7 @@ func Test_ProcessScrape(t *testing.T) {
 		scraperinttest.WithCustomConfig(
 			func(_ *testing.T, cfg component.Config, _ *scraperinttest.ContainerInfo) {
 				rCfg := cfg.(*Config)
-				rCfg.CollectionInterval = time.Second
+				rCfg.ControllerConfig.CollectionInterval = time.Second
 				f := processscraper.NewFactory()
 				pCfg := f.CreateDefaultConfig().(*processscraper.Config)
 				pCfg.MuteProcessExeError = true
@@ -68,7 +68,7 @@ func Test_ProcessScrapeWithCustomRootPath(t *testing.T) {
 			func(_ *testing.T, cfg component.Config, _ *scraperinttest.ContainerInfo) {
 				rootPath := filepath.Join("testdata", "e2e")
 				rCfg := cfg.(*Config)
-				rCfg.CollectionInterval = time.Second
+				rCfg.ControllerConfig.CollectionInterval = time.Second
 				rCfg.RootPath = rootPath
 				f := processscraper.NewFactory()
 				pCfg := f.CreateDefaultConfig().(*processscraper.Config)
@@ -98,7 +98,7 @@ func Test_ProcessScrapeWithBadRootPathAndEnvVar(t *testing.T) {
 		scraperinttest.WithCustomConfig(
 			func(_ *testing.T, cfg component.Config, _ *scraperinttest.ContainerInfo) {
 				rCfg := cfg.(*Config)
-				rCfg.CollectionInterval = time.Second
+				rCfg.ControllerConfig.CollectionInterval = time.Second
 				rCfg.RootPath = badRootPath
 				f := processscraper.NewFactory()
 				pCfg := f.CreateDefaultConfig().(*processscraper.Config)

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/config.go
@@ -9,5 +9,5 @@ import (
 
 // Config relating to CPU Metric Scraper.
 type Config struct {
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -73,7 +73,7 @@ func (s *cpuScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
-	if s.config.Metrics.SystemCPUPhysicalCount.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.SystemCPUPhysicalCount.Enabled {
 		numCPU, err := cpu.Counts(false)
 		if err != nil {
 			return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
@@ -81,7 +81,7 @@ func (s *cpuScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.mb.RecordSystemCPUPhysicalCountDataPoint(now, int64(numCPU))
 	}
 
-	if s.config.Metrics.SystemCPULogicalCount.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.SystemCPULogicalCount.Enabled {
 		numCPU, err := cpu.Counts(true)
 		if err != nil {
 			return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
@@ -89,7 +89,7 @@ func (s *cpuScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.mb.RecordSystemCPULogicalCountDataPoint(now, int64(numCPU))
 	}
 
-	if s.config.Metrics.SystemCPUFrequency.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.SystemCPUFrequency.Enabled {
 		cpuInfos, err := s.getCPUInfo()
 		if err != nil {
 			return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/config.go
@@ -11,7 +11,7 @@ import (
 // Config relating to Disk Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows to customize scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 
 	// Include specifies a filter on the devices that should be included from the generated metrics.
 	// Exclude specifies a filter on the devices that should be excluded from the generated metrics.
@@ -21,7 +21,7 @@ type Config struct {
 }
 
 type MatchConfig struct {
-	filterset.Config `mapstructure:",squash"`
+	Config filterset.Config `mapstructure:",squash"`
 
 	Devices []string `mapstructure:"devices"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -80,7 +80,7 @@ func TestScrape(t *testing.T) {
 			name: "Disable one metric",
 			config: (func() *Config {
 				config := Config{MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig()}
-				config.Metrics.SystemDiskIo.Enabled = false
+				config.MetricsBuilderConfig.Metrics.SystemDiskIo.Enabled = false
 				return &config
 			})(),
 			expectMetrics: metricsLen - 1,

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
@@ -13,7 +13,7 @@ import (
 // Config relating to FileSystem Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows to customize scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 
 	// IncludeVirtualFS will also capture filesystems such as tmpfs, ramfs
 	// and other filesystem types that do no have an associated physical device.
@@ -40,19 +40,19 @@ type Config struct {
 }
 
 type DeviceMatchConfig struct {
-	filterset.Config `mapstructure:",squash"`
+	Config filterset.Config `mapstructure:",squash"`
 
 	Devices []string `mapstructure:"devices"`
 }
 
 type FSTypeMatchConfig struct {
-	filterset.Config `mapstructure:",squash"`
+	Config filterset.Config `mapstructure:",squash"`
 
 	FSTypes []string `mapstructure:"fs_types"`
 }
 
 type MountPointMatchConfig struct {
-	filterset.Config `mapstructure:",squash"`
+	Config filterset.Config `mapstructure:",squash"`
 
 	MountPoints []string `mapstructure:"mount_points"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
@@ -12,5 +12,5 @@ type Config struct {
 	// If true, metrics will be average load per cpu
 	CPUAverage bool `mapstructure:"cpu_average"`
 	// MetricsBuilderConfig allows to customize scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/config.go
@@ -9,5 +9,5 @@ import (
 
 // Config relating to Memory Metric Scraper.
 type Config struct {
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/config.go
@@ -10,7 +10,7 @@ import (
 
 // Config relating to Network Metric Scraper.
 type Config struct {
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	// Include specifies a filter on the network interfaces that should be included from the generated metrics.
 	Include MatchConfig `mapstructure:"include"`
 	// Exclude specifies a filter on the network interfaces that should be excluded from the generated metrics.
@@ -18,7 +18,7 @@ type Config struct {
 }
 
 type MatchConfig struct {
-	filterset.Config `mapstructure:",squash"`
+	Config filterset.Config `mapstructure:",squash"`
 
 	Interfaces []string `mapstructure:"interfaces"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
@@ -33,7 +33,7 @@ var allTCPStates = []string{
 }
 
 func (s *networkScraper) recordNetworkConntrackMetrics(ctx context.Context) error {
-	if !s.config.Metrics.SystemNetworkConntrackCount.Enabled && !s.config.Metrics.SystemNetworkConntrackMax.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.SystemNetworkConntrackCount.Enabled && !s.config.MetricsBuilderConfig.Metrics.SystemNetworkConntrackMax.Enabled {
 		return nil
 	}
 	now := pcommon.NewTimestampFromTime(time.Now())

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -154,7 +154,7 @@ func (s *networkScraper) recordNetworkIOMetric(now pcommon.Timestamp, ioCounters
 }
 
 func (s *networkScraper) recordNetworkConnectionsMetrics(ctx context.Context) error {
-	if !s.config.Metrics.SystemNetworkConnections.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.SystemNetworkConnections.Enabled {
 		return nil
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -129,7 +129,7 @@ func TestScrape(t *testing.T) {
 			name: "Connections metrics is disabled",
 			config: func() *Config {
 				cfg := Config{MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig()}
-				cfg.Metrics.SystemNetworkConnections.Enabled = false
+				cfg.MetricsBuilderConfig.Metrics.SystemNetworkConnections.Enabled = false
 				return &cfg
 			}(),
 			connectionsFunc: func(context.Context, string) ([]net.ConnectionStat, error) {

--- a/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/config.go
@@ -10,5 +10,5 @@ import (
 // Config relating to NFS Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows to customize scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/config.go
@@ -10,5 +10,5 @@ import (
 // Config relating to Paging Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows customizing scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/config.go
@@ -10,5 +10,5 @@ import (
 // Config relating to Processes Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows customizing scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -13,7 +13,7 @@ import (
 // Config relating to Process Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows to customize scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	// Include specifies a filter on the process names that should be included from the generated metrics.
 	// Exclude specifies a filter on the process names that should be excluded from the generated metrics.
 	// If neither `include` or `exclude` are set, process metrics will be generated for all processes.
@@ -56,7 +56,7 @@ type Config struct {
 }
 
 type MatchConfig struct {
-	filterset.Config `mapstructure:",squash"`
+	Config filterset.Config `mapstructure:",squash"`
 
 	Names []string `mapstructure:"names"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -264,7 +264,7 @@ func (s *processScraper) getProcessMetadata(ctx context.Context) ([]*processMeta
 		}
 
 		parentProcessID := int32(0)
-		if s.config.ResourceAttributes.ProcessParentPid.Enabled {
+		if s.config.MetricsBuilderConfig.ResourceAttributes.ProcessParentPid.Enabled {
 			parentProcessID, err = parentPid(ctx, handle, pid)
 			if err != nil {
 				errs.AddPartial(0, fmt.Errorf("error reading parent pid for process %q (pid %v): %w", executable.name, pid, err))
@@ -288,7 +288,7 @@ func (s *processScraper) getProcessMetadata(ctx context.Context) ([]*processMeta
 }
 
 func (s *processScraper) scrapeAndAppendCPUTimeMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle, pid int32) error {
-	if !s.config.Metrics.ProcessCPUTime.Enabled && !s.config.Metrics.ProcessCPUUtilization.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessCPUTime.Enabled && !s.config.MetricsBuilderConfig.Metrics.ProcessCPUUtilization.Enabled {
 		return nil
 	}
 
@@ -297,11 +297,11 @@ func (s *processScraper) scrapeAndAppendCPUTimeMetric(ctx context.Context, now p
 		return err
 	}
 
-	if s.config.Metrics.ProcessCPUTime.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.ProcessCPUTime.Enabled {
 		s.recordCPUTimeMetric(now, times)
 	}
 
-	if !s.config.Metrics.ProcessCPUUtilization.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessCPUUtilization.Enabled {
 		return nil
 	}
 
@@ -314,7 +314,7 @@ func (s *processScraper) scrapeAndAppendCPUTimeMetric(ctx context.Context, now p
 }
 
 func (s *processScraper) scrapeAndAppendMemoryUsageMetrics(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessMemoryUsage.Enabled && !s.config.Metrics.ProcessMemoryVirtual.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessMemoryUsage.Enabled && !s.config.MetricsBuilderConfig.Metrics.ProcessMemoryVirtual.Enabled {
 		return nil
 	}
 
@@ -329,7 +329,7 @@ func (s *processScraper) scrapeAndAppendMemoryUsageMetrics(ctx context.Context, 
 }
 
 func (s *processScraper) scrapeAndAppendMemoryUtilizationMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessMemoryUtilization.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessMemoryUtilization.Enabled {
 		return nil
 	}
 
@@ -344,7 +344,7 @@ func (s *processScraper) scrapeAndAppendMemoryUtilizationMetric(ctx context.Cont
 }
 
 func (s *processScraper) scrapeAndAppendDiskMetrics(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if (!s.config.Metrics.ProcessDiskIo.Enabled && !s.config.Metrics.ProcessDiskOperations.Enabled) || runtime.GOOS == "darwin" {
+	if (!s.config.MetricsBuilderConfig.Metrics.ProcessDiskIo.Enabled && !s.config.MetricsBuilderConfig.Metrics.ProcessDiskOperations.Enabled) || runtime.GOOS == "darwin" {
 		return nil
 	}
 
@@ -365,7 +365,7 @@ func (s *processScraper) scrapeAndAppendDiskMetrics(ctx context.Context, now pco
 }
 
 func (s *processScraper) scrapeAndAppendPagingMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessPagingFaults.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled {
 		return nil
 	}
 
@@ -384,7 +384,7 @@ func (s *processScraper) scrapeAndAppendPagingMetric(ctx context.Context, now pc
 }
 
 func (s *processScraper) scrapeAndAppendThreadsMetrics(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessThreads.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessThreads.Enabled {
 		return nil
 	}
 	threads, err := handle.NumThreadsWithContext(ctx)
@@ -403,7 +403,7 @@ func (s *processScraper) scrapeAndAppendThreadsMetrics(ctx context.Context, now 
 // the implementation may end up needing to change or be separated
 // into individual platform implementations.
 func (s *processScraper) scrapeAndAppendContextSwitchMetrics(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessContextSwitches.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled {
 		return nil
 	}
 
@@ -457,7 +457,7 @@ func (s *processScraper) scrapeAndAppendContextSwitchMetrics(ctx context.Context
 }
 
 func (s *processScraper) scrapeAndAppendOpenFileDescriptorsMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessOpenFileDescriptors.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessOpenFileDescriptors.Enabled {
 		return nil
 	}
 
@@ -472,7 +472,7 @@ func (s *processScraper) scrapeAndAppendOpenFileDescriptorsMetric(ctx context.Co
 }
 
 func (s *processScraper) scrapeAndAppendHandlesMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessHandles.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled {
 		return nil
 	}
 
@@ -487,7 +487,7 @@ func (s *processScraper) scrapeAndAppendHandlesMetric(ctx context.Context, now p
 }
 
 func (s *processScraper) scrapeAndAppendSignalsPendingMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessSignalsPending.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled {
 		return nil
 	}
 
@@ -507,7 +507,7 @@ func (s *processScraper) scrapeAndAppendSignalsPendingMetric(ctx context.Context
 }
 
 func (s *processScraper) scrapeAndAppendUptimeMetric(ctx context.Context, now pcommon.Timestamp, handle processHandle) error {
-	if !s.config.Metrics.ProcessUptime.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.ProcessUptime.Enabled {
 		return nil
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux.go
@@ -16,8 +16,8 @@ import (
 // See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
 // replace this with the generated equivalent once it lands.
 func validatePlatformEnabledMetrics(cfg *Config, logger *zap.Logger) {
-	if cfg.Metrics.ProcessHandles.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled {
 		logger.Warn("process.handles is only supported on Windows; disabling metric on this platform")
-		cfg.Metrics.ProcessHandles.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled = false
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_linux_test.go
@@ -19,11 +19,11 @@ func TestValidatePlatformEnabledMetrics_Linux_LeavesContextSwitchesEnabled(t *te
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessContextSwitches.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, zap.NewNop())
 
-	assert.True(t, cfg.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should remain enabled on Linux")
+	assert.True(t, cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should remain enabled on Linux")
 }
 
 func TestValidatePlatformEnabledMetrics_Linux_DisablesHandles(t *testing.T) {
@@ -33,11 +33,11 @@ func TestValidatePlatformEnabledMetrics_Linux_DisablesHandles(t *testing.T) {
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessHandles.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessHandles.Enabled, "process.handles should be disabled on Linux")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled, "process.handles should be disabled on Linux")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.handles")
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others.go
@@ -16,20 +16,20 @@ import (
 // See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
 // replace this with the generated equivalent once it lands.
 func validatePlatformEnabledMetrics(cfg *Config, logger *zap.Logger) {
-	if cfg.Metrics.ProcessContextSwitches.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled {
 		logger.Warn("process.context_switches is only supported on Linux; disabling metric on this platform")
-		cfg.Metrics.ProcessContextSwitches.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled = false
 	}
-	if cfg.Metrics.ProcessPagingFaults.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled {
 		logger.Warn("process.paging.faults is only supported on Linux; disabling metric on this platform")
-		cfg.Metrics.ProcessPagingFaults.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled = false
 	}
-	if cfg.Metrics.ProcessSignalsPending.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled {
 		logger.Warn("process.signals_pending is only supported on Linux; disabling metric on this platform")
-		cfg.Metrics.ProcessSignalsPending.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled = false
 	}
-	if cfg.Metrics.ProcessHandles.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled {
 		logger.Warn("process.handles is only supported on Windows; disabling metric on this platform")
-		cfg.Metrics.ProcessHandles.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled = false
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_others_test.go
@@ -22,11 +22,11 @@ func TestValidatePlatformEnabledMetrics_Others_DisablesContextSwitches(t *testin
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessContextSwitches.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should be disabled")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should be disabled")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.context_switches")
 }
@@ -38,11 +38,11 @@ func TestValidatePlatformEnabledMetrics_Others_DisablesPagingFaults(t *testing.T
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessPagingFaults.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessPagingFaults.Enabled, "process.paging.faults should be disabled")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled, "process.paging.faults should be disabled")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.paging.faults")
 }
@@ -54,11 +54,11 @@ func TestValidatePlatformEnabledMetrics_Others_DisablesSignalsPending(t *testing
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessSignalsPending.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessSignalsPending.Enabled, "process.signals_pending should be disabled")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled, "process.signals_pending should be disabled")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.signals_pending")
 }
@@ -70,11 +70,11 @@ func TestValidatePlatformEnabledMetrics_Others_DisablesHandles(t *testing.T) {
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessHandles.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessHandles.Enabled, "process.handles should be disabled")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled, "process.handles should be disabled")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.handles")
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_windows.go
@@ -16,16 +16,16 @@ import (
 // See https://github.com/open-telemetry/opentelemetry-collector/issues/15020;
 // replace this with the generated equivalent once it lands.
 func validatePlatformEnabledMetrics(cfg *Config, logger *zap.Logger) {
-	if cfg.Metrics.ProcessContextSwitches.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled {
 		logger.Warn("process.context_switches is only supported on Linux; disabling metric on this platform")
-		cfg.Metrics.ProcessContextSwitches.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled = false
 	}
-	if cfg.Metrics.ProcessPagingFaults.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled {
 		logger.Warn("process.paging.faults is only supported on Linux; disabling metric on this platform")
-		cfg.Metrics.ProcessPagingFaults.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled = false
 	}
-	if cfg.Metrics.ProcessSignalsPending.Enabled {
+	if cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled {
 		logger.Warn("process.signals_pending is only supported on Linux; disabling metric on this platform")
-		cfg.Metrics.ProcessSignalsPending.Enabled = false
+		cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled = false
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/validate_platform_windows_test.go
@@ -22,11 +22,11 @@ func TestValidatePlatformEnabledMetrics_Windows_DisablesContextSwitches(t *testi
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessContextSwitches.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should be disabled on Windows")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessContextSwitches.Enabled, "process.context_switches should be disabled on Windows")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.context_switches")
 }
@@ -38,11 +38,11 @@ func TestValidatePlatformEnabledMetrics_Windows_DisablesPagingFaults(t *testing.
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessPagingFaults.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessPagingFaults.Enabled, "process.paging.faults should be disabled on Windows")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessPagingFaults.Enabled, "process.paging.faults should be disabled on Windows")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.paging.faults")
 }
@@ -54,11 +54,11 @@ func TestValidatePlatformEnabledMetrics_Windows_DisablesSignalsPending(t *testin
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessSignalsPending.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.False(t, cfg.Metrics.ProcessSignalsPending.Enabled, "process.signals_pending should be disabled on Windows")
+	assert.False(t, cfg.MetricsBuilderConfig.Metrics.ProcessSignalsPending.Enabled, "process.signals_pending should be disabled on Windows")
 	assert.Equal(t, 1, logs.Len(), "expected one warning log entry")
 	assert.Contains(t, logs.All()[0].Message, "process.signals_pending")
 }
@@ -70,10 +70,10 @@ func TestValidatePlatformEnabledMetrics_Windows_LeavesHandlesEnabled(t *testing.
 	cfg := &Config{
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.ProcessHandles.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled = true
 
 	validatePlatformEnabledMetrics(cfg, logger)
 
-	assert.True(t, cfg.Metrics.ProcessHandles.Enabled, "process.handles should remain enabled on Windows")
+	assert.True(t, cfg.MetricsBuilderConfig.Metrics.ProcessHandles.Enabled, "process.handles should remain enabled on Windows")
 	assert.Equal(t, 0, logs.Len(), "no log entry for handles on Windows")
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/config.go
@@ -10,5 +10,5 @@ import (
 // Config relating to System Metric Scraper.
 type Config struct {
 	// MetricsBuilderConfig allows to customize scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }

--- a/receiver/kafkametricsreceiver/broker_scraper_franz.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_franz.go
@@ -91,7 +91,7 @@ func (s *brokerScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, error
 	s.mb.RecordKafkaBrokersDataPoint(now, int64(len(brokerIDs)))
 
 	// If log retention metric is disabled, we are done.
-	if !s.config.Metrics.KafkaBrokerLogRetentionPeriod.Enabled {
+	if !s.config.MetricsBuilderConfig.Metrics.KafkaBrokerLogRetentionPeriod.Enabled {
 		return s.mb.Emit(metadata.WithResource(rb.Emit())), scrapeErrs.Combine()
 	}
 

--- a/receiver/kafkametricsreceiver/broker_scraper_franz_bench_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_franz_bench_test.go
@@ -50,9 +50,9 @@ func Benchmark_BrokerScraperFranz_Scrape(b *testing.B) {
 				MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 				ClusterAlias:         "bench-cluster",
 			}
-			cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+			cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
 			// Enable the config-derived metric so DescribeBrokerConfigs runs.
-			cfg.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
+			cfg.MetricsBuilderConfig.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
 
 			s, err := createBrokerScraperFranz(b.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 			require.NoError(b, err)

--- a/receiver/kafkametricsreceiver/broker_scraper_franz_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_franz_test.go
@@ -30,7 +30,7 @@ func franzTestConfig(t *testing.T) Config {
 		ClusterAlias:         "test-cluster",
 	}
 	// keep retention metric disabled here (kfake does not expose broker config values)
-	cfg.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = false
+	cfg.MetricsBuilderConfig.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = false
 	return cfg
 }
 
@@ -129,9 +129,9 @@ func TestBrokerScraperFranz_ScrapeMetricValues(t *testing.T) {
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 		ClusterAlias:         "test-cluster",
 	}
-	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
-	cfg.ResourceAttributes.KafkaClusterID.Enabled = true
-	cfg.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
 
 	s, err := createBrokerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestBrokerScraperFranz_EmptyClusterID(t *testing.T) {
 		ClientConfig:         clientCfg,
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.ResourceAttributes.KafkaClusterID.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled = true
 
 	s, err := createBrokerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestBrokerScraperFranz_ScrapePartialError_UnparseableRetention(t *testing.T
 		ClientConfig:         clientCfg,
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
-	cfg.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaBrokerLogRetentionPeriod.Enabled = true
 
 	s, err := createBrokerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)

--- a/receiver/kafkametricsreceiver/config.go
+++ b/receiver/kafkametricsreceiver/config.go
@@ -15,8 +15,8 @@ import (
 
 // Config represents user settings for kafkametrics receiver
 type Config struct {
-	scraperhelper.ControllerConfig `mapstructure:",squash"`
-	configkafka.ClientConfig       `mapstructure:",squash"`
+	ControllerConfig scraperhelper.ControllerConfig `mapstructure:",squash"`
+	ClientConfig     configkafka.ClientConfig       `mapstructure:",squash"`
 
 	// Alias name of the kafka cluster
 	ClusterAlias string `mapstructure:"cluster_alias"`
@@ -39,7 +39,7 @@ type Config struct {
 	Scrapers []string `mapstructure:"scrapers"`
 
 	// MetricsBuilderConfig allows customizing scraped metrics/attributes representation.
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }
 
 func (c *Config) Unmarshal(conf *confmap.Conf) error {

--- a/receiver/kafkametricsreceiver/consumer_scraper_franz.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_franz.go
@@ -134,7 +134,7 @@ func (s *consumerScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, err
 	rb.SetKafkaClusterAlias(s.config.ClusterAlias)
 	// Cluster ID needs an extra metadata request here, so only fetch it when enabled.
 	// It is opt-in and loses no data points on failure, so warn rather than error.
-	if s.config.ResourceAttributes.KafkaClusterID.Enabled {
+	if s.config.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled {
 		if meta, merr := s.adm.BrokerMetadata(ctx); merr != nil {
 			s.settings.Logger.Warn("franz-go: BrokerMetadata failed; kafka.cluster.id will be omitted", zap.Error(merr))
 		} else if meta.Cluster != "" { // skip empty IDs so we never emit an empty-string attribute

--- a/receiver/kafkametricsreceiver/consumer_scraper_franz_bench_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_franz_bench_test.go
@@ -150,7 +150,7 @@ func Benchmark_ConsumerScraperFranz_Scrape(b *testing.B) {
 				TopicMatch:           ".*",
 				GroupMatch:           ".*",
 			}
-			cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+			cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
 
 			s, err := createConsumerScraperFranz(b.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 			require.NoError(b, err)

--- a/receiver/kafkametricsreceiver/consumer_scraper_franz_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_franz_test.go
@@ -142,8 +142,8 @@ func TestConsumerScraperFranz_ScrapeMetricValues(t *testing.T) {
 		TopicMatch:           ".*",
 		GroupMatch:           ".*",
 	}
-	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
-	cfg.ResourceAttributes.KafkaClusterID.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled = true
 
 	s, err := createConsumerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func TestConsumerScraperFranz_EmptyClusterID(t *testing.T) {
 		TopicMatch:           ".*",
 		GroupMatch:           ".*",
 	}
-	cfg.ResourceAttributes.KafkaClusterID.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled = true
 
 	s, err := createConsumerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)
@@ -303,7 +303,7 @@ func TestConsumerScraperFranz_ScrapeNoEmittedDataPointsForUncommitted(t *testing
 		TopicMatch:           ".*",
 		GroupMatch:           ".*",
 	}
-	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
 
 	s, err := createConsumerScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)

--- a/receiver/kafkametricsreceiver/factory.go
+++ b/receiver/kafkametricsreceiver/factory.go
@@ -40,7 +40,7 @@ func createDefaultConfig() component.Config {
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 	}
 	if config.ClusterAlias != "" {
-		config.ResourceAttributes.KafkaClusterAlias.Enabled = true
+		config.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
 	}
 	return config
 }

--- a/receiver/kafkametricsreceiver/topic_scraper_franz.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_franz.go
@@ -109,12 +109,12 @@ func (s *topicScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, error)
 	}
 
 	// 3) per-topic configs & replication factor
-	if s.config.Metrics.KafkaTopicLogRetentionPeriod.Enabled ||
-		s.config.Metrics.KafkaTopicLogRetentionSize.Enabled ||
-		s.config.Metrics.KafkaTopicMinInsyncReplicas.Enabled ||
-		s.config.Metrics.KafkaTopicReplicationFactor.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionPeriod.Enabled ||
+		s.config.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionSize.Enabled ||
+		s.config.MetricsBuilderConfig.Metrics.KafkaTopicMinInsyncReplicas.Enabled ||
+		s.config.MetricsBuilderConfig.Metrics.KafkaTopicReplicationFactor.Enabled {
 		// replication factor: derive from first partition's replica count
-		if s.config.Metrics.KafkaTopicReplicationFactor.Enabled {
+		if s.config.MetricsBuilderConfig.Metrics.KafkaTopicReplicationFactor.Enabled {
 			for _, topic := range matched {
 				if det, ok := td[topic]; ok {
 					var rf int
@@ -143,7 +143,7 @@ func (s *topicScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, error)
 				for _, kv := range rc.Configs {
 					switch kv.Key {
 					case minInsyncReplicas:
-						if s.config.Metrics.KafkaTopicMinInsyncReplicas.Enabled {
+						if s.config.MetricsBuilderConfig.Metrics.KafkaTopicMinInsyncReplicas.Enabled {
 							if v, err := strconv.Atoi(kv.MaybeValue()); err == nil {
 								s.mb.RecordKafkaTopicMinInsyncReplicasDataPoint(now, int64(v), topic)
 							} else {
@@ -151,7 +151,7 @@ func (s *topicScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, error)
 							}
 						}
 					case retentionMs:
-						if s.config.Metrics.KafkaTopicLogRetentionPeriod.Enabled {
+						if s.config.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionPeriod.Enabled {
 							if v, err := strconv.Atoi(kv.MaybeValue()); err == nil {
 								// seconds = ms / 1000
 								s.mb.RecordKafkaTopicLogRetentionPeriodDataPoint(now, int64(v/1000), topic)
@@ -160,7 +160,7 @@ func (s *topicScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, error)
 							}
 						}
 					case retentionBytes:
-						if s.config.Metrics.KafkaTopicLogRetentionSize.Enabled {
+						if s.config.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionSize.Enabled {
 							if v, err := strconv.Atoi(kv.MaybeValue()); err == nil {
 								s.mb.RecordKafkaTopicLogRetentionSizeDataPoint(now, int64(v), topic)
 							} else {
@@ -187,11 +187,11 @@ func (s *topicScraperFranz) scrape(ctx context.Context) (pmetric.Metrics, error)
 			pd := det.Partitions[pid]
 
 			// replicas
-			if s.config.Metrics.KafkaPartitionReplicas.Enabled {
+			if s.config.MetricsBuilderConfig.Metrics.KafkaPartitionReplicas.Enabled {
 				s.mb.RecordKafkaPartitionReplicasDataPoint(now, int64(len(pd.Replicas)), topic, int64(pid))
 			}
 			// in-sync replicas
-			if s.config.Metrics.KafkaPartitionReplicasInSync.Enabled {
+			if s.config.MetricsBuilderConfig.Metrics.KafkaPartitionReplicasInSync.Enabled {
 				s.mb.RecordKafkaPartitionReplicasInSyncDataPoint(now, int64(len(pd.ISR)), topic, int64(pid))
 			}
 

--- a/receiver/kafkametricsreceiver/topic_scraper_franz_bench_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_franz_bench_test.go
@@ -55,12 +55,12 @@ func Benchmark_TopicScraperFranz_Scrape(b *testing.B) {
 				ClusterAlias:         "bench-cluster",
 				TopicMatch:           ".*",
 			}
-			cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
+			cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
 			// Enable the config-derived metrics so DescribeTopicConfigs runs.
-			cfg.Metrics.KafkaTopicLogRetentionPeriod.Enabled = true
-			cfg.Metrics.KafkaTopicLogRetentionSize.Enabled = true
-			cfg.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
-			cfg.Metrics.KafkaTopicReplicationFactor.Enabled = true
+			cfg.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionPeriod.Enabled = true
+			cfg.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionSize.Enabled = true
+			cfg.MetricsBuilderConfig.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
+			cfg.MetricsBuilderConfig.Metrics.KafkaTopicReplicationFactor.Enabled = true
 
 			s, err := createTopicsScraperFranz(b.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 			require.NoError(b, err)

--- a/receiver/kafkametricsreceiver/topic_scraper_franz_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_franz_test.go
@@ -104,12 +104,12 @@ func TestTopicScraperFranz_ScrapeMetricValues(t *testing.T) {
 		ClusterAlias:         "franz-topics",
 		TopicMatch:           ".*",
 	}
-	cfg.ResourceAttributes.KafkaClusterAlias.Enabled = true
-	cfg.ResourceAttributes.KafkaClusterID.Enabled = true
-	cfg.Metrics.KafkaTopicLogRetentionPeriod.Enabled = true
-	cfg.Metrics.KafkaTopicLogRetentionSize.Enabled = true
-	cfg.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
-	cfg.Metrics.KafkaTopicReplicationFactor.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterAlias.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionPeriod.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaTopicLogRetentionSize.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaTopicReplicationFactor.Enabled = true
 
 	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestTopicScraperFranz_EmptyClusterID(t *testing.T) {
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 		TopicMatch:           ".*",
 	}
-	cfg.ResourceAttributes.KafkaClusterID.Enabled = true
+	cfg.MetricsBuilderConfig.ResourceAttributes.KafkaClusterID.Enabled = true
 
 	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestTopicScraperFranz_ScrapePartialError_UnparseableConfig(t *testing.T) {
 		MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 		TopicMatch:           ".*",
 	}
-	cfg.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.KafkaTopicMinInsyncReplicas.Enabled = true
 
 	s, err := createTopicsScraperFranz(t.Context(), cfg, receivertest.NewNopSettings(metadata.Type))
 	require.NoError(t, err)

--- a/receiver/mongodbatlasreceiver/access_logs.go
+++ b/receiver/mongodbatlasreceiver/access_logs.go
@@ -71,7 +71,7 @@ func newAccessLogsReceiver(settings rcvr.Settings, cfg *Config, consumer consume
 	}
 
 	for _, p := range cfg.Logs.Projects {
-		p.populateIncludesAndExcludes()
+		p.ProjectConfig.populateIncludesAndExcludes()
 		if p.AccessLogs != nil && p.AccessLogs.IsEnabled() {
 			if p.AccessLogs.PageSize <= 0 {
 				p.AccessLogs.PageSize = defaultAccessLogsPageSize
@@ -132,9 +132,9 @@ func (alr *accessLogsReceiver) pollAccessLogs(ctx context.Context, pc *LogsProje
 	st := pcommon.NewTimestampFromTime(time.Now().Add(-1 * pc.AccessLogs.PollInterval)).AsTime()
 	et := time.Now()
 
-	project, err := alr.client.GetProject(ctx, pc.Name)
+	project, err := alr.client.GetProject(ctx, pc.ProjectConfig.Name)
 	if err != nil {
-		alr.logger.Error("error retrieving project information", zap.Error(err), zap.String("project", pc.Name))
+		alr.logger.Error("error retrieving project information", zap.Error(err), zap.String("project", pc.ProjectConfig.Name))
 		return err
 	}
 
@@ -142,12 +142,12 @@ func (alr *accessLogsReceiver) pollAccessLogs(ctx context.Context, pc *LogsProje
 
 	clusters, err := alr.client.GetClusters(ctx, project.ID)
 	if err != nil {
-		alr.logger.Error("error retrieving cluster information", zap.Error(err), zap.String("project", pc.Name))
+		alr.logger.Error("error retrieving cluster information", zap.Error(err), zap.String("project", pc.ProjectConfig.Name))
 		return err
 	}
 	filteredClusters, err := filterClusters(clusters, pc.ProjectConfig)
 	if err != nil {
-		alr.logger.Error("error filtering clusters", zap.Error(err), zap.String("project", pc.Name))
+		alr.logger.Error("error filtering clusters", zap.Error(err), zap.String("project", pc.ProjectConfig.Name))
 		return err
 	}
 	for i := range filteredClusters {
@@ -163,7 +163,7 @@ func (alr *accessLogsReceiver) pollAccessLogs(ctx context.Context, pc *LogsProje
 		}
 		clusterCheckpoint.NextPollStartTime = alr.pollCluster(ctx, pc, project, cluster, clusterCheckpoint.NextPollStartTime, et)
 		if err = alr.checkpoint(ctx, project.ID); err != nil {
-			alr.logger.Warn("error checkpointing", zap.Error(err), zap.String("project", pc.Name))
+			alr.logger.Warn("error checkpointing", zap.Error(err), zap.String("project", pc.ProjectConfig.Name))
 		}
 	}
 

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -24,18 +24,18 @@ import (
 var _ component.Config = (*Config)(nil)
 
 type Config struct {
-	scraperhelper.ControllerConfig `mapstructure:",squash"`
-	BaseURL                        string                                `mapstructure:"base_url"`
-	PublicKey                      string                                `mapstructure:"public_key"`
-	PrivateKey                     configopaque.String                   `mapstructure:"private_key"`
-	Granularity                    string                                `mapstructure:"granularity"`
-	MetricsBuilderConfig           metadata.MetricsBuilderConfig         `mapstructure:",squash"`
-	Projects                       []ProjectConfig                       `mapstructure:"projects"`
-	Alerts                         AlertConfig                           `mapstructure:"alerts"`
-	Events                         configoptional.Optional[EventsConfig] `mapstructure:"events"`
-	Logs                           LogConfig                             `mapstructure:"logs"`
-	BackOffConfig                  configretry.BackOffConfig             `mapstructure:"retry_on_failure"`
-	StorageID                      *component.ID                         `mapstructure:"storage"`
+	ControllerConfig     scraperhelper.ControllerConfig        `mapstructure:",squash"`
+	BaseURL              string                                `mapstructure:"base_url"`
+	PublicKey            string                                `mapstructure:"public_key"`
+	PrivateKey           configopaque.String                   `mapstructure:"private_key"`
+	Granularity          string                                `mapstructure:"granularity"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig         `mapstructure:",squash"`
+	Projects             []ProjectConfig                       `mapstructure:"projects"`
+	Alerts               AlertConfig                           `mapstructure:"alerts"`
+	Events               configoptional.Optional[EventsConfig] `mapstructure:"events"`
+	Logs                 LogConfig                             `mapstructure:"logs"`
+	BackOffConfig        configretry.BackOffConfig             `mapstructure:"retry_on_failure"`
+	StorageID            *component.ID                         `mapstructure:"storage"`
 }
 
 type AlertConfig struct {
@@ -71,7 +71,7 @@ type EventsConfig struct {
 }
 
 type LogsProjectConfig struct {
-	ProjectConfig `mapstructure:",squash"`
+	ProjectConfig ProjectConfig `mapstructure:",squash"`
 
 	EnableAuditLogs bool              `mapstructure:"collect_audit_logs"`
 	EnableHostLogs  *bool             `mapstructure:"collect_host_logs"`
@@ -175,7 +175,7 @@ func (l *LogConfig) validate() error {
 	}
 
 	for _, project := range l.Projects {
-		if len(project.ExcludeClusters) != 0 && len(project.IncludeClusters) != 0 {
+		if len(project.ProjectConfig.ExcludeClusters) != 0 && len(project.ProjectConfig.IncludeClusters) != 0 {
 			errs = multierr.Append(errs, errClusterConfig)
 		}
 

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -129,6 +129,6 @@ func createDefaultConfig() component.Config {
 	}
 	// reset default of 1 minute to be 3 minutes in order to avoid null values for some metrics that do not publish
 	// more frequently
-	c.CollectionInterval = 3 * time.Minute
+	c.ControllerConfig.CollectionInterval = 3 * time.Minute
 	return c
 }

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -51,7 +51,7 @@ func newMongoDBAtlasLogsReceiver(settings rcvr.Settings, cfg *Config, consumer c
 	}
 
 	for _, p := range cfg.Logs.Projects {
-		p.populateIncludesAndExcludes()
+		p.ProjectConfig.populateIncludesAndExcludes()
 	}
 
 	return &logsReceiver{
@@ -115,9 +115,9 @@ func parseHostNames(s string, logger *zap.Logger) []string {
 // collect spins off functionality of the receiver from the Start function
 func (s *logsReceiver) collect(ctx context.Context) {
 	for _, projectCfg := range s.cfg.Logs.Projects {
-		project, err := s.client.GetProject(ctx, projectCfg.Name)
+		project, err := s.client.GetProject(ctx, projectCfg.ProjectConfig.Name)
 		if err != nil {
-			s.log.Error("Error retrieving project "+projectCfg.Name+":", zap.Error(err))
+			s.log.Error("Error retrieving project "+projectCfg.ProjectConfig.Name+":", zap.Error(err))
 			continue
 		}
 		pc := projectContext{Project: *project}

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -73,7 +73,7 @@ func (s *mongodbatlasreceiver) scrape(ctx context.Context) (pmetric.Metrics, err
 func (s *mongodbatlasreceiver) timeConstraints(now time.Time) timeconstraints {
 	var start time.Time
 	if s.lastRun.IsZero() {
-		start = now.Add(s.cfg.CollectionInterval * -1)
+		start = now.Add(s.cfg.ControllerConfig.CollectionInterval * -1)
 	} else {
 		start = s.lastRun
 	}

--- a/receiver/mongodbatlasreceiver/receiver_test.go
+++ b/receiver/mongodbatlasreceiver/receiver_test.go
@@ -19,7 +19,7 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	require.Equal(t, 3*time.Minute, cfg.(*Config).CollectionInterval)
+	require.Equal(t, 3*time.Minute, cfg.(*Config).ControllerConfig.CollectionInterval)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -52,7 +52,7 @@ func TestTimeConstraints(t *testing.T) {
 				now := time.Now()
 				tc := recv.timeConstraints(now)
 				require.NotNil(t, tc)
-				require.Equal(t, tc.start, now.Add(cfg.CollectionInterval*-1).UTC().Format(time.RFC3339))
+				require.Equal(t, tc.start, now.Add(cfg.ControllerConfig.CollectionInterval*-1).UTC().Format(time.RFC3339))
 			},
 		},
 		{
@@ -64,7 +64,7 @@ func TestTimeConstraints(t *testing.T) {
 				recv := mongodbatlasreceiver{
 					cfg: cfg,
 					// set last run to 1 collection ago
-					lastRun: now.Add(cfg.CollectionInterval * -1),
+					lastRun: now.Add(cfg.ControllerConfig.CollectionInterval * -1),
 				}
 				tc := recv.timeConstraints(now)
 				require.NotNil(t, tc)

--- a/scraper/zookeeperscraper/config.go
+++ b/scraper/zookeeperscraper/config.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Config struct {
-	TCPAddrConfig                 confignet.TCPAddrConfig `mapstructure:",squash"`
-	metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	TCPAddrConfig        confignet.TCPAddrConfig       `mapstructure:",squash"`
+	MetricsBuilderConfig metadata.MetricsBuilderConfig `mapstructure:",squash"`
 }
 
 func (cfg *Config) Validate() error {

--- a/scraper/zookeeperscraper/scraper.go
+++ b/scraper/zookeeperscraper/scraper.go
@@ -46,7 +46,7 @@ func newZookeeperMetricsScraper(settings scraper.Settings, config *Config) *zook
 	return &zookeeperMetricsScraper{
 		logger:                settings.Logger,
 		config:                config,
-		rb:                    metadata.NewResourceBuilder(config.ResourceAttributes),
+		rb:                    metadata.NewResourceBuilder(config.MetricsBuilderConfig.ResourceAttributes),
 		mb:                    metadata.NewMetricsBuilder(config.MetricsBuilderConfig, settings),
 		closeConnection:       closeConnection,
 		setConnectionDeadline: setConnectionDeadline,

--- a/scraper/zookeeperscraper/scraper_test.go
+++ b/scraper/zookeeperscraper/scraper_test.go
@@ -306,7 +306,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			cfg := createDefaultConfig().(*Config)
 			cfg.TCPAddrConfig.Endpoint = localAddr
 			if tt.metricsConfig != nil {
-				cfg.Metrics = tt.metricsConfig()
+				cfg.MetricsBuilderConfig.Metrics = tt.metricsConfig()
 			}
 
 			core, observedLogs := observer.New(zap.DebugLevel)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Stops embedding some more types in component config structs, similar to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49797.

Embedding in general does not work well with mapstructure hooks and should be avoided.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
