### PR TITLE
[receiver/netflow] Add optional goflow2 mapping config file support

### DIFF
--- a/.chloggen/netflowreceiver-mapping.yaml
+++ b/.chloggen/netflowreceiver-mapping.yaml
@@ -10,7 +10,7 @@ component: receiver/netflow
 note: Add an optional `mapping` config option to supply a goflow2 mapping YAML file for mapping extra template fields or extracting fields from the raw payload by offset.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [40763]
+issues: [50140]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/netflowreceiver-mapping.yaml
+++ b/.chloggen/netflowreceiver-mapping.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/netflow
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an optional `mapping` config option to supply a goflow2 mapping YAML file for mapping extra template fields or extracting fields from the raw payload by offset.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40763]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/netflowreceiver/README.md
+++ b/receiver/netflowreceiver/README.md
@@ -79,6 +79,7 @@ You would then configure your network devices to send netflow, sflow, or ipfix d
 | workers | The number of workers used to decode incoming flow messages | 2 | 2 |
 | queue_size | The size of the incoming netflow packets queue, it will always be at least 1000. | 5000 | 1000 |
 | send_raw   | Whether to send raw flow messages instead of parsing them                        | `true`, `false`    | `false`   |
+| mapping | Optional path to a [goflow2 mapping YAML file](https://github.com/netsampler/goflow2#mapping-extra-fields), used to map extra template fields or extract fields from the raw payload by byte offset (e.g. a VXLAN VNI). | `/etc/otel/netflow-mapping.yaml` | (none) |
 
 When `send_raw` is set to `true`, the receiver will:
 
@@ -145,11 +146,11 @@ The log record timestamps will be:
 * Process [Template Records](https://www.cisco.com/en/US/technologies/tk648/tk362/technologies_white_paper09186a00800a3db9.html) if present
 * Process Netflow V5, V9, and IPFIX messages
 * Extract the attributes documented above
-* Mapping of custom fields is not yet supported
+* Custom field mapping is supported via the `mapping` option (see [goflow2 mapping](https://github.com/netsampler/goflow2#mapping-extra-fields))
 
 #### sflow
 
 * Process [sFlow version 5](https://sflow.org/sflow_version_5.txt) datagrams
 * `flow_sample` and `flow_sample_expanded` are supported.
 * `counter_sample` and `counter_sample_expanded` are NOT yet supported.
-* Mapping of custom fields is not yet supported
+* Custom field mapping is supported via the `mapping` option (see [goflow2 mapping](https://github.com/netsampler/goflow2#mapping-extra-fields))

--- a/receiver/netflowreceiver/config.go
+++ b/receiver/netflowreceiver/config.go
@@ -5,6 +5,8 @@ package netflowreceiver // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"errors"
+	"fmt"
+	"os"
 )
 
 // Config represents the receiver config settings within the collector's config.yaml
@@ -33,6 +35,11 @@ type Config struct {
 
 	// SendRaw determines whether to send raw flow messages instead of parsing them
 	SendRaw bool `mapstructure:"send_raw"`
+
+	// Mapping is an optional path to a goflow2 mapping YAML file, used to map
+	// extra template fields or extract fields from the raw payload by offset
+	// (e.g. a VXLAN VNI). See https://github.com/netsampler/goflow2#mapping-extra-fields
+	Mapping string `mapstructure:"mapping"`
 }
 
 // Validate checks if the receiver configuration is valid
@@ -64,6 +71,12 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Port <= 0 {
 		return errors.New("port must be greater than 0")
+	}
+
+	if cfg.Mapping != "" {
+		if _, err := os.Stat(cfg.Mapping); err != nil {
+			return fmt.Errorf("mapping file %q is not readable: %w", cfg.Mapping, err)
+		}
 	}
 
 	return nil

--- a/receiver/netflowreceiver/config_test.go
+++ b/receiver/netflowreceiver/config_test.go
@@ -71,6 +71,17 @@ func TestLoadConfig(t *testing.T) {
 				SendRaw:   true,
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "valid_mapping"),
+			expected: &Config{
+				Scheme:    "sflow",
+				Port:      2055,
+				Sockets:   1,
+				Workers:   1,
+				QueueSize: 1000,
+				Mapping:   "testdata/mapping.yaml",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +124,10 @@ func TestInvalidConfig(t *testing.T) {
 		{
 			id:  component.NewIDWithName(metadata.Type, "zero_workers"),
 			err: "workers must be greater than 0",
+		},
+		{
+			id:  component.NewIDWithName(metadata.Type, "invalid_mapping"),
+			err: "is not readable",
 		},
 	}
 

--- a/receiver/netflowreceiver/go.mod
+++ b/receiver/netflowreceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -55,5 +56,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/receiver/netflowreceiver/receiver.go
+++ b/receiver/netflowreceiver/receiver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 
 	"github.com/netsampler/goflow2/v2/decoders/netflow"
@@ -17,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 var _ utils.ReceiverCallback = (*dropHandler)(nil)
@@ -106,8 +108,16 @@ func (nr *netflowReceiver) Shutdown(context.Context) error {
 // This is the fuction that will be invoked for every netflow packet received
 // The function depends on the type of schema (netflow, sflow, flow)
 func (nr *netflowReceiver) buildDecodeFunc() (utils.DecoderFunc, error) {
-	// Eventually this can be used to configure mappings
 	cfgProducer := &protoproducer.ProducerConfig{}
+	if nr.config.Mapping != "" {
+		b, err := os.ReadFile(nr.config.Mapping)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read mapping file %q: %w", nr.config.Mapping, err)
+		}
+		if err := yaml.Unmarshal(b, cfgProducer); err != nil {
+			return nil, fmt.Errorf("failed to parse mapping file %q: %w", nr.config.Mapping, err)
+		}
+	}
 	cfgm, err := cfgProducer.Compile() // converts configuration into a format that can be used by a protobuf producer
 	if err != nil {
 		return nil, err

--- a/receiver/netflowreceiver/receiver_test.go
+++ b/receiver/netflowreceiver/receiver_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver/internal/metadata"
 )
@@ -21,4 +23,21 @@ func TestCreateValidDefaultReceiver(t *testing.T) {
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, receiver, "receiver creation failed")
 	assert.NotNil(t, receiver.(*netflowReceiver).udpReceiver)
+}
+
+func TestBuildDecodeFuncWithMapping(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Mapping = "testdata/mapping.yaml"
+	nr := &netflowReceiver{config: *cfg, logger: zap.NewNop()}
+	decodeFunc, err := nr.buildDecodeFunc()
+	require.NoError(t, err)
+	require.NotNil(t, decodeFunc)
+}
+
+func TestBuildDecodeFuncWithBadMapping(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Mapping = "testdata/does_not_exist.yaml"
+	nr := &netflowReceiver{config: *cfg, logger: zap.NewNop()}
+	_, err := nr.buildDecodeFunc()
+	require.Error(t, err)
 }

--- a/receiver/netflowreceiver/testdata/config.yaml
+++ b/receiver/netflowreceiver/testdata/config.yaml
@@ -48,3 +48,17 @@ netflow/raw_logs:
   workers: 1
   queue_size: 0
   send_raw: true
+
+netflow/valid_mapping:
+  scheme: sflow
+  port: 2055
+  sockets: 1
+  workers: 1
+  mapping: testdata/mapping.yaml
+
+netflow/invalid_mapping:
+  scheme: netflow
+  port: 2055
+  sockets: 1
+  workers: 1
+  mapping: testdata/does_not_exist.yaml

--- a/receiver/netflowreceiver/testdata/mapping.yaml
+++ b/receiver/netflowreceiver/testdata/mapping.yaml
@@ -1,0 +1,20 @@
+# Example goflow2 mapping file used by the netflow receiver tests.
+# See https://github.com/netsampler/goflow2#mapping-extra-fields
+#
+# Extracts the VXLAN VNI from the raw sFlow sampled header by byte offset:
+# the VNI sits 12 bytes into the UDP payload (8B UDP header + 4B into the VXLAN
+# header) -> offset 96 bits, length 24 bits, for VXLAN packets (UDP/4789).
+formatter:
+  fields:
+    - vni
+  protobuf:
+    - name: vni
+      index: 1000
+      type: varint
+sflow:
+  mapping:
+    - layer: udp
+      encap: false
+      offset: 96
+      length: 24
+      destination: vni


### PR DESCRIPTION
#### Description

Adds an optional `mapping` config field to the netflow receiver pointing to a goflow2 mapping YAML file. When set, the file is loaded and unmarshalled into goflow2's `protoproducer.ProducerConfig`, allowing users to map extra template fields or extract fields from the raw payload by offset (e.g. a vxlan vni). The path is validated at config time. When unset, behavior is unchanged.

#### Testing

- Added config tests for a valid mapping path and a missing/unreadable path.
- Added `buildDecodeFunc` tests covering a valid mapping file and a bad path.
- `go build ./...`, `go test ./...`, and `make chlog-validate` pass.

#### Documentation

- Documented the `mapping` option in the receiver README.
- Added a changelog entry under `.chloggen/`.