### PR TITLE
[chore] Update GitHub Actions configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,7 @@
   "minimumReleaseAge": "2 days",
   "extends": [
     "config:recommended",
-    "customManagers:githubActionsVersions",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "ignorePaths": [
     "**/receiver/apachesparkreceiver/testdata/integration/Dockerfile.apache-spark",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This enables `helpers:pinGitHubActionDigestsToSemver` as mentioned in https://github.com/open-telemetry/sig-security/issues/116

Setting is explained at https://docs.renovatebot.com/presets-helpers/

This just brings consistency to the versions specified for github actions.

The `custommanagers:githubActionsVersion` has been removed as it is not used and the code it was added for https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/ad84ba67bc7e68835427736d8dae3f94a85dfc98 has been removed

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
