### PR TITLE
[chore]: add filter and transform to benchmarks

### DIFF
--- a/testbed/tests/filter_processor_test.go
+++ b/testbed/tests/filter_processor_test.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
+)
+
+// These load tests exercise OTTL through the filter processor so that its CPU and
+// memory usage for traces, metrics, and logs is published to the load test benchmark
+// dashboard. The conditions are evaluated for every item but are written so that they
+// never match the generated telemetry, so nothing is dropped and the sent and received
+// counters still match.
+
+func TestFilterProcessorTraces(t *testing.T) {
+	sender := testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "filter",
+			Body: `
+  filter:
+    error_mode: ignore
+    traces:
+      span:
+        - span.name == "nonexistent-span-name"
+        - span.attributes["load_generator.span_seq_num"] < 0
+        - span.attributes["nonexistent.attr"] == "value"
+        - IsMatch(span.name, "^this-will-never-match-[0-9]+$")
+`,
+		},
+	}
+
+	Scenario10kItemsPerSecond(
+		t,
+		sender,
+		receiver,
+		testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200},
+		performanceResultsSummary,
+		processors,
+		nil,
+		nil,
+	)
+}
+
+func TestFilterProcessorMetrics(t *testing.T) {
+	sender := testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "filter",
+			Body: `
+  filter:
+    error_mode: ignore
+    metrics:
+      metric:
+        - metric.name == "nonexistent_metric"
+        - IsMatch(metric.name, "^never_match_[0-9]+$")
+      datapoint:
+        - datapoint.attributes["item_index"] == "item_does_not_exist"
+        - datapoint.value_int < 0
+`,
+		},
+	}
+
+	Scenario10kItemsPerSecond(
+		t,
+		sender,
+		receiver,
+		testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200},
+		performanceResultsSummary,
+		processors,
+		nil,
+		nil,
+	)
+}
+
+func TestFilterProcessorLogs(t *testing.T) {
+	sender := testbed.NewOTLPLogsDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "filter",
+			Body: `
+  filter:
+    error_mode: ignore
+    logs:
+      log_record:
+        - log.body == "this message never appears"
+        - log.attributes["c"] > 100
+        - log.severity_number == 17
+        - IsMatch(log.body, "^never-[0-9]+$")
+`,
+		},
+	}
+
+	Scenario10kItemsPerSecond(
+		t,
+		sender,
+		receiver,
+		testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200},
+		performanceResultsSummary,
+		processors,
+		nil,
+		nil,
+	)
+}

--- a/testbed/tests/transform_processor_test.go
+++ b/testbed/tests/transform_processor_test.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
+)
+
+// These load tests exercise OTTL through the transform processor so that its CPU and
+// memory usage for traces, metrics, and logs is published to the load test benchmark
+// dashboard. The statements mutate telemetry but never drop items, so the sent and
+// received counters still match.
+
+func TestTransformProcessorTraces(t *testing.T) {
+	sender := testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "transform",
+			Body: `
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - set(resource.attributes["transform.env"], "benchmark")
+      - set(span.attributes["transform.processed"], "true")
+      - set(span.attributes["transform.seq_num"], span.attributes["load_generator.span_seq_num"]) where span.attributes["load_generator.span_seq_num"] != nil
+      - replace_pattern(span.name, "load-generator-span", "span-")
+      - limit(span.attributes, 100, [])
+      - truncate_all(span.attributes, 4096)
+`,
+		},
+	}
+
+	Scenario10kItemsPerSecond(
+		t,
+		sender,
+		receiver,
+		testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200},
+		performanceResultsSummary,
+		processors,
+		nil,
+		nil,
+	)
+}
+
+func TestTransformProcessorMetrics(t *testing.T) {
+	sender := testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "transform",
+			Body: `
+  transform:
+    error_mode: ignore
+    metric_statements:
+      - set(resource.attributes["transform.env"], "benchmark")
+      - set(metric.description, "benchmark metric")
+      - set(datapoint.attributes["transform.processed"], "true")
+      - truncate_all(datapoint.attributes, 4096)
+`,
+		},
+	}
+
+	Scenario10kItemsPerSecond(
+		t,
+		sender,
+		receiver,
+		testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200},
+		performanceResultsSummary,
+		processors,
+		nil,
+		nil,
+	)
+}
+
+func TestTransformProcessorLogs(t *testing.T) {
+	sender := testbed.NewOTLPLogsDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t))
+
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "transform",
+			Body: `
+  transform:
+    error_mode: ignore
+    log_statements:
+      - set(resource.attributes["transform.env"], "benchmark")
+      - set(log.attributes["transform.processed"], "true")
+      - set(log.severity_text, "WARN") where log.attributes["c"] == 3
+      - replace_pattern(log.body, "Counter", "Ctr")
+      - truncate_all(log.attributes, 4096)
+`,
+		},
+	}
+
+	Scenario10kItemsPerSecond(
+		t,
+		sender,
+		receiver,
+		testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200},
+		performanceResultsSummary,
+		processors,
+		nil,
+		nil,
+	)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add filterprocessor and transformprocessor to loadtest benchmarks. I can't add OTTL directly to this because it is a library, but filterprocessor and transformprocessor are good examples of OTTL performance. Once these are included in the report, I'll update the processor READMEs to reference them. I'll also update OTTL's readme to reference its own benchmarks and these.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

- related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50092

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
