### PR TITLE
[chore][exporter/awscloudwatchlogs] fix tests using xconfmap

### DIFF
--- a/exporter/awscloudwatchlogsexporter/config_test.go
+++ b/exporter/awscloudwatchlogsexporter/config_test.go
@@ -162,19 +162,19 @@ func TestMaxEventPayloadBytesValidate(t *testing.T) {
 	}
 
 	t.Run("zero is allowed (means use default)", func(t *testing.T) {
-		assert.NoError(t, xconfmap.Validate(base(0)))
+		assert.NoError(t, confmap.Validate(base(0)))
 	})
 	t.Run("256 KiB is allowed", func(t *testing.T) {
-		assert.NoError(t, xconfmap.Validate(base(1024*256)))
+		assert.NoError(t, confmap.Validate(base(1024*256)))
 	})
 	t.Run("1 MiB is allowed (post 2025-04-02 service limit)", func(t *testing.T) {
-		assert.NoError(t, xconfmap.Validate(base(1024*1024)))
+		assert.NoError(t, confmap.Validate(base(1024*1024)))
 	})
 	t.Run("below minimum is rejected", func(t *testing.T) {
-		assert.Error(t, xconfmap.Validate(base(10)))
+		assert.Error(t, confmap.Validate(base(10)))
 	})
 	t.Run("above 1 MiB is rejected", func(t *testing.T) {
-		assert.Error(t, xconfmap.Validate(base(1024*1024+1)))
+		assert.Error(t, confmap.Validate(base(1024*1024+1)))
 	})
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/31390881452/job/93462702270?pr=50141

Caused by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48559

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
