### PR TITLE
[processor/dynamic_sampling] add configurable eviction policy

### DIFF
--- a/.chloggen/dynamicsampling-eviction-policy.yaml
+++ b/.chloggen/dynamicsampling-eviction-policy.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/dynamic_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Evicted traces now receive a real sampling decision instead of being dropped silently, with a configurable `eviction` policy.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49311]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `num_traces` is full the oldest pending trace is evicted and decided immediately.
+  `eviction.policy: evaluate` (default) runs the normal rules on the spans seen so far;
+  `eviction.policy: probabilistic` decides with a threshold derived from
+  `eviction.sampling_percentage` in constant time, shedding load under pressure. Both modes
+  record the decision for late spans and stamp kept traces with a correct `ot=th`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/dynamicsamplingprocessor/README.md
+++ b/processor/dynamicsamplingprocessor/README.md
@@ -311,17 +311,45 @@ path and may produce a second (possibly inconsistent) decision; with both caches
 disabled, every late span falls through. Operators tune the cache sizes against
 observed late-span volume.
 
-### Buffer overflow vs decision cache
+### Buffer overflow and eviction policy
 
-The in-memory accumulation buffer is sized by `num_traces`. If the buffer is full
-when a span for a brand-new trace arrives, the processor evicts an existing
-pending trace to make room; the evicted trace is dropped without a sampling
-decision and without `ot=th` annotations, and is counted on
-`processor_dynamic_sampling_traces_evicted`. The decision cache
-(`decision_cache.*`) is a separate structure that records the outcome of
-*completed* decisions for late-arriving spans, it does not protect pending traces
-from eviction. Operators sizing the processor should watch `traces_evicted` and
-increase `num_traces` if it is non-zero in steady state.
+The in-memory accumulation buffer is sized by `num_traces`. When the buffer is
+full and spans for brand-new traces arrive, the processor evicts the **oldest**
+pending traces to make room (the buffer may transiently exceed `num_traces` by
+the number of new traces in a single incoming batch). Every evicted trace
+receives a real sampling decision immediately, with the spans seen so far and
+no `decision_delay`; the decision is recorded in the decision cache so
+late-arriving spans are handled consistently, and kept traces carry correct
+`ot=th` annotations. How that decision is made is configurable:
+
+```yaml
+eviction:
+  policy: evaluate            # evaluate (default) | probabilistic
+  sampling_percentage: 10     # required for probabilistic
+```
+
+- `evaluate` (default): the evicted trace runs through the normal rules and
+  sampler path. Your rules keep working under pressure (e.g. a keep-errors
+  rule still keeps error traces), at the cost of OTTL evaluation over every
+  span of every evicted trace.
+- `probabilistic`: rule evaluation is skipped and the trace is decided by
+  comparing a threshold derived from `sampling_percentage` against the trace's
+  randomness. Constant-time work per evicted trace regardless of trace size or
+  rule count, so an overloaded instance sheds load instead of amplifying it.
+  Kept traces are stamped with the corresponding `ot=th` (and the sentinel
+  rule attribution `_eviction`), so downstream weighting stays accurate.
+  Recommended for high-throughput deployments where eviction indicates
+  genuine overload.
+
+Note the decision may be made on an incomplete trace in both modes: spans
+still in flight when the trace is evicted are treated as late spans and follow
+the recorded decision. The decision cache (`decision_cache.*`) is a separate
+structure recording *completed* decisions; it does not protect pending traces
+from eviction.
+
+Operators sizing the processor should watch `traces_evicted` (every eviction)
+and `decision_triggers{trigger="eviction"}` and increase `num_traces` if they
+are non-zero in steady state.
 
 ## Deployment considerations
 

--- a/processor/dynamicsamplingprocessor/benchmark_test.go
+++ b/processor/dynamicsamplingprocessor/benchmark_test.go
@@ -117,24 +117,47 @@ func benchTrace(traceID pcommon.TraceID, nSpans int, traceState string) ptrace.T
 // BenchmarkConsumeTraces_Accumulate measures the buffering path: per-span
 // bucketing, the per-span root-span OTTL evaluation, span copy into the
 // pending buffer, and the trace_timeout timer arm for new traces. Timers use
-// a 1h timeout so none fire during measurement; NumTraces caps the buffer so
-// long runs exercise eviction the way a saturated deployment would.
+// a 1h timeout so none fire during measurement. The eviction-pressure cases
+// cap NumTraces low so every new trace also evicts and decides the oldest,
+// exercising the saturated-deployment path for both eviction policies.
 func BenchmarkConsumeTraces_Accumulate(b *testing.B) {
 	for _, bc := range []struct {
 		name          string
 		spansPerTrace int
 		rootCondition string
+		numTraces     int
+		eviction      EvictionConfig
 	}{
-		{name: "10spans_default_root_condition", spansPerTrace: 10},
-		{name: "1span_default_root_condition", spansPerTrace: 1},
+		// Pure accumulation: NumTraces is set high enough that no eviction
+		// happens during measurement (evictions now decide traces, which
+		// would fold decision cost into these numbers).
+		{name: "10spans_default_root_condition", spansPerTrace: 10, numTraces: 2_000_000},
+		{name: "1span_default_root_condition", spansPerTrace: 1, numTraces: 2_000_000},
 		{
 			name: "10spans_custom_root_condition", spansPerTrace: 10,
 			rootCondition: `span.attributes["otelcol.dynamic_sampling.root_span"] == true`,
+			numTraces:     2_000_000,
+		},
+		// Sustained buffer pressure: every new trace evicts (and decides) the
+		// oldest one. The two policies bound the cost of overload differently;
+		// this makes the delta visible in the baseline.
+		{
+			name: "10spans_eviction_pressure_evaluate", spansPerTrace: 10,
+			numTraces: 64,
+		},
+		{
+			name: "10spans_eviction_pressure_probabilistic", spansPerTrace: 10,
+			numTraces: 64,
+			eviction:  EvictionConfig{Policy: EvictionProbabilistic, SamplingPercentage: 10},
 		},
 	} {
 		b.Run(bc.name, func(b *testing.B) {
 			cfg := benchConfig(benchCatchAllRules())
 			cfg.RootSpanCondition = bc.rootCondition
+			if bc.numTraces > 0 {
+				cfg.NumTraces = bc.numTraces
+			}
+			cfg.Eviction = bc.eviction
 			p := newBenchProcessor(b, cfg)
 			ctx := b.Context()
 

--- a/processor/dynamicsamplingprocessor/config.go
+++ b/processor/dynamicsamplingprocessor/config.go
@@ -67,6 +67,11 @@ type Config struct {
 	//   - Only trigger on explicit hints (no default):
 	//       span.attributes["otelcol.dynamic_sampling.root_span"] == true
 	RootSpanCondition string `mapstructure:"root_span_condition"`
+	// Eviction controls what happens to the oldest pending trace when the
+	// buffer is full (NumTraces reached) and a new trace arrives. Both
+	// policies emit a real decision (recorded in the decision cache and, for
+	// kept traces, stamped with ot=th) rather than silently dropping spans.
+	Eviction EvictionConfig `mapstructure:"eviction"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -75,6 +80,34 @@ type Config struct {
 // It matches any span whose ParentSpanID is empty, preserving the behavior
 // the processor shipped with before root_span_condition was configurable.
 const defaultRootSpanCondition = "IsRootSpan()"
+
+// EvictionPolicy selects how an evicted trace is decided.
+type EvictionPolicy string
+
+const (
+	// EvictionEvaluate runs the evicted trace through the normal rules and
+	// threshold path immediately, with the spans seen so far and no
+	// decision_delay. Honors the configured rules at the cost of OTTL
+	// evaluation per evicted span.
+	EvictionEvaluate EvictionPolicy = "evaluate"
+	// EvictionProbabilistic skips rule evaluation and decides the evicted
+	// trace by comparing a threshold derived from SamplingPercentage against
+	// the trace's randomness. Constant-time load shedding under pressure;
+	// kept traces still carry a correct ot=th.
+	EvictionProbabilistic EvictionPolicy = "probabilistic"
+)
+
+// EvictionConfig configures the decision made for evicted traces.
+type EvictionConfig struct {
+	// Policy selects the eviction decision mode. Defaults to evaluate.
+	Policy EvictionPolicy `mapstructure:"policy"`
+	// SamplingPercentage is the percentage of evicted traces to keep (0-100]
+	// under the probabilistic policy. Required for probabilistic; must be
+	// unset for evaluate.
+	SamplingPercentage float64 `mapstructure:"sampling_percentage"`
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
 
 // DecisionCacheConfig sizes the LRU caches that record sampling decisions.
 // When a span arrives for a traceID that already has a recorded decision, the
@@ -221,6 +254,25 @@ func (c *Config) Validate() error {
 		if _, err := filterottl.NewBoolExprForSpan([]string{cond}, filterottl.StandardSpanFuncs(), ottl.PropagateError, settings); err != nil {
 			return fmt.Errorf("root_span_condition: %w", err)
 		}
+	}
+	if err := c.Eviction.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *EvictionConfig) validate() error {
+	switch e.Policy {
+	case "", EvictionEvaluate:
+		if e.SamplingPercentage != 0 {
+			return errors.New("eviction: sampling_percentage is only used by the probabilistic policy")
+		}
+	case EvictionProbabilistic:
+		if e.SamplingPercentage <= 0 || e.SamplingPercentage > 100 {
+			return errors.New("eviction: sampling_percentage must be in (0, 100] for the probabilistic policy")
+		}
+	default:
+		return fmt.Errorf("eviction: policy must be %q or %q", EvictionEvaluate, EvictionProbabilistic)
 	}
 	return nil
 }

--- a/processor/dynamicsamplingprocessor/config_test.go
+++ b/processor/dynamicsamplingprocessor/config_test.go
@@ -268,6 +268,58 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: "ema_dynamic does not use update_frequency",
 		},
 		{
+			name: "eviction_evaluate_default_valid",
+			cfg: func() Config {
+				c := baseCfg(RuleConfig{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}})
+				c.Eviction = EvictionConfig{Policy: EvictionEvaluate}
+				return c
+			}(),
+		},
+		{
+			name: "eviction_probabilistic_valid",
+			cfg: func() Config {
+				c := baseCfg(RuleConfig{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}})
+				c.Eviction = EvictionConfig{Policy: EvictionProbabilistic, SamplingPercentage: 10}
+				return c
+			}(),
+		},
+		{
+			name: "eviction_probabilistic_missing_percentage",
+			cfg: func() Config {
+				c := baseCfg(RuleConfig{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}})
+				c.Eviction = EvictionConfig{Policy: EvictionProbabilistic}
+				return c
+			}(),
+			wantErr: "sampling_percentage must be in (0, 100]",
+		},
+		{
+			name: "eviction_percentage_out_of_range",
+			cfg: func() Config {
+				c := baseCfg(RuleConfig{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}})
+				c.Eviction = EvictionConfig{Policy: EvictionProbabilistic, SamplingPercentage: 150}
+				return c
+			}(),
+			wantErr: "sampling_percentage must be in (0, 100]",
+		},
+		{
+			name: "eviction_evaluate_rejects_percentage",
+			cfg: func() Config {
+				c := baseCfg(RuleConfig{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}})
+				c.Eviction = EvictionConfig{SamplingPercentage: 10}
+				return c
+			}(),
+			wantErr: "sampling_percentage is only used by the probabilistic policy",
+		},
+		{
+			name: "eviction_unknown_policy",
+			cfg: func() Config {
+				c := baseCfg(RuleConfig{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}})
+				c.Eviction = EvictionConfig{Policy: "magic"}
+				return c
+			}(),
+			wantErr: "eviction: policy must be",
+		},
+		{
 			name: "root_span_condition_valid",
 			cfg: Config{
 				TraceTimeout:      time.Second,

--- a/processor/dynamicsamplingprocessor/documentation.md
+++ b/processor/dynamicsamplingprocessor/documentation.md
@@ -16,7 +16,7 @@ Distribution of effective sample rates produced per rule. Useful for detecting a
 
 ### otelcol_processor_dynamic_sampling_decision_triggers
 
-Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout).
+Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction).
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
@@ -56,7 +56,7 @@ Number of traces that were dropped, labelled by the rule that selected them.
 
 ### otelcol_processor_dynamic_sampling_traces_evicted
 
-Number of traces evicted from the buffer before a decision could be made.
+Number of traces evicted from the buffer due to num_traces pressure. Evicted traces are decided immediately per the configured eviction policy.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |

--- a/processor/dynamicsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/dynamicsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -72,7 +72,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessorDynamicSamplingDecisionTriggers, err = builder.meter.Int64Counter(
 		"otelcol_processor_dynamic_sampling_decision_triggers",
-		metric.WithDescription("Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout). [Development]"),
+		metric.WithDescription("Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction). [Development]"),
 		metric.WithUnit("{decisions}"),
 	)
 	errs = errors.Join(errs, err)
@@ -102,7 +102,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessorDynamicSamplingTracesEvicted, err = builder.meter.Int64Counter(
 		"otelcol_processor_dynamic_sampling_traces_evicted",
-		metric.WithDescription("Number of traces evicted from the buffer before a decision could be made. [Development]"),
+		metric.WithDescription("Number of traces evicted from the buffer due to num_traces pressure. Evicted traces are decided immediately per the configured eviction policy. [Development]"),
 		metric.WithUnit("{traces}"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/dynamicsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/dynamicsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -39,7 +39,7 @@ func AssertEqualProcessorDynamicSamplingDecisionSampleRate(t *testing.T, tt *com
 func AssertEqualProcessorDynamicSamplingDecisionTriggers(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_dynamic_sampling_decision_triggers",
-		Description: "Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout). [Development]",
+		Description: "Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction). [Development]",
 		Unit:        "{decisions}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -117,7 +117,7 @@ func AssertEqualProcessorDynamicSamplingTracesDropped(t *testing.T, tt *componen
 func AssertEqualProcessorDynamicSamplingTracesEvicted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_dynamic_sampling_traces_evicted",
-		Description: "Number of traces evicted from the buffer before a decision could be made. [Development]",
+		Description: "Number of traces evicted from the buffer due to num_traces pressure. Evicted traces are decided immediately per the configured eviction policy. [Development]",
 		Unit:        "{traces}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/processor/dynamicsamplingprocessor/metadata.yaml
+++ b/processor/dynamicsamplingprocessor/metadata.yaml
@@ -27,7 +27,7 @@ telemetry:
       stability: development
     processor_dynamic_sampling_decision_triggers:
       enabled: true
-      description: Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout).
+      description: Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction).
       unit: "{decisions}"
       sum:
         value_type: int
@@ -66,7 +66,7 @@ telemetry:
       stability: development
     processor_dynamic_sampling_traces_evicted:
       enabled: true
-      description: Number of traces evicted from the buffer before a decision could be made.
+      description: Number of traces evicted from the buffer due to num_traces pressure. Evicted traces are decided immediately per the configured eviction policy.
       unit: "{traces}"
       sum:
         value_type: int

--- a/processor/dynamicsamplingprocessor/processor.go
+++ b/processor/dynamicsamplingprocessor/processor.go
@@ -47,7 +47,13 @@ type triggerSource string
 const (
 	triggerRootSpan     triggerSource = "root_span"
 	triggerTraceTimeout triggerSource = "trace_timeout"
+	triggerEviction     triggerSource = "eviction"
 )
+
+// evictionRuleLabel is the sentinel `rule` label used on decision metrics for
+// traces decided by the probabilistic eviction policy, which bypasses rule
+// evaluation entirely. Same convention as rootSpanConditionRuleLabel.
+const evictionRuleLabel = "_eviction"
 
 // pendingTrace holds spans accumulated for a single trace plus its arrival
 // metadata. Access is guarded by dynamicSamplingProcessor.mu.
@@ -75,6 +81,11 @@ type dynamicSamplingProcessor struct {
 	rules   []*rule
 	stopped bool
 	cache   *decisionCache
+	// arrival records traceIDs in first-seen order so eviction can pick the
+	// oldest pending trace. Entries are appended exactly once per trace and
+	// lazily skipped when the trace has already been decided (popped ids are
+	// checked against the traces map). Guarded by mu.
+	arrival []pcommon.TraceID
 
 	rootSpanCond         *ottl.Condition[*ottlspan.TransformContext]
 	rootSpanCondEvalErrs metric.Int64Counter
@@ -272,6 +283,7 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 	}
 	var lateForwards []lateSampled
 	var newTraces []pcommon.TraceID
+	var evicted []*pendingTrace
 	triggered := make(map[pcommon.TraceID]struct{})
 
 	p.mu.Lock()
@@ -309,18 +321,12 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 				}
 				pt, exists := p.traces[id]
 				if !exists {
-					if len(p.traces) >= p.cfg.NumTraces {
-						for evictID := range p.traces {
-							delete(p.traces, evictID)
-							p.telemetry.ProcessorDynamicSamplingTracesEvicted.Add(ctx, 1)
-							break
-						}
-					}
 					pt = &pendingTrace{
 						traceID:   id,
 						firstSeen: now,
 					}
 					p.traces[id] = pt
+					p.arrival = append(p.arrival, id)
 					newTraces = append(newTraces, id)
 				}
 				pt.spanCount++
@@ -354,6 +360,20 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 		}
 	}
 
+	// Enforce the buffer cap after the whole batch is attached, so an evicted
+	// trace always carries every span seen so far (evicting mid-batch would
+	// decide it without the spans still sitting in this batch's buckets, and
+	// a trace evicted then re-seen within one batch would split in two). The
+	// buffer may transiently exceed NumTraces by the number of new traces in
+	// a single batch.
+	for len(p.traces) > p.cfg.NumTraces {
+		ev := p.evictOldestLocked(ctx)
+		if ev == nil {
+			break
+		}
+		evicted = append(evicted, ev)
+	}
+
 	active := len(p.traces)
 	stopped := p.stopped
 	p.mu.Unlock()
@@ -374,7 +394,13 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 			p.mu.Unlock()
 		})
 		p.mu.Lock()
-		if p.stopped {
+		// Skip storing the timer if we're shutting down, if the trace was
+		// evicted within this same batch (created and then displaced before
+		// its timer was armed), or if a timer already exists (trace evicted
+		// and re-created within one batch lists the id in newTraces twice).
+		_, stillPending := p.traces[traceID]
+		_, hasTimer := p.timers[traceID]
+		if p.stopped || !stillPending || hasTimer {
 			if timer.Stop() {
 				p.wg.Done()
 			}
@@ -386,9 +412,15 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 	}
 
 	if stopped {
-		// Drop late forwards if we're shutting down rather than push into the
-		// downstream consumer.
+		// Drop late forwards and evicted traces if we're shutting down rather
+		// than push into the downstream consumer.
 		return nil
+	}
+
+	// Decide evicted traces outside the lock. Bounded work: at most one
+	// eviction per new trace in the batch.
+	for _, pt := range evicted {
+		p.decideEvicted(ctx, pt)
 	}
 
 	for _, lf := range lateForwards {
@@ -396,6 +428,36 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 		if err := p.next.ConsumeTraces(ctx, lf.td); err != nil {
 			p.logger.Error("forwarding late span failed", zap.Error(err), zap.Stringer("traceID", lf.traceID))
 		}
+	}
+	return nil
+}
+
+// evictOldestLocked removes and returns the oldest pending trace, canceling
+// its trace_timeout timer. Returns nil if nothing is evictable. The caller
+// must hold p.mu.
+func (p *dynamicSamplingProcessor) evictOldestLocked(ctx context.Context) *pendingTrace {
+	for len(p.arrival) > 0 {
+		id := p.arrival[0]
+		p.arrival = p.arrival[1:]
+		// Reclaim the backing array once the live window is a small fraction
+		// of it, so popped head entries don't pin memory indefinitely.
+		if cap(p.arrival) > 1024 && len(p.arrival)*4 < cap(p.arrival) {
+			p.arrival = append([]pcommon.TraceID(nil), p.arrival...)
+		}
+		pt, ok := p.traces[id]
+		if !ok {
+			// Already decided; its arrival entry was left behind by design.
+			continue
+		}
+		delete(p.traces, id)
+		if t, ok := p.timers[id]; ok {
+			if t.Stop() {
+				p.wg.Done()
+			}
+			delete(p.timers, id)
+		}
+		p.telemetry.ProcessorDynamicSamplingTracesEvicted.Add(ctx, 1)
+		return pt
 	}
 	return nil
 }
@@ -493,18 +555,25 @@ func (p *dynamicSamplingProcessor) decide(id pcommon.TraceID) {
 	delete(p.timers, id)
 	p.mu.Unlock()
 
+	p.decideTrace(ctx, pt)
+}
+
+// decideTrace evaluates rules for an already-popped pending trace and either
+// forwards or drops its spans. Shared by the timer-driven decide path and the
+// evaluate eviction policy.
+func (p *dynamicSamplingProcessor) decideTrace(ctx context.Context, pt *pendingTrace) {
 	matchedRule, rate := p.evaluate(ctx, pt)
 	if matchedRule == nil {
 		// No matching rule and no catch-all: drop the trace.
 		p.telemetry.ProcessorDynamicSamplingTracesDropped.Add(ctx, 1,
 			metric.WithAttributes(attribute.String("rule", "unmatched")))
-		p.cache.recordNotSampled(id)
+		p.cache.recordNotSampled(pt.traceID)
 		return
 	}
 
 	ruleAttr := metric.WithAttributes(attribute.String("rule", matchedRule.name))
 
-	upstreamTh, randomness := p.readIncomingSampling(ctx, pt.spans, id)
+	upstreamTh, randomness := p.readIncomingSampling(ctx, pt.spans, pt.traceID)
 	effectiveTh, err := effectiveThreshold(upstreamTh, rate)
 	if err != nil {
 		// The error path is unreachable in practice (rate is clamped to >= 1
@@ -512,25 +581,66 @@ func (p *dynamicSamplingProcessor) decide(id pcommon.TraceID) {
 		// falling back to the upstream threshold preserves whatever decision
 		// upstream already made rather than dropping the trace outright.
 		p.logger.Debug("effective threshold calculation failed, falling back to upstream",
-			zap.Error(err), zap.Stringer("traceID", id))
+			zap.Error(err), zap.Stringer("traceID", pt.traceID))
 		effectiveTh = upstreamTh
 	}
+	p.finishDecision(ctx, pt, matchedRule.name, ruleAttr, effectiveTh, randomness)
+}
+
+// finishDecision applies an already-composed effective threshold: records the
+// sample-rate histogram, performs the keep/drop check, updates the decision
+// cache, and forwards sampled traces. Shared by every decision path.
+func (p *dynamicSamplingProcessor) finishDecision(ctx context.Context, pt *pendingTrace, ruleName string, ruleAttr metric.MeasurementOption, effectiveTh sampling.Threshold, randomness sampling.Randomness) {
 	// Record the effective (post-composition) rate rather than the raw sampler
 	// rate: under equalizing, an upstream stricter than the sampler's rate caps
 	// what we emit, and the histogram should reflect that.
 	p.telemetry.ProcessorDynamicSamplingDecisionSampleRate.Record(ctx, int64(effectiveTh.AdjustedCount()), ruleAttr)
 	if !effectiveTh.ShouldSample(randomness) {
 		p.telemetry.ProcessorDynamicSamplingTracesDropped.Add(ctx, 1, ruleAttr)
-		p.cache.recordNotSampled(id)
+		p.cache.recordNotSampled(pt.traceID)
 		return
 	}
 
-	p.cache.recordSampled(id, cachedDecision{ruleName: matchedRule.name, threshold: effectiveTh})
-	annotated := p.assembleTrace(ctx, pt.spans, matchedRule.name, effectiveTh)
+	p.cache.recordSampled(pt.traceID, cachedDecision{ruleName: ruleName, threshold: effectiveTh})
+	annotated := p.assembleTrace(ctx, pt.spans, ruleName, effectiveTh)
 	p.telemetry.ProcessorDynamicSamplingTracesSampled.Add(ctx, 1, ruleAttr)
 	if err := p.next.ConsumeTraces(ctx, annotated); err != nil {
-		p.logger.Error("forwarding sampled trace failed", zap.Error(err), zap.Stringer("traceID", id))
+		p.logger.Error("forwarding sampled trace failed", zap.Error(err), zap.Stringer("traceID", pt.traceID))
 	}
+}
+
+// decideEvicted decides a trace displaced by buffer pressure, per the
+// configured eviction policy. The trace may be incomplete; decision_delay is
+// deliberately skipped because there is no room to wait.
+func (p *dynamicSamplingProcessor) decideEvicted(ctx context.Context, pt *pendingTrace) {
+	p.telemetry.ProcessorDynamicSamplingDecisionTriggers.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("trigger", string(triggerEviction))))
+	if p.cfg.Eviction.Policy == EvictionProbabilistic {
+		p.decideEvictedProbabilistic(ctx, pt)
+		return
+	}
+	p.decideTrace(ctx, pt)
+}
+
+// decideEvictedProbabilistic sheds an evicted trace with constant-time work:
+// no rule evaluation, just the configured probability composed with any
+// upstream threshold. Kept traces still carry a correct ot=th, so downstream
+// weighting remains accurate even under pressure.
+func (p *dynamicSamplingProcessor) decideEvictedProbabilistic(ctx context.Context, pt *pendingTrace) {
+	evAttr := metric.WithAttributes(attribute.String("rule", evictionRuleLabel))
+	upstreamTh, randomness := p.readIncomingSampling(ctx, pt.spans, pt.traceID)
+	effectiveTh := upstreamTh
+	if ours, err := sampling.ProbabilityToThreshold(p.cfg.Eviction.SamplingPercentage / 100); err == nil {
+		if !sampling.ThresholdGreater(upstreamTh, ours) {
+			effectiveTh = ours
+		}
+	} else {
+		// Unreachable with a validated config; fall back to the upstream
+		// threshold rather than dropping outright.
+		p.logger.Debug("eviction threshold calculation failed, falling back to upstream",
+			zap.Error(err), zap.Stringer("traceID", pt.traceID))
+	}
+	p.finishDecision(ctx, pt, evictionRuleLabel, evAttr, effectiveTh, randomness)
 }
 
 // evaluate returns the first matching rule and the sample rate it produced.

--- a/processor/dynamicsamplingprocessor/processor.go
+++ b/processor/dynamicsamplingprocessor/processor.go
@@ -374,6 +374,14 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 		evicted = append(evicted, ev)
 	}
 
+	// The arrival list is only consumed by eviction, so during normal
+	// operation (buffer never full) entries for decided traces would
+	// accumulate forever. Compact it once stale entries dominate; amortized
+	// O(1) per trace.
+	if len(p.arrival) > arrivalCompactionFactor*len(p.traces)+arrivalCompactionFloor {
+		p.compactArrivalLocked()
+	}
+
 	active := len(p.traces)
 	stopped := p.stopped
 	p.mu.Unlock()
@@ -430,6 +438,29 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 		}
 	}
 	return nil
+}
+
+// Compaction tuning for the arrival list. Not configurable: entries are
+// 16-byte traceIDs, so the factor bounds the list's memory at a fraction of a
+// percent of the buffered span data it shadows, and the floor only prevents
+// thrashing on a near-empty buffer. Compaction cost is amortized O(1) per
+// trace at any factor > 1.
+const (
+	arrivalCompactionFactor = 2
+	arrivalCompactionFloor  = 1024
+)
+
+// compactArrivalLocked rebuilds the arrival order in place, dropping ids
+// whose traces have already been decided, preserving first-seen order for the
+// rest. The caller must hold p.mu.
+func (p *dynamicSamplingProcessor) compactArrivalLocked() {
+	live := p.arrival[:0]
+	for _, id := range p.arrival {
+		if _, ok := p.traces[id]; ok {
+			live = append(live, id)
+		}
+	}
+	p.arrival = live
 }
 
 // evictOldestLocked removes and returns the oldest pending trace, canceling

--- a/processor/dynamicsamplingprocessor/processor_test.go
+++ b/processor/dynamicsamplingprocessor/processor_test.go
@@ -415,6 +415,45 @@ func TestProcessor_EvictionWithinSingleBatch(t *testing.T) {
 	p.mu.Unlock()
 }
 
+func TestProcessor_ArrivalListCompaction(t *testing.T) {
+	// During normal operation (buffer never full) eviction never pops the
+	// arrival list, so entries for decided traces must be reclaimed by
+	// compaction or the list grows forever.
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  5 * time.Millisecond,
+		DecisionDelay: 5 * time.Millisecond,
+		NumTraces:     10_000,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p := newTestProcessor(t, cfg, sink)
+
+	const total = 2000
+	for i := range total {
+		var id pcommon.TraceID
+		id[0] = byte(i)
+		id[1] = byte(i >> 8)
+		id[15] = 0x77
+		require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(id, ptrace.StatusCodeUnset)))
+	}
+	// Wait for the whole population to be decided through the normal timer
+	// flow, then run one more batch so the end-of-batch compaction check
+	// observes the (now almost entirely stale) arrival list.
+	require.Eventually(t, func() bool {
+		return sink.SpanCount() == total
+	}, 30*time.Second, 10*time.Millisecond)
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xEE}), ptrace.StatusCodeUnset)))
+
+	p.mu.Lock()
+	arrivalLen := len(p.arrival)
+	live := len(p.traces)
+	p.mu.Unlock()
+	assert.LessOrEqual(t, arrivalLen, arrivalCompactionFactor*live+arrivalCompactionFloor,
+		"arrival list must be compacted once decided-trace entries dominate")
+}
+
 func TestProcessor_EvictionMetrics(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() {

--- a/processor/dynamicsamplingprocessor/processor_test.go
+++ b/processor/dynamicsamplingprocessor/processor_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	"go.uber.org/zap"
@@ -302,6 +303,154 @@ func TestProcessor_Eviction(t *testing.T) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	assert.LessOrEqual(t, len(p.traces), 2, "buffer should be capped at NumTraces")
+}
+
+func TestProcessor_EvictionEvaluate_DecidesOldest(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour, // decisions can only come from eviction
+		DecisionDelay: time.Hour,
+		NumTraces:     2,
+		DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p := newTestProcessor(t, cfg, sink)
+
+	oldest := pcommon.TraceID([16]byte{0xA1})
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(oldest, ptrace.StatusCodeUnset)))
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xA2}), ptrace.StatusCodeUnset)))
+	// Third trace overflows the buffer and must evict the OLDEST trace, which
+	// is decided immediately through the rules (always_sample keeps it).
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xA3}), ptrace.StatusCodeUnset)))
+
+	require.Equal(t, 1, sink.SpanCount(), "evicted trace should be decided and forwarded synchronously")
+	out := sink.AllTraces()[0]
+	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, oldest, span.TraceID(), "the oldest trace should be the eviction victim")
+	rule, ok := span.Attributes().Get(ruleAttributeKey)
+	require.True(t, ok)
+	assert.Equal(t, "default", rule.AsString())
+	assert.Contains(t, span.TraceState().AsRaw(), "th:", "evicted-and-kept trace must carry ot=th")
+
+	// The decision was recorded: a late span for the evicted trace takes the
+	// sampled-cache fast path instead of forming a new partial trace.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(oldest, ptrace.StatusCodeUnset)))
+	assert.Eventually(t, func() bool {
+		return sink.SpanCount() == 2
+	}, time.Second, 10*time.Millisecond)
+	p.mu.Lock()
+	_, buffered := p.traces[oldest]
+	p.mu.Unlock()
+	assert.False(t, buffered, "late span of evicted trace must not re-open a pending trace")
+}
+
+func TestProcessor_EvictionProbabilistic(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Hour,
+		NumTraces:     1,
+		DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		Eviction:      EvictionConfig{Policy: EvictionProbabilistic, SamplingPercentage: 50},
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p := newTestProcessor(t, cfg, sink)
+
+	// Randomness comes from the last 7 bytes of the traceID: all-zero sorts
+	// below the 50% threshold (dropped), all-0xFF above it (kept).
+	low := pcommon.TraceID([16]byte{0xB1})
+	high := pcommon.TraceID([16]byte{0xB2, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(low, ptrace.StatusCodeUnset)))
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(high, ptrace.StatusCodeUnset)))                            // evicts low: dropped
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xB3}), ptrace.StatusCodeUnset))) // evicts high: kept
+
+	require.Equal(t, 1, sink.SpanCount())
+	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, high, span.TraceID())
+	rule, ok := span.Attributes().Get(ruleAttributeKey)
+	require.True(t, ok)
+	assert.Equal(t, evictionRuleLabel, rule.AsString(), "probabilistic evictions carry the sentinel rule label")
+	assert.Contains(t, span.TraceState().AsRaw(), "th:8", "50%% keep must encode ot=th:8")
+
+	// The dropped trace's decision is cached: its late spans are discarded.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(low, ptrace.StatusCodeUnset)))
+	assert.Equal(t, 1, sink.SpanCount(), "late span of a probabilistically dropped trace must be discarded")
+}
+
+func TestProcessor_EvictionWithinSingleBatch(t *testing.T) {
+	// Multiple new traces in one ConsumeTraces call with NumTraces: 1 forces
+	// evictions before the evicted traces' timers were ever armed. Shutdown
+	// hanging (leaked waitgroup slot) is the failure mode this guards.
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Hour,
+		NumTraces:     1,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p := newTestProcessor(t, cfg, sink)
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	for i := range byte(3) {
+		span := ss.Spans().AppendEmpty()
+		span.SetTraceID(pcommon.TraceID([16]byte{0xC0 + i}))
+		span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		span.SetParentSpanID([8]byte{9, 9, 9, 9, 9, 9, 9, 9})
+		span.SetName("op")
+	}
+	require.NoError(t, p.ConsumeTraces(t.Context(), td))
+
+	assert.Equal(t, 2, sink.SpanCount(), "two of three traces should be evicted and decided")
+	p.mu.Lock()
+	assert.Len(t, p.traces, 1)
+	p.mu.Unlock()
+}
+
+func TestProcessor_EvictionMetrics(t *testing.T) {
+	tt := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+	})
+
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Hour,
+		NumTraces:     1,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p, err := newProcessor(metadatatest.NewSettings(tt), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), nil))
+	t.Cleanup(func() { require.NoError(t, p.Shutdown(t.Context())) })
+
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xD1}), ptrace.StatusCodeUnset)))
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xD2}), ptrace.StatusCodeUnset)))
+
+	metadatatest.AssertEqualProcessorDynamicSamplingTracesEvicted(t, tt,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+	)
+	metadatatest.AssertEqualProcessorDynamicSamplingDecisionTriggers(t, tt,
+		[]metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("trigger", "eviction")),
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+	)
 }
 
 func TestProcessor_RootSpanTriggersEarlyDecision(t *testing.T) {


### PR DESCRIPTION
#### Description

When `num_traces` is full, the processor used to evict a random pending trace and drop its spans silently, with no `ot=th`, no decision-cache record, and a dangling timer. Late spans of an evicted trace then formed a new partial trace that could be decided on its own.

This change makes eviction deterministic and gives every evicted trace a real decision. The oldest pending trace is evicted (first-seen order), its timer cancelled, and it's decided immediately with the spans seen so far. How that decision is made is configurable via a new `eviction` block:

```yaml
dynamic_sampling:
  eviction:
    policy: evaluate            # evaluate (default) | probabilistic
    sampling_percentage: 10     # required for probabilistic
```

- `policy: evaluate` (default) runs the normal rules path, so configured rules keep working under pressure.
- `policy: probabilistic` skips rule evaluation and decides against a threshold derived from `sampling_percentage`. That's constant-time work per evicted trace, so an overloaded instance sheds load instead of amplifying it (same idea as Refinery's stress relief). Kept traces carry the sentinel rule attribution `_eviction`.

Both modes record the decision in the cache so late spans follow it, and stamp kept traces with a correct `ot=th` composed with any upstream threshold. The buffer cap is enforced at the end of each batch, so it can transiently exceed `num_traces` by the number of new traces in a batch. That guarantees an evicted trace always carries every span seen so far.

#### Link to tracking issue
Refs #49311

#### Testing

- Unit tests for the eviction behaviour: oldest-first victim selection, probabilistic keep/drop determinism, multiple evictions in one batch, late spans following the decision cache, and arrival-list compaction during steady-state turnover.
- Metrics and config validation for both policies.
- Eviction-pressure benchmarks for both policies.

#### Documentation
README "Buffer overflow and eviction policy" section rewritten with the config block, policy semantics and trade-offs, and the metrics to watch. Metric descriptions updated in `metadata.yaml`. Changelog entry included.

#### Authorship
- [x] I, a human, wrote this pull request description myself.

