### PR TITLE
[exporter/googlecloudpubsub] Allow domain-scoped project IDs in topic validation

### DIFF
--- a/.chloggen/48197-googlecloudpubsub-domain-scoped-project.yaml
+++ b/.chloggen/48197-googlecloudpubsub-domain-scoped-project.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow domain-scoped project IDs (e.g. `example.com:my-project`) in the `topic` configuration option.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48197]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/googlecloudpubsubexporter/config.go
+++ b/exporter/googlecloudpubsubexporter/config.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-var topicMatcher = regexp.MustCompile(`^projects/[a-z][a-z0-9\-]*/topics/`)
+var topicMatcher = regexp.MustCompile(`^projects/[a-z]([a-z0-9\-.:]*[a-z0-9])?/topics/`)
 
 type Config struct {
 	// Timeout for all API calls. If not set, defaults to 12 seconds.

--- a/exporter/googlecloudpubsubexporter/config_test.go
+++ b/exporter/googlecloudpubsubexporter/config_test.go
@@ -70,8 +70,26 @@ func TestTopicConfigValidation(t *testing.T) {
 	assert.Error(t, c.Validate())
 	c.Topic = "projects/my-project/subscriptions/my-subscription"
 	assert.Error(t, c.Validate())
+	c.Topic = "projects/my-project-/topics/my-topic"
+	assert.Error(t, c.Validate())
 	c.Topic = "projects/my-project/topics/my-topic"
 	assert.NoError(t, c.Validate())
+
+	// Domain-scoped project IDs (legacy Google Cloud feature).
+	c.Topic = "projects/example.com:my-project/topics/my-topic"
+	assert.NoError(t, c.Validate())
+	c.Topic = "projects/my-project:sub-project/topics/my-topic"
+	assert.NoError(t, c.Validate())
+
+	// Invalid domain-scoped project IDs.
+	c.Topic = "projects/:my-project/topics/my-topic"
+	assert.Error(t, c.Validate())
+	c.Topic = "projects/my-project:/topics/my-topic"
+	assert.Error(t, c.Validate())
+	c.Topic = "projects/.my-project/topics/my-topic"
+	assert.Error(t, c.Validate())
+	c.Topic = "projects/my-project./topics/my-topic"
+	assert.Error(t, c.Validate())
 }
 
 func TestCompressionConfigValidation(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `topicMatcher` regex used to validate the `topic` config option in `exporter/googlecloudpubsubexporter` rejects legacy domain-scoped Google Cloud project IDs (e.g. `example.com:my-project`), even though they are valid on Google Cloud Pub/Sub. This widens the regex to allow `.` and `:` inside the project ID segment, while still requiring it to start with a lowercase letter and end with an alphanumeric character.

Two prior community PRs (#48198, #48199) proposed essentially the same fix but were closed as stale due to lack of author follow-up (#48199 had a maintainer request to add a changelog and fix the build that was never addressed). This redoes the exporter-side fix with a changelog entry included. Only the exporter is touched here; the receiver has a separate, differently-shaped `subscriptionMatcher` regex and is left out of scope for this change.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48197

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added test cases to `TestTopicConfigValidation` covering valid domain-scoped project IDs (`example.com:my-project`, `my-project:sub-project`) and invalid ones (leading/trailing colon, leading/trailing dot, trailing hyphen).

Ran `go test ./exporter/googlecloudpubsubexporter/... -run TestTopicConfigValidation -v` and confirmed it passes with the new regex. Verified this is a genuine failing-then-passing reproduction: temporarily reverting only the regex change causes the new domain-scoped-ID test cases to fail, and reapplying it makes them pass. Also ran `go build ./...`, `go vet ./...`, and the full package test suite (`go test ./...`) for `exporter/googlecloudpubsubexporter`, all passing, and `golangci-lint run ./...` from within that package directory, which reported no issues. `make chlog-validate` passes for the new changelog entry.

<!--Describe the documentation added.-->
#### Documentation

No documentation changes; this is a config validation bug fix with no change to documented behavior (domain-scoped project IDs were always intended to be usable, per the linked issue).

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->

---
AI assistance: this change was drafted with Claude Code.

Fixes #48197