### PR TITLE
[ci] remove permissions narrowing from first time contributor action

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          permission-pull-requests: write
-          # convertPullRequestToDraft additionally requires contents: write
-          # https://github.com/cli/cli/discussions/6924
-          permission-contents: write
-
       # Allow up to two non-draft PRs so that the author can change which PR they mark as ready for review.
       - name: Convert to draft if author has two other non-draft PRs open
         env:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `draft_if_multiple_prs` job fails at `gh pr ready --undo` with `GraphQL: Resource not accessible by integration (convertPullRequestToDraft)` ([run](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/31370361182/job/93397724142)) because the otelbot token is narrowed to `permission-pull-requests: write`, which is not sufficient for that mutation, this is why #48203 didn't help, as it swapped the token but kept the same narrowing.

My follow-up [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50141) added `permission-contents: write`, which the installation doesn't grant, so token creation now fails with a 422 and the draft step is skipped entirely, meaning every first-time contributor gets a failure ([run](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/31646490917/job/94281200375)).

This PR removes that and drops the narrowing so the token is minted with the installation's existing grant, matching how `tidy-dependencies.yml`, `prepare-release.yml` and `update-otel.yaml` already request it. This widens the token's permissions but not its reach (still repo-scoped), and the job has no `actions/checkout`, only a SHA-pinned action, and passes untrusted values via `env:`, so no PR-controlled code runs with it. The 422 also confirms the installation has no `Contents: write`, so it can't push.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
