### PR TITLE
[receiver/mongodb] Add WiredTiger log, fsync, and concurrent-transact…

### DIFF
--- a/.chloggen/50214-mongodb-wiredtiger-internals.yaml
+++ b/.chloggen/50214-mongodb-wiredtiger-internals.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add WiredTiger log, fsync, and concurrent-transaction ticket metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50208]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Five opt-in metrics (disabled by default) read from serverStatus.wiredTiger: mongodb.wt.log.write,
+  mongodb.wt.log.operation.count, mongodb.wt.log.sync.time, mongodb.wt.fsync.count, and
+  mongodb.wt.concurrent_transactions.in_use. All emit only on the WiredTiger storage engine.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -301,7 +301,7 @@ The following metrics are version-gated:
 
 - `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
 - `mongodb.wt.concurrent_transactions.out` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
-- `mongodb.wt.log.bytes`, `mongodb.wt.log.operations`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
+- `mongodb.wt.log.bytes`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -300,8 +300,8 @@ The default Kerberos service name is `mongodb`. Users can authenticate with an e
 The following metrics are version-gated:
 
 - `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
-- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, `mongodb.wt.fsync.count`, and `mongodb.wt.concurrent_transactions.in_use` — require the WiredTiger storage engine (the default since MongoDB 3.2; MMAPv1, the previous default, was removed in 4.2). No data points are emitted on other storage engines, such as the Enterprise-only inMemory engine.
-- `mongodb.wt.concurrent_transactions.in_use` is additionally read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
+- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, `mongodb.wt.fsync.count`, and `mongodb.wt.concurrent_transaction.ticket.in_use` — require the WiredTiger storage engine (the default since MongoDB 3.2; MMAPv1, the previous default, was removed in 4.2). No data points are emitted on other storage engines, such as the Enterprise-only inMemory engine.
+- `mongodb.wt.concurrent_transaction.ticket.in_use` is additionally read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -300,8 +300,8 @@ The default Kerberos service name is `mongodb`. Users can authenticate with an e
 The following metrics are version-gated:
 
 - `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
-- `mongodb.wt.concurrent_transactions.in_use` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
-- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (the default since MongoDB 3.2; MMAPv1, the previous default, was removed in 4.2). No data points are emitted on other storage engines, such as the Enterprise-only inMemory engine.
+- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, `mongodb.wt.fsync.count`, and `mongodb.wt.concurrent_transactions.in_use` — require the WiredTiger storage engine (the default since MongoDB 3.2; MMAPv1, the previous default, was removed in 4.2). No data points are emitted on other storage engines, such as the Enterprise-only inMemory engine.
+- `mongodb.wt.concurrent_transactions.in_use` is additionally read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -300,7 +300,7 @@ The default Kerberos service name is `mongodb`. Users can authenticate with an e
 The following metrics are version-gated:
 
 - `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
-- `mongodb.wt.concurrent_transactions.out` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
+- `mongodb.wt.concurrent_transactions.in_use` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
 - `mongodb.wt.log.bytes`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -301,7 +301,7 @@ The following metrics are version-gated:
 
 - `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
 - `mongodb.wt.concurrent_transactions.in_use` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
-- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
+- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (the default since MongoDB 3.2; MMAPv1, the previous default, was removed in 4.2). No data points are emitted on other storage engines, such as the Enterprise-only inMemory engine.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -301,7 +301,7 @@ The following metrics are version-gated:
 
 - `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
 - `mongodb.wt.concurrent_transactions.in_use` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
-- `mongodb.wt.log.bytes`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
+- `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -297,9 +297,11 @@ The default Kerberos service name is `mongodb`. Users can authenticate with an e
 
 ## Metrics
 
-The following metric are available with versions:
+The following metrics are version-gated:
 
-- `mongodb.extent.count` < 4.4 with mmapv1 storage engine
+- `mongodb.extent.count` — MongoDB `< 4.4` with the MMAPv1 storage engine only.
+- `mongodb.wt.concurrent_transactions.out` — read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
+- `mongodb.wt.log.bytes`, `mongodb.wt.log.operations`, `mongodb.wt.log.sync.time`, and `mongodb.wt.fsync.count` — require the WiredTiger storage engine (default since MongoDB 3.2, mandatory since 4.2). No data points are emitted on other storage engines.
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -556,7 +556,7 @@ The total number of bytes written to the WiredTiger journal.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | By | Sum | Int | Cumulative | true | Development |
 
-### mongodb.wt.log.operations
+### mongodb.wt.log.operation.count
 
 The total number of WiredTiger journal operations.
 

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -538,7 +538,7 @@ The number of in-flight WiredTiger read/write concurrent-transaction tickets.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| disk.io.direction | The disk I/O operation direction. | Str: ``read``, ``write`` | Recommended | - |
+| mongodb.wt.concurrent_transaction.type | The WiredTiger concurrent-transaction ticket type. | Str: ``read``, ``write`` | Recommended | - |
 
 ### mongodb.wt.fsync.count
 

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -526,7 +526,7 @@ The amount of time that the server has been running.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | ms | Sum | Int | Cumulative | true | Development |
 
-### mongodb.wt.concurrent_transactions.out
+### mongodb.wt.concurrent_transactions.in_use
 
 The number of in-flight WiredTiger read/write concurrent-transaction tickets.
 

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -530,9 +530,9 @@ The amount of time that the server has been running.
 
 The number of in-flight WiredTiger read/write concurrent-transaction tickets.
 
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| {transaction} | Gauge | Int | Development |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {transaction} | Sum | Int | Cumulative | false | Development |
 
 #### Attributes
 

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -526,6 +526,58 @@ The amount of time that the server has been running.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | ms | Sum | Int | Cumulative | true | Development |
 
+### mongodb.wt.concurrent_transactions.out
+
+The number of in-flight WiredTiger read/write concurrent-transaction tickets.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transaction} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| disk.io.direction | The disk I/O operation direction. | Str: ``read``, ``write`` | Recommended | - |
+
+### mongodb.wt.fsync.count
+
+The total number of fsync I/Os issued by the WiredTiger storage engine.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {fsync} | Sum | Int | Cumulative | true | Development |
+
+### mongodb.wt.log.bytes
+
+The total number of bytes written to the WiredTiger journal.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | Development |
+
+### mongodb.wt.log.operations
+
+The total number of WiredTiger journal operations.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| mongodb.wt.log.operation.type | The WiredTiger journal operation type. | Str: ``write``, ``sync``, ``flush`` | Recommended | - |
+
+### mongodb.wt.log.sync.time
+
+The cumulative time spent syncing the WiredTiger journal.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | Development |
+
 ### mongodb.wtcache.bytes.read
 
 The number of bytes read into the WiredTiger cache.

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -548,14 +548,6 @@ The total number of fsync I/Os issued by the WiredTiger storage engine.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {fsync} | Sum | Int | Cumulative | true | Development |
 
-### mongodb.wt.log.bytes
-
-The total number of bytes written to the WiredTiger journal.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
-| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| By | Sum | Int | Cumulative | true | Development |
-
 ### mongodb.wt.log.operation.count
 
 The total number of WiredTiger journal operations.
@@ -577,6 +569,14 @@ The cumulative time spent syncing the WiredTiger journal.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Cumulative | true | Development |
+
+### mongodb.wt.log.write
+
+The total number of bytes written to the WiredTiger journal.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | Development |
 
 ### mongodb.wtcache.bytes.read
 

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -526,19 +526,19 @@ The amount of time that the server has been running.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | ms | Sum | Int | Cumulative | true | Development |
 
-### mongodb.wt.concurrent_transactions.in_use
+### mongodb.wt.concurrent_transaction.ticket.in_use
 
 The number of in-flight WiredTiger read/write concurrent-transaction tickets.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
-| {transaction} | Sum | Int | Cumulative | false | Development |
+| {ticket} | Sum | Int | Cumulative | false | Development |
 
 #### Attributes
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| mongodb.wt.concurrent_transaction.type | The WiredTiger concurrent-transaction ticket type. | Str: ``read``, ``write`` | Recommended | - |
+| mongodb.wt.concurrent_transaction.ticket.type | The WiredTiger concurrent-transaction ticket type. | Str: ``read``, ``write`` | Recommended | - |
 
 ### mongodb.wt.fsync.count
 

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -1916,7 +1916,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
 			Enabled:             false,
-			AggregationStrategy: AggregationStrategyAvg,
+			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
 		},
 		MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -1502,23 +1502,23 @@ func (ms *MongodbUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MongodbWtConcurrentTransactionsInUseMetricAttributeKey specifies the key of an attribute for the mongodb.wt.concurrent_transactions.in_use metric.
-type MongodbWtConcurrentTransactionsInUseMetricAttributeKey string
+// MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey specifies the key of an attribute for the mongodb.wt.concurrent_transaction.ticket.in_use metric.
+type MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey string
 
 const (
-	MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType MongodbWtConcurrentTransactionsInUseMetricAttributeKey = "mongodb.wt.concurrent_transaction.type"
+	MongodbWtConcurrentTransactionTicketInUseMetricAttributeKeyMongodbWtConcurrentTransactionTicketType MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey = "mongodb.wt.concurrent_transaction.ticket.type"
 )
 
-// MongodbWtConcurrentTransactionsInUseMetricConfig provides config for the mongodb.wt.concurrent_transactions.in_use metric.
-type MongodbWtConcurrentTransactionsInUseMetricConfig struct {
+// MongodbWtConcurrentTransactionTicketInUseMetricConfig provides config for the mongodb.wt.concurrent_transaction.ticket.in_use metric.
+type MongodbWtConcurrentTransactionTicketInUseMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
-	AggregationStrategy string                                                   `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey `mapstructure:"attributes"`
+	AggregationStrategy string                                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *MongodbWtConcurrentTransactionTicketInUseMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1532,12 +1532,12 @@ func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Unmarshal(parser *co
 	return nil
 }
 
-func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Validate() error {
+func (ms *MongodbWtConcurrentTransactionTicketInUseMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType:
+		case MongodbWtConcurrentTransactionTicketInUseMetricAttributeKeyMongodbWtConcurrentTransactionTicketType:
 		default:
-			return fmt.Errorf("metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute %v, valid attributes: [mongodb.wt.concurrent_transaction.type]", val)
+			return fmt.Errorf("metric mongodb.wt.concurrent_transaction.ticket.in_use doesn't have an attribute %v, valid attributes: [mongodb.wt.concurrent_transaction.ticket.type]", val)
 		}
 	}
 
@@ -1680,58 +1680,58 @@ func (ms *MongodbWtcacheBytesReadMetricConfig) Unmarshal(parser *confmap.Conf) e
 
 // MetricsConfig provides config for mongodb metrics.
 type MetricsConfig struct {
-	MongodbActiveReads                   MongodbActiveReadsMetricConfig                   `mapstructure:"mongodb.active.reads"`
-	MongodbActiveWrites                  MongodbActiveWritesMetricConfig                  `mapstructure:"mongodb.active.writes"`
-	MongodbCacheOperations               MongodbCacheOperationsMetricConfig               `mapstructure:"mongodb.cache.operations"`
-	MongodbCollectionCount               MongodbCollectionCountMetricConfig               `mapstructure:"mongodb.collection.count"`
-	MongodbCommandsRate                  MongodbCommandsRateMetricConfig                  `mapstructure:"mongodb.commands.rate"`
-	MongodbConnectionCount               MongodbConnectionCountMetricConfig               `mapstructure:"mongodb.connection.count"`
-	MongodbCursorCount                   MongodbCursorCountMetricConfig                   `mapstructure:"mongodb.cursor.count"`
-	MongodbCursorTimeoutCount            MongodbCursorTimeoutCountMetricConfig            `mapstructure:"mongodb.cursor.timeout.count"`
-	MongodbDataSize                      MongodbDataSizeMetricConfig                      `mapstructure:"mongodb.data.size"`
-	MongodbDatabaseCount                 MongodbDatabaseCountMetricConfig                 `mapstructure:"mongodb.database.count"`
-	MongodbDeletesRate                   MongodbDeletesRateMetricConfig                   `mapstructure:"mongodb.deletes.rate"`
-	MongodbDocumentOperationCount        MongodbDocumentOperationCountMetricConfig        `mapstructure:"mongodb.document.operation.count"`
-	MongodbExtentCount                   MongodbExtentCountMetricConfig                   `mapstructure:"mongodb.extent.count"`
-	MongodbFlushesRate                   MongodbFlushesRateMetricConfig                   `mapstructure:"mongodb.flushes.rate"`
-	MongodbGetmoresRate                  MongodbGetmoresRateMetricConfig                  `mapstructure:"mongodb.getmores.rate"`
-	MongodbGlobalLockTime                MongodbGlobalLockTimeMetricConfig                `mapstructure:"mongodb.global_lock.time"`
-	MongodbHealth                        MongodbHealthMetricConfig                        `mapstructure:"mongodb.health"`
-	MongodbIndexAccessCount              MongodbIndexAccessCountMetricConfig              `mapstructure:"mongodb.index.access.count"`
-	MongodbIndexCount                    MongodbIndexCountMetricConfig                    `mapstructure:"mongodb.index.count"`
-	MongodbIndexSize                     MongodbIndexSizeMetricConfig                     `mapstructure:"mongodb.index.size"`
-	MongodbInsertsRate                   MongodbInsertsRateMetricConfig                   `mapstructure:"mongodb.inserts.rate"`
-	MongodbLockAcquireCount              MongodbLockAcquireCountMetricConfig              `mapstructure:"mongodb.lock.acquire.count"`
-	MongodbLockAcquireTime               MongodbLockAcquireTimeMetricConfig               `mapstructure:"mongodb.lock.acquire.time"`
-	MongodbLockAcquireWaitCount          MongodbLockAcquireWaitCountMetricConfig          `mapstructure:"mongodb.lock.acquire.wait_count"`
-	MongodbLockDeadlockCount             MongodbLockDeadlockCountMetricConfig             `mapstructure:"mongodb.lock.deadlock.count"`
-	MongodbMemoryUsage                   MongodbMemoryUsageMetricConfig                   `mapstructure:"mongodb.memory.usage"`
-	MongodbNetworkIoReceive              MongodbNetworkIoReceiveMetricConfig              `mapstructure:"mongodb.network.io.receive"`
-	MongodbNetworkIoTransmit             MongodbNetworkIoTransmitMetricConfig             `mapstructure:"mongodb.network.io.transmit"`
-	MongodbNetworkRequestCount           MongodbNetworkRequestCountMetricConfig           `mapstructure:"mongodb.network.request.count"`
-	MongodbObjectCount                   MongodbObjectCountMetricConfig                   `mapstructure:"mongodb.object.count"`
-	MongodbOperationCount                MongodbOperationCountMetricConfig                `mapstructure:"mongodb.operation.count"`
-	MongodbOperationLatencyTime          MongodbOperationLatencyTimeMetricConfig          `mapstructure:"mongodb.operation.latency.time"`
-	MongodbOperationReplCount            MongodbOperationReplCountMetricConfig            `mapstructure:"mongodb.operation.repl.count"`
-	MongodbOperationTime                 MongodbOperationTimeMetricConfig                 `mapstructure:"mongodb.operation.time"`
-	MongodbPageFaults                    MongodbPageFaultsMetricConfig                    `mapstructure:"mongodb.page_faults"`
-	MongodbQueriesRate                   MongodbQueriesRateMetricConfig                   `mapstructure:"mongodb.queries.rate"`
-	MongodbReplCommandsPerSec            MongodbReplCommandsPerSecMetricConfig            `mapstructure:"mongodb.repl_commands_per_sec"`
-	MongodbReplDeletesPerSec             MongodbReplDeletesPerSecMetricConfig             `mapstructure:"mongodb.repl_deletes_per_sec"`
-	MongodbReplGetmoresPerSec            MongodbReplGetmoresPerSecMetricConfig            `mapstructure:"mongodb.repl_getmores_per_sec"`
-	MongodbReplInsertsPerSec             MongodbReplInsertsPerSecMetricConfig             `mapstructure:"mongodb.repl_inserts_per_sec"`
-	MongodbReplQueriesPerSec             MongodbReplQueriesPerSecMetricConfig             `mapstructure:"mongodb.repl_queries_per_sec"`
-	MongodbReplUpdatesPerSec             MongodbReplUpdatesPerSecMetricConfig             `mapstructure:"mongodb.repl_updates_per_sec"`
-	MongodbSessionCount                  MongodbSessionCountMetricConfig                  `mapstructure:"mongodb.session.count"`
-	MongodbStorageSize                   MongodbStorageSizeMetricConfig                   `mapstructure:"mongodb.storage.size"`
-	MongodbUpdatesRate                   MongodbUpdatesRateMetricConfig                   `mapstructure:"mongodb.updates.rate"`
-	MongodbUptime                        MongodbUptimeMetricConfig                        `mapstructure:"mongodb.uptime"`
-	MongodbWtConcurrentTransactionsInUse MongodbWtConcurrentTransactionsInUseMetricConfig `mapstructure:"mongodb.wt.concurrent_transactions.in_use"`
-	MongodbWtFsyncCount                  MongodbWtFsyncCountMetricConfig                  `mapstructure:"mongodb.wt.fsync.count"`
-	MongodbWtLogOperationCount           MongodbWtLogOperationCountMetricConfig           `mapstructure:"mongodb.wt.log.operation.count"`
-	MongodbWtLogSyncTime                 MongodbWtLogSyncTimeMetricConfig                 `mapstructure:"mongodb.wt.log.sync.time"`
-	MongodbWtLogWrite                    MongodbWtLogWriteMetricConfig                    `mapstructure:"mongodb.wt.log.write"`
-	MongodbWtcacheBytesRead              MongodbWtcacheBytesReadMetricConfig              `mapstructure:"mongodb.wtcache.bytes.read"`
+	MongodbActiveReads                        MongodbActiveReadsMetricConfig                        `mapstructure:"mongodb.active.reads"`
+	MongodbActiveWrites                       MongodbActiveWritesMetricConfig                       `mapstructure:"mongodb.active.writes"`
+	MongodbCacheOperations                    MongodbCacheOperationsMetricConfig                    `mapstructure:"mongodb.cache.operations"`
+	MongodbCollectionCount                    MongodbCollectionCountMetricConfig                    `mapstructure:"mongodb.collection.count"`
+	MongodbCommandsRate                       MongodbCommandsRateMetricConfig                       `mapstructure:"mongodb.commands.rate"`
+	MongodbConnectionCount                    MongodbConnectionCountMetricConfig                    `mapstructure:"mongodb.connection.count"`
+	MongodbCursorCount                        MongodbCursorCountMetricConfig                        `mapstructure:"mongodb.cursor.count"`
+	MongodbCursorTimeoutCount                 MongodbCursorTimeoutCountMetricConfig                 `mapstructure:"mongodb.cursor.timeout.count"`
+	MongodbDataSize                           MongodbDataSizeMetricConfig                           `mapstructure:"mongodb.data.size"`
+	MongodbDatabaseCount                      MongodbDatabaseCountMetricConfig                      `mapstructure:"mongodb.database.count"`
+	MongodbDeletesRate                        MongodbDeletesRateMetricConfig                        `mapstructure:"mongodb.deletes.rate"`
+	MongodbDocumentOperationCount             MongodbDocumentOperationCountMetricConfig             `mapstructure:"mongodb.document.operation.count"`
+	MongodbExtentCount                        MongodbExtentCountMetricConfig                        `mapstructure:"mongodb.extent.count"`
+	MongodbFlushesRate                        MongodbFlushesRateMetricConfig                        `mapstructure:"mongodb.flushes.rate"`
+	MongodbGetmoresRate                       MongodbGetmoresRateMetricConfig                       `mapstructure:"mongodb.getmores.rate"`
+	MongodbGlobalLockTime                     MongodbGlobalLockTimeMetricConfig                     `mapstructure:"mongodb.global_lock.time"`
+	MongodbHealth                             MongodbHealthMetricConfig                             `mapstructure:"mongodb.health"`
+	MongodbIndexAccessCount                   MongodbIndexAccessCountMetricConfig                   `mapstructure:"mongodb.index.access.count"`
+	MongodbIndexCount                         MongodbIndexCountMetricConfig                         `mapstructure:"mongodb.index.count"`
+	MongodbIndexSize                          MongodbIndexSizeMetricConfig                          `mapstructure:"mongodb.index.size"`
+	MongodbInsertsRate                        MongodbInsertsRateMetricConfig                        `mapstructure:"mongodb.inserts.rate"`
+	MongodbLockAcquireCount                   MongodbLockAcquireCountMetricConfig                   `mapstructure:"mongodb.lock.acquire.count"`
+	MongodbLockAcquireTime                    MongodbLockAcquireTimeMetricConfig                    `mapstructure:"mongodb.lock.acquire.time"`
+	MongodbLockAcquireWaitCount               MongodbLockAcquireWaitCountMetricConfig               `mapstructure:"mongodb.lock.acquire.wait_count"`
+	MongodbLockDeadlockCount                  MongodbLockDeadlockCountMetricConfig                  `mapstructure:"mongodb.lock.deadlock.count"`
+	MongodbMemoryUsage                        MongodbMemoryUsageMetricConfig                        `mapstructure:"mongodb.memory.usage"`
+	MongodbNetworkIoReceive                   MongodbNetworkIoReceiveMetricConfig                   `mapstructure:"mongodb.network.io.receive"`
+	MongodbNetworkIoTransmit                  MongodbNetworkIoTransmitMetricConfig                  `mapstructure:"mongodb.network.io.transmit"`
+	MongodbNetworkRequestCount                MongodbNetworkRequestCountMetricConfig                `mapstructure:"mongodb.network.request.count"`
+	MongodbObjectCount                        MongodbObjectCountMetricConfig                        `mapstructure:"mongodb.object.count"`
+	MongodbOperationCount                     MongodbOperationCountMetricConfig                     `mapstructure:"mongodb.operation.count"`
+	MongodbOperationLatencyTime               MongodbOperationLatencyTimeMetricConfig               `mapstructure:"mongodb.operation.latency.time"`
+	MongodbOperationReplCount                 MongodbOperationReplCountMetricConfig                 `mapstructure:"mongodb.operation.repl.count"`
+	MongodbOperationTime                      MongodbOperationTimeMetricConfig                      `mapstructure:"mongodb.operation.time"`
+	MongodbPageFaults                         MongodbPageFaultsMetricConfig                         `mapstructure:"mongodb.page_faults"`
+	MongodbQueriesRate                        MongodbQueriesRateMetricConfig                        `mapstructure:"mongodb.queries.rate"`
+	MongodbReplCommandsPerSec                 MongodbReplCommandsPerSecMetricConfig                 `mapstructure:"mongodb.repl_commands_per_sec"`
+	MongodbReplDeletesPerSec                  MongodbReplDeletesPerSecMetricConfig                  `mapstructure:"mongodb.repl_deletes_per_sec"`
+	MongodbReplGetmoresPerSec                 MongodbReplGetmoresPerSecMetricConfig                 `mapstructure:"mongodb.repl_getmores_per_sec"`
+	MongodbReplInsertsPerSec                  MongodbReplInsertsPerSecMetricConfig                  `mapstructure:"mongodb.repl_inserts_per_sec"`
+	MongodbReplQueriesPerSec                  MongodbReplQueriesPerSecMetricConfig                  `mapstructure:"mongodb.repl_queries_per_sec"`
+	MongodbReplUpdatesPerSec                  MongodbReplUpdatesPerSecMetricConfig                  `mapstructure:"mongodb.repl_updates_per_sec"`
+	MongodbSessionCount                       MongodbSessionCountMetricConfig                       `mapstructure:"mongodb.session.count"`
+	MongodbStorageSize                        MongodbStorageSizeMetricConfig                        `mapstructure:"mongodb.storage.size"`
+	MongodbUpdatesRate                        MongodbUpdatesRateMetricConfig                        `mapstructure:"mongodb.updates.rate"`
+	MongodbUptime                             MongodbUptimeMetricConfig                             `mapstructure:"mongodb.uptime"`
+	MongodbWtConcurrentTransactionTicketInUse MongodbWtConcurrentTransactionTicketInUseMetricConfig `mapstructure:"mongodb.wt.concurrent_transaction.ticket.in_use"`
+	MongodbWtFsyncCount                       MongodbWtFsyncCountMetricConfig                       `mapstructure:"mongodb.wt.fsync.count"`
+	MongodbWtLogOperationCount                MongodbWtLogOperationCountMetricConfig                `mapstructure:"mongodb.wt.log.operation.count"`
+	MongodbWtLogSyncTime                      MongodbWtLogSyncTimeMetricConfig                      `mapstructure:"mongodb.wt.log.sync.time"`
+	MongodbWtLogWrite                         MongodbWtLogWriteMetricConfig                         `mapstructure:"mongodb.wt.log.write"`
+	MongodbWtcacheBytesRead                   MongodbWtcacheBytesReadMetricConfig                   `mapstructure:"mongodb.wtcache.bytes.read"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -1914,10 +1914,10 @@ func DefaultMetricsConfig() MetricsConfig {
 		MongodbUptime: MongodbUptimeMetricConfig{
 			Enabled: false,
 		},
-		MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
+		MongodbWtConcurrentTransactionTicketInUse: MongodbWtConcurrentTransactionTicketInUseMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
+			EnabledAttributes:   []MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey{MongodbWtConcurrentTransactionTicketInUseMetricAttributeKeyMongodbWtConcurrentTransactionTicketType},
 		},
 		MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
 			Enabled: false,

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -1502,6 +1502,162 @@ func (ms *MongodbUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
+// MongodbWtConcurrentTransactionsInUseMetricAttributeKey specifies the key of an attribute for the mongodb.wt.concurrent_transactions.in_use metric.
+type MongodbWtConcurrentTransactionsInUseMetricAttributeKey string
+
+const (
+	MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection MongodbWtConcurrentTransactionsInUseMetricAttributeKey = "disk.io.direction"
+)
+
+// MongodbWtConcurrentTransactionsInUseMetricConfig provides config for the mongodb.wt.concurrent_transactions.in_use metric.
+type MongodbWtConcurrentTransactionsInUseMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection:
+		default:
+			return fmt.Errorf("metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute %v, valid attributes: [disk.io.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbWtFsyncCountMetricConfig provides config for the mongodb.wt.fsync.count metric.
+type MongodbWtFsyncCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbWtFsyncCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbWtLogOperationCountMetricAttributeKey specifies the key of an attribute for the mongodb.wt.log.operation.count metric.
+type MongodbWtLogOperationCountMetricAttributeKey string
+
+const (
+	MongodbWtLogOperationCountMetricAttributeKeyMongodbWtLogOperationType MongodbWtLogOperationCountMetricAttributeKey = "mongodb.wt.log.operation.type"
+)
+
+// MongodbWtLogOperationCountMetricConfig provides config for the mongodb.wt.log.operation.count metric.
+type MongodbWtLogOperationCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbWtLogOperationCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbWtLogOperationCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbWtLogOperationCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbWtLogOperationCountMetricAttributeKeyMongodbWtLogOperationType:
+		default:
+			return fmt.Errorf("metric mongodb.wt.log.operation.count doesn't have an attribute %v, valid attributes: [mongodb.wt.log.operation.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbWtLogSyncTimeMetricConfig provides config for the mongodb.wt.log.sync.time metric.
+type MongodbWtLogSyncTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbWtLogSyncTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbWtLogWriteMetricConfig provides config for the mongodb.wt.log.write metric.
+type MongodbWtLogWriteMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbWtLogWriteMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MongodbWtcacheBytesReadMetricConfig provides config for the mongodb.wtcache.bytes.read metric.
 type MongodbWtcacheBytesReadMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -1524,53 +1680,58 @@ func (ms *MongodbWtcacheBytesReadMetricConfig) Unmarshal(parser *confmap.Conf) e
 
 // MetricsConfig provides config for mongodb metrics.
 type MetricsConfig struct {
-	MongodbActiveReads            MongodbActiveReadsMetricConfig            `mapstructure:"mongodb.active.reads"`
-	MongodbActiveWrites           MongodbActiveWritesMetricConfig           `mapstructure:"mongodb.active.writes"`
-	MongodbCacheOperations        MongodbCacheOperationsMetricConfig        `mapstructure:"mongodb.cache.operations"`
-	MongodbCollectionCount        MongodbCollectionCountMetricConfig        `mapstructure:"mongodb.collection.count"`
-	MongodbCommandsRate           MongodbCommandsRateMetricConfig           `mapstructure:"mongodb.commands.rate"`
-	MongodbConnectionCount        MongodbConnectionCountMetricConfig        `mapstructure:"mongodb.connection.count"`
-	MongodbCursorCount            MongodbCursorCountMetricConfig            `mapstructure:"mongodb.cursor.count"`
-	MongodbCursorTimeoutCount     MongodbCursorTimeoutCountMetricConfig     `mapstructure:"mongodb.cursor.timeout.count"`
-	MongodbDataSize               MongodbDataSizeMetricConfig               `mapstructure:"mongodb.data.size"`
-	MongodbDatabaseCount          MongodbDatabaseCountMetricConfig          `mapstructure:"mongodb.database.count"`
-	MongodbDeletesRate            MongodbDeletesRateMetricConfig            `mapstructure:"mongodb.deletes.rate"`
-	MongodbDocumentOperationCount MongodbDocumentOperationCountMetricConfig `mapstructure:"mongodb.document.operation.count"`
-	MongodbExtentCount            MongodbExtentCountMetricConfig            `mapstructure:"mongodb.extent.count"`
-	MongodbFlushesRate            MongodbFlushesRateMetricConfig            `mapstructure:"mongodb.flushes.rate"`
-	MongodbGetmoresRate           MongodbGetmoresRateMetricConfig           `mapstructure:"mongodb.getmores.rate"`
-	MongodbGlobalLockTime         MongodbGlobalLockTimeMetricConfig         `mapstructure:"mongodb.global_lock.time"`
-	MongodbHealth                 MongodbHealthMetricConfig                 `mapstructure:"mongodb.health"`
-	MongodbIndexAccessCount       MongodbIndexAccessCountMetricConfig       `mapstructure:"mongodb.index.access.count"`
-	MongodbIndexCount             MongodbIndexCountMetricConfig             `mapstructure:"mongodb.index.count"`
-	MongodbIndexSize              MongodbIndexSizeMetricConfig              `mapstructure:"mongodb.index.size"`
-	MongodbInsertsRate            MongodbInsertsRateMetricConfig            `mapstructure:"mongodb.inserts.rate"`
-	MongodbLockAcquireCount       MongodbLockAcquireCountMetricConfig       `mapstructure:"mongodb.lock.acquire.count"`
-	MongodbLockAcquireTime        MongodbLockAcquireTimeMetricConfig        `mapstructure:"mongodb.lock.acquire.time"`
-	MongodbLockAcquireWaitCount   MongodbLockAcquireWaitCountMetricConfig   `mapstructure:"mongodb.lock.acquire.wait_count"`
-	MongodbLockDeadlockCount      MongodbLockDeadlockCountMetricConfig      `mapstructure:"mongodb.lock.deadlock.count"`
-	MongodbMemoryUsage            MongodbMemoryUsageMetricConfig            `mapstructure:"mongodb.memory.usage"`
-	MongodbNetworkIoReceive       MongodbNetworkIoReceiveMetricConfig       `mapstructure:"mongodb.network.io.receive"`
-	MongodbNetworkIoTransmit      MongodbNetworkIoTransmitMetricConfig      `mapstructure:"mongodb.network.io.transmit"`
-	MongodbNetworkRequestCount    MongodbNetworkRequestCountMetricConfig    `mapstructure:"mongodb.network.request.count"`
-	MongodbObjectCount            MongodbObjectCountMetricConfig            `mapstructure:"mongodb.object.count"`
-	MongodbOperationCount         MongodbOperationCountMetricConfig         `mapstructure:"mongodb.operation.count"`
-	MongodbOperationLatencyTime   MongodbOperationLatencyTimeMetricConfig   `mapstructure:"mongodb.operation.latency.time"`
-	MongodbOperationReplCount     MongodbOperationReplCountMetricConfig     `mapstructure:"mongodb.operation.repl.count"`
-	MongodbOperationTime          MongodbOperationTimeMetricConfig          `mapstructure:"mongodb.operation.time"`
-	MongodbPageFaults             MongodbPageFaultsMetricConfig             `mapstructure:"mongodb.page_faults"`
-	MongodbQueriesRate            MongodbQueriesRateMetricConfig            `mapstructure:"mongodb.queries.rate"`
-	MongodbReplCommandsPerSec     MongodbReplCommandsPerSecMetricConfig     `mapstructure:"mongodb.repl_commands_per_sec"`
-	MongodbReplDeletesPerSec      MongodbReplDeletesPerSecMetricConfig      `mapstructure:"mongodb.repl_deletes_per_sec"`
-	MongodbReplGetmoresPerSec     MongodbReplGetmoresPerSecMetricConfig     `mapstructure:"mongodb.repl_getmores_per_sec"`
-	MongodbReplInsertsPerSec      MongodbReplInsertsPerSecMetricConfig      `mapstructure:"mongodb.repl_inserts_per_sec"`
-	MongodbReplQueriesPerSec      MongodbReplQueriesPerSecMetricConfig      `mapstructure:"mongodb.repl_queries_per_sec"`
-	MongodbReplUpdatesPerSec      MongodbReplUpdatesPerSecMetricConfig      `mapstructure:"mongodb.repl_updates_per_sec"`
-	MongodbSessionCount           MongodbSessionCountMetricConfig           `mapstructure:"mongodb.session.count"`
-	MongodbStorageSize            MongodbStorageSizeMetricConfig            `mapstructure:"mongodb.storage.size"`
-	MongodbUpdatesRate            MongodbUpdatesRateMetricConfig            `mapstructure:"mongodb.updates.rate"`
-	MongodbUptime                 MongodbUptimeMetricConfig                 `mapstructure:"mongodb.uptime"`
-	MongodbWtcacheBytesRead       MongodbWtcacheBytesReadMetricConfig       `mapstructure:"mongodb.wtcache.bytes.read"`
+	MongodbActiveReads                   MongodbActiveReadsMetricConfig                   `mapstructure:"mongodb.active.reads"`
+	MongodbActiveWrites                  MongodbActiveWritesMetricConfig                  `mapstructure:"mongodb.active.writes"`
+	MongodbCacheOperations               MongodbCacheOperationsMetricConfig               `mapstructure:"mongodb.cache.operations"`
+	MongodbCollectionCount               MongodbCollectionCountMetricConfig               `mapstructure:"mongodb.collection.count"`
+	MongodbCommandsRate                  MongodbCommandsRateMetricConfig                  `mapstructure:"mongodb.commands.rate"`
+	MongodbConnectionCount               MongodbConnectionCountMetricConfig               `mapstructure:"mongodb.connection.count"`
+	MongodbCursorCount                   MongodbCursorCountMetricConfig                   `mapstructure:"mongodb.cursor.count"`
+	MongodbCursorTimeoutCount            MongodbCursorTimeoutCountMetricConfig            `mapstructure:"mongodb.cursor.timeout.count"`
+	MongodbDataSize                      MongodbDataSizeMetricConfig                      `mapstructure:"mongodb.data.size"`
+	MongodbDatabaseCount                 MongodbDatabaseCountMetricConfig                 `mapstructure:"mongodb.database.count"`
+	MongodbDeletesRate                   MongodbDeletesRateMetricConfig                   `mapstructure:"mongodb.deletes.rate"`
+	MongodbDocumentOperationCount        MongodbDocumentOperationCountMetricConfig        `mapstructure:"mongodb.document.operation.count"`
+	MongodbExtentCount                   MongodbExtentCountMetricConfig                   `mapstructure:"mongodb.extent.count"`
+	MongodbFlushesRate                   MongodbFlushesRateMetricConfig                   `mapstructure:"mongodb.flushes.rate"`
+	MongodbGetmoresRate                  MongodbGetmoresRateMetricConfig                  `mapstructure:"mongodb.getmores.rate"`
+	MongodbGlobalLockTime                MongodbGlobalLockTimeMetricConfig                `mapstructure:"mongodb.global_lock.time"`
+	MongodbHealth                        MongodbHealthMetricConfig                        `mapstructure:"mongodb.health"`
+	MongodbIndexAccessCount              MongodbIndexAccessCountMetricConfig              `mapstructure:"mongodb.index.access.count"`
+	MongodbIndexCount                    MongodbIndexCountMetricConfig                    `mapstructure:"mongodb.index.count"`
+	MongodbIndexSize                     MongodbIndexSizeMetricConfig                     `mapstructure:"mongodb.index.size"`
+	MongodbInsertsRate                   MongodbInsertsRateMetricConfig                   `mapstructure:"mongodb.inserts.rate"`
+	MongodbLockAcquireCount              MongodbLockAcquireCountMetricConfig              `mapstructure:"mongodb.lock.acquire.count"`
+	MongodbLockAcquireTime               MongodbLockAcquireTimeMetricConfig               `mapstructure:"mongodb.lock.acquire.time"`
+	MongodbLockAcquireWaitCount          MongodbLockAcquireWaitCountMetricConfig          `mapstructure:"mongodb.lock.acquire.wait_count"`
+	MongodbLockDeadlockCount             MongodbLockDeadlockCountMetricConfig             `mapstructure:"mongodb.lock.deadlock.count"`
+	MongodbMemoryUsage                   MongodbMemoryUsageMetricConfig                   `mapstructure:"mongodb.memory.usage"`
+	MongodbNetworkIoReceive              MongodbNetworkIoReceiveMetricConfig              `mapstructure:"mongodb.network.io.receive"`
+	MongodbNetworkIoTransmit             MongodbNetworkIoTransmitMetricConfig             `mapstructure:"mongodb.network.io.transmit"`
+	MongodbNetworkRequestCount           MongodbNetworkRequestCountMetricConfig           `mapstructure:"mongodb.network.request.count"`
+	MongodbObjectCount                   MongodbObjectCountMetricConfig                   `mapstructure:"mongodb.object.count"`
+	MongodbOperationCount                MongodbOperationCountMetricConfig                `mapstructure:"mongodb.operation.count"`
+	MongodbOperationLatencyTime          MongodbOperationLatencyTimeMetricConfig          `mapstructure:"mongodb.operation.latency.time"`
+	MongodbOperationReplCount            MongodbOperationReplCountMetricConfig            `mapstructure:"mongodb.operation.repl.count"`
+	MongodbOperationTime                 MongodbOperationTimeMetricConfig                 `mapstructure:"mongodb.operation.time"`
+	MongodbPageFaults                    MongodbPageFaultsMetricConfig                    `mapstructure:"mongodb.page_faults"`
+	MongodbQueriesRate                   MongodbQueriesRateMetricConfig                   `mapstructure:"mongodb.queries.rate"`
+	MongodbReplCommandsPerSec            MongodbReplCommandsPerSecMetricConfig            `mapstructure:"mongodb.repl_commands_per_sec"`
+	MongodbReplDeletesPerSec             MongodbReplDeletesPerSecMetricConfig             `mapstructure:"mongodb.repl_deletes_per_sec"`
+	MongodbReplGetmoresPerSec            MongodbReplGetmoresPerSecMetricConfig            `mapstructure:"mongodb.repl_getmores_per_sec"`
+	MongodbReplInsertsPerSec             MongodbReplInsertsPerSecMetricConfig             `mapstructure:"mongodb.repl_inserts_per_sec"`
+	MongodbReplQueriesPerSec             MongodbReplQueriesPerSecMetricConfig             `mapstructure:"mongodb.repl_queries_per_sec"`
+	MongodbReplUpdatesPerSec             MongodbReplUpdatesPerSecMetricConfig             `mapstructure:"mongodb.repl_updates_per_sec"`
+	MongodbSessionCount                  MongodbSessionCountMetricConfig                  `mapstructure:"mongodb.session.count"`
+	MongodbStorageSize                   MongodbStorageSizeMetricConfig                   `mapstructure:"mongodb.storage.size"`
+	MongodbUpdatesRate                   MongodbUpdatesRateMetricConfig                   `mapstructure:"mongodb.updates.rate"`
+	MongodbUptime                        MongodbUptimeMetricConfig                        `mapstructure:"mongodb.uptime"`
+	MongodbWtConcurrentTransactionsInUse MongodbWtConcurrentTransactionsInUseMetricConfig `mapstructure:"mongodb.wt.concurrent_transactions.in_use"`
+	MongodbWtFsyncCount                  MongodbWtFsyncCountMetricConfig                  `mapstructure:"mongodb.wt.fsync.count"`
+	MongodbWtLogOperationCount           MongodbWtLogOperationCountMetricConfig           `mapstructure:"mongodb.wt.log.operation.count"`
+	MongodbWtLogSyncTime                 MongodbWtLogSyncTimeMetricConfig                 `mapstructure:"mongodb.wt.log.sync.time"`
+	MongodbWtLogWrite                    MongodbWtLogWriteMetricConfig                    `mapstructure:"mongodb.wt.log.write"`
+	MongodbWtcacheBytesRead              MongodbWtcacheBytesReadMetricConfig              `mapstructure:"mongodb.wtcache.bytes.read"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -1751,6 +1912,25 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		MongodbUptime: MongodbUptimeMetricConfig{
+			Enabled: false,
+		},
+		MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection},
+		},
+		MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
+			Enabled: false,
+		},
+		MongodbWtLogOperationCount: MongodbWtLogOperationCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MongodbWtLogOperationCountMetricAttributeKey{MongodbWtLogOperationCountMetricAttributeKeyMongodbWtLogOperationType},
+		},
+		MongodbWtLogSyncTime: MongodbWtLogSyncTimeMetricConfig{
+			Enabled: false,
+		},
+		MongodbWtLogWrite: MongodbWtLogWriteMetricConfig{
 			Enabled: false,
 		},
 		MongodbWtcacheBytesRead: MongodbWtcacheBytesReadMetricConfig{

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -1506,7 +1506,7 @@ func (ms *MongodbUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 type MongodbWtConcurrentTransactionsInUseMetricAttributeKey string
 
 const (
-	MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection MongodbWtConcurrentTransactionsInUseMetricAttributeKey = "disk.io.direction"
+	MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType MongodbWtConcurrentTransactionsInUseMetricAttributeKey = "mongodb.wt.concurrent_transaction.type"
 )
 
 // MongodbWtConcurrentTransactionsInUseMetricConfig provides config for the mongodb.wt.concurrent_transactions.in_use metric.
@@ -1535,9 +1535,9 @@ func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Unmarshal(parser *co
 func (ms *MongodbWtConcurrentTransactionsInUseMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection:
+		case MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType:
 		default:
-			return fmt.Errorf("metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute %v, valid attributes: [disk.io.direction]", val)
+			return fmt.Errorf("metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute %v, valid attributes: [mongodb.wt.concurrent_transaction.type]", val)
 		}
 	}
 
@@ -1917,7 +1917,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection},
+			EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
 		},
 		MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
 			Enabled: false,

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -205,6 +205,25 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbUptime: MongodbUptimeMetricConfig{
 						Enabled: true,
 					},
+					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection},
+					},
+					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
+						Enabled: true,
+					},
+					MongodbWtLogOperationCount: MongodbWtLogOperationCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbWtLogOperationCountMetricAttributeKey{MongodbWtLogOperationCountMetricAttributeKeyMongodbWtLogOperationType},
+					},
+					MongodbWtLogSyncTime: MongodbWtLogSyncTimeMetricConfig{
+						Enabled: true,
+					},
+					MongodbWtLogWrite: MongodbWtLogWriteMetricConfig{
+						Enabled: true,
+					},
 					MongodbWtcacheBytesRead: MongodbWtcacheBytesReadMetricConfig{
 						Enabled: true,
 					},
@@ -400,6 +419,25 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbUptime: MongodbUptimeMetricConfig{
 						Enabled: false,
 					},
+					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection},
+					},
+					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
+						Enabled: false,
+					},
+					MongodbWtLogOperationCount: MongodbWtLogOperationCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbWtLogOperationCountMetricAttributeKey{MongodbWtLogOperationCountMetricAttributeKeyMongodbWtLogOperationType},
+					},
+					MongodbWtLogSyncTime: MongodbWtLogSyncTimeMetricConfig{
+						Enabled: false,
+					},
+					MongodbWtLogWrite: MongodbWtLogWriteMetricConfig{
+						Enabled: false,
+					},
 					MongodbWtcacheBytesRead: MongodbWtcacheBytesReadMetricConfig{
 						Enabled: false,
 					},
@@ -417,7 +455,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionsInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -659,6 +697,30 @@ func TestMongodbStorageSizeMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric mongodb.storage.size doesn't have an attribute invalid, valid attributes: [db.namespace]")
 
 	cfg = DefaultMetricsConfig().MongodbStorageSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMongodbWtConcurrentTransactionsInUseMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbWtConcurrentTransactionsInUse
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute invalid, valid attributes: [disk.io.direction]")
+
+	cfg = DefaultMetricsConfig().MongodbWtConcurrentTransactionsInUse
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMongodbWtLogOperationCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbWtLogOperationCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MongodbWtLogOperationCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.wt.log.operation.count doesn't have an attribute invalid, valid attributes: [mongodb.wt.log.operation.type]")
+
+	cfg = DefaultMetricsConfig().MongodbWtLogOperationCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -207,7 +207,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
 						Enabled:             true,
-						AggregationStrategy: AggregationStrategyAvg,
+						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
 					},
 					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
@@ -421,7 +421,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
 						Enabled:             false,
-						AggregationStrategy: AggregationStrategyAvg,
+						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
 					},
 					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -208,7 +208,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection},
+						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
 					},
 					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
 						Enabled: true,
@@ -422,7 +422,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection},
+						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
 					},
 					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
 						Enabled: false,
@@ -706,7 +706,7 @@ func TestMongodbWtConcurrentTransactionsInUseMetricsConfig_Validate(t *testing.T
 	require.NoError(t, cfg.Validate())
 
 	cfg.EnabledAttributes = []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute invalid, valid attributes: [disk.io.direction]")
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute invalid, valid attributes: [mongodb.wt.concurrent_transaction.type]")
 
 	cfg = DefaultMetricsConfig().MongodbWtConcurrentTransactionsInUse
 	cfg.AggregationStrategy = "invalid"

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -205,10 +205,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbUptime: MongodbUptimeMetricConfig{
 						Enabled: true,
 					},
-					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
+					MongodbWtConcurrentTransactionTicketInUse: MongodbWtConcurrentTransactionTicketInUseMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
+						EnabledAttributes:   []MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey{MongodbWtConcurrentTransactionTicketInUseMetricAttributeKeyMongodbWtConcurrentTransactionTicketType},
 					},
 					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
 						Enabled: true,
@@ -419,10 +419,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbUptime: MongodbUptimeMetricConfig{
 						Enabled: false,
 					},
-					MongodbWtConcurrentTransactionsInUse: MongodbWtConcurrentTransactionsInUseMetricConfig{
+					MongodbWtConcurrentTransactionTicketInUse: MongodbWtConcurrentTransactionTicketInUseMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType},
+						EnabledAttributes:   []MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey{MongodbWtConcurrentTransactionTicketInUseMetricAttributeKeyMongodbWtConcurrentTransactionTicketType},
 					},
 					MongodbWtFsyncCount: MongodbWtFsyncCountMetricConfig{
 						Enabled: false,
@@ -455,7 +455,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionsInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionTicketInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -701,14 +701,14 @@ func TestMongodbStorageSizeMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
-func TestMongodbWtConcurrentTransactionsInUseMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().MongodbWtConcurrentTransactionsInUse
+func TestMongodbWtConcurrentTransactionTicketInUseMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbWtConcurrentTransactionTicketInUse
 	require.NoError(t, cfg.Validate())
 
-	cfg.EnabledAttributes = []MongodbWtConcurrentTransactionsInUseMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric mongodb.wt.concurrent_transactions.in_use doesn't have an attribute invalid, valid attributes: [mongodb.wt.concurrent_transaction.type]")
+	cfg.EnabledAttributes = []MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.wt.concurrent_transaction.ticket.in_use doesn't have an attribute invalid, valid attributes: [mongodb.wt.concurrent_transaction.ticket.type]")
 
-	cfg = DefaultMetricsConfig().MongodbWtConcurrentTransactionsInUse
+	cfg = DefaultMetricsConfig().MongodbWtConcurrentTransactionTicketInUse
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -72,6 +72,32 @@ var MapAttributeDbSystemName = map[string]AttributeDbSystemName{
 	"mongodb": AttributeDbSystemNameMongodb,
 }
 
+// AttributeDiskIoDirection specifies the value disk.io.direction attribute.
+type AttributeDiskIoDirection int
+
+const (
+	_ AttributeDiskIoDirection = iota
+	AttributeDiskIoDirectionRead
+	AttributeDiskIoDirectionWrite
+)
+
+// String returns the string representation of the AttributeDiskIoDirection.
+func (av AttributeDiskIoDirection) String() string {
+	switch av {
+	case AttributeDiskIoDirectionRead:
+		return "read"
+	case AttributeDiskIoDirectionWrite:
+		return "write"
+	}
+	return ""
+}
+
+// MapAttributeDiskIoDirection is a helper map of string to AttributeDiskIoDirection attribute value.
+var MapAttributeDiskIoDirection = map[string]AttributeDiskIoDirection{
+	"read":  AttributeDiskIoDirectionRead,
+	"write": AttributeDiskIoDirectionWrite,
+}
+
 // AttributeLockMode specifies the value lock_mode attribute.
 type AttributeLockMode int
 
@@ -206,6 +232,36 @@ func (av AttributeMongodbOperationState) String() string {
 var MapAttributeMongodbOperationState = map[string]AttributeMongodbOperationState{
 	"active":  AttributeMongodbOperationStateActive,
 	"waiting": AttributeMongodbOperationStateWaiting,
+}
+
+// AttributeMongodbWtLogOperationType specifies the value mongodb.wt.log.operation.type attribute.
+type AttributeMongodbWtLogOperationType int
+
+const (
+	_ AttributeMongodbWtLogOperationType = iota
+	AttributeMongodbWtLogOperationTypeWrite
+	AttributeMongodbWtLogOperationTypeSync
+	AttributeMongodbWtLogOperationTypeFlush
+)
+
+// String returns the string representation of the AttributeMongodbWtLogOperationType.
+func (av AttributeMongodbWtLogOperationType) String() string {
+	switch av {
+	case AttributeMongodbWtLogOperationTypeWrite:
+		return "write"
+	case AttributeMongodbWtLogOperationTypeSync:
+		return "sync"
+	case AttributeMongodbWtLogOperationTypeFlush:
+		return "flush"
+	}
+	return ""
+}
+
+// MapAttributeMongodbWtLogOperationType is a helper map of string to AttributeMongodbWtLogOperationType attribute value.
+var MapAttributeMongodbWtLogOperationType = map[string]AttributeMongodbWtLogOperationType{
+	"write": AttributeMongodbWtLogOperationTypeWrite,
+	"sync":  AttributeMongodbWtLogOperationTypeSync,
+	"flush": AttributeMongodbWtLogOperationTypeFlush,
 }
 
 // AttributeOperation specifies the value operation attribute.
@@ -465,59 +521,81 @@ var MetricsInfo = metricsInfo{
 	MongodbUptime: metricInfo{
 		Name: "mongodb.uptime",
 	},
+	MongodbWtConcurrentTransactionsInUse: metricInfo{
+		Name:       "mongodb.wt.concurrent_transactions.in_use",
+		Attributes: []string{"disk.io.direction"},
+	},
+	MongodbWtFsyncCount: metricInfo{
+		Name: "mongodb.wt.fsync.count",
+	},
+	MongodbWtLogOperationCount: metricInfo{
+		Name:       "mongodb.wt.log.operation.count",
+		Attributes: []string{"mongodb.wt.log.operation.type"},
+	},
+	MongodbWtLogSyncTime: metricInfo{
+		Name: "mongodb.wt.log.sync.time",
+	},
+	MongodbWtLogWrite: metricInfo{
+		Name: "mongodb.wt.log.write",
+	},
 	MongodbWtcacheBytesRead: metricInfo{
 		Name: "mongodb.wtcache.bytes.read",
 	},
 }
 
 type metricsInfo struct {
-	MongodbActiveReads            metricInfo
-	MongodbActiveWrites           metricInfo
-	MongodbCacheOperations        metricInfo
-	MongodbCollectionCount        metricInfo
-	MongodbCommandsRate           metricInfo
-	MongodbConnectionCount        metricInfo
-	MongodbCursorCount            metricInfo
-	MongodbCursorTimeoutCount     metricInfo
-	MongodbDataSize               metricInfo
-	MongodbDatabaseCount          metricInfo
-	MongodbDeletesRate            metricInfo
-	MongodbDocumentOperationCount metricInfo
-	MongodbExtentCount            metricInfo
-	MongodbFlushesRate            metricInfo
-	MongodbGetmoresRate           metricInfo
-	MongodbGlobalLockTime         metricInfo
-	MongodbHealth                 metricInfo
-	MongodbIndexAccessCount       metricInfo
-	MongodbIndexCount             metricInfo
-	MongodbIndexSize              metricInfo
-	MongodbInsertsRate            metricInfo
-	MongodbLockAcquireCount       metricInfo
-	MongodbLockAcquireTime        metricInfo
-	MongodbLockAcquireWaitCount   metricInfo
-	MongodbLockDeadlockCount      metricInfo
-	MongodbMemoryUsage            metricInfo
-	MongodbNetworkIoReceive       metricInfo
-	MongodbNetworkIoTransmit      metricInfo
-	MongodbNetworkRequestCount    metricInfo
-	MongodbObjectCount            metricInfo
-	MongodbOperationCount         metricInfo
-	MongodbOperationLatencyTime   metricInfo
-	MongodbOperationReplCount     metricInfo
-	MongodbOperationTime          metricInfo
-	MongodbPageFaults             metricInfo
-	MongodbQueriesRate            metricInfo
-	MongodbReplCommandsPerSec     metricInfo
-	MongodbReplDeletesPerSec      metricInfo
-	MongodbReplGetmoresPerSec     metricInfo
-	MongodbReplInsertsPerSec      metricInfo
-	MongodbReplQueriesPerSec      metricInfo
-	MongodbReplUpdatesPerSec      metricInfo
-	MongodbSessionCount           metricInfo
-	MongodbStorageSize            metricInfo
-	MongodbUpdatesRate            metricInfo
-	MongodbUptime                 metricInfo
-	MongodbWtcacheBytesRead       metricInfo
+	MongodbActiveReads                   metricInfo
+	MongodbActiveWrites                  metricInfo
+	MongodbCacheOperations               metricInfo
+	MongodbCollectionCount               metricInfo
+	MongodbCommandsRate                  metricInfo
+	MongodbConnectionCount               metricInfo
+	MongodbCursorCount                   metricInfo
+	MongodbCursorTimeoutCount            metricInfo
+	MongodbDataSize                      metricInfo
+	MongodbDatabaseCount                 metricInfo
+	MongodbDeletesRate                   metricInfo
+	MongodbDocumentOperationCount        metricInfo
+	MongodbExtentCount                   metricInfo
+	MongodbFlushesRate                   metricInfo
+	MongodbGetmoresRate                  metricInfo
+	MongodbGlobalLockTime                metricInfo
+	MongodbHealth                        metricInfo
+	MongodbIndexAccessCount              metricInfo
+	MongodbIndexCount                    metricInfo
+	MongodbIndexSize                     metricInfo
+	MongodbInsertsRate                   metricInfo
+	MongodbLockAcquireCount              metricInfo
+	MongodbLockAcquireTime               metricInfo
+	MongodbLockAcquireWaitCount          metricInfo
+	MongodbLockDeadlockCount             metricInfo
+	MongodbMemoryUsage                   metricInfo
+	MongodbNetworkIoReceive              metricInfo
+	MongodbNetworkIoTransmit             metricInfo
+	MongodbNetworkRequestCount           metricInfo
+	MongodbObjectCount                   metricInfo
+	MongodbOperationCount                metricInfo
+	MongodbOperationLatencyTime          metricInfo
+	MongodbOperationReplCount            metricInfo
+	MongodbOperationTime                 metricInfo
+	MongodbPageFaults                    metricInfo
+	MongodbQueriesRate                   metricInfo
+	MongodbReplCommandsPerSec            metricInfo
+	MongodbReplDeletesPerSec             metricInfo
+	MongodbReplGetmoresPerSec            metricInfo
+	MongodbReplInsertsPerSec             metricInfo
+	MongodbReplQueriesPerSec             metricInfo
+	MongodbReplUpdatesPerSec             metricInfo
+	MongodbSessionCount                  metricInfo
+	MongodbStorageSize                   metricInfo
+	MongodbUpdatesRate                   metricInfo
+	MongodbUptime                        metricInfo
+	MongodbWtConcurrentTransactionsInUse metricInfo
+	MongodbWtFsyncCount                  metricInfo
+	MongodbWtLogOperationCount           metricInfo
+	MongodbWtLogSyncTime                 metricInfo
+	MongodbWtLogWrite                    metricInfo
+	MongodbWtcacheBytesRead              metricInfo
 }
 
 type metricInfo struct {
@@ -3703,6 +3781,342 @@ func newMetricMongodbUptime(cfg MongodbUptimeMetricConfig) metricMongodbUptime {
 	return m
 }
 
+type metricMongodbWtConcurrentTransactionsInUse struct {
+	data          pmetric.Metric                                   // data buffer for generated metric.
+	config        MongodbWtConcurrentTransactionsInUseMetricConfig // metric config provided by user.
+	capacity      int                                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mongodb.wt.concurrent_transactions.in_use metric with initial data.
+func (m *metricMongodbWtConcurrentTransactionsInUse) init() {
+	m.data.SetName("mongodb.wt.concurrent_transactions.in_use")
+	m.data.SetDescription("The number of in-flight WiredTiger read/write concurrent-transaction tickets.")
+	m.data.SetUnit("{transaction}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskIoDirectionAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection) {
+		dp.Attributes().PutStr("disk.io.direction", diskIoDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbWtConcurrentTransactionsInUse) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbWtConcurrentTransactionsInUse) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbWtConcurrentTransactionsInUse(cfg MongodbWtConcurrentTransactionsInUseMetricConfig) metricMongodbWtConcurrentTransactionsInUse {
+	m := metricMongodbWtConcurrentTransactionsInUse{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbWtFsyncCount struct {
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   MongodbWtFsyncCountMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.wt.fsync.count metric with initial data.
+func (m *metricMongodbWtFsyncCount) init() {
+	m.data.SetName("mongodb.wt.fsync.count")
+	m.data.SetDescription("The total number of fsync I/Os issued by the WiredTiger storage engine.")
+	m.data.SetUnit("{fsync}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbWtFsyncCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbWtFsyncCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbWtFsyncCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbWtFsyncCount(cfg MongodbWtFsyncCountMetricConfig) metricMongodbWtFsyncCount {
+	m := metricMongodbWtFsyncCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbWtLogOperationCount struct {
+	data          pmetric.Metric                         // data buffer for generated metric.
+	config        MongodbWtLogOperationCountMetricConfig // metric config provided by user.
+	capacity      int                                    // max observed number of data points added to the metric.
+	aggDataPoints []int64                                // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mongodb.wt.log.operation.count metric with initial data.
+func (m *metricMongodbWtLogOperationCount) init() {
+	m.data.SetName("mongodb.wt.log.operation.count")
+	m.data.SetDescription("The total number of WiredTiger journal operations.")
+	m.data.SetUnit("{operation}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMongodbWtLogOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mongodbWtLogOperationTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbWtLogOperationCountMetricAttributeKeyMongodbWtLogOperationType) {
+		dp.Attributes().PutStr("mongodb.wt.log.operation.type", mongodbWtLogOperationTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbWtLogOperationCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbWtLogOperationCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbWtLogOperationCount(cfg MongodbWtLogOperationCountMetricConfig) metricMongodbWtLogOperationCount {
+	m := metricMongodbWtLogOperationCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbWtLogSyncTime struct {
+	data     pmetric.Metric                   // data buffer for generated metric.
+	config   MongodbWtLogSyncTimeMetricConfig // metric config provided by user.
+	capacity int                              // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.wt.log.sync.time metric with initial data.
+func (m *metricMongodbWtLogSyncTime) init() {
+	m.data.SetName("mongodb.wt.log.sync.time")
+	m.data.SetDescription("The cumulative time spent syncing the WiredTiger journal.")
+	m.data.SetUnit("s")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbWtLogSyncTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbWtLogSyncTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbWtLogSyncTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbWtLogSyncTime(cfg MongodbWtLogSyncTimeMetricConfig) metricMongodbWtLogSyncTime {
+	m := metricMongodbWtLogSyncTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbWtLogWrite struct {
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   MongodbWtLogWriteMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.wt.log.write metric with initial data.
+func (m *metricMongodbWtLogWrite) init() {
+	m.data.SetName("mongodb.wt.log.write")
+	m.data.SetDescription("The total number of bytes written to the WiredTiger journal.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbWtLogWrite) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbWtLogWrite) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbWtLogWrite) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbWtLogWrite(cfg MongodbWtLogWriteMetricConfig) metricMongodbWtLogWrite {
+	m := metricMongodbWtLogWrite{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbWtcacheBytesRead struct {
 	data     pmetric.Metric                      // data buffer for generated metric.
 	config   MongodbWtcacheBytesReadMetricConfig // metric config provided by user.
@@ -3758,60 +4172,65 @@ func newMetricMongodbWtcacheBytesRead(cfg MongodbWtcacheBytesReadMetricConfig) m
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                              MetricsBuilderConfig // config of the metrics builder.
-	startTime                           pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                     int                  // maximum observed number of metrics per resource.
-	metricsBuffer                       pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                           component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter      map[string]filter.Filter
-	resourceAttributeExcludeFilter      map[string]filter.Filter
-	metricMongodbActiveReads            metricMongodbActiveReads
-	metricMongodbActiveWrites           metricMongodbActiveWrites
-	metricMongodbCacheOperations        metricMongodbCacheOperations
-	metricMongodbCollectionCount        metricMongodbCollectionCount
-	metricMongodbCommandsRate           metricMongodbCommandsRate
-	metricMongodbConnectionCount        metricMongodbConnectionCount
-	metricMongodbCursorCount            metricMongodbCursorCount
-	metricMongodbCursorTimeoutCount     metricMongodbCursorTimeoutCount
-	metricMongodbDataSize               metricMongodbDataSize
-	metricMongodbDatabaseCount          metricMongodbDatabaseCount
-	metricMongodbDeletesRate            metricMongodbDeletesRate
-	metricMongodbDocumentOperationCount metricMongodbDocumentOperationCount
-	metricMongodbExtentCount            metricMongodbExtentCount
-	metricMongodbFlushesRate            metricMongodbFlushesRate
-	metricMongodbGetmoresRate           metricMongodbGetmoresRate
-	metricMongodbGlobalLockTime         metricMongodbGlobalLockTime
-	metricMongodbHealth                 metricMongodbHealth
-	metricMongodbIndexAccessCount       metricMongodbIndexAccessCount
-	metricMongodbIndexCount             metricMongodbIndexCount
-	metricMongodbIndexSize              metricMongodbIndexSize
-	metricMongodbInsertsRate            metricMongodbInsertsRate
-	metricMongodbLockAcquireCount       metricMongodbLockAcquireCount
-	metricMongodbLockAcquireTime        metricMongodbLockAcquireTime
-	metricMongodbLockAcquireWaitCount   metricMongodbLockAcquireWaitCount
-	metricMongodbLockDeadlockCount      metricMongodbLockDeadlockCount
-	metricMongodbMemoryUsage            metricMongodbMemoryUsage
-	metricMongodbNetworkIoReceive       metricMongodbNetworkIoReceive
-	metricMongodbNetworkIoTransmit      metricMongodbNetworkIoTransmit
-	metricMongodbNetworkRequestCount    metricMongodbNetworkRequestCount
-	metricMongodbObjectCount            metricMongodbObjectCount
-	metricMongodbOperationCount         metricMongodbOperationCount
-	metricMongodbOperationLatencyTime   metricMongodbOperationLatencyTime
-	metricMongodbOperationReplCount     metricMongodbOperationReplCount
-	metricMongodbOperationTime          metricMongodbOperationTime
-	metricMongodbPageFaults             metricMongodbPageFaults
-	metricMongodbQueriesRate            metricMongodbQueriesRate
-	metricMongodbReplCommandsPerSec     metricMongodbReplCommandsPerSec
-	metricMongodbReplDeletesPerSec      metricMongodbReplDeletesPerSec
-	metricMongodbReplGetmoresPerSec     metricMongodbReplGetmoresPerSec
-	metricMongodbReplInsertsPerSec      metricMongodbReplInsertsPerSec
-	metricMongodbReplQueriesPerSec      metricMongodbReplQueriesPerSec
-	metricMongodbReplUpdatesPerSec      metricMongodbReplUpdatesPerSec
-	metricMongodbSessionCount           metricMongodbSessionCount
-	metricMongodbStorageSize            metricMongodbStorageSize
-	metricMongodbUpdatesRate            metricMongodbUpdatesRate
-	metricMongodbUptime                 metricMongodbUptime
-	metricMongodbWtcacheBytesRead       metricMongodbWtcacheBytesRead
+	config                                     MetricsBuilderConfig // config of the metrics builder.
+	startTime                                  pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                            int                  // maximum observed number of metrics per resource.
+	metricsBuffer                              pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                                  component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter             map[string]filter.Filter
+	resourceAttributeExcludeFilter             map[string]filter.Filter
+	metricMongodbActiveReads                   metricMongodbActiveReads
+	metricMongodbActiveWrites                  metricMongodbActiveWrites
+	metricMongodbCacheOperations               metricMongodbCacheOperations
+	metricMongodbCollectionCount               metricMongodbCollectionCount
+	metricMongodbCommandsRate                  metricMongodbCommandsRate
+	metricMongodbConnectionCount               metricMongodbConnectionCount
+	metricMongodbCursorCount                   metricMongodbCursorCount
+	metricMongodbCursorTimeoutCount            metricMongodbCursorTimeoutCount
+	metricMongodbDataSize                      metricMongodbDataSize
+	metricMongodbDatabaseCount                 metricMongodbDatabaseCount
+	metricMongodbDeletesRate                   metricMongodbDeletesRate
+	metricMongodbDocumentOperationCount        metricMongodbDocumentOperationCount
+	metricMongodbExtentCount                   metricMongodbExtentCount
+	metricMongodbFlushesRate                   metricMongodbFlushesRate
+	metricMongodbGetmoresRate                  metricMongodbGetmoresRate
+	metricMongodbGlobalLockTime                metricMongodbGlobalLockTime
+	metricMongodbHealth                        metricMongodbHealth
+	metricMongodbIndexAccessCount              metricMongodbIndexAccessCount
+	metricMongodbIndexCount                    metricMongodbIndexCount
+	metricMongodbIndexSize                     metricMongodbIndexSize
+	metricMongodbInsertsRate                   metricMongodbInsertsRate
+	metricMongodbLockAcquireCount              metricMongodbLockAcquireCount
+	metricMongodbLockAcquireTime               metricMongodbLockAcquireTime
+	metricMongodbLockAcquireWaitCount          metricMongodbLockAcquireWaitCount
+	metricMongodbLockDeadlockCount             metricMongodbLockDeadlockCount
+	metricMongodbMemoryUsage                   metricMongodbMemoryUsage
+	metricMongodbNetworkIoReceive              metricMongodbNetworkIoReceive
+	metricMongodbNetworkIoTransmit             metricMongodbNetworkIoTransmit
+	metricMongodbNetworkRequestCount           metricMongodbNetworkRequestCount
+	metricMongodbObjectCount                   metricMongodbObjectCount
+	metricMongodbOperationCount                metricMongodbOperationCount
+	metricMongodbOperationLatencyTime          metricMongodbOperationLatencyTime
+	metricMongodbOperationReplCount            metricMongodbOperationReplCount
+	metricMongodbOperationTime                 metricMongodbOperationTime
+	metricMongodbPageFaults                    metricMongodbPageFaults
+	metricMongodbQueriesRate                   metricMongodbQueriesRate
+	metricMongodbReplCommandsPerSec            metricMongodbReplCommandsPerSec
+	metricMongodbReplDeletesPerSec             metricMongodbReplDeletesPerSec
+	metricMongodbReplGetmoresPerSec            metricMongodbReplGetmoresPerSec
+	metricMongodbReplInsertsPerSec             metricMongodbReplInsertsPerSec
+	metricMongodbReplQueriesPerSec             metricMongodbReplQueriesPerSec
+	metricMongodbReplUpdatesPerSec             metricMongodbReplUpdatesPerSec
+	metricMongodbSessionCount                  metricMongodbSessionCount
+	metricMongodbStorageSize                   metricMongodbStorageSize
+	metricMongodbUpdatesRate                   metricMongodbUpdatesRate
+	metricMongodbUptime                        metricMongodbUptime
+	metricMongodbWtConcurrentTransactionsInUse metricMongodbWtConcurrentTransactionsInUse
+	metricMongodbWtFsyncCount                  metricMongodbWtFsyncCount
+	metricMongodbWtLogOperationCount           metricMongodbWtLogOperationCount
+	metricMongodbWtLogSyncTime                 metricMongodbWtLogSyncTime
+	metricMongodbWtLogWrite                    metricMongodbWtLogWrite
+	metricMongodbWtcacheBytesRead              metricMongodbWtcacheBytesRead
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -3833,59 +4252,64 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                              mbc,
-		startTime:                           pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                       pmetric.NewMetrics(),
-		buildInfo:                           settings.BuildInfo,
-		metricMongodbActiveReads:            newMetricMongodbActiveReads(mbc.Metrics.MongodbActiveReads),
-		metricMongodbActiveWrites:           newMetricMongodbActiveWrites(mbc.Metrics.MongodbActiveWrites),
-		metricMongodbCacheOperations:        newMetricMongodbCacheOperations(mbc.Metrics.MongodbCacheOperations),
-		metricMongodbCollectionCount:        newMetricMongodbCollectionCount(mbc.Metrics.MongodbCollectionCount),
-		metricMongodbCommandsRate:           newMetricMongodbCommandsRate(mbc.Metrics.MongodbCommandsRate),
-		metricMongodbConnectionCount:        newMetricMongodbConnectionCount(mbc.Metrics.MongodbConnectionCount),
-		metricMongodbCursorCount:            newMetricMongodbCursorCount(mbc.Metrics.MongodbCursorCount),
-		metricMongodbCursorTimeoutCount:     newMetricMongodbCursorTimeoutCount(mbc.Metrics.MongodbCursorTimeoutCount),
-		metricMongodbDataSize:               newMetricMongodbDataSize(mbc.Metrics.MongodbDataSize),
-		metricMongodbDatabaseCount:          newMetricMongodbDatabaseCount(mbc.Metrics.MongodbDatabaseCount),
-		metricMongodbDeletesRate:            newMetricMongodbDeletesRate(mbc.Metrics.MongodbDeletesRate),
-		metricMongodbDocumentOperationCount: newMetricMongodbDocumentOperationCount(mbc.Metrics.MongodbDocumentOperationCount),
-		metricMongodbExtentCount:            newMetricMongodbExtentCount(mbc.Metrics.MongodbExtentCount),
-		metricMongodbFlushesRate:            newMetricMongodbFlushesRate(mbc.Metrics.MongodbFlushesRate),
-		metricMongodbGetmoresRate:           newMetricMongodbGetmoresRate(mbc.Metrics.MongodbGetmoresRate),
-		metricMongodbGlobalLockTime:         newMetricMongodbGlobalLockTime(mbc.Metrics.MongodbGlobalLockTime),
-		metricMongodbHealth:                 newMetricMongodbHealth(mbc.Metrics.MongodbHealth),
-		metricMongodbIndexAccessCount:       newMetricMongodbIndexAccessCount(mbc.Metrics.MongodbIndexAccessCount),
-		metricMongodbIndexCount:             newMetricMongodbIndexCount(mbc.Metrics.MongodbIndexCount),
-		metricMongodbIndexSize:              newMetricMongodbIndexSize(mbc.Metrics.MongodbIndexSize),
-		metricMongodbInsertsRate:            newMetricMongodbInsertsRate(mbc.Metrics.MongodbInsertsRate),
-		metricMongodbLockAcquireCount:       newMetricMongodbLockAcquireCount(mbc.Metrics.MongodbLockAcquireCount),
-		metricMongodbLockAcquireTime:        newMetricMongodbLockAcquireTime(mbc.Metrics.MongodbLockAcquireTime),
-		metricMongodbLockAcquireWaitCount:   newMetricMongodbLockAcquireWaitCount(mbc.Metrics.MongodbLockAcquireWaitCount),
-		metricMongodbLockDeadlockCount:      newMetricMongodbLockDeadlockCount(mbc.Metrics.MongodbLockDeadlockCount),
-		metricMongodbMemoryUsage:            newMetricMongodbMemoryUsage(mbc.Metrics.MongodbMemoryUsage),
-		metricMongodbNetworkIoReceive:       newMetricMongodbNetworkIoReceive(mbc.Metrics.MongodbNetworkIoReceive),
-		metricMongodbNetworkIoTransmit:      newMetricMongodbNetworkIoTransmit(mbc.Metrics.MongodbNetworkIoTransmit),
-		metricMongodbNetworkRequestCount:    newMetricMongodbNetworkRequestCount(mbc.Metrics.MongodbNetworkRequestCount),
-		metricMongodbObjectCount:            newMetricMongodbObjectCount(mbc.Metrics.MongodbObjectCount),
-		metricMongodbOperationCount:         newMetricMongodbOperationCount(mbc.Metrics.MongodbOperationCount),
-		metricMongodbOperationLatencyTime:   newMetricMongodbOperationLatencyTime(mbc.Metrics.MongodbOperationLatencyTime),
-		metricMongodbOperationReplCount:     newMetricMongodbOperationReplCount(mbc.Metrics.MongodbOperationReplCount),
-		metricMongodbOperationTime:          newMetricMongodbOperationTime(mbc.Metrics.MongodbOperationTime),
-		metricMongodbPageFaults:             newMetricMongodbPageFaults(mbc.Metrics.MongodbPageFaults),
-		metricMongodbQueriesRate:            newMetricMongodbQueriesRate(mbc.Metrics.MongodbQueriesRate),
-		metricMongodbReplCommandsPerSec:     newMetricMongodbReplCommandsPerSec(mbc.Metrics.MongodbReplCommandsPerSec),
-		metricMongodbReplDeletesPerSec:      newMetricMongodbReplDeletesPerSec(mbc.Metrics.MongodbReplDeletesPerSec),
-		metricMongodbReplGetmoresPerSec:     newMetricMongodbReplGetmoresPerSec(mbc.Metrics.MongodbReplGetmoresPerSec),
-		metricMongodbReplInsertsPerSec:      newMetricMongodbReplInsertsPerSec(mbc.Metrics.MongodbReplInsertsPerSec),
-		metricMongodbReplQueriesPerSec:      newMetricMongodbReplQueriesPerSec(mbc.Metrics.MongodbReplQueriesPerSec),
-		metricMongodbReplUpdatesPerSec:      newMetricMongodbReplUpdatesPerSec(mbc.Metrics.MongodbReplUpdatesPerSec),
-		metricMongodbSessionCount:           newMetricMongodbSessionCount(mbc.Metrics.MongodbSessionCount),
-		metricMongodbStorageSize:            newMetricMongodbStorageSize(mbc.Metrics.MongodbStorageSize),
-		metricMongodbUpdatesRate:            newMetricMongodbUpdatesRate(mbc.Metrics.MongodbUpdatesRate),
-		metricMongodbUptime:                 newMetricMongodbUptime(mbc.Metrics.MongodbUptime),
-		metricMongodbWtcacheBytesRead:       newMetricMongodbWtcacheBytesRead(mbc.Metrics.MongodbWtcacheBytesRead),
-		resourceAttributeIncludeFilter:      make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:      make(map[string]filter.Filter),
+		config:                                     mbc,
+		startTime:                                  pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                              pmetric.NewMetrics(),
+		buildInfo:                                  settings.BuildInfo,
+		metricMongodbActiveReads:                   newMetricMongodbActiveReads(mbc.Metrics.MongodbActiveReads),
+		metricMongodbActiveWrites:                  newMetricMongodbActiveWrites(mbc.Metrics.MongodbActiveWrites),
+		metricMongodbCacheOperations:               newMetricMongodbCacheOperations(mbc.Metrics.MongodbCacheOperations),
+		metricMongodbCollectionCount:               newMetricMongodbCollectionCount(mbc.Metrics.MongodbCollectionCount),
+		metricMongodbCommandsRate:                  newMetricMongodbCommandsRate(mbc.Metrics.MongodbCommandsRate),
+		metricMongodbConnectionCount:               newMetricMongodbConnectionCount(mbc.Metrics.MongodbConnectionCount),
+		metricMongodbCursorCount:                   newMetricMongodbCursorCount(mbc.Metrics.MongodbCursorCount),
+		metricMongodbCursorTimeoutCount:            newMetricMongodbCursorTimeoutCount(mbc.Metrics.MongodbCursorTimeoutCount),
+		metricMongodbDataSize:                      newMetricMongodbDataSize(mbc.Metrics.MongodbDataSize),
+		metricMongodbDatabaseCount:                 newMetricMongodbDatabaseCount(mbc.Metrics.MongodbDatabaseCount),
+		metricMongodbDeletesRate:                   newMetricMongodbDeletesRate(mbc.Metrics.MongodbDeletesRate),
+		metricMongodbDocumentOperationCount:        newMetricMongodbDocumentOperationCount(mbc.Metrics.MongodbDocumentOperationCount),
+		metricMongodbExtentCount:                   newMetricMongodbExtentCount(mbc.Metrics.MongodbExtentCount),
+		metricMongodbFlushesRate:                   newMetricMongodbFlushesRate(mbc.Metrics.MongodbFlushesRate),
+		metricMongodbGetmoresRate:                  newMetricMongodbGetmoresRate(mbc.Metrics.MongodbGetmoresRate),
+		metricMongodbGlobalLockTime:                newMetricMongodbGlobalLockTime(mbc.Metrics.MongodbGlobalLockTime),
+		metricMongodbHealth:                        newMetricMongodbHealth(mbc.Metrics.MongodbHealth),
+		metricMongodbIndexAccessCount:              newMetricMongodbIndexAccessCount(mbc.Metrics.MongodbIndexAccessCount),
+		metricMongodbIndexCount:                    newMetricMongodbIndexCount(mbc.Metrics.MongodbIndexCount),
+		metricMongodbIndexSize:                     newMetricMongodbIndexSize(mbc.Metrics.MongodbIndexSize),
+		metricMongodbInsertsRate:                   newMetricMongodbInsertsRate(mbc.Metrics.MongodbInsertsRate),
+		metricMongodbLockAcquireCount:              newMetricMongodbLockAcquireCount(mbc.Metrics.MongodbLockAcquireCount),
+		metricMongodbLockAcquireTime:               newMetricMongodbLockAcquireTime(mbc.Metrics.MongodbLockAcquireTime),
+		metricMongodbLockAcquireWaitCount:          newMetricMongodbLockAcquireWaitCount(mbc.Metrics.MongodbLockAcquireWaitCount),
+		metricMongodbLockDeadlockCount:             newMetricMongodbLockDeadlockCount(mbc.Metrics.MongodbLockDeadlockCount),
+		metricMongodbMemoryUsage:                   newMetricMongodbMemoryUsage(mbc.Metrics.MongodbMemoryUsage),
+		metricMongodbNetworkIoReceive:              newMetricMongodbNetworkIoReceive(mbc.Metrics.MongodbNetworkIoReceive),
+		metricMongodbNetworkIoTransmit:             newMetricMongodbNetworkIoTransmit(mbc.Metrics.MongodbNetworkIoTransmit),
+		metricMongodbNetworkRequestCount:           newMetricMongodbNetworkRequestCount(mbc.Metrics.MongodbNetworkRequestCount),
+		metricMongodbObjectCount:                   newMetricMongodbObjectCount(mbc.Metrics.MongodbObjectCount),
+		metricMongodbOperationCount:                newMetricMongodbOperationCount(mbc.Metrics.MongodbOperationCount),
+		metricMongodbOperationLatencyTime:          newMetricMongodbOperationLatencyTime(mbc.Metrics.MongodbOperationLatencyTime),
+		metricMongodbOperationReplCount:            newMetricMongodbOperationReplCount(mbc.Metrics.MongodbOperationReplCount),
+		metricMongodbOperationTime:                 newMetricMongodbOperationTime(mbc.Metrics.MongodbOperationTime),
+		metricMongodbPageFaults:                    newMetricMongodbPageFaults(mbc.Metrics.MongodbPageFaults),
+		metricMongodbQueriesRate:                   newMetricMongodbQueriesRate(mbc.Metrics.MongodbQueriesRate),
+		metricMongodbReplCommandsPerSec:            newMetricMongodbReplCommandsPerSec(mbc.Metrics.MongodbReplCommandsPerSec),
+		metricMongodbReplDeletesPerSec:             newMetricMongodbReplDeletesPerSec(mbc.Metrics.MongodbReplDeletesPerSec),
+		metricMongodbReplGetmoresPerSec:            newMetricMongodbReplGetmoresPerSec(mbc.Metrics.MongodbReplGetmoresPerSec),
+		metricMongodbReplInsertsPerSec:             newMetricMongodbReplInsertsPerSec(mbc.Metrics.MongodbReplInsertsPerSec),
+		metricMongodbReplQueriesPerSec:             newMetricMongodbReplQueriesPerSec(mbc.Metrics.MongodbReplQueriesPerSec),
+		metricMongodbReplUpdatesPerSec:             newMetricMongodbReplUpdatesPerSec(mbc.Metrics.MongodbReplUpdatesPerSec),
+		metricMongodbSessionCount:                  newMetricMongodbSessionCount(mbc.Metrics.MongodbSessionCount),
+		metricMongodbStorageSize:                   newMetricMongodbStorageSize(mbc.Metrics.MongodbStorageSize),
+		metricMongodbUpdatesRate:                   newMetricMongodbUpdatesRate(mbc.Metrics.MongodbUpdatesRate),
+		metricMongodbUptime:                        newMetricMongodbUptime(mbc.Metrics.MongodbUptime),
+		metricMongodbWtConcurrentTransactionsInUse: newMetricMongodbWtConcurrentTransactionsInUse(mbc.Metrics.MongodbWtConcurrentTransactionsInUse),
+		metricMongodbWtFsyncCount:                  newMetricMongodbWtFsyncCount(mbc.Metrics.MongodbWtFsyncCount),
+		metricMongodbWtLogOperationCount:           newMetricMongodbWtLogOperationCount(mbc.Metrics.MongodbWtLogOperationCount),
+		metricMongodbWtLogSyncTime:                 newMetricMongodbWtLogSyncTime(mbc.Metrics.MongodbWtLogSyncTime),
+		metricMongodbWtLogWrite:                    newMetricMongodbWtLogWrite(mbc.Metrics.MongodbWtLogWrite),
+		metricMongodbWtcacheBytesRead:              newMetricMongodbWtcacheBytesRead(mbc.Metrics.MongodbWtcacheBytesRead),
+		resourceAttributeIncludeFilter:             make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:             make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.ServerAddress.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["server.address"] = filter.CreateFilter(mbc.ResourceAttributes.ServerAddress.MetricsInclude)
@@ -4032,6 +4456,11 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMongodbStorageSize.emit(ils.Metrics())
 	mb.metricMongodbUpdatesRate.emit(ils.Metrics())
 	mb.metricMongodbUptime.emit(ils.Metrics())
+	mb.metricMongodbWtConcurrentTransactionsInUse.emit(ils.Metrics())
+	mb.metricMongodbWtFsyncCount.emit(ils.Metrics())
+	mb.metricMongodbWtLogOperationCount.emit(ils.Metrics())
+	mb.metricMongodbWtLogSyncTime.emit(ils.Metrics())
+	mb.metricMongodbWtLogWrite.emit(ils.Metrics())
 	mb.metricMongodbWtcacheBytesRead.emit(ils.Metrics())
 
 	for _, op := range options {
@@ -4292,6 +4721,31 @@ func (mb *MetricsBuilder) RecordMongodbUpdatesRateDataPoint(ts pcommon.Timestamp
 // RecordMongodbUptimeDataPoint adds a data point to mongodb.uptime metric.
 func (mb *MetricsBuilder) RecordMongodbUptimeDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricMongodbUptime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbWtConcurrentTransactionsInUseDataPoint adds a data point to mongodb.wt.concurrent_transactions.in_use metric.
+func (mb *MetricsBuilder) RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts pcommon.Timestamp, val int64, diskIoDirectionAttributeValue AttributeDiskIoDirection) {
+	mb.metricMongodbWtConcurrentTransactionsInUse.recordDataPoint(mb.startTime, ts, val, diskIoDirectionAttributeValue.String())
+}
+
+// RecordMongodbWtFsyncCountDataPoint adds a data point to mongodb.wt.fsync.count metric.
+func (mb *MetricsBuilder) RecordMongodbWtFsyncCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbWtFsyncCount.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbWtLogOperationCountDataPoint adds a data point to mongodb.wt.log.operation.count metric.
+func (mb *MetricsBuilder) RecordMongodbWtLogOperationCountDataPoint(ts pcommon.Timestamp, val int64, mongodbWtLogOperationTypeAttributeValue AttributeMongodbWtLogOperationType) {
+	mb.metricMongodbWtLogOperationCount.recordDataPoint(mb.startTime, ts, val, mongodbWtLogOperationTypeAttributeValue.String())
+}
+
+// RecordMongodbWtLogSyncTimeDataPoint adds a data point to mongodb.wt.log.sync.time metric.
+func (mb *MetricsBuilder) RecordMongodbWtLogSyncTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricMongodbWtLogSyncTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbWtLogWriteDataPoint adds a data point to mongodb.wt.log.write metric.
+func (mb *MetricsBuilder) RecordMongodbWtLogWriteDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbWtLogWrite.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordMongodbWtcacheBytesReadDataPoint adds a data point to mongodb.wtcache.bytes.read metric.

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -208,30 +208,30 @@ var MapAttributeMongodbOperationState = map[string]AttributeMongodbOperationStat
 	"waiting": AttributeMongodbOperationStateWaiting,
 }
 
-// AttributeMongodbWtConcurrentTransactionType specifies the value mongodb.wt.concurrent_transaction.type attribute.
-type AttributeMongodbWtConcurrentTransactionType int
+// AttributeMongodbWtConcurrentTransactionTicketType specifies the value mongodb.wt.concurrent_transaction.ticket.type attribute.
+type AttributeMongodbWtConcurrentTransactionTicketType int
 
 const (
-	_ AttributeMongodbWtConcurrentTransactionType = iota
-	AttributeMongodbWtConcurrentTransactionTypeRead
-	AttributeMongodbWtConcurrentTransactionTypeWrite
+	_ AttributeMongodbWtConcurrentTransactionTicketType = iota
+	AttributeMongodbWtConcurrentTransactionTicketTypeRead
+	AttributeMongodbWtConcurrentTransactionTicketTypeWrite
 )
 
-// String returns the string representation of the AttributeMongodbWtConcurrentTransactionType.
-func (av AttributeMongodbWtConcurrentTransactionType) String() string {
+// String returns the string representation of the AttributeMongodbWtConcurrentTransactionTicketType.
+func (av AttributeMongodbWtConcurrentTransactionTicketType) String() string {
 	switch av {
-	case AttributeMongodbWtConcurrentTransactionTypeRead:
+	case AttributeMongodbWtConcurrentTransactionTicketTypeRead:
 		return "read"
-	case AttributeMongodbWtConcurrentTransactionTypeWrite:
+	case AttributeMongodbWtConcurrentTransactionTicketTypeWrite:
 		return "write"
 	}
 	return ""
 }
 
-// MapAttributeMongodbWtConcurrentTransactionType is a helper map of string to AttributeMongodbWtConcurrentTransactionType attribute value.
-var MapAttributeMongodbWtConcurrentTransactionType = map[string]AttributeMongodbWtConcurrentTransactionType{
-	"read":  AttributeMongodbWtConcurrentTransactionTypeRead,
-	"write": AttributeMongodbWtConcurrentTransactionTypeWrite,
+// MapAttributeMongodbWtConcurrentTransactionTicketType is a helper map of string to AttributeMongodbWtConcurrentTransactionTicketType attribute value.
+var MapAttributeMongodbWtConcurrentTransactionTicketType = map[string]AttributeMongodbWtConcurrentTransactionTicketType{
+	"read":  AttributeMongodbWtConcurrentTransactionTicketTypeRead,
+	"write": AttributeMongodbWtConcurrentTransactionTicketTypeWrite,
 }
 
 // AttributeMongodbWtLogOperationType specifies the value mongodb.wt.log.operation.type attribute.
@@ -521,9 +521,9 @@ var MetricsInfo = metricsInfo{
 	MongodbUptime: metricInfo{
 		Name: "mongodb.uptime",
 	},
-	MongodbWtConcurrentTransactionsInUse: metricInfo{
-		Name:       "mongodb.wt.concurrent_transactions.in_use",
-		Attributes: []string{"mongodb.wt.concurrent_transaction.type"},
+	MongodbWtConcurrentTransactionTicketInUse: metricInfo{
+		Name:       "mongodb.wt.concurrent_transaction.ticket.in_use",
+		Attributes: []string{"mongodb.wt.concurrent_transaction.ticket.type"},
 	},
 	MongodbWtFsyncCount: metricInfo{
 		Name: "mongodb.wt.fsync.count",
@@ -544,58 +544,58 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	MongodbActiveReads                   metricInfo
-	MongodbActiveWrites                  metricInfo
-	MongodbCacheOperations               metricInfo
-	MongodbCollectionCount               metricInfo
-	MongodbCommandsRate                  metricInfo
-	MongodbConnectionCount               metricInfo
-	MongodbCursorCount                   metricInfo
-	MongodbCursorTimeoutCount            metricInfo
-	MongodbDataSize                      metricInfo
-	MongodbDatabaseCount                 metricInfo
-	MongodbDeletesRate                   metricInfo
-	MongodbDocumentOperationCount        metricInfo
-	MongodbExtentCount                   metricInfo
-	MongodbFlushesRate                   metricInfo
-	MongodbGetmoresRate                  metricInfo
-	MongodbGlobalLockTime                metricInfo
-	MongodbHealth                        metricInfo
-	MongodbIndexAccessCount              metricInfo
-	MongodbIndexCount                    metricInfo
-	MongodbIndexSize                     metricInfo
-	MongodbInsertsRate                   metricInfo
-	MongodbLockAcquireCount              metricInfo
-	MongodbLockAcquireTime               metricInfo
-	MongodbLockAcquireWaitCount          metricInfo
-	MongodbLockDeadlockCount             metricInfo
-	MongodbMemoryUsage                   metricInfo
-	MongodbNetworkIoReceive              metricInfo
-	MongodbNetworkIoTransmit             metricInfo
-	MongodbNetworkRequestCount           metricInfo
-	MongodbObjectCount                   metricInfo
-	MongodbOperationCount                metricInfo
-	MongodbOperationLatencyTime          metricInfo
-	MongodbOperationReplCount            metricInfo
-	MongodbOperationTime                 metricInfo
-	MongodbPageFaults                    metricInfo
-	MongodbQueriesRate                   metricInfo
-	MongodbReplCommandsPerSec            metricInfo
-	MongodbReplDeletesPerSec             metricInfo
-	MongodbReplGetmoresPerSec            metricInfo
-	MongodbReplInsertsPerSec             metricInfo
-	MongodbReplQueriesPerSec             metricInfo
-	MongodbReplUpdatesPerSec             metricInfo
-	MongodbSessionCount                  metricInfo
-	MongodbStorageSize                   metricInfo
-	MongodbUpdatesRate                   metricInfo
-	MongodbUptime                        metricInfo
-	MongodbWtConcurrentTransactionsInUse metricInfo
-	MongodbWtFsyncCount                  metricInfo
-	MongodbWtLogOperationCount           metricInfo
-	MongodbWtLogSyncTime                 metricInfo
-	MongodbWtLogWrite                    metricInfo
-	MongodbWtcacheBytesRead              metricInfo
+	MongodbActiveReads                        metricInfo
+	MongodbActiveWrites                       metricInfo
+	MongodbCacheOperations                    metricInfo
+	MongodbCollectionCount                    metricInfo
+	MongodbCommandsRate                       metricInfo
+	MongodbConnectionCount                    metricInfo
+	MongodbCursorCount                        metricInfo
+	MongodbCursorTimeoutCount                 metricInfo
+	MongodbDataSize                           metricInfo
+	MongodbDatabaseCount                      metricInfo
+	MongodbDeletesRate                        metricInfo
+	MongodbDocumentOperationCount             metricInfo
+	MongodbExtentCount                        metricInfo
+	MongodbFlushesRate                        metricInfo
+	MongodbGetmoresRate                       metricInfo
+	MongodbGlobalLockTime                     metricInfo
+	MongodbHealth                             metricInfo
+	MongodbIndexAccessCount                   metricInfo
+	MongodbIndexCount                         metricInfo
+	MongodbIndexSize                          metricInfo
+	MongodbInsertsRate                        metricInfo
+	MongodbLockAcquireCount                   metricInfo
+	MongodbLockAcquireTime                    metricInfo
+	MongodbLockAcquireWaitCount               metricInfo
+	MongodbLockDeadlockCount                  metricInfo
+	MongodbMemoryUsage                        metricInfo
+	MongodbNetworkIoReceive                   metricInfo
+	MongodbNetworkIoTransmit                  metricInfo
+	MongodbNetworkRequestCount                metricInfo
+	MongodbObjectCount                        metricInfo
+	MongodbOperationCount                     metricInfo
+	MongodbOperationLatencyTime               metricInfo
+	MongodbOperationReplCount                 metricInfo
+	MongodbOperationTime                      metricInfo
+	MongodbPageFaults                         metricInfo
+	MongodbQueriesRate                        metricInfo
+	MongodbReplCommandsPerSec                 metricInfo
+	MongodbReplDeletesPerSec                  metricInfo
+	MongodbReplGetmoresPerSec                 metricInfo
+	MongodbReplInsertsPerSec                  metricInfo
+	MongodbReplQueriesPerSec                  metricInfo
+	MongodbReplUpdatesPerSec                  metricInfo
+	MongodbSessionCount                       metricInfo
+	MongodbStorageSize                        metricInfo
+	MongodbUpdatesRate                        metricInfo
+	MongodbUptime                             metricInfo
+	MongodbWtConcurrentTransactionTicketInUse metricInfo
+	MongodbWtFsyncCount                       metricInfo
+	MongodbWtLogOperationCount                metricInfo
+	MongodbWtLogSyncTime                      metricInfo
+	MongodbWtLogWrite                         metricInfo
+	MongodbWtcacheBytesRead                   metricInfo
 }
 
 type metricInfo struct {
@@ -3781,18 +3781,18 @@ func newMetricMongodbUptime(cfg MongodbUptimeMetricConfig) metricMongodbUptime {
 	return m
 }
 
-type metricMongodbWtConcurrentTransactionsInUse struct {
-	data          pmetric.Metric                                   // data buffer for generated metric.
-	config        MongodbWtConcurrentTransactionsInUseMetricConfig // metric config provided by user.
-	capacity      int                                              // max observed number of data points added to the metric.
-	aggDataPoints []int64                                          // slice containing number of aggregated datapoints at each index
+type metricMongodbWtConcurrentTransactionTicketInUse struct {
+	data          pmetric.Metric                                        // data buffer for generated metric.
+	config        MongodbWtConcurrentTransactionTicketInUseMetricConfig // metric config provided by user.
+	capacity      int                                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                                               // slice containing number of aggregated datapoints at each index
 }
 
-// init fills mongodb.wt.concurrent_transactions.in_use metric with initial data.
-func (m *metricMongodbWtConcurrentTransactionsInUse) init() {
-	m.data.SetName("mongodb.wt.concurrent_transactions.in_use")
+// init fills mongodb.wt.concurrent_transaction.ticket.in_use metric with initial data.
+func (m *metricMongodbWtConcurrentTransactionTicketInUse) init() {
+	m.data.SetName("mongodb.wt.concurrent_transaction.ticket.in_use")
 	m.data.SetDescription("The number of in-flight WiredTiger read/write concurrent-transaction tickets.")
-	m.data.SetUnit("{transaction}")
+	m.data.SetUnit("{ticket}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -3800,7 +3800,7 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mongodbWtConcurrentTransactionTypeAttributeValue string) {
+func (m *metricMongodbWtConcurrentTransactionTicketInUse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mongodbWtConcurrentTransactionTicketTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -3808,8 +3808,8 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcomm
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType) {
-		dp.Attributes().PutStr("mongodb.wt.concurrent_transaction.type", mongodbWtConcurrentTransactionTypeAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, MongodbWtConcurrentTransactionTicketInUseMetricAttributeKeyMongodbWtConcurrentTransactionTicketType) {
+		dp.Attributes().PutStr("mongodb.wt.concurrent_transaction.ticket.type", mongodbWtConcurrentTransactionTicketTypeAttributeValue)
 	}
 
 	var s string
@@ -3842,14 +3842,14 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcomm
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMongodbWtConcurrentTransactionsInUse) updateCapacity() {
+func (m *metricMongodbWtConcurrentTransactionTicketInUse) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMongodbWtConcurrentTransactionsInUse) emit(metrics pmetric.MetricSlice) {
+func (m *metricMongodbWtConcurrentTransactionTicketInUse) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
@@ -3862,8 +3862,8 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) emit(metrics pmetric.Metric
 	}
 }
 
-func newMetricMongodbWtConcurrentTransactionsInUse(cfg MongodbWtConcurrentTransactionsInUseMetricConfig) metricMongodbWtConcurrentTransactionsInUse {
-	m := metricMongodbWtConcurrentTransactionsInUse{config: cfg}
+func newMetricMongodbWtConcurrentTransactionTicketInUse(cfg MongodbWtConcurrentTransactionTicketInUseMetricConfig) metricMongodbWtConcurrentTransactionTicketInUse {
+	m := metricMongodbWtConcurrentTransactionTicketInUse{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4174,65 +4174,65 @@ func newMetricMongodbWtcacheBytesRead(cfg MongodbWtcacheBytesReadMetricConfig) m
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                                     MetricsBuilderConfig // config of the metrics builder.
-	startTime                                  pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                            int                  // maximum observed number of metrics per resource.
-	metricsBuffer                              pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                                  component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter             map[string]filter.Filter
-	resourceAttributeExcludeFilter             map[string]filter.Filter
-	metricMongodbActiveReads                   metricMongodbActiveReads
-	metricMongodbActiveWrites                  metricMongodbActiveWrites
-	metricMongodbCacheOperations               metricMongodbCacheOperations
-	metricMongodbCollectionCount               metricMongodbCollectionCount
-	metricMongodbCommandsRate                  metricMongodbCommandsRate
-	metricMongodbConnectionCount               metricMongodbConnectionCount
-	metricMongodbCursorCount                   metricMongodbCursorCount
-	metricMongodbCursorTimeoutCount            metricMongodbCursorTimeoutCount
-	metricMongodbDataSize                      metricMongodbDataSize
-	metricMongodbDatabaseCount                 metricMongodbDatabaseCount
-	metricMongodbDeletesRate                   metricMongodbDeletesRate
-	metricMongodbDocumentOperationCount        metricMongodbDocumentOperationCount
-	metricMongodbExtentCount                   metricMongodbExtentCount
-	metricMongodbFlushesRate                   metricMongodbFlushesRate
-	metricMongodbGetmoresRate                  metricMongodbGetmoresRate
-	metricMongodbGlobalLockTime                metricMongodbGlobalLockTime
-	metricMongodbHealth                        metricMongodbHealth
-	metricMongodbIndexAccessCount              metricMongodbIndexAccessCount
-	metricMongodbIndexCount                    metricMongodbIndexCount
-	metricMongodbIndexSize                     metricMongodbIndexSize
-	metricMongodbInsertsRate                   metricMongodbInsertsRate
-	metricMongodbLockAcquireCount              metricMongodbLockAcquireCount
-	metricMongodbLockAcquireTime               metricMongodbLockAcquireTime
-	metricMongodbLockAcquireWaitCount          metricMongodbLockAcquireWaitCount
-	metricMongodbLockDeadlockCount             metricMongodbLockDeadlockCount
-	metricMongodbMemoryUsage                   metricMongodbMemoryUsage
-	metricMongodbNetworkIoReceive              metricMongodbNetworkIoReceive
-	metricMongodbNetworkIoTransmit             metricMongodbNetworkIoTransmit
-	metricMongodbNetworkRequestCount           metricMongodbNetworkRequestCount
-	metricMongodbObjectCount                   metricMongodbObjectCount
-	metricMongodbOperationCount                metricMongodbOperationCount
-	metricMongodbOperationLatencyTime          metricMongodbOperationLatencyTime
-	metricMongodbOperationReplCount            metricMongodbOperationReplCount
-	metricMongodbOperationTime                 metricMongodbOperationTime
-	metricMongodbPageFaults                    metricMongodbPageFaults
-	metricMongodbQueriesRate                   metricMongodbQueriesRate
-	metricMongodbReplCommandsPerSec            metricMongodbReplCommandsPerSec
-	metricMongodbReplDeletesPerSec             metricMongodbReplDeletesPerSec
-	metricMongodbReplGetmoresPerSec            metricMongodbReplGetmoresPerSec
-	metricMongodbReplInsertsPerSec             metricMongodbReplInsertsPerSec
-	metricMongodbReplQueriesPerSec             metricMongodbReplQueriesPerSec
-	metricMongodbReplUpdatesPerSec             metricMongodbReplUpdatesPerSec
-	metricMongodbSessionCount                  metricMongodbSessionCount
-	metricMongodbStorageSize                   metricMongodbStorageSize
-	metricMongodbUpdatesRate                   metricMongodbUpdatesRate
-	metricMongodbUptime                        metricMongodbUptime
-	metricMongodbWtConcurrentTransactionsInUse metricMongodbWtConcurrentTransactionsInUse
-	metricMongodbWtFsyncCount                  metricMongodbWtFsyncCount
-	metricMongodbWtLogOperationCount           metricMongodbWtLogOperationCount
-	metricMongodbWtLogSyncTime                 metricMongodbWtLogSyncTime
-	metricMongodbWtLogWrite                    metricMongodbWtLogWrite
-	metricMongodbWtcacheBytesRead              metricMongodbWtcacheBytesRead
+	config                                          MetricsBuilderConfig // config of the metrics builder.
+	startTime                                       pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                                 int                  // maximum observed number of metrics per resource.
+	metricsBuffer                                   pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                                       component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter                  map[string]filter.Filter
+	resourceAttributeExcludeFilter                  map[string]filter.Filter
+	metricMongodbActiveReads                        metricMongodbActiveReads
+	metricMongodbActiveWrites                       metricMongodbActiveWrites
+	metricMongodbCacheOperations                    metricMongodbCacheOperations
+	metricMongodbCollectionCount                    metricMongodbCollectionCount
+	metricMongodbCommandsRate                       metricMongodbCommandsRate
+	metricMongodbConnectionCount                    metricMongodbConnectionCount
+	metricMongodbCursorCount                        metricMongodbCursorCount
+	metricMongodbCursorTimeoutCount                 metricMongodbCursorTimeoutCount
+	metricMongodbDataSize                           metricMongodbDataSize
+	metricMongodbDatabaseCount                      metricMongodbDatabaseCount
+	metricMongodbDeletesRate                        metricMongodbDeletesRate
+	metricMongodbDocumentOperationCount             metricMongodbDocumentOperationCount
+	metricMongodbExtentCount                        metricMongodbExtentCount
+	metricMongodbFlushesRate                        metricMongodbFlushesRate
+	metricMongodbGetmoresRate                       metricMongodbGetmoresRate
+	metricMongodbGlobalLockTime                     metricMongodbGlobalLockTime
+	metricMongodbHealth                             metricMongodbHealth
+	metricMongodbIndexAccessCount                   metricMongodbIndexAccessCount
+	metricMongodbIndexCount                         metricMongodbIndexCount
+	metricMongodbIndexSize                          metricMongodbIndexSize
+	metricMongodbInsertsRate                        metricMongodbInsertsRate
+	metricMongodbLockAcquireCount                   metricMongodbLockAcquireCount
+	metricMongodbLockAcquireTime                    metricMongodbLockAcquireTime
+	metricMongodbLockAcquireWaitCount               metricMongodbLockAcquireWaitCount
+	metricMongodbLockDeadlockCount                  metricMongodbLockDeadlockCount
+	metricMongodbMemoryUsage                        metricMongodbMemoryUsage
+	metricMongodbNetworkIoReceive                   metricMongodbNetworkIoReceive
+	metricMongodbNetworkIoTransmit                  metricMongodbNetworkIoTransmit
+	metricMongodbNetworkRequestCount                metricMongodbNetworkRequestCount
+	metricMongodbObjectCount                        metricMongodbObjectCount
+	metricMongodbOperationCount                     metricMongodbOperationCount
+	metricMongodbOperationLatencyTime               metricMongodbOperationLatencyTime
+	metricMongodbOperationReplCount                 metricMongodbOperationReplCount
+	metricMongodbOperationTime                      metricMongodbOperationTime
+	metricMongodbPageFaults                         metricMongodbPageFaults
+	metricMongodbQueriesRate                        metricMongodbQueriesRate
+	metricMongodbReplCommandsPerSec                 metricMongodbReplCommandsPerSec
+	metricMongodbReplDeletesPerSec                  metricMongodbReplDeletesPerSec
+	metricMongodbReplGetmoresPerSec                 metricMongodbReplGetmoresPerSec
+	metricMongodbReplInsertsPerSec                  metricMongodbReplInsertsPerSec
+	metricMongodbReplQueriesPerSec                  metricMongodbReplQueriesPerSec
+	metricMongodbReplUpdatesPerSec                  metricMongodbReplUpdatesPerSec
+	metricMongodbSessionCount                       metricMongodbSessionCount
+	metricMongodbStorageSize                        metricMongodbStorageSize
+	metricMongodbUpdatesRate                        metricMongodbUpdatesRate
+	metricMongodbUptime                             metricMongodbUptime
+	metricMongodbWtConcurrentTransactionTicketInUse metricMongodbWtConcurrentTransactionTicketInUse
+	metricMongodbWtFsyncCount                       metricMongodbWtFsyncCount
+	metricMongodbWtLogOperationCount                metricMongodbWtLogOperationCount
+	metricMongodbWtLogSyncTime                      metricMongodbWtLogSyncTime
+	metricMongodbWtLogWrite                         metricMongodbWtLogWrite
+	metricMongodbWtcacheBytesRead                   metricMongodbWtcacheBytesRead
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -4254,64 +4254,64 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                                     mbc,
-		startTime:                                  pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                              pmetric.NewMetrics(),
-		buildInfo:                                  settings.BuildInfo,
-		metricMongodbActiveReads:                   newMetricMongodbActiveReads(mbc.Metrics.MongodbActiveReads),
-		metricMongodbActiveWrites:                  newMetricMongodbActiveWrites(mbc.Metrics.MongodbActiveWrites),
-		metricMongodbCacheOperations:               newMetricMongodbCacheOperations(mbc.Metrics.MongodbCacheOperations),
-		metricMongodbCollectionCount:               newMetricMongodbCollectionCount(mbc.Metrics.MongodbCollectionCount),
-		metricMongodbCommandsRate:                  newMetricMongodbCommandsRate(mbc.Metrics.MongodbCommandsRate),
-		metricMongodbConnectionCount:               newMetricMongodbConnectionCount(mbc.Metrics.MongodbConnectionCount),
-		metricMongodbCursorCount:                   newMetricMongodbCursorCount(mbc.Metrics.MongodbCursorCount),
-		metricMongodbCursorTimeoutCount:            newMetricMongodbCursorTimeoutCount(mbc.Metrics.MongodbCursorTimeoutCount),
-		metricMongodbDataSize:                      newMetricMongodbDataSize(mbc.Metrics.MongodbDataSize),
-		metricMongodbDatabaseCount:                 newMetricMongodbDatabaseCount(mbc.Metrics.MongodbDatabaseCount),
-		metricMongodbDeletesRate:                   newMetricMongodbDeletesRate(mbc.Metrics.MongodbDeletesRate),
-		metricMongodbDocumentOperationCount:        newMetricMongodbDocumentOperationCount(mbc.Metrics.MongodbDocumentOperationCount),
-		metricMongodbExtentCount:                   newMetricMongodbExtentCount(mbc.Metrics.MongodbExtentCount),
-		metricMongodbFlushesRate:                   newMetricMongodbFlushesRate(mbc.Metrics.MongodbFlushesRate),
-		metricMongodbGetmoresRate:                  newMetricMongodbGetmoresRate(mbc.Metrics.MongodbGetmoresRate),
-		metricMongodbGlobalLockTime:                newMetricMongodbGlobalLockTime(mbc.Metrics.MongodbGlobalLockTime),
-		metricMongodbHealth:                        newMetricMongodbHealth(mbc.Metrics.MongodbHealth),
-		metricMongodbIndexAccessCount:              newMetricMongodbIndexAccessCount(mbc.Metrics.MongodbIndexAccessCount),
-		metricMongodbIndexCount:                    newMetricMongodbIndexCount(mbc.Metrics.MongodbIndexCount),
-		metricMongodbIndexSize:                     newMetricMongodbIndexSize(mbc.Metrics.MongodbIndexSize),
-		metricMongodbInsertsRate:                   newMetricMongodbInsertsRate(mbc.Metrics.MongodbInsertsRate),
-		metricMongodbLockAcquireCount:              newMetricMongodbLockAcquireCount(mbc.Metrics.MongodbLockAcquireCount),
-		metricMongodbLockAcquireTime:               newMetricMongodbLockAcquireTime(mbc.Metrics.MongodbLockAcquireTime),
-		metricMongodbLockAcquireWaitCount:          newMetricMongodbLockAcquireWaitCount(mbc.Metrics.MongodbLockAcquireWaitCount),
-		metricMongodbLockDeadlockCount:             newMetricMongodbLockDeadlockCount(mbc.Metrics.MongodbLockDeadlockCount),
-		metricMongodbMemoryUsage:                   newMetricMongodbMemoryUsage(mbc.Metrics.MongodbMemoryUsage),
-		metricMongodbNetworkIoReceive:              newMetricMongodbNetworkIoReceive(mbc.Metrics.MongodbNetworkIoReceive),
-		metricMongodbNetworkIoTransmit:             newMetricMongodbNetworkIoTransmit(mbc.Metrics.MongodbNetworkIoTransmit),
-		metricMongodbNetworkRequestCount:           newMetricMongodbNetworkRequestCount(mbc.Metrics.MongodbNetworkRequestCount),
-		metricMongodbObjectCount:                   newMetricMongodbObjectCount(mbc.Metrics.MongodbObjectCount),
-		metricMongodbOperationCount:                newMetricMongodbOperationCount(mbc.Metrics.MongodbOperationCount),
-		metricMongodbOperationLatencyTime:          newMetricMongodbOperationLatencyTime(mbc.Metrics.MongodbOperationLatencyTime),
-		metricMongodbOperationReplCount:            newMetricMongodbOperationReplCount(mbc.Metrics.MongodbOperationReplCount),
-		metricMongodbOperationTime:                 newMetricMongodbOperationTime(mbc.Metrics.MongodbOperationTime),
-		metricMongodbPageFaults:                    newMetricMongodbPageFaults(mbc.Metrics.MongodbPageFaults),
-		metricMongodbQueriesRate:                   newMetricMongodbQueriesRate(mbc.Metrics.MongodbQueriesRate),
-		metricMongodbReplCommandsPerSec:            newMetricMongodbReplCommandsPerSec(mbc.Metrics.MongodbReplCommandsPerSec),
-		metricMongodbReplDeletesPerSec:             newMetricMongodbReplDeletesPerSec(mbc.Metrics.MongodbReplDeletesPerSec),
-		metricMongodbReplGetmoresPerSec:            newMetricMongodbReplGetmoresPerSec(mbc.Metrics.MongodbReplGetmoresPerSec),
-		metricMongodbReplInsertsPerSec:             newMetricMongodbReplInsertsPerSec(mbc.Metrics.MongodbReplInsertsPerSec),
-		metricMongodbReplQueriesPerSec:             newMetricMongodbReplQueriesPerSec(mbc.Metrics.MongodbReplQueriesPerSec),
-		metricMongodbReplUpdatesPerSec:             newMetricMongodbReplUpdatesPerSec(mbc.Metrics.MongodbReplUpdatesPerSec),
-		metricMongodbSessionCount:                  newMetricMongodbSessionCount(mbc.Metrics.MongodbSessionCount),
-		metricMongodbStorageSize:                   newMetricMongodbStorageSize(mbc.Metrics.MongodbStorageSize),
-		metricMongodbUpdatesRate:                   newMetricMongodbUpdatesRate(mbc.Metrics.MongodbUpdatesRate),
-		metricMongodbUptime:                        newMetricMongodbUptime(mbc.Metrics.MongodbUptime),
-		metricMongodbWtConcurrentTransactionsInUse: newMetricMongodbWtConcurrentTransactionsInUse(mbc.Metrics.MongodbWtConcurrentTransactionsInUse),
-		metricMongodbWtFsyncCount:                  newMetricMongodbWtFsyncCount(mbc.Metrics.MongodbWtFsyncCount),
-		metricMongodbWtLogOperationCount:           newMetricMongodbWtLogOperationCount(mbc.Metrics.MongodbWtLogOperationCount),
-		metricMongodbWtLogSyncTime:                 newMetricMongodbWtLogSyncTime(mbc.Metrics.MongodbWtLogSyncTime),
-		metricMongodbWtLogWrite:                    newMetricMongodbWtLogWrite(mbc.Metrics.MongodbWtLogWrite),
-		metricMongodbWtcacheBytesRead:              newMetricMongodbWtcacheBytesRead(mbc.Metrics.MongodbWtcacheBytesRead),
-		resourceAttributeIncludeFilter:             make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:             make(map[string]filter.Filter),
+		config:                                          mbc,
+		startTime:                                       pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                                   pmetric.NewMetrics(),
+		buildInfo:                                       settings.BuildInfo,
+		metricMongodbActiveReads:                        newMetricMongodbActiveReads(mbc.Metrics.MongodbActiveReads),
+		metricMongodbActiveWrites:                       newMetricMongodbActiveWrites(mbc.Metrics.MongodbActiveWrites),
+		metricMongodbCacheOperations:                    newMetricMongodbCacheOperations(mbc.Metrics.MongodbCacheOperations),
+		metricMongodbCollectionCount:                    newMetricMongodbCollectionCount(mbc.Metrics.MongodbCollectionCount),
+		metricMongodbCommandsRate:                       newMetricMongodbCommandsRate(mbc.Metrics.MongodbCommandsRate),
+		metricMongodbConnectionCount:                    newMetricMongodbConnectionCount(mbc.Metrics.MongodbConnectionCount),
+		metricMongodbCursorCount:                        newMetricMongodbCursorCount(mbc.Metrics.MongodbCursorCount),
+		metricMongodbCursorTimeoutCount:                 newMetricMongodbCursorTimeoutCount(mbc.Metrics.MongodbCursorTimeoutCount),
+		metricMongodbDataSize:                           newMetricMongodbDataSize(mbc.Metrics.MongodbDataSize),
+		metricMongodbDatabaseCount:                      newMetricMongodbDatabaseCount(mbc.Metrics.MongodbDatabaseCount),
+		metricMongodbDeletesRate:                        newMetricMongodbDeletesRate(mbc.Metrics.MongodbDeletesRate),
+		metricMongodbDocumentOperationCount:             newMetricMongodbDocumentOperationCount(mbc.Metrics.MongodbDocumentOperationCount),
+		metricMongodbExtentCount:                        newMetricMongodbExtentCount(mbc.Metrics.MongodbExtentCount),
+		metricMongodbFlushesRate:                        newMetricMongodbFlushesRate(mbc.Metrics.MongodbFlushesRate),
+		metricMongodbGetmoresRate:                       newMetricMongodbGetmoresRate(mbc.Metrics.MongodbGetmoresRate),
+		metricMongodbGlobalLockTime:                     newMetricMongodbGlobalLockTime(mbc.Metrics.MongodbGlobalLockTime),
+		metricMongodbHealth:                             newMetricMongodbHealth(mbc.Metrics.MongodbHealth),
+		metricMongodbIndexAccessCount:                   newMetricMongodbIndexAccessCount(mbc.Metrics.MongodbIndexAccessCount),
+		metricMongodbIndexCount:                         newMetricMongodbIndexCount(mbc.Metrics.MongodbIndexCount),
+		metricMongodbIndexSize:                          newMetricMongodbIndexSize(mbc.Metrics.MongodbIndexSize),
+		metricMongodbInsertsRate:                        newMetricMongodbInsertsRate(mbc.Metrics.MongodbInsertsRate),
+		metricMongodbLockAcquireCount:                   newMetricMongodbLockAcquireCount(mbc.Metrics.MongodbLockAcquireCount),
+		metricMongodbLockAcquireTime:                    newMetricMongodbLockAcquireTime(mbc.Metrics.MongodbLockAcquireTime),
+		metricMongodbLockAcquireWaitCount:               newMetricMongodbLockAcquireWaitCount(mbc.Metrics.MongodbLockAcquireWaitCount),
+		metricMongodbLockDeadlockCount:                  newMetricMongodbLockDeadlockCount(mbc.Metrics.MongodbLockDeadlockCount),
+		metricMongodbMemoryUsage:                        newMetricMongodbMemoryUsage(mbc.Metrics.MongodbMemoryUsage),
+		metricMongodbNetworkIoReceive:                   newMetricMongodbNetworkIoReceive(mbc.Metrics.MongodbNetworkIoReceive),
+		metricMongodbNetworkIoTransmit:                  newMetricMongodbNetworkIoTransmit(mbc.Metrics.MongodbNetworkIoTransmit),
+		metricMongodbNetworkRequestCount:                newMetricMongodbNetworkRequestCount(mbc.Metrics.MongodbNetworkRequestCount),
+		metricMongodbObjectCount:                        newMetricMongodbObjectCount(mbc.Metrics.MongodbObjectCount),
+		metricMongodbOperationCount:                     newMetricMongodbOperationCount(mbc.Metrics.MongodbOperationCount),
+		metricMongodbOperationLatencyTime:               newMetricMongodbOperationLatencyTime(mbc.Metrics.MongodbOperationLatencyTime),
+		metricMongodbOperationReplCount:                 newMetricMongodbOperationReplCount(mbc.Metrics.MongodbOperationReplCount),
+		metricMongodbOperationTime:                      newMetricMongodbOperationTime(mbc.Metrics.MongodbOperationTime),
+		metricMongodbPageFaults:                         newMetricMongodbPageFaults(mbc.Metrics.MongodbPageFaults),
+		metricMongodbQueriesRate:                        newMetricMongodbQueriesRate(mbc.Metrics.MongodbQueriesRate),
+		metricMongodbReplCommandsPerSec:                 newMetricMongodbReplCommandsPerSec(mbc.Metrics.MongodbReplCommandsPerSec),
+		metricMongodbReplDeletesPerSec:                  newMetricMongodbReplDeletesPerSec(mbc.Metrics.MongodbReplDeletesPerSec),
+		metricMongodbReplGetmoresPerSec:                 newMetricMongodbReplGetmoresPerSec(mbc.Metrics.MongodbReplGetmoresPerSec),
+		metricMongodbReplInsertsPerSec:                  newMetricMongodbReplInsertsPerSec(mbc.Metrics.MongodbReplInsertsPerSec),
+		metricMongodbReplQueriesPerSec:                  newMetricMongodbReplQueriesPerSec(mbc.Metrics.MongodbReplQueriesPerSec),
+		metricMongodbReplUpdatesPerSec:                  newMetricMongodbReplUpdatesPerSec(mbc.Metrics.MongodbReplUpdatesPerSec),
+		metricMongodbSessionCount:                       newMetricMongodbSessionCount(mbc.Metrics.MongodbSessionCount),
+		metricMongodbStorageSize:                        newMetricMongodbStorageSize(mbc.Metrics.MongodbStorageSize),
+		metricMongodbUpdatesRate:                        newMetricMongodbUpdatesRate(mbc.Metrics.MongodbUpdatesRate),
+		metricMongodbUptime:                             newMetricMongodbUptime(mbc.Metrics.MongodbUptime),
+		metricMongodbWtConcurrentTransactionTicketInUse: newMetricMongodbWtConcurrentTransactionTicketInUse(mbc.Metrics.MongodbWtConcurrentTransactionTicketInUse),
+		metricMongodbWtFsyncCount:                       newMetricMongodbWtFsyncCount(mbc.Metrics.MongodbWtFsyncCount),
+		metricMongodbWtLogOperationCount:                newMetricMongodbWtLogOperationCount(mbc.Metrics.MongodbWtLogOperationCount),
+		metricMongodbWtLogSyncTime:                      newMetricMongodbWtLogSyncTime(mbc.Metrics.MongodbWtLogSyncTime),
+		metricMongodbWtLogWrite:                         newMetricMongodbWtLogWrite(mbc.Metrics.MongodbWtLogWrite),
+		metricMongodbWtcacheBytesRead:                   newMetricMongodbWtcacheBytesRead(mbc.Metrics.MongodbWtcacheBytesRead),
+		resourceAttributeIncludeFilter:                  make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:                  make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.ServerAddress.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["server.address"] = filter.CreateFilter(mbc.ResourceAttributes.ServerAddress.MetricsInclude)
@@ -4458,7 +4458,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMongodbStorageSize.emit(ils.Metrics())
 	mb.metricMongodbUpdatesRate.emit(ils.Metrics())
 	mb.metricMongodbUptime.emit(ils.Metrics())
-	mb.metricMongodbWtConcurrentTransactionsInUse.emit(ils.Metrics())
+	mb.metricMongodbWtConcurrentTransactionTicketInUse.emit(ils.Metrics())
 	mb.metricMongodbWtFsyncCount.emit(ils.Metrics())
 	mb.metricMongodbWtLogOperationCount.emit(ils.Metrics())
 	mb.metricMongodbWtLogSyncTime.emit(ils.Metrics())
@@ -4725,9 +4725,9 @@ func (mb *MetricsBuilder) RecordMongodbUptimeDataPoint(ts pcommon.Timestamp, val
 	mb.metricMongodbUptime.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordMongodbWtConcurrentTransactionsInUseDataPoint adds a data point to mongodb.wt.concurrent_transactions.in_use metric.
-func (mb *MetricsBuilder) RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts pcommon.Timestamp, val int64, mongodbWtConcurrentTransactionTypeAttributeValue AttributeMongodbWtConcurrentTransactionType) {
-	mb.metricMongodbWtConcurrentTransactionsInUse.recordDataPoint(mb.startTime, ts, val, mongodbWtConcurrentTransactionTypeAttributeValue.String())
+// RecordMongodbWtConcurrentTransactionTicketInUseDataPoint adds a data point to mongodb.wt.concurrent_transaction.ticket.in_use metric.
+func (mb *MetricsBuilder) RecordMongodbWtConcurrentTransactionTicketInUseDataPoint(ts pcommon.Timestamp, val int64, mongodbWtConcurrentTransactionTicketTypeAttributeValue AttributeMongodbWtConcurrentTransactionTicketType) {
+	mb.metricMongodbWtConcurrentTransactionTicketInUse.recordDataPoint(mb.startTime, ts, val, mongodbWtConcurrentTransactionTicketTypeAttributeValue.String())
 }
 
 // RecordMongodbWtFsyncCountDataPoint adds a data point to mongodb.wt.fsync.count metric.

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -3793,8 +3793,10 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) init() {
 	m.data.SetName("mongodb.wt.concurrent_transactions.in_use")
 	m.data.SetDescription("The number of in-flight WiredTiger read/write concurrent-transaction tickets.")
 	m.data.SetUnit("{transaction}")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
@@ -3811,7 +3813,7 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcomm
 	}
 
 	var s string
-	dps := m.data.Gauge().DataPoints()
+	dps := m.data.Sum().DataPoints()
 	for i := 0; i < dps.Len(); i++ {
 		dpi := dps.At(i)
 		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
@@ -3841,17 +3843,17 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcomm
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricMongodbWtConcurrentTransactionsInUse) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbWtConcurrentTransactionsInUse) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
-				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
 			}
 		}
 		m.updateCapacity()

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -72,32 +72,6 @@ var MapAttributeDbSystemName = map[string]AttributeDbSystemName{
 	"mongodb": AttributeDbSystemNameMongodb,
 }
 
-// AttributeDiskIoDirection specifies the value disk.io.direction attribute.
-type AttributeDiskIoDirection int
-
-const (
-	_ AttributeDiskIoDirection = iota
-	AttributeDiskIoDirectionRead
-	AttributeDiskIoDirectionWrite
-)
-
-// String returns the string representation of the AttributeDiskIoDirection.
-func (av AttributeDiskIoDirection) String() string {
-	switch av {
-	case AttributeDiskIoDirectionRead:
-		return "read"
-	case AttributeDiskIoDirectionWrite:
-		return "write"
-	}
-	return ""
-}
-
-// MapAttributeDiskIoDirection is a helper map of string to AttributeDiskIoDirection attribute value.
-var MapAttributeDiskIoDirection = map[string]AttributeDiskIoDirection{
-	"read":  AttributeDiskIoDirectionRead,
-	"write": AttributeDiskIoDirectionWrite,
-}
-
 // AttributeLockMode specifies the value lock_mode attribute.
 type AttributeLockMode int
 
@@ -232,6 +206,32 @@ func (av AttributeMongodbOperationState) String() string {
 var MapAttributeMongodbOperationState = map[string]AttributeMongodbOperationState{
 	"active":  AttributeMongodbOperationStateActive,
 	"waiting": AttributeMongodbOperationStateWaiting,
+}
+
+// AttributeMongodbWtConcurrentTransactionType specifies the value mongodb.wt.concurrent_transaction.type attribute.
+type AttributeMongodbWtConcurrentTransactionType int
+
+const (
+	_ AttributeMongodbWtConcurrentTransactionType = iota
+	AttributeMongodbWtConcurrentTransactionTypeRead
+	AttributeMongodbWtConcurrentTransactionTypeWrite
+)
+
+// String returns the string representation of the AttributeMongodbWtConcurrentTransactionType.
+func (av AttributeMongodbWtConcurrentTransactionType) String() string {
+	switch av {
+	case AttributeMongodbWtConcurrentTransactionTypeRead:
+		return "read"
+	case AttributeMongodbWtConcurrentTransactionTypeWrite:
+		return "write"
+	}
+	return ""
+}
+
+// MapAttributeMongodbWtConcurrentTransactionType is a helper map of string to AttributeMongodbWtConcurrentTransactionType attribute value.
+var MapAttributeMongodbWtConcurrentTransactionType = map[string]AttributeMongodbWtConcurrentTransactionType{
+	"read":  AttributeMongodbWtConcurrentTransactionTypeRead,
+	"write": AttributeMongodbWtConcurrentTransactionTypeWrite,
 }
 
 // AttributeMongodbWtLogOperationType specifies the value mongodb.wt.log.operation.type attribute.
@@ -523,7 +523,7 @@ var MetricsInfo = metricsInfo{
 	},
 	MongodbWtConcurrentTransactionsInUse: metricInfo{
 		Name:       "mongodb.wt.concurrent_transactions.in_use",
-		Attributes: []string{"disk.io.direction"},
+		Attributes: []string{"mongodb.wt.concurrent_transaction.type"},
 	},
 	MongodbWtFsyncCount: metricInfo{
 		Name: "mongodb.wt.fsync.count",
@@ -3798,7 +3798,7 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskIoDirectionAttributeValue string) {
+func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mongodbWtConcurrentTransactionTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -3806,8 +3806,8 @@ func (m *metricMongodbWtConcurrentTransactionsInUse) recordDataPoint(start pcomm
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, MongodbWtConcurrentTransactionsInUseMetricAttributeKeyDiskIoDirection) {
-		dp.Attributes().PutStr("disk.io.direction", diskIoDirectionAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, MongodbWtConcurrentTransactionsInUseMetricAttributeKeyMongodbWtConcurrentTransactionType) {
+		dp.Attributes().PutStr("mongodb.wt.concurrent_transaction.type", mongodbWtConcurrentTransactionTypeAttributeValue)
 	}
 
 	var s string
@@ -4724,8 +4724,8 @@ func (mb *MetricsBuilder) RecordMongodbUptimeDataPoint(ts pcommon.Timestamp, val
 }
 
 // RecordMongodbWtConcurrentTransactionsInUseDataPoint adds a data point to mongodb.wt.concurrent_transactions.in_use metric.
-func (mb *MetricsBuilder) RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts pcommon.Timestamp, val int64, diskIoDirectionAttributeValue AttributeDiskIoDirection) {
-	mb.metricMongodbWtConcurrentTransactionsInUse.recordDataPoint(mb.startTime, ts, val, diskIoDirectionAttributeValue.String())
+func (mb *MetricsBuilder) RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts pcommon.Timestamp, val int64, mongodbWtConcurrentTransactionTypeAttributeValue AttributeMongodbWtConcurrentTransactionType) {
+	mb.metricMongodbWtConcurrentTransactionsInUse.recordDataPoint(mb.startTime, ts, val, mongodbWtConcurrentTransactionTypeAttributeValue.String())
 }
 
 // RecordMongodbWtFsyncCountDataPoint adds a data point to mongodb.wt.fsync.count metric.

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -87,6 +87,8 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["mongodb.operation.repl.count"] = mb.metricMongodbOperationReplCount.config.AggregationStrategy
 			aggMap["mongodb.operation.time"] = mb.metricMongodbOperationTime.config.AggregationStrategy
 			aggMap["mongodb.storage.size"] = mb.metricMongodbStorageSize.config.AggregationStrategy
+			aggMap["mongodb.wt.concurrent_transactions.in_use"] = mb.metricMongodbWtConcurrentTransactionsInUse.config.AggregationStrategy
+			aggMap["mongodb.wt.log.operation.count"] = mb.metricMongodbWtLogOperationCount.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet != testDataSetReag {
@@ -295,6 +297,27 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordMongodbUptimeDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 1, AttributeDiskIoDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 3, AttributeDiskIoDirectionWrite)
+			}
+
+			allMetricsCount++
+			mb.RecordMongodbWtFsyncCountDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordMongodbWtLogOperationCountDataPoint(ts, 1, AttributeMongodbWtLogOperationTypeWrite)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbWtLogOperationCountDataPoint(ts, 3, AttributeMongodbWtLogOperationTypeSync)
+			}
+
+			allMetricsCount++
+			mb.RecordMongodbWtLogSyncTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordMongodbWtLogWriteDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordMongodbWtcacheBytesReadDataPoint(ts, 1)
 
 			rb := mb.NewResourceBuilder()
@@ -326,6 +349,8 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricMongodbOperationReplCount.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbOperationTime.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbStorageSize.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbWtConcurrentTransactionsInUse.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbWtLogOperationCount.aggDataPoints)
 			}
 
 			if tt.expectEmpty {
@@ -1618,6 +1643,132 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 					assert.Equal(t, "The amount of time that the server has been running.", mi.Description())
 					assert.Equal(t, "ms", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "mongodb.wt.concurrent_transactions.in_use":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
+						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of in-flight WiredTiger read/write concurrent-transaction tickets.", mi.Description())
+						assert.Equal(t, "{transaction}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						diskIoDirectionAttrVal, ok := dp.Attributes().Get("disk.io.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskIoDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
+						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of in-flight WiredTiger read/write concurrent-transaction tickets.", mi.Description())
+						assert.Equal(t, "{transaction}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["mongodb.wt.concurrent_transactions.in_use"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("disk.io.direction")
+						assert.False(t, ok)
+					}
+				case "mongodb.wt.fsync.count":
+					assert.False(t, validatedMetrics["mongodb.wt.fsync.count"], "Found a duplicate in the metrics slice: mongodb.wt.fsync.count")
+					validatedMetrics["mongodb.wt.fsync.count"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The total number of fsync I/Os issued by the WiredTiger storage engine.", mi.Description())
+					assert.Equal(t, "{fsync}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "mongodb.wt.log.operation.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodb.wt.log.operation.count"], "Found a duplicate in the metrics slice: mongodb.wt.log.operation.count")
+						validatedMetrics["mongodb.wt.log.operation.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The total number of WiredTiger journal operations.", mi.Description())
+						assert.Equal(t, "{operation}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						mongodbWtLogOperationTypeAttrVal, ok := dp.Attributes().Get("mongodb.wt.log.operation.type")
+						assert.True(t, ok)
+						assert.Equal(t, "write", mongodbWtLogOperationTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodb.wt.log.operation.count"], "Found a duplicate in the metrics slice: mongodb.wt.log.operation.count")
+						validatedMetrics["mongodb.wt.log.operation.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The total number of WiredTiger journal operations.", mi.Description())
+						assert.Equal(t, "{operation}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["mongodb.wt.log.operation.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("mongodb.wt.log.operation.type")
+						assert.False(t, ok)
+					}
+				case "mongodb.wt.log.sync.time":
+					assert.False(t, validatedMetrics["mongodb.wt.log.sync.time"], "Found a duplicate in the metrics slice: mongodb.wt.log.sync.time")
+					validatedMetrics["mongodb.wt.log.sync.time"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The cumulative time spent syncing the WiredTiger journal.", mi.Description())
+					assert.Equal(t, "s", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "mongodb.wt.log.write":
+					assert.False(t, validatedMetrics["mongodb.wt.log.write"], "Found a duplicate in the metrics slice: mongodb.wt.log.write")
+					validatedMetrics["mongodb.wt.log.write"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The total number of bytes written to the WiredTiger journal.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -297,9 +297,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordMongodbUptimeDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 1, AttributeDiskIoDirectionRead)
+			mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 1, AttributeMongodbWtConcurrentTransactionTypeRead)
 			if tt.name == "reaggregate_set" {
-				mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 3, AttributeDiskIoDirectionWrite)
+				mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 3, AttributeMongodbWtConcurrentTransactionTypeWrite)
 			}
 
 			allMetricsCount++
@@ -1663,9 +1663,9 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						diskIoDirectionAttrVal, ok := dp.Attributes().Get("disk.io.direction")
+						mongodbWtConcurrentTransactionTypeAttrVal, ok := dp.Attributes().Get("mongodb.wt.concurrent_transaction.type")
 						assert.True(t, ok)
-						assert.Equal(t, "read", diskIoDirectionAttrVal.Str())
+						assert.Equal(t, "read", mongodbWtConcurrentTransactionTypeAttrVal.Str())
 					} else {
 						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
 						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
@@ -1687,7 +1687,7 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("disk.io.direction")
+						_, ok := dp.Attributes().Get("mongodb.wt.concurrent_transaction.type")
 						assert.False(t, ok)
 					}
 				case "mongodb.wt.fsync.count":

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -87,7 +87,7 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["mongodb.operation.repl.count"] = mb.metricMongodbOperationReplCount.config.AggregationStrategy
 			aggMap["mongodb.operation.time"] = mb.metricMongodbOperationTime.config.AggregationStrategy
 			aggMap["mongodb.storage.size"] = mb.metricMongodbStorageSize.config.AggregationStrategy
-			aggMap["mongodb.wt.concurrent_transactions.in_use"] = mb.metricMongodbWtConcurrentTransactionsInUse.config.AggregationStrategy
+			aggMap["mongodb.wt.concurrent_transaction.ticket.in_use"] = mb.metricMongodbWtConcurrentTransactionTicketInUse.config.AggregationStrategy
 			aggMap["mongodb.wt.log.operation.count"] = mb.metricMongodbWtLogOperationCount.config.AggregationStrategy
 
 			expectedWarnings := 0
@@ -297,9 +297,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordMongodbUptimeDataPoint(ts, 1)
 
 			allMetricsCount++
-			mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 1, AttributeMongodbWtConcurrentTransactionTypeRead)
+			mb.RecordMongodbWtConcurrentTransactionTicketInUseDataPoint(ts, 1, AttributeMongodbWtConcurrentTransactionTicketTypeRead)
 			if tt.name == "reaggregate_set" {
-				mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(ts, 3, AttributeMongodbWtConcurrentTransactionTypeWrite)
+				mb.RecordMongodbWtConcurrentTransactionTicketInUseDataPoint(ts, 3, AttributeMongodbWtConcurrentTransactionTicketTypeWrite)
 			}
 
 			allMetricsCount++
@@ -349,7 +349,7 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricMongodbOperationReplCount.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbOperationTime.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbStorageSize.aggDataPoints)
-				assert.Empty(t, mb.metricMongodbWtConcurrentTransactionsInUse.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbWtConcurrentTransactionTicketInUse.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbWtLogOperationCount.aggDataPoints)
 			}
 
@@ -1650,14 +1650,14 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-				case "mongodb.wt.concurrent_transactions.in_use":
+				case "mongodb.wt.concurrent_transaction.ticket.in_use":
 					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
-						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
+						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transaction.ticket.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transaction.ticket.in_use")
+						validatedMetrics["mongodb.wt.concurrent_transaction.ticket.in_use"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "The number of in-flight WiredTiger read/write concurrent-transaction tickets.", mi.Description())
-						assert.Equal(t, "{transaction}", mi.Unit())
+						assert.Equal(t, "{ticket}", mi.Unit())
 						assert.False(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 						dp := mi.Sum().DataPoints().At(0)
@@ -1665,23 +1665,23 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						mongodbWtConcurrentTransactionTypeAttrVal, ok := dp.Attributes().Get("mongodb.wt.concurrent_transaction.type")
+						mongodbWtConcurrentTransactionTicketTypeAttrVal, ok := dp.Attributes().Get("mongodb.wt.concurrent_transaction.ticket.type")
 						assert.True(t, ok)
-						assert.Equal(t, "read", mongodbWtConcurrentTransactionTypeAttrVal.Str())
+						assert.Equal(t, "read", mongodbWtConcurrentTransactionTicketTypeAttrVal.Str())
 					} else {
-						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
-						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
+						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transaction.ticket.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transaction.ticket.in_use")
+						validatedMetrics["mongodb.wt.concurrent_transaction.ticket.in_use"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "The number of in-flight WiredTiger read/write concurrent-transaction tickets.", mi.Description())
-						assert.Equal(t, "{transaction}", mi.Unit())
+						assert.Equal(t, "{ticket}", mi.Unit())
 						assert.False(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 						dp := mi.Sum().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["mongodb.wt.concurrent_transactions.in_use"] {
+						switch aggMap["mongodb.wt.concurrent_transaction.ticket.in_use"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":
@@ -1691,7 +1691,7 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("mongodb.wt.concurrent_transaction.type")
+						_, ok := dp.Attributes().Get("mongodb.wt.concurrent_transaction.ticket.type")
 						assert.False(t, ok)
 					}
 				case "mongodb.wt.fsync.count":

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -1654,11 +1654,13 @@ func TestMetricsBuilder(t *testing.T) {
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
 						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "The number of in-flight WiredTiger read/write concurrent-transaction tickets.", mi.Description())
 						assert.Equal(t, "{transaction}", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
@@ -1669,11 +1671,13 @@ func TestMetricsBuilder(t *testing.T) {
 					} else {
 						assert.False(t, validatedMetrics["mongodb.wt.concurrent_transactions.in_use"], "Found a duplicate in the metrics slice: mongodb.wt.concurrent_transactions.in_use")
 						validatedMetrics["mongodb.wt.concurrent_transactions.in_use"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "The number of in-flight WiredTiger read/write concurrent-transaction tickets.", mi.Description())
 						assert.Equal(t, "{transaction}", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -113,6 +113,18 @@ all_set:
       enabled: true
     mongodb.uptime:
       enabled: true
+    mongodb.wt.concurrent_transactions.in_use:
+      enabled: true
+      attributes: ["disk.io.direction"]
+    mongodb.wt.fsync.count:
+      enabled: true
+    mongodb.wt.log.operation.count:
+      enabled: true
+      attributes: ["mongodb.wt.log.operation.type"]
+    mongodb.wt.log.sync.time:
+      enabled: true
+    mongodb.wt.log.write:
+      enabled: true
     mongodb.wtcache.bytes.read:
       enabled: true
   events:
@@ -245,6 +257,18 @@ reaggregate_set:
       enabled: true
     mongodb.uptime:
       enabled: true
+    mongodb.wt.concurrent_transactions.in_use:
+      enabled: true
+      attributes: []
+    mongodb.wt.fsync.count:
+      enabled: true
+    mongodb.wt.log.operation.count:
+      enabled: true
+      attributes: []
+    mongodb.wt.log.sync.time:
+      enabled: true
+    mongodb.wt.log.write:
+      enabled: true
     mongodb.wtcache.bytes.read:
       enabled: true
   events:
@@ -376,6 +400,18 @@ none_set:
     mongodb.updates.rate:
       enabled: false
     mongodb.uptime:
+      enabled: false
+    mongodb.wt.concurrent_transactions.in_use:
+      enabled: false
+      attributes: ["disk.io.direction"]
+    mongodb.wt.fsync.count:
+      enabled: false
+    mongodb.wt.log.operation.count:
+      enabled: false
+      attributes: ["mongodb.wt.log.operation.type"]
+    mongodb.wt.log.sync.time:
+      enabled: false
+    mongodb.wt.log.write:
       enabled: false
     mongodb.wtcache.bytes.read:
       enabled: false

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -115,7 +115,7 @@ all_set:
       enabled: true
     mongodb.wt.concurrent_transactions.in_use:
       enabled: true
-      attributes: ["disk.io.direction"]
+      attributes: ["mongodb.wt.concurrent_transaction.type"]
     mongodb.wt.fsync.count:
       enabled: true
     mongodb.wt.log.operation.count:
@@ -403,7 +403,7 @@ none_set:
       enabled: false
     mongodb.wt.concurrent_transactions.in_use:
       enabled: false
-      attributes: ["disk.io.direction"]
+      attributes: ["mongodb.wt.concurrent_transaction.type"]
     mongodb.wt.fsync.count:
       enabled: false
     mongodb.wt.log.operation.count:

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -113,9 +113,9 @@ all_set:
       enabled: true
     mongodb.uptime:
       enabled: true
-    mongodb.wt.concurrent_transactions.in_use:
+    mongodb.wt.concurrent_transaction.ticket.in_use:
       enabled: true
-      attributes: ["mongodb.wt.concurrent_transaction.type"]
+      attributes: ["mongodb.wt.concurrent_transaction.ticket.type"]
     mongodb.wt.fsync.count:
       enabled: true
     mongodb.wt.log.operation.count:
@@ -257,7 +257,7 @@ reaggregate_set:
       enabled: true
     mongodb.uptime:
       enabled: true
-    mongodb.wt.concurrent_transactions.in_use:
+    mongodb.wt.concurrent_transaction.ticket.in_use:
       enabled: true
       attributes: []
     mongodb.wt.fsync.count:
@@ -401,9 +401,9 @@ none_set:
       enabled: false
     mongodb.uptime:
       enabled: false
-    mongodb.wt.concurrent_transactions.in_use:
+    mongodb.wt.concurrent_transaction.ticket.in_use:
       enabled: false
-      attributes: ["mongodb.wt.concurrent_transaction.type"]
+      attributes: ["mongodb.wt.concurrent_transaction.ticket.type"]
     mongodb.wt.fsync.count:
       enabled: false
     mongodb.wt.log.operation.count:

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -773,16 +773,6 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: true
     attributes: []
-  mongodb.wt.log.bytes:
-    description: The total number of bytes written to the WiredTiger journal.
-    stability: development
-    unit: By
-    enabled: false
-    sum:
-      value_type: int
-      aggregation_temporality: cumulative
-      monotonic: true
-    attributes: []
   mongodb.wt.log.operation.count:
     description: The total number of WiredTiger journal operations.
     stability: development
@@ -800,6 +790,16 @@ metrics:
     enabled: false
     sum:
       value_type: double
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: []
+  mongodb.wt.log.write:
+    description: The total number of bytes written to the WiredTiger journal.
+    stability: development
+    unit: By
+    enabled: false
+    sum:
+      value_type: int
       aggregation_temporality: cumulative
       monotonic: true
     attributes: []

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -783,7 +783,7 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: true
     attributes: []
-  mongodb.wt.log.operations:
+  mongodb.wt.log.operation.count:
     description: The total number of WiredTiger journal operations.
     stability: development
     unit: "{operation}"

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -755,7 +755,7 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: []
-  mongodb.wt.concurrent_transactions.out:
+  mongodb.wt.concurrent_transactions.in_use:
     description: The number of in-flight WiredTiger read/write concurrent-transaction tickets.
     stability: development
     unit: "{transaction}"

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -78,6 +78,13 @@ attributes:
     description: The database management system (DBMS) product as identified by the client instrumentation.
     type: string
     enum: [ mongodb ]
+  disk.io.direction:
+    description: The disk I/O operation direction.
+    type: string
+    requirement_level: recommended
+    enum:
+      - read
+      - write
   lock_mode:
     description: The mode of Lock which denotes the degree of access
     type: string
@@ -201,6 +208,14 @@ attributes:
   mongodb.query.truncated:
     description: Whether the value carried by db.query.text is a truncated rendering of the MongoDB command, as indicated by `$truncated` in the currentOp output.
     type: bool
+  mongodb.wt.log.operation.type:
+    description: The WiredTiger journal operation type.
+    type: string
+    requirement_level: recommended
+    enum:
+      - write
+      - sync
+      - flush
   operation:
     description: The MongoDB operation being counted.
     type: string
@@ -739,6 +754,54 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
+    attributes: []
+  mongodb.wt.concurrent_transactions.out:
+    description: The number of in-flight WiredTiger read/write concurrent-transaction tickets.
+    stability: development
+    unit: "{transaction}"
+    enabled: false
+    gauge:
+      value_type: int
+    attributes: [disk.io.direction]
+  mongodb.wt.fsync.count:
+    description: The total number of fsync I/Os issued by the WiredTiger storage engine.
+    stability: development
+    unit: "{fsync}"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: []
+  mongodb.wt.log.bytes:
+    description: The total number of bytes written to the WiredTiger journal.
+    stability: development
+    unit: By
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: []
+  mongodb.wt.log.operations:
+    description: The total number of WiredTiger journal operations.
+    stability: development
+    unit: "{operation}"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: [mongodb.wt.log.operation.type]
+  mongodb.wt.log.sync.time:
+    description: The cumulative time spent syncing the WiredTiger journal.
+    stability: development
+    unit: s
+    enabled: false
+    sum:
+      value_type: double
+      aggregation_temporality: cumulative
+      monotonic: true
     attributes: []
   mongodb.wtcache.bytes.read:
     description: The number of bytes read into the WiredTiger cache.

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -760,8 +760,10 @@ metrics:
     stability: development
     unit: "{transaction}"
     enabled: false
-    gauge:
+    sum:
       value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
     attributes: [mongodb.wt.concurrent_transaction.type]
   mongodb.wt.fsync.count:
     description: The total number of fsync I/Os issued by the WiredTiger storage engine.

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -78,13 +78,6 @@ attributes:
     description: The database management system (DBMS) product as identified by the client instrumentation.
     type: string
     enum: [ mongodb ]
-  disk.io.direction:
-    description: The disk I/O operation direction.
-    type: string
-    requirement_level: recommended
-    enum:
-      - read
-      - write
   lock_mode:
     description: The mode of Lock which denotes the degree of access
     type: string
@@ -208,6 +201,13 @@ attributes:
   mongodb.query.truncated:
     description: Whether the value carried by db.query.text is a truncated rendering of the MongoDB command, as indicated by `$truncated` in the currentOp output.
     type: bool
+  mongodb.wt.concurrent_transaction.type:
+    description: The WiredTiger concurrent-transaction ticket type.
+    type: string
+    requirement_level: recommended
+    enum:
+      - read
+      - write
   mongodb.wt.log.operation.type:
     description: The WiredTiger journal operation type.
     type: string
@@ -762,7 +762,7 @@ metrics:
     enabled: false
     gauge:
       value_type: int
-    attributes: [disk.io.direction]
+    attributes: [mongodb.wt.concurrent_transaction.type]
   mongodb.wt.fsync.count:
     description: The total number of fsync I/Os issued by the WiredTiger storage engine.
     stability: development

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -201,7 +201,7 @@ attributes:
   mongodb.query.truncated:
     description: Whether the value carried by db.query.text is a truncated rendering of the MongoDB command, as indicated by `$truncated` in the currentOp output.
     type: bool
-  mongodb.wt.concurrent_transaction.type:
+  mongodb.wt.concurrent_transaction.ticket.type:
     description: The WiredTiger concurrent-transaction ticket type.
     type: string
     requirement_level: recommended
@@ -755,16 +755,16 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: []
-  mongodb.wt.concurrent_transactions.in_use:
+  mongodb.wt.concurrent_transaction.ticket.in_use:
     description: The number of in-flight WiredTiger read/write concurrent-transaction tickets.
     stability: development
-    unit: "{transaction}"
+    unit: "{ticket}"
     enabled: false
     sum:
       value_type: int
       aggregation_temporality: cumulative
       monotonic: false
-    attributes: [mongodb.wt.concurrent_transaction.type]
+    attributes: [mongodb.wt.concurrent_transaction.ticket.type]
   mongodb.wt.fsync.count:
     description: The total number of fsync I/Os issued by the WiredTiger storage engine.
     stability: development

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -407,6 +407,122 @@ func (s *mongodbScraper) recordWTCacheBytes(now pcommon.Timestamp, doc bson.M, e
 	s.mb.RecordMongodbWtcacheBytesReadDataPoint(now, val)
 }
 
+const storageEngineWiredTiger = "wiredTiger"
+
+// isWiredTiger reports whether serverStatus indicates the WiredTiger storage engine.
+func isWiredTiger(doc bson.M) bool {
+	name, err := dig(doc, []string{"storageEngine", "name"})
+	if err != nil {
+		return false
+	}
+	return name == storageEngineWiredTiger
+}
+
+// wtLogOperationsMap keys are the serverStatus.wiredTiger.log.<key> field names; values
+// are the mdatagen-generated attribute enums for mongodb.wt.log.operation.type.
+var wtLogOperationsMap = map[string]metadata.AttributeMongodbWtLogOperationType{
+	"log write operations": metadata.AttributeMongodbWtLogOperationTypeWrite,
+	"log sync operations":  metadata.AttributeMongodbWtLogOperationTypeSync,
+	"log flush operations": metadata.AttributeMongodbWtLogOperationTypeFlush,
+}
+
+func (s *mongodbScraper) recordWTLogBytes(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	if !isWiredTiger(doc) {
+		return
+	}
+	metricPath := []string{"wiredTiger", "log", "log bytes written"}
+	metricName := "mongodb.wt.log.bytes"
+	val, err := collectMetric(doc, metricPath)
+	if err != nil {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, err))
+		return
+	}
+	s.mb.RecordMongodbWtLogBytesDataPoint(now, val)
+}
+
+func (s *mongodbScraper) recordWTLogOperations(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	if !isWiredTiger(doc) {
+		return
+	}
+	metricName := "mongodb.wt.log.operations"
+	for fieldKey, attr := range wtLogOperationsMap {
+		val, err := collectMetric(doc, []string{"wiredTiger", "log", fieldKey})
+		if err != nil {
+			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, attr.String(), err))
+			continue
+		}
+		s.mb.RecordMongodbWtLogOperationsDataPoint(now, val, attr)
+	}
+}
+
+func (s *mongodbScraper) recordWTLogSyncTime(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	if !isWiredTiger(doc) {
+		return
+	}
+	metricPath := []string{"wiredTiger", "log", "log sync time duration"}
+	metricName := "mongodb.wt.log.sync.time"
+	val, err := collectMetric(doc, metricPath)
+	if err != nil {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, err))
+		return
+	}
+	// Source field is microseconds; emit seconds.
+	seconds := float64(val) / 1_000_000.0
+	s.mb.RecordMongodbWtLogSyncTimeDataPoint(now, seconds)
+}
+
+func (s *mongodbScraper) recordWTFsyncCount(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	if !isWiredTiger(doc) {
+		return
+	}
+	metricPath := []string{"wiredTiger", "connection", "total fsync I/Os"}
+	metricName := "mongodb.wt.fsync.count"
+	val, err := collectMetric(doc, metricPath)
+	if err != nil {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, err))
+		return
+	}
+	s.mb.RecordMongodbWtFsyncCountDataPoint(now, val)
+}
+
+// recordWTConcurrentTransactionsOut reads WiredTiger concurrent-transaction ticket usage,
+// with a version-gated dual-path read to handle the MongoDB 8.0 rename of
+// serverStatus.wiredTiger.concurrentTransactions.{read,write} to
+// serverStatus.queues.execution.{read,write}. On 8.0+ the legacy path is absent; on
+// pre-8.0 the new queues.execution path is absent. The receiver tries the new path
+// first (cheap probe) and falls back to the legacy WiredTiger path if needed.
+func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	metricName := "mongodb.wt.concurrent_transactions.out"
+	directions := map[string]metadata.AttributeDiskIoDirection{
+		"read":  metadata.AttributeDiskIoDirectionRead,
+		"write": metadata.AttributeDiskIoDirectionWrite,
+	}
+	// MongoDB 8.0+ path
+	if _, err := dig(doc, []string{"queues", "execution"}); err == nil {
+		for dir, attr := range directions {
+			val, e := collectMetric(doc, []string{"queues", "execution", dir, "out"})
+			if e != nil {
+				errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, dir, e))
+				continue
+			}
+			s.mb.RecordMongodbWtConcurrentTransactionsOutDataPoint(now, val, attr)
+		}
+		return
+	}
+	// Pre-8.0 path: only meaningful with WiredTiger storage engine
+	if !isWiredTiger(doc) {
+		return
+	}
+	for dir, attr := range directions {
+		val, e := collectMetric(doc, []string{"wiredTiger", "concurrentTransactions", dir, "out"})
+		if e != nil {
+			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, dir, e))
+			continue
+		}
+		s.mb.RecordMongodbWtConcurrentTransactionsOutDataPoint(now, val, attr)
+	}
+}
+
 func (s *mongodbScraper) recordPageFaults(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
 	metricPath := []string{"extra_info", "page_faults"}
 	metricName := "mongodb.page_faults"

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -459,7 +459,7 @@ func (s *mongodbScraper) recordWTLogSyncTime(now pcommon.Timestamp, doc bson.M, 
 	if !isWiredTiger(doc) {
 		return
 	}
-	metricPath := []string{"wiredTiger", "log", "log sync time duration"}
+	metricPath := []string{"wiredTiger", "log", "log sync time duration (usecs)"}
 	metricName := "mongodb.wt.log.sync.time"
 	val, err := collectMetric(doc, metricPath)
 	if err != nil {

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -492,6 +492,13 @@ func (s *mongodbScraper) recordWTFsyncCount(now pcommon.Timestamp, doc bson.M, e
 // pre-8.0 the new queues.execution path is absent. The receiver tries the new path
 // first (cheap probe) and falls back to the legacy WiredTiger path if needed.
 func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	// These are WiredTiger concurrency tickets, so only emit on the WiredTiger storage
+	// engine. The gate covers both version paths below: on 8.0+ the queues.execution
+	// section can also be present under non-WiredTiger engines (e.g. inMemory), and this
+	// metric should not be emitted there.
+	if !isWiredTiger(doc) {
+		return
+	}
 	metricName := "mongodb.wt.concurrent_transactions.in_use"
 	directions := map[string]metadata.AttributeDiskIoDirection{
 		"read":  metadata.AttributeDiskIoDirectionRead,
@@ -509,10 +516,7 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 		}
 		return
 	}
-	// Pre-8.0 path: only meaningful with WiredTiger storage engine
-	if !isWiredTiger(doc) {
-		return
-	}
+	// Pre-8.0 path
 	for dir, attr := range directions {
 		val, e := collectMetric(doc, []string{"wiredTiger", "concurrentTransactions", dir, "out"})
 		if e != nil {

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -426,18 +426,18 @@ var wtLogOperationsMap = map[string]metadata.AttributeMongodbWtLogOperationType{
 	"log flush operations": metadata.AttributeMongodbWtLogOperationTypeFlush,
 }
 
-func (s *mongodbScraper) recordWTLogBytes(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+func (s *mongodbScraper) recordWTLogWrite(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
 	if !isWiredTiger(doc) {
 		return
 	}
 	metricPath := []string{"wiredTiger", "log", "log bytes written"}
-	metricName := "mongodb.wt.log.bytes"
+	metricName := "mongodb.wt.log.write"
 	val, err := collectMetric(doc, metricPath)
 	if err != nil {
 		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, err))
 		return
 	}
-	s.mb.RecordMongodbWtLogBytesDataPoint(now, val)
+	s.mb.RecordMongodbWtLogWriteDataPoint(now, val)
 }
 
 func (s *mongodbScraper) recordWTLogOperations(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -492,7 +492,7 @@ func (s *mongodbScraper) recordWTFsyncCount(now pcommon.Timestamp, doc bson.M, e
 // pre-8.0 the new queues.execution path is absent. The receiver tries the new path
 // first (cheap probe) and falls back to the legacy WiredTiger path if needed.
 func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
-	metricName := "mongodb.wt.concurrent_transactions.out"
+	metricName := "mongodb.wt.concurrent_transactions.in_use"
 	directions := map[string]metadata.AttributeDiskIoDirection{
 		"read":  metadata.AttributeDiskIoDirectionRead,
 		"write": metadata.AttributeDiskIoDirectionWrite,
@@ -505,7 +505,7 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 				errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, dir, e))
 				continue
 			}
-			s.mb.RecordMongodbWtConcurrentTransactionsOutDataPoint(now, val, attr)
+			s.mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(now, val, attr)
 		}
 		return
 	}
@@ -519,7 +519,7 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, dir, e))
 			continue
 		}
-		s.mb.RecordMongodbWtConcurrentTransactionsOutDataPoint(now, val, attr)
+		s.mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(now, val, attr)
 	}
 }
 

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -499,10 +499,10 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 	if !isWiredTiger(doc) {
 		return
 	}
-	metricName := "mongodb.wt.concurrent_transactions.in_use"
-	directions := map[string]metadata.AttributeMongodbWtConcurrentTransactionType{
-		"read":  metadata.AttributeMongodbWtConcurrentTransactionTypeRead,
-		"write": metadata.AttributeMongodbWtConcurrentTransactionTypeWrite,
+	metricName := "mongodb.wt.concurrent_transaction.ticket.in_use"
+	directions := map[string]metadata.AttributeMongodbWtConcurrentTransactionTicketType{
+		"read":  metadata.AttributeMongodbWtConcurrentTransactionTicketTypeRead,
+		"write": metadata.AttributeMongodbWtConcurrentTransactionTicketTypeWrite,
 	}
 	// MongoDB 8.0+ path
 	if _, err := dig(doc, []string{"queues", "execution"}); err == nil {
@@ -512,7 +512,7 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 				errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, dir, e))
 				continue
 			}
-			s.mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(now, val, attr)
+			s.mb.RecordMongodbWtConcurrentTransactionTicketInUseDataPoint(now, val, attr)
 		}
 		return
 	}
@@ -523,7 +523,7 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, dir, e))
 			continue
 		}
-		s.mb.RecordMongodbWtConcurrentTransactionsInUseDataPoint(now, val, attr)
+		s.mb.RecordMongodbWtConcurrentTransactionTicketInUseDataPoint(now, val, attr)
 	}
 }
 

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -500,9 +500,9 @@ func (s *mongodbScraper) recordWTConcurrentTransactionsOut(now pcommon.Timestamp
 		return
 	}
 	metricName := "mongodb.wt.concurrent_transactions.in_use"
-	directions := map[string]metadata.AttributeDiskIoDirection{
-		"read":  metadata.AttributeDiskIoDirectionRead,
-		"write": metadata.AttributeDiskIoDirectionWrite,
+	directions := map[string]metadata.AttributeMongodbWtConcurrentTransactionType{
+		"read":  metadata.AttributeMongodbWtConcurrentTransactionTypeRead,
+		"write": metadata.AttributeMongodbWtConcurrentTransactionTypeWrite,
 	}
 	// MongoDB 8.0+ path
 	if _, err := dig(doc, []string{"queues", "execution"}); err == nil {

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -444,14 +444,14 @@ func (s *mongodbScraper) recordWTLogOperations(now pcommon.Timestamp, doc bson.M
 	if !isWiredTiger(doc) {
 		return
 	}
-	metricName := "mongodb.wt.log.operations"
+	metricName := "mongodb.wt.log.operation.count"
 	for fieldKey, attr := range wtLogOperationsMap {
 		val, err := collectMetric(doc, []string{"wiredTiger", "log", fieldKey})
 		if err != nil {
 			errs.AddPartial(1, fmt.Errorf(collectMetricWithAttributes, metricName, attr.String(), err))
 			continue
 		}
-		s.mb.RecordMongodbWtLogOperationsDataPoint(now, val, attr)
+		s.mb.RecordMongodbWtLogOperationCountDataPoint(now, val, attr)
 	}
 }
 

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -66,7 +66,7 @@ func newWTScraper(t *testing.T) *mongodbScraper {
 	t.Helper()
 	cfg := createDefaultConfig().(*Config)
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogBytes.Enabled = true
-	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogOperations.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogOperationCount.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogSyncTime.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtFsyncCount.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsOut.Enabled = true
@@ -99,7 +99,7 @@ func TestRecordWTLogOperations(t *testing.T) {
 	s.recordWTLogOperations(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.operations")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.operation.count")
 	require.Equal(t, pmetric.MetricTypeSum, m.Type())
 	byType := sumIntByAttr(t, m, "mongodb.wt.log.operation.type")
 	require.Equal(t, map[string]int64{

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -194,6 +194,30 @@ func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
 	require.Equal(t, map[string]int64{"read": 7, "write": 4}, byDir)
 }
 
+// TestRecordWTConcurrentTransactionsNonWiredTiger80 asserts that on MongoDB 8.0+ the
+// queues.execution path is still gated by the storage engine: a non-WiredTiger engine
+// (e.g. inMemory) that exposes queues.execution must not emit the metric.
+func TestRecordWTConcurrentTransactionsNonWiredTiger80(t *testing.T) {
+	doc := bson.M{
+		"queues": bson.M{
+			"execution": bson.M{
+				"read":  bson.M{"out": int64(7)},
+				"write": bson.M{"out": int64(4)},
+			},
+		},
+		"storageEngine": bson.M{"name": "inMemory"},
+	}
+	s := newWTScraper(t)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTConcurrentTransactionsOut(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	md := s.mb.Emit()
+	require.Equal(t, 0, md.ResourceMetrics().Len())
+}
+
 // TestRecordWTMetricsNonWiredTiger asserts the log/fsync metrics emit nothing when the
 // storage engine is not WiredTiger.
 func TestRecordWTMetricsNonWiredTiger(t *testing.T) {
@@ -206,6 +230,7 @@ func TestRecordWTMetricsNonWiredTiger(t *testing.T) {
 	s.recordWTLogOperations(now, doc, errs)
 	s.recordWTLogSyncTime(now, doc, errs)
 	s.recordWTFsyncCount(now, doc, errs)
+	s.recordWTConcurrentTransactionsOut(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
 	md := s.mb.Emit()

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -69,7 +69,7 @@ func newWTScraper(t *testing.T) *mongodbScraper {
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogOperationCount.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogSyncTime.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtFsyncCount.Enabled = true
-	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsOut.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.Enabled = true
 	return newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
 }
 
@@ -154,7 +154,7 @@ func TestRecordWTConcurrentTransactionsOutLegacy(t *testing.T) {
 	s.recordWTConcurrentTransactionsOut(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.out")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
 	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
 	byDir := gaugeIntByAttr(t, m, "disk.io.direction")
 	require.Equal(t, map[string]int64{"read": 3, "write": 1}, byDir)
@@ -188,7 +188,7 @@ func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
 	s.recordWTConcurrentTransactionsOut(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.out")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
 	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
 	byDir := gaugeIntByAttr(t, m, "disk.io.direction")
 	require.Equal(t, map[string]int64{"read": 7, "write": 4}, byDir)

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -55,7 +55,7 @@ func newWTScraper(t *testing.T) *mongodbScraper {
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogOperationCount.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogSyncTime.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtFsyncCount.Enabled = true
-	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionTicketInUse.Enabled = true
 	return newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
 }
 
@@ -140,9 +140,9 @@ func TestRecordWTConcurrentTransactionsOutLegacy(t *testing.T) {
 	s.recordWTConcurrentTransactionsOut(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transaction.ticket.in_use")
 	require.Equal(t, pmetric.MetricTypeSum, m.Type())
-	byDir := sumIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
+	byDir := sumIntByAttr(t, m, "mongodb.wt.concurrent_transaction.ticket.type")
 	require.Equal(t, map[string]int64{"read": 3, "write": 1}, byDir)
 }
 
@@ -174,9 +174,9 @@ func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
 	s.recordWTConcurrentTransactionsOut(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transaction.ticket.in_use")
 	require.Equal(t, pmetric.MetricTypeSum, m.Type())
-	byDir := sumIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
+	byDir := sumIntByAttr(t, m, "mongodb.wt.concurrent_transaction.ticket.type")
 	require.Equal(t, map[string]int64{"read": 7, "write": 4}, byDir)
 }
 
@@ -185,8 +185,8 @@ func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
 // addition (7 + 4 = 11), not by averaging (which a Gauge would do, yielding 5).
 func TestRecordWTConcurrentTransactionsAttributeDisabled(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.Enabled = true
-	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.EnabledAttributes = []metadata.MongodbWtConcurrentTransactionsInUseMetricAttributeKey{}
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionTicketInUse.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionTicketInUse.EnabledAttributes = []metadata.MongodbWtConcurrentTransactionTicketInUseMetricAttributeKey{}
 	s := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
 
 	doc := bson.M{
@@ -204,7 +204,7 @@ func TestRecordWTConcurrentTransactionsAttributeDisabled(t *testing.T) {
 	s.recordWTConcurrentTransactionsOut(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transaction.ticket.in_use")
 	require.Equal(t, pmetric.MetricTypeSum, m.Type())
 	require.Equal(t, 1, m.Sum().DataPoints().Len())
 	require.Equal(t, int64(11), m.Sum().DataPoints().At(0).IntValue())

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -65,7 +65,7 @@ func gaugeIntByAttr(t *testing.T, m pmetric.Metric, attrKey string) map[string]i
 func newWTScraper(t *testing.T) *mongodbScraper {
 	t.Helper()
 	cfg := createDefaultConfig().(*Config)
-	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogBytes.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogWrite.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogOperationCount.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogSyncTime.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.MongodbWtFsyncCount.Enabled = true
@@ -73,17 +73,17 @@ func newWTScraper(t *testing.T) *mongodbScraper {
 	return newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
 }
 
-func TestRecordWTLogBytes(t *testing.T) {
+func TestRecordWTLogWrite(t *testing.T) {
 	s := newWTScraper(t)
 	doc, err := loadAdminStatusAsMap()
 	require.NoError(t, err)
 	errs := &scrapererror.ScrapeErrors{}
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	s.recordWTLogBytes(now, doc, errs)
+	s.recordWTLogWrite(now, doc, errs)
 	require.NoError(t, errs.Combine())
 
-	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.bytes")
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.write")
 	require.Equal(t, pmetric.MetricTypeSum, m.Type())
 	require.Equal(t, 1, m.Sum().DataPoints().Len())
 	require.Equal(t, int64(1048576000), m.Sum().DataPoints().At(0).IntValue())
@@ -202,7 +202,7 @@ func TestRecordWTMetricsNonWiredTiger(t *testing.T) {
 	errs := &scrapererror.ScrapeErrors{}
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	s.recordWTLogBytes(now, doc, errs)
+	s.recordWTLogWrite(now, doc, errs)
 	s.recordWTLogOperations(now, doc, errs)
 	s.recordWTLogSyncTime(now, doc, errs)
 	s.recordWTFsyncCount(now, doc, errs)

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -1,0 +1,213 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mongodbreceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/collector/scraper/scrapererror"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver/internal/metadata"
+)
+
+// findMetric returns the emitted metric with the given name, failing the test if absent.
+func findMetric(t *testing.T, md pmetric.Metrics, name string) pmetric.Metric {
+	t.Helper()
+	require.Equal(t, 1, md.ResourceMetrics().Len())
+	sms := md.ResourceMetrics().At(0).ScopeMetrics()
+	require.Equal(t, 1, sms.Len())
+	ms := sms.At(0).Metrics()
+	for i := 0; i < ms.Len(); i++ {
+		if ms.At(i).Name() == name {
+			return ms.At(i)
+		}
+	}
+	t.Fatalf("metric %q not found among emitted metrics", name)
+	return pmetric.Metric{}
+}
+
+// sumIntByAttr maps an attribute value to its int data-point value for a Sum metric.
+func sumIntByAttr(t *testing.T, m pmetric.Metric, attrKey string) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	dps := m.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		v, ok := dp.Attributes().Get(attrKey)
+		require.True(t, ok, "data point missing attribute %q", attrKey)
+		out[v.Str()] = dp.IntValue()
+	}
+	return out
+}
+
+// gaugeIntByAttr maps an attribute value to its int data-point value for a Gauge metric.
+func gaugeIntByAttr(t *testing.T, m pmetric.Metric, attrKey string) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	dps := m.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		v, ok := dp.Attributes().Get(attrKey)
+		require.True(t, ok, "data point missing attribute %q", attrKey)
+		out[v.Str()] = dp.IntValue()
+	}
+	return out
+}
+
+// newWTScraper builds a scraper with all five WiredTiger metrics enabled.
+func newWTScraper(t *testing.T) *mongodbScraper {
+	t.Helper()
+	cfg := createDefaultConfig().(*Config)
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogBytes.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogOperations.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtLogSyncTime.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtFsyncCount.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsOut.Enabled = true
+	return newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+}
+
+func TestRecordWTLogBytes(t *testing.T) {
+	s := newWTScraper(t)
+	doc, err := loadAdminStatusAsMap()
+	require.NoError(t, err)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTLogBytes(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.bytes")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	require.Equal(t, 1, m.Sum().DataPoints().Len())
+	require.Equal(t, int64(1048576000), m.Sum().DataPoints().At(0).IntValue())
+}
+
+func TestRecordWTLogOperations(t *testing.T) {
+	s := newWTScraper(t)
+	doc, err := loadAdminStatusAsMap()
+	require.NoError(t, err)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTLogOperations(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.operations")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	byType := sumIntByAttr(t, m, "mongodb.wt.log.operation.type")
+	require.Equal(t, map[string]int64{
+		"write": 12345,
+		"sync":  2345,
+		"flush": 8100,
+	}, byType)
+}
+
+func TestRecordWTLogSyncTime(t *testing.T) {
+	s := newWTScraper(t)
+	doc, err := loadAdminStatusAsMap()
+	require.NoError(t, err)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTLogSyncTime(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.log.sync.time")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	require.Equal(t, 1, m.Sum().DataPoints().Len())
+	// Source field is 5_000_000 microseconds; emitted as 5.0 seconds.
+	require.InDelta(t, 5.0, m.Sum().DataPoints().At(0).DoubleValue(), 1e-9)
+}
+
+func TestRecordWTFsyncCount(t *testing.T) {
+	s := newWTScraper(t)
+	doc, err := loadAdminStatusAsMap()
+	require.NoError(t, err)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTFsyncCount(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.fsync.count")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	require.Equal(t, 1, m.Sum().DataPoints().Len())
+	require.Equal(t, int64(42), m.Sum().DataPoints().At(0).IntValue())
+}
+
+// TestRecordWTConcurrentTransactionsOutLegacy exercises the pre-8.0 path that reads
+// serverStatus.wiredTiger.concurrentTransactions.{read,write}.out (present in admin.json).
+func TestRecordWTConcurrentTransactionsOutLegacy(t *testing.T) {
+	s := newWTScraper(t)
+	doc, err := loadAdminStatusAsMap()
+	require.NoError(t, err)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTConcurrentTransactionsOut(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.out")
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	byDir := gaugeIntByAttr(t, m, "disk.io.direction")
+	require.Equal(t, map[string]int64{"read": 3, "write": 1}, byDir)
+}
+
+// TestRecordWTConcurrentTransactionsOut80 exercises the MongoDB 8.0+ path where the field
+// was renamed to serverStatus.queues.execution.{read,write}.out. The receiver must read the
+// queues.execution path preferentially, even when the legacy WiredTiger path is also present.
+func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
+	// Document with the 8.0 queues.execution path AND a conflicting legacy path, to assert
+	// the 8.0 path wins.
+	doc := bson.M{
+		"queues": bson.M{
+			"execution": bson.M{
+				"read":  bson.M{"out": int64(7)},
+				"write": bson.M{"out": int64(4)},
+			},
+		},
+		"storageEngine": bson.M{"name": "wiredTiger"},
+		"wiredTiger": bson.M{
+			"concurrentTransactions": bson.M{
+				"read":  bson.M{"out": int64(999)},
+				"write": bson.M{"out": int64(999)},
+			},
+		},
+	}
+	s := newWTScraper(t)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTConcurrentTransactionsOut(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.out")
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	byDir := gaugeIntByAttr(t, m, "disk.io.direction")
+	require.Equal(t, map[string]int64{"read": 7, "write": 4}, byDir)
+}
+
+// TestRecordWTMetricsNonWiredTiger asserts the log/fsync metrics emit nothing when the
+// storage engine is not WiredTiger.
+func TestRecordWTMetricsNonWiredTiger(t *testing.T) {
+	doc := bson.M{"storageEngine": bson.M{"name": "inMemory"}}
+	s := newWTScraper(t)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTLogBytes(now, doc, errs)
+	s.recordWTLogOperations(now, doc, errs)
+	s.recordWTLogSyncTime(now, doc, errs)
+	s.recordWTFsyncCount(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	md := s.mb.Emit()
+	require.Equal(t, 0, md.ResourceMetrics().Len())
+}

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -47,20 +47,6 @@ func sumIntByAttr(t *testing.T, m pmetric.Metric, attrKey string) map[string]int
 	return out
 }
 
-// gaugeIntByAttr maps an attribute value to its int data-point value for a Gauge metric.
-func gaugeIntByAttr(t *testing.T, m pmetric.Metric, attrKey string) map[string]int64 {
-	t.Helper()
-	out := map[string]int64{}
-	dps := m.Gauge().DataPoints()
-	for i := 0; i < dps.Len(); i++ {
-		dp := dps.At(i)
-		v, ok := dp.Attributes().Get(attrKey)
-		require.True(t, ok, "data point missing attribute %q", attrKey)
-		out[v.Str()] = dp.IntValue()
-	}
-	return out
-}
-
 // newWTScraper builds a scraper with all five WiredTiger metrics enabled.
 func newWTScraper(t *testing.T) *mongodbScraper {
 	t.Helper()
@@ -155,8 +141,8 @@ func TestRecordWTConcurrentTransactionsOutLegacy(t *testing.T) {
 	require.NoError(t, errs.Combine())
 
 	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
-	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
-	byDir := gaugeIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	byDir := sumIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
 	require.Equal(t, map[string]int64{"read": 3, "write": 1}, byDir)
 }
 
@@ -189,9 +175,39 @@ func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
 	require.NoError(t, errs.Combine())
 
 	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
-	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
-	byDir := gaugeIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	byDir := sumIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
 	require.Equal(t, map[string]int64{"read": 7, "write": 4}, byDir)
+}
+
+// TestRecordWTConcurrentTransactionsAttributeDisabled verifies the metric is a non-monotonic
+// Sum, not a Gauge: when the read/write attribute is disabled the two data points collapse by
+// addition (7 + 4 = 11), not by averaging (which a Gauge would do, yielding 5).
+func TestRecordWTConcurrentTransactionsAttributeDisabled(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.EnabledAttributes = []metadata.MongodbWtConcurrentTransactionsInUseMetricAttributeKey{}
+	s := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+
+	doc := bson.M{
+		"storageEngine": bson.M{"name": "wiredTiger"},
+		"wiredTiger": bson.M{
+			"concurrentTransactions": bson.M{
+				"read":  bson.M{"out": int64(7)},
+				"write": bson.M{"out": int64(4)},
+			},
+		},
+	}
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordWTConcurrentTransactionsOut(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	require.Equal(t, 1, m.Sum().DataPoints().Len())
+	require.Equal(t, int64(11), m.Sum().DataPoints().At(0).IntValue())
 }
 
 // TestRecordWTConcurrentTransactionsNonWiredTiger80 asserts that on MongoDB 8.0+ the

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -156,7 +156,7 @@ func TestRecordWTConcurrentTransactionsOutLegacy(t *testing.T) {
 
 	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
 	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
-	byDir := gaugeIntByAttr(t, m, "disk.io.direction")
+	byDir := gaugeIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
 	require.Equal(t, map[string]int64{"read": 3, "write": 1}, byDir)
 }
 
@@ -190,7 +190,7 @@ func TestRecordWTConcurrentTransactionsOut80(t *testing.T) {
 
 	m := findMetric(t, s.mb.Emit(), "mongodb.wt.concurrent_transactions.in_use")
 	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
-	byDir := gaugeIntByAttr(t, m, "disk.io.direction")
+	byDir := gaugeIntByAttr(t, m, "mongodb.wt.concurrent_transaction.type")
 	require.Equal(t, map[string]int64{"read": 7, "write": 4}, byDir)
 }
 

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -764,7 +764,7 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 		s.recordWTFsyncCount(now, document, errs)
 	}
 
-	if s.config.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsOut.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.Enabled {
 		s.recordWTConcurrentTransactionsOut(now, document, errs)
 	}
 

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -752,7 +752,7 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 		s.recordWTLogBytes(now, document, errs)
 	}
 
-	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogOperations.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogOperationCount.Enabled {
 		s.recordWTLogOperations(now, document, errs)
 	}
 

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -748,6 +748,26 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 		s.recordWTCacheBytes(now, document, errs)
 	}
 
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogBytes.Enabled {
+		s.recordWTLogBytes(now, document, errs)
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogOperations.Enabled {
+		s.recordWTLogOperations(now, document, errs)
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogSyncTime.Enabled {
+		s.recordWTLogSyncTime(now, document, errs)
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtFsyncCount.Enabled {
+		s.recordWTFsyncCount(now, document, errs)
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsOut.Enabled {
+		s.recordWTConcurrentTransactionsOut(now, document, errs)
+	}
+
 	if s.config.MetricsBuilderConfig.Metrics.MongodbPageFaults.Enabled {
 		s.recordPageFaults(now, document, errs)
 	}

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -764,7 +764,7 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 		s.recordWTFsyncCount(now, document, errs)
 	}
 
-	if s.config.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionsInUse.Enabled {
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtConcurrentTransactionTicketInUse.Enabled {
 		s.recordWTConcurrentTransactionsOut(now, document, errs)
 	}
 

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -748,8 +748,8 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 		s.recordWTCacheBytes(now, document, errs)
 	}
 
-	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogBytes.Enabled {
-		s.recordWTLogBytes(now, document, errs)
+	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogWrite.Enabled {
+		s.recordWTLogWrite(now, document, errs)
 	}
 
 	if s.config.MetricsBuilderConfig.Metrics.MongodbWtLogOperationCount.Enabled {

--- a/receiver/mongodbreceiver/testdata/admin.json
+++ b/receiver/mongodbreceiver/testdata/admin.json
@@ -418,7 +418,7 @@
 			"log flush operations": {
 				"$numberLong": "8100"
 			},
-			"log sync time duration": {
+			"log sync time duration (usecs)": {
 				"$numberLong": "5000000"
 			}
 		},

--- a/receiver/mongodbreceiver/testdata/admin.json
+++ b/receiver/mongodbreceiver/testdata/admin.json
@@ -404,6 +404,52 @@
 			"total succeed number of checkpoints": {
 				"$numberInt": "42"
 			}
+		},
+		"log": {
+			"log bytes written": {
+				"$numberLong": "1048576000"
+			},
+			"log write operations": {
+				"$numberLong": "12345"
+			},
+			"log sync operations": {
+				"$numberLong": "2345"
+			},
+			"log flush operations": {
+				"$numberLong": "8100"
+			},
+			"log sync time duration": {
+				"$numberLong": "5000000"
+			}
+		},
+		"connection": {
+			"total fsync I/Os": {
+				"$numberLong": "42"
+			}
+		},
+		"concurrentTransactions": {
+			"read": {
+				"out": {
+					"$numberInt": "3"
+				},
+				"available": {
+					"$numberInt": "125"
+				},
+				"totalTickets": {
+					"$numberInt": "128"
+				}
+			},
+			"write": {
+				"out": {
+					"$numberInt": "1"
+				},
+				"available": {
+					"$numberInt": "127"
+				},
+				"totalTickets": {
+					"$numberInt": "128"
+				}
+			}
 		}
 	},
 	"version": "4.0.25"


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The MongoDB receiver already scrapes `serverStatus`, including part of the `wiredTiger` sub-document (`wiredTiger.cache."bytes read into cache"` for `mongodb.wtcache.bytes.read`). It does not expose WiredTiger's **journal (write-ahead log) throughput**, its **fsync activity**, or the **in-use** count of the concurrent-transaction ticket pool. These fields have no equivalent elsewhere in the receiver, so dashboards cannot reconstruct them from the metrics collected today.

The fields are already present in the `serverStatus` document fetched on every scrape, so this is forwarded native data via new record logic in the existing `recordAdminStats` path — **no new server command**.

This change adds **5 new opt-in metrics** (disabled by default, `stability: development`). Four are monotonic cumulative **Sums** (WiredTiger journal + fsync counters); one is a non-monotonic cumulative **Sum** (tickets in use — an additive absolute count, i.e. UpDownCounter semantics). Two new receiver-specific attributes are introduced: `mongodb.wt.log.operation.type` (write/sync/flush) and `mongodb.wt.concurrent_transaction.ticket.type` (read/write):

| Metric | Type | Unit | Source `serverStatus` field | Conversion |
|---|---|---|---|---|
| `mongodb.wt.log.write` | Sum (int, monotonic) | `By` | `wiredTiger.log."log bytes written"` | none |
| `mongodb.wt.log.operation.count` (attr `mongodb.wt.log.operation.type`) | Sum (int, monotonic) | `{operation}` | `wiredTiger.log."log {write,sync,flush} operations"` | none |
| `mongodb.wt.log.sync.time` | Sum (double, monotonic) | `s` | `wiredTiger.log."log sync time duration (usecs)"` | µs ÷ 1,000,000 |
| `mongodb.wt.fsync.count` | Sum (int, monotonic) | `{fsync}` | `wiredTiger.connection."total fsync I/Os"` | none |
| `mongodb.wt.concurrent_transaction.ticket.in_use` (attr `mongodb.wt.concurrent_transaction.ticket.type`) | Sum (int, non-monotonic) | `{ticket}` | `wiredTiger.concurrentTransactions.{read,write}.out` **or** `queues.execution.{read,write}.out` (8.0+) | none |

All 5 metrics emit **only** when the storage engine is WiredTiger (the default since MongoDB 3.2; MMAPv1 was removed in 4.2). `mongodb.wt.log.sync.time` divides the source microseconds by 1,000,000, matching the receiver's second-based time convention. `mongodb.wt.concurrent_transaction.ticket.in_use` reports the in-use WiredTiger read/write concurrency tickets (`concurrentTransactions.{read,write}.out`) — a saturation signal for the storage engine's admission control. It is modeled as a non-monotonic cumulative Sum (an absolute current count that is additive across the read/write attribute), consistent with the existing `mongodb.active.reads`/`mongodb.active.writes`/`mongodb.session.count` metrics.

**MongoDB 8.0 field rename — handled here.** `serverStatus.wiredTiger.concurrentTransactions.{read,write}` was renamed to `serverStatus.queues.execution.{read,write}` in MongoDB 8.0. `mongodb.wt.concurrent_transaction.ticket.in_use` performs a dual-path read (prefers `queues.execution`, falls back to the legacy path), so the same metric emits across all supported versions without configuration changes.

These metrics can be enabled in the collector configuration:

```yaml
receivers:
  mongodb:
    hosts:
      - endpoint: localhost:27017
    metrics:
      mongodb.wt.log.write:
        enabled: true
      mongodb.wt.log.operation.count:
        enabled: true
      mongodb.wt.log.sync.time:
        enabled: true
      mongodb.wt.fsync.count:
        enabled: true
      mongodb.wt.concurrent_transaction.ticket.in_use:
        enabled: true
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50208 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests in `metrics_test.go` (new), each enabling the WiredTiger metrics and asserting emitted values through the metrics builder:

- `TestRecordWTLogWrite`, `TestRecordWTFsyncCount` — assert the raw counter values.
- `TestRecordWTLogOperations` — asserts all three `mongodb.wt.log.operation.type` data points (write, sync, flush).
- `TestRecordWTLogSyncTime` — verifies the unit conversion: `5,000,000` µs from `wiredTiger.log."log sync time duration (usecs)"` produces `5.0` s.
- `TestRecordWTConcurrentTransactionsOutLegacy` — the pre-8.0 path reading `wiredTiger.concurrentTransactions.{read,write}.out`.
- `TestRecordWTConcurrentTransactionsOut80` — the MongoDB 8.0 path reading `queues.execution.{read,write}.out`, asserting the 8.0 path is preferred even when the legacy path is also present in the document.
- `TestRecordWTMetricsNonWiredTiger` — asserts no data points are emitted when the storage engine is not WiredTiger.
- The `testdata/admin.json` fixture is extended with the `wiredTiger.log.*`, `wiredTiger.connection."total fsync I/Os"`, and `wiredTiger.concurrentTransactions.{read,write}` fields, so existing scraper tests continue to pass unchanged.
- Auto-generated tests in `internal/metadata/generated_metrics_test.go` and `generated_config_test.go` cover the new metric configs / metric builders.

<!--Describe the documentation added.-->
#### Documentation

Auto-generated `documentation.md` updated with descriptions and metadata for the 5 new metrics. `README.md` gains version-availability notes under `## Metrics`: the WiredTiger-engine requirement for all 5 metrics and the MongoDB 8.0 `concurrentTransactions` → `queues.execution` dual-path behaviour for `mongodb.wt.concurrent_transaction.ticket.in_use`.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
