### PR TITLE
receiver/statsdreceiver: close TCP connection on client disconnect and bound unterminated line size

### DIFF
--- a/.chloggen/statsdreceiver-tcp-close-and-bound-line.yaml
+++ b/.chloggen/statsdreceiver-tcp-close-and-bound-line.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/statsd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Close the TCP connection when the client disconnects and bound the size of an unterminated line, fixing a per-connection file descriptor leak and an unbounded memory growth path in the TCP transport.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50123]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+change_logs: []

--- a/receiver/statsdreceiver/internal/transport/tcp_server.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server.go
@@ -94,9 +94,13 @@ func handleTCPConn(c net.Conn, reporter Reporter, transferChan chan<- Metric) {
 					reporter.OnDebugf("TCP transport (%s): line exceeded %d bytes without a newline, closing connection", c.LocalAddr(), maxLineSize)
 					return
 				}
-				if len(bytes) != 0 {
-					remainder = bytes
-				}
+				// Always replace remainder with what ReadBytes returned on this
+				// EOF, including when it's empty. If the buffer's last line ended
+				// exactly at a '\n', bytes is empty here and remainder must be
+				// cleared to nil - otherwise a stale partial line from an earlier
+				// read would survive and get re-prepended (and duplicated) on the
+				// next outer iteration.
+				remainder = bytes
 				break
 			}
 			line := strings.TrimSpace(string(bytes))

--- a/receiver/statsdreceiver/internal/transport/tcp_server.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server.go
@@ -17,6 +17,13 @@ import (
 
 var errTCPServerDone = errors.New("server stopped")
 
+// maxLineSize bounds how many bytes handleTCPConn buffers while waiting for
+// a newline. It matches the max UDP/UDS packet body size the packet-based
+// transports already treat as one message's ceiling (see packet_server.go),
+// so a TCP client that never sends '\n' can't grow the per-connection
+// remainder buffer without limit.
+const maxLineSize = 65527
+
 type tcpServer struct {
 	listener  net.Listener
 	wg        sync.WaitGroup
@@ -68,6 +75,7 @@ func (t *tcpServer) ListenAndServe(nextConsumer consumer.Metrics, reporter Repor
 
 // handleTCPConn is helper that parses the buffer and split it line by line to be parsed upstream.
 func handleTCPConn(c net.Conn, reporter Reporter, transferChan chan<- Metric) {
+	defer c.Close()
 	payload := make([]byte, 4096)
 	var remainder []byte
 	for {
@@ -82,6 +90,10 @@ func handleTCPConn(c net.Conn, reporter Reporter, transferChan chan<- Metric) {
 		for {
 			bytes, err := buf.ReadBytes(byte('\n'))
 			if errors.Is(err, io.EOF) {
+				if len(bytes) > maxLineSize {
+					reporter.OnDebugf("TCP transport (%s): line exceeded %d bytes without a newline, closing connection", c.LocalAddr(), maxLineSize)
+					return
+				}
 				if len(bytes) != 0 {
 					remainder = bytes
 				}

--- a/receiver/statsdreceiver/internal/transport/tcp_server_test.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server_test.go
@@ -1,0 +1,127 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package transport
+
+import (
+	"net"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type closeTrackingConn struct {
+	net.Conn
+	closed int32
+}
+
+func (c *closeTrackingConn) Close() error {
+	atomic.StoreInt32(&c.closed, 1)
+	return c.Conn.Close()
+}
+
+// Test_handleTCPConn_ClosesConnectionOnClientDisconnect checks that
+// handleTCPConn closes the accepted connection once the client disconnects,
+// even for ordinary, well-behaved traffic (one valid line, then a clean
+// close). Without this, every TCP connection's server-side file descriptor
+// leaks for as long as the process runs.
+func Test_handleTCPConn_ClosesConnectionOnClientDisconnect(t *testing.T) {
+	server, client := net.Pipe()
+	tracked := &closeTrackingConn{Conn: server}
+
+	transferChan := make(chan Metric, 10)
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for range transferChan {
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTCPConn(tracked, NewMockReporter(0), transferChan)
+	}()
+
+	_, err := client.Write([]byte("ordinary.client.metric:1|c\n"))
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTCPConn did not return after the client disconnected")
+	}
+	close(transferChan)
+	<-drainDone
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&tracked.closed),
+		"handleTCPConn must close the server-side connection once the client disconnects")
+}
+
+// Test_handleTCPConn_BoundsUnterminatedLineSize checks that a client
+// streaming data without ever sending '\n' cannot make handleTCPConn buffer
+// an unbounded amount of memory in its `remainder` accumulator.
+func Test_handleTCPConn_BoundsUnterminatedLineSize(t *testing.T) {
+	server, client := net.Pipe()
+	transferChan := make(chan Metric, 10)
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for range transferChan {
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handleTCPConn(server, NewMockReporter(0), transferChan)
+	}()
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	const totalSize = 32 * 1024 * 1024 // 32MB, single logical line, no '\n'
+	chunk := make([]byte, 1<<20)
+	for i := range chunk {
+		chunk[i] = 'A'
+	}
+
+	sendDone := make(chan struct{})
+	go func() {
+		defer close(sendDone)
+		sent := 0
+		for sent < totalSize {
+			n, err := client.Write(chunk)
+			if err != nil {
+				return
+			}
+			sent += n
+		}
+	}()
+
+	// Snapshot heap while the connection is still open, i.e. while any
+	// unbounded `remainder` buffer would still be live.
+	<-sendDone
+	runtime.GC()
+	var peak runtime.MemStats
+	runtime.ReadMemStats(&peak)
+
+	client.Close()
+	wg.Wait()
+	close(transferChan)
+	<-drainDone
+
+	peakDeltaMB := int64(peak.HeapAlloc-before.HeapAlloc) / (1024 * 1024)
+	t.Logf("sent %dMB with zero newlines over one connection; heap grew by %dMB while the connection was open", totalSize/(1024*1024), peakDeltaMB)
+
+	const boundMB = 4
+	require.LessOrEqualf(t, peakDeltaMB, int64(boundMB),
+		"a single unterminated-line connection must not buffer more than ~maxLineSize bytes, got %dMB of heap growth", peakDeltaMB)
+}

--- a/receiver/statsdreceiver/internal/transport/tcp_server_test.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server_test.go
@@ -16,11 +16,11 @@ import (
 
 type closeTrackingConn struct {
 	net.Conn
-	closed int32
+	closed atomic.Int32
 }
 
 func (c *closeTrackingConn) Close() error {
-	atomic.StoreInt32(&c.closed, 1)
+	c.closed.Store(1)
 	return c.Conn.Close()
 }
 
@@ -37,7 +37,8 @@ func Test_handleTCPConn_ClosesConnectionOnClientDisconnect(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		for range transferChan {
+		for m := range transferChan {
+			_ = m // this test only cares about connection lifecycle, not parsed metrics
 		}
 	}()
 
@@ -59,8 +60,59 @@ func Test_handleTCPConn_ClosesConnectionOnClientDisconnect(t *testing.T) {
 	close(transferChan)
 	<-drainDone
 
-	require.Equal(t, int32(1), atomic.LoadInt32(&tracked.closed),
+	require.Equal(t, int32(1), tracked.closed.Load(),
 		"handleTCPConn must close the server-side connection once the client disconnects")
+}
+
+// Test_handleTCPConn_NoStaleRemainderAtReadBoundary is a regression test for
+// a bug where remainder was only updated on io.EOF when ReadBytes returned a
+// non-empty leftover. When a partial line spans two reads and the second
+// read's data ends exactly at the '\n' that completes it, ReadBytes's final
+// call in that read returns empty bytes with io.EOF, so remainder would keep
+// its old value from the first read - already-consumed data - and wrongly
+// get re-prepended to the next read, corrupting and duplicating the
+// following line.
+func Test_handleTCPConn_NoStaleRemainderAtReadBoundary(t *testing.T) {
+	server, client := net.Pipe()
+	transferChan := make(chan Metric, 10)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTCPConn(server, NewMockReporter(0), transferChan)
+	}()
+
+	// Three separate writes, chosen so each is drained by exactly one Read
+	// inside handleTCPConn's outer loop: net.Pipe's Write blocks until fully
+	// consumed, and each write here is well under the 4096-byte read
+	// buffer, so a write can't be split or coalesced with another across
+	// reads. This reproduces the exact sequence from the bug: a partial
+	// line with no newline, then a read that completes it exactly at the
+	// newline, then an independent third line.
+	for _, w := range []string{"abc", "def\n", "ghi\n"} {
+		_, err := client.Write([]byte(w))
+		require.NoError(t, err)
+	}
+	require.NoError(t, client.Close())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTCPConn did not return after the client disconnected")
+	}
+	close(transferChan)
+
+	var got []string
+	for m := range transferChan {
+		got = append(got, m.Raw)
+	}
+
+	// Before the fix, the stale remainder from the first write ("abc")
+	// would survive the second write's EOF-with-empty-bytes and get
+	// wrongly re-prepended to the third write, producing
+	// []string{"abcdef", "abcghi"} instead.
+	require.Equal(t, []string{"abcdef", "ghi"}, got,
+		"remainder must not survive an EOF where ReadBytes returned no leftover bytes; a stale value corrupts/duplicates the next line")
 }
 
 // Test_handleTCPConn_BoundsUnterminatedLineSize checks that a client
@@ -72,16 +124,15 @@ func Test_handleTCPConn_BoundsUnterminatedLineSize(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		for range transferChan {
+		for m := range transferChan {
+			_ = m // this test only cares about the size bound, not parsed metrics
 		}
 	}()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		handleTCPConn(server, NewMockReporter(0), transferChan)
-	}()
+	})
 
 	runtime.GC()
 	var before runtime.MemStats
@@ -93,16 +144,21 @@ func Test_handleTCPConn_BoundsUnterminatedLineSize(t *testing.T) {
 		chunk[i] = 'A'
 	}
 
+	var sentBytes atomic.Int64
 	sendDone := make(chan struct{})
 	go func() {
 		defer close(sendDone)
-		sent := 0
-		for sent < totalSize {
+		for sentBytes.Load() < int64(totalSize) {
 			n, err := client.Write(chunk)
+			// Record n even on error: once handleTCPConn closes the connection
+			// (expected here, since we deliberately exceed maxLineSize),
+			// net.Pipe's Write can return a non-zero partial count alongside
+			// the error, and that partial count is what actually reached the
+			// server - it's the number we want for the assertions below.
+			sentBytes.Add(int64(n))
 			if err != nil {
 				return
 			}
-			sent += n
 		}
 	}()
 
@@ -118,8 +174,18 @@ func Test_handleTCPConn_BoundsUnterminatedLineSize(t *testing.T) {
 	close(transferChan)
 	<-drainDone
 
+	actualSent := sentBytes.Load()
 	peakDeltaMB := int64(peak.HeapAlloc-before.HeapAlloc) / (1024 * 1024)
-	t.Logf("sent %dMB with zero newlines over one connection; heap grew by %dMB while the connection was open", totalSize/(1024*1024), peakDeltaMB)
+	t.Logf("client wrote %d bytes with zero newlines before the connection closed (of a possible %dMB); heap grew by %dMB while the connection was open",
+		actualSent, totalSize/(1024*1024), peakDeltaMB)
+
+	// The server is expected to close the connection once the unterminated
+	// line exceeds maxLineSize, well short of the full totalSize. Assert we
+	// actually crossed that threshold so this test can't silently pass by
+	// having the client finish writing all 32MB before the bound ever kicks
+	// in - which would exercise nothing about the new bounded-line behavior.
+	require.Greaterf(t, actualSent, int64(maxLineSize),
+		"test must write more than maxLineSize (%d) bytes to actually exercise the bounded-line closure path, only wrote %d", maxLineSize, actualSent)
 
 	const boundMB = 4
 	require.LessOrEqualf(t, peakDeltaMB, int64(boundMB),


### PR DESCRIPTION
#### Description

handleTCPConn (statsd receiver TCP transport) never closed the accepted connection, leaking a file descriptor per client. It also buffered an unbounded remainder slice while waiting for a newline, so a client that never sends one can grow server memory without limit. This adds defer c.Close() and a maxLineSize bound matching the existing UDP/UDS per-message ceiling.

#### Link to tracking issue
Fixes #50123

#### Testing

Added Test_handleTCPConn_ClosesConnectionOnClientDisconnect (asserts the server-side connection closes after the client disconnects) and Test_handleTCPConn_BoundsUnterminatedLineSize (streams 32MB with no newline over one connection, asserts heap growth stays under 4MB). Ran the existing statsdreceiver test suite with no regressions.

#### Documentation

N/A

#### Authorship

- [ ] I, a human, wrote this pull request description myself.
