### PR TITLE
Revert "[ci] pin prometheus-compliance tests to pre golang 1.25 requirement"

### DIFF
--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           repository: prometheus/compliance
           path: compliance
-          ref: adfa690dd4df11f9c1bc1b130db5843fdca219f1 # Pin to commit using Go 1.23.0
       - name: Copy binary to compliance directory
         # The required name of the downloaded artifact is `otelcol_0.42.0_linux_amd64`, so we place the collector contrib artifact under the same name in the bin folder to run.
         # Source: https://github.com/prometheus/compliance/blob/12cbdf92abf7737531871ab7620a2de965fc5382/remote_write_sender/targets/otel.go#L8


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Now that we are on go 1.25, we should unpin the compliance tests.

This will unblock the [fix](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49992) for this [bug](https://prometheus.io/docs/prometheus/latest/migration/#le-and-quantile-label-values)

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45353


<!--Describe what testing was performed and which tests were added.-->
#### Testing

#### Authorship

- [x] I, a human, wrote this pull request description myself.


