### PR TITLE
feat: Missing metrics on AWS RDS Oracle

### DIFF
--- a/.chloggen/oracledb-rds-missing-metrics.yaml
+++ b/.chloggen/oracledb-rds-missing-metrics.yaml
@@ -1,0 +1,29 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/oracledb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added support for collecting sysmetric and resource limit metrics on AWS RDS Oracle
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50147]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  On AWS RDS Oracle, the receiver connects to a PDB (Pluggable Database) where
+  sysmetric and resource limit metrics were previously unavailable. This adds
+  fallback queries to collect 9 sysmetric metrics and 7 resource limit metrics
+  on RDS and other Oracle 12c+ multitenant deployments.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/oracledbreceiver/README.md
+++ b/receiver/oracledbreceiver/README.md
@@ -199,6 +199,48 @@ GRANT SELECT ON DBA_OBJECTS TO <username>;
 GRANT SELECT ON DBA_PROCEDURES TO <username>;
 ```
 
+## AWS RDS Oracle grants
+
+Run the following as the master/admin user using `rdsadmin.rdsadmin_util.grant_sys_object` to grant permissions on the required views.
+The following grants cover all metrics and events collected by this receiver:
+
+```sql
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SYSMETRIC',      '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$CON_SYSMETRIC',  '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$CONTAINERS',     '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SESSION',        '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SESSION_EVENT',  '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SYSSTAT',        '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$CON_SYSSTAT',    '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$OSSTAT',         '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SGAINFO',        '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SGASTAT',        '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL',            '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL_PLAN',       '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL_PLAN_STATISTICS_ALL', '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$PARAMETER',      '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$ROWCACHE',       '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$RESOURCE_LIMIT', '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$LOCK',           '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$PROCESS',        '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$TRANSACTION',    '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$DATABASE',       '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$INSTANCE',       '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$DATAFILE',       '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('V_$PDBS',           '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_DATA_FILES',               '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_FREE_SPACE',               '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_RECYCLEBIN',               '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_TABLESPACES',              '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_TABLESPACE_USAGE_METRICS', '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_PROCEDURES',               '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('DBA_OBJECTS',                  '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('CDB_TABLESPACE_USAGE_METRICS', '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('CDB_TABLESPACES',              '<username>', 'SELECT', false);
+EXEC rdsadmin.rdsadmin_util.grant_sys_object('CDB_SERVICES',                 '<username>', 'SELECT', false);
+GRANT CREATE SESSION TO <username>;
+```
+
 ## Enabling metrics.
 
 See [documentation](./documentation.md).

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -43,6 +43,13 @@ const (
 	// Note: unlike V$SYSMETRIC, V$CON_SYSMETRIC only exposes short-interval (60s)
 	// rows, so no group_id filter is required.
 	sysmetricCDBSQL = "SELECT s.metric_name AS METRIC_NAME, s.value AS VALUE, c.name AS PDB_NAME FROM v$con_sysmetric s, v$containers c WHERE s.con_id = c.con_id(+)"
+	// sysmetricComputedSQL derives Shared Pool Free % from v$sgastat for PDB connections
+	// (e.g. RDS Oracle) where v$sysmetric is empty in PDB context.
+	sysmetricComputedSQL = `SELECT 'Shared Pool Free %' AS METRIC_NAME,
+       CASE WHEN NVL(SUM(bytes),0) > 0
+            THEN NVL(SUM(CASE WHEN name = 'free memory' THEN bytes ELSE 0 END),0) / SUM(bytes) * 100
+            ELSE 0 END AS VALUE
+FROM v$sgastat WHERE pool = 'shared pool'`
 
 	// containerGrantsProbeSQL detects whether the user has the grants needed
 	// for per-PDB collection. On failure the receiver falls back to the
@@ -204,6 +211,38 @@ const (
 	// sessionCountCDBSQL extends sessionCountSQL with per-PDB breakdown via v$containers join.
 	sessionCountCDBSQL      = "select s.status, s.type, c.name as PDB_NAME, count(*) as VALUE FROM v$session s, v$containers c WHERE s.con_id = c.con_id(+) GROUP BY s.status, s.type, c.name"
 	systemResourceLimitsSQL = "select RESOURCE_NAME, CURRENT_UTILIZATION, LIMIT_VALUE, CASE WHEN TRIM(INITIAL_ALLOCATION) LIKE 'UNLIMITED' THEN '-1' ELSE TRIM(INITIAL_ALLOCATION) END as INITIAL_ALLOCATION, CASE WHEN TRIM(LIMIT_VALUE) LIKE 'UNLIMITED' THEN '-1' ELSE TRIM(LIMIT_VALUE) END as LIMIT_VALUE from v$resource_limit"
+	// systemResourceLimitsPDBSQL derives resource limits for PDB connections (e.g. RDS Oracle) where
+	// v$resource_limit returns no rows. Limits from v$parameter; usage from v$process, v$session,
+	// v$transaction, v$lock. enqueue_locks and enqueue_resources are auto-managed in Oracle 19c and
+	// not exposed as init parameters, so they are omitted.
+	systemResourceLimitsPDBSQL = `SELECT
+    RESOURCE_NAME,
+    CURRENT_UTILIZATION,
+    CASE
+        WHEN LIMIT_VALUE IS NULL OR TRIM(LIMIT_VALUE) IN ('UNLIMITED', '0') THEN '-1'
+        ELSE TRIM(LIMIT_VALUE)
+    END AS LIMIT_VALUE
+FROM (
+  SELECT 'processes' AS RESOURCE_NAME,
+         (SELECT COUNT(*) FROM v$process) AS CURRENT_UTILIZATION,
+         (SELECT value FROM v$parameter WHERE name = 'processes') AS LIMIT_VALUE
+  FROM dual
+  UNION ALL
+  SELECT 'sessions',
+         (SELECT COUNT(*) FROM v$session),
+         (SELECT value FROM v$parameter WHERE name = 'sessions')
+  FROM dual
+  UNION ALL
+  SELECT 'transactions',
+         (SELECT COUNT(*) FROM v$transaction),
+         (SELECT value FROM v$parameter WHERE name = 'transactions')
+  FROM dual
+  UNION ALL
+  SELECT 'dml_locks',
+         (SELECT COUNT(*) FROM v$lock WHERE type = 'TM'),
+         (SELECT value FROM v$parameter WHERE name = 'dml_locks')
+  FROM dual
+)`
 	tablespaceUsageSQL      = `
 		select um.TABLESPACE_NAME, um.USED_SPACE, um.TABLESPACE_SIZE, ts.BLOCK_SIZE, ts.STATUS
 		FROM DBA_TABLESPACE_USAGE_METRICS um INNER JOIN DBA_TABLESPACES ts
@@ -337,10 +376,11 @@ type dbProviderFunc func() (*sql.DB, error)
 type clientProviderFunc func(*sql.DB, string, *zap.Logger) dbClient
 
 type oracleScraper struct {
-	statsClient                dbClient
-	tablespaceUsageClient      dbClient
-	systemResourceLimitsClient dbClient
-	sessionCountClient         dbClient
+	statsClient                   dbClient
+	tablespaceUsageClient         dbClient
+	systemResourceLimitsClient    dbClient
+	systemResourceLimitsPDBClient dbClient
+	sessionCountClient            dbClient
 	// isCDBRoot is true when connected to a CDB root (Oracle 12c+); enables per-PDB queries.
 	isCDBRoot                bool
 	oracleQueryMetricsClient dbClient
@@ -352,9 +392,10 @@ type oracleScraper struct {
 	recycleBinSizeClient     dbClient
 	sgaInfoClient            dbClient
 	storageUsageClient       dbClient
-	sysmetricClient          dbClient
-	sysmetricCDBClient       dbClient
-	db                       *sql.DB
+	sysmetricClient         dbClient
+	sysmetricCDBClient      dbClient
+	sysmetricComputedClient dbClient
+	db                      *sql.DB
 	clientProviderFunc       clientProviderFunc
 	mb                       *metadata.MetricsBuilder
 	lb                       *metadata.LogsBuilder
@@ -469,6 +510,9 @@ func (s *oracleScraper) start(ctx context.Context, _ component.Host) error {
 	}
 	s.tablespaceUsageClient = s.clientProviderFunc(s.db, s.buildTablespaceSQL(), s.logger)
 	s.systemResourceLimitsClient = s.clientProviderFunc(s.db, systemResourceLimitsSQL, s.logger)
+	if s.instanceInfo.connectedToPDB {
+		s.systemResourceLimitsPDBClient = s.clientProviderFunc(s.db, systemResourceLimitsPDBSQL, s.logger)
+	}
 	s.samplesQueryClient = s.clientProviderFunc(s.db, samplesQuery, s.logger)
 	s.sessionEventClient = s.clientProviderFunc(s.db, sessionEventQuery, s.logger)
 	s.dataDictHitRatioClient = s.clientProviderFunc(s.db, dataDictHitRatioSQL, s.logger)
@@ -477,8 +521,14 @@ func (s *oracleScraper) start(ctx context.Context, _ component.Host) error {
 	s.sgaInfoClient = s.clientProviderFunc(s.db, sgaInfoSQL, s.logger)
 	s.storageUsageClient = s.clientProviderFunc(s.db, storageUsageSQL, s.logger)
 	s.sysmetricClient = s.clientProviderFunc(s.db, sysmetricSQL, s.logger)
-	if s.isCDBRoot {
+	// sysmetricCDBSQL works from both CDB root and PDB connections (v$containers is accessible in both).
+	// For PDB connections (e.g. RDS Oracle), it returns the sysmetric metrics available in PDB context.
+	if s.isCDBRoot || (s.instanceInfo.isCDB && s.instanceInfo.connectedToPDB) {
 		s.sysmetricCDBClient = s.clientProviderFunc(s.db, sysmetricCDBSQL, s.logger)
+	}
+	// PDB connection: V$SYSMETRIC is empty, so the remaining metrics must be computed from raw stats.
+	if s.instanceInfo.isCDB && s.instanceInfo.connectedToPDB {
+		s.sysmetricComputedClient = s.clientProviderFunc(s.db, sysmetricComputedSQL, s.logger)
 	}
 	return nil
 }
@@ -1057,9 +1107,14 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.metricsBuilderConfig.Metrics.OracledbEnqueueResourcesLimit.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbEnqueueLocksLimit.Enabled ||
 		s.metricsBuilderConfig.Metrics.OracledbEnqueueLocksUsage.Enabled {
-		rows, err := s.systemResourceLimitsClient.metricRows(ctx)
+		// For PDB connections (e.g. RDS), v$resource_limit returns no rows; use derived query instead.
+		resourceLimitsClient := s.systemResourceLimitsClient
+		if s.instanceInfo.connectedToPDB && s.systemResourceLimitsPDBClient != nil {
+			resourceLimitsClient = s.systemResourceLimitsPDBClient
+		}
+		rows, err := resourceLimitsClient.metricRows(ctx)
 		if err != nil {
-			scrapeErrors = append(scrapeErrors, fmt.Errorf("error executing %s: %w", systemResourceLimitsSQL, err))
+			scrapeErrors = append(scrapeErrors, fmt.Errorf("error executing resource limits query: %w", err))
 		}
 		for _, row := range rows {
 			resourceName := row["RESOURCE_NAME"]
@@ -1423,6 +1478,38 @@ func (s *oracleScraper) collectSysMetrics(ctx context.Context, scrapeErrors *[]e
 				seenInContainerMetrics[metricName] = true
 			}
 		}
+	}
+
+	// PDB connection (e.g. RDS Oracle): V$SYSMETRIC is empty in PDB context.
+	// sysmetricCDBClient (v$con_sysmetric) covers some metrics; sysmetricComputedClient
+	// derives Shared Pool Free % from v$sgastat. seenPDBMetrics prevents double-recording.
+	if s.instanceInfo.isCDB && s.instanceInfo.connectedToPDB {
+		seenPDBMetrics := make(map[string]bool)
+		for _, client := range []dbClient{s.sysmetricCDBClient, s.sysmetricComputedClient} {
+			if client == nil {
+				continue
+			}
+			pdbRows, pdbErr := client.metricRows(ctx)
+			if pdbErr != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("error executing sysmetric PDB query: %w", pdbErr))
+				continue
+			}
+			for _, row := range pdbRows {
+				metricName := row[colMetricName]
+				if seenPDBMetrics[metricName] {
+					continue
+				}
+				seenPDBMetrics[metricName] = true
+				rawVal := row[colValue]
+				val, parseErr := strconv.ParseFloat(rawVal, 64)
+				if parseErr != nil {
+					*scrapeErrors = append(*scrapeErrors, fmt.Errorf("sysmetric %q: failed to parse float64 from %q: %w", metricName, rawVal, parseErr))
+					continue
+				}
+				s.recordSysmetric(now, metricName, val, s.pdbNameForRow(row))
+			}
+		}
+		return
 	}
 
 	// Query V$SYSMETRIC for metrics not already seen in V$CON_SYSMETRIC (or all 12 for non-CDB).

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -46,10 +46,10 @@ const (
 	// sysmetricComputedSQL derives Shared Pool Free % from v$sgastat for PDB connections
 	// (e.g. RDS Oracle) where v$sysmetric is empty in PDB context.
 	sysmetricComputedSQL = `SELECT 'Shared Pool Free %' AS METRIC_NAME,
-       CASE WHEN NVL(SUM(bytes),0) > 0
-            THEN NVL(SUM(CASE WHEN name = 'free memory' THEN bytes ELSE 0 END),0) / SUM(bytes) * 100
-            ELSE 0 END AS VALUE
-FROM v$sgastat WHERE pool = 'shared pool'`
+		CASE WHEN NVL(SUM(bytes),0) > 0
+		     THEN NVL(SUM(CASE WHEN name = 'free memory' THEN bytes ELSE 0 END),0) / SUM(bytes) * 100
+		     ELSE 0 END AS VALUE
+	FROM v$sgastat WHERE pool = 'shared pool'`
 
 	// containerGrantsProbeSQL detects whether the user has the grants needed
 	// for per-PDB collection. On failure the receiver falls back to the
@@ -219,7 +219,7 @@ FROM v$sgastat WHERE pool = 'shared pool'`
     RESOURCE_NAME,
     CURRENT_UTILIZATION,
     CASE
-        WHEN LIMIT_VALUE IS NULL OR TRIM(LIMIT_VALUE) IN ('UNLIMITED', '0') THEN '-1'
+        WHEN LIMIT_VALUE IS NULL OR TRIM(LIMIT_VALUE) = 'UNLIMITED' THEN '-1'
         ELSE TRIM(LIMIT_VALUE)
     END AS LIMIT_VALUE
 FROM (

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -243,7 +243,7 @@ FROM (
          (SELECT value FROM v$parameter WHERE name = 'dml_locks')
   FROM dual
 )`
-	tablespaceUsageSQL      = `
+	tablespaceUsageSQL = `
 		select um.TABLESPACE_NAME, um.USED_SPACE, um.TABLESPACE_SIZE, ts.BLOCK_SIZE, ts.STATUS
 		FROM DBA_TABLESPACE_USAGE_METRICS um INNER JOIN DBA_TABLESPACES ts
 		ON um.TABLESPACE_NAME = ts.TABLESPACE_NAME`
@@ -392,10 +392,10 @@ type oracleScraper struct {
 	recycleBinSizeClient     dbClient
 	sgaInfoClient            dbClient
 	storageUsageClient       dbClient
-	sysmetricClient         dbClient
-	sysmetricCDBClient      dbClient
-	sysmetricComputedClient dbClient
-	db                      *sql.DB
+	sysmetricClient          dbClient
+	sysmetricCDBClient       dbClient
+	sysmetricComputedClient  dbClient
+	db                       *sql.DB
 	clientProviderFunc       clientProviderFunc
 	mb                       *metadata.MetricsBuilder
 	lb                       *metadata.LogsBuilder


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
On AWS RDS Oracle multitenant instances, the receiver
connects directly to a PDB (Pluggable Database). The sysmetric and resource
limit views (`v$sysmetric`, `v$resource_limit`) are not available in PDB
context, causing 23 metrics to be missing.

This PR adds fallback queries for PDB connections to recover 16 of the
23 missing metrics. No impact on standalone or CDB-root deployments.

**Sysmetric (9 recovered):** uses `v$con_sysmetric` for interval-based metrics
and `v$sgastat` for Shared Pool Free %.

**Resource limits (7 recovered):** derives limit values from `v$parameter` and
usage counts from `v$process`, `v$session`, `v$transaction`, and `v$lock`.

**Remaining 7 not recovered:**
- 3 deferred — only cumulative % available from PDB context, inconsistent with
  standalone Oracle's 60-second interval values
- 4 impossible — `enqueue_locks.*` and `enqueue_resources.*` are auto-managed
  by Oracle 19c+ and not exposed in any PDB-accessible view

## Changes

- `scraper.go` — PDB fallback queries for sysmetric and resource limit collection
- `README.md` — added AWS RDS Oracle grants section
- `scraper.go` — added deduplication guard (`seenPDBMetrics`) across both
  PDB fallback sources (`v$con_sysmetric` and computed queries) so a metric
  returned by both is recorded only once

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
#50147 
<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated tests in `scraper_test.go` 
Manual testing was performed against AWS RDS Oracle 19c (multitenant, PDB connection):

- Confirmed `v$sysmetric` and `v$resource_limit` return 0 rows on direct PDB connection
- Verified 9 sysmetric metrics are collected via the PDB fallback path
- Verified 7 resource limit metrics are collected via the PDB fallback path
- Verified standalone Oracle (non-CDB) behavior is unchanged — all existing
  tests pass and no new code paths are triggered
- Verified CDB-root behavior is unchanged — `isCDBRoot` path unaffected

<!--Describe the documentation added.-->
#### Documentation
- `README.md` — added a dedicated **AWS RDS Oracle grants** section listing
  all `rdsadmin.rdsadmin_util.grant_sys_object` commands needed to enable
  metrics and events collection on RDS. Standard `GRANT SELECT ON V_$...`
  syntax does not work on RDS and is not documented there.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
