### PR TITLE
fix(logstransform): use dedicated context for converter loop

### DIFF
--- a/.chloggen/31140-logstransform-long-lived-context.yaml
+++ b/.chloggen/31140-logstransform-long-lived-context.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: processor/logstransform
+
+note: Fix a bug where the logstransform processor's internal converter loop was tied to the short-lived Start context, causing the processor to stop processing logs shortly after startup. The loop now runs for the full lifetime of the component and stops cleanly on Shutdown.
+
+issues: [31140]
+
+change_logs: [user]

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -35,6 +35,7 @@ type logsTransformProcessor struct {
 	emitter       helper.LogEmitter
 	fromConverter *adapter.FromPdataConverter
 	shutdownFns   []component.ShutdownFunc
+	wg            sync.WaitGroup
 }
 
 func newProcessor(config *Config, nextConsumer consumer.Logs, set component.TelemetrySettings) (*logsTransformProcessor, error) {
@@ -77,7 +78,7 @@ func (ltp *logsTransformProcessor) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) error {
+func (ltp *logsTransformProcessor) Start(_ context.Context, _ component.Host) error {
 	wkrCount := int(math.Max(1, float64(runtime.NumCPU())))
 	ltp.fromConverter = adapter.NewFromPdataConverter(ltp.set, wkrCount)
 
@@ -94,7 +95,15 @@ func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) 
 	if err != nil {
 		return err
 	}
-	ltp.startConverterLoop(ctx)
+	// component.Start documents that any long-running operation must not use the context passed to Start,
+	// since the collector cancels it shortly after Start returns. The converter loop is exactly such a
+	// long-running goroutine, so derive a dedicated context that is cancelled by the shutdown path instead (#31140).
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
+		loopCancel()
+		return nil
+	})
+	ltp.startConverterLoop(loopCtx)
 	ltp.startFromConverter()
 
 	return nil
@@ -112,12 +121,10 @@ func (ltp *logsTransformProcessor) startFromConverter() {
 // startConverterLoop starts the converter loop, which reads all the logs translated by the fromConverter and then forwards
 // them to pipeline
 func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context) {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go ltp.converterLoop(ctx, wg)
+	ltp.wg.Go(func() { ltp.converterLoop(ctx) })
 
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
-		wg.Wait()
+		ltp.wg.Wait()
 		return nil
 	})
 }
@@ -149,9 +156,7 @@ func (ltp *logsTransformProcessor) ConsumeLogs(_ context.Context, ld plog.Logs) 
 
 // converterLoop reads the log entries produced by the fromConverter and sends them
 // into the pipeline
-func (ltp *logsTransformProcessor) converterLoop(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (ltp *logsTransformProcessor) converterLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -99,11 +99,11 @@ func (ltp *logsTransformProcessor) Start(_ context.Context, _ component.Host) er
 	// since the collector cancels it shortly after Start returns. The converter loop is exactly such a
 	// long-running goroutine, so derive a dedicated context that is cancelled by the shutdown path instead (#31140).
 	loopCtx, loopCancel := context.WithCancel(context.Background())
+	ltp.startConverterLoop(loopCtx)
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		loopCancel()
 		return nil
 	})
-	ltp.startConverterLoop(loopCtx)
 	ltp.startFromConverter()
 
 	return nil

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -122,7 +122,7 @@ func (ltp *logsTransformProcessor) startFromConverter() {
 // them to pipeline
 func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Go(func() {
-	ltp.converterLoop(ctx)
+	    ltp.converterLoop(ctx)
     })
 
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -121,11 +121,9 @@ func (ltp *logsTransformProcessor) startFromConverter() {
 // startConverterLoop starts the converter loop, which reads all the logs translated by the fromConverter and then forwards
 // them to pipeline
 func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context, wg *sync.WaitGroup) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ltp.converterLoop(ctx)
-	}()
+	wg.Go(func() {
+	ltp.converterLoop(ctx)
+    })
 
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		wg.Wait()

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -35,7 +35,6 @@ type logsTransformProcessor struct {
 	emitter       helper.LogEmitter
 	fromConverter *adapter.FromPdataConverter
 	shutdownFns   []component.ShutdownFunc
-	wg            sync.WaitGroup
 }
 
 func newProcessor(config *Config, nextConsumer consumer.Logs, set component.TelemetrySettings) (*logsTransformProcessor, error) {
@@ -99,7 +98,8 @@ func (ltp *logsTransformProcessor) Start(_ context.Context, _ component.Host) er
 	// since the collector cancels it shortly after Start returns. The converter loop is exactly such a
 	// long-running goroutine, so derive a dedicated context that is cancelled by the shutdown path instead (#31140).
 	loopCtx, loopCancel := context.WithCancel(context.Background())
-	ltp.startConverterLoop(loopCtx)
+	var wg sync.WaitGroup
+	ltp.startConverterLoop(loopCtx, &wg)
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		loopCancel()
 		return nil
@@ -120,11 +120,15 @@ func (ltp *logsTransformProcessor) startFromConverter() {
 
 // startConverterLoop starts the converter loop, which reads all the logs translated by the fromConverter and then forwards
 // them to pipeline
-func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context) {
-	ltp.wg.Go(func() { ltp.converterLoop(ctx) })
+func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context, wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ltp.converterLoop(ctx)
+	}()
 
 	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
-		ltp.wg.Wait()
+		wg.Wait()
 		return nil
 	})
 }

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -288,3 +288,42 @@ func TestProcessorShutdownWithSlowOperator(t *testing.T) {
 	err = ltp.Shutdown(t.Context())
 	require.NoError(t, err)
 }
+
+// TestProcessorConverterLoopSurvivesStartContextCancellation is a regression test for
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31140.
+// The collector cancels the context passed to Start shortly after Start returns, so the
+// converter loop must not be tied to it; otherwise the processor stops processing logs
+// right after startup.
+func TestProcessorConverterLoopSurvivesStartContextCancellation(t *testing.T) {
+	tln := new(consumertest.LogsSink)
+	factory := NewFactory()
+	ltp, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, tln)
+	require.NoError(t, err)
+
+	startCtx, cancelStart := context.WithCancel(t.Context())
+	err = ltp.Start(startCtx, componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// Simulate the collector cancelling the Start context shortly after Start returns.
+	cancelStart()
+
+	// Give the converter loop a moment to observe the cancellation if it were still
+	// tied to the Start context.
+	time.Sleep(100 * time.Millisecond)
+
+	// The converter loop should still be alive and process logs.
+	sourceLogData := generateLogData([]testLogMessage{
+		{
+			body:         pcommon.NewValueStr("2022-01-01 01:02:03 INFO this is a test message"),
+			observedTime: parseTime("2006-01-02", "2022-01-02"),
+		},
+	})
+	err = ltp.ConsumeLogs(t.Context(), sourceLogData)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(tln.AllLogs()) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, ltp.Shutdown(t.Context()))
+}

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -304,7 +304,7 @@ func TestProcessorConverterLoopSurvivesStartContextCancellation(t *testing.T) {
 	err = ltp.Start(startCtx, componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	// Simulate the collector cancelling the Start context shortly after Start returns.
+	// Simulate the collector canceling the Start context shortly after Start returns.
 	cancelStart()
 
 	// Give the converter loop a moment to observe the cancellation if it were still


### PR DESCRIPTION
The logstransform processor was starting its long-running converter loop with the context passed to Start(). Since that context is cancelled shortly after Start() returns, the converter loop could stop too early and stop processing logs.

This change gives the converter loop a dedicated context derived from context.Background() and cancels it during shutdown, so the loop runs for the full lifetime of the component.

Link to tracking issue
Fixes #31140

Testing

Added TestProcessorConverterLoopSurvivesStartContextCancellation, a regression test that cancels the Start() context and verifies the processor still processes logs.
go build ./...
go vet ./...
go test ./...
chloggen validate

☑️ I, a human, wrote this pull request description myself.
