### PR TITLE
[cmd/telemetrygen] Stop accumulating attributes with --unique-timeseries

### DIFF
--- a/.chloggen/telemetrygen-unique-timeseries-attr-growth.yaml
+++ b/.chloggen/telemetrygen-unique-timeseries-attr-growth.yaml
@@ -1,0 +1,17 @@
+change_type: bug_fix
+
+component: cmd/telemetrygen
+
+note: Stop accumulating attributes across data points when `--unique-timeseries` is set
+
+issues: [49950]
+
+subtext: |
+  The timebox attribute was appended to the shared signal attribute slice on every
+  iteration, so the slice grew by one attribute per data point and the cost of building
+  each data point grew with it. Generation rate decayed steadily over a run. The slice is
+  now rebuilt per data point, which also stops the worker from mutating the caller's slice.
+  Exponential histogram data points now also carry the `--load-size` attributes, matching
+  the other metric types.
+
+change_logs: [user]

--- a/cmd/telemetrygen/pkg/metrics/worker.go
+++ b/cmd/telemetrygen/pkg/metrics/worker.go
@@ -101,19 +101,24 @@ func (w *worker) simulateMetrics(res *resource.Resource, exporter sdkmetric.Expo
 
 	startTime := w.clock.Now()
 
+	// Reused across iterations and rebuilt from signalAttrs every time. Appending to
+	// signalAttrs directly would grow it by one attribute per data point and mutate
+	// the caller's slice.
+	attrs := make([]attribute.KeyValue, 0, len(signalAttrs)+1+w.loadSize)
+
 	var i int64
 	for w.running.Load() {
+		attrs = append(attrs[:0], signalAttrs...)
 		if w.enforceUnique {
-			signalAttrs = append(signalAttrs, tb.getAttribute())
+			attrs = append(attrs, tb.getAttribute())
 		}
 
 		// Add load size attributes if specified
-		loadAttrs := signalAttrs
-		if w.loadSize > 0 {
-			for j := 0; j < w.loadSize; j++ {
-				loadAttrs = append(loadAttrs, config.CreateLoadAttribute(fmt.Sprintf("load-%v", j), 1))
-			}
+		for j := 0; j < w.loadSize; j++ {
+			attrs = append(attrs, config.CreateLoadAttribute(fmt.Sprintf("load-%v", j), 1))
 		}
+		attrSet := attribute.NewSet(attrs...)
+
 		var metrics []metricdata.Metrics
 		now := w.clock.Now()
 		if w.aggregationTemporality.AsTemporality() == metricdata.DeltaTemporality {
@@ -129,7 +134,7 @@ func (w *worker) simulateMetrics(res *resource.Resource, exporter sdkmetric.Expo
 						{
 							Time:       now,
 							Value:      i,
-							Attributes: attribute.NewSet(loadAttrs...),
+							Attributes: attrSet,
 							Exemplars:  w.exemplars,
 						},
 					},
@@ -146,7 +151,7 @@ func (w *worker) simulateMetrics(res *resource.Resource, exporter sdkmetric.Expo
 							StartTime:  startTime,
 							Time:       now,
 							Value:      i,
-							Attributes: attribute.NewSet(loadAttrs...),
+							Attributes: attrSet,
 							Exemplars:  w.exemplars,
 						},
 					},
@@ -168,7 +173,7 @@ func (w *worker) simulateMetrics(res *resource.Resource, exporter sdkmetric.Expo
 						{
 							StartTime:  startTime,
 							Time:       now,
-							Attributes: attribute.NewSet(loadAttrs...),
+							Attributes: attrSet,
 							Exemplars:  w.exemplars,
 							Count:      totalCount,
 							Sum:        sum,
@@ -195,7 +200,7 @@ func (w *worker) simulateMetrics(res *resource.Resource, exporter sdkmetric.Expo
 			dp := &metricdata.ExponentialHistogramDataPoint[int64]{
 				StartTime:  startTime,
 				Time:       now,
-				Attributes: attribute.NewSet(signalAttrs...),
+				Attributes: attrSet,
 				Exemplars:  w.exemplars,
 			}
 			expoHistToSDKExponentialDataPoint(hist, dp)

--- a/cmd/telemetrygen/pkg/metrics/worker_test.go
+++ b/cmd/telemetrygen/pkg/metrics/worker_test.go
@@ -647,6 +647,60 @@ func TestUniqueSumTimeseries(t *testing.T) {
 	}
 }
 
+// TestUniqueTimeseriesDoesNotAccumulateAttributes covers the regression where
+// simulateMetrics appended the timebox attribute to signalAttrs itself, growing the
+// slice by one attribute per data point and mutating the caller's backing array.
+func TestUniqueTimeseriesDoesNotAccumulateAttributes(t *testing.T) {
+	const qty = 20
+
+	m := &mockExporter{}
+	running := &atomic.Bool{}
+	running.Store(true)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	tb := newTimeBox(true, time.Hour)
+	defer tb.shutdown()
+
+	w := worker{
+		metricName:             "test_metric",
+		metricType:             MetricTypeSum,
+		aggregationTemporality: AggregationTemporality(metricdata.DeltaTemporality),
+		numMetrics:             qty,
+		enforceUnique:          true,
+		running:                running,
+		limitPerSecond:         rate.Inf,
+		logger:                 zap.NewNop(),
+		wg:                     wg,
+		clock:                  &realClock{},
+	}
+
+	// Spare capacity makes any in-place append visible to the caller.
+	signalAttrs := make([]attribute.KeyValue, 1, 8)
+	signalAttrs[0] = attribute.String(telemetryAttrKeyOne, telemetryAttrValueOne)
+
+	w.simulateMetrics(resource.Default(), m, signalAttrs, tb)
+	wg.Wait()
+
+	require.Len(t, m.rms, qty)
+
+	// simulateMetrics must not append into the spare capacity of the caller's slice.
+	for i, kv := range signalAttrs[:cap(signalAttrs)][1:] {
+		assert.Empty(t, string(kv.Key), "signalAttrs backing array written at index %d", i+1)
+	}
+
+	seen := make(map[int64]bool, qty)
+	for i, rm := range m.rms {
+		attrs := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Attributes
+		assert.Equal(t, 2, attrs.Len(), "data point %d should carry the signal attribute and one timebox attribute", i)
+
+		value, exist := attrs.Value(timeBoxAttributeName)
+		require.True(t, exist, "data point %d should have the timebox attribute", i)
+		assert.False(t, seen[value.AsInt64()], "timebox value %d reused", value.AsInt64())
+		seen[value.AsInt64()] = true
+	}
+}
+
 // TestBatching tests the basic batching functionality
 func TestBatching(t *testing.T) {
 	mockExp := &mockExporter{}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`simulateMetrics` receives `signalAttrs` from `run()`, a single slice shared by every data point the worker emits. With `--unique-timeseries`, the per-timebox attribute was added inside the emit loop with `signalAttrs = append(signalAttrs, tb.getAttribute())`, which reassigns that shared slice. It therefore grew by one attribute per data point for the lifetime of the run.

Two consequences:

- **Throughput decay.** Every data point calls `attribute.NewSet`, which sorts and dedupes its input. As the slice grows, the cost of emitting a data point scales with the number of points already emitted, so the generation rate decays steadily over a run. This is the behaviour reported in #49950.
- **Caller memory retained.** The append also wrote into the spare capacity of the caller's backing array, and `--load-size` attributes were appended on the same slice. With `--load-size 1` that left 1 MB attribute strings reachable from the caller's array for the rest of the run.

The emitted telemetry was never wrong: `attribute.NewSet` dedupes with last-value-wins and every accumulated entry shares the `timebox` key, so the newest value always won. The defect is purely cost and retention.

**Fix:** rebuild the attribute slice per data point into a buffer that is reused across iterations (`attrs = append(attrs[:0], signalAttrs...)`), and compute a single `attribute.Set` shared by all four metric-type branches. `signalAttrs` is no longer mutated.

**One reviewer-visible behaviour change:** the exponential histogram branch previously used `attribute.NewSet(signalAttrs...)` instead of the load-attribute slice, so it never received `--load-size` attributes and only picked up a timebox attribute as a side effect of the accumulation bug. It now uses the same attribute set as sum, gauge, and histogram.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49950

<!--Describe what testing was performed and which tests were added.-->
#### Testing

New regression test `TestUniqueTimeseriesDoesNotAccumulateAttributes` in `cmd/telemetrygen/pkg/metrics/worker_test.go`. It calls `simulateMetrics` directly rather than going through `run()`, because it needs to control the capacity of `signalAttrs`, which `run()` builds internally.

The test passes a slice with `len 1, cap 8`. The spare capacity is the whole detector: the buggy append writes into slots 1..7 of the caller's backing array, whereas with `len == cap` every append would allocate a fresh array and the bug would be invisible from outside. Assertions, in order:

1. 20 `ResourceMetrics` were exported, so the worker actually ran.
2. Slots 1..7 of the caller's backing array still hold zero-valued keys. This is the assertion that catches the bug.
3. Every data point carries exactly 2 attributes including a `timebox` key, and no timebox value repeats, so the fix neither breaks `--unique-timeseries` nor leaks extra attributes.

Assertion 2 has to reach into the backing array because the exported data alone cannot detect this, for the last-value-wins reason described above. I confirmed that experimentally before writing the fix.

Verified against unpatched `main` by restoring the previous `worker.go` and running the test with `-count=1`: it fails with `signalAttrs backing array written at index 1..7`. It passes with the fix. Existing tests, including `TestUniqueSumTimeseries`, still pass.

For the decay itself I used a throwaway harness (a `nopExporter`, `rate.Inf`, `enforceUnique`, timing `simulateMetrics` for several values of `n` and reporting mean cost per data point), run once with the fix and once with `worker.go` reverted:

| data points | before   | after  |
| ----------: | -------- | ------ |
|       2,000 | 13.4 µs  | 544 ns |
|       8,000 | 43.6 µs  | 441 ns |
|      32,000 | 173.6 µs | 366 ns |

Per-point cost before the fix scales with the number of points already emitted; after the fix it is flat. The harness was scratch code and is not included here. Happy to add a committed `Benchmark` if you would like one in-tree.

Also run across the whole `cmd/telemetrygen` module: `gofmt -l` clean, `go vet ./...` clean, `go test ./...` green, `make lint` clean, `make chlog-validate` passes.

<!--Describe the documentation added.-->
#### Documentation

None. No flag, README, or config surface changes. The user-facing note is in the `.chloggen` entry.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
