### PR TITLE
[exporter/datadog] Map the Rate metric intake type

### DIFF
--- a/.chloggen/datadogexporter-rate-metric-type.yaml
+++ b/.chloggen/datadogexporter-rate-metric-type.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: exporter/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Map the `Rate` metric intake type so delta-sum datapoints carrying `datadog.metric.as_type=rate` are no longer silently dropped.
+note: Map the `Rate` metric intake type in legacy metric clients so delta-sum datapoints carrying `datadog.metric.as_type=rate` are no longer silently dropped.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [50119]

--- a/.chloggen/datadogexporter-rate-metric-type.yaml
+++ b/.chloggen/datadogexporter-rate-metric-type.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Map the `Rate` metric intake type so delta-sum datapoints carrying `datadog.metric.as_type=rate` are no longer silently dropped.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50119]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `toDataType` previously mapped only `Count` and `Gauge`, so a `Rate` datatype fell through to
+  `METRICINTAKETYPE_UNSPECIFIED` and the series was rejected by the intake.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -53,6 +53,8 @@ func (*Consumer) toDataType(dt metrics.DataType) (out datadogV2.MetricIntakeType
 		out = datadogV2.METRICINTAKETYPE_COUNT
 	case metrics.Gauge:
 		out = datadogV2.METRICINTAKETYPE_GAUGE
+	case metrics.Rate:
+		out = datadogV2.METRICINTAKETYPE_RATE
 	}
 
 	return out

--- a/exporter/datadogexporter/internal/metrics/consumer_test.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -188,5 +189,25 @@ func TestConsumeTimeSeriesUnits(t *testing.T) {
 	require.Len(t, consumer.ms, 4)
 	for _, m := range consumer.ms {
 		assert.Nil(t, m.Unit)
+	}
+}
+
+func TestToDataType(t *testing.T) {
+	consumer := NewConsumer(nil)
+	for _, tt := range []struct {
+		name string
+		in   metrics.DataType
+		want datadogV2.MetricIntakeType
+	}{
+		{"count", metrics.Count, datadogV2.METRICINTAKETYPE_COUNT},
+		{"gauge", metrics.Gauge, datadogV2.METRICINTAKETYPE_GAUGE},
+		// Rate is reachable when an OTLP delta-sum datapoint carries the
+		// datadog.metric.as_type=rate attribute; before this case existed it fell
+		// through to METRICINTAKETYPE_UNSPECIFIED and the metric was silently dropped.
+		{"rate", metrics.Rate, datadogV2.METRICINTAKETYPE_RATE},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, consumer.toDataType(tt.in))
+		})
 	}
 }


### PR DESCRIPTION
Fixes #50119

#### Testing

Added a table-driven `TestToDataType` covering `Count`, `Gauge`, and `Rate`. Before this change the `rate` case returns `METRICINTAKETYPE_UNSPECIFIED` and the assertion fails; after it, all three pass.

```
--- PASS: TestToDataType (0.00s)
    --- PASS: TestToDataType/count (0.00s)
    --- PASS: TestToDataType/gauge (0.00s)
    --- PASS: TestToDataType/rate (0.00s)
```

#### Documentation

None — behavior fix, no user-facing configuration change. Added a `bug_fix` changelog entry.

---
*AI assistance was used on this change and is disclosed with an `Assisted-by:` trailer on the commit, per [AGENTS.md](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/AGENTS.md#commit-formatting). I root-caused, tested, and verified it myself, and this description is my own writing.*
