### PR TITLE
[extension/observer/hostobserver] Fix stale Linux-only description, document Windows support

### DIFF
--- a/extension/observer/hostobserver/README.md
+++ b/extension/observer/hostobserver/README.md
@@ -17,7 +17,15 @@ The `host_observer` looks at the current host for listening network endpoints.
 
 It will look for all listening sockets on TCP and UDP over IPv4 and IPv6.
 
-It uses the /proc filesystem and requires the SYS_PTRACE and DAC_READ_SEARCH capabilities so that it can determine what processes own the listening sockets.
+It is cross-platform, using [gopsutil](https://github.com/shirou/gopsutil) to enumerate listening sockets and
+resolve the owning process for each one: the `/proc` filesystem on Linux, and `iphlpapi.dll`
+(`GetExtendedTcpTable`/`GetExtendedUdpTable`) plus the Windows process APIs on Windows.
+
+Resolving the owning process's name and command line requires permission to inspect that process. On Linux this
+means the `SYS_PTRACE` and `DAC_READ_SEARCH` capabilities; on Windows it means running as `LocalSystem` or under an
+account with `SeDebugPrivilege` enabled. Without the right permissions, sockets owned by processes running under a
+different account (e.g. most built-in OS services) are still reported, but without a resolved process name or
+command.
 
 ### Configuration
 


### PR DESCRIPTION
#### Description

The `host_observer` README described it as Linux-only, using `/proc` and requiring the `SYS_PTRACE`/`DAC_READ_SEARCH` capabilities. That's stale — the implementation has used `gopsutil` (cross-platform) for a while and already works on Windows via `iphlpapi.dll` (`GetExtendedTcpTable`/`GetExtendedUdpTable`) and the Windows process APIs. This updates the README to document Windows support and the equivalent Windows permission requirement (`LocalSystem` or `SeDebugPrivilege`) needed to resolve the process name/command line for endpoints owned by other accounts.

#### Link to tracking issue
N/A — no existing issue found for this; happy to file one if maintainers prefer that over a direct doc fix.

#### Testing

Docs-only change, no code touched. Verified accuracy against current behavior: read `extension.go` and confirmed it uses `github.com/shirou/gopsutil/v4/net` and `.../process` rather than any `/proc`-specific code; cross-compiled `internal/components` (which registers `hostobserver.NewFactory()`) for `GOOS=windows`; ran a standalone Go program using the same `gopsutil` calls on a live Windows host, confirming it lists real TCP/UDP listeners via `iphlpapi.dll` and resolves process name/cmdline via `QueryFullProcessImageName`, with `Access is denied` on processes owned by other accounts when not running elevated — matching the privilege note added to the README.

#### Documentation

This PR is itself the documentation fix (`extension/observer/hostobserver/README.md` only).

#### Authorship

- [x] I, a human, wrote this pull request description myself.
