### PR TITLE
[exporter/loadbalancing] Stop holding the routing lock while new backend exporters are created and started

### DIFF
--- a/.chloggen/loadbalancingexporter-nonblocking-backend-changes.yaml
+++ b/.chloggen/loadbalancingexporter-nonblocking-backend-changes.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/load_balancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop holding the routing lock while new backend exporters are created and started
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [8843]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Backend changes now create and start the missing exporters outside of the lock that guards
+  the ring and the exporter map, and only take that lock for the short commit that installs
+  them. A slow exporter creation or startup no longer blocks data from being routed through
+  the already resolved backends.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -41,6 +42,11 @@ type loadBalancer struct {
 
 	stopped    bool
 	updateLock sync.RWMutex
+
+	// backendChangeMu serializes the resolver callbacks, so that topology updates are still
+	// applied one at a time without having to hold updateLock while exporters are being
+	// created and started.
+	backendChangeMu sync.Mutex
 }
 
 // Create new load balancer
@@ -151,41 +157,73 @@ func (lb *loadBalancer) Start(ctx context.Context, host component.Host) error {
 }
 
 func (lb *loadBalancer) onBackendChanges(resolved []string) {
+	lb.backendChangeMu.Lock()
+	defer lb.backendChangeMu.Unlock()
+
 	newRing := newHashRing(resolved)
 
-	if !newRing.equal(lb.ring) {
-		lb.updateLock.Lock()
-		defer lb.updateLock.Unlock()
+	// prepare phase: take a snapshot of the current state, holding updateLock only for the
+	// duration of the copy
+	lb.updateLock.RLock()
+	unchanged := newRing.equal(lb.ring)
+	existing := maps.Clone(lb.exporters)
+	lb.updateLock.RUnlock()
 
-		lb.ring = newRing
-
-		// TODO: set a timeout?
-		ctx := context.Background()
-
-		// add the missing exporters first
-		lb.addMissingExporters(ctx, resolved)
-		lb.removeExtraExporters(ctx, resolved)
+	if unchanged {
+		return
 	}
+
+	// TODO: set a timeout?
+	ctx := context.Background()
+
+	// create and start the missing exporters without holding updateLock, so that slow
+	// component factories or Start calls don't block the data path
+	added := lb.startMissingExporters(ctx, resolved, existing)
+
+	// commit phase: install the new exporters and publish the new ring atomically
+	lb.updateLock.Lock()
+	defer lb.updateLock.Unlock()
+
+	maps.Copy(lb.exporters, added)
+	lb.ring = newRing
+	lb.removeExtraExporters(ctx, resolved)
 }
 
-func (lb *loadBalancer) addMissingExporters(ctx context.Context, endpoints []string) {
+// startMissingExporters creates and starts an exporter for every endpoint that isn't part of the
+// given existing exporters, returning the successfully started ones keyed by endpoint. The returned
+// exporters are not installed into the load balancer, so that partially constructed state stays
+// private to the caller.
+func (lb *loadBalancer) startMissingExporters(ctx context.Context, endpoints []string, existing map[string]*wrappedExporter) map[string]*wrappedExporter {
+	added := make(map[string]*wrappedExporter)
 	for _, endpoint := range endpoints {
 		endpoint = endpointWithPort(endpoint)
 
-		if _, exists := lb.exporters[endpoint]; !exists {
+		_, exists := existing[endpoint]
+		if !exists {
+			_, exists = added[endpoint]
+		}
+
+		if !exists {
 			exp, err := lb.componentFactory(ctx, endpoint)
 			if err != nil {
 				lb.logger.Error("failed to create new exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
 				continue
 			}
+
 			we := newWrappedExporter(exp, endpoint)
 			if err = we.Start(ctx, lb.host); err != nil {
 				lb.logger.Error("failed to start new exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
 				continue
 			}
-			lb.exporters[endpoint] = we
+			added[endpoint] = we
 		}
 	}
+
+	return added
+}
+
+func (lb *loadBalancer) addMissingExporters(ctx context.Context, endpoints []string) {
+	maps.Copy(lb.exporters, lb.startMissingExporters(ctx, endpoints, lb.exporters))
 }
 
 func endpointWithPort(endpoint string) string {

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -165,13 +165,14 @@ func (lb *loadBalancer) onBackendChanges(resolved []string) {
 	// prepare phase: take a snapshot of the current state, holding updateLock only for the
 	// duration of the copy
 	lb.updateLock.RLock()
-	unchanged := newRing.equal(lb.ring)
-	existing := maps.Clone(lb.exporters)
-	lb.updateLock.RUnlock()
+	if newRing.equal(lb.ring) {
+		lb.updateLock.RUnlock()
 
-	if unchanged {
 		return
 	}
+
+	existing := maps.Clone(lb.exporters)
+	lb.updateLock.RUnlock()
 
 	// TODO: set a timeout?
 	ctx := context.Background()

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -255,6 +256,9 @@ func TestOnBackendChanges_SlowStartDoesNotBlockDataPath(t *testing.T) {
 
 	reached := make(chan struct{})
 	release := make(chan struct{})
+	closeRelease := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(closeRelease) // Register in case of test failure to avoid a leak.
+
 	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
 		if endpoint == endpointWithPort("endpoint-2") {
 			close(reached)
@@ -301,7 +305,7 @@ func TestOnBackendChanges_SlowStartDoesNotBlockDataPath(t *testing.T) {
 	}
 
 	// test
-	close(release)
+	closeRelease()
 
 	select {
 	case <-done:

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,6 +245,72 @@ func TestOnBackendChanges(t *testing.T) {
 	p.onBackendChanges(endpoints)
 
 	// verify
+	assert.Len(t, p.ring.items, 2*defaultWeight)
+}
+
+func TestOnBackendChanges_SlowStartDoesNotBlockDataPath(t *testing.T) {
+	// prepare
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		if endpoint == endpointWithPort("endpoint-2") {
+			close(reached)
+			<-release
+		}
+
+		return newNopMockExporter(), nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.onBackendChanges([]string{"endpoint-1"})
+	require.Len(t, p.exporters, 1)
+
+	// test
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+	}()
+
+	// the transition is now blocked inside the component factory for endpoint-2
+	<-reached
+
+	type lookup struct {
+		endpoint string
+		err      error
+	}
+	result := make(chan lookup, 1)
+	go func() {
+		_, endpoint, lookupErr := p.exporterAndEndpoint([]byte{128, 128, 0, 0})
+		result <- lookup{endpoint: endpoint, err: lookupErr}
+	}()
+
+	// verify the data path is still served by the existing ring
+	select {
+	case res := <-result:
+		require.NoError(t, res.err)
+		assert.Equal(t, "endpoint-1", res.endpoint)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "exporterAndEndpoint blocked while the new exporter was being started")
+	}
+
+	// test
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "the backend transition didn't complete")
+	}
+
+	// verify
+	assert.Len(t, p.exporters, 2)
 	assert.Len(t, p.ring.items, 2*defaultWeight)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Backend changes no longer hold the lock that guards the ring whilst
starting new exporters. Now the lock is taken only for the short commit
that installs them. A slow exporter creation or startup no longer blocks
data from being routed through.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #8843.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a regression test to verify the new behavior.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
