### PR TITLE
[processor/transform]: bump set_semconv_span_name to v1.43.0 semconv

### DIFF
--- a/.chloggen/transformprocessor-set-semconv-span-name-1.43.yaml
+++ b/.chloggen/transformprocessor-set-semconv-span-name-1.43.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/transform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for semconv `1.41.0`, `1.42.0` and `1.43.0` in the `set_semconv_span_name()` function.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The supported `semconvVersion` range is now `1.37.0` to `1.43.0`. The span-name-relevant attributes are unchanged across these versions, so backward compatibility is preserved.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/transformprocessor-set-semconv-span-name-1.43.yaml
+++ b/.chloggen/transformprocessor-set-semconv-span-name-1.43.yaml
@@ -10,12 +10,12 @@ component: processor/transform
 note: Add support for semconv `1.41.0`, `1.42.0` and `1.43.0` in the `set_semconv_span_name()` function.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50198]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: The supported `semconvVersion` range is now `1.37.0` to `1.43.0`. The span-name-relevant attributes are unchanged across these versions, so backward compatibility is preserved.
+subtext:
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,6 +223,7 @@ linters:
             - go.opentelemetry.io/otel/semconv/v1.40.0
             - go.opentelemetry.io/otel/semconv/v1.41.0
             - go.opentelemetry.io/otel/semconv/v1.42.0
+            - go.opentelemetry.io/otel/semconv/v1.43.0
 
         semconv-in-test:
           list-mode: lax

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -850,7 +850,7 @@ The primary use case of the `set_semconv_span_name()` function is to address hig
 
 Parameters:
 
-* `semconvVersion` is the version of the Semantic Conventions used to generate the `span.name`, older semconv attributes are supported. Versions `1.37.0` to `1.40.0` are supported.
+* `semconvVersion` is the version of the Semantic Conventions used to generate the `span.name`. A set of older/deprecated semconv attributes are also supported for backward compatibility (see the table below). Versions `1.37.0` to `1.43.0` are supported.
 * `originalSpanNameAttribute` is the optional name of the attribute used to copy the original `span.name` if different from the name derived from semantic conventions.
 
 Sanitization examples:
@@ -865,7 +865,7 @@ Sanitization examples:
            http.route: /api/v1/users/{id}
            url.path: /api/v1/users/123
         ```
-   * Span name after applying `set_semconv_span_name("1.40.0")`: `GET /api/v1/users/{id}`
+   * Span name after applying `set_semconv_span_name("1.43.0")`: `GET /api/v1/users/{id}`
    * No loss of information on `span.name` occurs because the recommended attribute `http.route` is present.
 * Span with high-cardinality name lacking recommended semantic convention attribute `http.route`
     * Incoming span:
@@ -876,7 +876,7 @@ Sanitization examples:
             http.request.method: GET
             url.path: /api/v1/users/123
          ```
-    * Span name after applying `set_semconv_span_name("1.40.0")`: `GET`
+    * Span name after applying `set_semconv_span_name("1.43.0")`: `GET`
     * Loss of information on `span.name` occurs because the recommended attribute `http.route` is missing.
     Note that this loss of information is mitigated if the instrumentation produced attributes that contain the URL path like `url.path` or `url.full`.
 * Compliant span name is unchanged
@@ -889,26 +889,28 @@ Sanitization examples:
             http.route: /api/v1/users/{id}
             url.path: /api/v1/users/123
          ```
-    * Span name after applying `set_semconv_span_name("1.40.0")`: `GET /api/v1/users/{id}`
+    * Span name after applying `set_semconv_span_name("1.43.0")`: `GET /api/v1/users/{id}`
 
 
-Backward compatibility: `set_semconv_span_name` will map the following attributes to their equivalents per the v1.39.0 semantic conventions:
+Backward compatibility: `set_semconv_span_name` will also read the following deprecated attributes, mapping each to its current equivalent:
 
-| v1.40.0 Attribute     | Older attribute    |
-|-----------------------|--------------------|
-| `http.request.method` | `http.method`      |
-| `rpc.method`          | `rpc.grpc.method`  |
-| `rpc.service`         | `rpc.grpc.service` |
-| `rpc.system.name`     | `rpc.system`       |
-| `db.system.name`      | `db.system`        |
-| `db.operation.name`   | `db.operation`     |
-| `db.collection.name`  | `db.name`          |
+| v1.43.0 Attribute            | Older attribute         |
+|------------------------------|-------------------------|
+| `http.request.method`        | `http.method`           |
+| `rpc.method`                 | `rpc.grpc.method`       |
+| `rpc.service`                | `rpc.grpc.service`      |
+| `rpc.system.name`            | `rpc.system`            |
+| `db.system.name`             | `db.system`             |
+| `db.operation.name`          | `db.operation`          |
+| `db.namespace`               | `db.name`               |
+| `messaging.operation.name`   | `messaging.operation`   |
+| `messaging.destination.name` | `messaging.destination` |
 
 Examples:
 
-- `set_semconv_span_name("1.40.0")`
+- `set_semconv_span_name("1.43.0")`
 
-- `set_semconv_span_name("1.40.0", "original_span_name")`
+- `set_semconv_span_name("1.43.0", "original_span_name")`
 
 ## Examples
 

--- a/processor/transformprocessor/internal/traces/func_set_semconv_span_name.go
+++ b/processor/transformprocessor/internal/traces/func_set_semconv_span_name.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
-	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.43.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
@@ -20,7 +20,7 @@ import (
 
 var (
 	minKnownSemConvVersion = semver.MustParse("1.37.0")
-	maxKnownSemConvVersion = semver.MustParse("1.40.0")
+	maxKnownSemConvVersion = semver.MustParse("1.43.0")
 )
 
 type setSemconvSpanNameArguments struct {

--- a/processor/transformprocessor/internal/traces/func_set_semconv_span_name_test.go
+++ b/processor/transformprocessor/internal/traces/func_set_semconv_span_name_test.go
@@ -24,6 +24,24 @@ func Test_createSetSemconvSpanNameFunction_parameterChecks(t *testing.T) {
 		wantError                 bool
 	}{
 		{
+			name:                      "valid semconv version 1.43.0 and original span name attribute",
+			semconvVersion:            "1.43.0",
+			originalSpanNameAttribute: ottl.NewTestingOptional("original_span_name"),
+			wantError:                 false,
+		},
+		{
+			name:                      "valid semconv version 1.42.0 and original span name attribute",
+			semconvVersion:            "1.42.0",
+			originalSpanNameAttribute: ottl.NewTestingOptional("original_span_name"),
+			wantError:                 false,
+		},
+		{
+			name:                      "valid semconv version 1.41.0 and original span name attribute",
+			semconvVersion:            "1.41.0",
+			originalSpanNameAttribute: ottl.NewTestingOptional("original_span_name"),
+			wantError:                 false,
+		},
+		{
 			name:                      "valid semconv version 1.40.0 and original span name attribute",
 			semconvVersion:            "1.40.0",
 			originalSpanNameAttribute: ottl.NewTestingOptional("original_span_name"),
@@ -60,8 +78,14 @@ func Test_createSetSemconvSpanNameFunction_parameterChecks(t *testing.T) {
 			wantError:                 true,
 		},
 		{
-			name:                      "unsupported semconv version and valid original span name attribute",
+			name:                      "unsupported semconv version below minimum and valid original span name attribute",
 			semconvVersion:            "1.36.0",
+			originalSpanNameAttribute: ottl.NewTestingOptional("original_span_name"),
+			wantError:                 true,
+		},
+		{
+			name:                      "unsupported semconv version above maximum and valid original span name attribute",
+			semconvVersion:            "1.44.0",
 			originalSpanNameAttribute: ottl.NewTestingOptional("original_span_name"),
 			wantError:                 true,
 		},


### PR DESCRIPTION
#### Description

Bumps the used semconv version to v1.43.0. Not span name rules have changed since v1.40.0 so this is essentially a no-op. 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

added new tests

<!--Describe the documentation added.-->
#### Documentation

Also cleaned up the README to explicitly list each v1.39.0 attribute it still supports.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
