### PR TITLE
[exporter/signalfx] Do not exclude container.memory.rss metric

### DIFF
--- a/.chloggen/signalfx-include-mem-rss.yaml
+++ b/.chloggen/signalfx-include-mem-rss.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop excluding `container.memory.rss` in SignalFx exporter by default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50162]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -669,9 +669,36 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 46, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 45, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 	require.Empty(t, dps)
+}
+
+func TestDefaultExcludesKubeletMemoryMetrics(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	require.NoError(t, setDefaultExcludes(cfg))
+
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics, "", false, true)
+	require.NoError(t, err)
+
+	var metrics []map[string]string
+	for _, prefix := range []string{"container", "k8s.node", "k8s.pod"} {
+		for _, suffix := range []string{"available", "major_page_faults", "page_faults", "rss", "usage", "working_set"} {
+			metrics = append(metrics, map[string]string{prefix + ".memory." + suffix: ""})
+		}
+	}
+
+	dps := converter.MetricsToSignalFxV2(getMetrics(metrics))
+	metricNames := make([]string, 0, len(dps))
+	for _, dp := range dps {
+		metricNames = append(metricNames, dp.Metric)
+	}
+	require.ElementsMatch(t, []string{
+		"container.memory.rss",
+		"container.memory.usage",
+		"container.memory.working_set",
+	}, metricNames)
 }
 
 // Benchmark test for default translation rules on an example hostmetrics dataset.

--- a/exporter/signalfxexporter/internal/translation/default_metrics.yaml
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.yaml
@@ -85,7 +85,7 @@ exclude_metrics:
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.available$/
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.major_page_faults$/
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.page_faults$/
-  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.rss$/
+  - /^(?i:(k8s\.node)|(k8s\.pod))\.memory\.rss$/
   - /^(?i:(k8s\.node)|(k8s\.pod))\.memory\.usage$/
   - /^(?i:(k8s\.node)|(k8s\.pod))\.memory\.working_set$/
 

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -56,9 +56,6 @@
     "container.memory.page_faults": null
   },
   {
-    "container.memory.rss": null
-  },
-  {
     "k8s.pod.memory.available": null
   },
   {


### PR DESCRIPTION
#### Description
Metric `container.memory.rss` was previously excluded by default. It turned out to be desired in some cases, so removing it from exclusion.

#### Link to tracking issue
N/A

#### Testing
Adjusted one test that checked that it was removed, and added a new test that tests the filtering pattern of all container/k8s memory metrics.

#### Documentation
No changes, this did not affect anything that was previously documented which would need updating.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
