### PR TITLE
[receiver/sqlserver] Fix XML query plan dropped on obfuscation failure

### DIFF
--- a/.chloggen/fix-sqlserver-xmlplan-obfuscation-failure.yaml
+++ b/.chloggen/fix-sqlserver-xmlplan-obfuscation-failure.yaml
@@ -1,0 +1,15 @@
+change_type: bug_fix
+
+component: receiver/sqlserver
+
+note: Fix `obfuscateXMLPlan` silently dropping the entire XML query plan when a single attribute (e.g. `StatementText`) fails obfuscation due to SQL Server's ~4000-character truncation limit.
+
+issues: [50065]
+
+subtext: |
+  Previously, any obfuscation failure caused the full plan to be discarded and an empty
+  string returned. The failing attribute is now replaced with `?` and processing continues,
+  preserving all other plan content (operator costs, row estimates, join types, index usage).
+  The error is logged via the collector's structured logger instead of `fmt.Println`.
+
+change_logs: [user]

--- a/receiver/sqlserverreceiver/obfuscate.go
+++ b/receiver/sqlserverreceiver/obfuscate.go
@@ -6,10 +6,10 @@ package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"bytes"
 	"encoding/xml"
-	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	"go.uber.org/zap"
 )
 
 var xmlPlanObfuscationAttrs = []string{
@@ -38,7 +38,7 @@ func (o *obfuscator) obfuscateSQLString(sql string) (string, error) {
 }
 
 // obfuscateXMLPlan obfuscates SQL text & parameters from the provided SQL Server XML Plan
-func (o *obfuscator) obfuscateXMLPlan(rawPlan string) (string, error) {
+func (o *obfuscator) obfuscateXMLPlan(rawPlan string, logger *zap.Logger) (string, error) {
 	decoder := xml.NewDecoder(strings.NewReader(rawPlan))
 	var buffer bytes.Buffer
 	encoder := xml.NewEncoder(&buffer)
@@ -62,8 +62,11 @@ func (o *obfuscator) obfuscateXMLPlan(rawPlan string) (string, error) {
 						}
 						val, err := o.obfuscateSQLString(elem.Attr[i].Value)
 						if err != nil {
-							fmt.Println("Unable to obfuscate SQL statement in query plan, skipping: " + elem.Attr[i].Value)
-							return "", nil
+							logger.Warn("Unable to obfuscate SQL statement in query plan, replacing with ?",
+								zap.String("attr", attrName),
+								zap.Error(err))
+							elem.Attr[i].Value = "?"
+							continue
 						}
 						elem.Attr[i].Value = val
 					}

--- a/receiver/sqlserverreceiver/obfuscate_test.go
+++ b/receiver/sqlserverreceiver/obfuscate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestObfuscateSQL(t *testing.T) {
@@ -48,48 +49,50 @@ func TestObfuscateQueryPlan(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "inputQueryPlan.xml"))
 	assert.NoError(t, err)
 
-	result, err := newObfuscator().obfuscateXMLPlan(string(input))
+	result, err := newObfuscator().obfuscateXMLPlan(string(input), zap.NewNop())
 	assert.NoError(t, err)
 	assert.Equal(t, expectedQueryPlan, result)
 }
 
 func TestInvalidQueryPlans(t *testing.T) {
 	obf := newObfuscator()
+	logger := zap.NewNop()
 
 	plan := `<ShowPlanXml</ShowPlanXML>`
-	result, err := obf.obfuscateXMLPlan(plan)
+	result, err := obf.obfuscateXMLPlan(plan, logger)
 	assert.Empty(t, result)
 	assert.Error(t, err)
 
 	plan = `<ShowPlanXML></ShowPlanXML`
-	result, err = obf.obfuscateXMLPlan(plan)
+	result, err = obf.obfuscateXMLPlan(plan, logger)
 	assert.Empty(t, result)
 	assert.Error(t, err)
 
 	plan = `<ShowPlanXML></ShowPlan>`
-	result, err = obf.obfuscateXMLPlan(plan)
+	result, err = obf.obfuscateXMLPlan(plan, logger)
 	assert.Empty(t, result)
 	assert.Error(t, err)
 
-	// obfuscate failure, return empty string
+	// obfuscate failure on StatementText: attribute replaced with "?", plan preserved
 	plan = `<ShowPlanXML StatementText="[msdb].[dbo].[sysjobhistory].[run_duration] as [sjh].[run_duration]/(10000)*(3600)+[msdb].[dbo].[sysjobhistory].[run_duration] as [sjh].[run_duration]%(10000)/(100)*(60)+[msdb].[dbo].[sysjobhistory].[run_duration] as [sjh].[run_duration]%(100)"></ShowPlanXML>`
-	result, err = obf.obfuscateXMLPlan(plan)
-	assert.Empty(t, result)
+	result, err = obf.obfuscateXMLPlan(plan, logger)
 	assert.NoError(t, err)
+	assert.Contains(t, result, `StatementText="?"`)
 }
 
 func TestValidQueryPlans(t *testing.T) {
 	obf := newObfuscator()
+	logger := zap.NewNop()
 
 	plan := `<ShowPlanXML value="abc"></ShowPlanXML>`
-	_, err := obf.obfuscateXMLPlan(plan)
+	_, err := obf.obfuscateXMLPlan(plan, logger)
 	assert.NoError(t, err)
 
 	plan = `<ShowPlanXML StatementText=""></ShowPlanXML>`
-	_, err = obf.obfuscateXMLPlan(plan)
+	_, err = obf.obfuscateXMLPlan(plan, logger)
 	assert.NoError(t, err)
 
 	plan = `<ShowPlanXML StatementText="SELECT * FROM table"><!-- comment --></ShowPlanXML>`
-	_, err = obf.obfuscateXMLPlan(plan)
+	_, err = obf.obfuscateXMLPlan(plan, logger)
 	assert.NoError(t, err)
 }

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -1691,7 +1691,7 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 		}
 
 		queryPlanVal := s.retrieveValue(row, queryPlan, &errs, func(row sqlquery.StringMap, columnName string) (any, error) {
-			return s.obfuscator.obfuscateXMLPlan(row[columnName])
+			return s.obfuscator.obfuscateXMLPlan(row[columnName], s.logger)
 		})
 
 		rowsReturnedVal := s.retrieveValue(row, rowsReturned, &errs, retrieveInt)


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When a SQL attribute (e.g. StatementText) exceeded SQL Server's ~4000-char truncation limit, obfuscateXMLPlan discarded the entire plan and returned "". Now the failing attribute is replaced with "?" and processing continues, preserving operator costs, row estimates, join types, and index usage.

Also replaces the fmt.Println with structured zap logging.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50065

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated unit tests in receiver/sqlserverreceiver/obfuscate_test.go:
- TestInvalidQueryPlans: changed the truncated-StatementText case to assert the plan is preserved with StatementText="?" instead of being dropped — directly validates the fix.
- Updated all obfuscateXMLPlan call sites to pass the logger (required by the new signature).

Run with:
go test ./receiver/sqlserverreceiver/... -run TestInvalidQueryPlans

<!--Describe the documentation added.-->
#### Documentation
No documentation changes needed — this is a bug fix with no new configuration, metrics, or attributes introduced. The changelog entry is in .chloggen/fix-sqlserver-xmlplan-obfuscation-failure.yaml.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ yes] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
