### PR TITLE
[receiver/postgresql] Fix EXPLAIN parameter count for repeated/literal placeholders

### DIFF
--- a/.chloggen/50054-postgresql-explain-param-count.yaml
+++ b/.chloggen/50054-postgresql-explain-param-count.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/postgresql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix EXPLAIN failing on queries with a repeated placeholder or a `$N`-looking string literal, by counting real bind parameters from `pg_prepared_statements` instead of regex-matching `$N` in the query text.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50054]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/sqlquery/db_wrappers.go
+++ b/internal/sqlquery/db_wrappers.go
@@ -34,6 +34,16 @@ func (d DbWrapper) QueryContext(ctx context.Context, query string, args ...any) 
 	return rowsWrapper{rows}, err
 }
 
+// ConnWrapper wraps a dedicated *sql.Conn so a sequence of calls share one connection.
+type ConnWrapper struct {
+	Conn *sql.Conn
+}
+
+func (c ConnWrapper) QueryContext(ctx context.Context, query string, args ...any) (rows, error) {
+	r, err := c.Conn.QueryContext(ctx, query, args...)
+	return rowsWrapper{r}, err
+}
+
 type rowsWrapper struct {
 	rows *sql.Rows
 }

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -139,6 +138,16 @@ func isExplainableQuery(query string) bool {
 }
 
 // explainQuery implements client.
+//
+// The real parameter count comes from pg_prepared_statements, not from counting "$N"
+// occurrences in the query text: a placeholder can repeat (e.g. "$1" used twice for one
+// real parameter) or appear inside a string literal ("$1" is not a placeholder there), and
+// either case makes a text-based count wrong. Once PREPARE succeeds, PostgreSQL has already
+// parsed and deduplicated the real list, so pg_prepared_statements.parameter_types is
+// authoritative. Reading it back requires a second round trip after PREPARE, and since
+// PREPARE is session-scoped, every step (PREPARE, the count lookup, EXPLAIN EXECUTE,
+// DEALLOCATE) has to run on the one connection that ran PREPARE, not just whatever the pool
+// hands out for each call.
 func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID string, logger *zap.Logger) (string, error) {
 	// Check if the query is explainable before attempting EXPLAIN
 	if !isExplainableQuery(query) {
@@ -148,40 +157,72 @@ func (c *postgreSQLClient) explainQuery(ctx context.Context, query, queryID stri
 
 	normalizedQueryID := strings.ReplaceAll(queryID, "-", "_")
 
-	// PostgreSQL's pg_stat_statements returns queries with $1, $2 placeholders
-	paramRegex := regexp.MustCompile(`\$\d+`)
-	matches := paramRegex.FindAllString(query, -1)
-
-	// Build nulls array for placeholders
-	nulls := make([]string, len(matches))
-	for i := range nulls {
-		nulls[i] = "null"
+	conn, err := c.client.Conn(ctx)
+	if err != nil {
+		logger.Error("failed to obtain a dedicated connection for EXPLAIN", zap.Error(err), zap.String("queryID", queryID))
+		return "", err
 	}
+	defer conn.Close()
 
 	// Deallocate the prepared statement on a context detached from ctx so the
-	// cleanup still runs even if ctx was already canceled or timed out.
+	// cleanup still runs even if ctx was already canceled or timed out. Runs on the
+	// same dedicated connection that ran PREPARE, since DEALLOCATE on any other
+	// connection wouldn't find it.
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), detachedCleanupTimeout)
 		defer cancel()
-		_, _ = c.client.ExecContext(cleanupCtx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
+		_, _ = conn.ExecContext(cleanupCtx, fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID))
 	}()
 
-	// if there is no parameter needed, we can not put an empty bracket
-
-	nullsString := ""
-	if len(nulls) > 0 {
-		nullsString = "(" + strings.Join(nulls, ", ") + ")"
-	}
 	setPlanCacheMode := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;"
 	prepareStatement := fmt.Sprintf("PREPARE otel_%s AS %s;", normalizedQueryID, query)
+
+	prepareDb := sqlquery.NewDbClient(sqlquery.ConnWrapper{Conn: conn}, setPlanCacheMode+prepareStatement, logger, sqlquery.TelemetryConfig{})
+	if _, err = prepareDb.QueryRows(ctx); err != nil {
+		logger.Error("failed to prepare statement for EXPLAIN", zap.Error(err), zap.String("queryID", queryID))
+		return "", err
+	}
+
+	paramCountSQL := fmt.Sprintf(
+		"/* otel-collector-ignore */ SELECT COALESCE(array_length(parameter_types, 1), 0) AS param_count FROM pg_prepared_statements WHERE name = 'otel_%s';",
+		normalizedQueryID,
+	)
+	paramCountDb := sqlquery.NewDbClient(sqlquery.ConnWrapper{Conn: conn}, paramCountSQL, logger, sqlquery.TelemetryConfig{})
+	paramCountResult, err := paramCountDb.QueryRows(ctx)
+	if err != nil {
+		logger.Error("failed to look up prepared statement parameter count", zap.Error(err), zap.String("queryID", queryID))
+		return "", err
+	}
+	if len(paramCountResult) == 0 {
+		logger.Error("prepared statement not found in pg_prepared_statements after PREPARE succeeded", zap.String("queryID", queryID))
+		return "", fmt.Errorf("prepared statement otel_%s not found in pg_prepared_statements", normalizedQueryID)
+	}
+
+	paramCount, err := strconv.Atoi(paramCountResult[0]["param_count"])
+	if err != nil {
+		logger.Error("failed to parse prepared statement parameter count", zap.Error(err), zap.String("queryID", queryID))
+		return "", err
+	}
+
+	nullsString := ""
+	if paramCount > 0 {
+		nulls := make([]string, paramCount)
+		for i := range nulls {
+			nulls[i] = "null"
+		}
+		nullsString = "(" + strings.Join(nulls, ", ") + ")"
+	}
 	explainStatement := fmt.Sprintf("EXPLAIN(FORMAT JSON) EXECUTE otel_%s%s;", normalizedQueryID, nullsString)
 
-	wrappedDb := sqlquery.NewDbClient(sqlquery.DbWrapper{Db: c.client}, setPlanCacheMode+prepareStatement+explainStatement, logger, sqlquery.TelemetryConfig{})
-
-	result, err := wrappedDb.QueryRows(ctx)
+	explainDb := sqlquery.NewDbClient(sqlquery.ConnWrapper{Conn: conn}, explainStatement, logger, sqlquery.TelemetryConfig{})
+	result, err := explainDb.QueryRows(ctx)
 	if err != nil {
 		logger.Error("failed to explain statement", zap.Error(err))
 		return "", err
+	}
+
+	if len(result) == 0 {
+		return "", nil
 	}
 
 	plan, err := obfuscateSQLExecPlan(result[0]["QUERY PLAN"])

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -331,6 +331,84 @@ func TestGetIndexStatsIgnoresAccessExclusiveLocks(t *testing.T) {
 	require.Contains(t, indexStats, indexKey("otel", "public", "table2", "table2_pkey"))
 }
 
+// TestExplainQueryParamCount verifies pg_prepared_statements reports the correct parameter
+// count for the two shapes that broke text-based $N counting: a placeholder repeated in the
+// query text, and a string literal that merely looks like one.
+func TestExplainQueryParamCount(t *testing.T) {
+	ci, err := testcontainers.GenericContainer(
+		t.Context(),
+		testcontainers.GenericContainerRequest{
+			ProviderType: testcontainers.ProviderPodman,
+			ContainerRequest: testcontainers.ContainerRequest{
+				Image: fmt.Sprintf("postgres:%s", post17TestVersion),
+				Env: map[string]string{
+					"POSTGRES_USER":     "root",
+					"POSTGRES_PASSWORD": "otel",
+					"POSTGRES_DB":       "otel",
+				},
+				Files: []testcontainers.ContainerFile{{
+					HostFilePath:      filepath.Join("testdata", "integration", "01-init.sql"),
+					ContainerFilePath: "/docker-entrypoint-initdb.d/01-init.sql",
+					FileMode:          700,
+				}},
+				ExposedPorts: []string{postgresqlPort},
+				WaitingFor: wait.ForListeningPort(postgresqlPort).
+					WithStartupTimeout(2 * time.Minute),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, ci.Start(t.Context()))
+	defer testcontainers.CleanupContainer(t, ci)
+
+	p, err := ci.MappedPort(t.Context(), postgresqlPort)
+	require.NoError(t, err)
+
+	clientDB, err := getDB(t.Context(), postgreSQLConfig{
+		username: "otelu",
+		password: "otelp",
+		address: confignet.AddrConfig{
+			Endpoint: net.JoinHostPort("localhost", p.Port()),
+		},
+		tls: configtls.ClientConfig{
+			Insecure: true,
+		},
+	}, "otel")
+	require.NoError(t, err)
+	client := postgreSQLClient{client: clientDB, closeFn: clientDB.Close}
+	defer func() {
+		require.NoError(t, client.Close())
+	}()
+
+	logger := zap.Must(zap.NewProduction())
+
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "repeated placeholder counts as one parameter",
+			query: "SELECT * FROM table1 WHERE id = $1 OR id = $1",
+		},
+		{
+			name:  "dollar-sign inside a string literal is not a parameter",
+			query: "SELECT * FROM table1 WHERE id::text = '$123'",
+		},
+	}
+
+	// A text-based $N count gets both cases wrong: 2 instead of 1 for the repeated
+	// placeholder (which PostgreSQL rejects outright -- "wrong number of parameters"), and
+	// 1 instead of 0 for the string literal (which happens to still run, just with an unused
+	// bound null). pg_prepared_statements reports the correct count either way.
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := client.explainQuery(t.Context(), tc.query, fmt.Sprintf("paramcount%d", i), logger)
+			require.NoError(t, err)
+			require.NotEmpty(t, plan)
+		})
+	}
+}
+
 func TestScrapeLogsFromContainer(t *testing.T) {
 	ci, err := testcontainers.GenericContainer(
 		t.Context(),

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -1228,7 +1228,11 @@ func TestScrapeTopQueries(t *testing.T) {
 	scraper.cache.Add(queryid+tempBlksWrittenColumnName, 1110)
 
 	mock.ExpectQuery(expectedScrapeTopQuery).WillReturnRows(sqlmock.NewRows(expectedRows).FromCSVString(expectedValues[:len(expectedValues)-1]))
-	mock.ExpectQuery(expectedExplain).WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow("[{\"Plan\":{\"Node Type\":\"Merge Join\",\"Parallel Aware\":false,\"Async Capable\":false,\"Join Type\":\"Inner\",\"Startup Cost\":0.43,\"Total Cost\":55.27,\"Plan Rows\":290,\"Plan Width\":1675,\"Inner Unique\":\"?\",\"Merge Cond\":\"( e.businessentityid = p.businessentityid )\",\"Plans\":[{\"Node Type\":\"Index Scan\",\"Parent Relationship\":\"Outer\",\"Parallel Aware\":false,\"Async Capable\":false,\"Scan Direction\":\"Forward\",\"Index Name\":\"PK_Employee_BusinessEntityID\",\"Relation Name\":\"employee\",\"Alias\":\"e\",\"Startup Cost\":0.15,\"Total Cost\":21.5,\"Plan Rows\":290,\"Plan Width\":112},{\"Node Type\":\"Index Scan\",\"Parent Relationship\":\"Inner\",\"Parallel Aware\":false,\"Async Capable\":false,\"Scan Direction\":\"Forward\",\"Index Name\":\"PK_Person_BusinessEntityID\",\"Relation Name\":\"person\",\"Alias\":\"p\",\"Startup Cost\":0.29,\"Total Cost\":2261.87,\"Plan Rows\":19972,\"Plan Width\":1563}]}}]"))
+	mock.ExpectQuery(expectedExplain).WillReturnRows(sqlmock.NewRows([]string{"result"}))
+	mock.ExpectQuery("/* otel-collector-ignore */ SELECT COALESCE(array_length(parameter_types, 1), 0) AS param_count FROM pg_prepared_statements WHERE name = 'otel_114514';").
+		WillReturnRows(sqlmock.NewRows([]string{"param_count"}).AddRow("0"))
+	mock.ExpectQuery("EXPLAIN(FORMAT JSON) EXECUTE otel_114514;").WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow("[{\"Plan\":{\"Node Type\":\"Merge Join\",\"Parallel Aware\":false,\"Async Capable\":false,\"Join Type\":\"Inner\",\"Startup Cost\":0.43,\"Total Cost\":55.27,\"Plan Rows\":290,\"Plan Width\":1675,\"Inner Unique\":\"?\",\"Merge Cond\":\"( e.businessentityid = p.businessentityid )\",\"Plans\":[{\"Node Type\":\"Index Scan\",\"Parent Relationship\":\"Outer\",\"Parallel Aware\":false,\"Async Capable\":false,\"Scan Direction\":\"Forward\",\"Index Name\":\"PK_Employee_BusinessEntityID\",\"Relation Name\":\"employee\",\"Alias\":\"e\",\"Startup Cost\":0.15,\"Total Cost\":21.5,\"Plan Rows\":290,\"Plan Width\":112},{\"Node Type\":\"Index Scan\",\"Parent Relationship\":\"Inner\",\"Parallel Aware\":false,\"Async Capable\":false,\"Scan Direction\":\"Forward\",\"Index Name\":\"PK_Person_BusinessEntityID\",\"Relation Name\":\"person\",\"Alias\":\"p\",\"Startup Cost\":0.29,\"Total Cost\":2261.87,\"Plan Rows\":19972,\"Plan Width\":1563}]}}]"))
+	mock.ExpectExec("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_114514").WillReturnResult(sqlmock.NewResult(0, 0))
 	actualLogs, err := scraper.scrapeTopQuery(t.Context(), 31, 32, 33, time.Minute)
 	assert.NoError(t, err)
 	expectedFile := filepath.Join("testdata", "scraper", "top-query", "expected.yaml")
@@ -1376,39 +1380,76 @@ func TestIsCollectionDue(t *testing.T) {
 
 func TestExplainQuery(t *testing.T) {
 	testCases := []struct {
-		name           string
-		query          string
-		queryID        string
-		expectedSQL    string
-		mockPlanResult string
+		name              string
+		query             string
+		queryID           string
+		normalizedQueryID string
+		paramCount        int
+		mockPlanResult    string
 	}{
 		{
-			name:           "query with no parameters",
-			query:          "SELECT * FROM users",
-			queryID:        "12345",
-			expectedSQL:    "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;EXPLAIN(FORMAT JSON) EXECUTE otel_12345;",
-			mockPlanResult: `[{"Plan":{"Node Type":"Seq Scan","Relation Name":"users"}}]`,
+			name:              "query with no parameters",
+			query:             "SELECT * FROM users",
+			queryID:           "12345",
+			normalizedQueryID: "12345",
+			paramCount:        0,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Seq Scan","Relation Name":"users"}}]`,
 		},
 		{
-			name:           "query with single parameter",
-			query:          "SELECT * FROM users WHERE id = $1",
-			queryID:        "12346",
-			expectedSQL:    "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12346 AS SELECT * FROM users WHERE id = $1;EXPLAIN(FORMAT JSON) EXECUTE otel_12346(null);",
-			mockPlanResult: `[{"Plan":{"Node Type":"Index Scan","Relation Name":"users"}}]`,
+			name:              "query with single parameter",
+			query:             "SELECT * FROM users WHERE id = $1",
+			queryID:           "12346",
+			normalizedQueryID: "12346",
+			paramCount:        1,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Index Scan","Relation Name":"users"}}]`,
 		},
 		{
-			name:           "query with multiple parameters",
-			query:          "SELECT * FROM orders WHERE user_id = $1 AND status = $2 AND created_at > $3",
-			queryID:        "12347",
-			expectedSQL:    "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12347 AS SELECT * FROM orders WHERE user_id = $1 AND status = $2 AND created_at > $3;EXPLAIN(FORMAT JSON) EXECUTE otel_12347(null, null, null);",
-			mockPlanResult: `[{"Plan":{"Node Type":"Index Scan","Relation Name":"orders"}}]`,
+			name:              "query with multiple distinct parameters",
+			query:             "SELECT * FROM orders WHERE user_id = $1 AND status = $2 AND created_at > $3",
+			queryID:           "12347",
+			normalizedQueryID: "12347",
+			paramCount:        3,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Index Scan","Relation Name":"orders"}}]`,
 		},
 		{
-			name:           "query with hyphenated queryID",
-			query:          "SELECT * FROM products WHERE id = $1",
-			queryID:        "abc-def-123",
-			expectedSQL:    "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_abc_def_123 AS SELECT * FROM products WHERE id = $1;EXPLAIN(FORMAT JSON) EXECUTE otel_abc_def_123(null);",
-			mockPlanResult: `[{"Plan":{"Node Type":"Index Scan","Relation Name":"products"}}]`,
+			name:              "query with hyphenated queryID",
+			query:             "SELECT * FROM products WHERE id = $1",
+			queryID:           "abc-def-123",
+			normalizedQueryID: "abc_def_123",
+			paramCount:        1,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Index Scan","Relation Name":"products"}}]`,
+		},
+		{
+			// Bug-fix regression: the old regex counted "$1" twice here (it appears twice in
+			// the query text) and would have tried to bind 2 nulls against a 1-parameter
+			// prepared statement. The real parameter count from pg_prepared_statements is 1.
+			name:              "query with repeated placeholder",
+			query:             "SELECT * FROM orders WHERE customer_id = $1 OR referred_by = $1",
+			queryID:           "20001",
+			normalizedQueryID: "20001",
+			paramCount:        1,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Seq Scan","Relation Name":"orders"}}]`,
+		},
+		{
+			// Bug-fix regression: the old regex matched "$123" inside the string literal and
+			// would have tried to bind 1 null against a 0-parameter prepared statement.
+			name:              "query with dollar-sign inside string literal",
+			query:             "SELECT * FROM logs WHERE message = '$123'",
+			queryID:           "20002",
+			normalizedQueryID: "20002",
+			paramCount:        0,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Seq Scan","Relation Name":"logs"}}]`,
+		},
+		{
+			// Combines both bug modes in one query to prove the fix isn't order-dependent or
+			// only catching one at a time: one real (repeated) parameter, plus a string
+			// literal that looks like a second placeholder but isn't.
+			name:              "query with repeated placeholder and a literal dollar-sign",
+			query:             "SELECT * FROM orders WHERE customer_id = $1 OR referred_by = $1 AND note = '$99'",
+			queryID:           "20003",
+			normalizedQueryID: "20003",
+			paramCount:        1,
+			mockPlanResult:    `[{"Plan":{"Node Type":"Seq Scan","Relation Name":"orders"}}]`,
 		},
 	}
 
@@ -1426,15 +1467,36 @@ func TestExplainQuery(t *testing.T) {
 				closeFn: func() error { return nil },
 			}
 
-			// Expect the EXPLAIN query
-			mock.ExpectQuery(tc.expectedSQL).WillReturnRows(
+			expectedPrepareSQL := fmt.Sprintf(
+				"/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_%s AS %s;",
+				tc.normalizedQueryID, tc.query,
+			)
+			mock.ExpectQuery(expectedPrepareSQL).WillReturnRows(sqlmock.NewRows([]string{"result"}))
+
+			expectedParamCountSQL := fmt.Sprintf(
+				"/* otel-collector-ignore */ SELECT COALESCE(array_length(parameter_types, 1), 0) AS param_count FROM pg_prepared_statements WHERE name = 'otel_%s';",
+				tc.normalizedQueryID,
+			)
+			mock.ExpectQuery(expectedParamCountSQL).WillReturnRows(
+				sqlmock.NewRows([]string{"param_count"}).AddRow(fmt.Sprintf("%d", tc.paramCount)),
+			)
+
+			nullsString := ""
+			if tc.paramCount > 0 {
+				nulls := make([]string, tc.paramCount)
+				for i := range nulls {
+					nulls[i] = "null"
+				}
+				nullsString = "(" + strings.Join(nulls, ", ") + ")"
+			}
+			expectedExplainSQL := fmt.Sprintf("EXPLAIN(FORMAT JSON) EXECUTE otel_%s%s;", tc.normalizedQueryID, nullsString)
+			mock.ExpectQuery(expectedExplainSQL).WillReturnRows(
 				sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(tc.mockPlanResult),
 			)
 
 			// The prepared statement must always be deallocated afterwards,
 			// otherwise it leaks server-side state on pooled connections.
-			normalizedQueryID := strings.ReplaceAll(tc.queryID, "-", "_")
-			mock.ExpectExec(fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", normalizedQueryID)).
+			mock.ExpectExec(fmt.Sprintf("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_%s", tc.normalizedQueryID)).
 				WillReturnResult(sqlmock.NewResult(0, 0))
 
 			plan, err := client.explainQuery(t.Context(), tc.query, tc.queryID, logger)
@@ -1456,11 +1518,12 @@ func TestExplainQueryErrorStillCleansUp(t *testing.T) {
 		closeFn: func() error { return nil },
 	}
 
-	expectedSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;EXPLAIN(FORMAT JSON) EXECUTE otel_12345;"
-	mock.ExpectQuery(expectedSQL).WillReturnError(errors.New("syntax error"))
+	expectedPrepareSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;"
+	mock.ExpectQuery(expectedPrepareSQL).WillReturnError(errors.New("syntax error"))
 
-	// Even though the EXPLAIN itself failed, PREPARE may have already
-	// registered the statement server-side, so cleanup must still run.
+	// Even though PREPARE itself failed, cleanup must still run: PostgreSQL's DEALLOCATE
+	// has no IF EXISTS clause, and a failed PREPARE can still register partial server-side
+	// state, so the receiver always attempts cleanup rather than checking first.
 	mock.ExpectExec("/* otel-collector-ignore */ DEALLOCATE PREPARE otel_12345").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -1480,10 +1543,10 @@ func TestExplainQueryUsesContext(t *testing.T) {
 		closeFn: func() error { return nil },
 	}
 
-	expectedSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;EXPLAIN(FORMAT JSON) EXECUTE otel_12345;"
-	mock.ExpectQuery(expectedSQL).
+	expectedPrepareSQL := "/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_12345 AS SELECT * FROM users;"
+	mock.ExpectQuery(expectedPrepareSQL).
 		WillDelayFor(200 * time.Millisecond).
-		WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow(`[{"Plan":{"Node Type":"Seq Scan","Relation Name":"users"}}]`))
+		WillReturnRows(sqlmock.NewRows([]string{"result"}))
 
 	// Cleanup (DEALLOCATE PREPARE) must still run even though ctx expires
 	// mid-query, otherwise the prepared statement leaks on pooled connections.

--- a/receiver/postgresqlreceiver/testdata/integration/01-init.sql
+++ b/receiver/postgresqlreceiver/testdata/integration/01-init.sql
@@ -9,6 +9,7 @@ CREATE TABLE table1 (
 CREATE TABLE table2 (
     id serial PRIMARY KEY
 );
+GRANT SELECT ON table1, table2 TO otelu;
 
 CREATE DATABASE otel2;
 \c otel2

--- a/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedExplain.sql
+++ b/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedExplain.sql
@@ -1,1 +1,1 @@
-/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_114514 AS select * from pg_stat_activity where id = 32;EXPLAIN(FORMAT JSON) EXECUTE otel_114514;
+/* otel-collector-ignore */ SET plan_cache_mode = force_generic_plan;PREPARE otel_114514 AS select * from pg_stat_activity where id = 32;


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
`explainQuery` determines how many nulls to bind for `EXPLAIN EXECUTE` by regex-matching `$N` against the raw query text and counting matches. This overcounts whenever a placeholder repeats (`WHERE a = $1 OR b = $1` has one real parameter, the regex finds two) or when `$N`-looking text appears inside a string literal (`WHERE msg = '$123'` has
zero real parameters, the regex finds one). Both cases make `EXECUTE` fail with "wrong number of parameters", so `EXPLAIN` never runs for those queries.

This change:
- Replaces the regex-based count in `explainQuery` with a lookup against `pg_prepared_statements.parameter_types`, read after `PREPARE` succeeds
- Adds `ConnWrapper` to `internal/sqlquery` so `PREPARE`, the parameter-count lookup, `EXPLAIN EXECUTE`, and `DEALLOCATE` all run on one dedicated connection instead of the pool, since `PREPARE` is session-scoped and the count lookup needs a second round trip
- Adds the empty-result guard to `explainQuery` that other `EXPLAIN` paths in the file already had

The dedicated connection is required because reading `pg_prepared_statements` back is a separate call from `PREPARE`, and without pinning both to the same connection, the pool could hand a later step a different connection than the one that ran `PREPARE`.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50054

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added test cases to `TestExplainQuery` for a repeated placeholder, a `$N`-looking string literal, and a query combining both
- Updated `TestExplainQueryErrorStillCleansUp` and `TestExplainQueryUsesContext` for the new multi-step SQL sequence
- Updated `TestScrapeTopQueries` and its `expectedExplain.sql` fixture to match
- `go test`, `go vet`, and `golangci-lint` all pass
- Manually verified against real PostgreSQL 12, 14, and 16 that `pg_prepared_statements` reports the correct count and `EXPLAIN` succeeds on all three
<!--Describe the documentation added.-->
#### Documentation
None, no config or README changes.
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
