### PR TITLE
feat[exporter/awss3]: Respect AWS_REQUEST_CHECKSUM_CALCULATION env var for uploads

### DIFF
--- a/.chloggen/awss3-honor-request-checksum-calculation.yaml
+++ b/.chloggen/awss3-honor-request-checksum-calculation.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/awss3
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Honor the AWS SDK RequestChecksumCalculation setting when uploading objects
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50184]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously the setting always defaulted to `when_supported` for uploads, forcing a CRC32 trailing checksum (aws-chunked / x-amz-trailer). 
+  This change allows the setting to be controlled by the value of the `AWS_REQUEST_CHECKSUM_CALCULATION` environment variable.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awss3exporter/internal/upload/writer.go
+++ b/exporter/awss3exporter/internal/upload/writer.go
@@ -41,12 +41,14 @@ type s3manager struct {
 
 var _ Manager = (*s3manager)(nil)
 
-func NewS3Manager(logger *zap.Logger, bucket string, builder *PartitionKeyBuilder, service *s3.Client, storageClass s3types.StorageClass, opts ...ManagerOpt) Manager {
+func NewS3Manager(logger *zap.Logger, bucket string, builder *PartitionKeyBuilder, service *s3.Client, storageClass s3types.StorageClass, cfg aws.Config, opts ...ManagerOpt) Manager {
 	manager := &s3manager{
-		logger:       logger,
-		bucket:       bucket,
-		builder:      builder,
-		uploader:     transfermanager.New(service),
+		logger:  logger,
+		bucket:  bucket,
+		builder: builder,
+		uploader: transfermanager.New(service, func(o *transfermanager.Options) {
+			o.RequestChecksumCalculation = cfg.RequestChecksumCalculation
+		}),
 		storageClass: storageClass,
 	}
 	for _, opt := range opts {

--- a/exporter/awss3exporter/internal/upload/writer_test.go
+++ b/exporter/awss3exporter/internal/upload/writer_test.go
@@ -30,6 +30,7 @@ func TestNewS3Manager(t *testing.T) {
 		&PartitionKeyBuilder{},
 		s3.New(s3.Options{}),
 		"STANDARD",
+		aws.Config{},
 		WithACL(s3types.ObjectCannedACLPrivate),
 	)
 
@@ -316,6 +317,7 @@ func TestS3ManagerUpload(t *testing.T) {
 					Region:       "local",
 				}),
 				"STANDARD_IA",
+				aws.Config{},
 				WithACL(s3types.ObjectCannedACLPrivate),
 			)
 
@@ -328,6 +330,70 @@ func TestS3ManagerUpload(t *testing.T) {
 				assert.EqualError(t, err, tc.errVal, "Must match the expected error")
 			} else {
 				assert.NoError(t, err, "Must not have return an error")
+			}
+		})
+	}
+}
+
+// TestS3ManagerUploadRequestChecksumCalculation verifies that the RequestChecksumCalculation
+// from the AWS config is honored on upload.
+func TestS3ManagerUploadRequestChecksumCalculation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		checksumCalc aws.RequestChecksumCalculation
+		wantChecksum bool
+	}{
+		{
+			name:         "when_supported calculates a CRC32 checksum",
+			checksumCalc: aws.RequestChecksumCalculationWhenSupported,
+			wantChecksum: true,
+		},
+		{
+			name:         "when_required omits the checksum",
+			checksumCalc: aws.RequestChecksumCalculationWhenRequired,
+			wantChecksum: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotAlgo, gotCRC32 string
+			s := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotAlgo = r.Header.Get("x-amz-sdk-checksum-algorithm")
+				gotCRC32 = r.Header.Get("x-amz-checksum-crc32")
+				_, err := io.Copy(io.Discard, r.Body)
+				assert.NoError(t, err)
+				err = r.Body.Close()
+				assert.NoError(t, err)
+			}))
+			t.Cleanup(s.Close)
+
+			sm := NewS3Manager(
+				zap.NewNop(),
+				"my-bucket",
+				&PartitionKeyBuilder{
+					FileFormat:    "metrics",
+					UniqueKeyFunc: func() string { return "random" },
+				},
+				s3.New(s3.Options{
+					BaseEndpoint: aws.String(s.URL),
+					Region:       "local",
+				}),
+				"STANDARD",
+				aws.Config{RequestChecksumCalculation: tc.checksumCalc},
+			)
+
+			err := sm.Upload(t.Context(), []byte("hello world"), nil)
+			assert.NoError(t, err, "Must not error uploading")
+
+			if tc.wantChecksum {
+				assert.Equal(t, "CRC32", gotAlgo, "Must calculate a CRC32 checksum")
+				assert.NotEmpty(t, gotCRC32, "Must send the CRC32 checksum value")
+			} else {
+				assert.Empty(t, gotAlgo, "Must not calculate a checksum")
+				assert.Empty(t, gotCRC32, "Must not send a checksum value")
 			}
 		})
 	}

--- a/exporter/awss3exporter/s3_writer.go
+++ b/exporter/awss3exporter/s3_writer.go
@@ -118,6 +118,7 @@ func newUploadManager(
 		},
 		s3.NewFromConfig(cfg, s3Opts...),
 		s3types.StorageClass(conf.S3Uploader.StorageClass),
+		cfg,
 		managerOpts...,
 	), nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR enhances the AWS S3 exporter to have its uploads respect the AWS_REQUEST_CHECKSUM_CALCULATION environment variable.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50184 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit testing added against a test server to verify the behavior change when the setting is set.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
