### PR TITLE
[extension/opampextension] deduplicate health events before sending to OpAMP server

### DIFF
--- a/.chloggen/opamp-extension-duplicate-health-events.yaml
+++ b/.chloggen/opamp-extension-duplicate-health-events.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/opampextension
+component: extension/opamp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Avoid sending duplicate health status updates to the OpAMP server

--- a/.chloggen/opamp-extension-duplicate-health-events.yaml
+++ b/.chloggen/opamp-extension-duplicate-health-events.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opampextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid sending duplicate health status updates to the OpAMP server
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50197]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -665,6 +665,13 @@ func (o *opampAgent) statusAggregatorEventLoop(unsubscribeFunc status.Unsubscrib
 		unsubscribeFunc()
 		o.statusSubscriptionWg.Done()
 	}()
+
+	var (
+		lastStatus componentstatus.Status
+		lastErr    string
+		currentErr string
+	)
+
 	for {
 		select {
 		case <-o.lifetimeCtx.Done():
@@ -677,6 +684,18 @@ func (o *opampAgent) statusAggregatorEventLoop(unsubscribeFunc status.Unsubscrib
 			if statusUpdate == nil || statusUpdate.Status() == componentstatus.StatusNone {
 				continue
 			}
+
+			currentStatus := statusUpdate.Status()
+			if statusUpdate.Err() != nil {
+				currentErr = statusUpdate.Err().Error()
+			}
+
+			if currentStatus == lastStatus && currentErr == lastErr {
+				continue
+			}
+
+			lastStatus = currentStatus
+			lastErr = currentErr
 
 			componentHealth := convertComponentHealth(statusUpdate)
 

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -446,14 +446,47 @@ func TestHealthReportingReceiveUpdateFromAggregator(t *testing.T) {
 		{
 			Healthy:            false,
 			Status:             "StatusPermanentError",
-			StatusTimeUnixNano: uint64(now.UnixNano()),
-			LastError:          "unexpected error",
+			StatusTimeUnixNano: uint64(now.Add(1 * time.Second).UnixNano()),
+			LastError:          "error A",
 			ComponentHealthMap: map[string]*protobufs.ComponentHealth{
 				"test-receiver": {
 					Healthy:            false,
 					Status:             "StatusPermanentError",
-					StatusTimeUnixNano: uint64(now.UnixNano()),
-					LastError:          "unexpected error",
+					StatusTimeUnixNano: uint64(now.Add(1 * time.Second).UnixNano()),
+					LastError:          "error A",
+				},
+			},
+		},
+		{
+			Healthy:            false,
+			Status:             "StatusPermanentError",
+			StatusTimeUnixNano: uint64(now.Add(2 * time.Second).UnixNano()),
+			LastError:          "error B",
+			ComponentHealthMap: map[string]*protobufs.ComponentHealth{
+				"test-receiver": {
+					Healthy:            false,
+					Status:             "StatusPermanentError",
+					StatusTimeUnixNano: uint64(now.Add(2 * time.Second).UnixNano()),
+					LastError:          "error B",
+				},
+			},
+		},
+		{
+			Healthy:            false,
+			Status:             "StatusPermanentError",
+			StatusTimeUnixNano: uint64(now.Add(4 * time.Second).UnixNano()),
+			LastError:          "exporter error",
+			ComponentHealthMap: map[string]*protobufs.ComponentHealth{
+				"test-receiver": {
+					Healthy:            true,
+					Status:             "StatusOK",
+					StatusTimeUnixNano: uint64(now.Add(4 * time.Second).UnixNano()),
+				},
+				"test-exporter": {
+					Healthy:            false,
+					Status:             "StatusPermanentError",
+					StatusTimeUnixNano: uint64(now.Add(4 * time.Second).UnixNano()),
+					LastError:          "exporter error",
 				},
 			},
 		},
@@ -499,15 +532,15 @@ func TestHealthReportingReceiveUpdateFromAggregator(t *testing.T) {
 	}
 	statusUpdateChannel <- &status.AggregateStatus{
 		Event: &mockStatusEvent{
-			status:    componentstatus.StatusOK,
-			err:       nil,
+			status:    componentstatus.StatusPermanentError,
+			err:       errors.New("error A"),
 			timestamp: now.Add(1 * time.Second),
 		},
 		ComponentStatusMap: map[string]*status.AggregateStatus{
 			"test-receiver": {
 				Event: &mockStatusEvent{
-					status:    componentstatus.StatusOK,
-					err:       nil,
+					status:    componentstatus.StatusPermanentError,
+					err:       errors.New("error A"),
 					timestamp: now.Add(1 * time.Second),
 				},
 			},
@@ -516,15 +549,61 @@ func TestHealthReportingReceiveUpdateFromAggregator(t *testing.T) {
 	statusUpdateChannel <- &status.AggregateStatus{
 		Event: &mockStatusEvent{
 			status:    componentstatus.StatusPermanentError,
-			err:       errors.New("unexpected error"),
-			timestamp: now,
+			err:       errors.New("error B"),
+			timestamp: now.Add(2 * time.Second),
 		},
 		ComponentStatusMap: map[string]*status.AggregateStatus{
 			"test-receiver": {
 				Event: &mockStatusEvent{
 					status:    componentstatus.StatusPermanentError,
-					err:       errors.New("unexpected error"),
-					timestamp: now,
+					err:       errors.New("error B"),
+					timestamp: now.Add(2 * time.Second),
+				},
+			},
+		},
+	}
+	statusUpdateChannel <- &status.AggregateStatus{
+		Event: &mockStatusEvent{
+			status:    componentstatus.StatusPermanentError,
+			err:       errors.New("error B"),
+			timestamp: now.Add(3 * time.Second),
+		},
+		ComponentStatusMap: map[string]*status.AggregateStatus{
+			"test-receiver": {
+				Event: &mockStatusEvent{
+					status:    componentstatus.StatusPermanentError,
+					err:       errors.New("error B"),
+					timestamp: now.Add(3 * time.Second),
+				},
+			},
+			"test-exporter": {
+				Event: &mockStatusEvent{
+					status:    componentstatus.StatusPermanentError,
+					err:       errors.New("exporter error"),
+					timestamp: now.Add(3 * time.Second),
+				},
+			},
+		},
+	}
+	statusUpdateChannel <- &status.AggregateStatus{
+		Event: &mockStatusEvent{
+			status:    componentstatus.StatusPermanentError,
+			err:       errors.New("exporter error"),
+			timestamp: now.Add(4 * time.Second),
+		},
+		ComponentStatusMap: map[string]*status.AggregateStatus{
+			"test-receiver": {
+				Event: &mockStatusEvent{
+					status:    componentstatus.StatusOK,
+					err:       nil,
+					timestamp: now.Add(4 * time.Second),
+				},
+			},
+			"test-exporter": {
+				Event: &mockStatusEvent{
+					status:    componentstatus.StatusPermanentError,
+					err:       errors.New("exporter error"),
+					timestamp: now.Add(4 * time.Second),
 				},
 			},
 		},

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -499,6 +499,22 @@ func TestHealthReportingReceiveUpdateFromAggregator(t *testing.T) {
 	}
 	statusUpdateChannel <- &status.AggregateStatus{
 		Event: &mockStatusEvent{
+			status:    componentstatus.StatusOK,
+			err:       nil,
+			timestamp: now.Add(1 * time.Second),
+		},
+		ComponentStatusMap: map[string]*status.AggregateStatus{
+			"test-receiver": {
+				Event: &mockStatusEvent{
+					status:    componentstatus.StatusOK,
+					err:       nil,
+					timestamp: now.Add(1 * time.Second),
+				},
+			},
+		},
+	}
+	statusUpdateChannel <- &status.AggregateStatus{
+		Event: &mockStatusEvent{
 			status:    componentstatus.StatusPermanentError,
 			err:       errors.New("unexpected error"),
 			timestamp: now,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently, the extension subscribes to component health events using `status.Verbose`. Because `statusAggregatorEventLoop` processes every event from `statusChan` without state diffing, this results in continuous, identical `StatusOK` health reports being transmitted over the wire to the OpAMP server, causing unnecessary load and network traffic.

This PR introduces a local deduplication check inside `statusAggregatorEventLoop` to ensure `setHealth` is only executed when there is an actual change in the state or error message.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50197 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran `maketest`, `makegotest`, and the changes were tested with `go test ./extension/opampextension`. Additionally the a test case was added to test whether a duplicate case will be filtered or not.

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
