### PR TITLE
[internal/kafka] Reuse cached AWS credentials for MSK IAM authentication

### DIFF
--- a/.chloggen/50038-msk-iam-cache-credentials.yaml
+++ b/.chloggen/50038-msk-iam-cache-credentials.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: internal/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reuse the resolved AWS credentials provider across `AWS_MSK_IAM_OAUTHBEARER` token generations instead of reloading AWS configuration and credentials on every SASL authentication
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50038]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, the OAUTHBEARER callback called `signer.GenerateAuthToken`, which reloads the
+  default AWS config and resolves AWS credentials from scratch on every SASL handshake. For
+  credential sources backed by AWS STS (e.g. web identity), this caused a new `AssumeRoleWithWebIdentity`
+  call on every broker authentication, even though the SDK's own credentials cache was already
+  discarded and rebuilt each time. The AWS config and credentials provider are now resolved once
+  per Kafka client, and `signer.GenerateAuthTokenFromCredentialsProvider` reuses that cached
+  provider for subsequent token generations.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	krb5client "github.com/jcmturner/gokrb5/v8/client"
 	krb5config "github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/keytab"
@@ -327,7 +328,7 @@ func commonOpts(
 		opts = append(opts, kgo.SASL(auth.AsMechanism()))
 	}
 	if clientCfg.Authentication.SASL != nil {
-		saslOpt, err := configureKgoSASL(clientCfg.Authentication.SASL, host)
+		saslOpt, err := configureKgoSASL(ctx, clientCfg.Authentication.SASL, host)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure SASL: %w", err)
 		}
@@ -374,7 +375,7 @@ func commonOpts(
 	return opts, nil
 }
 
-func configureKgoSASL(cfg *configkafka.SASLConfig, host component.Host) (kgo.Opt, error) {
+func configureKgoSASL(ctx context.Context, cfg *configkafka.SASLConfig, host component.Host) (kgo.Opt, error) {
 	var m sasl.Mechanism
 	switch cfg.Mechanism {
 	case PLAIN:
@@ -384,8 +385,16 @@ func configureKgoSASL(cfg *configkafka.SASLConfig, host component.Host) (kgo.Opt
 	case SCRAMSHA512:
 		m = scram.Auth{User: cfg.Username, Pass: cfg.Password}.AsSha512Mechanism()
 	case AWSMSKIAMOAUTHBEARER:
+		// Resolve the AWS credentials provider once and reuse it (via the SDK's
+		// built-in aws.CredentialsCache) for every token generation over this
+		// client's lifetime, instead of resolving credentials -- and potentially
+		// calling AWS STS -- on every single SASL handshake.
+		awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(cfg.AWSMSK.Region))
+		if err != nil {
+			return nil, fmt.Errorf("failed to load AWS config for MSK IAM authentication: %w", err)
+		}
 		m = oauth.Oauth(func(ctx context.Context) (oauth.Auth, error) {
-			token, _, err := signer.GenerateAuthToken(ctx, cfg.AWSMSK.Region)
+			token, _, err := signer.GenerateAuthTokenFromCredentialsProvider(ctx, cfg.AWSMSK.Region, awsCfg.Credentials)
 			return oauth.Auth{Token: token}, err
 		})
 	case OAUTHBEARER:

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -750,7 +750,7 @@ func TestConfigureKgoKerberos(t *testing.T) {
 }
 
 func TestConfigureKgoSASL_AWSMSKIAMOAUTHBEARER(t *testing.T) {
-	opt, err := configureKgoSASL(&configkafka.SASLConfig{
+	opt, err := configureKgoSASL(t.Context(), &configkafka.SASLConfig{
 		Mechanism: AWSMSKIAMOAUTHBEARER,
 		AWSMSK:    configkafka.AWSMSKConfig{Region: "us-west-2"},
 	}, componenttest.NewNopHost())
@@ -762,7 +762,7 @@ func TestConfigureKgoSASL_OAUTHBEARER(t *testing.T) {
 	extID := component.MustNewID("oauth2client")
 
 	t.Run("missing_extension", func(t *testing.T) {
-		_, err := configureKgoSASL(&configkafka.SASLConfig{
+		_, err := configureKgoSASL(t.Context(), &configkafka.SASLConfig{
 			Mechanism:              OAUTHBEARER,
 			OAuthBearerTokenSource: extID,
 		}, componenttest.NewNopHost())
@@ -774,7 +774,7 @@ func TestConfigureKgoSASL_OAUTHBEARER(t *testing.T) {
 		host := &mockHost{extensions: map[component.ID]component.Component{
 			extID: &mockTokenSource{token: "tok"},
 		}}
-		opt, err := configureKgoSASL(&configkafka.SASLConfig{
+		opt, err := configureKgoSASL(t.Context(), &configkafka.SASLConfig{
 			Mechanism:              OAUTHBEARER,
 			OAuthBearerTokenSource: extID,
 		}, host)
@@ -784,7 +784,7 @@ func TestConfigureKgoSASL_OAUTHBEARER(t *testing.T) {
 }
 
 func TestConfigureKgoSASL_UnsupportedMechanism(t *testing.T) {
-	_, err := configureKgoSASL(&configkafka.SASLConfig{
+	_, err := configureKgoSASL(t.Context(), &configkafka.SASLConfig{
 		Mechanism: "BOGUS",
 	}, componenttest.NewNopHost())
 	require.ErrorContains(t, err, "unsupported SASL mechanism")

--- a/internal/kafka/go.mod
+++ b/internal/kafka/go.mod
@@ -35,7 +35,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.25 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `AWS_MSK_IAM_OAUTHBEARER` SASL callback in `internal/kafka/franz_client.go` called
`signer.GenerateAuthToken(ctx, region)` on every SASL handshake (initial connection and every
broker-requested reauth). That function calls `config.LoadDefaultConfig` fresh on every
invocation, which discards and rebuilds the AWS credentials provider (and its cache) each time.
For STS-backed credential sources such as web identity, this meant every Kafka broker
(re)authentication triggered a fresh `AssumeRoleWithWebIdentity` call, even though STS
credentials normally remain valid far longer than the ~15 minute MSK token lifetime.

This change resolves the AWS config/credentials provider once per Kafka client, outside the SASL
callback, and reuses it for every token generation over that client's lifetime via
`signer.GenerateAuthTokenFromCredentialsProvider` instead of `signer.GenerateAuthToken`. The
reused provider is already wrapped in `aws.CredentialsCache` by `config.LoadDefaultConfig` for
STS-backed sources, so credential caching, expiry handling, and single-flight concurrent-refresh
collapsing are inherited from the AWS SDK's default behavior without a custom wrapper.

This intentionally does not implement every item in the issue's "Expected Behavior" list --
bounded refresh jitter tuning, a custom strategy to retain credentials past their
AWS-SDK-adjusted expiry window on a failed refresh, and sharing one provider across multiple
Kafka clients/components in a single Collector process are left as explicit open design
questions in the issue and are not addressed here. This change only fixes the literal root
cause described in the issue: the credential provider (and its cache) being rebuilt from
scratch on every single authentication instead of once per client.

One behavior change worth calling out: AWS config/credentials-provider resolution now happens
synchronously when the Kafka client is constructed, instead of being deferred until the first
SASL handshake. `LoadDefaultConfig` only builds the provider chain and does not eagerly call
`Retrieve()`, so in practice this rarely performs I/O or fails, but it does mean AWS
configuration errors now surface at client-construction time rather than on first
authentication.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50038

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- `cd internal/kafka && go build ./...`
- `cd internal/kafka && go test ./...` (includes the 3 existing `TestConfigureKgoSASL_*` tests,
  updated to thread through the new `ctx` parameter; all pass)
- `cd internal/kafka && go vet ./... && gofmt -l .` (clean)
- `cd internal/kafka && golangci-lint run ./...` (clean)
- `cd exporter/kafkaexporter && go build ./...` and `cd receiver/kafkareceiver && go build ./...`
  (both downstream consumers of `internal/kafka` build clean)
- `make chlog-validate` (passes)

All validation above was run offline; no live AWS account, STS, or MSK cluster was used, since
this fix is a structural change (moving a function call from inside a per-authentication closure
to outside it, so it runs once per client instead of once per handshake) that is verifiable by
code inspection and the existing/updated unit tests, not one that depends on live AWS credential
behavior to prove correct.

<!--Describe the documentation added.-->
#### Documentation

No user-facing documentation changes; behavior of the `AWS_MSK_IAM_OAUTHBEARER` SASL mechanism
config is unchanged. A changelog entry was added at
`.chloggen/50038-msk-iam-cache-credentials.yaml`.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->

---
AI assistance: this change was drafted with Claude Code.

Relates to #50038
