### PR TITLE
[testbed] deprecate signalfxdatareceiver

### DIFF
--- a/.chloggen/deprecate_signalfxdatareceiver.yaml
+++ b/.chloggen/deprecate_signalfxdatareceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: testbed
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate testbed.signalfxdatareceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50200]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/testbed/datareceivers/signalfxdatareceiver/receiver.go
+++ b/testbed/datareceivers/signalfxdatareceiver/receiver.go
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Deprecated: use testbed instead
 package signalfxdatareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/signalfxdatareceiver"
 
 import (
@@ -19,6 +20,8 @@ import (
 )
 
 // SFxMetricsDataReceiver implements SignalFx format receiver.
+//
+// Deprecated: use testbed.BaseOTLPDataReceiver instead
 type SFxMetricsDataReceiver struct {
 	testbed.DataReceiverBase
 	receiver receiver.Metrics
@@ -29,6 +32,8 @@ var _ testbed.DataReceiver = (*SFxMetricsDataReceiver)(nil)
 
 // NewSFxMetricsDataReceiver creates a new SFxMetricsDataReceiver that will listen on the
 // specified port after Start is called.
+//
+// Deprecated: use testbed.NewOTLPDataReceiver(port int) instead
 func NewSFxMetricsDataReceiver(port int) *SFxMetricsDataReceiver {
 	return &SFxMetricsDataReceiver{DataReceiverBase: testbed.DataReceiverBase{Port: port}}
 }

--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/signalfxdatareceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/signalfxdatareceiver" //nolint:staticcheck // SA1019
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders/signalfxdatasender"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 	scenarios "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/tests"
@@ -34,7 +34,7 @@ func TestStabilityMetricsSignalFx(t *testing.T) {
 	scenarios.Scenario10kItemsPerSecond(
 		t,
 		signalfxdatasender.NewSFxMetricDataSender(testutil.GetAvailablePort(t)),
-		signalfxdatareceiver.NewSFxMetricsDataReceiver(testutil.GetAvailablePort(t)),
+		signalfxdatareceiver.NewSFxMetricsDataReceiver(testutil.GetAvailablePort(t)), //nolint:staticcheck // SA1019
 		testbed.ResourceSpec{
 			ExpectedMaxCPU:      120,
 			ExpectedMaxRAM:      95,

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/otelarrowdatareceiver"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/signalfxdatareceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/signalfxdatareceiver" //nolint:staticcheck // SA1019
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers/stefdatareceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders/otelarrowdatasender"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders/signalfxdatasender"
@@ -53,7 +53,7 @@ func TestMetric10kDPS(t *testing.T) {
 		{
 			name:     "SignalFx",
 			sender:   signalfxdatasender.NewSFxMetricDataSender(testutil.GetAvailablePort(t)),
-			receiver: signalfxdatareceiver.NewSFxMetricsDataReceiver(testutil.GetAvailablePort(t)),
+			receiver: signalfxdatareceiver.NewSFxMetricsDataReceiver(testutil.GetAvailablePort(t)), //nolint:staticcheck // SA1019
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 120,
 				ExpectedMaxRAM: 150,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate the package and function ahead of removal.
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
