### PR TITLE
[ci] Fix draft_if_multiple_prs by switching to GITHUB_TOKEN with contents: write

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -21,21 +21,19 @@ jobs:
 
   draft_if_multiple_prs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     if: >
       github.repository_owner == 'open-telemetry' &&
       github.event.pull_request.author_association == 'NONE' &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'keep-as-non-draft')
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: otelbot-token
-        with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
       # Allow up to two non-draft PRs so that the author can change which PR they mark as ready for review.
       - name: Convert to draft if author has two other non-draft PRs open
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `draft_if_multiple_prs` is still not working properly, the latest run after #50222 merged still fails at the `Convert to draft...` step (see: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/31674775137/job/94366853993).

The mutations behind `gh pr ready --undo` require both `pull-requests: write` and `contents: write` (https://github.com/cli/cli/discussions/6924), and the otelbot installation does not grant Contents at all, the #50141 proved that adding `permission-contents: write` made the token mint fail with a 422. #50222 fixed the minting but the mutation still fails, so no change that keeps the otelbot token can work here.

This PR drops the `actions/create-github-app-token` step, adds a job-level `permissions:` block with `pull-requests: write` and `contents: write`, and points `GH_TOKEN` at `secrets.GITHUB_TOKEN`, whose grants come from that block rather than an app installation. The trigger stays `pull_request_target`, so the token is write-capable for fork PRs, and job-level `contents: write` on `GITHUB_TOKEN` is already used elsewhere in this repo (`load-tests.yml`, `tidy-dependencies.yml`). The security posture matches the argument accepted in #50222, no `actions/checkout`, untrusted values via `env:`, workflow body from `main`, and is scoped to one job instead of an org app token. Trade-off: the comment is now authored by `github-actions[bot]` instead of `otelbot`.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
