### PR TITLE
[processor/dynamic_sampling] move buffered spans at decision time instead of copying

### DIFF
--- a/.chloggen/dynamicsampling-decide-moveto.yaml
+++ b/.chloggen/dynamicsampling-decide-moveto.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/dynamic_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move buffered spans into the output at decision time instead of copying them, halving decision-path allocations.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49311]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/dynamicsamplingprocessor/benchmark_test.go
+++ b/processor/dynamicsamplingprocessor/benchmark_test.go
@@ -261,22 +261,33 @@ func BenchmarkDecide(b *testing.B) {
 		{name: "10spans_5ottl_rules", spansPerTrace: 10, rules: benchOTTLRules()},
 		{name: "100spans_5ottl_rules", spansPerTrace: 100, rules: benchOTTLRules()},
 		{name: "10000spans_5ottl_rules", spansPerTrace: 10_000, rules: benchOTTLRules()},
-		{name: "10spans_catchall_incoming_tracestate", spansPerTrace: 10, rules: benchCatchAllRules(), traceState: "ot=th:8;rv:ab8befca837da2b0"},
+		{name: "10spans_catchall_incoming_tracestate", spansPerTrace: 10, rules: benchCatchAllRules(), traceState: "ot=th:8;rv:ab8befca837da2"},
 	} {
 		b.Run(bc.name, func(b *testing.B) {
 			p := newBenchProcessor(b, benchConfig(bc.rules))
 
 			id := benchTraceID(1)
-			td := benchTrace(id, bc.spansPerTrace, bc.traceState)
-			spans := make([]ptrace.ResourceSpans, 0, td.ResourceSpans().Len())
-			for _, rs := range td.ResourceSpans().All() {
-				spans = append(spans, rs)
+			template := benchTrace(id, bc.spansPerTrace, bc.traceState)
+
+			// The pending trace is rebuilt (untimed) every iteration: the
+			// decide path consumes pt.spans, and reusing one pendingTrace
+			// would also understate steady-state behavior.
+			newPT := func() *pendingTrace {
+				td := ptrace.NewTraces()
+				template.CopyTo(td)
+				spans := make([]ptrace.ResourceSpans, 0, td.ResourceSpans().Len())
+				for _, rs := range td.ResourceSpans().All() {
+					spans = append(spans, rs)
+				}
+				return &pendingTrace{traceID: id, spans: spans, spanCount: bc.spansPerTrace}
 			}
-			pt := &pendingTrace{traceID: id, spans: spans, spanCount: bc.spansPerTrace}
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				pt := newPT()
+				b.StartTimer()
 				p.mu.Lock()
 				p.traces[id] = pt
 				p.mu.Unlock()

--- a/processor/dynamicsamplingprocessor/processor.go
+++ b/processor/dynamicsamplingprocessor/processor.go
@@ -633,7 +633,9 @@ func (p *dynamicSamplingProcessor) finishDecision(ctx context.Context, pt *pendi
 	}
 
 	p.cache.recordSampled(pt.traceID, cachedDecision{ruleName: ruleName, threshold: effectiveTh})
+	// assembleTrace consumes pt.spans; nothing may read them after this call.
 	annotated := p.assembleTrace(ctx, pt.spans, ruleName, effectiveTh)
+	pt.spans = nil
 	p.telemetry.ProcessorDynamicSamplingTracesSampled.Add(ctx, 1, ruleAttr)
 	if err := p.next.ConsumeTraces(ctx, annotated); err != nil {
 		p.logger.Error("forwarding sampled trace failed", zap.Error(err), zap.Stringer("traceID", pt.traceID))
@@ -771,11 +773,15 @@ func effectiveThreshold(upstream sampling.Threshold, rate int) (sampling.Thresho
 
 // assembleTrace combines accumulated ResourceSpans into a single ptrace.Traces
 // and stamps every span with the rule attribute and `ot=th` TraceState.
+// The buffered ResourceSpans are MOVED into the output, not copied: they are
+// processor-owned (created fresh in ConsumeTraces) and the pendingTrace is
+// discarded after the decision, so the sources are left empty deliberately.
+// readIncomingSampling must run before this (it reads the same spans).
 func (p *dynamicSamplingProcessor) assembleTrace(ctx context.Context, spans []ptrace.ResourceSpans, ruleName string, threshold sampling.Threshold) ptrace.Traces {
 	out := ptrace.NewTraces()
 	for _, rs := range spans {
 		dst := out.ResourceSpans().AppendEmpty()
-		rs.CopyTo(dst)
+		rs.MoveTo(dst)
 		for _, ss := range dst.ScopeSpans().All() {
 			for _, span := range ss.Spans().All() {
 				span.Attributes().PutStr(ruleAttributeKey, ruleName)


### PR DESCRIPTION
#### Description

Companion to #50026, applied to the decision path. `assembleTrace` deep-copied every buffered ResourceSpans into the output at decision time, and profiling showed that copy was ~52% of decision-path allocation bytes. The buffered spans are processor-owned (created fresh in `ConsumeTraces`) and the pending trace is discarded after the decision, so they can be moved instead. `readIncomingSampling` reads the same spans and already runs before assembly; a comment now pins that ordering and `finishDecision` nils the consumed slice.

Also fixes two benchmark issues found while measuring:

- The incoming-tracestate decide benchmark used an `rv` of 16 hex digits (the spec requires exactly 14), so it exercised the parse-failure path and understated real tracestate cost.
- `BenchmarkDecide` reused one pendingTrace across iterations, which breaks once spans are consumed; it now rebuilds the trace per iteration (untimed).

Benchmarks (Apple M4 Pro, mean of 5 runs, measured after the benchmark fixes so before/after are like-for-like):

| BenchmarkDecide case | ns/op before | ns/op after | Δ | B/op before | B/op after | Δ | allocs/op before | allocs/op after | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1span_catchall | 1,931 | 1,436 | -26% | 1,272 | 648 | -49% | 24 | 13 | -46% |
| 10spans_catchall | 4,523 | 3,102 | -31% | 7,392 | 3,320 | -55% | 105 | 49 | -53% |
| 10spans_catchall_incoming_tracestate | 7,852 | 6,721 | -14% | 8,272 | 4,200 | -49% | 135 | 79 | -41% |
| 10spans_5ottl_rules | 6,677 | 5,424 | -19% | 8,042 | 3,967 | -51% | 145 | 89 | -39% |
| 100spans_catchall | 27,739 | 16,044 | -42% | 68,688 | 29,960 | -56% | 915 | 409 | -55% |
| 100spans_5ottl_rules | 44,015 | 34,277 | -22% | 75,174 | 36,416 | -52% | 1,315 | 809 | -38% |
| 1000spans_catchall | 264,149 | 150,837 | -43% | 680,791 | 296,364 | -56% | 9,015 | 4,009 | -56% |
| 10000spans_catchall | 2,435,400 | 1,163,242 | -52% | 6,802,536 | 2,960,366 | -56% | 90,015 | 40,009 | -56% |
| 10000spans_5ottl_rules | 4,084,604 | 2,673,498 | -35% | 7,444,723 | 3,602,399 | -52% | 130,018 | 80,011 | -38% |

#### Link to tracking issue
Refs #49311

#### Testing

- Full suite passes with the race detector; existing decide/eviction/late-span tests cover the consumed-spans semantics.
- Before/after benchmark comparison across all `BenchmarkDecide` cases (numbers above).

#### Documentation

Comments on `assembleTrace` and `finishDecision` documenting the move semantics and ordering constraint. Changelog entry included.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

