### PR TITLE
[processor/dynamicsamplingprocessor]: use MoveTo instead of CopyTo for reconstructing data

### DIFF
--- a/.chloggen/50026-dynamicsampling-moveto.yaml
+++ b/.chloggen/50026-dynamicsampling-moveto.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: processor/dynamic_sampling
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Use `MoveTo` instead of `CopyTo` when accumulating spans, reducing allocations and improving throughput.
+note: Use `MoveTo` instead of `CopyTo` when accumulating and forwarding spans, reducing allocations and improving throughput.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [49311]

--- a/.chloggen/50026-dynamicsampling-moveto.yaml
+++ b/.chloggen/50026-dynamicsampling-moveto.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: dynamicsamplingprocessor
+component: processor/dynamic_sampling
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Use `MoveTo` instead of `CopyTo` when accumulating spans, reducing allocations and improving throughput.

--- a/.chloggen/50026-dynamicsampling-moveto.yaml
+++ b/.chloggen/50026-dynamicsampling-moveto.yaml
@@ -10,7 +10,7 @@ component: dynamicsamplingprocessor
 note: Use `MoveTo` instead of `CopyTo` when accumulating spans, reducing allocations and improving throughput.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [50026]
+issues: [49311]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/50026-dynamicsampling-moveto.yaml
+++ b/.chloggen/50026-dynamicsampling-moveto.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: dynamicsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use `MoveTo` instead of `CopyTo` when accumulating spans, reducing allocations and improving throughput.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50026]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/dynamicsamplingprocessor/processor.go
+++ b/processor/dynamicsamplingprocessor/processor.go
@@ -634,7 +634,7 @@ func (p *dynamicSamplingProcessor) assembleTrace(ctx context.Context, spans []pt
 	out := ptrace.NewTraces()
 	for _, rs := range spans {
 		dst := out.ResourceSpans().AppendEmpty()
-		rs.CopyTo(dst)
+		rs.MoveTo(dst)
 		for _, ss := range dst.ScopeSpans().All() {
 			for _, span := range ss.Spans().All() {
 				span.Attributes().PutStr(ruleAttributeKey, ruleName)

--- a/processor/dynamicsamplingprocessor/processor.go
+++ b/processor/dynamicsamplingprocessor/processor.go
@@ -304,7 +304,7 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 						lateBuckets[id] = b
 					}
 					dstSS := findOrAppendScopeSpans(b.rs, ss)
-					span.CopyTo(dstSS.Spans().AppendEmpty())
+					span.MoveTo(dstSS.Spans().AppendEmpty())
 					continue
 				}
 				pt, exists := p.traces[id]
@@ -334,7 +334,7 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 					pendingBuckets[id] = rsCopy
 				}
 				dstSS := findOrAppendScopeSpans(pendingBuckets[id], ss)
-				span.CopyTo(dstSS.Spans().AppendEmpty())
+				span.MoveTo(dstSS.Spans().AppendEmpty())
 			}
 		}
 		for id, copied := range pendingBuckets {


### PR DESCRIPTION
#### Description

Based on existing benchmarks, the processor spends most of its ingest time copying data from the original trace-id-keyed batch structure. Since the processor doesn't forward the original trace data downstream, we can use `MoveTo` instead of allocating new memory.

The benchmark results below show significant improvement in both allocations and throughput.
 
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Refs #49311 

#### Testing

Benchmarked before/after on `processor/dynamicsamplingprocessor` (Apple M5 Pro):

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor
cpu: Apple M5 Pro
                                                           │ ./processor/dynamicsamplingprocessor/old.txt │ ./processor/dynamicsamplingprocessor/new.txt │
                                                           │                    sec/op                    │        sec/op         vs base                │
ConsumeTraces_Accumulate/10spans_default_root_condition-15                                   2.862µ ± 32%           2.220µ ± 35%  -22.43% (p=0.035 n=10)
ConsumeTraces_Accumulate/1span_default_root_condition-15                                     680.2n ±  7%           619.8n ±  8%   -8.88% (p=0.007 n=10)
ConsumeTraces_Accumulate/10spans_custom_root_condition-15                                    2.059µ ± 10%           1.740µ ± 13%  -15.52% (p=0.000 n=10)
geomean                                                                                       1.589µ                 1.338µ        -15.79%

                                                           │ ./processor/dynamicsamplingprocessor/old.txt │ ./processor/dynamicsamplingprocessor/new.txt │
                                                           │                  spans/sec                   │      spans/sec        vs base                │
ConsumeTraces_Accumulate/10spans_default_root_condition-15                                   3.504M ± 24%           4.533M ± 26%  +29.40% (p=0.035 n=10)
ConsumeTraces_Accumulate/1span_default_root_condition-15                                     1.472M ±  8%           1.617M ±  7%   +9.80% (p=0.007 n=10)
ConsumeTraces_Accumulate/10spans_custom_root_condition-15                                    4.858M ±  9%           5.753M ± 12%  +18.42% (p=0.000 n=10)
geomean                                                                                       2.926M                 3.481M        +18.94%

                                                           │ ./processor/dynamicsamplingprocessor/old.txt │ ./processor/dynamicsamplingprocessor/new.txt │
                                                           │                     B/op                     │         B/op          vs base                │
ConsumeTraces_Accumulate/10spans_default_root_condition-15                                   4.679Ki ± 0%           3.038Ki ± 0%  -35.07% (p=0.000 n=10)
ConsumeTraces_Accumulate/1span_default_root_condition-15                                      1167.0 ± 0%             999.0 ± 0%  -14.40% (p=0.000 n=10)
ConsumeTraces_Accumulate/10spans_custom_root_condition-15                                    4.679Ki ± 0%           3.038Ki ± 0%  -35.07% (p=0.000 n=10)
geomean                                                                                       2.922Ki                2.080Ki       -28.80%

                                                           │ ./processor/dynamicsamplingprocessor/old.txt │ ./processor/dynamicsamplingprocessor/new.txt │
                                                           │                  allocs/op                   │      allocs/op        vs base                │
ConsumeTraces_Accumulate/10spans_default_root_condition-15                                     67.00 ± 0%             27.00 ± 0%  -59.70% (p=0.000 n=10)
ConsumeTraces_Accumulate/1span_default_root_condition-15                                       18.00 ± 0%             14.00 ± 0%  -22.22% (p=0.000 n=10)
ConsumeTraces_Accumulate/10spans_custom_root_condition-15                                      67.00 ± 0%             27.00 ± 0%  -59.70% (p=0.000 n=10)
geomean                                                                                         43.23                  21.69       -49.83%
```

Full existing test suite passes.

#### Documentation

N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself.
